### PR TITLE
Handle parameter symbols in default/generated/properties of create table

### DIFF
--- a/server/src/main/java/io/crate/analyze/AnalyzedCreateTable.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedCreateTable.java
@@ -68,6 +68,9 @@ public record AnalyzedCreateTable(
 
     @Override
     public void visitSymbols(Consumer<? super Symbol> consumer) {
+        for (var refBuilder : columns.values()) {
+            refBuilder.visitSymbols(consumer);
+        }
         for (AnalyzedCheck check : checks.values()) {
             consumer.accept(check.check());
         }

--- a/server/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
@@ -30,6 +30,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.elasticsearch.common.UUIDs;
@@ -315,6 +316,17 @@ public class TableElementsAnalyzer implements FieldProvider<Reference> {
 
             builtReference = ref;
             return ref;
+        }
+
+        public void visitSymbols(Consumer<? super Symbol> consumer) {
+            if (defaultExpression != null) {
+                consumer.accept(defaultExpression);
+            }
+            if (generated != null) {
+                consumer.accept(generated);
+            }
+            indexProperties.properties().values().forEach(consumer);
+            storageProperties.properties().values().forEach(consumer);
         }
     }
 

--- a/server/src/test/java/io/crate/action/sql/SessionTest.java
+++ b/server/src/test/java/io/crate/action/sql/SessionTest.java
@@ -23,6 +23,7 @@ package io.crate.action.sql;
 
 import static io.crate.testing.Asserts.assertThat;
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -623,5 +624,19 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
         ParameterTypeExtractor typeExtractor = new ParameterTypeExtractor();
         DataType[] parameterTypes = typeExtractor.getParameterTypes(stmt::visitSymbols);
         assertThat(parameterTypes).containsExactly(DataTypes.STRING);
+    }
+
+
+    @Test
+    @SuppressWarnings("rawtypes")
+    public void test_can_extract_parameters_from_create_table_defaults() throws Exception {
+        SQLExecutor e = SQLExecutor.builder(clusterService)
+            .build();
+
+        AnalyzedStatement stmt = e.analyze("create table tbl (x int, y int default $1)");
+        ParameterTypeExtractor typeExtractor = new ParameterTypeExtractor();
+        DataType[] parameterTypes = typeExtractor.getParameterTypes(stmt::visitSymbols);
+        assertThat(parameterTypes).containsExactly(DataTypes.INTEGER);
+
     }
 }


### PR DESCRIPTION
Follow up to https://github.com/crate/crate/pull/14360

Statements like the following resulted in an error because the parameter
type wasn't found:

    create table tbl (x int, y int default $1)
