### PR TITLE
Fix query building for columns with INDEX OFF

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/collect/collectors/OptimizeQueryForSearchAfter.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/collectors/OptimizeQueryForSearchAfter.java
@@ -82,20 +82,20 @@ public class OptimizeQueryForSearchAfter implements Function<FieldDoc, Query> {
                     BooleanQuery.Builder booleanQuery = new BooleanQuery.Builder();
                     booleanQuery.add(new MatchAllDocsQuery(), BooleanClause.Occur.MUST);
                     if (orderBy.reverseFlags()[i]) {
-                        booleanQuery.add(eqQuery.rangeQuery(columnName, null, value, false, true, ref.hasDocValues()),
+                        booleanQuery.add(eqQuery.rangeQuery(columnName, null, value, false, true, ref.hasDocValues(), ref.indexType()),
                                          BooleanClause.Occur.MUST_NOT);
                     } else {
-                        booleanQuery.add(eqQuery.rangeQuery(columnName, value, null, true, false, ref.hasDocValues()),
+                        booleanQuery.add(eqQuery.rangeQuery(columnName, value, null, true, false, ref.hasDocValues(), ref.indexType()),
                                          BooleanClause.Occur.MUST_NOT);
                     }
                     orderQuery = booleanQuery.build();
                 } else {
                     if (orderBy.reverseFlags()[i]) {
                         orderQuery = eqQuery.rangeQuery(
-                                columnName, value, null, false, false, ref.hasDocValues());
+                                columnName, value, null, false, false, ref.hasDocValues(), ref.indexType());
                     } else {
                         orderQuery = eqQuery.rangeQuery(
-                                columnName, null, value, false, false, ref.hasDocValues());
+                                columnName, null, value, false, false, ref.hasDocValues(), ref.indexType());
                     }
                 }
                 queryBuilder.add(orderQuery, BooleanClause.Occur.MUST);

--- a/server/src/main/java/io/crate/expression/operator/CmpOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/CmpOperator.java
@@ -94,13 +94,13 @@ public final class CmpOperator extends Operator<Object> {
         String field = ref.column().fqn();
         return switch (functionName) {
             case GtOperator.NAME -> eqQuery.rangeQuery(
-                    field, value, null, false, false, ref.hasDocValues());
+                    field, value, null, false, false, ref.hasDocValues(), ref.indexType());
             case GteOperator.NAME -> eqQuery.rangeQuery(
-                    field, value, null, true, false, ref.hasDocValues());
+                    field, value, null, true, false, ref.hasDocValues(), ref.indexType());
             case LtOperator.NAME ->
-                    eqQuery.rangeQuery(field, null, value, false, false, ref.hasDocValues());
+                    eqQuery.rangeQuery(field, null, value, false, false, ref.hasDocValues(), ref.indexType());
             case LteOperator.NAME ->
-                    eqQuery.rangeQuery(field, null, value, false, true, ref.hasDocValues());
+                    eqQuery.rangeQuery(field, null, value, false, true, ref.hasDocValues(), ref.indexType());
             default -> throw new IllegalArgumentException(functionName + " is not a supported comparison operator");
         };
     }

