### PR TITLE
Fixed parsing of ``ARRAY`` literals in PostgreSQL ``simple`` query mode

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -220,3 +220,5 @@ Fixes
 
 - Added validation to prevent creation of invalid nested array columns via
   ``INSERT INTO`` and dynamic column policy.
+
+- Fixed parsing of ``ARRAY`` literals in PostgreSQL ``simple`` query mode.

--- a/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -31,6 +31,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.RandomAccess;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.jetbrains.annotations.Nullable;
@@ -250,6 +251,12 @@ class AstBuilder extends SqlBaseParserBaseVisitor<Node> {
     private static final String TABLE = "TABLE";
     private static final String VIEW = "VIEW";
 
+    @Nullable
+    private final Function<String, Expression> parseStringLiteral;
+
+    public AstBuilder(@Nullable Function<String, Expression> parseStringLiteral) {
+        this.parseStringLiteral = parseStringLiteral;
+    }
 
     @Override
     public Node visitSingleStatement(SqlBaseParser.SingleStatementContext context) {
@@ -2079,7 +2086,15 @@ class AstBuilder extends SqlBaseParserBaseVisitor<Node> {
     @Override
     public Node visitStringLiteral(SqlBaseParser.StringLiteralContext context) {
         if (context.STRING() != null) {
-            return new StringLiteral(unquote(context.STRING().getText()));
+            var text = unquote(context.STRING().getText());
+            if (parseStringLiteral != null) {
+                try {
+                    return parseStringLiteral.apply(text);
+                } catch (Exception e) {
+                    return new StringLiteral(text);
+                }
+            }
+            return new StringLiteral(text);
         }
         return visitDollarQuotedStringLiteral(context.dollarQuotedStringLiteral());
     }

--- a/libs/sql-parser/src/main/java/io/crate/sql/parser/SqlParser.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/parser/SqlParser.java
@@ -25,6 +25,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.function.Function;
 
 import org.antlr.v4.runtime.BaseErrorListener;
@@ -39,6 +40,7 @@ import org.antlr.v4.runtime.atn.PredictionMode;
 import org.antlr.v4.runtime.misc.Pair;
 import org.antlr.v4.runtime.misc.ParseCancellationException;
 import org.antlr.v4.runtime.tree.TerminalNodeImpl;
+import org.jetbrains.annotations.Nullable;
 
 import io.crate.sql.parser.antlr.v4.SqlBaseLexer;
 import io.crate.sql.parser.antlr.v4.SqlBaseParser;
@@ -74,16 +76,27 @@ public class SqlParser {
         return INSTANCE.generateStatement(sql);
     }
 
-    public static List<Statement> createStatements(String sql) {
-        return ((MultiStatement) INSTANCE.generateStatements(sql)).statements();
+
+    public static List<Statement> createStatementsForSimpleQuery(String sql, Function<String, Object> stringLiteralParser) {
+        return ((MultiStatement) INSTANCE.invokeParser(
+                "statements",
+                sql,
+                SqlBaseParser::statements,
+                str -> (Expression) INSTANCE.invokeParser(
+                        "parameterOrLiteral",
+                        String.format(Locale.ENGLISH, "%s", stringLiteralParser.apply(str)),
+                        SqlBaseParser::parameterOrLiteral,
+                        null
+                )
+        )).statements();
     }
 
     private Statement generateStatements(String sql) {
-        return (Statement) invokeParser("statements", sql, SqlBaseParser::statements);
+        return (Statement) invokeParser("statements", sql, SqlBaseParser::statements, null);
     }
 
     private Statement generateStatement(String sql) {
-        return (Statement) invokeParser("statement", sql, SqlBaseParser::singleStatement);
+        return (Statement) invokeParser("statement", sql, SqlBaseParser::singleStatement, null);
     }
 
     public static Expression createExpression(String expression) {
@@ -91,10 +104,13 @@ public class SqlParser {
     }
 
     private Expression generateExpression(String expression) {
-        return (Expression) invokeParser("expression", expression, SqlBaseParser::singleExpression);
+        return (Expression) invokeParser("expression", expression, SqlBaseParser::singleExpression, null);
     }
 
-    private Node invokeParser(String name, String sql, Function<SqlBaseParser, ParserRuleContext> parseFunction) {
+    private Node invokeParser(String name,
+                              String sql,
+                              Function<SqlBaseParser, ParserRuleContext> parseFunction,
+                              @Nullable Function<String, Expression> parseStringLiteral) {
         try {
             SqlBaseLexer lexer = new SqlBaseLexer(new CaseInsensitiveStream(CharStreams.fromString(sql, name)));
             CommonTokenStream tokenStream = new CommonTokenStream(lexer);
@@ -123,7 +139,7 @@ public class SqlParser {
                 tree = parseFunction.apply(parser);
             }
 
-            return new AstBuilder().visit(tree);
+            return new AstBuilder(parseStringLiteral).visit(tree);
         } catch (StackOverflowError e) {
             throw new ParsingException(name + " is too large (stack overflow while parsing)");
         }

--- a/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -100,21 +100,21 @@ public class TestStatementBuilder {
 
     @Test
     public void testMultipleStatements() {
-        List<Statement> statements = SqlParser.createStatements("BEGIN; END;");
+        List<Statement> statements = SqlParser.createStatementsForSimpleQuery("BEGIN; END;", str -> str);
         assertThat(statements).hasSize(2);
         assertThat(statements.get(0)).isExactlyInstanceOf(BeginStatement.class);
         assertThat(statements.get(1)).isExactlyInstanceOf(CommitStatement.class);
 
-        statements = SqlParser.createStatements("BEGIN; END");
+        statements = SqlParser.createStatementsForSimpleQuery("BEGIN; END", str -> str);
         assertThat(statements).hasSize(2);
         assertThat(statements.get(0)).isExactlyInstanceOf(BeginStatement.class);
         assertThat(statements.get(1)).isExactlyInstanceOf(CommitStatement.class);
 
-        statements = SqlParser.createStatements("BEGIN");
+        statements = SqlParser.createStatementsForSimpleQuery("BEGIN", str -> str);
         assertThat(statements).hasSize(1);
         assertThat(statements.get(0)).isExactlyInstanceOf(BeginStatement.class);
 
-        statements = SqlParser.createStatements("SET extra_float_digits = 3");
+        statements = SqlParser.createStatementsForSimpleQuery("SET extra_float_digits = 3", str -> str);
         assertThat(statements).hasSize(1);
         assertThat(statements.get(0)).isExactlyInstanceOf(SetStatement.class);
     }

--- a/server/src/test/java/io/crate/integrationtests/PostgresITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PostgresITest.java
@@ -1137,6 +1137,31 @@ public class PostgresITest extends IntegTestCase {
         }
     }
 
+    @Test
+    public void test_insert_array_in_simple_query_mode() throws Exception {
+        var properties = new Properties();
+        properties.setProperty("user", "crate");
+        properties.setProperty("preferQueryMode", "simple");
+        try (Connection conn = DriverManager.getConnection(url(RW), properties)) {
+            conn.createStatement().executeUpdate(
+                    "CREATE TABLE t (" +
+                    "   ints array(int)) " +
+                    "WITH (number_of_replicas = 0)");
+
+            PreparedStatement preparedStatement = conn.prepareStatement(
+                    "INSERT INTO t (ints) VALUES (?)");
+            preparedStatement.setArray(1, conn.createArrayOf("int", new Integer[]{1, 2}));
+            preparedStatement.executeUpdate();
+            conn.createStatement().execute("REFRESH TABLE t");
+
+            ResultSet resultSet = conn.createStatement().executeQuery("SELECT ints FROM t");
+            assertThat(resultSet.next()).isTrue();
+            assertThat(resultSet.getArray(1).getArray()).isEqualTo(new Integer[]{1, 2});
+        } catch (BatchUpdateException e) {
+            throw e.getNextException();
+        }
+
+    }
 
     private long getNumQueriesFromJobsLogs() {
         long result = 0;


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

When using the `simple` query mode with the pg protocol, array literals are passed to the server as string literals, e.g. `'{"1", "2"}'`. This commit adds special logic for the simple query mode, it tries to parse any string literal using `PGArrayParser` first.



## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
