### PR TITLE
Add knn_match & float_vector docs

### DIFF
--- a/docs/appendices/release-notes/5.5.0.rst
+++ b/docs/appendices/release-notes/5.5.0.rst
@@ -83,21 +83,22 @@ SQL Standard and PostgreSQL Compatibility
 
 None
 
+Data Types
+----------
+
+- Added a :ref:`FLOAT_VECTOR <type-float_vector>` type to store dense vectors of
+  float values which can be searched using a k-nearest neighbour algorithm via a
+  new :ref:`KNN_MATCH <scalar_knn_match>` scalar.
+
 
 Scalar and Aggregation Functions
 --------------------------------
 
-None
+- Added a :ref:`KNN_MATCH <scalar_knn_match>` scalar.
 
 
 Performance and Resilience Improvements
 ---------------------------------------
-
-None
-
-
-Data Types
-----------
 
 None
 

--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -4243,6 +4243,64 @@ Special functions
 =================
 
 
+.. _scalar_knn_match:
+
+
+``knn_match(float_vector, float_vector, int)``
+----------------------------------------------
+
+The ``knn_match`` function uses a k-nearest
+neighbour (kNN) search algorithm to find vectors that are similar
+to a query vector.
+
+The first argument is the column to search.
+The second argument is the query vector.
+The third argument is the number of nearest neighbours to search and return.
+
+``knn_match(search_vector, target, k)``
+
+This function must be used within a ``WHERE`` clause targeting a table to use it
+as a predicate that searches the whole dataset of a table.
+If used *outside* of a ``WHERE`` clause, or in a ``WHERE`` clause targeting a
+virtual table instead of a physical table, the search algorithm will only
+consider the current row, not the whole dataset.
+
+Similar to the :ref:`MATCH predicate <predicates_match>`, this function affects
+the :ref:`_score <sql_administration_system_column_score>` value.
+
+An example::
+
+
+    cr> CREATE TABLE IF NOT EXISTS doc.vectors (
+    ...    xs float_vector(2)
+    ...  );
+    CREATE OK, 1 row affected (... sec)
+
+    cr> INSERT INTO doc.vectors (xs)
+    ...   VALUES
+    ...   ([3.14, 8.17]),
+    ...   ([14.3, 19.4]);
+    INSERT OK, 2 rows affected (... sec)
+
+.. HIDE:
+
+    cr> REFRESH TABLE doc.vectors;
+    REFRESH OK, 1 row affected (... sec)
+
+::
+
+    cr> SELECT xs, _score FROM doc.vectors
+    ... WHERE knn_match(xs, [3.14, 8], 2)
+    ... ORDER BY _score DESC;
+    +--------------+--------------+
+    | xs           |       _score |
+    +--------------+--------------+
+    | [3.14, 8.17] | 0.9719117    |
+    | [14.3, 19.4] | 0.0039138086 |
+    +--------------+--------------+
+    SELECT 2 rows in set (... sec)
+
+
 .. _scalar-ignore3vl:
 
 ``ignore3vl(boolean)``

--- a/docs/general/ddl/data-types.rst
+++ b/docs/general/ddl/data-types.rst
@@ -124,6 +124,10 @@ CrateDB supports the following data types. Scroll down for more details.
 
             'POLYGON ((5 5, 10 5, 10 10, 5 10, 5 5))'
 
+    * - ``float_vector(n)``
+      - A fixed length vector of floating point numbers
+      - ``[3.14, 42.21]``
+
 
 .. _data-types-ranges-widths:
 
@@ -230,6 +234,10 @@ are likely to be larger due to additional metadata.
       - variable
       - Each coordinate is stored as a ``DOUBLE PRECISION`` type.
       - A ``GEO_SHAPE`` column can store different kinds of `GeoJSON geometry objects`_.
+    * - ``FLOAT_VECTOR``
+      - variable
+      - Minimum length: 1. Maximum length: 2^31-1
+      - A vector of floating point numbers.
 
 
 .. rubric:: Footnotes
