### PR TITLE
Fix issue with re-ordered pruned outputs

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -226,3 +226,13 @@ Fixes
 - Fixed value of ``sys.jobs_log.stmt`` for various statements when issued via
   the PostgreSQL ``simple`` query mode by using the original query string
   instead of the statements string representation.
+
+- Fixed an issue that could cause errors for queries with aggregations,
+  ``UNION`` and ``LIMIT``, e.g. ::
+
+    SELECT a, avg(c), b FROM t1 GROUP BY 1, 3
+    UNION
+    SELECT x, avg(z), y FROM t2 GROUP BY 1, 3
+    UNION
+    SELECT i, avg(k), j FROM t3 GROUP BY 1, 3
+    LIMIT 10

--- a/server/src/main/java/io/crate/planner/operators/LimitDistinct.java
+++ b/server/src/main/java/io/crate/planner/operators/LimitDistinct.java
@@ -25,6 +25,7 @@ import static io.crate.analyze.SymbolEvaluator.evaluate;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -157,7 +158,7 @@ public final class LimitDistinct extends ForwardingLogicalPlan {
 
     @Override
     public LogicalPlan pruneOutputsExcept(Collection<Symbol> outputsToKeep) {
-        HashSet<Symbol> toKeep = new HashSet<>();
+        HashSet<Symbol> toKeep = new LinkedHashSet<>();
         Consumer<Symbol> keep = toKeep::add;
         // Pruning unused outputs would change semantics. Need to keep all in any case
         for (var output : outputs) {

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlan.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlan.java
@@ -121,7 +121,8 @@ public interface LogicalPlan extends Plan {
      * <p>
      *  Note that `outputsToKeep` can contain scalars on top of the outputs that the "current" operator outputs.
      *  This doesn't mean that the operator has to pull-down the scalar as well, but it means it has to provide all outputs
-     *  that are required by the parent.
+     *  that are required by the parent. The new pruned outputs should be in the same original order, to avoid errors
+     *  regarding {@link Union} (which requires the order to be kept), or introduction of unnecessary {@link Eval} operators.
      *  Using {@link io.crate.expression.symbol.SymbolVisitors#intersection(Symbol, Collection, Consumer)} is an option
      *  To find the outputs required by the parent.
      * </p>
@@ -147,6 +148,10 @@ public interface LogicalPlan extends Plan {
      *  If there are no outputs to prune and if the source also didn't change, `this` must be returned.
      *  That allows implementations to do a cheap identity check to avoid LogicalPlan re-creations themselves.
      * </p>
+     *
+     * @param outputsToKeep The collection should provide those outputs in the same original order, to avoid errors
+     *                      regarding {@link Union} (which requires the order to be kept), or introduction of
+     *                      unnecessary {@link Eval} operators.
      */
     LogicalPlan pruneOutputsExcept(Collection<Symbol> outputsToKeep);
 

--- a/server/src/main/java/io/crate/planner/operators/ProjectSet.java
+++ b/server/src/main/java/io/crate/planner/operators/ProjectSet.java
@@ -27,7 +27,6 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -77,9 +76,9 @@ public class ProjectSet extends ForwardingLogicalPlan {
         while (true) {
             List<Function> childTableFunctions = tableFunctions.stream()
                 .flatMap(func -> func.arguments().stream())
-                .filter(arg -> arg instanceof Function && ((Function) arg).signature().getKind() == FunctionType.TABLE)
+                .filter(arg -> arg instanceof Function fn && fn.signature().getKind() == FunctionType.TABLE)
                 .map(x -> (Function) x)
-                .collect(Collectors.toList());
+                .toList();
 
             if (childTableFunctions.isEmpty()) {
                 break;
@@ -90,8 +89,8 @@ public class ProjectSet extends ForwardingLogicalPlan {
         LogicalPlan result = source;
         for (int i = nestedFunctions.size() - 1; i >= 0; i--) {
             List<Symbol> standalone = result.outputs().stream()
-                .filter(x -> !(x instanceof Function && ((Function) x).signature().getKind() == FunctionType.TABLE))
-                .collect(Collectors.toList());
+                .filter(x -> !(x instanceof Function fn && fn.signature().getKind() == FunctionType.TABLE))
+                .toList();
             result = new ProjectSet(result, nestedFunctions.get(i), standalone);
         }
         return result;
@@ -150,7 +149,7 @@ public class ProjectSet extends ForwardingLogicalPlan {
 
     @Override
     public LogicalPlan pruneOutputsExcept(Collection<Symbol> outputsToKeep) {
-        HashSet<Symbol> toKeep = new HashSet<>();
+        HashSet<Symbol> toKeep = new LinkedHashSet<>();
         LinkedHashSet<Symbol> newStandalone = new LinkedHashSet<>();
         for (Symbol outputToKeep : outputsToKeep) {
             SymbolVisitors.intersection(outputToKeep, standalone, newStandalone::add);

--- a/server/src/main/java/io/crate/planner/operators/WindowAgg.java
+++ b/server/src/main/java/io/crate/planner/operators/WindowAgg.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -114,7 +115,7 @@ public class WindowAgg extends ForwardingLogicalPlan {
 
     @Override
     public LogicalPlan pruneOutputsExcept(Collection<Symbol> outputsToKeep) {
-        HashSet<Symbol> toKeep = new HashSet<>();
+        HashSet<Symbol> toKeep = new LinkedHashSet<>();
         ArrayList<WindowFunction> newWindowFunctions = new ArrayList<>();
         for (Symbol outputToKeep : outputsToKeep) {
             SymbolVisitors.intersection(outputToKeep, windowFunctions, newWindowFunctions::add);
@@ -138,6 +139,7 @@ public class WindowAgg extends ForwardingLogicalPlan {
         return windowFunctions;
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public ExecutionPlan build(DependencyCarrier executor,
                                PlannerContext plannerContext,
@@ -154,7 +156,7 @@ public class WindowAgg extends ForwardingLogicalPlan {
         SubQueryAndParamBinder binder = new SubQueryAndParamBinder(params, subQueryResults);
         Function<Symbol, Symbol> toInputCols = binder.andThen(s -> InputColumns.create(s, sourceSymbols));
 
-        List<WindowFunction> boundWindowFunctions = (List<WindowFunction>)(List) Lists2.map(windowFunctions, toInputCols);
+        List<WindowFunction> boundWindowFunctions = (List<WindowFunction>)(List<?>) Lists2.map(windowFunctions, toInputCols);
         List<Projection> projections = new ArrayList<>();
         WindowAggProjection windowAggProjection = new WindowAggProjection(
             windowDefinition.map(toInputCols),

--- a/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -23,7 +23,6 @@ package io.crate.planner.operators;
 
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.MemoryLimits.assertMaxBytesAllocated;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.List;
@@ -567,7 +566,6 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
         );
     }
 
-
     // tracks a bug: https://github.com/crate/crate/issues/13779
     @Test
     public void test_prune_outputs_on_group_hash_aggregate() {
@@ -594,6 +592,63 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
                   └ GroupHashAggregate[cast(a AS integer) AS ai, cast(i AS bigint) | avg(x)]
                     └ Collect[doc.t1 | [x, cast(a AS integer) AS ai, cast(i AS bigint)] | (a = '3')]
             """);
+    }
+
+    // tracks a bug: https://github.com/crate/crate/issues/14330
+    @Test
+    public void test_prune_outputs_on_group_hash_aggregate_with_limit() {
+        LogicalPlan plan = sqlExecutor.logicalPlan("""
+            SELECT a::int ai, avg(x), i::long FROM t1 WHERE a='1' GROUP BY 1,3
+            UNION
+            SELECT a::int ai, avg(x), i::long FROM t1 WHERE a='2' GROUP BY 1,3
+            UNION
+            SELECT a::int ai, avg(x), i::long FROM t1 WHERE a='3' GROUP BY 1,3
+            LIMIT 10
+            """);
+        assertThat(plan).isEqualTo(
+            """
+                LimitDistinct[10::bigint;0 | [ai, "avg(x)", "cast(i AS bigint)"]]
+                  └ Union[ai, "avg(x)", "cast(i AS bigint)"]
+                    ├ GroupHashAggregate[ai, "avg(x)", "cast(i AS bigint)"]
+                    │  └ Union[ai, "avg(x)", "cast(i AS bigint)"]
+                    │    ├ Eval[cast(a AS integer) AS ai, avg(x), cast(i AS bigint)]
+                    │    │  └ GroupHashAggregate[cast(a AS integer) AS ai, cast(i AS bigint) | avg(x)]
+                    │    │    └ Collect[doc.t1 | [x, cast(a AS integer) AS ai, cast(i AS bigint)] | (a = '1')]
+                    │    └ Eval[cast(a AS integer) AS ai, avg(x), cast(i AS bigint)]
+                    │      └ GroupHashAggregate[cast(a AS integer) AS ai, cast(i AS bigint) | avg(x)]
+                    │        └ Collect[doc.t1 | [x, cast(a AS integer) AS ai, cast(i AS bigint)] | (a = '2')]
+                    └ Eval[cast(a AS integer) AS ai, avg(x), cast(i AS bigint)]
+                      └ GroupHashAggregate[cast(a AS integer) AS ai, cast(i AS bigint) | avg(x)]
+                        └ Collect[doc.t1 | [x, cast(a AS integer) AS ai, cast(i AS bigint)] | (a = '3')]""");
+    }
+
+    @Test
+    public void test_prune_outputs_on_window_functions() {
+        LogicalPlan plan = sqlExecutor.logicalPlan("""
+            SELECT i, avgx FROM (SELECT a, avg(x) OVER(ORDER BY i) as avgx, i FROM t1) as vt
+            """);
+        assertThat(plan).isEqualTo(
+            """
+                Rename[i, avgx] AS vt
+                  └ Eval[i, avg(x) OVER (ORDER BY i ASC) AS avgx]
+                    └ WindowAgg[x, i, avg(x) OVER (ORDER BY i ASC)]
+                      └ Collect[doc.t1 | [x, i] | true]""");
+    }
+
+    @Test
+    public void test_prune_outputs_on_table_functions() {
+        LogicalPlan plan = sqlExecutor.logicalPlan("""
+            SELECT sumx, umaxx, minx, uavgx FROM(
+               SELECT min(x) as minx, unnest([min(x)]) as uminx, max(x) as maxx, unnest([max(x)]) as umaxx,
+                      avg(x) as avgx, unnest([avg(x)]) as uavgx, sum(x) as sumx, unnest([sum(x)]) as usumx from t1) as vt
+            """);
+        assertThat(plan).isEqualTo(
+            """
+                Rename[sumx, umaxx, minx, uavgx] AS vt
+                  └ Eval[sum(x) AS sumx, unnest(_array(max(x))) AS umaxx, min(x) AS minx, unnest(_array(avg(x))) AS uavgx]
+                    └ ProjectSet[unnest(_array(min(x))), unnest(_array(max(x))), unnest(_array(avg(x))), unnest(_array(sum(x))), sum(x), max(x), min(x), avg(x)]
+                      └ HashAggregate[min(x), max(x), avg(x), sum(x)]
+                        └ Collect[doc.t1 | [x] | true]""");
     }
 
     @Test


### PR DESCRIPTION
Use a LinkedHashSet to keep the order of outputs `toKeep` when pruning other unnecessary outputs. Otherwise we might end up with mixed up outputs, without an intermmediate `Eval`.

Fixes: #14330
Follows: #13784
