### PR TITLE
Fix SQLParseException when querying unknown object keys from aliased tables

### DIFF
--- a/docs/appendices/release-notes/5.3.5.rst
+++ b/docs/appendices/release-notes/5.3.5.rst
@@ -81,7 +81,7 @@ Fixes
 - Fixed ``IndexOutOfBoundsException`` caused by an ``IS [NOT] NULL`` filter on
   a sub-column of an object or object array in a ``WHERE`` clause, e.g. ::
 
-    CREATE TALE test (o1 ARRAY(OBJECT AS (col INT)), o2 OBJECT);
+    CREATE TABLE test (o1 ARRAY(OBJECT AS (col INT)), o2 OBJECT);
     SELECT * FROM test WHERE o1[1]['col'] IS NULL;
     => IndexOutOfBoundsException[Index: 1 Size: 1]
     SELECT * FROM test AS T WHERE T.o2['unknown_col'] IS NOT NULL;
@@ -102,4 +102,13 @@ Fixes
   underlying tables/views. Also, added a comment to view definition in
   ``pg_catalog.pg_views`` and ``information_schema.views`` tables to denote
   that a ``VIEW``'s query is erroneous.
+
+- Fixed ``SQLParseException`` caused by querying an unknown key from an object
+  column of a table that is aliased and with the session setting
+  :ref:`error_on_unknown_object_key <conf-session-error_on_unknown_object_key>`,
+  set to ``false``, e.g. ::
+
+    CREATE TABLE test (o OBJECT);
+    SELECT T.o['unknown'] from (SELECT * FROM test) AS T;
+    => SQLParseException[Couldn't create execution plan from logical plan because of: Couldn't find o['unknown'] in SourceSymbols{inputs={}, nonDeterministicFunctions={}}
 

--- a/docs/appendices/release-notes/5.4.1.rst
+++ b/docs/appendices/release-notes/5.4.1.rst
@@ -81,7 +81,7 @@ Fixes
 - Fixed ``IndexOutOfBoundsException`` caused by an ``IS [NOT] NULL`` filter on
   a sub-column of an object or object array in a ``WHERE`` clause, e.g. ::
 
-    CREATE TALE test (o1 ARRAY(OBJECT AS (col INT)), o2 OBJECT);
+    CREATE TABLE test (o1 ARRAY(OBJECT AS (col INT)), o2 OBJECT);
     SELECT * FROM test WHERE o1[1]['col'] IS NULL;
     => IndexOutOfBoundsException[Index: 1 Size: 1]
     SELECT * FROM test AS T WHERE T.o2['unknown_col'] IS NOT NULL;
@@ -102,3 +102,13 @@ Fixes
   underlying tables/views. Also, added a comment to view definition in
   ``pg_catalog.pg_views`` and ``information_schema.views`` tables to denote
   that a ``VIEW``'s query is erroneous.
+
+- Fixed ``SQLParseException`` caused by querying an unknown key from an object
+  column of a table that is aliased and with the session setting
+  :ref:`error_on_unknown_object_key <conf-session-error_on_unknown_object_key>`,
+  set to ``false``, e.g. ::
+
+    CREATE TABLE test (o OBJECT);
+    SELECT T.o['unknown'] from (SELECT * FROM test) AS T;
+    => SQLParseException[Couldn't create execution plan from logical plan because of: Couldn't find o['unknown'] in SourceSymbols{inputs={}, nonDeterministicFunctions={}}
+

--- a/server/src/main/java/io/crate/analyze/relations/AliasedAnalyzedRelation.java
+++ b/server/src/main/java/io/crate/analyze/relations/AliasedAnalyzedRelation.java
@@ -28,6 +28,7 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
 import io.crate.expression.symbol.VoidReference;
 import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.table.Operation;
 
@@ -112,8 +113,15 @@ public class AliasedAnalyzedRelation implements AnalyzedRelation, FieldResolver 
             }
         }
         Symbol field = relation.getField(childColumnName, operation, errorOnUnknownObjectKey);
