### PR TITLE
Validate generated expressions of partitioned by columns

### DIFF
--- a/docs/appendices/release-notes/5.4.1.rst
+++ b/docs/appendices/release-notes/5.4.1.rst
@@ -55,3 +55,9 @@ Fixes
     => IndexOutOfBoundsException[Index: 1 Size: 1]
     SELECT * FROM test AS T WHERE T.o2['unknown_col'] IS NOT NULL;
     => IndexOutOfBoundsException[Index: 1 Size: 1]
+
+- Fixed an issue which caused INSERT INTO statements to skip generated
+  expression validation for partitioned columns.
+
+- Fixed an issue which caused INSERT INTO statements to leave behind
+  empty partitions if NULL or CHECK constraint on partitioned by column failed.

--- a/server/src/main/java/io/crate/execution/dml/Indexer.java
+++ b/server/src/main/java/io/crate/execution/dml/Indexer.java
@@ -525,7 +525,6 @@ public class Indexer {
                                       Context<?> ctxForRefs,
                                       Reference ref) {
         if (ref instanceof GeneratedReference generated
-                && ref.granularity() == RowGranularity.DOC
                 && Symbols.isDeterministic(generated.generatedExpression())) {
             Input<?> input = ctxForRefs.add(generated.generatedExpression());
             columnConstraints.put(ref.column(), new CheckGeneratedValue(input, generated));

--- a/server/src/main/java/io/crate/execution/dsl/projection/ColumnIndexWriterProjection.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/ColumnIndexWriterProjection.java
@@ -44,8 +44,6 @@ import java.util.function.Function;
 
 public class ColumnIndexWriterProjection extends AbstractIndexWriterProjection {
 
-    private final List<Symbol> targetColsSymbolsExclPartition;
-    private final List<Reference> targetColsExclPartitionCols;
     private final boolean ignoreDuplicateKeys;
     private final Map<Reference, Symbol> onDuplicateKeyAssignments;
     private final List<Reference> allTargetColumns;
@@ -70,8 +68,6 @@ public class ColumnIndexWriterProjection extends AbstractIndexWriterProjection {
                                        @Nullable String partitionIdent,
                                        List<ColumnIdent> primaryKeys,
                                        List<Reference> allTargetColumns,
-                                       List<Reference> targetColsExclPartitionCols,
-                                       List<Symbol> targetColsSymbolsExclPartition,
                                        boolean ignoreDuplicateKeys,
                                        Map<Reference, Symbol> onDuplicateKeyAssignments,
                                        List<Symbol> primaryKeySymbols,
@@ -90,9 +86,7 @@ public class ColumnIndexWriterProjection extends AbstractIndexWriterProjection {
         this.partitionedBySymbols = partitionedBySymbols;
         this.ignoreDuplicateKeys = ignoreDuplicateKeys;
         this.onDuplicateKeyAssignments = onDuplicateKeyAssignments;
-        this.targetColsExclPartitionCols = targetColsExclPartitionCols;
         this.clusteredBySymbol = clusteredBySymbol;
-        this.targetColsSymbolsExclPartition = targetColsSymbolsExclPartition;
         this.outputs = outputs;
         this.returnValues = returnValues;
     }
@@ -100,19 +94,20 @@ public class ColumnIndexWriterProjection extends AbstractIndexWriterProjection {
     ColumnIndexWriterProjection(StreamInput in) throws IOException {
         super(in);
 
-        if (in.readBoolean()) {
-            targetColsSymbolsExclPartition = Symbols.listFromStream(in);
-        } else {
-            targetColsSymbolsExclPartition = Collections.emptyList();
-        }
-        if (in.readBoolean()) {
-            int length = in.readVInt();
-            targetColsExclPartitionCols = new ArrayList<>(length);
-            for (int i = 0; i < length; i++) {
-                targetColsExclPartitionCols.add(Reference.fromStream(in));
+
+        if (in.getVersion().before(Version.V_5_5_0)) {
+            if (in.readBoolean()) {
+                // Ignore targetColsSymbolsExclPartition
+                Symbols.listFromStream(in);
             }
-        } else {
-            targetColsExclPartitionCols = Collections.emptyList();
+
+            if (in.readBoolean()) {
+                // Ignore targetColsExclPartitionCols
+                int length = in.readVInt();
+                for (int i = 0; i < length; i++) {
+                    Reference.fromStream(in);
+                }
+            }
         }
 
         ignoreDuplicateKeys = in.readBoolean();
@@ -173,13 +168,7 @@ public class ColumnIndexWriterProjection extends AbstractIndexWriterProjection {
         return allTargetColumns;
     }
 
-    public List<Symbol> columnSymbolsExclPartition() {
-        return targetColsSymbolsExclPartition;
-    }
 
-    public List<Reference> columnReferencesExclPartition() {
-        return targetColsExclPartitionCols;
-    }
 
     public boolean isIgnoreDuplicateKeys() {
         return ignoreDuplicateKeys;
@@ -206,9 +195,7 @@ public class ColumnIndexWriterProjection extends AbstractIndexWriterProjection {
         if (!super.equals(o)) return false;
 
         ColumnIndexWriterProjection that = (ColumnIndexWriterProjection) o;
-        return targetColsSymbolsExclPartition.equals(that.targetColsSymbolsExclPartition) &&
-               targetColsExclPartitionCols.equals(that.targetColsExclPartitionCols) &&
-               onDuplicateKeyAssignments.equals(that.onDuplicateKeyAssignments) &&
+        return onDuplicateKeyAssignments.equals(that.onDuplicateKeyAssignments) &&
                allTargetColumns.equals(that.allTargetColumns) &&
                Objects.equals(outputs, that.outputs) &&
                Objects.equals(returnValues, that.returnValues);
@@ -217,8 +204,6 @@ public class ColumnIndexWriterProjection extends AbstractIndexWriterProjection {
     @Override
     public int hashCode() {
         return Objects.hash(super.hashCode(),
-                            targetColsSymbolsExclPartition,
-                            targetColsExclPartitionCols,
                             onDuplicateKeyAssignments,
                             allTargetColumns,
                             outputs,
@@ -229,20 +214,11 @@ public class ColumnIndexWriterProjection extends AbstractIndexWriterProjection {
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
 
-        if (targetColsSymbolsExclPartition == null) {
+        if (out.getVersion().before(Version.V_5_5_0)) {
+            // We used to stream targetColsSymbolsExclPartition and targetColsExclPartitionCols.
+            // Imitating null for both of them.
             out.writeBoolean(false);
-        } else {
-            out.writeBoolean(true);
-            Symbols.toStream(targetColsSymbolsExclPartition, out);
-        }
-        if (targetColsExclPartitionCols == null) {
             out.writeBoolean(false);
-        } else {
-            out.writeBoolean(true);
-            out.writeVInt(targetColsExclPartitionCols.size());
-            for (Reference columnIdent : targetColsExclPartitionCols) {
-                Reference.toStream(out, columnIdent);
-            }
         }
 
         out.writeBoolean(ignoreDuplicateKeys);
@@ -291,8 +267,6 @@ public class ColumnIndexWriterProjection extends AbstractIndexWriterProjection {
             null,
             primaryKeys,
             allTargetColumns,
-            targetColsExclPartitionCols,
-            targetColsSymbolsExclPartition,
             ignoreDuplicateKeys,
             boundOnDuplicateKeyAssignments,
             (List<Symbol>) ids(),

--- a/server/src/main/java/io/crate/execution/engine/collect/ShardCollectorProvider.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/ShardCollectorProvider.java
@@ -86,6 +86,7 @@ public abstract class ShardCollectorProvider {
         );
         projectorFactory = new ProjectionToProjectorVisitor(
             clusterService,
+            schemas,
             nodeJobsCounter,
             circuitBreakerService,
             nodeCtx,

--- a/server/src/main/java/io/crate/execution/engine/collect/sources/CollectSourceResolver.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/sources/CollectSourceResolver.java
@@ -41,6 +41,7 @@ import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.metadata.IndexParts;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.RowGranularity;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.information.InformationSchemaInfo;
 import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
@@ -73,6 +74,7 @@ public class CollectSourceResolver {
 
     @Inject
     public CollectSourceResolver(ClusterService clusterService,
+                                 Schemas schemas,
                                  NodeLimits nodeJobsCounter,
                                  CircuitBreakerService circuitBreakerService,
                                  NodeContext nodeCtx,
@@ -92,6 +94,7 @@ public class CollectSourceResolver {
         EvaluatingNormalizer normalizer = EvaluatingNormalizer.functionOnlyNormalizer(nodeCtx);
         ProjectorFactory projectorFactory = new ProjectionToProjectorVisitor(
             clusterService,
+            schemas,
             nodeJobsCounter,
             circuitBreakerService,
             nodeCtx,

--- a/server/src/main/java/io/crate/execution/engine/collect/sources/ShardCollectSource.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/sources/ShardCollectSource.java
@@ -99,6 +99,7 @@ import io.crate.metadata.IndexParts;
 import io.crate.metadata.MapBackedRefResolver;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.RowGranularity;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocSysColumns;
 import io.crate.metadata.shard.unassigned.UnassignedShard;
@@ -159,6 +160,7 @@ public class ShardCollectSource implements CollectSource, IndexEventListener {
     public ShardCollectSource(Settings settings,
                               IndicesService indicesService,
                               NodeContext nodeCtx,
+                              Schemas schemas,
                               ClusterService clusterService,
                               NodeLimits nodeJobsCounter,
                               ThreadPool threadPool,
@@ -186,6 +188,7 @@ public class ShardCollectSource implements CollectSource, IndexEventListener {
 
         sharedProjectorFactory = new ProjectionToProjectorVisitor(
             clusterService,
+            schemas,
             nodeJobsCounter,
             circuitBreakerService,
             nodeCtx,

--- a/server/src/main/java/io/crate/execution/engine/indexing/ColumnIndexWriterProjector.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/ColumnIndexWriterProjector.java
@@ -26,8 +26,10 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
+import io.crate.execution.dml.IndexItem;
 import org.jetbrains.annotations.Nullable;
 
 import org.elasticsearch.client.ElasticsearchClient;
@@ -59,6 +61,8 @@ public class ColumnIndexWriterProjector implements Projector {
     private final ShardingUpsertExecutor shardingUpsertExecutor;
 
     public ColumnIndexWriterProjector(ClusterService clusterService,
+                                      BiConsumer<String, IndexItem> constraintsChecker,
+                                      Runnable onCompletion,
                                       NodeLimits nodeJobsCounter,
                                       CircuitBreaker queryCircuitBreaker,
                                       RamAccounting ramAccounting,
@@ -125,6 +129,8 @@ public class ColumnIndexWriterProjector implements Projector {
 
         shardingUpsertExecutor = new ShardingUpsertExecutor(
             clusterService,
+            constraintsChecker,
+            onCompletion,
             nodeJobsCounter,
             queryCircuitBreaker,
             ramAccounting,

--- a/server/src/main/java/io/crate/execution/engine/indexing/GroupRowsByShard.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/GroupRowsByShard.java
@@ -30,6 +30,7 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 
+import io.crate.execution.dml.IndexItem;
 import org.elasticsearch.common.TriFunction;
 import org.jetbrains.annotations.Nullable;
 
@@ -68,7 +69,10 @@ public final class GroupRowsByShard<TReq extends ShardRequest<TReq, TItem>, TIte
     private final UnsafeArrayRow spareRow = new UnsafeArrayRow();
     private Object[] spareCells;
 
+    private final BiConsumer<String, IndexItem> constraintsChecker;
+
     public GroupRowsByShard(ClusterService clusterService,
+                            BiConsumer<String, IndexItem> constraintsChecker,
                             RowShardResolver rowShardResolver,
                             Supplier<String> indexNameResolver,
                             List<? extends CollectExpression<Row, ?>> expressions,
@@ -79,6 +83,7 @@ public final class GroupRowsByShard<TReq extends ShardRequest<TReq, TItem>, TIte
             : "expressions should be a RandomAccess list for zero allocation iterations";
 
         this.clusterService = clusterService;
+        this.constraintsChecker = constraintsChecker;
         this.rowShardResolver = rowShardResolver;
         this.indexNameResolver = indexNameResolver;
         this.expressions = expressions;
@@ -92,12 +97,14 @@ public final class GroupRowsByShard<TReq extends ShardRequest<TReq, TItem>, TIte
     }
 
     public GroupRowsByShard(ClusterService clusterService,
+                            BiConsumer<String, IndexItem> constraintsChecker,
                             RowShardResolver rowShardResolver,
                             Supplier<String> indexNameResolver,
                             List<? extends CollectExpression<Row, ?>> expressions,
                             ItemFactory<TItem> itemFactory,
                             boolean autoCreateIndices) {
         this(clusterService,
+             constraintsChecker,
              rowShardResolver,
              indexNameResolver,
              expressions,
@@ -163,6 +170,11 @@ public final class GroupRowsByShard<TReq extends ShardRequest<TReq, TItem>, TIte
             RowSourceInfo rowSourceInfo = RowSourceInfo.emptyMarkerOrNewInstance(sourceUri, lineNumber);
             ShardLocation shardLocation = getShardLocation(indexName, id, routing);
             if (shardLocation == null) {
+                // Validation is done before creating an index in order to ensure
+                // that no "bad partitions" will be left behind in case of validation failure.
+                if (item instanceof IndexItem indexItem) {
+                    constraintsChecker.accept(indexNameResolver.get(), indexItem);
+                }
                 shardedRequests.add(item, indexName, routing, rowSourceInfo);
             } else {
                 shardedRequests.add(item, shardLocation, rowSourceInfo);

--- a/server/src/main/java/io/crate/execution/engine/indexing/IndexWriterProjector.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/IndexWriterProjector.java
@@ -132,6 +132,8 @@ public class IndexWriterProjector implements Projector {
 
         shardingUpsertExecutor = new ShardingUpsertExecutor(
             clusterService,
+            (ignored1, ignored2) -> {},
+            () -> {},
             nodeJobsCounter,
             queryCircuitBreaker,
             ramAccounting,

--- a/server/src/main/java/io/crate/execution/engine/indexing/ShardedRequests.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/ShardedRequests.java
@@ -57,9 +57,6 @@ public final class ShardedRequests<TReq extends ShardRequest<TReq, TItem>, TItem
         this.ramAccounting = ramAccounting;
     }
 
-    /**
-     * @param itemSizeInBytes an estimate of how many bytes the item occupies in memory
-     */
     public void add(TItem item, String indexName, String routing, RowSourceInfo rowSourceInfo) {
         long itemSizeInBytes = item.ramBytesUsed();
         ramAccounting.addBytes(itemSizeInBytes);

--- a/server/src/main/java/io/crate/execution/jobs/JobSetup.java
+++ b/server/src/main/java/io/crate/execution/jobs/JobSetup.java
@@ -177,6 +177,7 @@ public class JobSetup {
         EvaluatingNormalizer normalizer = EvaluatingNormalizer.functionOnlyNormalizer(nodeCtx);
         this.projectorFactory = new ProjectionToProjectorVisitor(
             clusterService,
+            schemas,
             nodeJobsCounter,
             circuitBreakerService,
             nodeCtx,

--- a/server/src/main/java/io/crate/planner/consumer/InsertFromSubQueryPlanner.java
+++ b/server/src/main/java/io/crate/planner/consumer/InsertFromSubQueryPlanner.java
@@ -22,7 +22,6 @@
 package io.crate.planner.consumer;
 
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.elasticsearch.Version;
@@ -32,11 +31,8 @@ import io.crate.analyze.AnalyzedInsertStatement;
 import io.crate.exceptions.UnsupportedFeatureException;
 import io.crate.execution.dsl.projection.ColumnIndexWriterProjection;
 import io.crate.execution.dsl.projection.EvalProjection;
-import io.crate.execution.dsl.projection.builder.InputColumns;
 import io.crate.expression.symbol.InputColumn;
-import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
-import io.crate.metadata.Reference;
 import io.crate.planner.PlannerContext;
 import io.crate.planner.SubqueryPlanner;
 import io.crate.planner.operators.Insert;
@@ -63,17 +59,7 @@ public final class InsertFromSubQueryPlanner {
             throw new UnsupportedFeatureException(RETURNING_VERSION_ERROR_MSG);
         }
 
-        List<Reference> targetColsExclPartitionCols = new ArrayList<>(
-            Math.max(1, statement.columns().size() - statement.tableInfo().partitionedBy().size()));
-        for (Reference column : statement.columns()) {
-            if (statement.tableInfo().partitionedBy().contains(column.column())) {
-                continue;
-            }
-            targetColsExclPartitionCols.add(column);
-        }
-        List<Symbol> columnSymbols = InputColumns.create(
-            targetColsExclPartitionCols,
-            new InputColumns.SourceSymbols(statement.columns()));
+
 
         // if fields are null default to number of rows imported
         var outputs = statement.outputs() == null ? List.of(new InputColumn(0, DataTypes.LONG)) : statement.outputs();
@@ -83,8 +69,6 @@ public final class InsertFromSubQueryPlanner {
             null,
             statement.tableInfo().primaryKey(),
             statement.columns(),
-            targetColsExclPartitionCols,
-            columnSymbols,
             statement.isIgnoreDuplicateKeys(),
             statement.onDuplicateKeyAssignments(),
             statement.primaryKeySymbols(),

--- a/server/src/test/java/io/crate/execution/dsl/projection/ColumnIndexWriterProjectionTest.java
+++ b/server/src/test/java/io/crate/execution/dsl/projection/ColumnIndexWriterProjectionTest.java
@@ -25,7 +25,6 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -34,9 +33,6 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
 import org.junit.Test;
 
-import io.crate.execution.dsl.projection.builder.InputColumns;
-import io.crate.expression.symbol.InputColumn;
-import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
@@ -49,67 +45,6 @@ import io.crate.types.DataTypes;
 public class ColumnIndexWriterProjectionTest {
 
     private RelationName relationName = new RelationName("dummy", "table");
-
-    @Test
-    public void testTargetColumnRefsAndSymbolsAreCorrectAfterExclusionOfPartitionColumns() {
-        /*
-         *  pk:             [ymd, domain, area, isp]
-         *  partitioned by: [ymd, isp]
-         *  insert into t   (ymd, domain, area, isp, h) select ...
-         *
-         *  We don't write PartitionedBy columns, so they're excluded from the allTargetColumns:
-         *
-         *  expected targetRefs:      [ domain, area, h ]
-         *  expected column symbols:  [ ic1,   ic2, ic4 ]
-         */
-        ColumnIdent ymd = new ColumnIdent("ymd");
-        ColumnIdent domain = new ColumnIdent("domain");
-        ColumnIdent area = new ColumnIdent("area");
-        ColumnIdent isp = new ColumnIdent("isp");
-        ColumnIdent h = new ColumnIdent("h");
-        Reference ymdRef = partitionRef(ymd, DataTypes.STRING);
-        Reference domainRef = ref(domain, DataTypes.STRING);
-        Reference areaRef = ref(area, DataTypes.STRING);
-        Reference ispRef = partitionRef(isp, DataTypes.STRING);
-        Reference hRef = ref(h, DataTypes.INTEGER);
-        List<ColumnIdent> primaryKeys = Arrays.asList(ymd, domain, area, isp);
-        List<Reference> targetColumns = Arrays.asList(ymdRef, domainRef, areaRef, ispRef, hRef);
-        List<Reference> targetColumnsExclPartitionColumns = Arrays.asList(domainRef, areaRef, hRef);
-        InputColumns.SourceSymbols targetColsCtx = new InputColumns.SourceSymbols(targetColumns);
-        List<Symbol> primaryKeySymbols = InputColumns.create(
-            Arrays.asList(ymdRef, domainRef, areaRef, ispRef), targetColsCtx);
-        List<Symbol> partitionedBySymbols = InputColumns.create(Arrays.asList(ymdRef, ispRef), targetColsCtx);
-        List<Symbol> columnSymbols = InputColumns.create(
-            targetColumnsExclPartitionColumns,
-            targetColsCtx);
-
-        ColumnIndexWriterProjection projection = new ColumnIndexWriterProjection(
-            relationName,
-            null,
-            primaryKeys,
-            targetColumns,
-            targetColumnsExclPartitionColumns,
-            columnSymbols,
-            false,
-            null,
-            primaryKeySymbols,
-            partitionedBySymbols,
-            null,
-            null,
-            Settings.EMPTY,
-            true,
-            List.of(),
-            null
-        );
-
-        assertThat(projection.columnReferencesExclPartition(), is(Arrays.asList(
-            domainRef, areaRef, hRef)
-        ));
-        assertThat(projection.columnSymbolsExclPartition(), is(Arrays.asList(
-            new InputColumn(1, DataTypes.STRING),
-            new InputColumn(2, DataTypes.STRING),
-            new InputColumn(4, DataTypes.INTEGER))));
-    }
 
     /**
      * Tests a fix for a regression introduced by an incorrect writing of the columns size by
@@ -124,17 +59,11 @@ public class ColumnIndexWriterProjectionTest {
             var ident = new ColumnIdent(String.valueOf(i));
             targetColumns.add(ref(ident, DataTypes.INTEGER));
         }
-        InputColumns.SourceSymbols targetColsCtx = new InputColumns.SourceSymbols(targetColumns);
-        List<Symbol> columnSymbols = InputColumns.create(
-            targetColumns,
-            targetColsCtx);
         var projection = new ColumnIndexWriterProjection(
             relationName,
             null,
             List.of(),
             targetColumns,
-            targetColumns,
-            columnSymbols,
             false,
             Collections.emptyMap(),
             List.of(),

--- a/server/src/test/java/io/crate/execution/engine/pipeline/ProjectingRowConsumerTest.java
+++ b/server/src/test/java/io/crate/execution/engine/pipeline/ProjectingRowConsumerTest.java
@@ -89,6 +89,7 @@ public class ProjectingRowConsumerTest extends CrateDummyClusterServiceUnitTest 
         memoryManager = new OnHeapMemoryManager(usedBytes -> {});
         projectorFactory = new ProjectionToProjectorVisitor(
             clusterService,
+            null,
             new NodeLimits(new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)),
             new NoneCircuitBreakerService(),
             nodeCtx,

--- a/server/src/test/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitorTest.java
@@ -102,6 +102,7 @@ public class ProjectionToProjectorVisitorTest extends CrateDummyClusterServiceUn
         MockitoAnnotations.initMocks(this);
         visitor = new ProjectionToProjectorVisitor(
             clusterService,
+            null,
             new NodeLimits(new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)),
             new NoneCircuitBreakerService(),
             nodeCtx,

--- a/server/src/test/java/io/crate/execution/engine/pipeline/ProjectorsTest.java
+++ b/server/src/test/java/io/crate/execution/engine/pipeline/ProjectorsTest.java
@@ -69,6 +69,7 @@ public class ProjectorsTest extends CrateDummyClusterServiceUnitTest {
         memoryManager = new OnHeapMemoryManager(bytes -> {});
         projectorFactory = new ProjectionToProjectorVisitor(
             clusterService,
+            null,
             new NodeLimits(new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)),
             new NoneCircuitBreakerService(),
             nodeCtx,

--- a/server/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
@@ -1869,4 +1869,53 @@ public class InsertIntoIntegrationTest extends IntegTestCase {
         execute("insert into t (id, obj) (select 1, {\"a\" = {\"b\" = null}} from sys.cluster)");
         assertThat(response.rowCount()).isEqualTo(0L);
     }
+
+    @Test
+    @UseRandomizedSchema(random = false)
+    public void test_values_of_the_partitioned_columns_are_validated_without_creating_partition_for_failed_rows() {
+        execute("""
+            CREATE TABLE t (
+                a INT,
+                b INT CONSTRAINT check_1 CHECK (b > 10),
+                c INT as a + 1,
+                d INT NOT NULL
+            ) PARTITIONED BY (b,c,d)
+            """
+        );
+
+        // Failing CHECK, NOT NULL constraints
+        // or wrong provided value for generated partitioned by columns
+        // should not leave invalid partitions behind.
+        // All failing scenarios followed by the last "partition does not exist" assertion.
+
+        // Failing CHECK constraint.
+        execute("insert into t (a, b, d) select 1, 9, 1");
+        assertThat(response.rowCount()).isEqualTo(0L);
+
+        // Failing NOT NULL constraint.
+        execute("insert into t (a, b, d) select 1, 12, null");
+        assertThat(response.rowCount()).isEqualTo(0L);
+
+        // Generated expression validation (https://github.com/crate/crate/issues/14304).
+        // insert from values used to fail as well because we used to explicitly skip that check for References with PARTITION granularity.
+        assertSQLError(() -> execute("insert into t (a, b, c, d) values (null, 12, 1, 1)"))
+            .hasPGError(INTERNAL_ERROR)
+            .hasHTTPError(BAD_REQUEST, 4000)
+            .hasMessageContaining("Given value 1 for generated column c does not match calculation (a + 1) = null");
+
+        execute("insert into t (a, b, c, d) select null, 12, 1, 1");
+        assertThat(response.rowCount()).isEqualTo(0L);
+
+
+        // We need to ensure that check is done before partition creation.
+        // If check is done too late, INSERT statement might work as expected and reject invalid records but invalid partitions will left behind.
+        // At this point all failing scenarios are done and haven't written anything.
+        // Checking that neither of them has created a partition.
+        Metadata updatedMetadata = cluster().clusterService().state().metadata();
+        String tableTemplateName = PartitionName.templateName("doc", "t");
+        for (ObjectCursor<String> cursor : updatedMetadata.indices().keys()) {
+            String indexName = cursor.value;
+            assertThat(PartitionName.templateName(indexName)).isNotEqualTo(tableTemplateName);
+        }
+    }
 }

--- a/server/src/test/java/io/crate/planner/InsertPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/InsertPlannerTest.java
@@ -165,9 +165,9 @@ public class InsertPlannerTest extends CrateDummyClusterServiceUnitTest {
         ColumnIndexWriterProjection projection = (ColumnIndexWriterProjection) mergePhase.projections().get(2);
         assertThat(projection.primaryKeys().size(), is(1));
         assertThat(projection.primaryKeys().get(0).fqn(), is("id"));
-        assertThat(projection.columnReferencesExclPartition().size(), is(2));
-        assertThat(projection.columnReferencesExclPartition().get(0).column().fqn(), is("id"));
-        assertThat(projection.columnReferencesExclPartition().get(1).column().fqn(), is("name"));
+        assertThat(projection.allTargetColumns().size(), is(2));
+        assertThat(projection.allTargetColumns().get(0).column().fqn(), is("id"));
+        assertThat(projection.allTargetColumns().get(1).column().fqn(), is("name"));
 
         assertNotNull(projection.clusteredByIdent());
         assertThat(projection.clusteredByIdent().fqn(), is("id"));
@@ -195,8 +195,8 @@ public class InsertPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(projection.primaryKeys().get(0).fqn(), is("id"));
         assertThat(projection.primaryKeys().get(1).fqn(), is("date"));
 
-        assertThat(projection.columnReferencesExclPartition().size(), is(1));
-        assertThat(projection.columnReferencesExclPartition().get(0).column().fqn(), is("id"));
+        assertThat(projection.allTargetColumns().size(), is(2));
+        assertThat(projection.allTargetColumns().get(0).column().fqn(), is("id"));
 
         assertThat(projection.partitionedBySymbols().size(), is(1));
         assertThat(((InputColumn) projection.partitionedBySymbols().get(0)).index(), is(1));
@@ -225,13 +225,9 @@ public class InsertPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(mergePhase.projections().get(1), instanceOf(ColumnIndexWriterProjection.class));
         ColumnIndexWriterProjection projection = (ColumnIndexWriterProjection) mergePhase.projections().get(1);
 
-        assertThat(projection.columnReferencesExclPartition().size(), is(2));
-        assertThat(projection.columnReferencesExclPartition().get(0).column().fqn(), is("name"));
-        assertThat(projection.columnReferencesExclPartition().get(1).column().fqn(), is("id"));
-
-        assertThat(projection.columnSymbolsExclPartition().size(), is(2));
-        assertThat(((InputColumn) projection.columnSymbolsExclPartition().get(0)).index(), is(0));
-        assertThat(((InputColumn) projection.columnSymbolsExclPartition().get(1)).index(), is(1));
+        assertThat(projection.allTargetColumns().size(), is(2));
+        assertThat(projection.allTargetColumns().get(0).column().fqn(), is("name"));
+        assertThat(projection.allTargetColumns().get(1).column().fqn(), is("id"));
 
         assertNotNull(projection.clusteredByIdent());
         assertThat(projection.clusteredByIdent().fqn(), is("id"));
@@ -250,10 +246,10 @@ public class InsertPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(collectPhase.projections().get(0), instanceOf(ColumnIndexWriterProjection.class));
         ColumnIndexWriterProjection projection = (ColumnIndexWriterProjection) collectPhase.projections().get(0);
 
-        assertThat(projection.columnReferencesExclPartition().size(), is(3));
-        assertThat(projection.columnReferencesExclPartition().get(0).column().fqn(), is("date"));
-        assertThat(projection.columnReferencesExclPartition().get(1).column().fqn(), is("id"));
-        assertThat(projection.columnReferencesExclPartition().get(2).column().fqn(), is("name"));
+        assertThat(projection.allTargetColumns().size(), is(3));
+        assertThat(projection.allTargetColumns().get(0).column().fqn(), is("date"));
+        assertThat(projection.allTargetColumns().get(1).column().fqn(), is("id"));
+        assertThat(projection.allTargetColumns().get(2).column().fqn(), is("name"));
         assertThat(((InputColumn) projection.ids().get(0)).index(), is(1));
         assertThat(((InputColumn) projection.clusteredBy()).index(), is(1));
         assertThat(projection.partitionedBySymbols().isEmpty(), is(true));
@@ -270,9 +266,9 @@ public class InsertPlannerTest extends CrateDummyClusterServiceUnitTest {
 
         ColumnIndexWriterProjection projection = (ColumnIndexWriterProjection) join.joinPhase().projections().get(1);
 
-        assertThat(projection.columnReferencesExclPartition().size(), is(2));
-        assertThat(projection.columnReferencesExclPartition().get(0).column().fqn(), is("id"));
-        assertThat(projection.columnReferencesExclPartition().get(1).column().fqn(), is("name"));
+        assertThat(projection.allTargetColumns().size(), is(2));
+        assertThat(projection.allTargetColumns().get(0).column().fqn(), is("id"));
+        assertThat(projection.allTargetColumns().get(1).column().fqn(), is("name"));
         assertThat(((InputColumn) projection.ids().get(0)).index(), is(0));
         assertThat(((InputColumn) projection.clusteredBy()).index(), is(0));
         assertThat(projection.partitionedBySymbols().isEmpty(), is(true));
@@ -343,7 +339,7 @@ public class InsertPlannerTest extends CrateDummyClusterServiceUnitTest {
         ));
         ColumnIndexWriterProjection columnIndexWriterProjection =
             (ColumnIndexWriterProjection) collectPhase.projections().get(1);
-        Asserts.assertThat(columnIndexWriterProjection.columnReferencesExclPartition()).satisfiesExactly(
+        Asserts.assertThat(columnIndexWriterProjection.allTargetColumns()).satisfiesExactly(
             isReference("id"), isReference("name"));
 
         MergePhase mergePhase = merge.mergePhase();
@@ -370,7 +366,7 @@ public class InsertPlannerTest extends CrateDummyClusterServiceUnitTest {
                     List.of(DataTypes.LONG, DataTypes.STRING)));
 
         ColumnIndexWriterProjection columnIndexWriterProjection = (ColumnIndexWriterProjection) collectPhase.projections().get(2);
-        Asserts.assertThat(columnIndexWriterProjection.columnReferencesExclPartition()).satisfiesExactly(
+        Asserts.assertThat(columnIndexWriterProjection.allTargetColumns()).satisfiesExactly(
             isReference("id"), isReference("name"));
 
         MergePhase mergePhase = merge.mergePhase();


### PR DESCRIPTION
Validate generated expressions of partitioned by columns.

Also, do it before creating a partition so that invalid rows don't cause abandoned partitions.

Closes https://github.com/crate/crate/issues/14304

Supersedes https://github.com/crate/crate/pull/14317