### PR TITLE
Support nested arrays in TableElementsAnalyzer

### DIFF
--- a/server/src/main/java/io/crate/planner/node/ddl/AlterTableAddColumnPlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/AlterTableAddColumnPlan.java
@@ -90,14 +90,13 @@ public class AlterTableAddColumnPlan implements Plan {
      * collectReferences is called with bound = true meaning that it expects analyzer, geo properties to be resolved at this point.
      */
     public static AddColumnRequest createRequest(AnalyzedTableElements<Object> tableElements, RelationName relationName) {
-
         LinkedHashMap<ColumnIdent, Reference> references = new LinkedHashMap<>();
         IntArrayList pKeysIndices = new IntArrayList();
         tableElements.collectReferences(relationName, references, pKeysIndices, true);
 
         return new AddColumnRequest(
             relationName,
-            new ArrayList<>(references.values()), // We don't use Map in the request itself since we need directly indexed structure referred by pKeysIndices.
+            new ArrayList<>(references.values()),
             tableElements.getCheckConstraints(),
             pKeysIndices
         );

--- a/server/src/test/java/io/crate/analyze/AlterTableAddColumnAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/AlterTableAddColumnAnalyzerTest.java
@@ -22,15 +22,16 @@
 package io.crate.analyze;
 
 import static io.crate.planner.node.ddl.AlterTableAddColumnPlan.validate;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.carrotsearch.hppc.cursors.IntCursor;
-
 import org.junit.Test;
+
+import com.carrotsearch.hppc.cursors.IntCursor;
 
 import io.crate.data.Row;
 import io.crate.planner.PlannerContext;
@@ -40,8 +41,6 @@ import io.crate.sql.parser.ParsingException;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.types.DataTypes;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class AlterTableAddColumnAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
@@ -131,7 +130,7 @@ public class AlterTableAddColumnAnalyzerTest extends CrateDummyClusterServiceUni
 
         assertThatThrownBy(() -> analyze("alter table users add column newpk array(string) primary key"))
             .isExactlyInstanceOf(UnsupportedOperationException.class)
-            .hasMessage("Cannot use columns of type \"array\" as primary key");
+            .hasMessage("Cannot use columns of type \"text_array\" as primary key");
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
@@ -30,6 +30,7 @@ import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.CONFLICT;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
@@ -206,9 +207,9 @@ public class DDLIntegrationTest extends IntegTestCase {
             "\"_meta\":{}," +
             "\"properties\":{" +
             "\"col1\":{\"type\":\"keyword\",\"position\":2,\"default_expr\":\"'foo'\"}," +
-            "\"col2\":{\"type\":\"array\",\"inner\":{\"type\":\"integer\",\"position\":3,\"default_expr\":\"_cast([1, 2], 'array(integer)')\"}}," +
+            "\"col2\":{\"type\":\"array\",\"inner\":{\"type\":\"integer\",\"position\":3,\"default_expr\":\"[1, 2]\"}}," +
             "\"id\":{\"type\":\"integer\",\"position\":1}}}}";
-        assertEquals(expectedMapping, getIndexMapping("test"));
+        assertThat(getIndexMapping("test")).isEqualTo(expectedMapping);
         execute("insert into test(id) values(1)");
         execute("refresh table test");
         execute("select id, col1, col2 from test");


### PR DESCRIPTION
Removes the `collectionType` indicator and instead re-uses the
`DataTypeAnalyzer` to convert a `ColumnType` into a `DataType`

This doesn't yet enable nested array type support, there is still a
limitation in the `ArrayTypeParser`

--- 

Not sure if this is still good to go during feature freeze. It is maybe gray area but I consider it more as a cleanup as it doesn't yet enable a new feature.