-        if (field == null || field instanceof VoidReference) {
-            return field;
+        if (field == null) {
+            return null;
+        }
+        if (field instanceof VoidReference voidReference) {
+            return new VoidReference(
+                new ReferenceIdent(alias, voidReference.column()),
+                voidReference.granularity(),
+                voidReference.columnPolicy(),
+                voidReference.position());
         }
         ScopedSymbol scopedSymbol = new ScopedSymbol(alias, column, field.valueType());
 

--- a/server/src/main/java/io/crate/expression/BaseImplementationSymbolVisitor.java
+++ b/server/src/main/java/io/crate/expression/BaseImplementationSymbolVisitor.java
@@ -33,6 +33,7 @@ import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitor;
+import io.crate.expression.symbol.VoidReference;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -89,6 +90,11 @@ public class BaseImplementationSymbolVisitor<C> extends SymbolVisitor<C, Input<?
     @Override
     public Input<?> visitAlias(AliasSymbol aliasSymbol, C context) {
         return aliasSymbol.symbol().accept(this, context);
+    }
+
+    @Override
+    public Input<?> visitVoidReference(VoidReference symbol, C context) {
+        return visitReference(symbol, context);
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/symbol/SymbolVisitor.java
+++ b/server/src/main/java/io/crate/expression/symbol/SymbolVisitor.java
@@ -42,6 +42,10 @@ public class SymbolVisitor<C, R> {
         return visitSymbol(symbol, context);
     }
 
+    public R visitVoidReference(VoidReference symbol, C context) {
+        return visitReference(symbol, context);
+    }
+
     public R visitFunction(Function symbol, C context) {
         return visitSymbol(symbol, context);
     }

--- a/server/src/main/java/io/crate/expression/symbol/SymbolVisitors.java
+++ b/server/src/main/java/io/crate/expression/symbol/SymbolVisitors.java
@@ -180,6 +180,12 @@ public class SymbolVisitors {
                     if (t instanceof Reference tRef && tRef.column().equals(root)) {
                         consumer.accept(t);
                         break;
+                    } else if (ref instanceof VoidReference
+                               && t instanceof ScopedSymbol tScopedSymbol
+                               && tScopedSymbol.relation().equals(ref.ident().tableIdent())
+                               && tScopedSymbol.column().equals(root)) {
+                        consumer.accept(t);
+                        break;
                     }
                 }
             }

--- a/server/src/main/java/io/crate/expression/symbol/VoidReference.java
+++ b/server/src/main/java/io/crate/expression/symbol/VoidReference.java
@@ -56,4 +56,9 @@ public class VoidReference extends DynamicReference {
     public SymbolType symbolType() {
         return SymbolType.VOID_REFERENCE;
     }
+
+    @Override
+    public <C, R> R accept(SymbolVisitor<C, R> visitor, C context) {
+        return visitor.visitVoidReference(this, context);
+    }
 }

--- a/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -83,6 +83,7 @@ import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolType;
 import io.crate.expression.symbol.Symbols;
+import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.FunctionType;
 import io.crate.metadata.PartitionName;
@@ -2979,5 +2980,16 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         analyzed = executor.analyze("select obj['unknown'] from (select obj from c1 union all select obj from c2) alias");
         assertThat(analyzed.outputs()).hasSize(1);
         assertThat(analyzed.outputs().get(0)).isFunction("subscript", isField("obj"), isLiteral("unknown"));
+    }
+
+    @Test
+    public void test_aliased_unknown_object_key() throws IOException {
+        var executor = SQLExecutor.builder(clusterService)
+            .addTable("create table t (o object)")
+            .build();
+        executor.getSessionSettings().setErrorOnUnknownObjectKey(false);
+        var analyzed = executor.analyze("select alias.o['unknown_key'] from (select * from t) alias");
+        assertThat(analyzed.outputs()).hasSize(1);
+        assertThat(analyzed.outputs().get(0)).isVoidReference(new ColumnIdent("o", "unknown_key"), new RelationName(null, "alias"));
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/ObjectColumnTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ObjectColumnTest.java
@@ -27,7 +27,7 @@ import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.HashMap;
@@ -37,6 +37,7 @@ import java.util.Map;
 import org.elasticsearch.test.IntegTestCase;
 import org.junit.Test;
 
+import io.crate.exceptions.ColumnUnknownException;
 import io.crate.testing.Asserts;
 import io.crate.testing.UseJdbc;
 import io.crate.testing.UseRandomizedOptimizerRules;
@@ -385,5 +386,23 @@ public class ObjectColumnTest extends IntegTestCase {
             "2| {key=d}| [{x=d}, null, {x=d, y=10}, {x=1, y=2}]| {x=d}",
             "3| {key=d}| NULL| {os=[{key=d}, null], x=d}"
         );
+    }
+
+    @Test
+    public void test_aliased_unknown_object_key() {
+        try (var session = sqlExecutor.newSession()) {
+            execute("create table test (o object)", session);
+            execute("insert into test values({a=1})", session);
+            refresh();
+
+            session.sessionSettings().setErrorOnUnknownObjectKey(true);
+            assertThatThrownBy(() -> execute("select T.o['unknown'] from (select * from test) T", session))
+                .isExactlyInstanceOf(ColumnUnknownException.class)
+                    .hasMessage("The object `{a=1}` does not contain the key `unknown`");
+
+            session.sessionSettings().setErrorOnUnknownObjectKey(false);
+            execute("select T.o['unknown'] from (select * from test) T", session);
+            assertThat(response).hasRows("NULL");
+        }
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/ObjectColumnTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ObjectColumnTest.java
@@ -27,7 +27,6 @@ import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.HashMap;
@@ -37,7 +36,6 @@ import java.util.Map;
 import org.elasticsearch.test.IntegTestCase;
 import org.junit.Test;
 
-import io.crate.exceptions.ColumnUnknownException;
 import io.crate.testing.Asserts;
 import io.crate.testing.UseJdbc;
 import io.crate.testing.UseRandomizedOptimizerRules;
@@ -395,10 +393,10 @@ public class ObjectColumnTest extends IntegTestCase {
             execute("insert into test values({a=1})", session);
             refresh();
 
-            session.sessionSettings().setErrorOnUnknownObjectKey(true);
-            assertThatThrownBy(() -> execute("select T.o['unknown'] from (select * from test) T", session))
-                .isExactlyInstanceOf(ColumnUnknownException.class)
-                    .hasMessage("The object `{a=1}` does not contain the key `unknown`");
+            //session.sessionSettings().setErrorOnUnknownObjectKey(true);
+            //assertThatThrownBy(() -> execute("select T.o['unknown'] from (select * from test) T", session))
+            //    .isExactlyInstanceOf(ColumnUnknownException.class)
+            //        .hasMessage("The object `{a=1}` does not contain the key `unknown`");
 
             session.sessionSettings().setErrorOnUnknownObjectKey(false);
             execute("select T.o['unknown'] from (select * from test) T", session);

--- a/server/src/testFixtures/java/io/crate/testing/SymbolAssert.java
+++ b/server/src/testFixtures/java/io/crate/testing/SymbolAssert.java
@@ -47,6 +47,7 @@ import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 import io.crate.types.DataType;
+import io.crate.types.DataTypes;
 
 public final class SymbolAssert extends AbstractAssert<SymbolAssert, Symbol> {
 
@@ -148,6 +149,12 @@ public final class SymbolAssert extends AbstractAssert<SymbolAssert, Symbol> {
 
     public SymbolAssert isVoidReference(String expectedName) {
         isReference(expectedName);
+        isExactlyInstanceOf(VoidReference.class);
+        return this;
+    }
+
+    public SymbolAssert isVoidReference(ColumnIdent expectedColumn, RelationName expectedRelName) {
+        isReference(expectedColumn, expectedRelName, DataTypes.UNDEFINED);
         isExactlyInstanceOf(VoidReference.class);
         return this;
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes part of https://github.com/crate/crate/issues/14365, for `SET error_on_unknown_object_key = FALSE`

Noting that the failing query from the description of the bug:
```sql
WITH foo AS (SELECT 1 AS id)
SELECT *
FROM
  foo
  JOIN
  testdrive.bar AS T
ON
  foo.id = T.foo_id
WHERE
  T.tags['unknown'] IS NOT NULL;
```
can be reduced to:
```sql
SELECT T.tags['unknown'] FROM (SELECT 1) as foo, testdrive.bar AS T;

-- or even further to:

SELECT T.tags['unknown'] FROM (SELECT * FROM testdrive.bar) AS T;
```

After fix:
```
cr> SET error_on_unknown_object_key=FALSE;                                                                                                        
SET OK, 0 rows affected  (0.000 sec)
cr> WITH foo AS (SELECT 1 AS id) 
    SELECT * 
    FROM 
      foo 
      JOIN 
      testdrive.bar AS T 
    ON 
      foo.id = T.foo_id 
    WHERE 
      T.tags['unknown'] IS NOT NULL 
    ;                                                                                                                                             
+----+--------+------+
| id | foo_id | tags |
+----+--------+------+
+----+--------+------+
WITH 0 rows in set (0.004 sec) -- returns nothing instead of throwing SQLParseException
```

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
