### PR TITLE
Change column policy for the test, verifying dynamic array creation

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
@@ -556,7 +556,7 @@ public class CopyIntegrationTest extends SQLHttpIntegrationTest {
     public void testCopyFromNestedArrayRow() throws Exception {
         // assert that rows with nested arrays aren't imported
         execute("create table users (id int, " +
-            "name string) with (number_of_replicas=0)");
+            "name string) with (number_of_replicas=0, column_policy = 'dynamic')");
         execute("copy users from ? with (shared=true)", new Object[]{
             nestedArrayCopyFilePath + "nested_array_copy_from.json"});
         assertEquals(1L, response.rowCount()); // only 1 document got inserted


### PR DESCRIPTION
`testCopyFromNestedArrayRow` was added in https://github.com/crate/crate/commit/959aba59c5a040c3436347f9c57227ca3355a222 to test dynamic array creation, back then column policy was dynamic by default.

Then we changed column policy to strict in
https://github.com/crate/crate/commit/e80cd3c9af630508816372043bdc9bd6edf81ab7

Now test passes but it doesn't test what is supposed to: Currently record rejected with
`mapping set to strict, dynamic introduction of [nested] within users is not allowed`

After the patch it's rejected with `"Nested arrays are not supported"`

Since https://github.com/crate/crate/issues/14251 is fixed, with this patch will be able to unmute `testCopyFromNestedArrayRow` in _raw optimization removal PR.