### PR TITLE
Remove map/mapExpression from TableElements

### DIFF
--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/CheckConstraint.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/CheckConstraint.java
@@ -21,11 +21,11 @@
 
 package io.crate.sql.tree;
 
-import org.jetbrains.annotations.Nullable;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
-import java.util.function.Function;
+
+import org.jetbrains.annotations.Nullable;
 
 public class CheckConstraint<T> extends TableElement<T> {
 
@@ -84,7 +84,7 @@ public class CheckConstraint<T> extends TableElement<T> {
         if (o == null || false == o instanceof CheckConstraint) {
             return false;
         }
-        CheckConstraint that = (CheckConstraint) o;
+        CheckConstraint<?> that = (CheckConstraint<?>) o;
         return Objects.equals(expression, that.expression) &&
                Objects.equals(name, that.name) &&
                Objects.equals(columnName, that.columnName);
@@ -93,11 +93,6 @@ public class CheckConstraint<T> extends TableElement<T> {
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
         return visitor.visitCheckConstraint(this, context);
-    }
-
-    @Override
-    public <U> TableElement<U> map(Function<? super T, ? extends U> mapper) {
-        return new CheckConstraint<>(name, columnName, mapper.apply(expression), expressionStr);
     }
 
     @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/CollectionColumnType.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/CollectionColumnType.java
@@ -21,8 +21,6 @@
 
 package io.crate.sql.tree;
 
-import java.util.function.Function;
-
 /**
  * columntype that contains many values of a single type
  */
@@ -39,18 +37,6 @@ public class CollectionColumnType<T> extends ColumnType<T> {
         return innerType;
     }
 
-    @Override
-    public <U> ColumnType<U> map(Function<? super T, ? extends U> mapper) {
-        return new CollectionColumnType<>(innerType.map(mapper));
-    }
-
-    @Override
-    public <U> ColumnType<U> mapExpressions(ColumnType<U> mappedType,
-                                            Function<? super T, ? extends U> mapper) {
-        CollectionColumnType<U> collectionColumnType = (CollectionColumnType<U>) mappedType;
-        return new CollectionColumnType<>(
-            innerType.mapExpressions(collectionColumnType.innerType, mapper));
-    }
 
     @Override
     public boolean equals(Object o) {
@@ -64,7 +50,7 @@ public class CollectionColumnType<T> extends ColumnType<T> {
             return false;
         }
 
-        CollectionColumnType that = (CollectionColumnType) o;
+        CollectionColumnType<?> that = (CollectionColumnType<?>) o;
 
         return innerType.equals(that.innerType);
     }

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/ColumnDefinition.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/ColumnDefinition.java
@@ -21,13 +21,11 @@
 
 package io.crate.sql.tree;
 
-import io.crate.common.collections.Lists2;
-
-import org.jetbrains.annotations.Nullable;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
-import java.util.function.Function;
+
+import org.jetbrains.annotations.Nullable;
 
 public class ColumnDefinition<T> extends TableElement<T> {
 
@@ -148,32 +146,6 @@ public class ColumnDefinition<T> extends TableElement<T> {
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
         return visitor.visitColumnDefinition(this, context);
-    }
-
-    @Override
-    public <U> ColumnDefinition<U> map(Function<? super T, ? extends U> mapper) {
-        return new ColumnDefinition<>(
-            ident,
-            null, // expression must be mapped later on using mapExpressions()
-            null,
-            type == null ? null : type.map(mapper),
-            Lists2.map(constraints, x -> x.map(mapper)),
-            false,
-            generatedExpression != null
-        );
-    }
-
-    @Override
-    public <U> TableElement<U> mapExpressions(TableElement<U> mappedElement,
-                                              Function<? super T, ? extends U> mapper) {
-        ColumnDefinition<U> mappedDefinition = (ColumnDefinition<U>) mappedElement;
-        return new ColumnDefinition<>(
-            mappedDefinition.ident,
-            defaultExpression == null ? null : mapper.apply(defaultExpression),
-            generatedExpression == null ? null : mapper.apply(generatedExpression),
-            type == null ? null : type.mapExpressions(mappedDefinition.type, mapper),
-            mappedDefinition.constraints
-        );
     }
 
     @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/ColumnType.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/ColumnType.java
@@ -24,7 +24,6 @@ package io.crate.sql.tree;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.function.Function;
 
 public class ColumnType<T> extends Expression {
 
@@ -73,15 +72,5 @@ public class ColumnType<T> extends Expression {
     @Override
     public int hashCode() {
         return Objects.hash(name, parameters);
-    }
-
-    @SuppressWarnings("unchecked")
-    public <U> ColumnType<U> map(Function<? super T, ? extends U> mapper) {
-        return (ColumnType<U>) this;
-    }
-
-    public <U> ColumnType<U> mapExpressions(ColumnType<U> mappedType,
-                                            Function<? super T, ? extends U> mapper) {
-        return mappedType;
     }
 }

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/CreateFunction.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/CreateFunction.java
@@ -23,7 +23,6 @@ package io.crate.sql.tree;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.function.Function;
 
 public class CreateFunction<T> extends Statement {
 
@@ -72,18 +71,6 @@ public class CreateFunction<T> extends Statement {
         return definition;
     }
 
-    public <U> CreateFunction<U> map(Function<? super T, ? extends U> mapper) {
-        return new CreateFunction<>(
-            name,
-            replace,
-            arguments,
-            returnType.map(mapper),
-            mapper.apply(language),
-            mapper.apply(definition)
-        );
-    }
-
-
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
         return visitor.visitCreateFunction(this, context);
@@ -94,7 +81,7 @@ public class CreateFunction<T> extends Statement {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
-        final CreateFunction that = (CreateFunction) o;
+        final CreateFunction<?> that = (CreateFunction<?>) o;
         return Objects.equals(this.name, that.name)
             && Objects.equals(this.replace, that.replace)
             && Objects.equals(this.arguments, that.arguments)

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/GenericProperty.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/GenericProperty.java
@@ -33,7 +33,7 @@ import java.util.Objects;
  * Instance of {@link io.crate.sql.tree.AnalyzerElement} but frequently used in other
  * {@link io.crate.sql.tree.GenericProperties} contexts.
  */
-public class GenericProperty<T> extends AnalyzerElement {
+public class GenericProperty<T> extends AnalyzerElement<T> {
 
     private final String key;
     private final T value;
@@ -42,7 +42,6 @@ public class GenericProperty<T> extends AnalyzerElement {
         this.key = key;
         this.value = value;
     }
-
 
     public String key() {
         return key;

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/IndexDefinition.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/IndexDefinition.java
@@ -21,12 +21,9 @@
 
 package io.crate.sql.tree;
 
-import io.crate.common.collections.Lists2;
-
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 public class IndexDefinition<T> extends TableElement<T> {
 
@@ -91,16 +88,6 @@ public class IndexDefinition<T> extends TableElement<T> {
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
         return visitor.visitIndexDefinition(this, context);
-    }
-
-    @Override
-    public <U> TableElement<U> map(Function<? super T, ? extends U> mapper) {
-        return new IndexDefinition<>(
-            ident,
-            method,
-            Lists2.map(columns, mapper),
-            properties.map(mapper)
-        );
     }
 
     @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/ObjectColumnType.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/ObjectColumnType.java
@@ -21,14 +21,10 @@
 
 package io.crate.sql.tree;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Function;
 
 import org.jetbrains.annotations.Nullable;
-
-import io.crate.common.collections.Lists2;
 
 public class ObjectColumnType<T> extends ColumnType<T> {
 
@@ -55,50 +51,6 @@ public class ObjectColumnType<T> extends ColumnType<T> {
     }
 
     @Override
-    public <U> ObjectColumnType<U> map(Function<? super T, ? extends U> mapper) {
-        checkNestedColumnConstraints(nestedColumns);
-
-        String objectTypeString = null;
-        if (columnPolicy.isPresent()) {
-            objectTypeString = columnPolicy.get().lowerCaseName();
-        }
-        return new ObjectColumnType<>(
-            objectTypeString,
-            Lists2.map(nestedColumns, x -> x.map(mapper))
-        );
-    }
-
-    private void checkNestedColumnConstraints(List<ColumnDefinition<T>> nestedColumns) {
-        for (var nestedColumn : nestedColumns) {
-            for (var constraint : nestedColumn.constraints()) {
-                if (constraint instanceof CheckColumnConstraint<T>) {
-                    throw new UnsupportedOperationException("Constraints on nested columns are not allowed");
-                }
-            }
-        }
-    }
-
-    @Override
-    public <U> ColumnType<U> mapExpressions(ColumnType<U> mappedType,
-                                            Function<? super T, ? extends U> mapper) {
-        ObjectColumnType<U> mappedObjectType = (ObjectColumnType<U>) mappedType;
-        String objectTypeString = null;
-        if (columnPolicy.isPresent()) {
-            objectTypeString = columnPolicy.get().lowerCaseName();
-        }
-        ArrayList<ColumnDefinition<U>> nestedMappedColumns = new ArrayList<>(nestedColumns.size());
-        for (int i = 0; i < nestedColumns.size(); i++) {
-            ColumnDefinition<U> columnDefinition =
-                (ColumnDefinition<U>) nestedColumns.get(i).mapExpressions(mappedObjectType.nestedColumns.get(i), mapper);
-            nestedMappedColumns.add(columnDefinition);
-        }
-        return new ObjectColumnType<>(
-            objectTypeString,
-            nestedMappedColumns
-        );
-    }
-
-    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;
@@ -110,7 +62,7 @@ public class ObjectColumnType<T> extends ColumnType<T> {
             return false;
         }
 
-        ObjectColumnType that = (ObjectColumnType) o;
+        ObjectColumnType<?> that = (ObjectColumnType<?>) o;
 
         if (!columnPolicy.equals(that.columnPolicy)) {
             return false;

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/PrimaryKeyConstraint.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/PrimaryKeyConstraint.java
@@ -21,12 +21,9 @@
 
 package io.crate.sql.tree;
 
-import io.crate.common.collections.Lists2;
-
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 public class PrimaryKeyConstraint<T> extends TableElement<T> {
 
@@ -67,11 +64,6 @@ public class PrimaryKeyConstraint<T> extends TableElement<T> {
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
         return visitor.visitPrimaryKeyConstraint(this, context);
-    }
-
-    @Override
-    public <U> TableElement<U> map(Function<? super T, ? extends U> mapper) {
-        return new PrimaryKeyConstraint<>(Lists2.map(columns, mapper));
     }
 
     @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/TableElement.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/TableElement.java
@@ -22,34 +22,12 @@
 package io.crate.sql.tree;
 
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 public abstract class TableElement<T> extends Node {
 
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
         return visitor.visitTableElement(this, context);
-    }
-
-    /**
-     * Map all generic properties using the given mapper.
-     * If a table element contains any expressions which should not be mapped in general (e.g. generated/default
-     * expression), NULL them here and use the concrete {@link #mapExpressions(TableElement, Function)}
-     * to map them using a concrete mapper.
-     */
-    public abstract <U> TableElement<U> map(Function<? super T, ? extends U> mapper);
-
-    /**
-     * Map any expressions which were NOT processed by the {@link #map(Function)} function in general
-     * like e.g. generated or default expressions.
-     *
-     * @param mappedElement     An already mapped table element were some expressions were left out.
-     * @param mapper            The mapper function
-     * @return                  The mapped table element including possible newly mapped expressions.
-     */
-    public <U> TableElement<U> mapExpressions(TableElement<U> mappedElement,
-                                              Function<? super T, ? extends U> mapper) {
-        return mappedElement;
     }
 
     public abstract void visit(Consumer<? super T> consumer);

--- a/server/src/main/java/io/crate/analyze/FunctionArgumentDefinition.java
+++ b/server/src/main/java/io/crate/analyze/FunctionArgumentDefinition.java
@@ -21,22 +21,20 @@
 
 package io.crate.analyze;
 
-import io.crate.expression.udf.UserDefinedFunctionMetadata;
-import io.crate.sql.tree.FunctionArgument;
-import io.crate.types.DataType;
-import io.crate.types.DataTypes;
+import java.io.IOException;
+import java.util.Objects;
+
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-
 import org.jetbrains.annotations.Nullable;
-import java.io.IOException;
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
+
+import io.crate.expression.udf.UserDefinedFunctionMetadata;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
 
 public class FunctionArgumentDefinition implements Writeable, ToXContent {
 
@@ -66,14 +64,6 @@ public class FunctionArgumentDefinition implements Writeable, ToXContent {
 
     public static FunctionArgumentDefinition of(DataType<?> dataType) {
         return new FunctionArgumentDefinition(null, dataType);
-    }
-
-    public static List<FunctionArgumentDefinition> toFunctionArgumentDefinitions(List<FunctionArgument> arguments) {
-        return arguments.stream()
-            .map(arg -> FunctionArgumentDefinition.of(
-                arg.name(),
-                DataTypeAnalyzer.convert(arg.type())))
-            .collect(Collectors.toList());
     }
 
     public DataType<?> type() {

--- a/server/src/main/java/io/crate/analyze/ResetStatementAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/ResetStatementAnalyzer.java
@@ -21,6 +21,8 @@
 
 package io.crate.analyze;
 
+import java.util.HashSet;
+
 import io.crate.analyze.expressions.ExpressionAnalysisContext;
 import io.crate.analyze.expressions.ExpressionAnalyzer;
 import io.crate.analyze.relations.FieldProvider;
@@ -28,8 +30,6 @@ import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.NodeContext;
 import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.ResetStatement;
-
-import java.util.HashSet;
 
 public class ResetStatementAnalyzer {
 


### PR DESCRIPTION
The idea to generically map from Expression to Symbol didn't work out
that well because the context of a expression is required to know _how_
to convert it.

https://github.com/crate/crate/pull/14360 moved away from that model and
this finalizes the move.
