### PR TITLE
Allow trailing `/` in connection URL for CREATE SUBSCRIPTION

### DIFF
--- a/docs/appendices/release-notes/5.3.5.rst
+++ b/docs/appendices/release-notes/5.3.5.rst
@@ -47,6 +47,9 @@ See the :ref:`version_5.3.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Allowed trailing ``/`` without a database name for connection URL of
+  :ref:`CREATE SUBSCRIPTION<sql-create-subscription>`.
+
 - Fixed a ``NullPointerException`` which could happen if using a cross join on a
   sub-query, where the sub-query was executed using a ``Fetch`` operator. An
   example query::

--- a/docs/appendices/release-notes/5.4.1.rst
+++ b/docs/appendices/release-notes/5.4.1.rst
@@ -47,6 +47,9 @@ See the :ref:`version_5.4.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Allowed trailing ``/`` without a database name for connection URL of
+  :ref:`CREATE SUBSCRIPTION<sql-create-subscription>`.
+
 - Fixed a ``NullPointerException`` which could happen if using a cross join on a
   sub-query, where the sub-query was executed using a ``Fetch`` operator. An
   example query::

--- a/server/src/main/java/io/crate/replication/logical/metadata/ConnectionInfo.java
+++ b/server/src/main/java/io/crate/replication/logical/metadata/ConnectionInfo.java
@@ -21,18 +21,6 @@
 
 package io.crate.replication.logical.metadata;
 
-import io.crate.exceptions.InvalidArgumentException;
-import io.crate.types.DataTypes;
-import io.crate.user.User;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.settings.Setting;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.transport.RemoteCluster;
-import org.elasticsearch.transport.RemoteCluster.ConnectionStrategy;
-
-import org.jetbrains.annotations.Nullable;
 import java.io.IOException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
@@ -42,6 +30,19 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.transport.RemoteCluster;
+import org.elasticsearch.transport.RemoteCluster.ConnectionStrategy;
+import org.jetbrains.annotations.Nullable;
+
+import io.crate.exceptions.InvalidArgumentException;
+import io.crate.types.DataTypes;
+import io.crate.user.User;
 
 
 public class ConnectionInfo implements Writeable {
@@ -126,11 +127,16 @@ public class ConnectionInfo implements Writeable {
         urlServer = urlServer.substring("crate://".length());
 
         int slash = urlServer.indexOf('/');
-        if (slash != -1 && slash != urlServer.length()) {
-            throw new InvalidArgumentException(
-                String.format(Locale.ENGLISH,
-                              "Database argument is not supported inside the connection string: %s", url)
-            );
+        if (slash != -1) {
+            if (slash != urlServer.length() - 1) {
+                throw new InvalidArgumentException(
+                    String.format(Locale.ENGLISH,
+                                  "Database argument \"%s\" is not supported inside the connection string: %s",
+                                  urlServer.substring(slash + 1),
+                                  url)
+                );
+            }
+            urlServer = urlServer.substring(0, slash);
         }
         slash = urlServer.length();
 

--- a/server/src/test/java/io/crate/replication/logical/metadata/ConnectionInfoTest.java
+++ b/server/src/test/java/io/crate/replication/logical/metadata/ConnectionInfoTest.java
@@ -47,22 +47,32 @@ public class ConnectionInfoTest extends ESTestCase {
     }
 
     @Test
+    public void test_db_not_allowed() {
+        assertThatThrownBy(() -> ConnectionInfo.fromURL("crate:///customdb"))
+            .isExactlyInstanceOf(InvalidArgumentException.class)
+            .hasMessageContaining("Database argument \"customdb\" is not supported inside the connection string: crate:///customdb");
+        assertThatThrownBy(() -> ConnectionInfo.fromURL("crate://host1:123,host2:456/customdb"))
+            .isExactlyInstanceOf(InvalidArgumentException.class)
+            .hasMessageContaining("Database argument \"customdb\" is not supported inside the connection string: crate://host1:123,host2:456/customdb");
+    }
+
+    @Test
     public void test_simple_url() {
-        var connInfo = ConnectionInfo.fromURL("crate://example.com:1234");
+        var connInfo = ConnectionInfo.fromURL("crate://example.com:1234" + (randomBoolean() ? "/" : ""));
         assertThat(connInfo.hosts()).containsExactly("example.com:1234");
         assertThat(connInfo.settings()).isEqualTo(Settings.EMPTY);
     }
 
     @Test
     public void test_url_without_host() {
-        var connInfo = ConnectionInfo.fromURL("crate://");
+        var connInfo = ConnectionInfo.fromURL("crate://" + (randomBoolean() ? "/" : ""));
         assertThat(connInfo.hosts()).containsExactly(":4300");
         assertThat(connInfo.settings()).isEqualTo(Settings.EMPTY);
     }
 
     @Test
     public void test_url_without_port() {
-        var connInfo = ConnectionInfo.fromURL("crate://123.123.123.123");
+        var connInfo = ConnectionInfo.fromURL("crate://123.123.123.123" + (randomBoolean() ? "/" : ""));
         assertThat(connInfo.hosts()).containsExactly("123.123.123.123:4300");
         assertThat(connInfo.settings()).isEqualTo(Settings.EMPTY);
     }
@@ -97,7 +107,8 @@ public class ConnectionInfoTest extends ESTestCase {
 
     @Test
     public void test_safe_connection_string() {
-        var connInfoSniff = ConnectionInfo.fromURL("crate://example.com:4310,123.123.123.123?" +
+        var connInfoSniff = ConnectionInfo.fromURL("crate://example.com:4310,123.123.123.123" +
+            (randomBoolean() ? "/?" : "?") +
             "user=my_user&password=1234&" +
             "sslmode=disable"       // <- sslMode is ignored on SNIFF mode
         );


### PR DESCRIPTION
-  tests: Migrate `ConnectionInfoTest` to assertj
-  Allow a trailing `/` but without a database name, so that
    ```
    crate://host:port/?user=crate
    ```
    is allowed, but:
    ```
    crate://host:port/myDB?user=crate
    ```
    is not.
    
Partially fixes: #14445
