### PR TITLE
Ensure that CLUSTERED BY column is not NULL on insert-from-subquery

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -256,3 +256,6 @@ Fixes
 - Fixed an issue which prevented ``INSERT INTO ... SELECT ...`` from inserting
   any records if the target table had a partitioned column of a non-string
   type, used in any expressions of ``GENERATED`` or ``CHECK`` definitions.
+
+- Fixed an issue which caused ``INSERT INTO ... SELECT ...`` statements to
+  skip ``NULL`` checks of ``CLUSTERED BY`` column values.

--- a/server/src/main/java/io/crate/execution/engine/collect/RowShardResolver.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/RowShardResolver.java
@@ -93,7 +93,12 @@ public class RowShardResolver {
         if (routingInput == null) {
             routing = null;
         } else {
-            routing = nullOrString(routingInput.value());
+            // If clustered by column is specified it cannot be null.
+            var clusteredBy = routingInput.value();
+            if (clusteredBy == null) {
+                throw new IllegalArgumentException("Clustered by value must not be NULL");
+            }
+            routing = clusteredBy.toString();
         }
     }
 

--- a/server/src/main/java/io/crate/execution/engine/indexing/GroupRowsByShard.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/GroupRowsByShard.java
@@ -26,10 +26,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.RandomAccess;
 import java.util.function.BiConsumer;
-import java.util.function.BiFunction;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
+
+import org.elasticsearch.common.TriFunction;
 import org.jetbrains.annotations.Nullable;
 
 import org.apache.logging.log4j.LogManager;
@@ -48,7 +49,7 @@ import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.execution.engine.collect.RowShardResolver;
 
 public final class GroupRowsByShard<TReq extends ShardRequest<TReq, TItem>, TItem extends ShardRequest.Item>
-    implements BiFunction<ShardedRequests<TReq, TItem>, Row, TItem>,
+    implements TriFunction<ShardedRequests<TReq, TItem>, Row, Boolean, TItem>,
                BiConsumer<ShardedRequests<TReq, TItem>, Row> {
 
     private static final Logger LOGGER = LogManager.getLogger(GroupRowsByShard.class);
@@ -105,13 +106,16 @@ public final class GroupRowsByShard<TReq extends ShardRequest<TReq, TItem>, TIte
              UpsertResultContext.forRowCount());
     }
 
+    /**
+     * BiConsumer is needed for compatibility of the grouper with BatchIterators.partition
+     */
     @Override
     public void accept(ShardedRequests<TReq, TItem> shardedRequests, Row row) {
-        apply(shardedRequests, row);
+        apply(shardedRequests, row, false);
     }
 
     @Override
-    public TItem apply(ShardedRequests<TReq, TItem> shardedRequests, Row row) {
+    public TItem apply(ShardedRequests<TReq, TItem> shardedRequests, Row row, Boolean propagateError) {
         // `Row` can be a `InputRow` which may be backed by expressions which have expensive `.value()` implementations
         // The code below (RowShardResolver.setNextRow, and estimateRowSize)
         // would lead to multiple `.value()` calls on the same underlying instance
@@ -167,6 +171,9 @@ public final class GroupRowsByShard<TReq extends ShardRequest<TReq, TItem>, TIte
         } catch (CircuitBreakingException e) {
             throw e;
         } catch (Throwable t) {
+            if (propagateError) {
+                throw t;
+            }
             itemFailureRecorder.accept(shardedRequests, t.getMessage());
             return null;
         }

--- a/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
+++ b/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
@@ -256,11 +256,10 @@ public class InsertFromValues implements LogicalPlan {
         var shardedRequests = new ShardedRequests<>(builder::newRequest, RamAccounting.NO_ACCOUNTING);
         HashMap<String, Consumer<IndexItem>> validatorsCache = new HashMap<>();
         for (Row row : rows) {
-            Item item = grouper.apply(shardedRequests, row);
+            Item item = grouper.apply(shardedRequests, row, true);
 
             try {
-                checkPrimaryKeyValuesNotNull(primaryKeyInputs);
-                checkClusterByValueNotNull(clusterByInput);
+                // Primary Key and CLUSTERED BY check is already done in grouper -> RowShardResolver, both cannot be null.
                 checkConstraintsOnGeneratedSource(
                     item,
                     indexNameResolver.get(),
@@ -403,10 +402,9 @@ public class InsertFromValues implements LogicalPlan {
 
                 while (rows.hasNext()) {
                     Row row = rows.next();
-                    Item item = grouper.apply(shardedRequests, row);
+                    Item item = grouper.apply(shardedRequests, row, true);
 
-                    checkPrimaryKeyValuesNotNull(primaryKeyInputs);
-                    checkClusterByValueNotNull(clusterByInput);
+                    // Primary Key and CLUSTERED BY check is already done in grouper -> RowShardResolver, both cannot be null.
                     checkConstraintsOnGeneratedSource(
                         item,
                         indexNameResolver.get(),
@@ -486,20 +484,6 @@ public class InsertFromValues implements LogicalPlan {
             itemFactory,
             true
         );
-    }
-
-    private static void checkPrimaryKeyValuesNotNull(ArrayList<Input<?>> primaryKeyInputs) {
-        for (var primaryKey : primaryKeyInputs) {
-            if (primaryKey.value() == null) {
-                throw new IllegalArgumentException("Primary key value must not be NULL");
-            }
-        }
-    }
-
-    private static void checkClusterByValueNotNull(@Nullable Input<?> clusterByInput) {
-        if (clusterByInput != null && clusterByInput.value() == null) {
-            throw new IllegalArgumentException("Clustered by value must not be NULL");
-        }
     }
 
     private void checkConstraintsOnGeneratedSource(@Nullable IndexItem indexItem,


### PR DESCRIPTION
Separate fix for one of the bugs reported in https://github.com/crate/crate/pull/14317/files#diff-6b4ff31a02425d333cc54423875ca7ab94432d3399bd0d6b45797763cbb5dcd7R247-R259

Since we are doing this check before creating a partition, even if we have a `partitioned by` column along with `clustered by` one, partition won't be created.

Same issue on 5.2.8, not a regression in 5.3