### PR TITLE
Fix NPE with cross joins and fetch phases (Reset state on moveToStart in AsyncFlatMapBatchIterator)

### DIFF
--- a/docs/appendices/release-notes/5.3.5.rst
+++ b/docs/appendices/release-notes/5.3.5.rst
@@ -47,6 +47,18 @@ See the :ref:`version_5.3.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed a ``NullPointerException`` which could happen if using a cross join on a
+  sub-query, where the sub-query was executed using a ``Fetch`` operator. An
+  example query::
+
+    SELECT
+      *
+    FROM
+      (SELECT a FROM tbl1 ORDER BY b DESC LIMIT 1) i,
+      tbl2
+    WHERE
+      c >= 50;
+
 - Fixed a ``NullPointerException` which was thrown, instead of using default
   ``no compression`` behavior, when
   :ref:`compression parameter<sql-copy-to-compression>` of

--- a/docs/appendices/release-notes/5.4.1.rst
+++ b/docs/appendices/release-notes/5.4.1.rst
@@ -47,7 +47,19 @@ See the :ref:`version_5.4.0` release notes for a full list of changes in the
 Fixes
 =====
 
-- Fixed a ``NullPointerException` which was thrown, instead of using default
+- Fixed a ``NullPointerException`` which could happen if using a cross join on a
+  sub-query, where the sub-query was executed using a ``Fetch`` operator. An
+  example query::
+
+    SELECT
+      *
+    FROM
+      (SELECT a FROM tbl1 ORDER BY b DESC LIMIT 1) i,
+      tbl2
+    WHERE
+      c >= 50;
+
+- Fixed a ``NullPointerException`` which was thrown, instead of using default
   ``no compression`` behavior, when
   :ref:`compression parameter<sql-copy-to-compression>` of
   :ref:`COPY TO<sql-copy-to>` statement is set to ``null``.

--- a/libs/dex/src/main/java/io/crate/data/AsyncFlatMapBatchIterator.java
+++ b/libs/dex/src/main/java/io/crate/data/AsyncFlatMapBatchIterator.java
@@ -58,6 +58,10 @@ public final class AsyncFlatMapBatchIterator<I, O> implements BatchIterator<O> {
     @Override
     public void moveToStart() {
         source.moveToStart();
+        sourceExhausted = false;
+        mappedElements = null;
+        nextAction = NextAction.SOURCE;
+        current = null;
     }
 
     @Override

--- a/libs/dex/src/test/java/io/crate/data/AsyncFlatMapBatchIteratorTest.java
+++ b/libs/dex/src/test/java/io/crate/data/AsyncFlatMapBatchIteratorTest.java
@@ -29,6 +29,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import org.junit.Test;
@@ -122,5 +124,71 @@ public class AsyncFlatMapBatchIteratorTest {
                 new Object[] { 3 }
             )
         );
+    }
+
+    @Test
+    public void test_repeats_source_after_intermediate_move_to_start() throws Exception {
+        var source = TestingBatchIterators.range(1, 4);
+        AsyncFlatMapper<Row, Row> duplicateRow = (row, isLast) -> {
+            CloseableIterator<Row> result = mkIter(
+                new RowN(row.materialize()),
+                new RowN(row.materialize())
+            );
+            return CompletableFuture.completedFuture(result);
+        };
+        var it = new AsyncFlatMapBatchIterator<>(source, duplicateRow);
+        assertThat(it.moveNext()).as("needs to load source first").isFalse();
+        assertThat(it.loadNextBatch()).succeedsWithin(1, TimeUnit.SECONDS);
+        // first duplicated row
+        assertThat(it.moveNext()).isTrue();
+        assertThat(it.currentElement().get(0)).isEqualTo(1);
+        assertThat(it.moveNext()).isTrue();
+        assertThat(it.currentElement().get(0)).isEqualTo(1);
+        assertThat(it.moveNext()).isFalse();
+
+        // load second duplicated row
+        assertThat(it.loadNextBatch()).succeedsWithin(1, TimeUnit.SECONDS);
+        assertThat(it.moveNext()).isTrue();
+        assertThat(it.currentElement().get(0)).isEqualTo(2);
+
+        it.moveToStart();
+        // needs to start with first row again
+        assertThat(it.moveNext()).isFalse();
+        assertThat(it.loadNextBatch()).succeedsWithin(1, TimeUnit.SECONDS);
+        assertThat(it.moveNext()).isTrue();
+        assertThat(it.currentElement().get(0))
+            .as("first row after moveToStart must contain 1")
+            .isEqualTo(1);
+    }
+
+    @Test
+    public void test_calls_mapper_with_isLast_set_to_false_after_move_to_start() throws Exception {
+        AtomicInteger numCalls = new AtomicInteger();
+        AtomicBoolean wasLast = new AtomicBoolean();
+        AsyncFlatMapper<Row, Row> duplicateRow = (row, isLast) -> {
+            wasLast.set(isLast);
+            CloseableIterator<Row> result = mkIter(
+                new RowN(row.materialize()),
+                new RowN(row.materialize())
+            );
+            numCalls.incrementAndGet();
+            return CompletableFuture.completedFuture(result);
+        };
+        var source = TestingBatchIterators.range(1, 2);
+        var it = new AsyncFlatMapBatchIterator<>(source, duplicateRow);
+
+        assertThat(it.moveNext()).isFalse();
+        assertThat(it.loadNextBatch()).succeedsWithin(1, TimeUnit.SECONDS);
+        assertThat(numCalls).hasValue(1);
+        assertThat(wasLast).isFalse();
+        assertThat(it.moveNext()).isTrue();
+        assertThat(it.moveNext()).isTrue();
+        assertThat(it.moveNext()).isFalse();
+        assertThat(it.allLoaded()).isTrue();
+
+        it.moveToStart();
+        it.moveNext();
+        assertThat(it.loadNextBatch()).succeedsWithin(1, TimeUnit.SECONDS);
+        assertThat(wasLast).as("move to start needs to reset sourceExhausted").isFalse();
     }
 }

--- a/server/src/main/java/io/crate/execution/engine/fetch/FetchRows.java
+++ b/server/src/main/java/io/crate/execution/engine/fetch/FetchRows.java
@@ -166,7 +166,10 @@ public final class FetchRows {
             } else {
                 int readerId = FetchId.decodeReaderId(fetchId);
                 int docId = FetchId.decodeDocId(fetchId);
-                fetchedRow.cells(getReaderBucket.apply(readerId).get(docId));
+                ReaderBucket readerBucket = getReaderBucket.apply(readerId);
+                Object[] cells = readerBucket.get(docId);
+                assert cells != null : "Must have cells in readerBucket docId=" + docId + ", readerId=" + readerId;
+                fetchedRow.cells(cells);
             }
         }
         inputRow.cells(incomingCells);


### PR DESCRIPTION
Fixes https://github.com/crate/crate/issues/14381

There were two issues with the `moveToStart()` implementation in
`AsyncFlatMapBatchIterator`:

- `isLast` (for `AsyncFlatMapper.apply`) was always set to `true` after a `moveToStart()` after the
  iterator was previously exhausted. This could close resources early in
  a fetch phase, making them unavailable for further
  `moveNext()/loadNextBatch()` calls.

- It continued outputting mapped rows if `moveToStart()` was called
  _before_ the iterator was exhausted. This was currently a non-issue
  as `moveToStart()` is only called after an iterator is exhausted, but
  it's still wrong.