### PR TITLE
Use original query for `jobs_log` instead of formatted stmt.

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -222,3 +222,7 @@ Fixes
   ``INSERT INTO`` and dynamic column policy.
 
 - Fixed parsing of ``ARRAY`` literals in PostgreSQL ``simple`` query mode.
+
+- Fixed value of ``sys.jobs_log.stmt`` for various statements when issued via
+  the PostgreSQL ``simple`` query mode by using the original query string
+  instead of the statements string representation.

--- a/server/src/test/java/io/crate/integrationtests/PostgresITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PostgresITest.java
@@ -1160,7 +1160,23 @@ public class PostgresITest extends IntegTestCase {
         } catch (BatchUpdateException e) {
             throw e.getNextException();
         }
+    }
 
+    @Test
+    public void test_original_query_appears_in_jobs_log() throws Exception {
+        var properties = new Properties();
+        properties.setProperty("user", "crate");
+        properties.setProperty("preferQueryMode", "simple");
+        try (Connection conn = DriverManager.getConnection(url(RW), properties)) {
+            var stmt = "SET timezone = 'Europe/Berlin'";
+            conn.createStatement().execute(stmt);
+
+            ResultSet resultSet = conn.createStatement().executeQuery("SELECT stmt FROM sys.jobs_log ORDER BY ended DESC LIMIT 1");
+            assertThat(resultSet.next()).isTrue();
+            assertThat(resultSet.getString(1)).isEqualTo(stmt);
+        } catch (BatchUpdateException e) {
+            throw e.getNextException();
+        }
     }
 
     private long getNumQueriesFromJobsLogs() {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We want to log the original query string provided into the `sys.jobs_log.stmt` column instead of formatting the SQL based on the parsed statement. This will also fix issues with various statements which aren't supported by the SqlFormatter.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
