### PR TITLE
Fix: Hiding errors in connection URL of CREATE SUBSCRIPTION

### DIFF
--- a/docs/appendices/release-notes/5.3.5.rst
+++ b/docs/appendices/release-notes/5.3.5.rst
@@ -47,6 +47,10 @@ See the :ref:`version_5.3.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Improved error message when passing settings with ``WITH`` clause on a
+  :ref:`CREATE SUBSCRIPTION<sql-create-subscription>` statement, which is not
+  currently supported.
+
 - Fixed an issue that resulted in hiding errors with the connection URL of
   :ref:`CREATE SUBSCRIPTION<sql-create-subscription>`, when executed from a
   non-superuser but with `AL` privileges.

--- a/docs/appendices/release-notes/5.3.5.rst
+++ b/docs/appendices/release-notes/5.3.5.rst
@@ -47,6 +47,10 @@ See the :ref:`version_5.3.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that resulted in hiding errors with the connection URL of
+  :ref:`CREATE SUBSCRIPTION<sql-create-subscription>`, when executed from a
+  non-superuser but with `AL` privileges.
+
 - Allowed trailing ``/`` without a database name for connection URL of
   :ref:`CREATE SUBSCRIPTION<sql-create-subscription>`.
 

--- a/docs/appendices/release-notes/5.4.1.rst
+++ b/docs/appendices/release-notes/5.4.1.rst
@@ -47,6 +47,10 @@ See the :ref:`version_5.4.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that resulted in hiding errors with the connection URL of
+  :ref:`CREATE SUBSCRIPTION<sql-create-subscription>`, when executed from a
+  non-superuser but with `AL` privileges.
+
 - Allowed trailing ``/`` without a database name for connection URL of
   :ref:`CREATE SUBSCRIPTION<sql-create-subscription>`.
 

--- a/docs/appendices/release-notes/5.4.1.rst
+++ b/docs/appendices/release-notes/5.4.1.rst
@@ -47,6 +47,10 @@ See the :ref:`version_5.4.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Improved error message when passing settings with ``WITH`` clause on a
+  :ref:`CREATE SUBSCRIPTION<sql-create-subscription>` statement, which is not
+  currently supported.
+
 - Fixed an issue that resulted in hiding errors with the connection URL of
   :ref:`CREATE SUBSCRIPTION<sql-create-subscription>`, when executed from a
   non-superuser but with `AL` privileges.

--- a/docs/sql/statements/create-subscription.rst
+++ b/docs/sql/statements/create-subscription.rst
@@ -30,7 +30,6 @@ Synopsis
     CREATE SUBSCRIPTION subscription_name
     CONNECTION 'conninfo'
     PUBLICATION publication_name [, ...]
-    [ WITH (parameter_name [= value], [, ...]) ]
 
 .. _sql-create-subscription-desc:
 
@@ -121,26 +120,3 @@ Parameters
 
 **PUBLICATION publication_name**
   Names of the publications on the publisher to subscribe to
-
-Clauses
-=======
-
-``WITH``
---------
-
-You can use the ``WITH`` clause to specify one or more repository parameter
-values:
-
-::
-
-    [ WITH (parameter_name [= value], [, ...]) ]
-
-Parameters
-----------
-
-This clause specifies optional parameters for a subscription. The following
-parameters are supported:
-
-**enabled**
-  Specifies whether the subscription should be actively replicating, or whether
-  it should be just setup but not started yet. The default is ``true``.

--- a/server/src/main/java/io/crate/replication/logical/analyze/AnalyzedCreateSubscription.java
+++ b/server/src/main/java/io/crate/replication/logical/analyze/AnalyzedCreateSubscription.java
@@ -21,13 +21,13 @@
 
 package io.crate.replication.logical.analyze;
 
+import java.util.List;
+import java.util.function.Consumer;
+
 import io.crate.analyze.AnalyzedStatementVisitor;
 import io.crate.analyze.DDLStatement;
 import io.crate.expression.symbol.Symbol;
 import io.crate.sql.tree.GenericProperties;