--- a/server/src/main/java/io/crate/expression/operator/EqOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/EqOperator.java
@@ -269,7 +269,7 @@ public final class EqOperator extends Operator<Object> {
         if (eqQuery == null) {
             return null;
         }
-        return ((EqQuery<Object>) eqQuery).exactQuery(column, value, hasDocValues, indexType);
+        return ((EqQuery<Object>) eqQuery).termQuery(column, value, hasDocValues, indexType);
     }
 
     /**

--- a/server/src/main/java/io/crate/expression/operator/EqOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/EqOperator.java
@@ -155,7 +155,7 @@ public final class EqOperator extends Operator<Object> {
                 context,
                 ref.hasDocValues(),
                 ref.indexType());
-            case ArrayType.ID -> termsAndGenericFilter(
+            case ArrayType.ID -> refEqArray(
                 function,
                 ref.column().fqn(),
                 ArrayType.unnest(dataType),
@@ -213,12 +213,12 @@ public final class EqOperator extends Operator<Object> {
         return new ConstantScoreQuery(builder.build());
     }
 
-    private static Query termsAndGenericFilter(Function function,
-                                               String column,
-                                               DataType<?> elementType, Collection<?> values,
-                                               Context context,
-                                               boolean hasDocValues,
-                                               IndexType indexType) {
+    private static Query refEqArray(Function function,
+                                    String column,
+                                    DataType<?> elementType, Collection<?> values,
+                                    Context context,
+                                    boolean hasDocValues,
+                                    IndexType indexType) {
         MappedFieldType fieldType = context.getFieldTypeOrNull(column);
         if (fieldType == null) {
             if (elementType.id() == ObjectType.ID) {
@@ -306,7 +306,7 @@ public final class EqOperator extends Operator<Object> {
             String fqNestedColumn = fqn + '.' + key;
             Query innerQuery;
             if (DataTypes.isArray(innerType)) {
-                innerQuery = termsAndGenericFilter(
+                innerQuery = refEqArray(
                     eq, fqNestedColumn, innerType, (Collection<?>) entry.getValue(), context, hasDocValues, indexType);
             } else {
                 innerQuery = fromPrimitive(innerType, fqNestedColumn, entry.getValue(), hasDocValues, indexType);

--- a/server/src/main/java/io/crate/expression/operator/EqOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/EqOperator.java
@@ -24,17 +24,11 @@ package io.crate.expression.operator;
 import static io.crate.lucene.LuceneQueryBuilder.genericFunctionFilter;
 import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
 
-import java.net.InetAddress;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import org.apache.lucene.document.DoublePoint;
-import org.apache.lucene.document.FloatPoint;
-import org.apache.lucene.document.InetAddressPoint;
-import org.apache.lucene.document.IntPoint;
-import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanClause.Occur;
@@ -45,8 +39,6 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermInSetQuery;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.lucene.BytesRefs;
-import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Uid;
 import org.jetbrains.annotations.Nullable;
@@ -64,20 +56,12 @@ import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocSysColumns;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
-import io.crate.sql.tree.BitString;
 import io.crate.types.ArrayType;
-import io.crate.types.BitStringType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
-import io.crate.types.DoubleType;
 import io.crate.types.EqQuery;
-import io.crate.types.FloatType;
-import io.crate.types.IntegerType;
-import io.crate.types.IpType;
-import io.crate.types.LongType;
 import io.crate.types.ObjectType;
 import io.crate.types.StorageSupport;
-import io.crate.types.StringType;
 import io.crate.types.TypeSignature;
 
 public final class EqOperator extends Operator<Object> {
@@ -170,7 +154,7 @@ public final class EqOperator extends Operator<Object> {
     @Nullable
     @SuppressWarnings("unchecked")
     public static Query termsQuery(String column, DataType<?> type, Collection<?> values, boolean hasDocValues, IndexType indexType) {
-        List<?> nonNullValues = values.stream().filter(Objects::nonNull).toList();
+        List<Object> nonNullValues = (List<Object>) values.stream().filter(Objects::nonNull).toList();
         if (nonNullValues.isEmpty()) {
             return null;
         }
@@ -182,22 +166,12 @@ public final class EqOperator extends Operator<Object> {
             }
             return new TermInSetQuery(column, bytesRefs);
         }
-        return switch (type.id()) {
-            case StringType.ID -> new TermInSetQuery(column, nonNullValues.stream().map(BytesRefs::toBytesRef).toList());
-            case IntegerType.ID -> IntPoint.newSetQuery(column, (List<Integer>) nonNullValues);
-            case LongType.ID -> LongPoint.newSetQuery(column, (List<Long>) nonNullValues);
-            case FloatType.ID -> FloatPoint.newSetQuery(column, (List<Float>) nonNullValues);
-            case DoubleType.ID -> DoublePoint.newSetQuery(column, (List<Double>) nonNullValues);
-            case IpType.ID -> InetAddressPoint.newSetQuery(
-                column,
-                nonNullValues.stream().map(x -> InetAddresses.forString((String) x)).toArray(InetAddress[]::new)
-            );
-            case BitStringType.ID -> new TermInSetQuery(
-                column,
-                nonNullValues.stream().map(x -> new BytesRef(((BitString) x).bitSet().toByteArray())).toList()
-            );
-            default -> booleanShould(column, type, nonNullValues, hasDocValues, indexType);
-        };
+        StorageSupport<?> storageSupport = type.storageSupport();
+        EqQuery<?> eqQuery = storageSupport == null ? null : storageSupport.eqQuery();
+        if (eqQuery == null) {
+            return booleanShould(column, type, nonNullValues, hasDocValues, indexType);
+        }
+        return ((EqQuery<Object>) eqQuery).setQuery(column, nonNullValues, hasDocValues, indexType);
     }
 
     @Nullable

--- a/server/src/main/java/io/crate/expression/operator/EqOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/EqOperator.java
@@ -24,11 +24,17 @@ package io.crate.expression.operator;
 import static io.crate.lucene.LuceneQueryBuilder.genericFunctionFilter;
 import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
 
+import java.net.InetAddress;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import org.apache.lucene.document.DoublePoint;
+import org.apache.lucene.document.FloatPoint;
+import org.apache.lucene.document.InetAddressPoint;
+import org.apache.lucene.document.IntPoint;
+import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanClause.Occur;
@@ -39,6 +45,8 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermInSetQuery;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.lucene.BytesRefs;
+import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Uid;
 import org.jetbrains.annotations.Nullable;
@@ -56,12 +64,20 @@ import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocSysColumns;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
+import io.crate.sql.tree.BitString;
 import io.crate.types.ArrayType;
+import io.crate.types.BitStringType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
+import io.crate.types.DoubleType;
 import io.crate.types.EqQuery;
+import io.crate.types.FloatType;
+import io.crate.types.IntegerType;
+import io.crate.types.IpType;
+import io.crate.types.LongType;
 import io.crate.types.ObjectType;
 import io.crate.types.StorageSupport;
+import io.crate.types.StringType;
 import io.crate.types.TypeSignature;
 
 public final class EqOperator extends Operator<Object> {
@@ -154,7 +170,7 @@ public final class EqOperator extends Operator<Object> {
     @Nullable
     @SuppressWarnings("unchecked")
     public static Query termsQuery(String column, DataType<?> type, Collection<?> values, boolean hasDocValues, IndexType indexType) {
-        List<Object> nonNullValues = (List<Object>) values.stream().filter(Objects::nonNull).toList();
+        List<?> nonNullValues = values.stream().filter(Objects::nonNull).toList();
         if (nonNullValues.isEmpty()) {
             return null;
         }
@@ -166,12 +182,22 @@ public final class EqOperator extends Operator<Object> {
             }
             return new TermInSetQuery(column, bytesRefs);
         }
-        StorageSupport<?> storageSupport = type.storageSupport();
-        EqQuery<?> eqQuery = storageSupport == null ? null : storageSupport.eqQuery();
-        if (eqQuery == null) {
-            return booleanShould(column, type, nonNullValues, hasDocValues, indexType);
-        }
-        return ((EqQuery<Object>) eqQuery).setQuery(column, nonNullValues, hasDocValues, indexType);
+        return switch (type.id()) {
+            case StringType.ID -> new TermInSetQuery(column, nonNullValues.stream().map(BytesRefs::toBytesRef).toList());
+            case IntegerType.ID -> IntPoint.newSetQuery(column, (List<Integer>) nonNullValues);
+            case LongType.ID -> LongPoint.newSetQuery(column, (List<Long>) nonNullValues);
+            case FloatType.ID -> FloatPoint.newSetQuery(column, (List<Float>) nonNullValues);
+            case DoubleType.ID -> DoublePoint.newSetQuery(column, (List<Double>) nonNullValues);
+            case IpType.ID -> InetAddressPoint.newSetQuery(
+                column,
+                nonNullValues.stream().map(x -> InetAddresses.forString((String) x)).toArray(InetAddress[]::new)
+            );
+            case BitStringType.ID -> new TermInSetQuery(
+                column,
+                nonNullValues.stream().map(x -> new BytesRef(((BitString) x).bitSet().toByteArray())).toList()
+            );
+            default -> booleanShould(column, type, nonNullValues, hasDocValues, indexType);
+        };
     }
 
     @Nullable

--- a/server/src/main/java/io/crate/expression/operator/any/AnyEqOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/any/AnyEqOperator.java
@@ -68,7 +68,7 @@ public final class AnyEqOperator extends AnyOperator {
             return new MatchNoDocsQuery("column does not exist in this index");
         }
         DataType<?> innerType = ArrayType.unnest(probe.valueType());
-        return EqOperator.termsQuery(columnName, innerType, values);
+        return EqOperator.termsQuery(columnName, innerType, values, probe.hasDocValues(), probe.indexType());
     }
 
     @Override
@@ -85,7 +85,12 @@ public final class AnyEqOperator extends AnyOperator {
             // [1, 2] = any(nested_array_ref)
             return arrayLiteralEqAnyArray(any, candidates, probe.value(), context);
         }
-        return EqOperator.fromPrimitive(ArrayType.unnest(candidates.valueType()), candidates.column().fqn(), probe.value());
+        return EqOperator.fromPrimitive(
+            ArrayType.unnest(candidates.valueType()),
+            candidates.column().fqn(),
+            probe.value(),
+            candidates.hasDocValues(),
+            candidates.indexType());
     }
 
     private static Query arrayLiteralEqAnyArray(Function function,
@@ -97,8 +102,9 @@ public final class AnyEqOperator extends AnyOperator {
         Query termsQuery = EqOperator.termsQuery(
             candidates.column().fqn(),
             ArrayType.unnest(candidates.valueType()),
-            terms
-        );
+            terms,
+            candidates.hasDocValues(),
+            candidates.indexType());
         Query genericFunctionFilter = LuceneQueryBuilder.genericFunctionFilter(function, context);
         if (termsQuery == null) {
             return genericFunctionFilter;

--- a/server/src/main/java/io/crate/expression/operator/any/AnyNeqOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/any/AnyNeqOperator.java
@@ -65,7 +65,14 @@ public final class AnyNeqOperator extends AnyOperator {
 
         BooleanQuery.Builder andBuilder = new BooleanQuery.Builder();
         for (Object value : (Iterable<?>) candidates.value()) {
-            andBuilder.add(EqOperator.fromPrimitive(probe.valueType(), probe.column().fqn(), value), BooleanClause.Occur.MUST);
+            andBuilder.add(
+                EqOperator.fromPrimitive(
+                    probe.valueType(),
+                    probe.column().fqn(),
+                    value,
+                    probe.hasDocValues(),
+                    probe.indexType()),
+                BooleanClause.Occur.MUST);
         }
         Query exists = IsNullPredicate.refExistsQuery(probe, context, false);
         return new BooleanQuery.Builder()
@@ -96,11 +103,11 @@ public final class AnyNeqOperator extends AnyOperator {
         BooleanQuery.Builder query = new BooleanQuery.Builder();
         query.setMinimumNumberShouldMatch(1);
         query.add(
-            eqQuery.rangeQuery(columnName, value, null, false, false, candidates.hasDocValues()),
+            eqQuery.rangeQuery(columnName, value, null, false, false, candidates.hasDocValues(), candidates.indexType()),
             BooleanClause.Occur.SHOULD
         );
         query.add(
-            eqQuery.rangeQuery(columnName, null, value, false, false, candidates.hasDocValues()),
+            eqQuery.rangeQuery(columnName, null, value, false, false, candidates.hasDocValues(), candidates.indexType()),
             BooleanClause.Occur.SHOULD
         );
         return query.build();

--- a/server/src/main/java/io/crate/expression/scalar/SubscriptFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/SubscriptFunction.java
@@ -229,7 +229,7 @@ public class SubscriptFunction extends Scalar<Object, Object[]> {
     }
 
     private static final Map<String, PreFilterQueryBuilder> PRE_FILTER_QUERY_BUILDER_BY_OP = Map.of(
-        EqOperator.NAME, (field, eqQuery, value, haDocValues, indexType) -> eqQuery.exactQuery(field, value, haDocValues, indexType),
+        EqOperator.NAME, (field, eqQuery, value, haDocValues, indexType) -> eqQuery.termQuery(field, value, haDocValues, indexType),
         GteOperator.NAME, (field, eqQuery, value, hasDocValues, indexType) ->
                 eqQuery.rangeQuery(field, value, null, true, false, hasDocValues, indexType),
         GtOperator.NAME, (field, eqQuery, value, hasDocValues, indexType) ->

--- a/server/src/main/java/io/crate/types/BitStringType.java
+++ b/server/src/main/java/io/crate/types/BitStringType.java
@@ -23,7 +23,6 @@ package io.crate.types;
 
 import java.io.IOException;
 import java.util.BitSet;
-import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -31,7 +30,6 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.apache.lucene.document.SortedSetDocValuesField;
-import org.apache.lucene.search.TermInSetQuery;
 import org.jetbrains.annotations.Nullable;
 
 import org.apache.lucene.document.FieldType;
@@ -78,17 +76,6 @@ public final class BitStringType extends DataType<BitString> implements Streamer
                     return SortedSetDocValuesField.newSlowExactQuery(field, new BytesRef(value.bitSet().toByteArray()));
                 }
                 return new TermQuery(new Term(field, new BytesRef(value.bitSet().toByteArray())));
-            }
-
-            @Override
-            public Query setQuery(String field,
-                                  Collection<BitString> values,
-                                  boolean hasDocValues,
-                                  IndexType indexType) {
-                if (hasDocValues) {
-                    return SortedSetDocValuesField.newSlowSetQuery(field, values.stream().map(v -> new BytesRef(v.bitSet().toByteArray())).toArray(BytesRef[]::new));
-                }
-                return new TermInSetQuery(field, values.stream().map(v -> new BytesRef(v.bitSet().toByteArray())).toList());
             }
 
             @Override

--- a/server/src/main/java/io/crate/types/BitStringType.java
+++ b/server/src/main/java/io/crate/types/BitStringType.java
@@ -71,7 +71,7 @@ public final class BitStringType extends DataType<BitString> implements Streamer
         new EqQuery<BitString>() {
 
             @Override
-            public Query exactQuery(String field, BitString value, boolean hasDocValues, IndexType indexType) {
+            public Query termQuery(String field, BitString value, boolean hasDocValues, IndexType indexType) {
                 if (hasDocValues) {
                     return SortedSetDocValuesField.newSlowExactQuery(field, new BytesRef(value.bitSet().toByteArray()));
                 }

--- a/server/src/main/java/io/crate/types/BooleanType.java
+++ b/server/src/main/java/io/crate/types/BooleanType.java
@@ -59,11 +59,11 @@ public class BooleanType extends DataType<Boolean> implements Streamer<Boolean>,
         }
 
         @Override
-        public Query exactQuery(String field, Boolean value, boolean hasDocValues, IndexType indexType) {
+        public Query termQuery(String field, Boolean value, boolean hasDocValues, IndexType indexType) {
+            assert value != null: "Cannot perform = NULL, IS NULL should be used";
             if (hasDocValues) {
                 return SortedNumericDocValuesField.newSlowExactQuery(
                     field,
-                    // TODO: need a null check?
                     value ? 1 : 0);
             }
             return new TermQuery(new Term(field, indexedValue(value)));
@@ -78,6 +78,9 @@ public class BooleanType extends DataType<Boolean> implements Streamer<Boolean>,
                                 boolean hasDocValues,
                                 IndexType indexType) {
             if (hasDocValues) {
+                if (lowerTerm == null || upperTerm == null) {
+                    return null;
+                }
                 return SortedNumericDocValuesField.newSlowRangeQuery(
                     field,
                     lowerTerm ? 1 : 0,

--- a/server/src/main/java/io/crate/types/BooleanType.java
+++ b/server/src/main/java/io/crate/types/BooleanType.java
@@ -22,7 +22,6 @@
 package io.crate.types;
 
 import java.io.IOException;
-import java.util.Collection;
 import java.util.Locale;
 import java.util.Map;
 import java.util.function.Function;
@@ -31,13 +30,11 @@ import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.TermInSetQuery;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TermRangeQuery;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.lucene.BytesRefs;
 
 import io.crate.Streamer;
 import io.crate.execution.dml.BooleanIndexer;
@@ -70,18 +67,6 @@ public class BooleanType extends DataType<Boolean> implements Streamer<Boolean>,
                     value ? 1 : 0);
             }
             return new TermQuery(new Term(field, indexedValue(value)));
-        }
-
-        @Override
-        public Query setQuery(String field, Collection<Boolean> values, boolean hasDocValues, IndexType indexType) {
-            if (hasDocValues) {
-                return SortedNumericDocValuesField.newSlowSetQuery(
-                    field,
-                    // TODO: need a null check?
-                    values.stream().mapToLong(v -> v ? 1 : 0).toArray());
-            }
-            // TODO: double check
-            return new TermInSetQuery(field, values.stream().map(BytesRefs::toBytesRef).toList());
         }
 
         @Override

--- a/server/src/main/java/io/crate/types/DoubleType.java
+++ b/server/src/main/java/io/crate/types/DoubleType.java
@@ -24,7 +24,6 @@ package io.crate.types;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.Collection;
 import java.util.function.Function;
 
 import org.apache.lucene.document.DoubleField;
@@ -65,19 +64,6 @@ public class DoubleType extends DataType<Double> implements FixedWidthType, Stre
                     return SortedNumericDocValuesField.newSlowExactQuery(field, NumericUtils.doubleToSortableLong(value));
                 } else if (isIndexed) {
                     return DoublePoint.newExactQuery(field, value);
-                }
-                return null;
-            }
-
-            @Override
-            public Query setQuery(String field, Collection<Double> values, boolean hasDocValues, IndexType indexType) {
-                boolean isIndexed = indexType != IndexType.NONE;
-                if (hasDocValues && isIndexed) {
-                    return DoubleField.newSetQuery(field, values.stream().mapToDouble(Double::doubleValue).toArray());
-                } else if (hasDocValues) {
-                    return SortedNumericDocValuesField.newSlowSetQuery(field, values.stream().mapToLong(NumericUtils::doubleToSortableLong).toArray());
-                } else if (isIndexed) {
-                    return DoublePoint.newSetQuery(field, values.stream().mapToDouble(Double::doubleValue).toArray());
                 }
                 return null;
             }

--- a/server/src/main/java/io/crate/types/DoubleType.java
+++ b/server/src/main/java/io/crate/types/DoubleType.java
@@ -56,7 +56,7 @@ public class DoubleType extends DataType<Double> implements FixedWidthType, Stre
         new EqQuery<Double>() {
 
             @Override
-            public Query exactQuery(String field, Double value, boolean hasDocValues, IndexType indexType) {
+            public Query termQuery(String field, Double value, boolean hasDocValues, IndexType indexType) {
                 boolean isIndexed = indexType != IndexType.NONE;
                 if (hasDocValues && isIndexed) {
                     return DoubleField.newExactQuery(field, value);

--- a/server/src/main/java/io/crate/types/DoubleType.java
+++ b/server/src/main/java/io/crate/types/DoubleType.java
@@ -24,6 +24,7 @@ package io.crate.types;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Collection;
 import java.util.function.Function;
 
 import org.apache.lucene.document.DoubleField;
@@ -64,6 +65,19 @@ public class DoubleType extends DataType<Double> implements FixedWidthType, Stre
                     return SortedNumericDocValuesField.newSlowExactQuery(field, NumericUtils.doubleToSortableLong(value));
                 } else if (isIndexed) {
                     return DoublePoint.newExactQuery(field, value);
+                }
+                return null;
+            }
+
+            @Override
+            public Query setQuery(String field, Collection<Double> values, boolean hasDocValues, IndexType indexType) {
+                boolean isIndexed = indexType != IndexType.NONE;
+                if (hasDocValues && isIndexed) {
+                    return DoubleField.newSetQuery(field, values.stream().mapToDouble(Double::doubleValue).toArray());
+                } else if (hasDocValues) {
+                    return SortedNumericDocValuesField.newSlowSetQuery(field, values.stream().mapToLong(NumericUtils::doubleToSortableLong).toArray());
+                } else if (isIndexed) {
+                    return DoublePoint.newSetQuery(field, values.stream().mapToDouble(Double::doubleValue).toArray());
                 }
                 return null;
             }

--- a/server/src/main/java/io/crate/types/EqQuery.java
+++ b/server/src/main/java/io/crate/types/EqQuery.java
@@ -23,17 +23,20 @@ package io.crate.types;
 
 import org.apache.lucene.search.Query;
 
+import io.crate.metadata.IndexType;
+
 /**
  * For types which can be stored in Lucene and support optimized equality related queries
  **/
 public interface EqQuery<T> {
 
-    Query termQuery(String field, T value);
+    Query exactQuery(String field, T value, boolean hasDocValues, IndexType indexType);
 
     Query rangeQuery(String field,
                      T lowerTerm,
                      T upperTerm,
                      boolean includeLower,
                      boolean includeUpper,
-                     boolean hasDocValues);
+                     boolean hasDocValues,
+                     IndexType indexType);
 }

