### PR TITLE
Add knn vector type

### DIFF
--- a/docs/appendices/release-notes/5.5.0.rst
+++ b/docs/appendices/release-notes/5.5.0.rst
@@ -83,21 +83,22 @@ SQL Standard and PostgreSQL Compatibility
 
 None
 
+Data Types
+----------
+
+- Added a :ref:`FLOAT_VECTOR <type-float_vector>` type to store dense vectors of
+  float values which can be searched using a k-nearest neighbour algorithm via a
+  new :ref:`KNN_MATCH <scalar_knn_match>` scalar.
+
 
 Scalar and Aggregation Functions
 --------------------------------
 
-None
+- Added a :ref:`KNN_MATCH <scalar_knn_match>` scalar.
 
 
 Performance and Resilience Improvements
 ---------------------------------------
-
-None
-
-
-Data Types
-----------
 
 None
 

--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -4243,6 +4243,64 @@ Special functions
 =================
 
 
+.. _scalar_knn_match:
+
+
+``knn_match(float_vector, float_vector, int)``
+----------------------------------------------
+
+The ``knn_match`` function uses a k-nearest
+neighbour (kNN) search algorithm to find vectors that are similar
+to a query vector.
+
+The first argument is the column to search.
+The second argument is the query vector.
+The third argument is the number of nearest neighbours to search and return.
+
+``knn_match(search_vector, target, k)``
+
+This function must be used within a ``WHERE`` clause targeting a table to use it
+as a predicate that searches the whole dataset of a table.
+If used *outside* of a ``WHERE`` clause, or in a ``WHERE`` clause targeting a
+virtual table instead of a physical table, the search algorithm will only
+consider the current row, not the whole dataset.
+
+Similar to the :ref:`MATCH predicate <predicates_match>`, this function affects
+the :ref:`_score <sql_administration_system_column_score>` value.
+
+An example::
+
+
+    cr> CREATE TABLE IF NOT EXISTS doc.vectors (
+    ...    xs float_vector(2)
+    ...  );
+    CREATE OK, 1 row affected (... sec)
+
+    cr> INSERT INTO doc.vectors (xs)
+    ...   VALUES
+    ...   ([3.14, 8.17]),
+    ...   ([14.3, 19.4]);
+    INSERT OK, 2 rows affected (... sec)
+
+.. HIDE:
+
+    cr> REFRESH TABLE doc.vectors;
+    REFRESH OK, 1 row affected (... sec)
+
+::
+
+    cr> SELECT xs, _score FROM doc.vectors
+    ... WHERE knn_match(xs, [3.14, 8], 2)
+    ... ORDER BY _score DESC;
+    +--------------+--------------+
+    | xs           |       _score |
+    +--------------+--------------+
+    | [3.14, 8.17] | 0.9719117    |
+    | [14.3, 19.4] | 0.0039138086 |
+    +--------------+--------------+
+    SELECT 2 rows in set (... sec)
+
+
 .. _scalar-ignore3vl:
 
 ``ignore3vl(boolean)``

--- a/docs/general/ddl/data-types.rst
+++ b/docs/general/ddl/data-types.rst
@@ -124,6 +124,10 @@ CrateDB supports the following data types. Scroll down for more details.
 
             'POLYGON ((5 5, 10 5, 10 10, 5 10, 5 5))'
 
+    * - ``float_vector(n)``
+      - A fixed length vector of floating point numbers
+      - ``[3.14, 42.21]``
+
 
 .. _data-types-ranges-widths:
 
@@ -230,6 +234,10 @@ are likely to be larger due to additional metadata.
       - variable
       - Each coordinate is stored as a ``DOUBLE PRECISION`` type.
       - A ``GEO_SHAPE`` column can store different kinds of `GeoJSON geometry objects`_.
+    * - ``FLOAT_VECTOR``
+      - variable
+      - Minimum length: 1. Maximum length: 2^31-1
+      - A vector of floating point numbers.
 
 
 .. rubric:: Footnotes
@@ -2915,6 +2923,64 @@ requires an intermediate cast:
     |                       1.0 |
     |                       2.0 |
     +---------------------------+
+
+
+.. _type-float_vector:
+
+``FLOAT_VECTOR``
+================
+
+A ``float_vector`` type allows to store dense vectors of float values of fixed
+length.
+
+It support :ref:`KNN_MATCH <scalar_knn_match>` for k-nearest neighbour search.
+This allows you to find vectors in a dataset which are similar to a query
+vector.
+
+The type can't be used as an element type of a regular array. ``float_vector``
+values are defined like float arrays.
+
+An example::
+
+    cr> CREATE TABLE my_vectors (
+    ...     xs FLOAT_VECTOR(2)
+    ... );
+    CREATE OK, 1 row affected (... sec)
+
+::
+
+    cr> INSERT INTO my_vectors (xs) VALUES ([3.14, 27.34]);
+    INSERT OK, 1 row affected (... sec)
+
+
+Inserting a value with a different dimension than declared in ``CREATE TABLE``
+results in an error.
+
+::
+
+    cr> INSERT INTO my_vectors (xs) VALUES ([3.14, 27.34, 38.4]);
+    SQLParseException[The number of vector dimensions does not match the field type]
+
+
+.. HIDE:
+
+    cr> REFRESH TABLE my_vectors;
+    REFRESH OK, 1 row affected (... sec)
+
+::
+
+    cr> SELECT * FROM my_vectors;
+    +---------------+
+    | xs            |
+    +---------------+
+    | [3.14, 27.34] |
+    +---------------+
+    SELECT 1 row in set (... sec)
+
+.. HIDE:
+
+    cr> DROP TABLE my_vectors;
+    DROP OK, 1 row affected (... sec)
 
 
 .. _data-types-geo:

--- a/server/src/main/java/io/crate/analyze/DataTypeAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/DataTypeAnalyzer.java
@@ -21,6 +21,8 @@
 
 package io.crate.analyze;
 
+import java.util.Locale;
+
 import io.crate.sql.tree.CollectionColumnType;
 import io.crate.sql.tree.ColumnDefinition;
 import io.crate.sql.tree.ColumnType;
@@ -29,9 +31,8 @@ import io.crate.sql.tree.ObjectColumnType;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
+import io.crate.types.FloatVectorType;
 import io.crate.types.ObjectType;
-
-import java.util.Locale;
 
 public final class DataTypeAnalyzer extends DefaultTraversalVisitor<DataType<?>, Void> {
 
@@ -71,6 +72,10 @@ public final class DataTypeAnalyzer extends DefaultTraversalVisitor<DataType<?>,
     @Override
     public DataType<?> visitCollectionColumnType(CollectionColumnType<?> node, Void context) {
         DataType<?> innerType = node.innerType().accept(this, context);
+        if (innerType instanceof FloatVectorType) {
+            // https://github.com/apache/lucene/issues/12313
+            throw new UnsupportedOperationException("Arrays of " + innerType.getName() + " are not supported");
+        }
         return new ArrayType<>(innerType);
     }
 }

--- a/server/src/main/java/io/crate/analyze/validator/SemanticSortValidator.java
+++ b/server/src/main/java/io/crate/analyze/validator/SemanticSortValidator.java
@@ -32,6 +32,7 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitor;
 import io.crate.types.BitStringType;
 import io.crate.types.DataTypes;
