### PR TITLE
Add `5.3.5.rst`-unreleased

### DIFF
--- a/docs/appendices/release-notes/5.3.5.rst
+++ b/docs/appendices/release-notes/5.3.5.rst
@@ -1,0 +1,50 @@
+.. _version_5.3.5:
+
+==========================
+Version 5.3.5 - Unreleased
+==========================
+
+.. comment 1. Remove the " - Unreleased" from the header above and adjust the ==
+.. comment 2. Remove the NOTE below and replace with: "Released on 20XX-XX-XX."
+.. comment    (without a NOTE entry, simply starting from col 1 of the line)
+
+.. NOTE::
+
+    In development. 5.3.5 isn't released yet. These are the release notes for
+    the upcoming release.
+
+.. NOTE::
+
+    If you are upgrading a cluster, you must be running CrateDB 4.0.2 or higher
+    before you upgrade to 5.3.5.
+
+    We recommend that you upgrade to the latest 5.3 release before moving to
+    5.3.5.
+
+    A rolling upgrade from 5.2.x to 5.3.5 is supported.
+    Before upgrading, you should `back up your data`_.
+
+.. WARNING::
+
+    Tables that were created before CrateDB 4.x will not function with 5.x
+    and must be recreated before moving to 5.x.x.
+
+    You can recreate tables using ``COPY TO`` and ``COPY FROM`` or by
+    `inserting the data into a new table`_.
+
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
+.. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
+
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
+See the :ref:`version_5.3.0` release notes for a full list of changes in the
+5.3 series.
+
+
+Fixes
+=====
+
+None

--- a/docs/appendices/release-notes/index.rst
+++ b/docs/appendices/release-notes/index.rst
@@ -35,6 +35,7 @@ Versions
 .. toctree::
     :maxdepth: 1
 
+    5.3.5
     5.3.4
     5.3.3
     5.3.2


### PR DESCRIPTION
To follow the new scheme, add a `5.3.5.rst` to reflect future possible hotfix release on `5.3`.
