### PR TITLE
Treat date_bin as rounding function for column expansion

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -92,6 +92,10 @@ None
 Changes
 =======
 
+- Improved the partition filtering logic to also narrow partitions if the
+  partition is based on a generated column using the :ref:`date_bin <date-bin>`
+  scalar.
+
 - Extended the :ref:`EXPLAIN <ref-explain>` statement output to include the
   estimated row count in the output of the execution plan. The statement also
   has now options for `ANALYZE` and `COSTS` to have better control on

--- a/server/src/main/java/io/crate/analyze/GeneratedColumnExpander.java
+++ b/server/src/main/java/io/crate/analyze/GeneratedColumnExpander.java
@@ -37,6 +37,7 @@ import io.crate.expression.operator.GteOperator;
 import io.crate.expression.operator.LtOperator;
 import io.crate.expression.operator.LteOperator;
 import io.crate.expression.operator.Operators;
+import io.crate.expression.scalar.DateBinFunction;
 import io.crate.expression.scalar.DateTruncFunction;
 import io.crate.expression.scalar.arithmetic.CeilFunction;
 import io.crate.expression.scalar.arithmetic.FloorFunction;
@@ -65,7 +66,8 @@ public final class GeneratedColumnExpander {
         CeilFunction.CEIL,
         FloorFunction.NAME,
         RoundFunction.NAME,
-        DateTruncFunction.NAME
+        DateTruncFunction.NAME,
+        DateBinFunction.NAME
     );
 
     private GeneratedColumnExpander() {

--- a/server/src/main/java/io/crate/expression/scalar/DateBinFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/DateBinFunction.java
@@ -47,7 +47,7 @@ public class DateBinFunction extends Scalar<Long, Object> {
                 DataTypes.TIMESTAMPZ.getTypeSignature(), // source
                 DataTypes.TIMESTAMPZ.getTypeSignature(), // origin
                 DataTypes.TIMESTAMPZ.getTypeSignature()
-            ).withFeatures(DETERMINISTIC_ONLY),
+            ).withFeatures(Scalar.DETERMINISTIC_AND_COMPARISON_REPLACEMENT),
             DateBinFunction::new);
 
         module.register(
@@ -57,7 +57,7 @@ public class DateBinFunction extends Scalar<Long, Object> {
                 DataTypes.TIMESTAMP.getTypeSignature(), // source
                 DataTypes.TIMESTAMP.getTypeSignature(), // origin
                 DataTypes.TIMESTAMP.getTypeSignature()
-            ).withFeatures(DETERMINISTIC_ONLY),
+            ).withFeatures(Scalar.DETERMINISTIC_AND_COMPARISON_REPLACEMENT),
             DateBinFunction::new);
     }
 
@@ -99,7 +99,8 @@ public class DateBinFunction extends Scalar<Long, Object> {
     }
 
     @Override
-    public final Long evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input[] args) {
+    @SafeVarargs
+    public final Long evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object> ... args) {
         assert args.length == 3 : "Invalid number of arguments";
 
         var interval = args[0].value();
@@ -172,7 +173,8 @@ public class DateBinFunction extends Scalar<Long, Object> {
         }
 
         @Override
-        public Long evaluate(TransactionContext txnCtx, NodeContext nodeContext, Input<Object>... args) {
+        @SafeVarargs
+        public final Long evaluate(TransactionContext txnCtx, NodeContext nodeContext, Input<Object>... args) {
             // Validation for arguments amount is done in compile.
 
             var timestamp = args[1].value();


### PR DESCRIPTION
To support partition filtering.
Closes https://github.com/crate/crate/issues/14250

I first thought this was a bug, but it's not really - just a missed optimization opportunity.

---

Just to be sure: date_bin is always rounding down right? Even with custom origin? If it were to round up too, this optimization doesn't work.