+import io.crate.types.FloatVectorType;
 
 /**
  * rudimentary sort symbol validation that can be used during analysis.
@@ -49,7 +50,8 @@ public class SemanticSortValidator {
         Stream.of(
             DataTypes.REGCLASS,
             DataTypes.REGPROC,
-            BitStringType.INSTANCE_ONE
+            BitStringType.INSTANCE_ONE,
+            FloatVectorType.INSTANCE
         )
     ).map(x -> x.id()).collect(Collectors.toSet());
 

--- a/server/src/main/java/io/crate/execution/dml/FloatVectorIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/FloatVectorIndexer.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.dml;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.apache.lucene.document.BinaryDocValuesField;
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.KnnFloatVectorField;
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.jetbrains.annotations.Nullable;
+
+import io.crate.execution.dml.Indexer.ColumnConstraint;
+import io.crate.execution.dml.Indexer.Synthetic;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.IndexType;
+import io.crate.metadata.Reference;
+
+public class FloatVectorIndexer implements ValueIndexer<float[]> {
+
+    private final FieldType fieldType;
+    private final String name;
+    private final Reference ref;
+
+    public FloatVectorIndexer(Reference ref, FieldType fieldType) {
+        this.ref = ref;
+        this.name = ref.column().fqn();
+        this.fieldType = fieldType;
+    }
+
+    @Override
+    public void indexValue(float @Nullable [] values,
+                           XContentBuilder xcontentBuilder,
+                           Consumer<? super IndexableField> addField,
+                           Consumer<? super Reference> onDynamicColumn,
+                           Map<ColumnIdent, Synthetic> synthetics,
+                           Map<ColumnIdent, ColumnConstraint> toValidate) throws IOException {
+        if (values == null) {
+            return;
+        }
+        xcontentBuilder.startArray();
+        for (float value : values) {
+            xcontentBuilder.value(value);
+        }
+        xcontentBuilder.endArray();
+
+        createFields(
+            name,
+            fieldType,
+            ref.indexType() != IndexType.NONE,
+            ref.hasDocValues(),
+            values,
+            addField
+        );
+        if (fieldType.stored()) {
+            throw new UnsupportedOperationException("Cannot store float_vector as stored field");
+        }
+    }
+
+    public static void createFields(String fqn,
+                                    FieldType fieldType,
+                                    boolean indexed,
+                                    boolean hasDocValues,
+                                    float @Nullable [] values,
+                                    Consumer<? super IndexableField> addField) {
+        if (indexed) {
+            addField.accept(new KnnFloatVectorField(fqn, values, fieldType));
+        }
+        if (hasDocValues) {
+            int capacity = values.length * Float.BYTES;
+            ByteBuffer buffer = ByteBuffer.allocate(capacity).order(ByteOrder.BIG_ENDIAN);
+            for (float value : values) {
+                buffer.putFloat(value);
+            }
+            byte[] bytes = new byte[buffer.flip().limit()];
+            buffer.get(bytes);
+            var field = new BinaryDocValuesField(fqn, new BytesRef(bytes));
+            addField.accept(field);
+        }
+    }
+}

--- a/server/src/main/java/io/crate/execution/engine/sort/SortSymbolVisitor.java
+++ b/server/src/main/java/io/crate/execution/engine/sort/SortSymbolVisitor.java
@@ -61,6 +61,7 @@ import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.DoubleType;
 import io.crate.types.FloatType;
+import io.crate.types.FloatVectorType;
 import io.crate.types.GeoPointType;
 import io.crate.types.IntegerType;
 import io.crate.types.LongType;
@@ -154,7 +155,9 @@ public class SortSymbolVisitor extends SymbolVisitor<SortSymbolVisitor.SortSymbo
                 columnIdent.fqn(),
                 fieldComparatorSource,
                 context.reverseFlag);
-        } else if (ref.valueType().equals(DataTypes.IP) || ref.valueType().id() == BitStringType.ID) {
+        } else if (ref.valueType().equals(DataTypes.IP)
+                || ref.valueType().id() == BitStringType.ID
+                || ref.valueType().id() == FloatVectorType.ID) {
             return customSortField(ref.toString(), ref, context);
         } else {
             return mappedSortField(

--- a/server/src/main/java/io/crate/expression/operator/EqOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/EqOperator.java
@@ -101,14 +101,18 @@ public final class EqOperator extends Operator<Object> {
 
     private final Signature signature;
     private final BoundSignature boundSignature;
+    private final DataType<Object> argType;
 
+    @SuppressWarnings("unchecked")
     private EqOperator(Signature signature, BoundSignature boundSignature) {
         this.signature = signature;
         this.boundSignature = boundSignature;
+        this.argType = (DataType<Object>) boundSignature.argTypes().get(0);
     }
 
     @Override
-    public Boolean evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>[] args) {
+    @SafeVarargs
+    public final Boolean evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>... args) {
         assert args.length == 2 : "number of args must be 2";
         Object left = args[0].value();
         if (left == null) {
@@ -118,7 +122,7 @@ public final class EqOperator extends Operator<Object> {
         if (right == null) {
             return null;
         }
-        return left.equals(right);
+        return argType.compare(left, right) == 0;
     }
 
     @Override
@@ -153,7 +157,7 @@ public final class EqOperator extends Operator<Object> {
                 function,
                 ref.column().fqn(),
                 ArrayType.unnest(dataType),
-                (Collection) value,
+                (Collection<?>) value,
                 context
             );
             default -> fromPrimitive(dataType, fqn, value);

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/FloatVectorColumnReference.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/FloatVectorColumnReference.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.reference.doc.lucene;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.util.BytesRef;
+
+import io.crate.execution.engine.fetch.ReaderContext;
+
+public class FloatVectorColumnReference extends LuceneCollectorExpression<float[]> {
+
+    private final String fqn;
+    private BinaryDocValues docValues;
+    private int doc;
+
+    public FloatVectorColumnReference(String fqn) {
+        this.fqn = fqn;
+    }
+
+    @Override
+    public float[] value() {
+        try {
+            if (docValues.advanceExact(doc)) {
+                BytesRef bytesRef = docValues.binaryValue();
+                float[] values = new float[bytesRef.length / Float.BYTES];
+                ByteBuffer buffer = ByteBuffer.wrap(bytesRef.bytes, bytesRef.offset, bytesRef.length);
+                buffer.asFloatBuffer().get(values);
+                return values;
+            }
+            return null;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public void setNextReader(ReaderContext context) throws IOException {
+        docValues = context.reader().getBinaryDocValues(fqn);
+    }
+
+    @Override
+    public void setNextDocId(int doc) {
+        this.doc = doc;
+    }
+}

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/LuceneReferenceResolver.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/LuceneReferenceResolver.java
@@ -51,6 +51,7 @@ import io.crate.types.ByteType;
 import io.crate.types.CharacterType;
 import io.crate.types.DoubleType;
 import io.crate.types.FloatType;
+import io.crate.types.FloatVectorType;
 import io.crate.types.GeoPointType;
 import io.crate.types.GeoShapeType;
 import io.crate.types.IntegerType;
@@ -193,6 +194,8 @@ public class LuceneReferenceResolver implements ReferenceResolver<LuceneCollecto
                 return new GeoPointColumnReference(fqn);
             case ArrayType.ID:
                 return DocCollectorExpression.create(toSourceLookup(ref));
+            case FloatVectorType.ID:
+                return new FloatVectorColumnReference(fqn);
             default:
                 throw new UnhandledServerException("Unsupported type: " + ref.valueType().getName());
         }

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/SourceParser.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/SourceParser.java
@@ -21,6 +21,9 @@
 
 package io.crate.expression.reference.doc.lucene;
 
+import static org.elasticsearch.common.xcontent.XContentParser.Token.START_ARRAY;
+import static org.elasticsearch.common.xcontent.XContentParser.Token.VALUE_NULL;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
@@ -30,14 +33,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.jetbrains.annotations.Nullable;
-
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.DeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentParser.Token;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.jetbrains.annotations.Nullable;
 
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.doc.DocSysColumns;
@@ -50,6 +52,7 @@ import io.crate.types.ByteType;
 import io.crate.types.DataType;
 import io.crate.types.DoubleType;
 import io.crate.types.FloatType;
+import io.crate.types.FloatVectorType;
 import io.crate.types.GeoPointType;
 import io.crate.types.GeoShapeType;
 import io.crate.types.IntegerType;
@@ -58,9 +61,6 @@ import io.crate.types.ObjectType;
 import io.crate.types.ShortType;
 import io.crate.types.TimestampType;
 import io.crate.types.UndefinedType;
-
-import static org.elasticsearch.common.xcontent.XContentParser.Token.START_ARRAY;
-import static org.elasticsearch.common.xcontent.XContentParser.Token.VALUE_NULL;
 
 public final class SourceParser {
 
@@ -119,7 +119,7 @@ public final class SourceParser {
     private static Object parseArray(XContentParser parser,
                                      @Nullable DataType<?> type,
                                      @Nullable Map<String, Object> requiredColumns) throws IOException {
-        if (type instanceof GeoPointType) {
+        if (type instanceof GeoPointType || type instanceof FloatVectorType) {
             return type.implicitCast(parser.list());
         } else {
             ArrayList<Object> values = new ArrayList<>();
@@ -163,6 +163,7 @@ public final class SourceParser {
                            && !(required instanceof ArrayType<?>)
                            && !(required instanceof GeoPointType)
                            && !(required instanceof GeoShapeType)
+                           && !(required instanceof FloatVectorType)
                            && !(required instanceof UndefinedType)) {
                     // due to a bug: https://github.com/crate/crate/issues/13990
                     parser.skipChildren();

--- a/server/src/main/java/io/crate/expression/scalar/KnnMatch.java
+++ b/server/src/main/java/io/crate/expression/scalar/KnnMatch.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+
+package io.crate.expression.scalar;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.List;
+
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.search.KnnFloatVectorQuery;
+import org.apache.lucene.search.Query;
+import org.jetbrains.annotations.Nullable;
+
+import io.crate.data.Input;
+import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.Literal;
+import io.crate.expression.symbol.Symbol;
+import io.crate.lucene.LuceneQueryBuilder.Context;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.Reference;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.BoundSignature;
+import io.crate.metadata.functions.Signature;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+import io.crate.types.FloatVectorType;
+import io.crate.types.TypeSignature;
+
+public class KnnMatch extends Scalar<Boolean, Object> {
+
+    private static final float DEFAULT_MIN_SCORE = 0.50f;
+
+    private final Signature signature;
+    private final BoundSignature boundSignature;
+    private final IndexWriterConfig conf;
+    private DataType<float[]> type;
+
+    public static void register(ScalarFunctionModule module) {
+        module.register(
+            Signature.scalar(
+                "knn_match",
+                TypeSignature.parse(FloatVectorType.NAME),
+                TypeSignature.parse(FloatVectorType.NAME),
+                DataTypes.INTEGER.getTypeSignature(),
+                DataTypes.BOOLEAN.getTypeSignature()
+            ),
+            KnnMatch::new
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    public KnnMatch(Signature signature, BoundSignature boundSignature) {
+        this.signature = signature;
+        this.boundSignature = boundSignature;
+        this.conf = new IndexWriterConfig(new StandardAnalyzer());
+        this.type = (DataType<float[]>) boundSignature.argTypes().get(0);
+    }
+
+    @Override
+    public Signature signature() {
+        return signature;
+    }
+
+    @Override
+    public BoundSignature boundSignature() {
+        return boundSignature;
+    }
+
+    @Override
+    @SafeVarargs
+    public final Boolean evaluate(TransactionContext txnCtx,
+                                  NodeContext nodeContext,
+                                  Input<Object>... args) {
+        Object field = args[0].value();
+        if (field == null) {
+            return null;
+        }
+        Object target = args[1].value();
+        if (target == null) {
+            return null;
+        }
+        Object k = args[2].value();
+        if (k == null) {
+            return null;
+        }
+        assert field instanceof float[] : "First parameter value must be a float array";
+        assert target instanceof float[] : "Second parameter value must be a float array";
+        assert k instanceof Integer : "Third parameter value must be an integer";
+
+        try {
+            return evaluate((float[]) field, (float[]) target, (int) k);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private boolean evaluate(float[] field, float[] target, int k) throws IOException {
+        if (field.length != target.length) {
+            throw new IllegalArgumentException("Field dimensions must match target dimensions for knn_query");
+        }
+        if (field.length != type.characterMaximumLength()) {
+            throw new IllegalArgumentException("Field dimensions must match type dimensions for knn_query");
+        }
+        return FloatVectorType.SIMILARITY_FUNC.compare(field, target) >= DEFAULT_MIN_SCORE;
+    }
+
+    @Override
+    @Nullable
+    public Query toQuery(Function function, Context context) {
+        List<Symbol> args = function.arguments();
+        if (args.get(0) instanceof Reference ref
+                && args.get(1) instanceof Literal<?> targetLiteral
+                && args.get(2) instanceof Literal<?> kLiteral) {
+
+            Object target = targetLiteral.value();
+            Object k = kLiteral.value();
+            if (target instanceof float[] && k instanceof Integer) {
+                return new KnnFloatVectorQuery(ref.column().fqn(), (float[]) target, (int) k);
+            }
+            return null;
+        }
+        return null;
+    }
+
+}

--- a/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
+++ b/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
@@ -237,5 +237,7 @@ public class ScalarFunctionModule extends AbstractFunctionModule<FunctionImpleme
         HasDatabasePrivilegeFunction.register(this);
         ParseURIFunction.register(this);
         ParseURLFunction.register(this);
+
+        KnnMatch.register(this);
     }
 }

--- a/server/src/main/java/io/crate/expression/symbol/Literal.java
+++ b/server/src/main/java/io/crate/expression/symbol/Literal.java
@@ -21,18 +21,6 @@
 
 package io.crate.expression.symbol;
 
-import io.crate.data.Input;
-import io.crate.expression.symbol.format.Style;
-import io.crate.types.ArrayType;
-import io.crate.types.DataType;
-import io.crate.types.DataTypes;
-import io.crate.types.ObjectType;
-
-import org.apache.lucene.util.RamUsageEstimator;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
-import org.joda.time.Period;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -43,6 +31,18 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.joda.time.Period;
+
+import io.crate.data.Input;
+import io.crate.expression.symbol.format.Style;
+import io.crate.types.ArrayType;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+import io.crate.types.ObjectType;
 
 
 public class Literal<T> implements Symbol, Input<T>, Comparable<Literal<T>> {
@@ -165,10 +165,33 @@ public class Literal<T> implements Symbol, Input<T>, Comparable<Literal<T>> {
         if (value == null) {
             return 0;
         }
-        if (value.getClass().isArray()) {
-            return Arrays.deepHashCode(((Object[]) value));
+        Class<?> componentType = value.getClass().getComponentType();
+        if (componentType == null) {
+            return value.hashCode();
         }
-        return value.hashCode();
+        if (value instanceof Object[] values) {
+            return Arrays.deepHashCode(values);
+        }
+        if (componentType == byte.class) {
+            return Arrays.hashCode((byte[]) value);
+        } else if (componentType == int.class) {
+            return Arrays.hashCode((int[]) value);
+        } else if (componentType == long.class) {
+            return Arrays.hashCode((long[]) value);
+        } else if (componentType == char.class) {
+            return Arrays.hashCode((char[]) value);
+        } else if (componentType == short.class) {
+            return Arrays.hashCode((short[]) value);
+        } else if (componentType == boolean.class) {
+            return Arrays.hashCode((boolean[]) value);
+        } else if (componentType == double.class) {
+            return Arrays.hashCode((double[]) value);
+        } else if (componentType == float.class) {
+            return Arrays.hashCode((float[]) value);
+        } else {
+            throw new UnsupportedOperationException(
+                "Unexpected value: " + value + ", was a new primitive type added to java?");
+        }
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})

--- a/server/src/main/java/io/crate/lucene/GenericFunctionQuery.java
+++ b/server/src/main/java/io/crate/lucene/GenericFunctionQuery.java
@@ -88,7 +88,7 @@ class GenericFunctionQuery extends Query {
         return new Weight(this) {
             @Override
             public boolean isCacheable(LeafReaderContext ctx) {
-                if (SymbolVisitors.any(s -> s instanceof Function && !((Function) s).signature().isDeterministic(), function)) {
+                if (SymbolVisitors.any(s -> s instanceof Function fn && !fn.signature().isDeterministic(), function)) {
                     return false;
                 }
                 var fields = new ArrayList<String>();
@@ -126,7 +126,7 @@ class GenericFunctionQuery extends Query {
     }
 
     private FilteredTwoPhaseIterator getTwoPhaseIterator(final LeafReaderContext context) throws IOException {
-        for (LuceneCollectorExpression expression : expressions) {
+        for (LuceneCollectorExpression<?> expression : expressions) {
             expression.setNextReader(new ReaderContext(context));
         }
         return new FilteredTwoPhaseIterator(context.reader(), condition, expressions);
@@ -160,7 +160,7 @@ class GenericFunctionQuery extends Query {
             if (!liveDocs.get(doc)) {
                 return false;
             }
-            for (LuceneCollectorExpression expression : expressions) {
+            for (LuceneCollectorExpression<?> expression : expressions) {
                 expression.setNextDocId(doc);
             }
             return InputCondition.matches(condition);

--- a/server/src/main/java/io/crate/metadata/doc/DocIndexMetadata.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocIndexMetadata.java
@@ -82,6 +82,7 @@ import io.crate.types.BitStringType;
 import io.crate.types.CharacterType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
+import io.crate.types.FloatVectorType;
 import io.crate.types.ObjectType;
 import io.crate.types.StorageSupport;
 import io.crate.types.StringType;
@@ -349,6 +350,10 @@ public class DocIndexMetadata {
                     Integer length = (Integer) columnProperties.get("length");
                     assert length != null : "Length is required for bit string type";
                     return new BitStringType(length);
+
+                case FloatVectorType.NAME:
+                    Integer dimensions = (Integer) columnProperties.get("dimensions");
+                    return new FloatVectorType(dimensions);
 
                 default:
                     type = Objects.requireNonNullElse(DataTypes.ofMappingName(typeName), DataTypes.NOT_SUPPORTED);

--- a/server/src/main/java/io/crate/protocols/postgres/types/PGTypes.java
+++ b/server/src/main/java/io/crate/protocols/postgres/types/PGTypes.java
@@ -37,6 +37,7 @@ import io.crate.types.ArrayType;
 import io.crate.types.BitStringType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
+import io.crate.types.FloatVectorType;
 import io.crate.types.ObjectType;
 import io.crate.types.RowType;
 import io.crate.types.StringType;
@@ -93,6 +94,7 @@ public class PGTypes {
         .put(new ArrayType<>(DataTypes.REGCLASS), PGArray.REGCLASS_ARRAY)
         .put(new ArrayType<>(BitStringType.INSTANCE_ONE), PGArray.BIT_ARRAY)
         .put(DataTypes.OIDVECTOR, PgOidVectorType.INSTANCE)
+        .put(FloatVectorType.INSTANCE, PGArray.FLOAT4_ARRAY)
         .immutableMap();
 
     private static final IntObjectMap<DataType<?>> PG_TYPES_TO_CRATE_TYPE = new IntObjectHashMap<>();

--- a/server/src/main/java/io/crate/types/ArrayType.java
+++ b/server/src/main/java/io/crate/types/ArrayType.java
@@ -33,8 +33,6 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import org.jetbrains.annotations.Nullable;
-
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.Strings;
@@ -44,6 +42,7 @@ import org.elasticsearch.common.xcontent.DeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.jetbrains.annotations.Nullable;
 import org.locationtech.spatial4j.shape.Point;
 
 import io.crate.Streamer;

--- a/server/src/main/java/io/crate/types/ArrayType.java
+++ b/server/src/main/java/io/crate/types/ArrayType.java
@@ -313,8 +313,10 @@ public class ArrayType<T> extends DataType<List<T>> {
 
     @Override
     public boolean isConvertableTo(DataType<?> other, boolean explicitCast) {
-        return other.id() == UndefinedType.ID || other.id() == GeoPointType.ID ||
-               ((other instanceof ArrayType)
+        return other.id() == UndefinedType.ID
+            || other.id() == GeoPointType.ID
+            || other.id() == FloatVectorType.ID
+            || ((other instanceof ArrayType)
                 && this.innerType.isConvertableTo(((ArrayType<?>) other).innerType(), explicitCast));
     }
 

--- a/server/src/main/java/io/crate/types/DataTypes.java
+++ b/server/src/main/java/io/crate/types/DataTypes.java
@@ -175,7 +175,8 @@ public final class DataTypes {
             entry(OidVectorType.ID, in -> OIDVECTOR),
             entry(DateType.ID, in -> DATE),
             entry(BitStringType.ID, BitStringType::new),
-            entry(JsonType.ID, in -> JsonType.INSTANCE)
+            entry(JsonType.ID, in -> JsonType.INSTANCE),
+            entry(FloatVectorType.ID, FloatVectorType::new)
         )
     );
 
@@ -428,7 +429,8 @@ public final class DataTypes {
         entry(DATE.getName(), DATE),
         entry(BitStringType.INSTANCE_ONE.getName(), BitStringType.INSTANCE_ONE),
         entry(JsonType.INSTANCE.getName(), JsonType.INSTANCE),
-        entry("decimal", NUMERIC)
+        entry("decimal", NUMERIC),
+        entry(FloatVectorType.INSTANCE.getName(), FloatVectorType.INSTANCE)
     );
 
     public static DataType<?> ofName(String typeName) {
@@ -453,6 +455,7 @@ public final class DataTypes {
                 case StringType.ID -> StringType.of(parameters);
                 case CharacterType.ID -> CharacterType.of(parameters);
                 case NumericType.ID -> NumericType.of(parameters);
+                case FloatVectorType.ID -> new FloatVectorType(parameters.get(0));
                 default -> throw new IllegalArgumentException(
                     "The '" + typeName + "' type doesn't support type parameters.");
             };
@@ -483,7 +486,8 @@ public final class DataTypes {
         entry("geo_shape", DataTypes.GEO_SHAPE),
         entry("object", UNTYPED_OBJECT),
         entry("nested", UNTYPED_OBJECT),
-        entry("interval", DataTypes.INTERVAL)
+        entry("interval", DataTypes.INTERVAL),
+        entry(FloatVectorType.INSTANCE.getName(), FloatVectorType.INSTANCE)
     );
 
     private static final Map<Integer, String> TYPE_IDS_TO_MAPPINGS = Map.ofEntries(
@@ -503,7 +507,8 @@ public final class DataTypes {
         entry(GEO_SHAPE.id(), "geo_shape"),
         entry(GEO_POINT.id(), "geo_point"),
         entry(INTERVAL.id(), "interval"),
-        entry(BitStringType.ID, "bit")
+        entry(BitStringType.ID, "bit"),
+        entry(FloatVectorType.ID, FloatVectorType.INSTANCE.getName())
     );
 
     @Nullable

--- a/server/src/main/java/io/crate/types/FloatVectorType.java
+++ b/server/src/main/java/io/crate/types/FloatVectorType.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.types;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.jetbrains.annotations.Nullable;
+
+import io.crate.Streamer;
+import io.crate.execution.dml.FloatVectorIndexer;
+import io.crate.execution.dml.ValueIndexer;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.Reference;
+import io.crate.metadata.RelationName;
+import io.crate.sql.tree.ColumnDefinition;
+import io.crate.sql.tree.ColumnPolicy;
+import io.crate.sql.tree.ColumnType;
+import io.crate.sql.tree.Expression;
+
+public class FloatVectorType extends DataType<float[]> implements Streamer<float[]> {
+
+    public static final int ID = 28;
+    public static final String NAME = "float_vector";
+    public static final FloatVectorType INSTANCE = new FloatVectorType(1);
+
+    private static final EqQuery<float[]> EQ_QUERY = new EqQuery<float[]>() {
+
+        @Override
+        public Query termQuery(String field, float[] value) {
+            return null;
+        }
+
+        @Override
+        public Query rangeQuery(String field,
+                                float[] lowerTerm,
+                                float[] upperTerm,
+                                boolean includeLower,
+                                boolean includeUpper,
+                                boolean hasDocValues) {
+            return null;
+        }
+    };
+
+    private static final StorageSupport<? super float[]> STORAGE_SUPPORT = new StorageSupport<>(
+            true,
+            true,
+            false,
+            EQ_QUERY) {
+
+        @Override
+        public ValueIndexer<? super float[]> valueIndexer(RelationName table,
+                                                          Reference ref,
+                                                          Function<ColumnIdent, FieldType> getFieldType,
+                                                          Function<ColumnIdent, Reference> getRef) {
+            return new FloatVectorIndexer(ref, getFieldType.apply(ref.column()));
+        }
+    };
+
+    private final int dimensions;
+
+    public FloatVectorType(int dimensions) {
+        this.dimensions = dimensions;
+    }
+
+    public FloatVectorType(StreamInput in) throws IOException {
+        this.dimensions = in.readVInt();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVInt(dimensions);
+    }
+
+    @Override
+    public int compare(float[] o1, float[] o2) {
+        return Arrays.compare(o1, o2);
+    }
+
+    @Override
+    public int id() {
+        return ID;
+    }
+
+    @Override
+    public Precedence precedence() {
+        return Precedence.CUSTOM;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public Streamer<float[]> streamer() {
+        return this;
+    }
+
+    @Override
+    public float[] sanitizeValue(Object value) {
+        // Value is stored as list in _raw/xcontent/json
+        if (value instanceof List<?> values) {
+            float[] result = new float[values.size()];
+            for (int i = 0; i < result.length; i++) {
+                result[i] = ((Number) values.get(i)).floatValue();
+            }
+            return result;
+        }
+        return (float[]) value;
+    }
+
+    @Override
+    public float[] implicitCast(Object value) throws IllegalArgumentException, ClassCastException {
+        return sanitizeValue(value);
+    }
+
+    @Override
+    public long valueBytes(float @Nullable [] value) {
+        if (value == null) {
+            return RamUsageEstimator.NUM_BYTES_OBJECT_REF;
+        }
+        return RamUsageEstimator.sizeOf(value);
+    }
+
+    @Override
+    public TypeSignature getTypeSignature() {
+        return new TypeSignature(getName(), List.of(TypeSignature.of(dimensions)));
+    }
+
+    @Override
+    public List<DataType<?>> getTypeParameters() {
+        return List.of(DataTypes.INTEGER);
+    }
+
+    @Override
+    public Integer characterMaximumLength() {
+        return dimensions;
+    }
+
+    @Override
+    public ColumnType<Expression> toColumnType(ColumnPolicy columnPolicy,
+                                               @Nullable Supplier<List<ColumnDefinition<Expression>>> convertChildColumn) {
+        return new ColumnType<>(getName(), List.of(dimensions));
+    }
+
+    @Override
+    public void addMappingOptions(Map<String, Object> mapping) {
+        mapping.put("dimensions", dimensions);
+    }
+
+    @Override
+    public float[] readValueFrom(StreamInput in) throws IOException {
+        if (in.readBoolean()) {
+            return in.readFloatArray();
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public void writeValueTo(StreamOutput out, float[] v) throws IOException {
+        if (v == null) {
+            out.writeBoolean(false);
+        } else {
+            out.writeBoolean(true);
+            out.writeFloatArray(v);
+        }
+    }
+
+    @Override
+    public StorageSupport<? super float[]> storageSupport() {
+        return STORAGE_SUPPORT;
+    }
+}

--- a/server/src/main/java/io/crate/types/FloatVectorType.java
+++ b/server/src/main/java/io/crate/types/FloatVectorType.java
@@ -29,6 +29,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.apache.lucene.document.FieldType;
+import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -51,6 +52,7 @@ public class FloatVectorType extends DataType<float[]> implements Streamer<float
     public static final int ID = 28;
     public static final String NAME = "float_vector";
     public static final FloatVectorType INSTANCE = new FloatVectorType(1);
+    public static final VectorSimilarityFunction SIMILARITY_FUNC = VectorSimilarityFunction.EUCLIDEAN;
 
     private static final EqQuery<float[]> EQ_QUERY = new EqQuery<float[]>() {
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/ArrayMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ArrayMapper.java
@@ -27,8 +27,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
-import org.jetbrains.annotations.Nullable;
-
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.IndexableField;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -37,6 +35,7 @@ import org.elasticsearch.common.xcontent.DeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * fieldmapper for encoding and handling of primitive arrays (non-object) explicitly
@@ -107,14 +106,18 @@ public class ArrayMapper extends FieldMapper implements ArrayValueMapperParser {
         public ArrayMapper build(BuilderContext context) {
             Mapper innerMapper = innerBuilder.build(context);
             MappedFieldType mappedFieldType = null;
+            FieldType innerFieldType;
             if (innerMapper instanceof FieldMapper fieldMapper) {
+                innerFieldType = fieldMapper.fieldType;
                 mappedFieldType = fieldMapper.fieldType();
+            } else {
+                innerFieldType = fieldType;
             }
             return new ArrayMapper(
                 name,
                 position,
                 defaultExpression,
-                fieldType,
+                innerFieldType,
                 mappedFieldType,
                 innerMapper
             );

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapperParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapperParser.java
@@ -24,7 +24,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
-
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentType;

--- a/server/src/main/java/org/elasticsearch/index/mapper/FloatVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FloatVectorFieldMapper.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentParser.Token;
+import org.jetbrains.annotations.Nullable;
+
+import com.carrotsearch.hppc.FloatArrayList;
+
+import io.crate.execution.dml.FloatVectorIndexer;
+import io.crate.types.FloatVectorType;
+
+public class FloatVectorFieldMapper extends FieldMapper implements ArrayValueMapperParser {
+
+    public static final class Defaults {
+
+        private Defaults() {}
+
+        public static final FieldType FIELD_TYPE = new FieldType();
+
+        static {
+            FIELD_TYPE.setIndexOptions(IndexOptions.NONE);
+            FIELD_TYPE.setStored(false);
+            FIELD_TYPE.freeze();
+        }
+    }
+
+    static class VectorFieldType extends MappedFieldType {
+
+        public VectorFieldType(String name, boolean isIndexed, boolean hasDocValues) {
+            super(name, isIndexed, hasDocValues);
+        }
+
+        @Override
+        public String typeName() {
+            return FloatVectorType.INSTANCE.getName();
+        }
+    }
+
+    public static class Builder extends FieldMapper.Builder<Builder> {
+
+        private int dimensions = 0;
+
+        protected Builder(String name) {
+            super(name, Defaults.FIELD_TYPE);
+        }
+
+        @Override
+        public Mapper build(BuilderContext context) {
+            fieldType.setVectorAttributes(
+                dimensions,
+                VectorEncoding.FLOAT32,
+                VectorSimilarityFunction.EUCLIDEAN
+            );
+            var mapper = new FloatVectorFieldMapper(
+                name,
+                position,
+                defaultExpression,
+                fieldType,
+                new VectorFieldType(buildFullName(context), indexed, hasDocValues),
+                copyTo
+            );
+            context.putPositionInfo(mapper, position);
+            return mapper;
+        }
+
+        public void dimensions(int dimensions) {
+            this.dimensions = dimensions;
+        }
+    }
+
+    public static class TypeParser implements Mapper.TypeParser {
+
+        @Override
+        public Mapper.Builder<?> parse(String name,
+                                       Map<String, Object> node,
+                                       ParserContext parserContext) throws MapperParsingException {
+            Builder builder = new Builder(name);
+            TypeParsers.parseField(builder, name, node);
+            builder.dimensions((Integer) node.remove("dimensions"));
+            return builder;
+        }
+    }
+
+    protected FloatVectorFieldMapper(String simpleName,
+                                int position,
+                                @Nullable String defaultExpression,
+                                FieldType fieldType,
+                                MappedFieldType mappedFieldType,
+                                CopyTo copyTo) {
+        super(simpleName, position, defaultExpression, fieldType, mappedFieldType, copyTo);
+    }
+
+    @Override
+    protected void parseCreateField(ParseContext context, Consumer<IndexableField> onField) throws IOException {
+        XContentParser.Token token = context.parser().currentToken();
+        if (token == Token.VALUE_NULL) {
+            return;
+        }
+        FloatArrayList vector = new FloatArrayList();
+        if (token == XContentParser.Token.START_ARRAY) {
+            token = context.parser().nextToken();
+            while (token != XContentParser.Token.END_ARRAY) {
+                float value = context.parser().floatValue();
+                vector.add(value);
+                token = context.parser().nextToken();
+            }
+        }
+        FloatVectorIndexer.createFields(
+            fieldType().name(),
+            fieldType,
+            fieldType().isSearchable(),
+            fieldType().hasDocValues(),
+            vector.toArray(),
+            onField
+        );
+    }
+
+    @Override
+    protected void mergeOptions(FieldMapper other, List<String> conflicts) {
+        FloatVectorFieldMapper o = (FloatVectorFieldMapper) other;
+        if (fieldType.vectorDimension() != o.fieldType.vectorDimension()) {
+            conflicts.add("mapper [" + name() + "] has different [dimensions] values");
+        }
+    }
+
+    @Override
+    protected String contentType() {
+        return FloatVectorType.INSTANCE.getName();
+    }
+
+    @Override
+    protected void doXContentBody(XContentBuilder builder, boolean includeDefaults) throws IOException {
+        super.doXContentBody(builder, includeDefaults);
+        builder.field("dimensions", fieldType.vectorDimension());
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/mapper/FloatVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FloatVectorFieldMapper.java
@@ -30,7 +30,6 @@ import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.VectorEncoding;
-import org.apache.lucene.index.VectorSimilarityFunction;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentParser.Token;
@@ -81,7 +80,7 @@ public class FloatVectorFieldMapper extends FieldMapper implements ArrayValueMap
             fieldType.setVectorAttributes(
                 dimensions,
                 VectorEncoding.FLOAT32,
-                VectorSimilarityFunction.EUCLIDEAN
+                FloatVectorType.SIMILARITY_FUNC
             );
             var mapper = new FloatVectorFieldMapper(
                 name,

--- a/server/src/main/java/org/elasticsearch/indices/IndicesModule.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesModule.java
@@ -41,6 +41,7 @@ import org.elasticsearch.index.mapper.BitStringFieldMapper;
 import org.elasticsearch.index.mapper.BooleanFieldMapper;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.FieldNamesFieldMapper;
+import org.elasticsearch.index.mapper.FloatVectorFieldMapper;
 import org.elasticsearch.index.mapper.GeoPointFieldMapper;
 import org.elasticsearch.index.mapper.GeoShapeFieldMapper;
 import org.elasticsearch.index.mapper.IdFieldMapper;
@@ -64,6 +65,7 @@ import org.elasticsearch.plugins.MapperPlugin;
 
 import io.crate.replication.logical.LogicalReplicationSettings;
 import io.crate.replication.logical.engine.SubscriberEngine;
+import io.crate.types.FloatVectorType;
 
 /**
  * Configures classes and services that are shared by indices on each node.
@@ -99,6 +101,7 @@ public class IndicesModule extends AbstractModule {
         mappers.put(ObjectMapper.CONTENT_TYPE, new ObjectMapper.TypeParser());
         mappers.put(GeoPointFieldMapper.CONTENT_TYPE, new GeoPointFieldMapper.TypeParser());
         mappers.put(BitStringFieldMapper.CONTENT_TYPE, new BitStringFieldMapper.TypeParser());
+        mappers.put(FloatVectorType.INSTANCE.getName(), new FloatVectorFieldMapper.TypeParser());
         mappers.put(ArrayMapper.CONTENT_TYPE, new ArrayTypeParser());
 
         if (ShapesAvailability.JTS_AVAILABLE && ShapesAvailability.SPATIAL4J_AVAILABLE) {

--- a/server/src/test/java/io/crate/execution/dml/IndexerTest.java
+++ b/server/src/test/java/io/crate/execution/dml/IndexerTest.java
@@ -83,6 +83,7 @@ import io.crate.types.BitStringType;
 import io.crate.types.BooleanType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
+import io.crate.types.FloatVectorType;
 import io.crate.types.IpType;
 import io.crate.types.ObjectType;
 
@@ -631,7 +632,8 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
                 List.of(
                     DataTypes.GEO_POINT,
                     DataTypes.GEO_SHAPE,
-                    new BitStringType(1)
+                    new BitStringType(1),
+                    FloatVectorType.INSTANCE
                 ))
             .stream()
             .filter(t -> t.storageSupport() != null)

--- a/server/src/test/java/io/crate/expression/operator/EqOperatorTest.java
+++ b/server/src/test/java/io/crate/expression/operator/EqOperatorTest.java
@@ -38,6 +38,7 @@ import io.crate.testing.DataTypeTesting;
 import io.crate.testing.QueryTester;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
+import io.crate.types.FloatVectorType;
 
 public class EqOperatorTest extends ScalarTestCase {
 
@@ -110,6 +111,9 @@ public class EqOperatorTest extends ScalarTestCase {
     @Test
     public void test_array_equals_empty_array_on_all_types() throws Exception {
         for (DataType<?> type : DataTypeTesting.ALL_STORED_TYPES_EXCEPT_ARRAYS) {
+            if (type instanceof FloatVectorType) {
+                continue;
+            }
             // Universal values for all types, '=[]' should match 1 row for all types.
             // Also covers cases when we need to add extra generic filter to differentiate between null and empty array.
             Object[] values = new Object[] {List.of(), null};

--- a/server/src/test/java/io/crate/expression/predicate/FieldExistsQueryTest.java
+++ b/server/src/test/java/io/crate/expression/predicate/FieldExistsQueryTest.java
@@ -38,6 +38,7 @@ import io.crate.testing.DataTypeTesting;
 import io.crate.testing.QueryTester;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
+import io.crate.types.FloatVectorType;
 
 public class FieldExistsQueryTest extends CrateDummyClusterServiceUnitTest {
 
@@ -106,6 +107,9 @@ public class FieldExistsQueryTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void test_is_null_does_not_match_empty_arrays() throws Exception {
         for (DataType<?> type : DataTypeTesting.ALL_STORED_TYPES_EXCEPT_ARRAYS) {
+            if (type instanceof FloatVectorType) {
+                continue;
+            }
             String createStatement = "create table t_" +
                 type.getName().replaceAll(" ", "_") +
                 " (xs array(" + type.getName() + "))";
@@ -116,6 +120,9 @@ public class FieldExistsQueryTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void test_is_null_does_not_match_empty_arrays_with_index_off() throws Exception {
         for (DataType<?> type : DataTypeTesting.ALL_STORED_TYPES_EXCEPT_ARRAYS) {
+            if (type instanceof FloatVectorType) {
+                continue;
+            }
             if (TableElementsAnalyzer.UNSUPPORTED_INDEX_TYPE_IDS.contains(type.id()) == false) {
                 String createStatement = "create table t_" +
                     type.getName().replaceAll(" ", "_") +
@@ -155,6 +162,9 @@ public class FieldExistsQueryTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void test_is_not_null_does_not_match_empty_arrays() throws Exception {
         for (DataType<?> type : DataTypeTesting.ALL_STORED_TYPES_EXCEPT_ARRAYS) {
+            if (type instanceof FloatVectorType) {
+                continue;
+            }
             // including geo_shape
             String createStatement = "create table t_" +
                 type.getName().replaceAll(" ", "_") +
@@ -166,6 +176,9 @@ public class FieldExistsQueryTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void test_is_not_null_does_not_match_empty_arrays_with_index_off() throws Exception {
         for (DataType<?> type : DataTypeTesting.ALL_STORED_TYPES_EXCEPT_ARRAYS) {
+            if (type instanceof FloatVectorType) {
+                continue;
+            }
             if (TableElementsAnalyzer.UNSUPPORTED_INDEX_TYPE_IDS.contains(type.id()) == false) {
                 String createStatement = "create table t_" +
                     type.getName().replaceAll(" ", "_") +

--- a/server/src/test/java/io/crate/expression/scalar/KnnMatchTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/KnnMatchTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.apache.lucene.search.Query;
+import org.elasticsearch.Version;
+import org.junit.Test;
+
+import io.crate.testing.QueryTester;
+
+public class KnnMatchTest extends ScalarTestCase {
+
+    @Test
+    public void test_null_arg_returns_null() throws Exception {
+        assertEvaluate("knn_match(null, [1.2]::float_vector(1), 2)", x -> assertThat(x).isNull());
+        assertEvaluate("knn_match([1.2]::float_vector(1), null, 2)", x -> assertThat(x).isNull());
+        assertEvaluate("knn_match([1.2]::float_vector(1), [1.2]::float_vector(1), null)", x -> assertThat(x).isNull());
+    }
+
+    @Test
+    public void test_knn_query_match() throws Exception {
+        assertEvaluate(
+            "knn_match([1.0, 2.0, 3.14]::float_vector(3), [1.0, 2.0, 3.14]::float_vector(3), 5)", true);
+    }
+
+    @Test
+    public void test_knn_query_below_min_score() throws Exception {
+        assertEvaluate(
+            "knn_match([1.0, 2.0, 3.14]::float_vector(3), [0.0, 0.0, 0.0]::float_vector(3), 5)", false);
+    }
+
+    @Test
+    public void test_knn_query_builder() throws Exception {
+        String createTable = "create table tbl (x float_vector(4))";
+        QueryTester.Builder builder = new QueryTester.Builder(
+            createTempDir(),
+            THREAD_POOL,
+            clusterService,
+            Version.CURRENT,
+            createTable
+        );
+        float[] vector1 = new float[] { 200.2f, 300.4f, 500.6f, 700.8f };
+        float[] vector2 = new float[] { 0.2f, 0.5f, 0.7f, 0.8f };
+        builder.indexValue("x", vector1);
+        builder.indexValue("x", vector2);
+        try (QueryTester tester = builder.build()) {
+            Query query = tester.toQuery("knn_match(x, [1.2, 3.4, 5.6, 7.8], 10)");
+            assertThat(query.toString()).isEqualTo("KnnFloatVectorQuery:x[1.2,...][10]");
+
+            List<Object> result = tester.runQuery("x", "knn_match(x, [200, 300, 500, 700], 1)");
+            assertThat(result).containsExactly(
+                vector1
+            );
+        }
+    }
+}
+

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -28,6 +28,7 @@ import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -1961,6 +1962,7 @@ public class TransportSQLActionTest extends IntegTestCase {
 
     @Test
     @UseJdbc(0)
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public void test_types_with_storage_can_be_inserted_and_queried() {
         for (var type : DataTypeTesting.ALL_STORED_TYPES_EXCEPT_ARRAYS) {
             if (type.equals(DataTypes.GEO_POINT)) {

--- a/server/src/test/java/io/crate/types/FloatVectorTypeTest.java
+++ b/server/src/test/java/io/crate/types/FloatVectorTypeTest.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.types;
+
+public class FloatVectorTypeTest extends DataTypeTestCase<float[]> {
+
+    @Override
+    public DataType<float[]> getType() {
+        return new FloatVectorType(4);
+    }
+}

--- a/server/src/testFixtures/java/io/crate/testing/DataTypeTesting.java
+++ b/server/src/testFixtures/java/io/crate/testing/DataTypeTesting.java
@@ -54,6 +54,7 @@ import io.crate.types.DataTypes;
 import io.crate.types.DateType;
 import io.crate.types.DoubleType;
 import io.crate.types.FloatType;
+import io.crate.types.FloatVectorType;
 import io.crate.types.GeoPointType;
 import io.crate.types.GeoShapeType;
 import io.crate.types.IntegerType;
@@ -174,6 +175,16 @@ public class DataTypeTesting {
                         bitSet.set(i, random.nextBoolean());
                     }
                     return (T) new BitString(bitSet, length);
+                };
+
+            case FloatVectorType.ID:
+                return () -> {
+                    int length = type.characterMaximumLength();
+                    float[] result = new float[length];
+                    for (int i = 0; i < length; i++) {
+                        result[i] = random.nextFloat();
+                    }
+                    return (T) result;
                 };
             default:
                 throw new AssertionError("No data generator for type " + type.getName());

--- a/server/src/testFixtures/java/io/crate/testing/QueryTester.java
+++ b/server/src/testFixtures/java/io/crate/testing/QueryTester.java
@@ -120,7 +120,7 @@ public final class QueryTester implements AutoCloseable {
             return this;
         }
 
-        void indexValue(String column, Object value) throws IOException {
+        public Builder indexValue(String column, Object value) throws IOException {
             MapperService mapperService = indexEnv.mapperService();
             Indexer indexer = new Indexer(
                 table.concreteIndices()[0],
@@ -134,6 +134,7 @@ public final class QueryTester implements AutoCloseable {
             var item = new IndexItem.StaticItem("dummy-id", List.of(), new Object[] { value }, -1L, -1L);
             ParsedDocument parsedDocument = indexer.index(item);
             indexEnv.writer().addDocument(parsedDocument.doc());
+            return this;
         }
 
         private LuceneBatchIterator getIterator(ColumnIdent column, Query query) {

--- a/server/src/testFixtures/java/io/crate/types/DataTypeTestCase.java
+++ b/server/src/testFixtures/java/io/crate/types/DataTypeTestCase.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.types;
+
+import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.Weight;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.ParsedDocument;
+import org.elasticsearch.index.mapper.SourceToParse;
+import org.junit.Test;
+
+import io.crate.Streamer;
+import io.crate.execution.dml.ValueIndexer;
+import io.crate.execution.engine.fetch.ReaderContext;
+import io.crate.expression.reference.doc.lucene.CollectorContext;
+import io.crate.expression.reference.doc.lucene.LuceneCollectorExpression;
+import io.crate.expression.reference.doc.lucene.LuceneReferenceResolver;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.DocReferences;
+import io.crate.metadata.Reference;
+import io.crate.metadata.doc.DocTableInfo;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.DataTypeTesting;
+import io.crate.testing.IndexEnv;
+import io.crate.testing.SQLExecutor;
+
+
+public abstract class DataTypeTestCase<T> extends CrateDummyClusterServiceUnitTest {
+
+    public abstract DataType<T> getType();
+
+    @Test
+    public void test_doc_values_write_and_read_roundtrip_inclusive_doc_mapper_parse() throws Exception {
+        DataType<T> type = getType();
+        StorageSupport<? super T> storageSupport = type.storageSupport();
+        if (storageSupport == null) {
+            return;
+        }
+        var sqlExecutor = SQLExecutor.builder(clusterService)
+            .addTable("create table tbl (id int, x " + type.getTypeSignature().toString() + ")")
+            .build();
+
+        Supplier<T> dataGenerator = DataTypeTesting.getDataGenerator(type);
+        DocTableInfo table = sqlExecutor.resolveTableInfo("tbl");
+        Reference reference = table.getReference(new ColumnIdent("x"));
+        assertThat(reference).isNotNull();
+
+        try (var indexEnv = new IndexEnv(
+                THREAD_POOL,
+                table,
+                clusterService.state(),
+                Version.CURRENT,
+                createTempDir())) {
+            T value = dataGenerator.get();
+
+            MapperService mapperService = indexEnv.mapperService();
+            ValueIndexer<? super T> valueIndexer = storageSupport.valueIndexer(
+                table.ident(),
+                reference,
+                column -> mapperService.getLuceneFieldType(column.fqn()),
+                table::getReference
+            );
+
+            IndexWriter writer = indexEnv.writer();
+            try (XContentBuilder xContentBuilder = XContentFactory.json(new BytesStreamOutput())) {
+                List<IndexableField> fields = new ArrayList<>();
+                xContentBuilder.startObject()
+                    .field(reference.column().fqn());
+                valueIndexer.indexValue(
+                    value,
+                    xContentBuilder,
+                    fields::add,
+                    ref -> {},
+                    Map.of(),
+                    Map.of()
+                );
+                xContentBuilder.endObject();
+                writer.addDocument(fields);
+                writer.commit();
+
+                // going through the document mapper must create the same fields
+                String id = "1";
+                ParsedDocument parsedDocument = mapperService.documentMapper().parse(new SourceToParse(
+                    table.ident().indexNameOrAlias(),
+                    id,
+                    BytesReference.bytes(xContentBuilder),
+                    XContentType.JSON
+                ));
+                IndexableField[] fieldsFromMapper = parsedDocument.doc().getFields("x");
+                assertThat(fieldsFromMapper).hasSize(fields.size());
+                for (int i = 0; i < fields.size(); i++) {
+                    var field1 = fields.get(i);
+                    var field2 = fieldsFromMapper[i];
+                    assertThat(field1.binaryValue()).isEqualTo(field2.binaryValue());
+                    assertThat(field1.stringValue()).isEqualTo(field2.stringValue());
+                    assertThat(field1.numericValue()).isEqualTo(field2.numericValue());
+                }
+            }
+
+            LuceneReferenceResolver luceneReferenceResolver = indexEnv.luceneReferenceResolver();
+            LuceneCollectorExpression<?> docValueImpl = luceneReferenceResolver.getImplementation(reference);
+            LuceneCollectorExpression<?> sourceLookup = luceneReferenceResolver.getImplementation(DocReferences.toSourceLookup(reference));
+            assertThat(docValueImpl).isNotNull();
+            assertThat(sourceLookup).isNotNull();
+
+            IndexSearcher indexSearcher;
+            try {
+                indexSearcher = new IndexSearcher(DirectoryReader.open(writer));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+
+            List<LeafReaderContext> leaves = indexSearcher.getTopReaderContext().leaves();
+            assertThat(leaves).hasSize(1);
+            LeafReaderContext leafReader = leaves.get(0);
+
+            Weight weight = indexSearcher.createWeight(
+                new MatchAllDocsQuery(),
+                ScoreMode.COMPLETE_NO_SCORES,
+                1.0f
+            );
+
+            Scorer scorer = weight.scorer(leafReader);
+            CollectorContext collectorContext = new CollectorContext(1);
+            ReaderContext readerContext = new ReaderContext(leafReader);
+            DocIdSetIterator iterator = scorer.iterator();
+            int nextDoc = iterator.nextDoc();
+
+            docValueImpl.startCollect(collectorContext);
+            docValueImpl.setNextReader(readerContext);
+            docValueImpl.setNextDocId(nextDoc);
+            assertThat(docValueImpl.value()).isEqualTo(value);
+        }
+    }
+
+    @Test
+    public void test_type_streaming_roundtrip() throws Exception {
+        DataType<T> type = getType();
+        BytesStreamOutput out = new BytesStreamOutput();
+        DataTypes.toStream(type, out);
+
+        StreamInput in = out.bytes().streamInput();
+        DataType<?> fromStream = DataTypes.fromStream(in);
+        assertThat(fromStream.id()).isEqualTo(type.id());
+        assertThat(fromStream.characterMaximumLength()).isEqualTo(type.characterMaximumLength());
+    }
+
+    @Test
+    public void test_value_streaming_roundtrip() throws Exception {
+        DataType<T> type = getType();
+        Supplier<T> dataGenerator = DataTypeTesting.getDataGenerator(type);
+        T value = dataGenerator.get();
+
+        Streamer<T> streamer = type.streamer();
+        BytesStreamOutput out = new BytesStreamOutput();
+        streamer.writeValueTo(out, value);
+
+        StreamInput in = out.bytes().streamInput();
+        assertThat(streamer.readValueFrom(in)).isEqualTo(value);
+    }
+}


### PR DESCRIPTION
First part for knn float vector support (https://github.com/crate/crate/issues/14319)
Adds the type. The basic create table, insert and select flow is working. Eq queries work via genericFunctionQuery. 

Follow up (next PR against feature branch; required for master merge)

- [x] Expose KnnFloatVectorQuery
- [x] Docs (Helps to have the query capability to talk about the use-case)

Optional Follow up once on master:
 
- [ ] Reduce spread of concrete DataType checks across code base
    - [ ] LuceneReferenceResolver -> add storageSupport.reader()?
    - [ ] SourceParser?
    - [ ] Type parameters handling
    - [ ] Connect FieldMapper more to type/StorageSupport
