### PR TITLE
Disallow creation of nested arrays

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -201,4 +201,5 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
-None
+- Added validation to prevent creation of invalid nested array columns via
+  ``INSERT INTO`` and dynamic column policy.

--- a/server/src/main/java/io/crate/execution/ddl/TransportSchemaUpdateAction.java
+++ b/server/src/main/java/io/crate/execution/ddl/TransportSchemaUpdateAction.java
@@ -299,7 +299,8 @@ public class TransportSchemaUpdateAction extends TransportMasterNodeAction<Schem
             contentPath.add(name);
             Map<String, Object> columnProperties = (Map<String, Object>) e.getValue();
             columnProperties = furtherColumnProperties(columnProperties);
-            assert columnProperties.containsKey("position") && columnProperties.get("position") != null : "Column position is missing: " + name;
+            assert columnProperties.containsKey("inner") || (columnProperties.containsKey("position") && columnProperties.get("position") != null)
+                : "Column position is missing: " + name;
             // BWC compatibility with nodes < 5.1, position could be NULL if column is created on that nodes
             Integer position = (Integer) columnProperties.get("position");
             if (position != null) {


### PR DESCRIPTION
See https://github.com/crate/crate/issues/14251

In 5.3.0 it became possible to insert nested arrays, but they got the wrong
type (E.g. `long[]` instead of `long[][]`)

The reason for that was that the `Indexer` correctly detected a new
column with a nested array (`long[][]`) and it also indexes the values
correctly, but the `AddColumnTask` / `MappingUtil` then dropped all but
1 dimension from the array mapping.

This adds support for nested arrays to `MappingUtil` - which then moves
the limitation to the `ArrayTypeParser` which raises an error.

With these changes, there should only be two places that restrict proper
full nested array support:

- `ArrayTypeParser` (mostly artifical)
- `TableElementsAnalyzer` (Would need a rework in how it handles column types)
