### PR TITLE
Make aggregations in INSERT INTO work

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -201,6 +201,9 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed a regression introduced in 4.7.0 which caused aggregations used in
+  ``INSERT INTO`` statements returning null instead of the aggregation result.
+
 - Fixed a regression introduced in 5.3.0 which caused
   ``CAST(<generated_partition_column> AS <targetType>)`` expressions to return
   ``NULL`` instead of the cast result.

--- a/server/src/main/java/io/crate/execution/engine/collect/DocValuesAggregates.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/DocValuesAggregates.java
@@ -68,6 +68,7 @@ import io.crate.memory.MemoryManager;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
+import io.crate.metadata.doc.DocSysColumns;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.types.DataTypes;
 
@@ -160,6 +161,8 @@ public class DocValuesAggregates {
                         // to the normal aggregation implementation
                         return null;
                     }
+                    assert reference.ident().columnIdent().fqn().startsWith(DocSysColumns.Names.DOC) == false :
+                        "Source look-up for Reference " + reference + " is not allowed in DocValuesAggregates.";
                     aggregationReferences.add(reference);
                 }
             }

--- a/server/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
@@ -558,18 +558,18 @@ public class InsertIntoIntegrationTest extends IntegTestCase {
         execute("refresh table locations");
 
         execute("create table aggs (" +
-                " c long," +
+                " c double," +
                 " s double" +
                 ") with (number_of_replicas=0)");
         ensureYellow();
 
-        execute("insert into aggs (c, s) (select count(*), sum(position) from locations)");
+        execute("insert into aggs (c, s) (select avg(position), sum(position) from locations)");
         assertThat(response).hasRowCount(1L);
 
         execute("refresh table aggs");
         execute("select c, s from aggs");
         assertThat(response).hasRowCount(1L);
-        assertThat(((Number) response.rows()[0][0]).longValue()).isEqualTo(13L);
+        assertThat(((Number) response.rows()[0][0]).longValue()).isEqualTo(2L);
         assertThat((Double) response.rows()[0][1]).isEqualTo(38.0);
     }
 


### PR DESCRIPTION
Aggregations used in `INSERT INTO` statement will return null e.g.:

```sql
INSERT INTO t2 SELECT AVG(a) FROM t1;
```

This applies to all types of aggregations used in this context. The root cause is that references in the ``INSERT INTO`` have a hint to prefer source look-ups, which should be ignored by aggregations as it leads to the wrong field name for doc values.

Fixes https://github.com/crate/crate/issues/14277

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
