### PR TITLE
Add storage class setting to S3 repository 

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -210,6 +210,9 @@ Administration and Operations
   has been lowered from `HIGH` to `MEDIUM` as leaving these to default
   or suboptimal values does not translate into data corruption or loss.
 
+- Added the ability to set a 
+  :ref:`storage_class <sql-create-repo-s3-storage_class>` for S3 repositories.
+
 
 Fixes
 =====

--- a/docs/sql/statements/create-repository.rst
+++ b/docs/sql/statements/create-repository.rst
@@ -378,6 +378,15 @@ Parameters
   When CrateDB creates new buckets and objects, the specified `Canned ACL`_ is
   added.
 
+.. _sql-create-repo-s3-storage_class:
+
+**storage_class**
+  | *Type:*    ``text``
+  | *Values:*  ``standard``, ``reduced_redundancy`` or ``standard_ia``
+  | *Default:* ``standard``
+
+  The S3 storage class used for objects stored in the repository. This only 
+  affects the S3 storage class used for newly created objects in the repository.
 
 .. _sql-create-repo-azure:
 

--- a/plugins/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
+++ b/plugins/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
@@ -84,7 +84,8 @@ public class S3Repository extends BlobStoreRepository {
                        PROTOCOL_SETTING,
                        MAX_RETRIES_SETTING,
                        USE_THROTTLE_RETRIES_SETTING,
-                       READONLY_SETTING);
+                       READONLY_SETTING,
+                       STORAGE_CLASS_SETTING);
     }
 
     private final S3Service service;

--- a/plugins/es-repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3RepositoryPluginAnalyzerTest.java
+++ b/plugins/es-repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3RepositoryPluginAnalyzerTest.java
@@ -115,6 +115,7 @@ public class S3RepositoryPluginAnalyzerTest extends CrateDummyClusterServiceUnit
         properties.put("protocol", new StringLiteral("http"));
         properties.put("secret_key", new StringLiteral("thisIsASecretKey"));
         properties.put("server_side_encryption", new StringLiteral("false"));
+        properties.put("storage_class", new StringLiteral("standard_ia"));
         GenericProperties<Expression> genericProperties = new GenericProperties<>(properties);
         repositoryParamValidator.validate(
             "s3",
@@ -149,7 +150,8 @@ public class S3RepositoryPluginAnalyzerTest extends CrateDummyClusterServiceUnit
             "   max_retries=2," +
             "   use_throttle_retries=false," +
             "   readonly=false, " +
-            "   canned_acl=false)");
+            "   canned_acl=false, " +
+            "   storage_class='standard_ia')");
         assertThat(request.name()).isEqualTo("foo");
         assertThat(request.type()).isEqualTo("s3");
         assertThat(request.settings().getAsStructuredMap())
@@ -166,7 +168,8 @@ public class S3RepositoryPluginAnalyzerTest extends CrateDummyClusterServiceUnit
                 .hasFieldOrPropertyWithValue("protocol", "http")
                 .hasFieldOrPropertyWithValue("secret_key", "0xCAFEE")
                 .hasFieldOrPropertyWithValue("server_side_encryption", "false")
-                .hasFieldOrPropertyWithValue("readonly", "false");
+                .hasFieldOrPropertyWithValue("readonly", "false")
+                .hasFieldOrPropertyWithValue("storage_class", "standard_ia");
     }
 
     private static Settings toSettings(GenericProperties<Expression> genericProperties) {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Added the ability to set a `storage_class`  for S3 repositories.
Since the implementation was already part of the forked S3 plugin, only the ability to set it was added.

S3 Plugin Tests covering storage class setting:
- https://github.com/crate/crate/blob/2c09fef429a2de2f8531526f1db4a8c0e3895937/plugins/es-repository-s3/src/test/java/org/elasticsearch/repositories/s3/
- https://github.com/crate/crate/blob/2c09fef429a2de2f8531526f1db4a8c0e3895937/plugins/es-repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3BlobStoreTests.java#L82C15-L108


closes https://github.com/crate/crate/issues/14298

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
