### PR TITLE
Clarify DataType.sanitizeValue and DataType.valueForInsert

### DIFF
--- a/benchmarks/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationBenchmark.java
@@ -128,7 +128,7 @@ public class HyperLogLogDistinctAggregationBenchmark {
     @Benchmark
     public long benchmarkHLLPlusPlusMurmur128() throws Exception {
         for (int i = 0; i < rows.size(); i++) {
-            String value = DataTypes.STRING.sanitizeValue(rows.get(i).get(0));
+            String value = DataTypes.STRING.sanitizeType(rows.get(i).get(0));
             byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
             MurmurHash3.Hash128 hash128 = MurmurHash3.hash128(bytes, 0, bytes.length, 0, hash);
             hyperLogLogPlusPlus.collect(hash128.h1);
@@ -139,7 +139,7 @@ public class HyperLogLogDistinctAggregationBenchmark {
     @Benchmark
     public long benchmarkHLLPlusPlusMurmur64() throws Exception {
         for (int i = 0; i < rows.size(); i++) {
-            String value = DataTypes.STRING.sanitizeValue(rows.get(i).get(0));
+            String value = DataTypes.STRING.sanitizeType(rows.get(i).get(0));
             byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
             hyperLogLogPlusPlus.collect(MurmurHash3.hash64(bytes, 0, bytes.length));
         }

--- a/extensions/functions/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregation.java
+++ b/extensions/functions/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregation.java
@@ -135,7 +135,7 @@ public class HyperLogLogDistinctAggregation extends AggregationFunction<HyperLog
         if (state.isInitialized() == false) {
             int precision = HyperLogLogPlusPlus.DEFAULT_PRECISION;
             if (args.length > 1) {
-                precision = DataTypes.INTEGER.sanitizeValue(args[1].value());
+                precision = DataTypes.INTEGER.sanitizeType(args[1].value());
             }
             state.init(memoryManager, precision);
         }
@@ -444,7 +444,7 @@ public class HyperLogLogDistinctAggregation extends AggregationFunction<HyperLog
         }
 
         @Override
-        public HllState sanitizeValue(Object value) {
+        public HllState sanitizeType(Object value) {
             return (HyperLogLogDistinctAggregation.HllState) value;
         }
 
@@ -518,7 +518,7 @@ public class HyperLogLogDistinctAggregation extends AggregationFunction<HyperLog
 
             @Override
             long hash(Object val) {
-                return BitMixer.mix64(DataTypes.LONG.sanitizeValue(val));
+                return BitMixer.mix64(DataTypes.LONG.sanitizeType(val));
             }
         }
 
@@ -529,7 +529,7 @@ public class HyperLogLogDistinctAggregation extends AggregationFunction<HyperLog
             @Override
             long hash(Object val) {
                 return BitMixer.mix64(
-                    doubleToLongBits(DataTypes.DOUBLE.sanitizeValue(val)));
+                    doubleToLongBits(DataTypes.DOUBLE.sanitizeType(val)));
             }
         }
 

--- a/extensions/lang-js/src/test/java/io/crate/operation/language/JavascriptUserDefinedFunctionTest.java
+++ b/extensions/lang-js/src/test/java/io/crate/operation/language/JavascriptUserDefinedFunctionTest.java
@@ -191,7 +191,7 @@ public class JavascriptUserDefinedFunctionTest extends ScalarTestCase {
             DataTypes.IP,
             List.of(),
             "function f() { return \"127.0.0.1\"; }");
-        assertEvaluate("f()", DataTypes.IP.sanitizeValue("127.0.0.1"));
+        assertEvaluate("f()", DataTypes.IP.sanitizeType("127.0.0.1"));
     }
 
     @Test

--- a/server/src/main/java/io/crate/analyze/AnalyzedColumnDefinition.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedColumnDefinition.java
@@ -400,7 +400,7 @@ public class AnalyzedColumnDefinition<T> {
                 throw new IllegalArgumentException("array literal not allowed for the analyzer property");
             }
 
-            String analyzerName = DataTypes.STRING.sanitizeValue(definition.analyzer);
+            String analyzerName = DataTypes.STRING.sanitizeType(definition.analyzer);
             if (fulltextAnalyzerResolver.hasCustomAnalyzer(analyzerName)) {
                 Settings settings = fulltextAnalyzerResolver.resolveFullCustomAnalyzerSettings(analyzerName);
                 definition.analyzerSettings(settings);

--- a/server/src/main/java/io/crate/analyze/NumberOfShards.java
+++ b/server/src/main/java/io/crate/analyze/NumberOfShards.java
@@ -46,7 +46,7 @@ public class NumberOfShards {
             throw new IllegalArgumentException(
                 String.format(Locale.ENGLISH, "invalid number '%s'", numberOfShards));
         }
-        var numShards = DataTypes.INTEGER.sanitizeValue(numberOfShards);
+        var numShards = DataTypes.INTEGER.sanitizeType(numberOfShards);
         if (numShards < 1) {
             throw new IllegalArgumentException("num_shards in CLUSTERED clause must be greater than 0");
         }

--- a/server/src/main/java/io/crate/analyze/SymbolEvaluator.java
+++ b/server/src/main/java/io/crate/analyze/SymbolEvaluator.java
@@ -85,6 +85,6 @@ public final class SymbolEvaluator extends BaseImplementationSymbolVisitor<Row> 
     @Override
     public Input<?> visitSelectSymbol(SelectSymbol selectSymbol, Row context) {
         DataType type = selectSymbol.valueType();
-        return Literal.of(type, type.sanitizeValue(subQueryResults.getSafe(selectSymbol)));
+        return Literal.of(type, type.sanitizeType(subQueryResults.getSafe(selectSymbol)));
     }
 }

--- a/server/src/main/java/io/crate/analyze/expressions/ValueNormalizer.java
+++ b/server/src/main/java/io/crate/analyze/expressions/ValueNormalizer.java
@@ -174,7 +174,7 @@ public final class ValueNormalizer {
             return primitiveValue;
         }
         try {
-            return info.valueType().sanitizeValue(primitiveValue);
+            return info.valueType().sanitizeType(primitiveValue);
         } catch (Exception e) {
             throw new ColumnValidationException(
                 info.column().sqlFqn(),

--- a/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -590,7 +590,7 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
             ord = intLiteral.getValue();
         } else if (expression instanceof LongLiteral longLiteral) {
             try {
-                ord = DataTypes.INTEGER.sanitizeValue(longLiteral.getValue());
+                ord = DataTypes.INTEGER.sanitizeType(longLiteral.getValue());
             } catch (ClassCastException | IllegalArgumentException e) {
                 throw new IllegalArgumentException(String.format(
                     Locale.ENGLISH,
@@ -650,7 +650,7 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
         }
         Integer ord;
         try {
-            ord = DataTypes.INTEGER.sanitizeValue(ordinal.value());
+            ord = DataTypes.INTEGER.sanitizeType(ordinal.value());
         } catch (ClassCastException | IllegalArgumentException e) {
             throw new IllegalArgumentException(String.format(
                 Locale.ENGLISH,

--- a/server/src/main/java/io/crate/analyze/where/DocKeys.java
+++ b/server/src/main/java/io/crate/analyze/where/DocKeys.java
@@ -71,7 +71,7 @@ public class DocKeys implements Iterable<DocKeys.DocKey> {
         public Optional<Long> version(TransactionContext txnCtx, NodeContext nodeCtx, Row params, SubQueryResults subQueryResults) {
             if (withVersions && key.get(width) != null) {
                 Object val = SymbolEvaluator.evaluate(txnCtx, nodeCtx, key.get(width), params, subQueryResults);
-                return Optional.of(DataTypes.LONG.sanitizeValue(val));
+                return Optional.of(DataTypes.LONG.sanitizeType(val));
             }
             return Optional.empty();
         }
@@ -79,7 +79,7 @@ public class DocKeys implements Iterable<DocKeys.DocKey> {
         public Optional<Long> sequenceNo(TransactionContext txnCtx, NodeContext nodeCtx, Row params, SubQueryResults subQueryResults) {
             if (withSequenceVersioning && key.get(width) != null) {
                 Object val = SymbolEvaluator.evaluate(txnCtx, nodeCtx, key.get(width), params, subQueryResults);
-                return Optional.of(LongType.INSTANCE.sanitizeValue(val));
+                return Optional.of(LongType.INSTANCE.sanitizeType(val));
             }
             return Optional.empty();
         }
@@ -87,7 +87,7 @@ public class DocKeys implements Iterable<DocKeys.DocKey> {
         public Optional<Long> primaryTerm(TransactionContext txnCtx, NodeContext nodeCtx, Row params, SubQueryResults subQueryResults) {
             if (withSequenceVersioning && key.get(width + 1) != null) {
                 Object val = SymbolEvaluator.evaluate(txnCtx, nodeCtx, key.get(width + 1), params, subQueryResults);
-                return Optional.of(LongType.INSTANCE.sanitizeValue(val));
+                return Optional.of(LongType.INSTANCE.sanitizeType(val));
             }
             return Optional.empty();
         }

--- a/server/src/main/java/io/crate/execution/dml/DynamicIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/DynamicIndexer.java
@@ -111,7 +111,7 @@ public final class DynamicIndexer implements ValueIndexer<Object> {
             );
             onDynamicColumn.accept(newColumn);
         }
-        value = type.sanitizeValue(value);
+        value = type.sanitizeType(value);
         indexer.indexValue(
             value,
             xcontentBuilder,
@@ -146,7 +146,7 @@ public final class DynamicIndexer implements ValueIndexer<Object> {
      * For example a `Integer` results in a BIGINT type.
      * </p>
      * <p>
-     *  Users should sanitize the value using {@link DataType#sanitizeValue(Object)}
+     *  Users should sanitize the value using {@link DataType#sanitizeType(Object)}
      *  of the result type.
      * </p>
      */

--- a/server/src/main/java/io/crate/execution/dml/Indexer.java
+++ b/server/src/main/java/io/crate/execution/dml/Indexer.java
@@ -328,8 +328,8 @@ public class Indexer {
             int compare = Comparator
                 .nullsFirst(valueType)
                 .compare(
-                    valueType.sanitizeValue(generatedValue),
-                    valueType.sanitizeValue(providedValue)
+                    valueType.sanitizeType(generatedValue),
+                    valueType.sanitizeType(providedValue)
                 );
             if (compare != 0) {
                 throw new IllegalArgumentException(
@@ -565,7 +565,7 @@ public class Indexer {
             Object[] values = item.insertValues();
             for (int i = 0; i < values.length; i++) {
                 Reference reference = columns.get(i);
-                Object value = reference.valueType().valueForInsert(values[i]);
+                Object value = reference.valueType().sanitizeValue(values[i]);
                 ColumnConstraint check = columnConstraints.get(reference.column());
                 if (check != null) {
                     check.verify(value);
@@ -579,7 +579,7 @@ public class Indexer {
                 ValueIndexer<Object> valueIndexer = (ValueIndexer<Object>) valueIndexers.get(i);
                 xContentBuilder.field(reference.column().leafName());
                 valueIndexer.indexValue(
-                    reference.valueType().sanitizeValue(value),
+                    reference.valueType().sanitizeType(value),
                     xContentBuilder,
                     addField,
                     onDynamicColumn,
@@ -711,7 +711,7 @@ public class Indexer {
             Object[] values = indexItem.insertValues();
             for (int i = 0; i < values.length; i++) {
                 Reference reference = targetColumns.get(i);
-                Object value = reference.valueType().valueForInsert(values[i]);
+                Object value = reference.valueType().sanitizeValue(values[i]);
                 ColumnConstraint check = columnConstraints.get(reference.column());
                 if (check != null) {
                     check.verify(value);

--- a/server/src/main/java/io/crate/execution/dml/ObjectIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/ObjectIndexer.java
@@ -127,7 +127,7 @@ public class ObjectIndexer implements ValueIndexer<Map<String, Object>> {
             if (valueIndexer != null) {
                 xContentBuilder.field(innerName);
                 valueIndexer.indexValue(
-                    type.sanitizeValue(innerValue),
+                    type.sanitizeType(innerValue),
                     xContentBuilder,
                     addField,
                     onDynamicColumn,
@@ -174,7 +174,7 @@ public class ObjectIndexer implements ValueIndexer<Map<String, Object>> {
                 continue;
             }
             var type = DynamicIndexer.guessType(innerValue);
-            innerValue = type.sanitizeValue(innerValue);
+            innerValue = type.sanitizeType(innerValue);
             StorageSupport<?> storageSupport = type.storageSupport();
             if (storageSupport == null) {
                 xContentBuilder.field(innerName);

--- a/server/src/main/java/io/crate/execution/dml/upsert/GeneratedColumns.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/GeneratedColumns.java
@@ -112,8 +112,8 @@ public final class GeneratedColumns<T> {
             if (Comparator
                     .nullsFirst(dataType)
                     .compare(
-                        dataType.sanitizeValue(generatedValue),
-                        dataType.sanitizeValue(providedValue)
+                        dataType.sanitizeType(generatedValue),
+                        dataType.sanitizeType(providedValue)
                     ) != 0) {
                 throw new IllegalArgumentException(
                     "Given value " + providedValue +

--- a/server/src/main/java/io/crate/execution/dml/upsert/ValidatedRawInsertSource.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/ValidatedRawInsertSource.java
@@ -116,7 +116,7 @@ public class ValidatedRawInsertSource implements InsertSourceGen, ParameterizedX
                 var value = entry.getValue().value();
                 var valueForInsert = reference
                     .valueType()
-                    .valueForInsert(value);
+                    .sanitizeValue(value);
                 var column = reference.column();
                 Maps.mergeInto(validatedSource, column.name(), column.path(), valueForInsert);
             }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregation.java
@@ -192,7 +192,7 @@ public class ArbitraryAggregation extends AggregationFunction<Object, Object> {
         public void apply(RamAccounting ramAccounting, int doc, MutableObject state) throws IOException {
             if (values.advanceExact(doc) && values.docValueCount() == 1) {
                 if (!state.hasValue()) {
-                    var value = dataType.sanitizeValue(values.nextValue());
+                    var value = dataType.sanitizeType(values.nextValue());
                     ramAccounting.addBytes(dataType.valueBytes(value));
                     state.setValue(value);
                 }
@@ -293,7 +293,7 @@ public class ArbitraryAggregation extends AggregationFunction<Object, Object> {
         public void apply(RamAccounting ramAccounting, int doc, MutableObject state) throws IOException {
             if (values.advanceExact(doc) && values.docValueCount() == 1) {
                 if (!state.hasValue()) {
-                    var value = dataType.sanitizeValue(values.nextValue().utf8ToString());
+                    var value = dataType.sanitizeType(values.nextValue().utf8ToString());
                     ramAccounting.addBytes(dataType.valueBytes(value));
                     state.setValue(value);
                 }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/CmpByAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/CmpByAggregation.java
@@ -348,7 +348,7 @@ public final class CmpByAggregation extends AggregationFunction<CmpByAggregation
         public Object partialResult(RamAccounting ramAccounting, CmpByLongState state) {
             CompareBy compareBy = new CompareBy();
             if (state.hasValue) {
-                compareBy.cmpValue = (Comparable) searchType.sanitizeValue(state.cmpValue);
+                compareBy.cmpValue = (Comparable) searchType.sanitizeType(state.cmpValue);
                 try {
                     resultExpression.setNextReader(new ReaderContext(state.leafReaderContext));
                     resultExpression.setNextDocId(state.docId);

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/CompareByType.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/CompareByType.java
@@ -79,7 +79,7 @@ public class CompareByType extends DataType<CompareBy> implements Streamer<Compa
     }
 
     @Override
-    public CompareBy sanitizeValue(Object value) {
+    public CompareBy sanitizeType(Object value) {
         return (CompareBy) value;
     }
 

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/CountAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/CountAggregation.java
@@ -198,7 +198,7 @@ public class CountAggregation extends AggregationFunction<MutableLong, Long> {
         }
 
         @Override
-        public MutableLong sanitizeValue(Object value) {
+        public MutableLong sanitizeType(Object value) {
             return (MutableLong) value;
         }
 

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregation.java
@@ -187,7 +187,7 @@ public class GeometricMeanAggregation extends AggregationFunction<GeometricMeanA
         }
 
         @Override
-        public GeometricMeanState sanitizeValue(Object value) {
+        public GeometricMeanState sanitizeType(Object value) {
             return (GeometricMeanState) value;
         }
 

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/IntervalSumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/IntervalSumAggregation.java
@@ -84,7 +84,7 @@ public class IntervalSumAggregation extends AggregationFunction<Period, Period> 
                           MemoryManager memoryManager,
                           Period state,
                           Input<?>[] args) throws CircuitBreakingException {
-        return reduce(ramAccounting, state, DataTypes.INTERVAL.sanitizeValue(args[0].value()));
+        return reduce(ramAccounting, state, DataTypes.INTERVAL.sanitizeType(args[0].value()));
     }
 
     @Override
@@ -127,7 +127,7 @@ public class IntervalSumAggregation extends AggregationFunction<Period, Period> 
     public Period removeFromAggregatedState(RamAccounting ramAccounting,
                                             Period previousAggState,
                                             Input<?>[] stateToRemove) {
-        return previousAggState.minus(DataTypes.INTERVAL.sanitizeValue(stateToRemove[0].value()));
+        return previousAggState.minus(DataTypes.INTERVAL.sanitizeType(stateToRemove[0].value()));
     }
 
     @Nullable

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
@@ -114,7 +114,7 @@ public abstract class MaximumAggregation extends AggregationFunction<Object, Obj
         @Override
         public Object partialResult(RamAccounting ramAccounting, MutableLong state) {
             if (state.hasValue()) {
-                return partialType.sanitizeValue(state.value());
+                return partialType.sanitizeType(state.value());
             } else {
                 return null;
             }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/MinimumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/MinimumAggregation.java
@@ -113,7 +113,7 @@ public abstract class MinimumAggregation extends AggregationFunction<Object, Obj
         @Override
         public Object partialResult(RamAccounting ramAccounting, MutableLong state) {
             if (state.hasValue()) {
-                return partialType.sanitizeValue(state.value());
+                return partialType.sanitizeType(state.value());
             } else {
                 return null;
             }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/PercentileAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/PercentileAggregation.java
@@ -106,7 +106,7 @@ class PercentileAggregation extends AggregationFunction<TDigestState, Object> {
             Object fractionValue = args[1].value();
             initState(state, fractionValue, ramAccounting);
         }
-        Double value = DataTypes.DOUBLE.sanitizeValue(args[0].value());
+        Double value = DataTypes.DOUBLE.sanitizeType(args[0].value());
         if (value != null) {
             int sizeBefore = state.byteSize();
             state.add(value);
@@ -128,7 +128,7 @@ class PercentileAggregation extends AggregationFunction<TDigestState, Object> {
                 state.fractions(toDoubleArray(values));
             } else {
                 ramAccounting.addBytes(Double.BYTES);
-                state.fractions(new double[]{DataTypes.DOUBLE.sanitizeValue(argValue)});
+                state.fractions(new double[]{DataTypes.DOUBLE.sanitizeType(argValue)});
             }
         }
     }
@@ -136,7 +136,7 @@ class PercentileAggregation extends AggregationFunction<TDigestState, Object> {
     private static double[] toDoubleArray(List<?> values) {
         double[] result = new double[values.size()];
         for (int i = 0; i < values.size(); i++) {
-            result[i] = DataTypes.DOUBLE.sanitizeValue(values.get(i));
+            result[i] = DataTypes.DOUBLE.sanitizeType(values.get(i));
         }
         return result;
     }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationAggregation.java
@@ -108,7 +108,7 @@ public class StandardDeviationAggregation extends AggregationFunction<StandardDe
         }
 
         @Override
-        public StandardDeviation sanitizeValue(Object value) {
+        public StandardDeviation sanitizeType(Object value) {
             return (StandardDeviation) value;
         }
 

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/StringAgg.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/StringAgg.java
@@ -117,7 +117,7 @@ public final class StringAgg extends AggregationFunction<StringAgg.StringAggStat
         }
 
         @Override
-        public StringAggState sanitizeValue(Object value) {
+        public StringAggState sanitizeType(Object value) {
             return (StringAggState) value;
         }
 

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/SumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/SumAggregation.java
@@ -142,7 +142,7 @@ public class SumAggregation<T extends Number> extends AggregationFunction<T, T> 
                      MemoryManager memoryManager,
                      T state,
                      Input<?>[] args) throws CircuitBreakingException {
-        return reduce(ramAccounting, state, returnType.sanitizeValue(args[0].value()));
+        return reduce(ramAccounting, state, returnType.sanitizeType(args[0].value()));
     }
 
     @Override
@@ -183,7 +183,7 @@ public class SumAggregation<T extends Number> extends AggregationFunction<T, T> 
 
     @Override
     public T removeFromAggregatedState(RamAccounting ramAccounting, T previousAggState, Input<?>[] stateToRemove) {
-        return subtraction.apply(previousAggState, returnType.sanitizeValue(stateToRemove[0].value()));
+        return subtraction.apply(previousAggState, returnType.sanitizeType(stateToRemove[0].value()));
     }
 
     @Nullable

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/TDigestStateType.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/TDigestStateType.java
@@ -67,7 +67,7 @@ class TDigestStateType extends DataType<TDigestState> implements Streamer<TDiges
     }
 
     @Override
-    public TDigestState sanitizeValue(Object value) {
+    public TDigestState sanitizeType(Object value) {
         return (TDigestState) value;
     }
 

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
@@ -108,7 +108,7 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
         }
 
         @Override
-        public Variance sanitizeValue(Object value) {
+        public Variance sanitizeType(Object value) {
             return (Variance) value;
         }
 

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/AverageAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/AverageAggregation.java
@@ -184,7 +184,7 @@ public class AverageAggregation extends AggregationFunction<AverageAggregation.A
         }
 
         @Override
-        public AverageState sanitizeValue(Object value) {
+        public AverageState sanitizeType(Object value) {
             return (AverageState) value;
         }
 

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/IntervalAverageAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/IntervalAverageAggregation.java
@@ -196,7 +196,7 @@ public class IntervalAverageAggregation extends AggregationFunction<IntervalAver
         }
 
         @Override
-        public IntervalAverageState sanitizeValue(Object value) {
+        public IntervalAverageState sanitizeType(Object value) {
             return (IntervalAverageState) value;
         }
 

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/numeric/NumericAverageStateType.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/numeric/NumericAverageStateType.java
@@ -59,7 +59,7 @@ public class NumericAverageStateType extends DataType<NumericAverageState> imple
     }
 
     @Override
-    public NumericAverageState sanitizeValue(Object value) {
+    public NumericAverageState sanitizeType(Object value) {
         return (NumericAverageState) value;
     }
 

--- a/server/src/main/java/io/crate/execution/engine/collect/DocInputFactory.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/DocInputFactory.java
@@ -57,7 +57,7 @@ public class DocInputFactory {
             refResolver = ref -> {
                 if (orderBy.orderBySymbols().contains(ref)) {
                     DataType<?> dataType = ref.valueType();
-                    return new OrderByCollectorExpression(ref, orderBy, dataType::sanitizeValue);
+                    return new OrderByCollectorExpression(ref, orderBy, dataType::sanitizeType);
                 }
                 return referenceResolver.getImplementation(ref);
             };

--- a/server/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
+++ b/server/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
@@ -373,7 +373,7 @@ public class ProjectionToProjectorVisitor
         }
 
         projection = projection.normalize(normalizer, context.txnCtx);
-        String uri = DataTypes.STRING.sanitizeValue(
+        String uri = DataTypes.STRING.sanitizeType(
             SymbolEvaluator.evaluate(context.txnCtx, nodeCtx, projection.uri(), Row.EMPTY, SubQueryResults.EMPTY));
         assert uri != null : "URI must not be null";
 

--- a/server/src/main/java/io/crate/execution/engine/window/WindowProjector.java
+++ b/server/src/main/java/io/crate/execution/engine/window/WindowProjector.java
@@ -251,7 +251,7 @@ public class WindowProjector {
             offsetColumnPosition = ((InputColumn) orderSymbol).index();
         }
         var finalOffsetValue =
-            offsetType.id() == IntervalType.ID ? offsetType.sanitizeValue(offsetValue) : orderSymbol.valueType().sanitizeValue(offsetValue);
+            offsetType.id() == IntervalType.ID ? offsetType.sanitizeType(offsetValue) : orderSymbol.valueType().sanitizeType(offsetValue);
         return (currentRow, x) -> {
             // if the offsetCell position is -1 the window is ordered by a Literal so we leave the
             // probe value to null so it doesn't impact ordering (ie. all values will be consistently GT or LT

--- a/server/src/main/java/io/crate/expression/reference/DocRefResolver.java
+++ b/server/src/main/java/io/crate/expression/reference/DocRefResolver.java
@@ -108,7 +108,7 @@ public final class DocRefResolver implements ReferenceResolver<CollectExpression
                         return null;
                     }
                     try {
-                        return ref.valueType().sanitizeValue(ValueExtractors.fromMap(response.getSource(), column));
+                        return ref.valueType().sanitizeType(ValueExtractors.fromMap(response.getSource(), column));
                     } catch (ClassCastException | ConversionException e) {
                         // due to a bug: https://github.com/crate/crate/issues/13990
                         Object value = ValueExtractors.fromMap(response.getSource(), column);

--- a/server/src/main/java/io/crate/expression/scalar/ArrayAppendFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayAppendFunction.java
@@ -80,10 +80,10 @@ class ArrayAppendFunction extends Scalar<List<Object>, Object> {
         Object valueToAdd = args[1].value();
         if (values != null) {
             for (Object value : values) {
-                resultList.add(innerType.sanitizeValue(value));
+                resultList.add(innerType.sanitizeType(value));
             }
         }
-        resultList.add(innerType.sanitizeValue(valueToAdd));
+        resultList.add(innerType.sanitizeType(valueToAdd));
         return resultList;
     }
 }

--- a/server/src/main/java/io/crate/expression/scalar/ArrayCatFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayCatFunction.java
@@ -84,7 +84,7 @@ class ArrayCatFunction extends Scalar<List<Object>, List<Object>> {
                 continue;
             }
             for (Object value : values) {
-                resultList.add(innerType.sanitizeValue(value));
+                resultList.add(innerType.sanitizeType(value));
             }
         }
         return resultList;

--- a/server/src/main/java/io/crate/expression/scalar/ArrayDifferenceFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayDifferenceFunction.java
@@ -108,7 +108,7 @@ class ArrayDifferenceFunction extends Scalar<List<Object>, List<Object>> {
         } else {
             subtractSet = new HashSet<>();
             for (Object element : values) {
-                subtractSet.add(innerType.sanitizeValue(element));
+                subtractSet.add(innerType.sanitizeType(element));
             }
         }
         return new ArrayDifferenceFunction(signature, boundSignature, subtractSet);
@@ -133,7 +133,7 @@ class ArrayDifferenceFunction extends Scalar<List<Object>, List<Object>> {
 
                 List<Object> values = (List<Object>) argValue;
                 for (Object element : values) {
-                    localSubtractSet.add(innerType.sanitizeValue(element));
+                    localSubtractSet.add(innerType.sanitizeType(element));
                 }
             }
         } else {
@@ -142,7 +142,7 @@ class ArrayDifferenceFunction extends Scalar<List<Object>, List<Object>> {
 
         ArrayList<Object> resultList = new ArrayList<>(inputValues.size());
         for (Object value : inputValues) {
-            if (!localSubtractSet.contains(innerType.sanitizeValue(value))) {
+            if (!localSubtractSet.contains(innerType.sanitizeType(value))) {
                 resultList.add(value);
             }
         }

--- a/server/src/main/java/io/crate/expression/scalar/ArrayUniqueFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayUniqueFunction.java
@@ -101,7 +101,7 @@ class ArrayUniqueFunction extends Scalar<List<Object>, List<Object>> {
                 continue;
             }
             for (Object element : values) {
-                Object value = elementType.sanitizeValue(element);
+                Object value = elementType.sanitizeType(element);
                 if (uniqueSet.add(value)) {
                     uniqueItems.add(value);
                 }

--- a/server/src/main/java/io/crate/expression/scalar/DateFormatFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/DateFormatFunction.java
@@ -102,7 +102,7 @@ public class DateFormatFunction extends Scalar<String, Object> {
         if (tsValue == null) {
             return null;
         }
-        Long timestamp = DataTypes.TIMESTAMPZ.sanitizeValue(tsValue);
+        Long timestamp = DataTypes.TIMESTAMPZ.sanitizeType(tsValue);
         DateTimeZone timezone = DateTimeZone.UTC;
         if (timezoneLiteral != null) {
             Object timezoneValue = timezoneLiteral.value();

--- a/server/src/main/java/io/crate/expression/scalar/DateTruncFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/DateTruncFunction.java
@@ -186,9 +186,9 @@ public class DateTruncFunction extends Scalar<Long, Object> {
             }
             return truncate(
                 rounding(interval, timeZone),
-                DataTypes.TIMESTAMPZ.sanitizeValue(value));
+                DataTypes.TIMESTAMPZ.sanitizeType(value));
         }
-        return truncate(tzRounding, DataTypes.TIMESTAMPZ.sanitizeValue(value));
+        return truncate(tzRounding, DataTypes.TIMESTAMPZ.sanitizeType(value));
     }
 
     private Rounding rounding(String interval, String timeZoneString) {

--- a/server/src/main/java/io/crate/expression/scalar/SubscriptObjectFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/SubscriptObjectFunction.java
@@ -118,7 +118,7 @@ public class SubscriptObjectFunction extends Scalar<Object, Map<String, Object>>
                 if (path == null) {
                     path = new ArrayList<>();
                 }
-                path.add(DataTypes.STRING.sanitizeValue(((Literal<?>) arg).value()));
+                path.add(DataTypes.STRING.sanitizeType(((Literal<?>) arg).value()));
             } else {
                 return null;
             }

--- a/server/src/main/java/io/crate/expression/scalar/TripleScalar.java
+++ b/server/src/main/java/io/crate/expression/scalar/TripleScalar.java
@@ -68,15 +68,15 @@ public final class TripleScalar<R, T> extends Scalar<R, T> {
     @Override
     public final R evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<T>... args) {
         assert args.length == 3 : "TripleScalar expects exactly 3 arguments, got: " + args.length;
-        T value1 = type.sanitizeValue(args[0].value());
+        T value1 = type.sanitizeType(args[0].value());
         if (value1 == null) {
             return null;
         }
-        T value2 = type.sanitizeValue(args[1].value());
+        T value2 = type.sanitizeType(args[1].value());
         if (value2 == null) {
             return null;
         }
-        T value3 = type.sanitizeValue(args[2].value());
+        T value3 = type.sanitizeType(args[2].value());
         if (value3 == null) {
             return null;
         }

--- a/server/src/main/java/io/crate/expression/scalar/UnaryScalar.java
+++ b/server/src/main/java/io/crate/expression/scalar/UnaryScalar.java
@@ -70,7 +70,7 @@ public class UnaryScalar<R, T> extends Scalar<R, T> {
     @Override
     public final R evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<T>... args) {
         assert args.length == 1 : "UnaryScalar expects exactly 1 argument, got: " + args.length;
-        T value = type.sanitizeValue(args[0].value());
+        T value = type.sanitizeType(args[0].value());
         if (value == null) {
             return null;
         }

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/AbsFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/AbsFunction.java
@@ -43,7 +43,7 @@ public final class AbsFunction {
                         signature,
                         boundSignature,
                         argType,
-                        x -> argType.sanitizeValue(Math.abs(((Number) x).doubleValue()))
+                        x -> argType.sanitizeType(Math.abs(((Number) x).doubleValue()))
                     );
                 }
             );

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/BinaryScalar.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/BinaryScalar.java
@@ -62,8 +62,8 @@ public final class BinaryScalar<T> extends Scalar<T, T> {
 
     @Override
     public T evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<T>[] args) {
-        T arg0Value = type.sanitizeValue(args[0].value());
-        T arg1Value = type.sanitizeValue(args[1].value());
+        T arg0Value = type.sanitizeType(args[0].value());
+        T arg1Value = type.sanitizeType(args[1].value());
 
         if (arg0Value == null) {
             return null;

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/CeilFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/CeilFunction.java
@@ -48,7 +48,7 @@ public final class CeilFunction {
                             signature,
                             boundSignature,
                             type,
-                            x -> returnType.sanitizeValue(Math.ceil(((Number) x).doubleValue()))
+                            x -> returnType.sanitizeType(Math.ceil(((Number) x).doubleValue()))
                         )
                 );
             }

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/ExpFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/ExpFunction.java
@@ -41,7 +41,7 @@ public class ExpFunction {
                         declaredSignature,
                         boundSignature,
                         type,
-                        x -> type.sanitizeValue(Math.exp(((Number) x).doubleValue()))
+                        x -> type.sanitizeType(Math.exp(((Number) x).doubleValue()))
                     )
             );
         }

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/FloorFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/FloorFunction.java
@@ -44,7 +44,7 @@ public final class FloorFunction {
                         signature,
                         boundSignature,
                         type,
-                        x -> returnType.sanitizeValue(Math.floor(((Number) x).doubleValue()))
+                        x -> returnType.sanitizeType(Math.floor(((Number) x).doubleValue()))
                     )
             );
         }

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/TruncFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/TruncFunction.java
@@ -63,7 +63,7 @@ public final class TruncFunction {
                         n -> {
                             double val = ((Number) n).doubleValue();
                             Function<Double, Double> f = val >= 0 ? Math::floor : Math::ceil;
-                            return (Number) returnType.sanitizeValue(f.apply(val));
+                            return (Number) returnType.sanitizeType(f.apply(val));
                         }
                     )
             );

--- a/server/src/main/java/io/crate/expression/scalar/formatting/ToCharFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/formatting/ToCharFunction.java
@@ -112,7 +112,7 @@ public class ToCharFunction extends Scalar<String, Object> {
         if (formatter == null) {
             formatter = new DateTimeFormatter(pattern);
         }
-        Long ts = DataTypes.TIMESTAMPZ.sanitizeValue(timestamp);
+        Long ts = DataTypes.TIMESTAMPZ.sanitizeType(timestamp);
         LocalDateTime dateTime = LocalDateTime.ofInstant(Instant.ofEpochMilli(ts), TimeZone.getTimeZone("UTC").toZoneId());
         return formatter.format(dateTime);
     }
@@ -121,7 +121,7 @@ public class ToCharFunction extends Scalar<String, Object> {
         if (formatter == null) {
             formatter = new DateTimeFormatter(pattern);
         }
-        Period period = DataTypes.INTERVAL.sanitizeValue(interval);
+        Period period = DataTypes.INTERVAL.sanitizeType(interval);
         LocalDateTime dateTime = LocalDateTime.of(0, 1, 1, 0, 0, 0, 0)
             .plusYears(period.getYears())
             .plusMonths(period.getMonths())
@@ -136,8 +136,8 @@ public class ToCharFunction extends Scalar<String, Object> {
 
     @Override
     public String evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>... args) {
-        Object expression = expressionType.sanitizeValue(args[0].value());
-        String pattern = DataTypes.STRING.sanitizeValue(args[1].value());
+        Object expression = expressionType.sanitizeType(args[0].value());
+        String pattern = DataTypes.STRING.sanitizeType(args[1].value());
 
         if (expression == null) {
             return null;

--- a/server/src/main/java/io/crate/expression/scalar/geo/AreaFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/geo/AreaFunction.java
@@ -72,7 +72,7 @@ public final class AreaFunction {
 
     protected static Double getArea(Object value) {
 
-        Map<String, Object> shapeAsMap = GeoShapeType.INSTANCE.sanitizeValue(value);
+        Map<String, Object> shapeAsMap = GeoShapeType.INSTANCE.sanitizeType(value);
         Shape shape = GeoJSONUtils.map2Shape(shapeAsMap);
 
         return shape.getArea(JtsSpatialContext.GEO);

--- a/server/src/main/java/io/crate/expression/scalar/geo/CoordinateFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/geo/CoordinateFunction.java
@@ -62,10 +62,10 @@ public final class CoordinateFunction {
 
 
     private static Double getLatitude(Object value) {
-        return (DataTypes.GEO_POINT.sanitizeValue(value)).getY();
+        return (DataTypes.GEO_POINT.sanitizeType(value)).getY();
     }
 
     private static Double getLongitude(Object value) {
-        return (DataTypes.GEO_POINT.sanitizeValue(value)).getX();
+        return (DataTypes.GEO_POINT.sanitizeType(value)).getX();
     }
 }

--- a/server/src/main/java/io/crate/expression/scalar/geo/GeoHashFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/geo/GeoHashFunction.java
@@ -50,7 +50,7 @@ public final class GeoHashFunction {
     }
 
     private static String getGeoHash(Object value) {
-        Point geoValue = GeoPointType.INSTANCE.sanitizeValue(value);
+        Point geoValue = GeoPointType.INSTANCE.sanitizeType(value);
         return GeoHashUtils.stringEncode(geoValue.getX(), geoValue.getY());
     }
 }

--- a/server/src/main/java/io/crate/expression/scalar/geo/IntersectsFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/geo/IntersectsFunction.java
@@ -72,8 +72,8 @@ public class IntersectsFunction extends Scalar<Boolean, Object> {
         if (right == null) {
             return null;
         }
-        Shape leftShape = GeoJSONUtils.map2Shape(DataTypes.GEO_SHAPE.sanitizeValue(left));
-        Shape rightShape = GeoJSONUtils.map2Shape(DataTypes.GEO_SHAPE.sanitizeValue(right));
+        Shape leftShape = GeoJSONUtils.map2Shape(DataTypes.GEO_SHAPE.sanitizeType(left));
+        Shape rightShape = GeoJSONUtils.map2Shape(DataTypes.GEO_SHAPE.sanitizeType(right));
         return leftShape.relate(rightShape).intersects();
     }
 

--- a/server/src/main/java/io/crate/expression/symbol/Literal.java
+++ b/server/src/main/java/io/crate/expression/symbol/Literal.java
@@ -111,11 +111,11 @@ public class Literal<T> implements Symbol, Input<T>, Comparable<Literal<T>> {
                 }
             }
             // lets do the expensive "deep" map value conversion only after everything else succeeded
-            Map<String, Object> safeValue = objectType.sanitizeValue(value);
+            Map<String, Object> safeValue = objectType.sanitizeType(value);
             return safeValue.size() == mapValue.size();
         }
 
-        return Objects.equals(type.sanitizeValue(value), value);
+        return Objects.equals(type.sanitizeType(value), value);
     }
 
     @Override

--- a/server/src/main/java/io/crate/metadata/information/InformationPartitionsTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/information/InformationPartitionsTableInfo.java
@@ -115,7 +115,7 @@ public class InformationPartitionsTableInfo {
 
                 .startObject("mapping")
                     .startObject("total_fields")
-                        .add("limit", INTEGER, fromSetting(MapperService.INDEX_MAPPING_TOTAL_FIELDS_LIMIT_SETTING, INTEGER::sanitizeValue))
+                        .add("limit", INTEGER, fromSetting(MapperService.INDEX_MAPPING_TOTAL_FIELDS_LIMIT_SETTING, INTEGER::sanitizeType))
                     .endObject()
                 .endObject()
 

--- a/server/src/main/java/io/crate/metadata/information/InformationTablesTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/information/InformationTablesTableInfo.java
@@ -211,7 +211,7 @@ public class InformationTablesTableInfo {
 
                 .startObject("mapping")
                     .startObject("total_fields")
-                        .add("limit", INTEGER, fromSetting(MapperService.INDEX_MAPPING_TOTAL_FIELDS_LIMIT_SETTING, INTEGER::sanitizeValue))
+                        .add("limit", INTEGER, fromSetting(MapperService.INDEX_MAPPING_TOTAL_FIELDS_LIMIT_SETTING, INTEGER::sanitizeType))
                     .endObject()
                 .endObject()
 

--- a/server/src/main/java/io/crate/metadata/settings/CrateSettings.java
+++ b/server/src/main/java/io/crate/metadata/settings/CrateSettings.java
@@ -135,7 +135,7 @@ public final class CrateSettings {
                 "Cannot set \"" + key + "\" to `null`. Use `RESET [GLOBAL] \"" + key +
                 "\"` to reset a setting to its default value");
         } else if (value instanceof List) {
-            List<String> values = DataTypes.STRING_ARRAY.sanitizeValue(value);
+            List<String> values = DataTypes.STRING_ARRAY.sanitizeType(value);
             settingsBuilder.put(key, String.join(",", values));
         } else {
             settingsBuilder.put(key, value.toString());

--- a/server/src/main/java/io/crate/planner/DecommissionNodePlan.java
+++ b/server/src/main/java/io/crate/planner/DecommissionNodePlan.java
@@ -86,6 +86,6 @@ public final class DecommissionNodePlan implements Plan {
             parameters,
             subQueryResults
         );
-        return DataTypes.STRING.sanitizeValue(boundedNodeIdOrName);
+        return DataTypes.STRING.sanitizeType(boundedNodeIdOrName);
     }
 }

--- a/server/src/main/java/io/crate/planner/SwapTablePlan.java
+++ b/server/src/main/java/io/crate/planner/SwapTablePlan.java
@@ -60,7 +60,7 @@ public class SwapTablePlan implements Plan {
                               Row params,
                               SubQueryResults subQueryResults) {
         boolean dropSource = Objects.requireNonNull(
-            DataTypes.BOOLEAN.sanitizeValue(SymbolEvaluator.evaluate(
+            DataTypes.BOOLEAN.sanitizeType(SymbolEvaluator.evaluate(
                 plannerContext.transactionContext(),
                 dependencies.nodeContext(),
                 swapTable.dropSource(),

--- a/server/src/main/java/io/crate/planner/node/ddl/CreateFunctionPlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/CreateFunctionPlan.java
@@ -71,8 +71,8 @@ public class CreateFunctionPlan implements Plan {
             createFunction.name(),
             createFunction.arguments(),
             createFunction.returnType(),
-            StringType.INSTANCE.sanitizeValue(eval.apply(createFunction.language())),
-            StringType.INSTANCE.sanitizeValue(eval.apply(createFunction.definition()))
+            StringType.INSTANCE.sanitizeType(eval.apply(createFunction.language())),
+            StringType.INSTANCE.sanitizeType(eval.apply(createFunction.definition()))
         );
         CreateUserDefinedFunctionRequest request = new CreateUserDefinedFunctionRequest(metadata, createFunction.replace());
         OneRowActionListener<AcknowledgedResponse> listener = new OneRowActionListener<>(consumer, r -> new Row1(1L));

--- a/server/src/main/java/io/crate/planner/node/management/AlterTableReroutePlan.java
+++ b/server/src/main/java/io/crate/planner/node/management/AlterTableReroutePlan.java
@@ -147,13 +147,13 @@ public class AlterTableReroutePlan implements Plan {
                 Lists2.map(statement.partitionProperties(), x -> x.map(context.eval)));
             String toNodeId = resolveNodeId(
                 context.nodes,
-                DataTypes.STRING.sanitizeValue(boundedPromoteReplica.node()));
+                DataTypes.STRING.sanitizeType(boundedPromoteReplica.node()));
 
             return new AllocateStalePrimaryAllocationCommand(
                 index,
-                DataTypes.INTEGER.sanitizeValue(boundedPromoteReplica.shardId()),
+                DataTypes.INTEGER.sanitizeType(boundedPromoteReplica.shardId()),
                 toNodeId,
-                DataTypes.BOOLEAN.sanitizeValue(context.eval.apply(statement.acceptDataLoss()))
+                DataTypes.BOOLEAN.sanitizeType(context.eval.apply(statement.acceptDataLoss()))
             );
 
         }
@@ -169,12 +169,12 @@ public class AlterTableReroutePlan implements Plan {
                 Lists2.map(statement.partitionProperties(), x -> x.map(context.eval)));
             String toNodeId = resolveNodeId(
                 context.nodes,
-                DataTypes.STRING.sanitizeValue(boundedMoveShard.toNodeIdOrName()));
+                DataTypes.STRING.sanitizeType(boundedMoveShard.toNodeIdOrName()));
 
             return new MoveAllocationCommand(
                 index,
-                DataTypes.INTEGER.sanitizeValue(boundedMoveShard.shardId()),
-                DataTypes.STRING.sanitizeValue(boundedMoveShard.fromNodeIdOrName()),
+                DataTypes.INTEGER.sanitizeType(boundedMoveShard.shardId()),
+                DataTypes.STRING.sanitizeType(boundedMoveShard.fromNodeIdOrName()),
                 toNodeId
             );
         }
@@ -192,11 +192,11 @@ public class AlterTableReroutePlan implements Plan {
                 Lists2.map(statement.partitionProperties(), x -> x.map(context.eval)));
             String toNodeId = resolveNodeId(
                 context.nodes,
-                DataTypes.STRING.sanitizeValue(boundedRerouteAllocateReplicaShard.nodeIdOrName()));
+                DataTypes.STRING.sanitizeType(boundedRerouteAllocateReplicaShard.nodeIdOrName()));
 
             return new AllocateReplicaAllocationCommand(
                 index,
-                DataTypes.INTEGER.sanitizeValue(boundedRerouteAllocateReplicaShard.shardId()),
+                DataTypes.INTEGER.sanitizeType(boundedRerouteAllocateReplicaShard.shardId()),
                 toNodeId
             );
         }
@@ -217,11 +217,11 @@ public class AlterTableReroutePlan implements Plan {
                 Lists2.map(statement.partitionProperties(), x -> x.map(context.eval)));
             String nodeId = resolveNodeId(
                 context.nodes,
-                DataTypes.STRING.sanitizeValue(boundedRerouteCancelShard.nodeIdOrName()));
+                DataTypes.STRING.sanitizeType(boundedRerouteCancelShard.nodeIdOrName()));
 
             return new CancelAllocationCommand(
                 index,
-                DataTypes.INTEGER.sanitizeValue(boundedRerouteCancelShard.shardId()),
+                DataTypes.INTEGER.sanitizeType(boundedRerouteCancelShard.shardId()),
                 nodeId,
                 allowPrimary
             );
@@ -254,7 +254,7 @@ public class AlterTableReroutePlan implements Plan {
                                                              GenericProperties<Object> properties) {
             for (String key : properties.keys()) {
                 if (propertyKey.equals(key)) {
-                    return DataTypes.BOOLEAN.sanitizeValue(properties.get(propertyKey));
+                    return DataTypes.BOOLEAN.sanitizeType(properties.get(propertyKey));
                 } else {
                     throw new IllegalArgumentException(
                         String.format(Locale.ENGLISH, "\"%s\" is not a valid setting for CANCEL SHARD", key));

--- a/server/src/main/java/io/crate/planner/node/management/KillPlan.java
+++ b/server/src/main/java/io/crate/planner/node/management/KillPlan.java
@@ -91,7 +91,7 @@ public class KillPlan implements Plan {
         if (jobId != null) {
             try {
                 return UUID.fromString(
-                    DataTypes.STRING.sanitizeValue(
+                    DataTypes.STRING.sanitizeType(
                         SymbolEvaluator.evaluate(
                             txnCtx,
                             nodeCtx,

--- a/server/src/main/java/io/crate/planner/operators/Limit.java
+++ b/server/src/main/java/io/crate/planner/operators/Limit.java
@@ -93,7 +93,7 @@ public class Limit extends ForwardingLogicalPlan {
                                Row params,
                                SubQueryResults subQueryResults) {
         int limit = Objects.requireNonNullElse(
-            DataTypes.INTEGER.sanitizeValue(evaluate(
+            DataTypes.INTEGER.sanitizeType(evaluate(
                 plannerContext.transactionContext(),
                 plannerContext.nodeContext(),
                 this.limit,
@@ -101,7 +101,7 @@ public class Limit extends ForwardingLogicalPlan {
                 subQueryResults)),
             NO_LIMIT);
         int offset = Objects.requireNonNullElse(
-            DataTypes.INTEGER.sanitizeValue(evaluate(
+            DataTypes.INTEGER.sanitizeType(evaluate(
                 plannerContext.transactionContext(),
                 plannerContext.nodeContext(),
                 this.offset,

--- a/server/src/main/java/io/crate/planner/operators/LimitDistinct.java
+++ b/server/src/main/java/io/crate/planner/operators/LimitDistinct.java
@@ -106,7 +106,7 @@ public final class LimitDistinct extends ForwardingLogicalPlan {
             );
             executionPlan.addProjection(evalProjection);
         }
-        int limit = DataTypes.INTEGER.sanitizeValue(
+        int limit = DataTypes.INTEGER.sanitizeType(
             evaluate(
                 plannerContext.transactionContext(),
                 plannerContext.nodeContext(),
@@ -115,7 +115,7 @@ public final class LimitDistinct extends ForwardingLogicalPlan {
                 subQueryResults
             )
         );
-        int offset = DataTypes.INTEGER.sanitizeValue(
+        int offset = DataTypes.INTEGER.sanitizeType(
             evaluate(
                 plannerContext.transactionContext(),
                 plannerContext.nodeContext(),

--- a/server/src/main/java/io/crate/planner/operators/SubQueryAndParamBinder.java
+++ b/server/src/main/java/io/crate/planner/operators/SubQueryAndParamBinder.java
@@ -69,14 +69,14 @@ public class SubQueryAndParamBinder extends FunctionCopyVisitor<Void>
             return selectSymbol;
         }
         Object value = subQueryResults.getSafe(selectSymbol);
-        return Literal.ofUnchecked(valueType, valueType.sanitizeValue(value));
+        return Literal.ofUnchecked(valueType, valueType.sanitizeType(value));
     }
 
     @Override
     public Symbol visitOuterColumn(OuterColumn outerColumn, Void context) {
         DataType<?> valueType = outerColumn.valueType();
         Object value = subQueryResults.get(outerColumn);
-        return Literal.ofUnchecked(valueType, valueType.sanitizeValue(value));
+        return Literal.ofUnchecked(valueType, valueType.sanitizeType(value));
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/optimizer/LoadedRules.java
+++ b/server/src/main/java/io/crate/planner/optimizer/LoadedRules.java
@@ -60,7 +60,7 @@ public class LoadedRules implements SessionSettingProvider {
         return new SessionSetting<>(
             optimizerRuleName,
             objects -> {},
-            objects -> DataTypes.BOOLEAN.sanitizeValue(objects[0]),
+            objects -> DataTypes.BOOLEAN.sanitizeType(objects[0]),
             (sessionSettings, activateRule) -> {
                 if (activateRule) {
                     // All rules are activated by default

--- a/server/src/main/java/io/crate/planner/optimizer/costs/PlanStats.java
+++ b/server/src/main/java/io/crate/planner/optimizer/costs/PlanStats.java
@@ -116,7 +116,7 @@ public class PlanStats {
         public Stats visitLimit(Limit limit, TransactionContext txnCtx) {
             var stats = limit.source().accept(this, txnCtx);
             if (limit.limit() instanceof Literal<?> literal) {
-                var numberOfRows = DataTypes.LONG.sanitizeValue(literal.value());
+                var numberOfRows = DataTypes.LONG.sanitizeType(literal.value());
                 return stats.withNumDocs(numberOfRows);
             }
             return stats;

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteGroupByKeysLimitToLimitDistinct.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteGroupByKeysLimitToLimitDistinct.java
@@ -91,7 +91,7 @@ public final class RewriteGroupByKeysLimitToLimitDistinct implements Rule<Limit>
         Stats groupHashAggregateStats = planStats.get(txnCtx, groupAggregate);
         var limitSymbol = limit.limit();
         if (limitSymbol instanceof Literal) {
-            var limitVal = DataTypes.INTEGER.sanitizeValue(((Literal<?>) limitSymbol).value());
+            var limitVal = DataTypes.INTEGER.sanitizeType(((Literal<?>) limitSymbol).value());
             // Would consume all source rows -> prefer default group by implementation which has other optimizations
             // which are more beneficial in this scenario
             if (limitVal > groupHashAggregateStats.numDocs()) {

--- a/server/src/main/java/io/crate/planner/statement/CopyFromPlan.java
+++ b/server/src/main/java/io/crate/planner/statement/CopyFromPlan.java
@@ -425,13 +425,13 @@ public final class CopyFromPlan implements Plan {
 
     private static Symbol validateAndConvertToLiteral(Object uri) {
         if (uri instanceof String) {
-            return Literal.of(DataTypes.STRING.sanitizeValue(uri));
+            return Literal.of(DataTypes.STRING.sanitizeType(uri));
         } else if (uri instanceof List) {
             Object value = ((List) uri).get(0);
             if (!(value instanceof String)) {
                 throw AnalyzedCopyFrom.raiseInvalidType(DataTypes.guessType(uri));
             }
-            return Literal.of(DataTypes.STRING_ARRAY, DataTypes.STRING_ARRAY.sanitizeValue(uri));
+            return Literal.of(DataTypes.STRING_ARRAY, DataTypes.STRING_ARRAY.sanitizeType(uri));
         }
         throw AnalyzedCopyFrom.raiseInvalidType(DataTypes.guessType(uri));
     }

--- a/server/src/main/java/io/crate/planner/statement/CopyToPlan.java
+++ b/server/src/main/java/io/crate/planner/statement/CopyToPlan.java
@@ -261,7 +261,7 @@ public final class CopyToPlan implements Plan {
             outputs,
             table,
             whereClause,
-            Literal.of(DataTypes.STRING.sanitizeValue(eval.apply(copyTo.uri()))),
+            Literal.of(DataTypes.STRING.sanitizeType(eval.apply(copyTo.uri()))),
             compressionType,
             outputFormat,
             outputNames.isEmpty() ? null : outputNames,

--- a/server/src/main/java/io/crate/planner/statement/DeletePlanner.java
+++ b/server/src/main/java/io/crate/planner/statement/DeletePlanner.java
@@ -104,7 +104,7 @@ public final class DeletePlanner {
             return new DeleteById(tableRel.tableInfo(), detailedQuery.docKeys().get());
         }
         Symbol query = detailedQuery.query();
-        if (table.isPartitioned() && query instanceof Input<?> input && DataTypes.BOOLEAN.sanitizeValue(input.value())) {
+        if (table.isPartitioned() && query instanceof Input<?> input && DataTypes.BOOLEAN.sanitizeType(input.value())) {
             return new DeleteAllPartitions(Lists2.map(table.partitions(), IndexParts::toIndexName));
         }
 

--- a/server/src/main/java/io/crate/types/ArrayType.java
+++ b/server/src/main/java/io/crate/types/ArrayType.java
@@ -175,8 +175,8 @@ public class ArrayType<T> extends DataType<List<T>> {
     }
 
     @Override
-    public List<T> sanitizeValue(Object value) {
-        return convert(value, innerType, innerType::sanitizeValue, CoordinatorTxnCtx.systemTransactionContext().sessionSettings());
+    public List<T> sanitizeType(Object value) {
+        return convert(value, innerType, innerType::sanitizeType, CoordinatorTxnCtx.systemTransactionContext().sessionSettings());
     }
 
     public List<String> fromAnyArray(Object[] values) throws IllegalArgumentException {
@@ -261,8 +261,8 @@ public class ArrayType<T> extends DataType<List<T>> {
         } else if (value instanceof Point point && DataTypes.isNumericPrimitive(innerType)) {
             // As per docs: [<lon_value>, <lat_value>]
             return (List<T>) List.of(
-                innerType.sanitizeValue(point.getLon()),
-                innerType.sanitizeValue(point.getLat()));
+                innerType.sanitizeType(point.getLon()),
+                innerType.sanitizeType(point.getLat()));
         } else {
             return convertObjectArray((Object[]) value, convertInner);
         }

--- a/server/src/main/java/io/crate/types/BitStringType.java
+++ b/server/src/main/java/io/crate/types/BitStringType.java
@@ -153,7 +153,7 @@ public final class BitStringType extends DataType<BitString> implements Streamer
     }
 
     @Override
-    public BitString sanitizeValue(Object value) {
+    public BitString sanitizeType(Object value) {
         if (value instanceof String str) {
             // InsertSourceGen.SOURCE_WRITERS writes a BitSet bytes as a byte array
             // which internally uses JsonGenerator.writeBinary which is by default Base64Variants.MIME_NO_LINEFEEDS encoder
@@ -188,7 +188,7 @@ public final class BitStringType extends DataType<BitString> implements Streamer
     }
 
     @Override
-    public BitString valueForInsert(Object value) {
+    public BitString sanitizeValue(Object value) {
         if (value == null) {
             return null;
         }

--- a/server/src/main/java/io/crate/types/BooleanType.java
+++ b/server/src/main/java/io/crate/types/BooleanType.java
@@ -142,7 +142,7 @@ public class BooleanType extends DataType<Boolean> implements Streamer<Boolean>,
     }
 
     @Override
-    public Boolean sanitizeValue(Object value) {
+    public Boolean sanitizeType(Object value) {
         if (value == null) {
             return null;
         } else if (value instanceof Boolean) {

--- a/server/src/main/java/io/crate/types/ByteType.java
+++ b/server/src/main/java/io/crate/types/ByteType.java
@@ -104,7 +104,7 @@ public class ByteType extends DataType<Byte> implements Streamer<Byte>, FixedWid
     }
 
     @Override
-    public Byte sanitizeValue(Object value) {
+    public Byte sanitizeType(Object value) {
         if (value == null) {
             return null;
         } else if (value instanceof Byte) {

--- a/server/src/main/java/io/crate/types/CharacterType.java
+++ b/server/src/main/java/io/crate/types/CharacterType.java
@@ -99,7 +99,7 @@ public class CharacterType extends StringType {
     }
 
     @Override
-    public String valueForInsert(Object value) {
+    public String sanitizeValue(Object value) {
         if (value == null) {
             return null;
         }

--- a/server/src/main/java/io/crate/types/DataType.java
+++ b/server/src/main/java/io/crate/types/DataType.java
@@ -139,12 +139,14 @@ public abstract class DataType<T> implements Comparable<DataType<?>>, Writeable,
 
     /**
      * To prepare a value of the same {@link DataType<T>} for insertion.
-     *
+     * <p>
+     * For example, to blank pad 'a' to 'a ' when inserting it to a char(2)
+     * column.
      * @param value The value of the {@link DataType<T>}.
      * @return The prepared for insertion value of the {@link DataType<T>}.
      */
     @SuppressWarnings("unchecked")
-    public T valueForInsert(Object value) {
+    public T sanitizeValue(Object value) {
         return (T) value;
     }
 
@@ -160,7 +162,7 @@ public abstract class DataType<T> implements Comparable<DataType<?>>, Writeable,
      * @return The value of {@link DataType}.
      * @see DataType#implicitCast(Object)
      */
-    public abstract T sanitizeValue(Object value);
+    public abstract T sanitizeType(Object value);
 
     public TypeSignature getTypeSignature() {
         return new TypeSignature(getName());

--- a/server/src/main/java/io/crate/types/DateType.java
+++ b/server/src/main/java/io/crate/types/DateType.java
@@ -98,7 +98,7 @@ public class DateType extends DataType<Long>
     }
 
     @Override
-    public Long sanitizeValue(Object value) {
+    public Long sanitizeType(Object value) {
         if (value == null) {
             return null;
         } else if (value instanceof Number) {

--- a/server/src/main/java/io/crate/types/DoubleType.java
+++ b/server/src/main/java/io/crate/types/DoubleType.java
@@ -150,7 +150,7 @@ public class DoubleType extends DataType<Double> implements FixedWidthType, Stre
     }
 
     @Override
-    public Double sanitizeValue(Object value) {
+    public Double sanitizeType(Object value) {
         if (value == null) {
             return null;
         } else if (value instanceof Double d) {

--- a/server/src/main/java/io/crate/types/FloatType.java
+++ b/server/src/main/java/io/crate/types/FloatType.java
@@ -154,7 +154,7 @@ public class FloatType extends DataType<Float> implements Streamer<Float>, Fixed
     }
 
     @Override
-    public Float sanitizeValue(Object value) {
+    public Float sanitizeType(Object value) {
         if (value == null) {
             return null;
         } else if (value instanceof Float f) {

--- a/server/src/main/java/io/crate/types/GeoPointType.java
+++ b/server/src/main/java/io/crate/types/GeoPointType.java
@@ -117,7 +117,7 @@ public class GeoPointType extends DataType<Point> implements Streamer<Point>, Fi
     }
 
     @Override
-    public Point sanitizeValue(Object value) {
+    public Point sanitizeType(Object value) {
         if (value == null) {
             return null;
         } else if (value instanceof List values) {

--- a/server/src/main/java/io/crate/types/GeoShapeType.java
+++ b/server/src/main/java/io/crate/types/GeoShapeType.java
@@ -102,7 +102,7 @@ public class GeoShapeType extends DataType<Map<String, Object>> implements Strea
 
     @Override
     @SuppressWarnings("unchecked")
-    public Map<String, Object> sanitizeValue(Object value) {
+    public Map<String, Object> sanitizeType(Object value) {
         if (value == null) {
             return null;
         } else if (value instanceof Map<?, ?> map) {

--- a/server/src/main/java/io/crate/types/IntegerType.java
+++ b/server/src/main/java/io/crate/types/IntegerType.java
@@ -108,7 +108,7 @@ public class IntegerType extends DataType<Integer> implements Streamer<Integer>,
     }
 
     @Override
-    public Integer sanitizeValue(Object value) {
+    public Integer sanitizeType(Object value) {
         if (value == null) {
             return null;
         } else if (value instanceof Integer i) {

--- a/server/src/main/java/io/crate/types/IntervalType.java
+++ b/server/src/main/java/io/crate/types/IntervalType.java
@@ -96,7 +96,7 @@ public class IntervalType extends DataType<Period> implements FixedWidthType, St
     }
 
     @Override
-    public Period sanitizeValue(Object value) {
+    public Period sanitizeType(Object value) {
         if (value == null) {
             return null;
         } else {

--- a/server/src/main/java/io/crate/types/IpType.java
+++ b/server/src/main/java/io/crate/types/IpType.java
@@ -132,7 +132,7 @@ public class IpType extends DataType<String> implements Streamer<String> {
     }
 
     @Override
-    public String sanitizeValue(Object value) {
+    public String sanitizeType(Object value) {
         if (value == null) {
             return null;
         } else {

--- a/server/src/main/java/io/crate/types/JsonType.java
+++ b/server/src/main/java/io/crate/types/JsonType.java
@@ -66,7 +66,7 @@ public final class JsonType extends DataType<String> implements Streamer<String>
     }
 
     @Override
-    public String sanitizeValue(Object value) {
+    public String sanitizeType(Object value) {
         return (String) value;
     }
 

--- a/server/src/main/java/io/crate/types/LongType.java
+++ b/server/src/main/java/io/crate/types/LongType.java
@@ -102,7 +102,7 @@ public class LongType extends DataType<Long> implements FixedWidthType, Streamer
     }
 
     @Override
-    public Long sanitizeValue(Object value) {
+    public Long sanitizeType(Object value) {
         if (value == null) {
             return null;
         } else if (value instanceof Long) {

--- a/server/src/main/java/io/crate/types/NotSupportedType.java
+++ b/server/src/main/java/io/crate/types/NotSupportedType.java
@@ -62,7 +62,7 @@ public class NotSupportedType extends DataType<Void> {
     }
 
     @Override
-    public Void sanitizeValue(Object value) {
+    public Void sanitizeType(Object value) {
         return null;
     }
 

--- a/server/src/main/java/io/crate/types/NumericType.java
+++ b/server/src/main/java/io/crate/types/NumericType.java
@@ -134,7 +134,7 @@ public class NumericType extends DataType<BigDecimal> implements Streamer<BigDec
     }
 
     @Override
-    public BigDecimal sanitizeValue(Object value) {
+    public BigDecimal sanitizeType(Object value) {
         if (value == null) {
             return null;
         } else {
@@ -143,7 +143,7 @@ public class NumericType extends DataType<BigDecimal> implements Streamer<BigDec
     }
 
     @Override
-    public BigDecimal valueForInsert(Object value) {
+    public BigDecimal sanitizeValue(Object value) {
         throw new UnsupportedOperationException(
             getName() + " type cannot be used in insert statements");
     }

--- a/server/src/main/java/io/crate/types/ObjectType.java
+++ b/server/src/main/java/io/crate/types/ObjectType.java
@@ -163,8 +163,8 @@ public class ObjectType extends DataType<Map<String, Object>> implements Streame
     }
 
     @Override
-    public Map<String, Object> sanitizeValue(Object value) {
-        return convert(value, DataType::sanitizeValue);
+    public Map<String, Object> sanitizeType(Object value) {
+        return convert(value, DataType::sanitizeType);
     }
 
     @SuppressWarnings("unchecked")

--- a/server/src/main/java/io/crate/types/OidVectorType.java
+++ b/server/src/main/java/io/crate/types/OidVectorType.java
@@ -63,7 +63,7 @@ public class OidVectorType extends DataType<List<Integer>> {
     }
 
     @Override
-    public List<Integer> sanitizeValue(Object value) {
+    public List<Integer> sanitizeType(Object value) {
         return (List<Integer>) value;
     }
 

--- a/server/src/main/java/io/crate/types/RegclassType.java
+++ b/server/src/main/java/io/crate/types/RegclassType.java
@@ -80,7 +80,7 @@ public final class RegclassType extends DataType<Regclass> implements Streamer<R
     }
 
     @Override
-    public Regclass sanitizeValue(Object value) {
+    public Regclass sanitizeType(Object value) {
         if (value == null) {
             return null;
         }

--- a/server/src/main/java/io/crate/types/RegprocType.java
+++ b/server/src/main/java/io/crate/types/RegprocType.java
@@ -76,13 +76,13 @@ public class RegprocType extends DataType<Regproc> implements Streamer<Regproc> 
     }
 
     @Override
-    public Regproc valueForInsert(Object value) {
+    public Regproc sanitizeValue(Object value) {
         throw new UnsupportedOperationException(
             getName() + " cannot be used in insert statements.");
     }
 
     @Override
-    public Regproc sanitizeValue(Object value) {
+    public Regproc sanitizeType(Object value) {
         if (value == null) {
             return null;
         } else {

--- a/server/src/main/java/io/crate/types/RowType.java
+++ b/server/src/main/java/io/crate/types/RowType.java
@@ -151,7 +151,7 @@ public final class RowType extends DataType<Row> implements Streamer<Row> {
     }
 
     @Override
-    public Row sanitizeValue(Object value) {
+    public Row sanitizeType(Object value) {
         return (Row) value;
     }
 

--- a/server/src/main/java/io/crate/types/ShortType.java
+++ b/server/src/main/java/io/crate/types/ShortType.java
@@ -102,7 +102,7 @@ public class ShortType extends DataType<Short> implements Streamer<Short>, Fixed
     }
 
     @Override
-    public Short sanitizeValue(Object value) {
+    public Short sanitizeType(Object value) {
         if (value == null) {
             return null;
         } else if (value instanceof Short s) {

--- a/server/src/main/java/io/crate/types/StringType.java
+++ b/server/src/main/java/io/crate/types/StringType.java
@@ -259,7 +259,7 @@ public class StringType extends DataType<String> implements Streamer<String> {
     }
 
     @Override
-    public String valueForInsert(Object value) {
+    public String sanitizeValue(Object value) {
         if (value == null) {
             return null;
         }
@@ -282,7 +282,7 @@ public class StringType extends DataType<String> implements Streamer<String> {
     }
 
     @Override
-    public String sanitizeValue(Object value) {
+    public String sanitizeType(Object value) {
         if (value == null) {
             return null;
         } else if (value instanceof BytesRef) {

--- a/server/src/main/java/io/crate/types/TimeTZType.java
+++ b/server/src/main/java/io/crate/types/TimeTZType.java
@@ -109,7 +109,7 @@ public final class TimeTZType extends DataType<TimeTZ> implements FixedWidthType
     }
 
     @Override
-    public TimeTZ sanitizeValue(Object value) {
+    public TimeTZ sanitizeType(Object value) {
         if (value == null) {
             return null;
         }
@@ -117,7 +117,7 @@ public final class TimeTZType extends DataType<TimeTZ> implements FixedWidthType
     }
 
     @Override
-    public TimeTZ valueForInsert(Object value) {
+    public TimeTZ sanitizeValue(Object value) {
         throw new UnsupportedOperationException(String.format(
             Locale.ENGLISH,
             "%s cannot be used in insert statements",

--- a/server/src/main/java/io/crate/types/TimestampType.java
+++ b/server/src/main/java/io/crate/types/TimestampType.java
@@ -133,7 +133,7 @@ public final class TimestampType extends DataType<Long>
     }
 
     @Override
-    public Long sanitizeValue(Object value) {
+    public Long sanitizeType(Object value) {
         if (value == null) {
             return null;
         } else if (value instanceof Long l) {

--- a/server/src/main/java/io/crate/types/UncheckedObjectType.java
+++ b/server/src/main/java/io/crate/types/UncheckedObjectType.java
@@ -92,7 +92,7 @@ public class UncheckedObjectType extends DataType<Map<Object, Object>> implement
     }
 
     @Override
-    public Map<Object, Object> sanitizeValue(Object value) {
+    public Map<Object, Object> sanitizeType(Object value) {
         //noinspection unchecked
         return (Map<Object, Object>) value;
     }

--- a/server/src/main/java/io/crate/types/UndefinedType.java
+++ b/server/src/main/java/io/crate/types/UndefinedType.java
@@ -68,7 +68,7 @@ public class UndefinedType extends DataType<Object> implements Streamer<Object> 
         return true;
     }
 
-    public Object sanitizeValue(Object value) {
+    public Object sanitizeType(Object value) {
         return value;
     }
 

--- a/server/src/main/java/io/crate/user/UserActions.java
+++ b/server/src/main/java/io/crate/user/UserActions.java
@@ -76,7 +76,7 @@ public final class UserActions {
         final String PASSWORD_PROPERTY = "password";
         for (String key : properties.keySet()) {
             if (PASSWORD_PROPERTY.equals(key)) {
-                String value = DataTypes.STRING.sanitizeValue(properties.get(key));
+                String value = DataTypes.STRING.sanitizeType(properties.get(key));
                 if (value != null) {
                     return new SecureString(value.toCharArray());
                 }

--- a/server/src/test/java/io/crate/execution/dml/IndexerTest.java
+++ b/server/src/test/java/io/crate/execution/dml/IndexerTest.java
@@ -675,7 +675,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
                 Object expected = values.get(i);
                 assertThat(source).hasEntrySatisfying(
                     "c_" + type.getName(),
-                    v -> assertThat(type.sanitizeValue(v)).isEqualTo(expected)
+                    v -> assertThat(type.sanitizeType(v)).isEqualTo(expected)
                 );
             }
         }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/PercentileAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/PercentileAggregationTest.java
@@ -114,7 +114,7 @@ public class PercentileAggregationTest extends AggregationTestCase {
             List<Double> fractions = Arrays.asList(0.5, 0.8);
             Object[][] rowsWithSingleFraction = new Object[10][];
             for (int i = 0; i < rowsWithSingleFraction.length; i++) {
-                rowsWithSingleFraction[i] = new Object[]{ valueType.sanitizeValue(i), fractions.get(0) };
+                rowsWithSingleFraction[i] = new Object[]{ valueType.sanitizeType(i), fractions.get(0) };
             }
             assertThat(execSingleFractionPercentile(valueType, rowsWithSingleFraction), is(4.5));
         }
@@ -126,7 +126,7 @@ public class PercentileAggregationTest extends AggregationTestCase {
             List<Double> fractions = Arrays.asList(0.5, 0.8);
             Object[][] rowsWithFractionsArray = new Object[10][];
             for (int i = 0; i < rowsWithFractionsArray.length; i++) {
-                rowsWithFractionsArray[i] = new Object[]{ valueType.sanitizeValue(i), fractions };
+                rowsWithFractionsArray[i] = new Object[]{ valueType.sanitizeType(i), fractions };
             }
             assertThat(
                 execArrayFractionPercentile(valueType, rowsWithFractionsArray),

--- a/server/src/test/java/io/crate/execution/engine/pipeline/ProjectorsTest.java
+++ b/server/src/test/java/io/crate/execution/engine/pipeline/ProjectorsTest.java
@@ -79,7 +79,7 @@ public class ProjectorsTest extends CrateDummyClusterServiceUnitTest {
             new EvaluatingNormalizer(
                 nodeCtx,
                 RowGranularity.SHARD,
-                r -> Literal.ofUnchecked(r.valueType(), r.valueType().sanitizeValue("1")),
+                r -> Literal.ofUnchecked(r.valueType(), r.valueType().sanitizeType("1")),
                 null),
             t -> null,
             t -> null,

--- a/server/src/test/java/io/crate/expression/scalar/systeminformation/PgTypeofFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/systeminformation/PgTypeofFunctionTest.java
@@ -106,7 +106,7 @@ public class PgTypeofFunctionTest extends ScalarTestCase {
             DataTypes.GEO_POINT.getName(),
             Literal.of(
                 DataTypes.GEO_POINT,
-                DataTypes.GEO_POINT.sanitizeValue(List.of(1.0, 2.0))
+                DataTypes.GEO_POINT.sanitizeType(List.of(1.0, 2.0))
             )
         );
 

--- a/server/src/test/java/io/crate/expression/symbol/LiteralTest.java
+++ b/server/src/test/java/io/crate/expression/symbol/LiteralTest.java
@@ -48,9 +48,9 @@ public class LiteralTest extends ESTestCase {
             if (type.id() == BooleanType.ID) {
                 value = true;
             } else if (type.id() == DataTypes.IP.id()) {
-                value = type.sanitizeValue("123.34.243.23");
+                value = type.sanitizeType("123.34.243.23");
             } else if (type.id() == DataTypes.INTERVAL.id()) {
-                value = type.sanitizeValue(new Period().withSeconds(100));
+                value = type.sanitizeType(new Period().withSeconds(100));
             } else {
                 value = type.implicitCast("0");
             }

--- a/server/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
+++ b/server/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
@@ -299,7 +299,7 @@ public class SymbolPrinterTest extends CrateDummyClusterServiceUnitTest {
         assertPrint(
             Literal.of(
                 DataTypes.GEO_SHAPE,
-                DataTypes.GEO_SHAPE.sanitizeValue(map)
+                DataTypes.GEO_SHAPE.sanitizeType(map)
             ),
             "{\"type\"='Point', \"coordinates\"=[1.0, 2.0]}"
         );

--- a/server/src/test/java/io/crate/testing/DataTypeTestingTest.java
+++ b/server/src/test/java/io/crate/testing/DataTypeTestingTest.java
@@ -31,7 +31,7 @@ public class DataTypeTestingTest extends ESTestCase {
     @Test
     public void testDataGeneratorReturnValidValues() throws Exception {
         for (DataType<?> type : DataTypeTesting.ALL_STORED_TYPES_EXCEPT_ARRAYS) {
-            type.sanitizeValue(DataTypeTesting.getDataGenerator(type).get());
+            type.sanitizeType(DataTypeTesting.getDataGenerator(type).get());
         }
     }
 }

--- a/server/src/test/java/io/crate/types/ArrayTypeTest.java
+++ b/server/src/test/java/io/crate/types/ArrayTypeTest.java
@@ -112,8 +112,8 @@ public class ArrayTypeTest extends ESTestCase {
     @Test
     public void test_compare_arrays_of_string_that_contain_nulls() {
         int cmp = DataTypes.STRING_ARRAY.compare(
-            DataTypes.STRING_ARRAY.sanitizeValue("{'a', null}"),
-            DataTypes.STRING_ARRAY.sanitizeValue("{'a', 'b'}")
+            DataTypes.STRING_ARRAY.sanitizeType("{'a', null}"),
+            DataTypes.STRING_ARRAY.sanitizeType("{'a', 'b'}")
         );
         assertThat(cmp, is(-1));
     }

--- a/server/src/test/java/io/crate/types/BitStringTypeTest.java
+++ b/server/src/test/java/io/crate/types/BitStringTypeTest.java
@@ -56,7 +56,7 @@ public class BitStringTypeTest extends ESTestCase {
     @Test
     public void test_value_for_insert_only_allows_exact_length_matches() throws Exception {
         BitStringType type = new BitStringType(3);
-        Assertions.assertThatThrownBy(() -> type.valueForInsert(BitString.ofRawBits("00010001")))
+        Assertions.assertThatThrownBy(() -> type.sanitizeValue(BitString.ofRawBits("00010001")))
             .isExactlyInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("bit string length 8 does not match type bit(3)");
     }

--- a/server/src/test/java/io/crate/types/BooleanTypeTest.java
+++ b/server/src/test/java/io/crate/types/BooleanTypeTest.java
@@ -69,12 +69,12 @@ public class BooleanTypeTest extends ESTestCase {
 
     @Test
     public void test_sanitize_boolean_value() {
-        assertThat(BooleanType.INSTANCE.sanitizeValue(Boolean.FALSE)).isFalse();
+        assertThat(BooleanType.INSTANCE.sanitizeType(Boolean.FALSE)).isFalse();
     }
 
     @Test
     public void test_sanitize_numeric_value() {
-        assertThat(BooleanType.INSTANCE.sanitizeValue(1)).isTrue();
+        assertThat(BooleanType.INSTANCE.sanitizeType(1)).isTrue();
     }
 
     @Test

--- a/server/src/test/java/io/crate/types/ByteTypeTest.java
+++ b/server/src/test/java/io/crate/types/ByteTypeTest.java
@@ -49,7 +49,7 @@ public class ByteTypeTest extends ESTestCase {
 
     @Test
     public void test_sanitize_numeric_value() {
-        assertThat(ByteType.INSTANCE.sanitizeValue(1f), is((byte) 1));
+        assertThat(ByteType.INSTANCE.sanitizeType(1f), is((byte) 1));
     }
 
     @Test

--- a/server/src/test/java/io/crate/types/CharacterTypeTest.java
+++ b/server/src/test/java/io/crate/types/CharacterTypeTest.java
@@ -36,7 +36,7 @@ public class CharacterTypeTest extends ESTestCase {
 
     @Test
     public void test_value_for_insert_adds_blank_padding() {
-        assertThat(CharacterType.of(5).valueForInsert("a"), is("a    "));
+        assertThat(CharacterType.of(5).sanitizeValue("a"), is("a    "));
     }
 
     @Test

--- a/server/src/test/java/io/crate/types/DataTypesTest.java
+++ b/server/src/test/java/io/crate/types/DataTypesTest.java
@@ -232,13 +232,13 @@ public class DataTypesTest extends ESTestCase {
         if (val1 == null || val2 == null) {
             assertThat(
                 Comparator.nullsFirst(dt).compare(
-                    dt.sanitizeValue(val1),
-                    dt.sanitizeValue(val2)
+                    dt.sanitizeType(val1),
+                    dt.sanitizeType(val2)
                 ),
                 is(expected)
             );
         } else {
-            assertThat(dt.compare(dt.sanitizeValue(val1), dt.sanitizeValue(val2)), is(expected));
+            assertThat(dt.compare(dt.sanitizeType(val1), dt.sanitizeType(val2)), is(expected));
         }
     }
 }

--- a/server/src/test/java/io/crate/types/DoubleTypeTest.java
+++ b/server/src/test/java/io/crate/types/DoubleTypeTest.java
@@ -61,7 +61,7 @@ public class DoubleTypeTest extends ESTestCase {
 
     @Test
     public void test_sanitize_numeric_value() {
-        assertThat(DoubleType.INSTANCE.sanitizeValue(1f), is(1d));
+        assertThat(DoubleType.INSTANCE.sanitizeType(1f), is(1d));
     }
 
     @Test

--- a/server/src/test/java/io/crate/types/FloatTypeTest.java
+++ b/server/src/test/java/io/crate/types/FloatTypeTest.java
@@ -51,7 +51,7 @@ public class FloatTypeTest extends ESTestCase {
 
     @Test
     public void test_sanitize_numeric_value() {
-        assertThat(FloatType.INSTANCE.sanitizeValue(1d), is(1f));
+        assertThat(FloatType.INSTANCE.sanitizeType(1d), is(1f));
     }
 
     @Test

--- a/server/src/test/java/io/crate/types/GeoPointTypeTest.java
+++ b/server/src/test/java/io/crate/types/GeoPointTypeTest.java
@@ -52,7 +52,7 @@ public class GeoPointTypeTest extends ESTestCase {
 
     @Test
     public void test_sanitize_list_of_doubles_value() {
-        Point value = DataTypes.GEO_POINT.sanitizeValue(List.of(1d, 2d));
+        Point value = DataTypes.GEO_POINT.sanitizeType(List.of(1d, 2d));
         assertThat(value.getX(), is(1.0d));
         assertThat(value.getY(), is(2.0d));
     }

--- a/server/src/test/java/io/crate/types/GeoShapeTypeTest.java
+++ b/server/src/test/java/io/crate/types/GeoShapeTypeTest.java
@@ -192,7 +192,7 @@ public class GeoShapeTypeTest extends ESTestCase {
     @Test
     public void test_sanitize_value_geo_shape_objects() {
         for (Shape shape : GeoJSONUtilsTest.SHAPES) {
-            Map<String, Object> map = type.sanitizeValue(shape);
+            Map<String, Object> map = type.sanitizeType(shape);
             GeoJSONUtils.validateGeoJson(map);
         }
     }

--- a/server/src/test/java/io/crate/types/IntegerTypeTest.java
+++ b/server/src/test/java/io/crate/types/IntegerTypeTest.java
@@ -49,7 +49,7 @@ public class IntegerTypeTest extends ESTestCase {
 
     @Test
     public void test_sanitize_numeric_value() {
-        assertThat(IntegerType.INSTANCE.sanitizeValue(1f), is(1));
+        assertThat(IntegerType.INSTANCE.sanitizeType(1f), is(1));
     }
 
     @Test

--- a/server/src/test/java/io/crate/types/IpTypeTest.java
+++ b/server/src/test/java/io/crate/types/IpTypeTest.java
@@ -32,15 +32,15 @@ public class IpTypeTest extends ESTestCase {
 
     @Test
     public void test_sanitize_value() {
-        assertThat(IpType.INSTANCE.sanitizeValue(null), is(nullValue()));
-        assertThat(IpType.INSTANCE.sanitizeValue("127.0.0.1"), is("127.0.0.1"));
+        assertThat(IpType.INSTANCE.sanitizeType(null), is(nullValue()));
+        assertThat(IpType.INSTANCE.sanitizeType("127.0.0.1"), is("127.0.0.1"));
     }
 
     @Test
     public void test_sanitize_invalid_ip_value_throws_exception() {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("Failed to validate ip [2000.0.0.1], not a valid ipv4 address");
-        IpType.INSTANCE.sanitizeValue("2000.0.0.1");
+        IpType.INSTANCE.sanitizeType("2000.0.0.1");
     }
 
     @Test

--- a/server/src/test/java/io/crate/types/LongTypeTest.java
+++ b/server/src/test/java/io/crate/types/LongTypeTest.java
@@ -48,7 +48,7 @@ public class LongTypeTest extends ESTestCase {
 
     @Test
     public void test_sanitize_numeric_value() {
-        assertThat(LongType.INSTANCE.sanitizeValue(1f), is(1L));
+        assertThat(LongType.INSTANCE.sanitizeType(1f), is(1L));
     }
 
     @Test

--- a/server/src/test/java/io/crate/types/NumericTypeTest.java
+++ b/server/src/test/java/io/crate/types/NumericTypeTest.java
@@ -110,7 +110,7 @@ public class NumericTypeTest extends ESTestCase {
     }
 
     public void test_sanitize_numeric_value() {
-        assertThat(NumericType.INSTANCE.sanitizeValue(BigDecimal.valueOf(1)), is(BigDecimal.valueOf(1)));
+        assertThat(NumericType.INSTANCE.sanitizeType(BigDecimal.valueOf(1)), is(BigDecimal.valueOf(1)));
     }
 
     @Test

--- a/server/src/test/java/io/crate/types/RegprocTypeTest.java
+++ b/server/src/test/java/io/crate/types/RegprocTypeTest.java
@@ -78,7 +78,7 @@ public class RegprocTypeTest extends ESTestCase {
         expectedException.expect(UnsupportedOperationException.class);
         expectedException.expectMessage(
             REGPROC.getName() + " cannot be used in insert statements");
-        REGPROC.valueForInsert(Regproc.of("func"));
+        REGPROC.sanitizeValue(Regproc.of("func"));
     }
 
     @Test

--- a/server/src/test/java/io/crate/types/ShortTypeTest.java
+++ b/server/src/test/java/io/crate/types/ShortTypeTest.java
@@ -50,7 +50,7 @@ public class ShortTypeTest extends ESTestCase {
 
     @Test
     public void test_sanitize_numeric_value() {
-        assertThat(ShortType.INSTANCE.sanitizeValue(1f), is((short) 1));
+        assertThat(ShortType.INSTANCE.sanitizeType(1f), is((short) 1));
     }
 
     @Test

--- a/server/src/test/java/io/crate/types/StringTypeTest.java
+++ b/server/src/test/java/io/crate/types/StringTypeTest.java
@@ -124,26 +124,26 @@ public class StringTypeTest extends ESTestCase {
 
     @Test
     public void test_value_for_insert_text_with_length_on_literals_of_length_lte_length() {
-        assertThat(StringType.of(4).valueForInsert("abcd"), is("abcd"));
-        assertThat(StringType.of(3).valueForInsert("a"), is("a"));
+        assertThat(StringType.of(4).sanitizeValue("abcd"), is("abcd"));
+        assertThat(StringType.of(3).sanitizeValue("a"), is("a"));
     }
 
     @Test
     public void test_value_for_insert_text_without_length_does_not_change_input_value() {
-        assertThat(StringType.INSTANCE.valueForInsert("abcd"), is("abcd"));
+        assertThat(StringType.INSTANCE.sanitizeValue("abcd"), is("abcd"));
     }
 
     @Test
     public void test_value_for_insert_text_with_length_trims_exceeding_chars_if_they_are_whitespaces() {
-        assertThat(StringType.of(2).valueForInsert("a    "), is("a "));
-        assertThat(StringType.of(2).valueForInsert("ab  "), is("ab"));
+        assertThat(StringType.of(2).sanitizeValue("a    "), is("a "));
+        assertThat(StringType.of(2).sanitizeValue("ab  "), is("ab"));
     }
 
     @Test
     public void test_value_for_insert_text_with_length_for_literal_exceeding_length_throws_exception() {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("'abcd' is too long for the text type of length: 3");
-        StringType.of(3).valueForInsert("abcd");
+        StringType.of(3).sanitizeValue("abcd");
     }
 
     @Test

--- a/server/src/testFixtures/java/io/crate/execution/engine/window/AbstractWindowFunctionTest.java
+++ b/server/src/testFixtures/java/io/crate/execution/engine/window/AbstractWindowFunctionTest.java
@@ -190,7 +190,7 @@ public abstract class AbstractWindowFunctionTest extends CrateDummyClusterServic
     private static void ensureInputRowsHaveCorrectType(List<Symbol> sourceSymbols, Object[][] inputRows) {
         for (int i = 0; i < sourceSymbols.size(); i++) {
             for (Object[] inputRow : inputRows) {
-                inputRow[i] = sourceSymbols.get(i).valueType().sanitizeValue(inputRow[i]);
+                inputRow[i] = sourceSymbols.get(i).valueType().sanitizeType(inputRow[i]);
             }
         }
     }

--- a/server/src/testFixtures/java/io/crate/testing/QueryTester.java
+++ b/server/src/testFixtures/java/io/crate/testing/QueryTester.java
@@ -172,7 +172,7 @@ public final class QueryTester implements AutoCloseable {
                             Object param = params[parameterSymbol.index()];
                             return Literal.ofUnchecked(
                                 parameterSymbol.valueType(),
-                                parameterSymbol.valueType().sanitizeValue(param)
+                                parameterSymbol.valueType().sanitizeType(param)
                             );
                         }
                     }, null);

--- a/server/src/testFixtures/java/io/crate/testing/TestingHelpers.java
+++ b/server/src/testFixtures/java/io/crate/testing/TestingHelpers.java
@@ -406,7 +406,7 @@ public class TestingHelpers {
             if (RandomizedTest.randomIntBetween(0, length - 1) == 0) {
                 values.add(null);
             } else {
-                values.add(dataType.sanitizeValue(generator.get()));
+                values.add(dataType.sanitizeType(generator.get()));
             }
         }
         return values;


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Resolves https://github.com/crate/crate/issues/14178

The two cannot be merged because for example `TimeTZType.INSTANCE.valueForInsert()` throws an `UnsupportedOperationException` since a `timetz` cannot be inserted while `TimeTZType.INSTANCE.sanitizeValue()` does not.

In order to make clear distinct of the two, I renamed `sanitizeValue` > `sanitizeType` and `valueForInsert` > `sanitizeValue` to characterize one is meant for types and the other is for values.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
