### PR TITLE
Fix cast of generated partitions

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -197,6 +197,10 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Fixed a regression introduced in 5.3.0 which caused
+  ``CAST(<generated_partition_column> AS <targetType>)`` expressions to return
+  ``NULL`` instead of the cast result.
+
 - Fixed a regression introduced in 5.3.0 which caused ``INSERT INTO`` statements
   with a ``ON CONFLICT`` clause on tables with generated primary key columns to
   fail with an ``ArrayIndexOutOfBoundsException``.

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/LuceneReferenceResolver.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/LuceneReferenceResolver.java
@@ -119,7 +119,7 @@ public class LuceneReferenceResolver implements ReferenceResolver<LuceneCollecto
             }
 
             default: {
-                int partitionPos = partitionColumns.indexOf(ref);
+                int partitionPos = Reference.indexOf(partitionColumns, column);
                 if (partitionPos >= 0) {
                     return new LiteralValueExpression(
                         ref.valueType().implicitCast(PartitionName.fromIndexOrTemplate(indexName).values().get(partitionPos))
@@ -202,7 +202,7 @@ public class LuceneReferenceResolver implements ReferenceResolver<LuceneCollecto
         return ref.symbolType() == SymbolType.DYNAMIC_REFERENCE && ref.columnPolicy() == ColumnPolicy.IGNORED;
     }
 
-    private static class LiteralValueExpression extends LuceneCollectorExpression<Object> {
+    static class LiteralValueExpression extends LuceneCollectorExpression<Object> {
 
         private final Object value;
 

--- a/server/src/main/java/io/crate/metadata/GeneratedReference.java
+++ b/server/src/main/java/io/crate/metadata/GeneratedReference.java
@@ -27,12 +27,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import org.jetbrains.annotations.Nullable;
-
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.jetbrains.annotations.Nullable;
 
 import io.crate.expression.scalar.cast.CastMode;
 import io.crate.expression.symbol.Symbol;
@@ -227,11 +226,11 @@ public class GeneratedReference implements Reference {
 
     @Override
     public Symbol cast(DataType<?> targetType, CastMode... modes) {
-        Symbol result = ref.cast(targetType, modes);
-        if (ref == result) {
+        Symbol result = Reference.super.cast(targetType, modes);
+        if (result == this) {
             return this;
         }
-        if (result instanceof Reference castRef) {
+        if (result instanceof Reference castRef && !(result instanceof GeneratedReference)) {
             return new GeneratedReference(
                 castRef,
                 formattedGeneratedExpression,

--- a/server/src/test/java/io/crate/expression/reference/doc/lucene/LuceneReferenceResolverTest.java
+++ b/server/src/test/java/io/crate/expression/reference/doc/lucene/LuceneReferenceResolverTest.java
@@ -22,8 +22,6 @@
 package io.crate.expression.reference.doc.lucene;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertThat;
 
 import java.util.List;
 
@@ -61,8 +59,8 @@ public class LuceneReferenceResolverTest extends CrateDummyClusterServiceUnitTes
         SimpleReference arrayRef = new SimpleReference(
             new ReferenceIdent(name, "a"), RowGranularity.DOC, DataTypes.DOUBLE_ARRAY, 0, null
         );
-        assertThat(luceneReferenceResolver.getImplementation(arrayRef),
-            instanceOf(DocCollectorExpression.ChildDocCollectorExpression.class));
+        assertThat(luceneReferenceResolver.getImplementation(arrayRef))
+            .isExactlyInstanceOf(DocCollectorExpression.ChildDocCollectorExpression.class);
     }
 
     @Test
@@ -70,7 +68,8 @@ public class LuceneReferenceResolverTest extends CrateDummyClusterServiceUnitTes
         SimpleReference seqNumberRef = new SimpleReference(
             new ReferenceIdent(name, "_seq_no"), RowGranularity.DOC, DataTypes.LONG, 0, null
         );
-        assertThat(luceneReferenceResolver.getImplementation(seqNumberRef), instanceOf(SeqNoCollectorExpression.class));
+        assertThat(luceneReferenceResolver.getImplementation(seqNumberRef))
+            .isExactlyInstanceOf(SeqNoCollectorExpression.class);
     }
 
     @Test
@@ -78,8 +77,8 @@ public class LuceneReferenceResolverTest extends CrateDummyClusterServiceUnitTes
         SimpleReference primaryTerm = new SimpleReference(
             new ReferenceIdent(name, "_primary_term"), RowGranularity.DOC, DataTypes.LONG, 0, null
         );
-        assertThat(luceneReferenceResolver.getImplementation(primaryTerm),
-                   instanceOf(PrimaryTermCollectorExpression.class));
+        assertThat(luceneReferenceResolver.getImplementation(primaryTerm))
+            .isExactlyInstanceOf(PrimaryTermCollectorExpression.class);
     }
 
     @Test
@@ -87,8 +86,8 @@ public class LuceneReferenceResolverTest extends CrateDummyClusterServiceUnitTes
         Reference ignored = new DynamicReference(
             new ReferenceIdent(name, "a", List.of("b")), RowGranularity.DOC, ColumnPolicy.IGNORED, 0);
 
-        assertThat(luceneReferenceResolver.getImplementation(ignored),
-                   instanceOf(DocCollectorExpression.ChildDocCollectorExpression.class));
+        assertThat(luceneReferenceResolver.getImplementation(ignored))
+            .isExactlyInstanceOf(DocCollectorExpression.ChildDocCollectorExpression.class);
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
@@ -59,7 +59,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import io.crate.testing.UseRandomizedOptimizerRules;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
 import org.elasticsearch.action.admin.indices.template.delete.DeleteIndexTemplateRequest;
@@ -90,6 +89,8 @@ import io.crate.metadata.Schemas;
 import io.crate.testing.Asserts;
 import io.crate.testing.SQLResponse;
 import io.crate.testing.TestingHelpers;
+import io.crate.testing.UseJdbc;
+import io.crate.testing.UseRandomizedOptimizerRules;
 import io.crate.testing.UseRandomizedSchema;
 
 @UseRandomizedOptimizerRules(0)
@@ -2418,5 +2419,23 @@ public class PartitionedTableIntegrationTest extends IntegTestCase {
         execute("ALTER TABLE p_t SET (\"number_of_replicas\" = '3')");
         execute("select number_of_replicas from information_schema.table_partitions");
         assertThat(printedTable(response.rows())).isEqualTo("3\n3\n");
+    }
+
+    @Test
+    @UseJdbc(0) // Jdbc layer would convert timestamp
+    public void test_can_select_casted_partitioned_column() throws Exception {
+        execute("""
+            CREATE TABLE tbl (
+                ts TIMESTAMP,
+                year TIMESTAMP GENERATED ALWAYS AS date_trunc('year',ts)
+            ) PARTITIONED BY (year)
+            """
+        );
+        execute("INSERT INTO tbl (ts) SELECT now()");
+        execute("refresh table tbl");
+        execute("select year, year::TEXT, ts from tbl LIMIT 10");
+        assertThat(response.rows()[0][0].toString())
+            .as("Column values must match: " + Arrays.toString(response.rows()[0]))
+            .isEqualTo(response.rows()[0][1]);
     }
 }

--- a/server/src/test/java/io/crate/metadata/GeneratedReferenceTest.java
+++ b/server/src/test/java/io/crate/metadata/GeneratedReferenceTest.java
@@ -24,8 +24,6 @@ package io.crate.metadata;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.T3.T1;
 import static io.crate.testing.T3.T1_DEFINITION;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import java.util.Collections;
 import java.util.List;
@@ -78,7 +76,7 @@ public class GeneratedReferenceTest extends CrateDummyClusterServiceUnitTest {
         StreamInput in = out.bytes().streamInput();
         GeneratedReference generatedReferenceInfo2 = Reference.fromStream(in);
 
-        assertThat(generatedReferenceInfo2, is(generatedReferenceInfo));
+        assertThat(generatedReferenceInfo2).isEqualTo(generatedReferenceInfo);
     }
 
     @Test
@@ -94,7 +92,7 @@ public class GeneratedReferenceTest extends CrateDummyClusterServiceUnitTest {
         StreamInput in = out.bytes().streamInput();
         GeneratedReference generatedReference2 = Reference.fromStream(in);
 
-        assertThat(generatedReference2, is(generatedReference));
+        assertThat(generatedReference2).isEqualTo(generatedReference);
 
     }
 


### PR DESCRIPTION
A cast can convert a `GeneratedReference` to a `SimpleReference` - that
broke a `indexOf(partitionColumns, column)` call when resolving the
reference implementation.

Closes https://github.com/crate/crate/issues/14307

---

First commit fixes the issue by making `LuceneReferenceResolver` more lenient in regards to concrete Reference instances, but I added another commit to also preserve the `GeneratedReference` instance on casts. This should help ensure that we don't have other places where a `.contains` or `.indexOf` broke.