-
-import java.util.List;
-import java.util.function.Consumer;
 
 public class AnalyzedCreateSubscription implements DDLStatement {
 

--- a/server/src/main/java/io/crate/replication/logical/exceptions/CreateSubscriptionException.java
+++ b/server/src/main/java/io/crate/replication/logical/exceptions/CreateSubscriptionException.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.replication.logical.exceptions;
+
+import java.io.IOException;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.io.stream.StreamInput;
+
+import io.crate.exceptions.ClusterScopeException;
+import io.crate.exceptions.ConflictException;
+
+public class CreateSubscriptionException extends ElasticsearchException implements ConflictException, ClusterScopeException {
+
+    public CreateSubscriptionException(Exception e) {
+        super(e);
+    }
+
+    public CreateSubscriptionException(String message) {
+        super(message);
+    }
+
+    public CreateSubscriptionException(StreamInput in) throws IOException {
+        super(in);
+    }
+}

--- a/server/src/main/java/io/crate/replication/logical/metadata/ConnectionInfo.java
+++ b/server/src/main/java/io/crate/replication/logical/metadata/ConnectionInfo.java
@@ -40,7 +40,7 @@ import org.elasticsearch.transport.RemoteCluster;
 import org.elasticsearch.transport.RemoteCluster.ConnectionStrategy;
 import org.jetbrains.annotations.Nullable;
 
-import io.crate.exceptions.InvalidArgumentException;
+import io.crate.replication.logical.exceptions.CreateSubscriptionException;
 import io.crate.types.DataTypes;
 import io.crate.user.User;
 
@@ -50,7 +50,6 @@ public class ConnectionInfo implements Writeable {
     public static final Setting<String> USERNAME = Setting.simpleString("user");
 
     public static final Setting<String> PASSWORD = Setting.simpleString("password");
-
 
     public enum SSLMode {
         PREFER,
@@ -65,7 +64,7 @@ public class ConnectionInfo implements Writeable {
             case "prefer" -> SSLMode.PREFER;
             case "disable" -> SSLMode.DISABLE;
             case "require" -> SSLMode.REQUIRE;
-            default -> throw new InvalidArgumentException("Invalid value for sslmode: " + input + " expected one of: prefer, disable, require");
+            default -> throw new CreateSubscriptionException("Invalid value for sslmode: " + input + " expected one of: prefer, disable, require");
         },
         DataTypes.STRING
     );
@@ -81,91 +80,95 @@ public class ConnectionInfo implements Writeable {
     private static final String DEFAULT_PG_PORT = "5432";
 
     public static ConnectionInfo fromURL(String url) {
-        List<String> hosts = new ArrayList<>();
+        try {
+            List<String> hosts = new ArrayList<>();
 
-        String urlServer = url;
-        String urlArgs = "";
+            String urlServer = url;
+            String urlArgs = "";
 
-        int qPos = url.indexOf('?');
-        if (qPos != -1) {
-            urlServer = url.substring(0, qPos);
-            urlArgs = url.substring(qPos + 1);
-        }
-
-        // parse the args part of the url
-        var settingsBuilder = Settings.builder();
-        String[] args = urlArgs.split("&");
-        for (String token : args) {
-            if (token.isEmpty()) {
-                continue;
+            int qPos = url.indexOf('?');
+            if (qPos != -1) {
+                urlServer = url.substring(0, qPos);
+                urlArgs = url.substring(qPos + 1);
             }
-            String settingName;
-            String settingValue;
-            int pos = token.indexOf('=');
-            if (pos == -1) {
-                settingName = token;
-                settingValue = "";
-            } else {
-                settingName = token.substring(0, pos);
-                settingValue = URLDecoder.decode(token.substring(pos + 1), StandardCharsets.UTF_8);
+
+            // parse the args part of the url
+            var settingsBuilder = Settings.builder();
+            String[] args = urlArgs.split("&");
+            for (String token : args) {
+                if (token.isEmpty()) {
+                    continue;
+                }
+                String settingName;
+                String settingValue;
+                int pos = token.indexOf('=');
+                if (pos == -1) {
+                    settingName = token;
+                    settingValue = "";
+                } else {
+                    settingName = token.substring(0, pos);
+                    settingValue = URLDecoder.decode(token.substring(pos + 1), StandardCharsets.UTF_8);
+                }
+                if (SUPPORTED_SETTINGS.contains(settingName) == false) {
+                    throw new CreateSubscriptionException(
+                        String.format(Locale.ENGLISH,
+                                      "Connection string argument '%s' is not supported", settingName)
+                    );
+                }
+                settingsBuilder.put(settingName, settingValue);
             }
-            if (SUPPORTED_SETTINGS.contains(settingName) == false) {
-                throw new InvalidArgumentException(
+
+            if (!urlServer.startsWith("crate://")) {
+                throw new CreateSubscriptionException(
                     String.format(Locale.ENGLISH,
-                                  "Connection string argument '%s' is not supported", settingName)
+                                  "The connection string must start with \"crate://\" but was: \"%s\"", url)
                 );
             }
-            settingsBuilder.put(settingName, settingValue);
-        }
+            urlServer = urlServer.substring("crate://".length());
 
-        if (!urlServer.startsWith("crate://")) {
-            throw new InvalidArgumentException(
-                String.format(Locale.ENGLISH,
-                              "The connection string must start with \"crate://\" but was: \"%s\"", url)
-            );
-        }
-        urlServer = urlServer.substring("crate://".length());
-
-        int slash = urlServer.indexOf('/');
-        if (slash != -1) {
-            if (slash != urlServer.length() - 1) {
-                throw new InvalidArgumentException(
-                    String.format(Locale.ENGLISH,
-                                  "Database argument \"%s\" is not supported inside the connection string: %s",
-                                  urlServer.substring(slash + 1),
-                                  url)
-                );
+            int slash = urlServer.indexOf('/');
+            if (slash != -1) {
+                if (slash != urlServer.length() - 1) {
+                    throw new CreateSubscriptionException(
+                        String.format(Locale.ENGLISH,
+                                      "Database name \"%s\" is not supported inside the connection string: %s",
+                                      urlServer.substring(slash + 1),
+                                      url)
+                    );
+                }
+                urlServer = urlServer.substring(0, slash);
             }
-            urlServer = urlServer.substring(0, slash);
-        }
-        slash = urlServer.length();
+            slash = urlServer.length();
 
-        Settings settings = settingsBuilder.build();
-        String[] addresses = urlServer.substring(0, slash).split(",");
-        for (String address : addresses) {
-            int portIdx = address.lastIndexOf(':');
-            if (portIdx != -1 && address.lastIndexOf(']') < portIdx) {
-                String portStr = address.substring(portIdx + 1);
-                try {
-                    int port = Integer.parseInt(portStr);
-                    if (port < 1 || port > 65535) {
-                        throw new InvalidArgumentException(
+            Settings settings = settingsBuilder.build();
+            String[] addresses = urlServer.substring(0, slash).split(",");
+            for (String address : addresses) {
+                int portIdx = address.lastIndexOf(':');
+                if (portIdx != -1 && address.lastIndexOf(']') < portIdx) {
+                    String portStr = address.substring(portIdx + 1);
+                    try {
+                        int port = Integer.parseInt(portStr);
+                        if (port < 1 || port > 65535) {
+                            throw new CreateSubscriptionException(
+                                String.format(Locale.ENGLISH,
+                                              "Invalid port number '%s' inside connection string (1:65535)", portStr)
+                            );
+                        }
+                    } catch (NumberFormatException ignore) {
+                        throw new CreateSubscriptionException(
                             String.format(Locale.ENGLISH,
                                           "Invalid port number '%s' inside connection string (1:65535)", portStr)
                         );
                     }
-                } catch (NumberFormatException ignore) {
-                    throw new InvalidArgumentException(
-                        String.format(Locale.ENGLISH,
-                                      "Invalid port number '%s' inside connection string (1:65535)", portStr)
-                    );
+                    hosts.add(address);
+                } else {
+                    hosts.add(address + ":" + defaultPort(settings));
                 }
-                hosts.add(address);
-            } else {
-                hosts.add(address + ":" + defaultPort(settings));
             }
+            return new ConnectionInfo(hosts, settings);
+        } catch (Exception e) {
+            throw new CreateSubscriptionException(e);
         }
-        return new ConnectionInfo(hosts, settings);
     }
 
     private static String defaultPort(Settings settings) {

--- a/server/src/main/java/io/crate/replication/logical/plan/CreateSubscriptionPlan.java
+++ b/server/src/main/java/io/crate/replication/logical/plan/CreateSubscriptionPlan.java
@@ -80,11 +80,9 @@ public class CreateSubscriptionPlan implements Plan {
                 String.format(Locale.ENGLISH, "Setting '%s' must be provided on CREATE SUBSCRIPTION", ConnectionInfo.USERNAME.getKey())
             );
         }
+
         if (settings.names().isEmpty() == false) {
-            var setting = settings.names().iterator().next();
-            throw new CreateSubscriptionException(
-                String.format(Locale.ENGLISH, "Setting '%s' is not support on CREATE SUBSCRIPTION", setting)
-            );
+            throw new CreateSubscriptionException("Settings with 'WITH' clause are not supported for CREATE SUBSCRIPTION");
         }
 
         var request = new CreateSubscriptionRequest(

--- a/server/src/main/java/io/crate/replication/logical/plan/CreateSubscriptionPlan.java
+++ b/server/src/main/java/io/crate/replication/logical/plan/CreateSubscriptionPlan.java
@@ -31,7 +31,6 @@ import io.crate.analyze.SymbolEvaluator;
 import io.crate.data.Row;
 import io.crate.data.Row1;
 import io.crate.data.RowConsumer;
-import io.crate.exceptions.InvalidArgumentException;
 import io.crate.execution.support.OneRowActionListener;
 import io.crate.expression.symbol.Symbol;
 import io.crate.planner.DependencyCarrier;
@@ -40,6 +39,7 @@ import io.crate.planner.PlannerContext;
 import io.crate.planner.operators.SubQueryResults;
 import io.crate.replication.logical.action.CreateSubscriptionRequest;
 import io.crate.replication.logical.analyze.AnalyzedCreateSubscription;
+import io.crate.replication.logical.exceptions.CreateSubscriptionException;
 import io.crate.replication.logical.metadata.ConnectionInfo;
 import io.crate.types.DataTypes;
 
@@ -76,12 +76,13 @@ public class CreateSubscriptionPlan implements Plan {
 
         var subscribingUser = connectionInfo.settings().get(ConnectionInfo.USERNAME.getKey());
         if (subscribingUser == null || subscribingUser.isEmpty()) {
-            throw new InvalidArgumentException(
+            throw new CreateSubscriptionException(
                 String.format(Locale.ENGLISH, "Setting '%s' must be provided on CREATE SUBSCRIPTION", ConnectionInfo.USERNAME.getKey())
             );
         }
-        for (var setting : settings.names()) {
-            throw new InvalidArgumentException(
+        if (settings.names().isEmpty() == false) {
+            var setting = settings.names().iterator().next();
+            throw new CreateSubscriptionException(
                 String.format(Locale.ENGLISH, "Setting '%s' is not support on CREATE SUBSCRIPTION", setting)
             );
         }
@@ -102,6 +103,6 @@ public class CreateSubscriptionPlan implements Plan {
         if (uri instanceof String str) {
             return str;
         }
-        throw new IllegalArgumentException("fileUri must be of type STRING. Got " + DataTypes.guessType(uri));
+        throw new CreateSubscriptionException("fileUri must be of type STRING. Got " + DataTypes.guessType(uri));
     }
 }

--- a/server/src/test/java/io/crate/replication/logical/metadata/ConnectionInfoTest.java
+++ b/server/src/test/java/io/crate/replication/logical/metadata/ConnectionInfoTest.java
@@ -28,32 +28,32 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
 
-import io.crate.exceptions.InvalidArgumentException;
+import io.crate.replication.logical.exceptions.CreateSubscriptionException;
 
 public class ConnectionInfoTest extends ESTestCase {
 
     @Test
     public void test_url_has_valid_prefix() {
         assertThatThrownBy(() -> ConnectionInfo.fromURL("postgres:"))
-            .isExactlyInstanceOf(InvalidArgumentException.class)
+            .isExactlyInstanceOf(CreateSubscriptionException.class)
             .hasMessageContaining("The connection string must start with \"crate://\" but was: \"postgres:\"");
     }
 
     @Test
     public void test_url_is_not_empty() {
         assertThatThrownBy(() -> ConnectionInfo.fromURL(""))
-            .isExactlyInstanceOf(InvalidArgumentException.class)
+            .isExactlyInstanceOf(CreateSubscriptionException.class)
             .hasMessageContaining("The connection string must start with \"crate://\" but was: \"\"");
     }
 
     @Test
     public void test_db_not_allowed() {
         assertThatThrownBy(() -> ConnectionInfo.fromURL("crate:///customdb"))
-            .isExactlyInstanceOf(InvalidArgumentException.class)
-            .hasMessageContaining("Database argument \"customdb\" is not supported inside the connection string: crate:///customdb");
+            .isExactlyInstanceOf(CreateSubscriptionException.class)
+            .hasMessageContaining("Database name \"customdb\" is not supported inside the connection string: crate:///customdb");
         assertThatThrownBy(() -> ConnectionInfo.fromURL("crate://host1:123,host2:456/customdb"))
-            .isExactlyInstanceOf(InvalidArgumentException.class)
-            .hasMessageContaining("Database argument \"customdb\" is not supported inside the connection string: crate://host1:123,host2:456/customdb");
+            .isExactlyInstanceOf(CreateSubscriptionException.class)
+            .hasMessageContaining("Database name \"customdb\" is not supported inside the connection string: crate://host1:123,host2:456/customdb");
     }
 
     @Test
@@ -131,18 +131,18 @@ public class ConnectionInfoTest extends ESTestCase {
     @Test
     public void test_invalid_argument() {
         assertThatThrownBy(() -> ConnectionInfo.fromURL("crate://?foo=bar"))
-            .isExactlyInstanceOf(InvalidArgumentException.class)
+            .isExactlyInstanceOf(CreateSubscriptionException.class)
             .hasMessageContaining("Connection string argument 'foo' is not supported");
     }
 
     @Test
     public void test_setting_invalid_mode_raises_error_including_valid_options() {
         assertThatThrownBy(() -> ConnectionInfo.fromURL("crate://example.com?mode=foo"))
-            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .isExactlyInstanceOf(CreateSubscriptionException.class)
             .hasMessageContaining("Invalid connection mode `foo`, supported modes are: `sniff`, `pg_tunnel`");
 
         assertThatThrownBy(() -> ConnectionInfo.fromURL("crate://example.com:5432?mode=foo"))
-            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .isExactlyInstanceOf(CreateSubscriptionException.class)
             .hasMessageContaining("Invalid connection mode `foo`, supported modes are: `sniff`, `pg_tunnel`");
     }
 }

--- a/server/src/test/java/io/crate/replication/logical/plan/CreateSubscriptionPlanTest.java
+++ b/server/src/test/java/io/crate/replication/logical/plan/CreateSubscriptionPlanTest.java
@@ -22,10 +22,16 @@
 package io.crate.replication.logical.plan;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
 
 import org.junit.Test;
+import org.mockito.Answers;
 
-import io.crate.planner.PlannerContext;
+import io.crate.data.Row;
+import io.crate.data.testing.TestingRowConsumer;
+import io.crate.planner.DependencyCarrier;
+import io.crate.planner.Plan;
+import io.crate.planner.operators.SubQueryResults;
 import io.crate.replication.logical.exceptions.CreateSubscriptionException;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
@@ -36,9 +42,29 @@ public class CreateSubscriptionPlanTest extends CrateDummyClusterServiceUnitTest
     public void test_create_subscription_plan_checks_subscribing_user() {
         SQLExecutor e = SQLExecutor.builder(clusterService).build();
         CreateSubscriptionPlan plan = e.plan("CREATE SUBSCRIPTION sub CONNECTION 'crate://example.com' publication pub1");
-        PlannerContext plannerContext = e.getPlannerContext(clusterService.state());
-        assertThatThrownBy(() -> plan.executeOrFail(null, plannerContext, null, null, null))
+        assertThatThrownBy(() -> executePlan(e, plan))
             .isExactlyInstanceOf(CreateSubscriptionException.class)
             .hasMessageContaining("Setting 'user' must be provided on CREATE SUBSCRIPTION");
+    }
+
+    @Test
+    public void test_create_subscription_with_settings_not_supported() {
+        SQLExecutor e = SQLExecutor.builder(clusterService).build();
+        CreateSubscriptionPlan plan = e.plan("CREATE SUBSCRIPTION sub CONNECTION 'crate://example.com?user=crate' publication pub1 WITH(enabled=true)");
+        assertThatThrownBy(() -> executePlan(e, plan))
+            .isExactlyInstanceOf(CreateSubscriptionException.class)
+            .hasMessageContaining("Settings with 'WITH' clause are not supported for CREATE SUBSCRIPTION");
+    }
+
+    private void executePlan(SQLExecutor executor, Plan plan) throws Exception {
+        TestingRowConsumer consumer = new TestingRowConsumer(true);
+        plan.execute(
+            mock(DependencyCarrier.class, Answers.RETURNS_MOCKS),
+            executor.getPlannerContext(clusterService.state()),
+            consumer,
+            Row.EMPTY,
+            SubQueryResults.EMPTY
+        );
+        consumer.getResult();
     }
 }

--- a/server/src/test/java/io/crate/replication/logical/plan/CreateSubscriptionPlanTest.java
+++ b/server/src/test/java/io/crate/replication/logical/plan/CreateSubscriptionPlanTest.java
@@ -21,26 +21,24 @@
 
 package io.crate.replication.logical.plan;
 
-import org.assertj.core.api.Assertions;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import org.junit.Test;
 
-import io.crate.exceptions.InvalidArgumentException;
 import io.crate.planner.PlannerContext;
+import io.crate.replication.logical.exceptions.CreateSubscriptionException;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 
 public class CreateSubscriptionPlanTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
-    public void test_create_subscription_plan_checks_subscribing_user() throws Exception {
+    public void test_create_subscription_plan_checks_subscribing_user() {
         SQLExecutor e = SQLExecutor.builder(clusterService).build();
-        Assertions.assertThatThrownBy(() -> {
-            CreateSubscriptionPlan plan = e.plan("CREATE SUBSCRIPTION sub CONNECTION 'crate://example.com' publication pub1");
-            PlannerContext plannerContext = e.getPlannerContext(clusterService.state());
-            plan.executeOrFail(null, plannerContext, null, null, null);
-        })
-            .isExactlyInstanceOf(InvalidArgumentException.class)
+        CreateSubscriptionPlan plan = e.plan("CREATE SUBSCRIPTION sub CONNECTION 'crate://example.com' publication pub1");
+        PlannerContext plannerContext = e.getPlannerContext(clusterService.state());
+        assertThatThrownBy(() -> plan.executeOrFail(null, plannerContext, null, null, null))
+            .isExactlyInstanceOf(CreateSubscriptionException.class)
             .hasMessageContaining("Setting 'user' must be provided on CREATE SUBSCRIPTION");
     }
-
 }


### PR DESCRIPTION
Since the parsing and the validation of the URL takes place inside the `CreateSubscriptionPlan` and not during the analysis, any `IllegalArgumentException` thrown is going through the `AccessControlImpl#ensureMaySee()`, and since there is no special privileges handler for those exceptions, the error returned to the user hides the original issue:
```
IllegalStateException[CrateException 'class io.crate.exceptions.InvalidArgumentException' not supported by privileges exception validator]
```

Introduce a `CreateSubscriptionException` which implements `ClusterScope` to throw from instead, so that users with `AL` privileges can see the original problem.

Fixes: #14445
