### PR TITLE
Disallow CHECK constraints for object sub-cols at column level

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -218,6 +218,10 @@ Fixes
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
 
+- Improved error message to be user-friendly, for definition of
+  :ref:`CHECK <check_constraint>` at column level for object sub-columns,
+  instead of a ``ConversionException``.
+
 - Added validation to prevent creation of invalid nested array columns via
   ``INSERT INTO`` and dynamic column policy.
 

--- a/docs/sql/general/constraints.rst
+++ b/docs/sql/general/constraints.rst
@@ -133,6 +133,22 @@ Multiple columns can be referenced::
    the ``CHECK`` constraint. That would cause a subsequent database dump and
    reload to fail.
 
+.. NOTE::
+
+   ``CHECK`` constraints cannot be added at "sub-column level" for object
+   sub-columns, e.g.::
+
+     CREATE TABLE t(o OBJECT AS (oi INTEGER CHECK (oi > 10)))
+
+   but they can be added at "table level", e.g.::
+
+     CREATE TABLE t(o OBJECT AS (oi INTEGER), CHECK (o['oi'] > 100))
+
+   or at the "root level" of the object column, e.g.::
+
+     CREATE TABLE t(o OBJECT AS (oi INTEGER) CHECK (o['oi'] > 100))
+
+
 .. hide:
 
    cr> drop table metrics1;

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/ObjectColumnType.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/ObjectColumnType.java
@@ -56,6 +56,8 @@ public class ObjectColumnType<T> extends ColumnType<T> {
 
     @Override
     public <U> ObjectColumnType<U> map(Function<? super T, ? extends U> mapper) {
+        checkNestedColumnConstraints(nestedColumns);
+
         String objectTypeString = null;
         if (columnPolicy.isPresent()) {
             objectTypeString = columnPolicy.get().lowerCaseName();
@@ -64,6 +66,16 @@ public class ObjectColumnType<T> extends ColumnType<T> {
             objectTypeString,
             Lists2.map(nestedColumns, x -> x.map(mapper))
         );
+    }
+
+    private void checkNestedColumnConstraints(List<ColumnDefinition<T>> nestedColumns) {
+        for (var nestedColumn : nestedColumns) {
+            for (var constraint : nestedColumn.constraints()) {
+                if (constraint instanceof CheckColumnConstraint<T>) {
+                    throw new UnsupportedOperationException("Constraints on nested columns are not allowed");
+                }
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
CHECK constraint at column level was never actually supported neither for `CREATE` nor for `ALTER TABLE t ADD COLUMN`, since it's introduction with CrateDB `4.2.0`. There has been a fix for https://github.com/crate/crate/issues/12936 but with this, it's only `string/text` columns. The issue relies in the 1st pass of analysis for those statements, where the fields of check constraint expression as converted to string literals, and then an implicit cast (e.g. `_cast('b', integer)` is automatically introduced to support the check expression, which in turn fails during normalization as `'b'` is understood as literal, not as a col.

Prevent the definition of such CHECK constraints for object sub-cols at column level, for the time being, and throw a user friendly error message.

Fixes: #14341
