### PR TITLE
Fix fields used in number value indexer when indexing is turned off

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -229,4 +229,8 @@ Fixes
   to skip generated column validation for sub-columns if provided value is
   ``NULL``.
 
+- Fixed an issue introduced with CrateDB ``5.3.0`` resulting in failing writes
+  and/or broken replica shards when ingesting into a table using a number type
+  column with explicit turned off indexing by declaring ``INDEX OFF``.
+
 

--- a/server/src/main/java/io/crate/execution/dml/DoubleIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/DoubleIndexer.java
@@ -31,8 +31,10 @@ import org.apache.lucene.document.DoubleField;
 import org.apache.lucene.document.DoublePoint;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.mapper.FieldNamesFieldMapper;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
@@ -40,6 +42,7 @@ import org.elasticsearch.index.mapper.NumberFieldMapper;
 import io.crate.execution.dml.Indexer.ColumnConstraint;
 import io.crate.execution.dml.Indexer.Synthetic;
 import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.IndexType;
 import io.crate.metadata.Reference;
 
 public class DoubleIndexer implements ValueIndexer<Number> {
@@ -63,17 +66,25 @@ public class DoubleIndexer implements ValueIndexer<Number> {
                            Map<ColumnIdent, ColumnConstraint> toValidate) throws IOException {
         xcontentBuilder.value(value);
         double doubleValue = value.doubleValue();
-        if (ref.hasDocValues()) {
-            addField.accept(new DoubleField(name, doubleValue));
+        if (ref.hasDocValues() && ref.indexType() != IndexType.NONE) {
+            addField.accept(new DoubleField(name, doubleValue, fieldType.stored() ? Field.Store.YES : Field.Store.NO));
         } else {
-            addField.accept(new DoublePoint(name, doubleValue));
-            addField.accept(new Field(
-                FieldNamesFieldMapper.NAME,
-                name,
-                FieldNamesFieldMapper.Defaults.FIELD_TYPE));
-        }
-        if (fieldType.stored()) {
-            addField.accept(new StoredField(name, doubleValue));
+            if (ref.indexType() != IndexType.NONE) {
+                addField.accept(new DoublePoint(name, doubleValue));
+            }
+            if (ref.hasDocValues()) {
+                addField.accept(
+                        new SortedNumericDocValuesField(name, NumericUtils.doubleToSortableLong(doubleValue))
+                );
+            } else {
+                addField.accept(new Field(
+                        FieldNamesFieldMapper.NAME,
+                        name,
+                        FieldNamesFieldMapper.Defaults.FIELD_TYPE));
+            }
+            if (fieldType.stored()) {
+                addField.accept(new StoredField(name, doubleValue));
+            }
         }
     }
 }

--- a/server/src/main/java/io/crate/execution/dml/FloatIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/FloatIndexer.java
@@ -29,14 +29,17 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.FloatField;
 import org.apache.lucene.document.FloatPoint;
+import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.mapper.FieldNamesFieldMapper;
 
 import io.crate.execution.dml.Indexer.ColumnConstraint;
 import io.crate.execution.dml.Indexer.Synthetic;
 import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.IndexType;
 import io.crate.metadata.Reference;
 
 public class FloatIndexer implements ValueIndexer<Float> {
@@ -60,17 +63,25 @@ public class FloatIndexer implements ValueIndexer<Float> {
                            Map<ColumnIdent, ColumnConstraint> toValidate) throws IOException {
         xcontentBuilder.value(value);
         float floatValue = value.floatValue();
-        if (ref.hasDocValues()) {
-            addField.accept(new FloatField(name, floatValue));
+        if (ref.hasDocValues() && ref.indexType() != IndexType.NONE) {
+            addField.accept(new FloatField(name, floatValue, fieldType.stored() ? Field.Store.YES : Field.Store.NO));
         } else {
-            addField.accept(new FloatPoint(name, floatValue));
-            addField.accept(new Field(
-                FieldNamesFieldMapper.NAME,
-                name,
-                FieldNamesFieldMapper.Defaults.FIELD_TYPE));
-        }
-        if (fieldType.stored()) {
-            addField.accept(new StoredField(name, floatValue));
+            if (ref.indexType() != IndexType.NONE) {
+                addField.accept(new FloatPoint(name, floatValue));
+            }
+            if (ref.hasDocValues()) {
+                addField.accept(
+                        new SortedNumericDocValuesField(name, NumericUtils.floatToSortableInt(floatValue))
+                );
+            } else {
+                addField.accept(new Field(
+                        FieldNamesFieldMapper.NAME,
+                        name,
+                        FieldNamesFieldMapper.Defaults.FIELD_TYPE));
+            }
+            if (fieldType.stored()) {
+                addField.accept(new StoredField(name, floatValue));
+            }
         }
     }
 }

--- a/server/src/main/java/io/crate/execution/dml/LongIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/LongIndexer.java
@@ -25,19 +25,20 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.function.Consumer;
 
-import org.jetbrains.annotations.Nullable;
-
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.LongField;
 import org.apache.lucene.document.LongPoint;
+import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.IndexableField;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.mapper.FieldNamesFieldMapper;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
+import org.jetbrains.annotations.Nullable;
 
 import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.IndexType;
 import io.crate.metadata.Reference;
 
 public class LongIndexer implements ValueIndexer<Long> {
@@ -61,17 +62,23 @@ public class LongIndexer implements ValueIndexer<Long> {
                            Map<ColumnIdent, Indexer.ColumnConstraint> toValidate) throws IOException {
         xcontentBuilder.value(value);
         long longValue = value.longValue();
-        if (ref.hasDocValues()) {
-            addField.accept(new LongField(name, longValue));
+        if (ref.hasDocValues() && ref.indexType() != IndexType.NONE) {
+            addField.accept(new LongField(name, longValue, fieldType.stored() ? Field.Store.YES : Field.Store.NO));
         } else {
-            addField.accept(new LongPoint(name, longValue));
-            addField.accept(new Field(
-                FieldNamesFieldMapper.NAME,
-                name,
-                FieldNamesFieldMapper.Defaults.FIELD_TYPE));
-        }
-        if (fieldType.stored()) {
-            addField.accept(new StoredField(name, longValue));
+            if (ref.indexType() != IndexType.NONE) {
+                addField.accept(new LongPoint(name, longValue));
+            }
+            if (ref.hasDocValues()) {
+                addField.accept(new SortedNumericDocValuesField(name, longValue));
+            } else {
+                addField.accept(new Field(
+                        FieldNamesFieldMapper.NAME,
+                        name,
+                        FieldNamesFieldMapper.Defaults.FIELD_TYPE));
+            }
+            if (fieldType.stored()) {
+                addField.accept(new StoredField(name, longValue));
+            }
         }
     }
 }

--- a/server/src/test/java/io/crate/metadata/doc/mappers/array/ArrayMapperTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/mappers/array/ArrayMapperTest.java
@@ -72,7 +72,7 @@ public class ArrayMapperTest extends CrateDummyClusterServiceUnitTest {
     /**
      * create index with type and mapping and validate DocumentMapper serialization
      */
-    private DocumentMapper mapper(String indexName, String mapping) throws IOException {
+    public static DocumentMapper mapper(String indexName, String mapping) throws IOException {
         IndicesModule indicesModule = new IndicesModule(List.of());
         MapperService mapperService = MapperTestUtils.newMapperService(
             NamedXContentRegistry.EMPTY,


### PR DESCRIPTION
 If the fields do not align with the ones used inside the NumberFieldMapper, recovery from translog may fail (when writing into existing segments) as in this case, the NumberFieldMapper is used.

In such cases, Lucene will throw an exception on direct writes like:
```
cannot change field "col1" from points dimensionCount=0, indexDimensionCount=0, numBytes=0 to inconsistent dimensionCount=1, indexDimensionCount=1, numBytes=8
```
or on recovery like:
```
Inconsistency of field data structures across documents for field [col1] of doc [1621]. point dimension: expected '1', but it has '0'.
```


Follow up of https://github.com/crate/crate/commit/b1d7fc5fe89.
