### PR TITLE
Adapt estimated row count for Limit to be aware of source estimate

### DIFF
--- a/server/src/main/java/io/crate/planner/optimizer/costs/PlanStats.java
+++ b/server/src/main/java/io/crate/planner/optimizer/costs/PlanStats.java
@@ -121,7 +121,9 @@ public class PlanStats {
             var stats = limit.source().accept(this, null);
             if (limit.limit() instanceof Literal<?> literal) {
                 var numberOfRows = DataTypes.LONG.sanitizeValue(literal.value());
-                return stats.withNumDocs(numberOfRows);
+                if (stats.numDocs() > numberOfRows) {
+                    return stats.withNumDocs(numberOfRows);
+                }
             }
             return stats;
         }

--- a/server/src/test/java/io/crate/planner/optimizer/costs/PlanStatsTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/costs/PlanStatsTest.java
@@ -22,6 +22,7 @@
 package io.crate.planner.optimizer.costs;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static io.crate.testing.Asserts.assertThat;
 
 import java.util.List;
 import java.util.Map;
@@ -55,6 +56,7 @@ import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.types.DataTypes;
 import io.crate.user.User;
+
 
 public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
 
@@ -126,6 +128,16 @@ public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
         PlanStats planStats = new PlanStats(nodeContext, txnCtx, tableStats, memo);
         var result = planStats.get(limit);
         assertThat(result.numDocs()).isEqualTo(5L);
+        assertThat(limit).withPlanStats(planStats).hasOperators("Limit[5;0] (rows=5)",
+                                                                "  └ Collect[doc.a | [x] | true] (rows=10)");
+
+        // now the source is smaller than the limit
+        tableStats.updateTableStats(Map.of(a.ident(), new Stats(3L, 1, Map.of())));
+
+        result = planStats.get(limit);
+        assertThat(result.numDocs()).isEqualTo(3L);
+        assertThat(limit).withPlanStats(planStats).hasOperators("Limit[5;0] (rows=3)",
+                                                                "  └ Collect[doc.a | [x] | true] (rows=3)");
     }
 
     @Test

--- a/server/src/testFixtures/java/io/crate/testing/LogicalPlanAssert.java
+++ b/server/src/testFixtures/java/io/crate/testing/LogicalPlanAssert.java
@@ -24,20 +24,34 @@ package io.crate.testing;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import org.assertj.core.api.AbstractAssert;
+import org.jetbrains.annotations.Nullable;
 
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.PrintContext;
+import io.crate.planner.optimizer.costs.PlanStats;
 
 public class LogicalPlanAssert extends AbstractAssert<LogicalPlanAssert, LogicalPlan> {
 
+    @Nullable
+    private final PlanStats planStats;
+
     protected LogicalPlanAssert(LogicalPlan actual) {
-        super(actual, LogicalPlanAssert.class);
+        this(actual, null);
     }
 
-    private static String printPlan(LogicalPlan logicalPlan) {
-        var printContext = new PrintContext(null);
+    protected LogicalPlanAssert(LogicalPlan actual, @Nullable PlanStats planStats) {
+        super(actual, LogicalPlanAssert.class);
+        this.planStats = planStats;
+    }
+
+    private String printPlan(LogicalPlan logicalPlan) {
+        var printContext = new PrintContext(planStats);
         logicalPlan.print(printContext);
         return printContext.toString();
+    }
+
+    public LogicalPlanAssert withPlanStats(PlanStats planStats) {
+        return new LogicalPlanAssert(this.actual, planStats);
     }
 
     public LogicalPlanAssert isEqualTo(String expectedPlan) {


### PR DESCRIPTION
This adapts the estimated row count for limit, to take the estimated row count from the underlying source into account. When then estimate from the source is less than the limit, use the estimate from the source e.g.:

```
cr> explain select * from doc.bla where id > 2 limit 10; 
+---------------------------------------------------------+
| QUERY PLAN                                              |
+---------------------------------------------------------+
| Fetch[id] (rows=5)                                      |
|   └ Limit[10::bigint;0] (rows=5)                        |
|     └ Collect[doc.bla | [_fetchid] | (id > 2)] (rows=5) |
+---------------------------------------------------------+
```
instead of:
```
cr> explain select * from doc.bla where id > 2 limit 10;
+---------------------------------------------------------+
| QUERY PLAN                                              |
+---------------------------------------------------------+
| Fetch[id] (rows=10)                                     |
|   └ Limit[10::bigint;0] (rows=10)                       |
|     └ Collect[doc.bla | [_fetchid] | (id > 2)] (rows=5) |
+---------------------------------------------------------+
```
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