@@ -2915,6 +2923,64 @@ requires an intermediate cast:
     |                       1.0 |
     |                       2.0 |
     +---------------------------+
+
+
+.. _type-float_vector:
+
+``FLOAT_VECTOR``
+================
+
+A ``float_vector`` type allows to store dense vectors of float values of fixed
+length.
+
+It support :ref:`KNN_MATCH <scalar_knn_match>` for k-nearest neighbour search.
+This allows you to find vectors in a dataset which are similar to a query
+vector.
+
+The type can't be used as an element type of a regular array. ``float_vector``
+values are defined like float arrays.
+
+An example::
+
+    cr> CREATE TABLE my_vectors (
+    ...     xs FLOAT_VECTOR(2)
+    ... );
+    CREATE OK, 1 row affected (... sec)
+
+::
+
+    cr> INSERT INTO my_vectors (xs) VALUES ([3.14, 27.34]);
+    INSERT OK, 1 row affected (... sec)
+
+
+Inserting a value with a different dimension than declared in ``CREATE TABLE``
+results in an error.
+
+::
+
+    cr> INSERT INTO my_vectors (xs) VALUES ([3.14, 27.34, 38.4]);
+    SQLParseException[The number of vector dimensions does not match the field type]
+
+
+.. HIDE:
+
+    cr> REFRESH TABLE my_vectors;
+    REFRESH OK, 1 row affected (... sec)
+
+::
+
+    cr> SELECT * FROM my_vectors;
+    +---------------+
+    | xs            |
+    +---------------+
+    | [3.14, 27.34] |
+    +---------------+
+    SELECT 1 row in set (... sec)
+
+.. HIDE:
+
+    cr> DROP TABLE my_vectors;
+    DROP OK, 1 row affected (... sec)
 
 
 .. _data-types-geo:

