### PR TITLE
Fix IndexOutOfBoundsException due to `IS_NULL` over a subscript function

### DIFF
--- a/docs/appendices/release-notes/5.3.5.rst
+++ b/docs/appendices/release-notes/5.3.5.rst
@@ -47,4 +47,11 @@ See the :ref:`version_5.3.0` release notes for a full list of changes in the
 Fixes
 =====
 
-None
+- Fixed ``IndexOutOfBoundsException`` caused by an ``IS [NOT] NULL`` filter on
+  a sub-column of an object or object array in a ``WHERE`` clause, e.g. ::
+
+    CREATE TALE test (o1 ARRAY(OBJECT AS (col INT)), o2 OBJECT);
+    SELECT * FROM test WHERE o1[1]['col'] IS NULL;
+    => IndexOutOfBoundsException[Index: 1 Size: 1]
+    SELECT * FROM test AS T WHERE T.o2['unknown_col'] IS NOT NULL;
+    => IndexOutOfBoundsException[Index: 1 Size: 1]

--- a/docs/appendices/release-notes/5.4.1.rst
+++ b/docs/appendices/release-notes/5.4.1.rst
@@ -47,4 +47,11 @@ See the :ref:`version_5.4.0` release notes for a full list of changes in the
 Fixes
 =====
 
-None
+- Fixed ``IndexOutOfBoundsException`` caused by an ``IS [NOT] NULL`` filter on
+  a sub-column of an object or object array in a ``WHERE`` clause, e.g. ::
+
+    CREATE TALE test (o1 ARRAY(OBJECT AS (col INT)), o2 OBJECT);
+    SELECT * FROM test WHERE o1[1]['col'] IS NULL;
+    => IndexOutOfBoundsException[Index: 1 Size: 1]
+    SELECT * FROM test AS T WHERE T.o2['unknown_col'] IS NOT NULL;
+    => IndexOutOfBoundsException[Index: 1 Size: 1]

--- a/server/src/main/java/io/crate/expression/scalar/SubscriptFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/SubscriptFunction.java
@@ -245,8 +245,9 @@ public class SubscriptFunction extends Scalar<Object, Object[]> {
         // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
         //       inner
         if (!(inner.arguments().get(0) instanceof Reference ref
-                && inner.arguments().get(1) instanceof Literal<?>
-                && parent.arguments().get(1) instanceof Literal<?> cmpLiteral)) {
+              && inner.arguments().get(1) instanceof Literal<?>
+              && parent.arguments().size() == 2 // parent could for example be `op_isnull`
+              && parent.arguments().get(1) instanceof Literal<?> cmpLiteral)) {
             return null;
         }
         if (DataTypes.isArray(ref.valueType())) {

--- a/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -472,6 +472,12 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
     }
 
     @Test
+    public void test_is_null_on_subscript_function() {
+        Query query = convert("o_array[1]['xs'] is null");
+        assertThat(query).isExactlyInstanceOf(GenericFunctionQuery.class);
+    }
+
+    @Test
     public void testMatchWithOperator() {
         assertThat(convert("match(tags, 'foo bar') using best_fields with (operator='and')")).hasToString(
             "+tags:foo +tags:bar");


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Shown below is one of the affected scenario (not all object and array accesses are resolved to subscript functions):

Before:
```
cr> create table t (a array(object as (b int)));                                                                                                  
CREATE OK, 1 row affected  (1.646 sec)

cr> select * from t where a[1]['b'] is null;                                                                                                      
IndexOutOfBoundsException[Index: 1 Size: 1]
```

After fix:
```
cr> select * from t where a[1]['b'] is null;                                                                                                       
+---+
| a |
+---+
+---+
SELECT 0 rows in set (3.817 sec)
```

Another is `IndexOutOfBoundsException` case described in https://github.com/crate/crate/issues/14365.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
