### PR TITLE
Validate generated partition column value

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -229,4 +229,6 @@ Fixes
   to skip generated column validation for sub-columns if provided value is
   ``NULL``.
 
+- Fixed an issue which caused ``INSERT INTO`` statements
+  to skip generated column validation for partitioned columns.
 


### PR DESCRIPTION
Fixes https://github.com/crate/crate/issues/14304

~~Not sure we need such "heavy" fix - we are basically streaming extra refs/values for the sake of validation.~~

~~Looks like narrow use case but then need to treat reported issue as a feature and go for it in only in case of multiple upvotes?~~

Actually not a big deal, we are not adding some payload _per_-ref, only generated partitioned cols (should be 1-2 in most cases)
