### PR TITLE
Fix `index` and `hasDocValues` propagation in BitStringFieldmapper

### DIFF
--- a/docs/appendices/release-notes/unreleased.rst
+++ b/docs/appendices/release-notes/unreleased.rst
@@ -269,3 +269,6 @@ Fixes
 
 - Fixed an issue which caused ``INSERT INTO ... SELECT ...`` statements to
   skip ``NULL`` checks of ``CLUSTERED BY`` column values.
+
+- Fixed an issue that resulted in enabled indexing for columns defined as
+  the `BIT` data type even when explicitly turning it of using ``INDEX OFF``.

--- a/server/src/main/java/io/crate/execution/dml/BitStringIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/BitStringIndexer.java
@@ -39,6 +39,7 @@ import org.elasticsearch.index.mapper.FieldNamesFieldMapper;
 import io.crate.execution.dml.Indexer.ColumnConstraint;
 import io.crate.execution.dml.Indexer.Synthetic;
 import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.IndexType;
 import io.crate.metadata.Reference;
 import io.crate.sql.tree.BitString;
 
@@ -68,7 +69,9 @@ public class BitStringIndexer implements ValueIndexer<BitString> {
         xcontentBuilder.value(bytes);
 
         BytesRef binaryValue = new BytesRef(bytes);
-        addField.accept(new Field(name, binaryValue, fieldType));
+        if (ref.indexType() != IndexType.NONE) {
+            addField.accept(new Field(name, binaryValue, fieldType));
+        }
 
         if (ref.hasDocValues()) {
             addField.accept(new SortedSetDocValuesField(name, binaryValue));

--- a/server/src/main/java/org/elasticsearch/index/mapper/BitStringFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BitStringFieldMapper.java
@@ -105,7 +105,7 @@ public class BitStringFieldMapper extends FieldMapper {
                 length,
                 defaultExpression,
                 fieldType,
-                new BitStringFieldType(buildFullName(context), true, true),
+                new BitStringFieldType(buildFullName(context), indexed, hasDocValues),
                 copyTo);
             context.putPositionInfo(mapper, position);
             return mapper;

--- a/server/src/test/java/io/crate/execution/dml/IndexerTest.java
+++ b/server/src/test/java/io/crate/execution/dml/IndexerTest.java
@@ -72,6 +72,7 @@ import io.crate.metadata.RowGranularity;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.doc.DocTableInfoFactory;
 import io.crate.server.xcontent.XContentHelper;
+import io.crate.sql.tree.BitString;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.DataTypeTesting;
 import io.crate.testing.IndexEnv;
@@ -1000,6 +1001,45 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
                     .startObject("x")
                         .field("type", DataTypes.esMappingNameFrom(dt.id()))
                         .field("index", false)
+                    .endObject()
+                .endObject()
+            .endObject());
+
+        var indexName = e.resolveTableInfo(tableName).ident().indexNameOrAlias();
+        DocumentMapper mapper = mapper(indexName, mapping);
+        ParsedDocument docFromSource = mapper.parse(
+                new SourceToParse(indexName, "dummy-id-1", doc.source(), XContentType.JSON)
+        );
+        IndexableField[] fieldsFromSource = docFromSource.doc().getFields("x");
+
+        assertThat(fields.length).isEqualTo(fieldsFromSource.length);
+        for (int i = 0; i < fields.length; i++) {
+            assertThat(fields[i].toString()).isEqualTo(fieldsFromSource[i].toString());
+        }
+    }
+
+    @Test
+    public void test_indexing_bitstring_results_in_same_fields_as_document_mapper_if_not_indexed() throws Exception {
+        var idx = 0;
+        var tableName = "tbl";
+        var dt = BitStringType.INSTANCE_ONE;
+        SQLExecutor e = SQLExecutor.builder(clusterService)
+                .addTable("create table " + tableName + " (x " + dt.getName() + "(1) INDEX OFF)")
+                .build();
+
+        Indexer indexer = getIndexer(e, tableName, NumberFieldMapper.FIELD_TYPE, "x");
+
+        ParsedDocument doc = indexer.index(item(BitString.ofRawBits("1")));
+        IndexableField[] fields = doc.doc().getFields("x");
+
+        // @formatter: off
+        String mapping = Strings.toString(JsonXContent.builder()
+            .startObject()
+                .startObject("properties")
+                    .startObject("x")
+                        .field("type", DataTypes.esMappingNameFrom(dt.id()))
+                        .field("index", false)
+                        .field("length", 1)
                     .endObject()
                 .endObject()
             .endObject());

--- a/server/src/test/java/org/elasticsearch/index/mapper/BitStringFieldMapperTest.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/BitStringFieldMapperTest.java
@@ -37,4 +37,26 @@ public class BitStringFieldMapperTest {
         BitStringFieldMapper mapper = builder.build(context);
         assertThat(mapper.name()).isEqualTo("o.x");
     }
+
+    @Test
+    public void test_indexed_value_is_applied() {
+        BitStringFieldMapper.Builder builder = new BitStringFieldMapper.Builder("x");
+        builder.index(false);
+        ContentPath contentPath = new ContentPath();
+        contentPath.add("o");
+        var context = new Mapper.BuilderContext(Settings.EMPTY, contentPath);
+        BitStringFieldMapper mapper = builder.build(context);
+        assertThat(mapper.mappedFieldType.isSearchable()).isFalse();
+    }
+
+    @Test
+    public void test_hasDocValues_value_is_applied() {
+        BitStringFieldMapper.Builder builder = new BitStringFieldMapper.Builder("x");
+        builder.docValues(false);
+        ContentPath contentPath = new ContentPath();
+        contentPath.add("o");
+        var context = new Mapper.BuilderContext(Settings.EMPTY, contentPath);
+        BitStringFieldMapper mapper = builder.build(context);
+        assertThat(mapper.mappedFieldType.hasDocValues()).isFalse();
+    }
 }


### PR DESCRIPTION
Both values were hardcoded to true, resulting in that the columns were always indexed even if explicit turned of by using ``INDEX OFF``
