### PR TITLE
Mark 5.3.0-5.3.2 as broken, add more details and advises to the 5.3.3 fix release notes entry

### DIFF
--- a/docs/appendices/release-notes/5.3.0.rst
+++ b/docs/appendices/release-notes/5.3.0.rst
@@ -6,6 +6,15 @@ Version 5.3.0
 
 Released on 2023-04-04.
 
+.. WARNING::
+
+    CrateDB 5.3.x versions up to :ref:`5.3.3 <version_5.3.3>` (excluding)
+    contain a critical bug which can lead to data corruption/loss when using
+    a column definition with a number data type and disabled index
+    (``INDEX OFF``).
+    It is not recommended to use those versions, use CrateDB >=
+    :ref:`5.3.3 <version_5.3.3>` instead.
+
 .. NOTE::
 
     If you are upgrading a cluster, you must be running CrateDB 4.0.2 or higher

--- a/docs/appendices/release-notes/5.3.1.rst
+++ b/docs/appendices/release-notes/5.3.1.rst
@@ -6,6 +6,15 @@ Version 5.3.1
 
 Released on 2023-04-28.
 
+.. WARNING::
+
+    CrateDB 5.3.x versions up to :ref:`5.3.3 <version_5.3.3>` (excluding)
+    contain a critical bug which can lead to data corruption/loss when using
+    a column definition with a number data type and disabled index
+    (``INDEX OFF``).
+    It is not recommended to use those versions, use CrateDB >=
+    :ref:`5.3.3 <version_5.3.3>` instead.
+
 .. NOTE::
 
     If you are upgrading a cluster, you must be running CrateDB 4.0.2 or higher

--- a/docs/appendices/release-notes/5.3.2.rst
+++ b/docs/appendices/release-notes/5.3.2.rst
@@ -6,6 +6,15 @@ Version 5.3.2
 
 Released on 2023-05-24.
 
+.. WARNING::
+
+    CrateDB 5.3.x versions up to :ref:`5.3.3 <version_5.3.3>` (excluding)
+    contain a critical bug which can lead to data corruption/loss when using
+    a column definition with a number data type and disabled index
+    (``INDEX OFF``).
+    It is not recommended to use those versions, use CrateDB >=
+    :ref:`5.3.3 <version_5.3.3>` instead.
+
 .. NOTE::
 
     If you are upgrading a cluster, you must be running CrateDB 4.0.2 or higher

--- a/docs/appendices/release-notes/5.3.3.rst
+++ b/docs/appendices/release-notes/5.3.3.rst
@@ -39,6 +39,16 @@ See the :ref:`version_5.3.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue introduced with CrateDB ``5.3.0`` resulting in failing writes,
+  broken replica shards, or even un-recoverable tables on tables using a
+  column definition with a number data type and an explicit ``INDEX OFF``.
+  Any table that was created with ``INDEX OFF`` on a number column and already
+  written to with CrateDB version >= ``5.3.0`` should be recreated using e.g.
+  :ref:`INSERT INTO new_table SELECT * FROM old_table<dml-inserting-by-query>`
+  (followed by swap table
+  :ref:`ALTER CLUSTER SWAP TABLE new_table TO old_table<alter_cluster_swap_table>`)
+  or :ref:`restored from a backup<sql-restore-snapshot>`.
+
 - Fixed a regression introduced in 4.7.0 which caused aggregations used in
   ``INSERT INTO`` statements returning null instead of the aggregation result.
 
@@ -77,7 +87,3 @@ Fixes
 - Fixed an issue which caused ``INSERT INTO`` statements
   to skip generated column validation for sub-columns if provided value is
   ``NULL``.
-
-- Fixed an issue introduced with CrateDB ``5.3.0`` resulting in failing writes
-  and/or broken replica shards when ingesting into a table using a number type
-  column with explicit turned off indexing by declaring ``INDEX OFF``.


### PR DESCRIPTION

- Add warning to 5.3.0, 5.3.1 and 5.3.2 release notes to not use it caused by the `INDEX OFF` broken index issue fixed with 5.3.3.
- Add more details about the affected scenarios of the issue fixed by https://github.com/crate/crate/commit/26accaf832d and advises on what to do once affected.
