### PR TITLE
Remove onCompletion from ColumnIndexWriterProjector/ShardingUpsertExecutor

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/indexing/ColumnIndexWriterProjector.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/ColumnIndexWriterProjector.java
@@ -29,13 +29,11 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
-import io.crate.execution.dml.IndexItem;
-import org.jetbrains.annotations.Nullable;
-
 import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.settings.Settings;
+import org.jetbrains.annotations.Nullable;
 
 import io.crate.data.BatchIterator;
 import io.crate.data.CollectingBatchIterator;
@@ -43,6 +41,7 @@ import io.crate.data.Input;
 import io.crate.data.Projector;
 import io.crate.data.Row;
 import io.crate.data.breaker.RamAccounting;
+import io.crate.execution.dml.IndexItem;
 import io.crate.execution.dml.upsert.ShardUpsertRequest;
 import io.crate.execution.dml.upsert.ShardUpsertRequest.DuplicateKeyAction;
 import io.crate.execution.engine.collect.CollectExpression;
@@ -62,7 +61,6 @@ public class ColumnIndexWriterProjector implements Projector {
 
     public ColumnIndexWriterProjector(ClusterService clusterService,
                                       BiConsumer<String, IndexItem> constraintsChecker,
-                                      Runnable onCompletion,
                                       NodeLimits nodeJobsCounter,
                                       CircuitBreaker queryCircuitBreaker,
                                       RamAccounting ramAccounting,
@@ -130,7 +128,6 @@ public class ColumnIndexWriterProjector implements Projector {
         shardingUpsertExecutor = new ShardingUpsertExecutor(
             clusterService,
             constraintsChecker,
-            onCompletion,
             nodeJobsCounter,
             queryCircuitBreaker,
             ramAccounting,

--- a/server/src/main/java/io/crate/execution/engine/indexing/IndexWriterProjector.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/IndexWriterProjector.java
@@ -33,8 +33,6 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
-import org.jetbrains.annotations.Nullable;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.client.ElasticsearchClient;
@@ -46,6 +44,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.jetbrains.annotations.Nullable;
 
 import io.crate.common.collections.Maps;
 import io.crate.data.BatchIterator;
@@ -133,7 +132,6 @@ public class IndexWriterProjector implements Projector {
         shardingUpsertExecutor = new ShardingUpsertExecutor(
             clusterService,
             (ignored1, ignored2) -> {},
-            () -> {},
             nodeJobsCounter,
             queryCircuitBreaker,
             ramAccounting,

--- a/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
+++ b/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
@@ -43,8 +43,6 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.StreamSupport;
 
-import org.jetbrains.annotations.Nullable;
-
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.create.CreatePartitionsAction;
 import org.elasticsearch.action.admin.indices.create.CreatePartitionsRequest;
@@ -60,6 +58,7 @@ import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.NotSerializableExceptionWrapper;
 import org.elasticsearch.index.IndexNotFoundException;
+import org.jetbrains.annotations.Nullable;
 
 import com.carrotsearch.hppc.IntArrayList;
 
@@ -196,11 +195,8 @@ public class InsertFromValues implements LogicalPlan {
             primaryKeyInputs.add(context.add(symbol));
         }
 
-        Input<?> clusterByInput;
         if (writerProjection.clusteredBy() != null) {
-            clusterByInput = context.add(writerProjection.clusteredBy());
-        } else {
-            clusterByInput = null;
+            context.add(writerProjection.clusteredBy());
         }
 
         String[] onConflictColumns;


### PR DESCRIPTION
`onCompletion` ran after each request - not on completion - making cache
hits less likely.

After the full operation is finished we don't need it to clear the
table, because the table will go out of scope and GC can clean it up.