--- a/server/src/main/java/io/crate/types/EqQuery.java
+++ b/server/src/main/java/io/crate/types/EqQuery.java
@@ -30,7 +30,7 @@ import io.crate.metadata.IndexType;
  **/
 public interface EqQuery<T> {
 
-    Query exactQuery(String field, T value, boolean hasDocValues, IndexType indexType);
+    Query termQuery(String field, T value, boolean hasDocValues, IndexType indexType);
 
     Query rangeQuery(String field,
                      T lowerTerm,

--- a/server/src/main/java/io/crate/types/EqQuery.java
+++ b/server/src/main/java/io/crate/types/EqQuery.java
@@ -21,8 +21,6 @@
 
 package io.crate.types;
 
-import java.util.Collection;
-
 import org.apache.lucene.search.Query;
 
 import io.crate.metadata.IndexType;
@@ -33,8 +31,6 @@ import io.crate.metadata.IndexType;
 public interface EqQuery<T> {
 
     Query exactQuery(String field, T value, boolean hasDocValues, IndexType indexType);
-
-    Query setQuery(String field, Collection<T> values, boolean hasDocValues, IndexType indexType);
 
     Query rangeQuery(String field,
                      T lowerTerm,

--- a/server/src/main/java/io/crate/types/EqQuery.java
+++ b/server/src/main/java/io/crate/types/EqQuery.java
@@ -21,6 +21,8 @@
 
 package io.crate.types;
 
+import java.util.Collection;
+
 import org.apache.lucene.search.Query;
 
 import io.crate.metadata.IndexType;
@@ -31,6 +33,8 @@ import io.crate.metadata.IndexType;
 public interface EqQuery<T> {
 
     Query exactQuery(String field, T value, boolean hasDocValues, IndexType indexType);
+
+    Query setQuery(String field, Collection<T> values, boolean hasDocValues, IndexType indexType);
 
     Query rangeQuery(String field,
                      T lowerTerm,

--- a/server/src/main/java/io/crate/types/FloatType.java
+++ b/server/src/main/java/io/crate/types/FloatType.java
@@ -24,7 +24,6 @@ package io.crate.types;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.Collection;
 import java.util.function.Function;
 
 import org.apache.lucene.document.FieldType;
@@ -65,24 +64,6 @@ public class FloatType extends DataType<Float> implements Streamer<Float>, Fixed
                     return SortedNumericDocValuesField.newSlowExactQuery(field, NumericUtils.floatToSortableInt(value));
                 } else if (isIndexed) {
                     return FloatPoint.newExactQuery(field, value);
-                }
-                return null;
-            }
-
-            @Override
-            public Query setQuery(String field, Collection<Float> values, boolean hasDocValues, IndexType indexType) {
-                boolean isIndexed = indexType != IndexType.NONE;
-                if (hasDocValues && isIndexed) {
-                    int idx = 0;
-                    float[] valuesArray = new float[values.size()];
-                    for (var f : values) {
-                        valuesArray[idx++] = f;
-                    }
-                    return FloatField.newSetQuery(field, valuesArray);
-                } else if (hasDocValues) {
-                    return SortedNumericDocValuesField.newSlowSetQuery(field, values.stream().mapToInt(NumericUtils::floatToSortableInt).mapToLong(Long::valueOf).toArray());
-                } else if (isIndexed) {
-                    return FloatPoint.newSetQuery(field, values);
                 }
                 return null;
             }

--- a/server/src/main/java/io/crate/types/FloatType.java
+++ b/server/src/main/java/io/crate/types/FloatType.java
@@ -24,6 +24,7 @@ package io.crate.types;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Collection;
 import java.util.function.Function;
 
 import org.apache.lucene.document.FieldType;
@@ -64,6 +65,24 @@ public class FloatType extends DataType<Float> implements Streamer<Float>, Fixed
                     return SortedNumericDocValuesField.newSlowExactQuery(field, NumericUtils.floatToSortableInt(value));
                 } else if (isIndexed) {
                     return FloatPoint.newExactQuery(field, value);
+                }
+                return null;
+            }
+
+            @Override
+            public Query setQuery(String field, Collection<Float> values, boolean hasDocValues, IndexType indexType) {
+                boolean isIndexed = indexType != IndexType.NONE;
+                if (hasDocValues && isIndexed) {
+                    int idx = 0;
+                    float[] valuesArray = new float[values.size()];
+                    for (var f : values) {
+                        valuesArray[idx++] = f;
+                    }
+                    return FloatField.newSetQuery(field, valuesArray);
+                } else if (hasDocValues) {
+                    return SortedNumericDocValuesField.newSlowSetQuery(field, values.stream().mapToInt(NumericUtils::floatToSortableInt).mapToLong(Long::valueOf).toArray());
+                } else if (isIndexed) {
+                    return FloatPoint.newSetQuery(field, values);
                 }
                 return null;
             }

--- a/server/src/main/java/io/crate/types/FloatType.java
+++ b/server/src/main/java/io/crate/types/FloatType.java
@@ -56,7 +56,7 @@ public class FloatType extends DataType<Float> implements Streamer<Float>, Fixed
         new EqQuery<Float>() {
 
             @Override
-            public Query exactQuery(String field, Float value, boolean hasDocValues, IndexType indexType) {
+            public Query termQuery(String field, Float value, boolean hasDocValues, IndexType indexType) {
                 boolean isIndexed = indexType != IndexType.NONE;
                 if (hasDocValues && isIndexed) {
                     return FloatField.newExactQuery(field, value);

--- a/server/src/main/java/io/crate/types/FloatVectorType.java
+++ b/server/src/main/java/io/crate/types/FloatVectorType.java
@@ -23,6 +23,7 @@ package io.crate.types;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -40,6 +41,7 @@ import io.crate.Streamer;
 import io.crate.execution.dml.FloatVectorIndexer;
 import io.crate.execution.dml.ValueIndexer;
 import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.IndexType;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 import io.crate.sql.tree.ColumnDefinition;
@@ -57,7 +59,12 @@ public class FloatVectorType extends DataType<float[]> implements Streamer<float
     private static final EqQuery<float[]> EQ_QUERY = new EqQuery<float[]>() {
 
         @Override
-        public Query termQuery(String field, float[] value) {
+        public Query exactQuery(String field, float[] value, boolean hasDocValues, IndexType indexType) {
+            return null;
+        }
+
+        @Override
+        public Query setQuery(String field, Collection<float[]> values, boolean hasDocValues, IndexType indexType) {
             return null;
         }
 
@@ -67,7 +74,8 @@ public class FloatVectorType extends DataType<float[]> implements Streamer<float
                                 float[] upperTerm,
                                 boolean includeLower,
                                 boolean includeUpper,
-                                boolean hasDocValues) {
+                                boolean hasDocValues,
+                                IndexType indexType) {
             return null;
         }
     };

--- a/server/src/main/java/io/crate/types/FloatVectorType.java
+++ b/server/src/main/java/io/crate/types/FloatVectorType.java
@@ -40,6 +40,7 @@ import io.crate.Streamer;
 import io.crate.execution.dml.FloatVectorIndexer;
 import io.crate.execution.dml.ValueIndexer;
 import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.IndexType;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 import io.crate.sql.tree.ColumnDefinition;
@@ -57,7 +58,7 @@ public class FloatVectorType extends DataType<float[]> implements Streamer<float
     private static final EqQuery<float[]> EQ_QUERY = new EqQuery<float[]>() {
 
         @Override
-        public Query termQuery(String field, float[] value) {
+        public Query termQuery(String field, float[] value, boolean hasDocValues, IndexType indexType) {
             return null;
         }
 
@@ -67,7 +68,8 @@ public class FloatVectorType extends DataType<float[]> implements Streamer<float
                                 float[] upperTerm,
                                 boolean includeLower,
                                 boolean includeUpper,
-                                boolean hasDocValues) {
+                                boolean hasDocValues,
+                                IndexType indexType) {
             return null;
         }
     };

--- a/server/src/main/java/io/crate/types/FloatVectorType.java
+++ b/server/src/main/java/io/crate/types/FloatVectorType.java
@@ -23,7 +23,6 @@ package io.crate.types;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -41,7 +40,6 @@ import io.crate.Streamer;
 import io.crate.execution.dml.FloatVectorIndexer;
 import io.crate.execution.dml.ValueIndexer;
 import io.crate.metadata.ColumnIdent;
-import io.crate.metadata.IndexType;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 import io.crate.sql.tree.ColumnDefinition;
@@ -59,12 +57,7 @@ public class FloatVectorType extends DataType<float[]> implements Streamer<float
     private static final EqQuery<float[]> EQ_QUERY = new EqQuery<float[]>() {
 
         @Override
-        public Query exactQuery(String field, float[] value, boolean hasDocValues, IndexType indexType) {
-            return null;
-        }
-
-        @Override
-        public Query setQuery(String field, Collection<float[]> values, boolean hasDocValues, IndexType indexType) {
+        public Query termQuery(String field, float[] value) {
             return null;
         }
 
@@ -74,8 +67,7 @@ public class FloatVectorType extends DataType<float[]> implements Streamer<float
                                 float[] upperTerm,
                                 boolean includeLower,
                                 boolean includeUpper,
-                                boolean hasDocValues,
-                                IndexType indexType) {
+                                boolean hasDocValues) {
             return null;
         }
     };

--- a/server/src/main/java/io/crate/types/IntEqQuery.java
+++ b/server/src/main/java/io/crate/types/IntEqQuery.java
@@ -21,8 +21,6 @@
 
 package io.crate.types;
 
-import java.util.Collection;
-
 import org.apache.lucene.document.IntField;
 import org.apache.lucene.document.IntPoint;
 import org.apache.lucene.document.SortedNumericDocValuesField;
@@ -41,19 +39,6 @@ public class IntEqQuery implements EqQuery<Number> {
             return SortedNumericDocValuesField.newSlowExactQuery(field, value.intValue());
         } else if (isIndexed) {
             return IntPoint.newExactQuery(field, value.intValue());
-        }
-        return null;
-    }
-
-    @Override
-    public Query setQuery(String field, Collection<Number> values, boolean hasDocValues, IndexType indexType) {
-        boolean isIndexed = indexType != IndexType.NONE;
-        if (hasDocValues && isIndexed) {
-            return IntField.newSetQuery(field, values.stream().mapToInt(Number::intValue).toArray());
-        } else if (hasDocValues) {
-            return SortedNumericDocValuesField.newSlowSetQuery(field, values.stream().mapToLong(Number::longValue).toArray());
-        } else if (isIndexed) {
-            return IntPoint.newSetQuery(field, values.stream().mapToInt(Number::intValue).toArray());
         }
         return null;
     }

--- a/server/src/main/java/io/crate/types/IntEqQuery.java
+++ b/server/src/main/java/io/crate/types/IntEqQuery.java
@@ -31,7 +31,7 @@ import io.crate.metadata.IndexType;
 public class IntEqQuery implements EqQuery<Number> {
 
     @Override
-    public Query exactQuery(String field, Number value, boolean hasDocValues, IndexType indexType) {
+    public Query termQuery(String field, Number value, boolean hasDocValues, IndexType indexType) {
         boolean isIndexed = indexType != IndexType.NONE;
         if (hasDocValues && isIndexed) {
             return IntField.newExactQuery(field, value.intValue());

--- a/server/src/main/java/io/crate/types/IntEqQuery.java
+++ b/server/src/main/java/io/crate/types/IntEqQuery.java
@@ -21,6 +21,8 @@
 
 package io.crate.types;
 
+import java.util.Collection;
+
 import org.apache.lucene.document.IntField;
 import org.apache.lucene.document.IntPoint;
 import org.apache.lucene.document.SortedNumericDocValuesField;
@@ -39,6 +41,19 @@ public class IntEqQuery implements EqQuery<Number> {
             return SortedNumericDocValuesField.newSlowExactQuery(field, value.intValue());
         } else if (isIndexed) {
             return IntPoint.newExactQuery(field, value.intValue());
+        }
+        return null;
+    }
+
+    @Override
+    public Query setQuery(String field, Collection<Number> values, boolean hasDocValues, IndexType indexType) {
+        boolean isIndexed = indexType != IndexType.NONE;
+        if (hasDocValues && isIndexed) {
+            return IntField.newSetQuery(field, values.stream().mapToInt(Number::intValue).toArray());
+        } else if (hasDocValues) {
+            return SortedNumericDocValuesField.newSlowSetQuery(field, values.stream().mapToLong(Number::longValue).toArray());
+        } else if (isIndexed) {
+            return IntPoint.newSetQuery(field, values.stream().mapToInt(Number::intValue).toArray());
         }
         return null;
     }

--- a/server/src/main/java/io/crate/types/IpType.java
+++ b/server/src/main/java/io/crate/types/IpType.java
@@ -23,7 +23,6 @@ package io.crate.types;
 
 import java.io.IOException;
 import java.net.InetAddress;
-import java.util.Collection;
 import java.util.function.Function;
 
 import org.apache.lucene.document.FieldType;
@@ -67,22 +66,6 @@ public class IpType extends DataType<String> implements Streamer<String> {
                     return SortedSetDocValuesField.newSlowExactQuery(field, new BytesRef(InetAddressPoint.encode(InetAddresses.forString(value))));
                 } else if (isIndexed) {
                     return InetAddressPoint.newExactQuery(field, InetAddresses.forString(value));
-                }
-                return null;
-            }
-
-            @Override
-            public Query setQuery(String field, Collection<String> values, boolean hasDocValues, IndexType indexType) {
-                boolean isIndexed = indexType != IndexType.NONE;
-                if (hasDocValues && isIndexed) {
-                    return new IndexOrDocValuesQuery(
-                        InetAddressPoint.newSetQuery(field, values.stream().map(InetAddresses::forString).toArray(InetAddress[]::new)),
-                        SortedSetDocValuesField.newSlowSetQuery(field, values.stream().map(v -> new BytesRef(InetAddressPoint.encode(InetAddresses.forString(v)))).toArray(BytesRef[]::new))
-                    );
-                } else if (hasDocValues) {
-                    return SortedSetDocValuesField.newSlowSetQuery(field, values.stream().map(v -> new BytesRef(InetAddressPoint.encode(InetAddresses.forString(v)))).toArray(BytesRef[]::new));
-                } else if (isIndexed) {
-                    return InetAddressPoint.newSetQuery(field, values.stream().map(InetAddresses::forString).toArray(InetAddress[]::new));
                 }
                 return null;
             }

--- a/server/src/main/java/io/crate/types/IpType.java
+++ b/server/src/main/java/io/crate/types/IpType.java
@@ -23,6 +23,7 @@ package io.crate.types;
 
 import java.io.IOException;
 import java.net.InetAddress;
+import java.util.Collection;
 import java.util.function.Function;
 
 import org.apache.lucene.document.FieldType;
@@ -66,6 +67,22 @@ public class IpType extends DataType<String> implements Streamer<String> {
                     return SortedSetDocValuesField.newSlowExactQuery(field, new BytesRef(InetAddressPoint.encode(InetAddresses.forString(value))));
                 } else if (isIndexed) {
                     return InetAddressPoint.newExactQuery(field, InetAddresses.forString(value));
+                }
+                return null;
+            }
+
+            @Override
+            public Query setQuery(String field, Collection<String> values, boolean hasDocValues, IndexType indexType) {
+                boolean isIndexed = indexType != IndexType.NONE;
+                if (hasDocValues && isIndexed) {
+                    return new IndexOrDocValuesQuery(
+                        InetAddressPoint.newSetQuery(field, values.stream().map(InetAddresses::forString).toArray(InetAddress[]::new)),
+                        SortedSetDocValuesField.newSlowSetQuery(field, values.stream().map(v -> new BytesRef(InetAddressPoint.encode(InetAddresses.forString(v)))).toArray(BytesRef[]::new))
+                    );
+                } else if (hasDocValues) {
+                    return SortedSetDocValuesField.newSlowSetQuery(field, values.stream().map(v -> new BytesRef(InetAddressPoint.encode(InetAddresses.forString(v)))).toArray(BytesRef[]::new));
+                } else if (isIndexed) {
+                    return InetAddressPoint.newSetQuery(field, values.stream().map(InetAddresses::forString).toArray(InetAddress[]::new));
                 }
                 return null;
             }

--- a/server/src/main/java/io/crate/types/LongEqQuery.java
+++ b/server/src/main/java/io/crate/types/LongEqQuery.java
@@ -21,6 +21,8 @@
 
 package io.crate.types;
 
+import java.util.Collection;
+
 import org.apache.lucene.document.LongField;
 import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.document.SortedNumericDocValuesField;
@@ -39,6 +41,19 @@ public class LongEqQuery implements EqQuery<Long> {
             return SortedNumericDocValuesField.newSlowExactQuery(field, value);
         } else if (isIndexed) {
             return LongPoint.newExactQuery(field, value);
+        }
+        return null;
+    }
+
+    @Override
+    public Query setQuery(String field, Collection<Long> values, boolean hasDocValues, IndexType indexType) {
+        boolean isIndexed = indexType != IndexType.NONE;
+        if (hasDocValues && isIndexed) {
+            return LongField.newSetQuery(field, values.stream().mapToLong(Number::longValue).toArray());
+        } else if (hasDocValues) {
+            return SortedNumericDocValuesField.newSlowSetQuery(field, values.stream().mapToLong(Number::longValue).toArray());
+        } else if (isIndexed) {
+            return LongPoint.newSetQuery(field, values.stream().mapToLong(Number::longValue).toArray());
         }
         return null;
     }

--- a/server/src/main/java/io/crate/types/LongEqQuery.java
+++ b/server/src/main/java/io/crate/types/LongEqQuery.java
@@ -31,7 +31,7 @@ import io.crate.metadata.IndexType;
 public class LongEqQuery implements EqQuery<Long> {
 
     @Override
-    public Query exactQuery(String field, Long value, boolean hasDocValues, IndexType indexType) {
+    public Query termQuery(String field, Long value, boolean hasDocValues, IndexType indexType) {
         boolean isIndexed = indexType != IndexType.NONE;
         if (hasDocValues && isIndexed) {
             return LongField.newExactQuery(field, value);

--- a/server/src/main/java/io/crate/types/LongEqQuery.java
+++ b/server/src/main/java/io/crate/types/LongEqQuery.java
@@ -21,8 +21,6 @@
 
 package io.crate.types;
 
-import java.util.Collection;
-
 import org.apache.lucene.document.LongField;
 import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.document.SortedNumericDocValuesField;
@@ -41,19 +39,6 @@ public class LongEqQuery implements EqQuery<Long> {
             return SortedNumericDocValuesField.newSlowExactQuery(field, value);
         } else if (isIndexed) {
             return LongPoint.newExactQuery(field, value);
-        }
-        return null;
-    }
-
-    @Override
-    public Query setQuery(String field, Collection<Long> values, boolean hasDocValues, IndexType indexType) {
-        boolean isIndexed = indexType != IndexType.NONE;
-        if (hasDocValues && isIndexed) {
-            return LongField.newSetQuery(field, values.stream().mapToLong(Number::longValue).toArray());
-        } else if (hasDocValues) {
-            return SortedNumericDocValuesField.newSlowSetQuery(field, values.stream().mapToLong(Number::longValue).toArray());
-        } else if (isIndexed) {
-            return LongPoint.newSetQuery(field, values.stream().mapToLong(Number::longValue).toArray());
         }
         return null;
     }

--- a/server/src/main/java/io/crate/types/StringType.java
+++ b/server/src/main/java/io/crate/types/StringType.java
@@ -34,7 +34,6 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.apache.lucene.document.SortedSetDocValuesField;
-import org.apache.lucene.search.TermInSetQuery;
 import org.jetbrains.annotations.Nullable;
 
 import org.apache.lucene.document.FieldType;
@@ -79,20 +78,13 @@ public class StringType extends DataType<String> implements Streamer<String> {
         true,
         true,
         new EqQuery<Object>() {
+
             @Override
             public Query exactQuery(String field, Object value, boolean hasDocValues, IndexType indexType) {
                 if (indexType == IndexType.PLAIN && hasDocValues) {
                     return SortedSetDocValuesField.newSlowExactQuery(field, BytesRefs.toBytesRef(value));
                 }
                 return new TermQuery(new Term(field, BytesRefs.toBytesRef(value)));
-            }
-
-            @Override
-            public Query setQuery(String field, Collection<Object> values, boolean hasDocValues, IndexType indexType) {
-                if (indexType == IndexType.PLAIN && hasDocValues) {
-                    return SortedSetDocValuesField.newSlowSetQuery(field, values.stream().map(BytesRefs::toBytesRef).toArray(BytesRef[]::new));
-                }
-                return new TermInSetQuery(field, values.stream().map(BytesRefs::toBytesRef).toList());
             }
 
             @Override

--- a/server/src/main/java/io/crate/types/StringType.java
+++ b/server/src/main/java/io/crate/types/StringType.java
@@ -34,6 +34,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.apache.lucene.document.SortedSetDocValuesField;
+import org.apache.lucene.search.TermInSetQuery;
 import org.jetbrains.annotations.Nullable;
 
 import org.apache.lucene.document.FieldType;
@@ -78,13 +79,20 @@ public class StringType extends DataType<String> implements Streamer<String> {
         true,
         true,
         new EqQuery<Object>() {
-
             @Override
             public Query exactQuery(String field, Object value, boolean hasDocValues, IndexType indexType) {
                 if (indexType == IndexType.PLAIN && hasDocValues) {
                     return SortedSetDocValuesField.newSlowExactQuery(field, BytesRefs.toBytesRef(value));
                 }
                 return new TermQuery(new Term(field, BytesRefs.toBytesRef(value)));
+            }
+
+            @Override
+            public Query setQuery(String field, Collection<Object> values, boolean hasDocValues, IndexType indexType) {
+                if (indexType == IndexType.PLAIN && hasDocValues) {
+                    return SortedSetDocValuesField.newSlowSetQuery(field, values.stream().map(BytesRefs::toBytesRef).toArray(BytesRef[]::new));
+                }
+                return new TermInSetQuery(field, values.stream().map(BytesRefs::toBytesRef).toList());
             }
 
             @Override

--- a/server/src/test/java/io/crate/expression/operator/EqOperatorTest.java
+++ b/server/src/test/java/io/crate/expression/operator/EqOperatorTest.java
@@ -34,6 +34,7 @@ import org.junit.Test;
 
 import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.lucene.GenericFunctionQuery;
+import io.crate.metadata.IndexType;
 import io.crate.metadata.doc.DocSysColumns;
 import io.crate.testing.Asserts;
 import io.crate.testing.DataTypeTesting;
@@ -141,7 +142,17 @@ public class EqOperatorTest extends ScalarTestCase {
 
     @Test
     public void test_terms_query_on__id_encodes_ids() throws Exception {
-        Query query = EqOperator.termsQuery(DocSysColumns.ID.name(), DataTypes.STRING, List.of("foo", "bar"));
+        Query query = EqOperator.termsQuery(DocSysColumns.ID.name(), DataTypes.STRING, List.of("foo", "bar"), true, IndexType.FULLTEXT);
+        assertThat(query).hasToString("_id:([7e 8a] [ff 62 61 72])");
+        query = EqOperator.termsQuery(DocSysColumns.ID.name(), DataTypes.STRING, List.of("foo", "bar"), true, IndexType.PLAIN);
+        assertThat(query).hasToString("_id:([7e 8a] [ff 62 61 72])");
+        query = EqOperator.termsQuery(DocSysColumns.ID.name(), DataTypes.STRING, List.of("foo", "bar"), true, IndexType.NONE);
+        assertThat(query).hasToString("_id:([7e 8a] [ff 62 61 72])");
+        query = EqOperator.termsQuery(DocSysColumns.ID.name(), DataTypes.STRING, List.of("foo", "bar"), false, IndexType.FULLTEXT);
+        assertThat(query).hasToString("_id:([7e 8a] [ff 62 61 72])");
+        query = EqOperator.termsQuery(DocSysColumns.ID.name(), DataTypes.STRING, List.of("foo", "bar"), false, IndexType.PLAIN);
+        assertThat(query).hasToString("_id:([7e 8a] [ff 62 61 72])");
+        query = EqOperator.termsQuery(DocSysColumns.ID.name(), DataTypes.STRING, List.of("foo", "bar"), false, IndexType.NONE);
         assertThat(query).hasToString("_id:([7e 8a] [ff 62 61 72])");
     }
 

--- a/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
@@ -30,7 +30,6 @@ import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.CONFLICT;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
@@ -292,11 +291,8 @@ public class DDLIntegrationTest extends IntegTestCase {
         String quote = "Would it save you a lot of time if I just gave up and went mad now?";
         execute("insert into quotes (id, quote) values (?, ?)", new Object[]{1, quote});
         execute("refresh table quotes");
-
-        Asserts.assertSQLError(() -> execute("select quote from quotes where quote = ?", new Object[]{quote}))
-            .hasPGError(INTERNAL_ERROR)
-            .hasHTTPError(BAD_REQUEST, 4000)
-            .hasMessageContaining("Cannot search on field [quote] since it is not indexed.");
+        execute("select quote from quotes where quote = ?", new Object[]{quote});
+        assertThat(response).hasRows(quote);
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/LuceneQueryBuilderIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/LuceneQueryBuilderIntegrationTest.java
@@ -464,12 +464,13 @@ public class LuceneQueryBuilderIntegrationTest extends IntegTestCase {
         assertThat(execute("select * from t where i = 'a'")).hasRows(expectedFirstRow);
 
         // EqQuery.RangeQuery
+        //UnsupportedFunctionException: Unknown function: (mgjihphcgyjgklnrovd.t.a > B'01'), no overload found for matching argument types: (bit, bit). Possible candidates: op_>(byte, byte):boolean, op_>(boolean, boolean):boolean, op_>(character, character):boolean, op_>(text, text):boolean, op_>(ip, ip):boolean, op_>(double precision, double precision):boolean, op_>(real, real):boolean, op_>(smallint, smallint):boolean, op_>(integer, integer):boolean, op_>(interval, interval):boolean, op_>(bigint, bigint):boolean, op_>(timestamp with time zone, timestamp with time zone):boolean, op_>(timestamp without time zone, timestamp without time zone):boolean, op_>(date, date):boolean
         //assertThat(execute("select * from t where a > B'01'")).hasRows(expectedSecondRow);
         assertThat(execute("select * from t where b > 1.1")).hasRows(expectedSecondRow);
         assertThat(execute("select * from t where c > 1.1")).hasRows(expectedSecondRow);
-        //assertThat(execute("select * from t where d > '1.1.1.1'")).hasRows(expectedSecondRow);
+        assertThat(execute("select * from t where d > '1.1.1.1'")).hasRows(expectedSecondRow);
         assertThat(execute("select * from t where e > 'a'")).hasRows(expectedSecondRow);
-        //assertThat(execute("select * from t where f > false")).hasRows(expectedSecondRow);
+        assertThat(execute("select * from t where f > false")).hasRows(expectedSecondRow);
         assertThat(execute("select * from t where g > 1")).hasRows(expectedSecondRow);
         assertThat(execute("select * from t where h > 1")).hasRows(expectedSecondRow);
         assertThat(execute("select * from t where i > 'a'")).hasRows(expectedSecondRow);
@@ -504,18 +505,19 @@ public class LuceneQueryBuilderIntegrationTest extends IntegTestCase {
         assertThat(execute("select * from t where b = 1.1")).hasRows(expectedFirstRow);
         assertThat(execute("select * from t where c = 1.1")).hasRows(expectedFirstRow);
         assertThat(execute("select * from t where d = '1.1.1.1'")).hasRows(expectedFirstRow);
-        //assertThat(execute("select * from t where e = 'a'")).hasRows(expectedFirstRow);
+        assertThat(execute("select * from t where e = 'a'")).hasRows(expectedFirstRow);
         assertThat(execute("select * from t where f = false")).hasRows(expectedFirstRow);
         assertThat(execute("select * from t where g = 1")).hasRows(expectedFirstRow);
         assertThat(execute("select * from t where h = 1")).hasRows(expectedFirstRow);
 
         // EqQuery.RangeQuery
+        // UnsupportedFunctionException: Unknown function
         //assertThat(execute("select * from t where a > B'01'")).hasRows(expectedSecondRow);
         assertThat(execute("select * from t where b > 1.1")).hasRows(expectedSecondRow);
         assertThat(execute("select * from t where c > 1.1")).hasRows(expectedSecondRow);
-        //assertThat(execute("select * from t where d > '1.1.1.1'")).hasRows(expectedSecondRow);
-        //assertThat(execute("select * from t where e > 'a'")).hasRows(expectedSecondRow);
-        //assertThat(execute("select * from t where f > false")).hasRows(expectedSecondRow);
+        assertThat(execute("select * from t where d > '1.1.1.1'")).hasRows(expectedSecondRow);
+        assertThat(execute("select * from t where e > 'a'")).hasRows(expectedSecondRow);
+        assertThat(execute("select * from t where f > false")).hasRows(expectedSecondRow);
         assertThat(execute("select * from t where g > 1")).hasRows(expectedSecondRow);
         assertThat(execute("select * from t where h > 1")).hasRows(expectedSecondRow);
     }
@@ -549,7 +551,7 @@ public class LuceneQueryBuilderIntegrationTest extends IntegTestCase {
         assertThat(execute("select * from t where b = 1.1")).hasRows(expectedFirstRow);
         assertThat(execute("select * from t where c = 1.1")).hasRows(expectedFirstRow);
         assertThat(execute("select * from t where d = '1.1.1.1'")).hasRows(expectedFirstRow);
-        //assertThat(execute("select * from t where e = 'a'")).hasRows(expectedFirstRow);
+        assertThat(execute("select * from t where e = 'a'")).hasRows(expectedFirstRow);
         assertThat(execute("select * from t where f = false")).hasRows(expectedFirstRow);
         assertThat(execute("select * from t where g = 1")).hasRows(expectedFirstRow);
         assertThat(execute("select * from t where h = 1")).hasRows(expectedFirstRow);
@@ -558,9 +560,9 @@ public class LuceneQueryBuilderIntegrationTest extends IntegTestCase {
         //assertThat(execute("select * from t where a > B'01'")).hasRows(expectedSecondRow);
         assertThat(execute("select * from t where b > 1.1")).hasRows(expectedSecondRow);
         assertThat(execute("select * from t where c > 1.1")).hasRows(expectedSecondRow);
-        //assertThat(execute("select * from t where d > '1.1.1.1'")).hasRows(expectedSecondRow);
-        //assertThat(execute("select * from t where e > 'a'")).hasRows(expectedSecondRow);
-        //assertThat(execute("select * from t where f > false")).hasRows(expectedSecondRow);
+        assertThat(execute("select * from t where d > '1.1.1.1'")).hasRows(expectedSecondRow);
+        assertThat(execute("select * from t where e > 'a'")).hasRows(expectedSecondRow);
+        assertThat(execute("select * from t where f > false")).hasRows(expectedSecondRow);
         assertThat(execute("select * from t where g > 1")).hasRows(expectedSecondRow);
         assertThat(execute("select * from t where h > 1")).hasRows(expectedSecondRow);
     }
@@ -605,9 +607,9 @@ public class LuceneQueryBuilderIntegrationTest extends IntegTestCase {
         //assertThat(execute("select * from t where a > B'01'")).hasRows(expectedSecondRow);
         assertThat(execute("select * from t where b > 1.1")).hasRows(expectedSecondRow);
         assertThat(execute("select * from t where c > 1.1")).hasRows(expectedSecondRow);
-        //assertThat(execute("select * from t where d > '1.1.1.1'")).hasRows(expectedSecondRow);
+        assertThat(execute("select * from t where d > '1.1.1.1'")).hasRows(expectedSecondRow);
         assertThat(execute("select * from t where e > 'a'")).hasRows(expectedSecondRow);
-        //assertThat(execute("select * from t where f > false")).hasRows(expectedSecondRow);
+        assertThat(execute("select * from t where f > false")).hasRows(expectedSecondRow);
         assertThat(execute("select * from t where g > 1")).hasRows(expectedSecondRow);
         assertThat(execute("select * from t where h > 1")).hasRows(expectedSecondRow);
         assertThat(execute("select * from t where i > 'a'")).hasRows(expectedSecondRow);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes https://github.com/crate/crate/issues/14407

`EqQuery.termQuery` or `EqQuery.rangeQuery` should utilize available Lucene fields. To do so, `termQuery` and `rangeQuery` implementations are adjusted to be more aligned to the corresponding indexers. (ex. `IntEqQuery` based on `IntIndexer`)

## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