--- a/server/src/main/java/io/crate/expression/scalar/KnnMatch.java
+++ b/server/src/main/java/io/crate/expression/scalar/KnnMatch.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+
+package io.crate.expression.scalar;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.List;
+
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.search.KnnFloatVectorQuery;
+import org.apache.lucene.search.Query;
+import org.jetbrains.annotations.Nullable;
+
+import io.crate.data.Input;
+import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.Literal;
+import io.crate.expression.symbol.Symbol;
+import io.crate.lucene.LuceneQueryBuilder.Context;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.Reference;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.BoundSignature;
+import io.crate.metadata.functions.Signature;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+import io.crate.types.FloatVectorType;
+import io.crate.types.TypeSignature;
+
+public class KnnMatch extends Scalar<Boolean, Object> {
+
+    private static final float DEFAULT_MIN_SCORE = 0.50f;
+
+    private final Signature signature;
+    private final BoundSignature boundSignature;
+    private final IndexWriterConfig conf;
+    private DataType<float[]> type;
+
+    public static void register(ScalarFunctionModule module) {
+        module.register(
+            Signature.scalar(
+                "knn_match",
+                TypeSignature.parse(FloatVectorType.NAME),
+                TypeSignature.parse(FloatVectorType.NAME),
+                DataTypes.INTEGER.getTypeSignature(),
+                DataTypes.BOOLEAN.getTypeSignature()
+            ),
+            KnnMatch::new
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    public KnnMatch(Signature signature, BoundSignature boundSignature) {
+        this.signature = signature;
+        this.boundSignature = boundSignature;
+        this.conf = new IndexWriterConfig(new StandardAnalyzer());
+        this.type = (DataType<float[]>) boundSignature.argTypes().get(0);
+    }
+
+    @Override
+    public Signature signature() {
+        return signature;
+    }
+
+    @Override
+    public BoundSignature boundSignature() {
+        return boundSignature;
+    }
+
+    @Override
+    @SafeVarargs
+    public final Boolean evaluate(TransactionContext txnCtx,
+                                  NodeContext nodeContext,
+                                  Input<Object>... args) {
+        Object field = args[0].value();
+        if (field == null) {
+            return null;
+        }
+        Object target = args[1].value();
+        if (target == null) {
+            return null;
+        }
+        Object k = args[2].value();
+        if (k == null) {
+            return null;
+        }
+        assert field instanceof float[] : "First parameter value must be a float array";
+        assert target instanceof float[] : "Second parameter value must be a float array";
+        assert k instanceof Integer : "Third parameter value must be an integer";
+
+        try {
+            return evaluate((float[]) field, (float[]) target, (int) k);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private boolean evaluate(float[] field, float[] target, int k) throws IOException {
+        if (field.length != target.length) {
+            throw new IllegalArgumentException("Field dimensions must match target dimensions for knn_query");
+        }
+        if (field.length != type.characterMaximumLength()) {
+            throw new IllegalArgumentException("Field dimensions must match type dimensions for knn_query");
+        }
+        return FloatVectorType.SIMILARITY_FUNC.compare(field, target) >= DEFAULT_MIN_SCORE;
+    }
+
+    @Override
+    @Nullable
+    public Query toQuery(Function function, Context context) {
+        List<Symbol> args = function.arguments();
+        if (args.get(0) instanceof Reference ref
+                && args.get(1) instanceof Literal<?> targetLiteral
+                && args.get(2) instanceof Literal<?> kLiteral) {
+
+            Object target = targetLiteral.value();
+            Object k = kLiteral.value();
+            if (target instanceof float[] && k instanceof Integer) {
+                return new KnnFloatVectorQuery(ref.column().fqn(), (float[]) target, (int) k);
+            }
+            return null;
+        }
+        return null;
+    }
+
+}

--- a/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
+++ b/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
@@ -237,5 +237,7 @@ public class ScalarFunctionModule extends AbstractFunctionModule<FunctionImpleme
         HasDatabasePrivilegeFunction.register(this);
         ParseURIFunction.register(this);
         ParseURLFunction.register(this);
+
+        KnnMatch.register(this);
     }
 }

--- a/server/src/main/java/io/crate/types/ArrayType.java
+++ b/server/src/main/java/io/crate/types/ArrayType.java
@@ -313,8 +313,10 @@ public class ArrayType<T> extends DataType<List<T>> {
 
     @Override
     public boolean isConvertableTo(DataType<?> other, boolean explicitCast) {
-        return other.id() == UndefinedType.ID || other.id() == GeoPointType.ID ||
-               ((other instanceof ArrayType)
+        return other.id() == UndefinedType.ID
+            || other.id() == GeoPointType.ID
+            || other.id() == FloatVectorType.ID
+            || ((other instanceof ArrayType)
                 && this.innerType.isConvertableTo(((ArrayType<?>) other).innerType(), explicitCast));
     }
 

--- a/server/src/main/java/io/crate/types/FloatVectorType.java
+++ b/server/src/main/java/io/crate/types/FloatVectorType.java
@@ -29,6 +29,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.apache.lucene.document.FieldType;
+import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -51,6 +52,7 @@ public class FloatVectorType extends DataType<float[]> implements Streamer<float
     public static final int ID = 28;
     public static final String NAME = "float_vector";
     public static final FloatVectorType INSTANCE = new FloatVectorType(1);
+    public static final VectorSimilarityFunction SIMILARITY_FUNC = VectorSimilarityFunction.EUCLIDEAN;
 
     private static final EqQuery<float[]> EQ_QUERY = new EqQuery<float[]>() {
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/FloatVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FloatVectorFieldMapper.java
@@ -30,7 +30,6 @@ import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.VectorEncoding;
-import org.apache.lucene.index.VectorSimilarityFunction;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentParser.Token;
@@ -81,7 +80,7 @@ public class FloatVectorFieldMapper extends FieldMapper implements ArrayValueMap
             fieldType.setVectorAttributes(
                 dimensions,
                 VectorEncoding.FLOAT32,
-                VectorSimilarityFunction.EUCLIDEAN
+                FloatVectorType.SIMILARITY_FUNC
             );
             var mapper = new FloatVectorFieldMapper(
                 name,

--- a/server/src/test/java/io/crate/expression/scalar/KnnMatchTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/KnnMatchTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.apache.lucene.search.Query;
+import org.elasticsearch.Version;
+import org.junit.Test;
+
+import io.crate.testing.QueryTester;
+
+public class KnnMatchTest extends ScalarTestCase {
+
+    @Test
+    public void test_null_arg_returns_null() throws Exception {
+        assertEvaluate("knn_match(null, [1.2]::float_vector(1), 2)", x -> assertThat(x).isNull());
+        assertEvaluate("knn_match([1.2]::float_vector(1), null, 2)", x -> assertThat(x).isNull());
+        assertEvaluate("knn_match([1.2]::float_vector(1), [1.2]::float_vector(1), null)", x -> assertThat(x).isNull());
+    }
+
+    @Test
+    public void test_knn_query_match() throws Exception {
+        assertEvaluate(
+            "knn_match([1.0, 2.0, 3.14]::float_vector(3), [1.0, 2.0, 3.14]::float_vector(3), 5)", true);
+    }
+
+    @Test
+    public void test_knn_query_below_min_score() throws Exception {
+        assertEvaluate(
+            "knn_match([1.0, 2.0, 3.14]::float_vector(3), [0.0, 0.0, 0.0]::float_vector(3), 5)", false);
+    }
+
+    @Test
+    public void test_knn_query_builder() throws Exception {
+        String createTable = "create table tbl (x float_vector(4))";
+        QueryTester.Builder builder = new QueryTester.Builder(
+            createTempDir(),
+            THREAD_POOL,
+            clusterService,
+            Version.CURRENT,
+            createTable
+        );
+        float[] vector1 = new float[] { 200.2f, 300.4f, 500.6f, 700.8f };
+        float[] vector2 = new float[] { 0.2f, 0.5f, 0.7f, 0.8f };
+        builder.indexValue("x", vector1);
+        builder.indexValue("x", vector2);
+        try (QueryTester tester = builder.build()) {
+            Query query = tester.toQuery("knn_match(x, [1.2, 3.4, 5.6, 7.8], 10)");
+            assertThat(query.toString()).isEqualTo("KnnFloatVectorQuery:x[1.2,...][10]");
+
+            List<Object> result = tester.runQuery("x", "knn_match(x, [200, 300, 500, 700], 1)");
+            assertThat(result).containsExactly(
+                vector1
+            );
+        }
+    }
+}
+

--- a/server/src/testFixtures/java/io/crate/testing/QueryTester.java
+++ b/server/src/testFixtures/java/io/crate/testing/QueryTester.java
@@ -120,7 +120,7 @@ public final class QueryTester implements AutoCloseable {
             return this;
         }
 
-        void indexValue(String column, Object value) throws IOException {
+        public Builder indexValue(String column, Object value) throws IOException {
             MapperService mapperService = indexEnv.mapperService();
             Indexer indexer = new Indexer(
                 table.concreteIndices()[0],
@@ -134,6 +134,7 @@ public final class QueryTester implements AutoCloseable {
             var item = new IndexItem.StaticItem("dummy-id", List.of(), new Object[] { value }, -1L, -1L);
             ParsedDocument parsedDocument = indexer.index(item);
             indexEnv.writer().addDocument(parsedDocument.doc());
+            return this;
         }
 
         private LuceneBatchIterator getIterator(ColumnIdent column, Query query) {


### PR DESCRIPTION
`knn_match` is implemented as scalar instead of adding a new special
predicate to avoid introducing a new dedicated symbol & special handling
around that.

The downside of this approach is that the function has a different
behavior depending on where it is used. If used in the WHERE clause
against a physical table it will search the full dataset. If used in
another context it operates only on the provided values or current row.
