### PR TITLE
Fix flaky testRelocatedShardCanNotBeRevivedConcurrently

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -3168,7 +3168,7 @@ public class IndexShardTests extends IndexShardTestCase {
         cancellingThread.join();
         if (shard.isRelocatedPrimary()) {
             logger.debug("shard was relocated successfully");
-            assertThat(cancellingException.get()).isExactlyInstanceOf(IllegalIndexShardStateException.class);
+            assertThat(cancellingException.get()).isInstanceOf(IllegalIndexShardStateException.class);
             assertThat(shard.routingEntry().relocating())
                 .as("current routing:" + shard.routingEntry())
                 .isEqualTo(true);


### PR DESCRIPTION
Follow up to https://github.com/crate/crate/pull/14302

    Expecting actual throwable to be exactly an instance of:
      org.elasticsearch.index.shard.IllegalIndexShardStateException
    but was:
      [index][[index][0]] org.elasticsearch.index.shard.IndexShardRelocatedException: CurrentState[STARTED] Shard is marked as relocated, cannot safely move to state STARTED
