### PR TITLE
Fix fields used in IP value indexer when indexing is turned off

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -219,7 +219,7 @@ Administration and Operations
   has been lowered from `HIGH` to `MEDIUM` as leaving these to default
   or suboptimal values does not translate into data corruption or loss.
 
-- Added the ability to set a 
+- Added the ability to set a
   :ref:`storage_class <sql-create-repo-s3-storage_class>` for S3 repositories.
 
 
@@ -229,6 +229,16 @@ Fixes
 .. If you add an entry here, the fix needs to be backported to the latest
 .. stable branch. You can add a version label (`v/X.Y`) to the pull request for
 .. an automated mergify backport.
+
+- Fixed an issue introduced with CrateDB ``5.3.0`` resulting in failing writes,
+  broken replica shards, or even un-recoverable tables on tables using a
+  column definition with a ``IP`` data type and an explicit ``INDEX OFF``.
+  Any table that was created with ``INDEX OFF`` on a ``IP`` column and already
+  written to with CrateDB version >= ``5.3.0`` should be recreated using e.g.
+  :ref:`INSERT INTO new_table SELECT * FROM old_table<dml-inserting-by-query>`
+  (followed by swap table
+  :ref:`ALTER CLUSTER SWAP TABLE new_table TO old_table<alter_cluster_swap_table>`)
+  or :ref:`restored from a backup<sql-restore-snapshot>`.
 
 - Improved error message to be user-friendly, for definition of
   :ref:`CHECK <check_constraint>` at column level for object sub-columns,

--- a/server/src/main/java/io/crate/execution/dml/IpIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/IpIndexer.java
@@ -40,6 +40,7 @@ import org.elasticsearch.index.mapper.FieldNamesFieldMapper;
 import io.crate.execution.dml.Indexer.ColumnConstraint;
 import io.crate.execution.dml.Indexer.Synthetic;
 import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.IndexType;
 import io.crate.metadata.Reference;
 
 public class IpIndexer implements ValueIndexer<String> {
@@ -63,7 +64,9 @@ public class IpIndexer implements ValueIndexer<String> {
                            Map<ColumnIdent, ColumnConstraint> toValidate) throws IOException {
         xContentBuilder.value(value);
         InetAddress address = InetAddresses.forString(value);
-        addField.accept(new InetAddressPoint(name, address));
+        if (ref.indexType() != IndexType.NONE) {
+            addField.accept(new InetAddressPoint(name, address));
+        }
         if (ref.hasDocValues()) {
             addField.accept(new SortedSetDocValuesField(name, new BytesRef(InetAddressPoint.encode(address))));
         } else {


### PR DESCRIPTION
If the fields do not align with the ones used inside the `IpFieldMapper`, recovery from translog may fail (when writing into existing segments) as in this case, the `IpFieldMapper` is used.

Follow up of https://github.com/crate/crate/commit/26accaf.

