### PR TITLE
Avoid newline splitting in hasRows() assertion

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/CorrelatedSubqueryITest.java
+++ b/server/src/test/java/io/crate/integrationtests/CorrelatedSubqueryITest.java
@@ -23,6 +23,7 @@ package io.crate.integrationtests;
 
 
 import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.sql.DriverManager;
@@ -33,13 +34,13 @@ import java.util.List;
 import java.util.Properties;
 import java.util.stream.Stream;
 
-import io.crate.testing.UseRandomizedOptimizerRules;
 import org.elasticsearch.test.IntegTestCase;
 import org.junit.Before;
 import org.junit.Test;
 
 import io.crate.testing.TestingHelpers;
 import io.crate.testing.UseHashJoins;
+import io.crate.testing.UseRandomizedOptimizerRules;
 import io.crate.testing.UseRandomizedSchema;
 
 @UseHashJoins(0)
@@ -403,7 +404,7 @@ public class CorrelatedSubqueryITest extends IntegTestCase {
         execute("refresh table a, b");
         String stmt = "SELECT count(*) FROM a "
             + "WHERE EXISTS (SELECT 1 FROM b where a.f1 = b.f1 and a.f2 = b.f2 and b.f3 ='c') and a.f3 IN ('a','b','c')";
-        assertThat(execute("explain (costs false)" + stmt)).hasRows(
+        assertThat(execute("explain (costs false)" + stmt)).hasLines(
             "HashAggregate[count(*)]",
             "  └ Filter[EXISTS (SELECT 1 FROM (doc.b))]",
             "    └ CorrelatedJoin[f1, f2, (SELECT 1 FROM (doc.b))]",

--- a/server/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
+++ b/server/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
@@ -24,6 +24,7 @@ package io.crate.integrationtests;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.randomAsciiLettersOfLength;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.printedTable;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -1336,7 +1337,7 @@ public class GroupByAggregateTest extends IntegTestCase {
         execute("refresh table m.tbl");
         execute("analyze");
         execute("explain (costs false) select distinct id from m.tbl limit 2");
-        assertThat(response).hasRows(
+        assertThat(response).hasLines(
             "LimitDistinct[2::bigint;0 | [id]]",
             "  └ Collect[m.tbl | [id] | true]"
         );
@@ -1374,7 +1375,7 @@ public class GroupByAggregateTest extends IntegTestCase {
 
 
         execute("explain (costs false) select name, count(x), count(x) from doc.tbl group by name");
-        assertThat(response).hasRows(
+        assertThat(response).hasLines(
             "Eval[name, count(x), count(x)]",
             "  └ GroupHashAggregate[name | count(x)]",
             "    └ Collect[doc.tbl | [x, name] | true]"

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -24,6 +24,7 @@ package io.crate.integrationtests;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 import java.util.Collections;
@@ -191,7 +192,7 @@ public class InformationSchemaTest extends IntegTestCase {
                 "FROM information_schema.columns " +
                 "WHERE table_name LIKE 't1%' " +
                 "ORDER BY 1, 2");
-        assertThat(response).hasRows("");
+        assertThat(response).isEmpty();
 
         // Clean up metadata that does not show up in information_schema any more
         execute("DROP VIEW t1_view1, t1_view2");

--- a/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -147,10 +147,10 @@ public class JoinIntegrationTest extends IntegTestCase {
         execute("create table bar (id long) partitioned by (id)");
         ensureYellow();
         execute("select * from foo f, bar b where f.id = b.id");
-        assertThat(response).hasRows("");
+        assertThat(response).isEmpty();
 
         execute("select * from foo f, bar b");
-        assertThat(response).hasRows("");
+        assertThat(response).isEmpty();
     }
 
     @Test
@@ -424,7 +424,7 @@ public class JoinIntegrationTest extends IntegTestCase {
         execute("insert into doc.t (x, y) values (1, 10), (2, 20)");
         execute("refresh table doc.t");
         execute("explain (costs false) select * from doc.t as t1, doc.t as t2 order by t1.x, t2.x limit 3");
-        assertThat(response).hasRows(
+        assertThat(response).hasLines(
             "Fetch[x, y, x, y]",
             "  └ Limit[3::bigint;0]",
             "    └ OrderBy[x ASC x ASC]",
@@ -1134,7 +1134,7 @@ public class JoinIntegrationTest extends IntegTestCase {
             FROM sys.health h, sys.cluster c
             GROUP BY 1""";
         execute(stmt);
-        assertThat(response).hasRows("");
+        assertThat(response).isEmpty();
     }
 
     @Test
@@ -1219,7 +1219,7 @@ public class JoinIntegrationTest extends IntegTestCase {
         execute("EXPLAIN (COSTS FALSE)" + stmt);
         // ensure that the query is using the execution plan we want to test
         // This should prevent from the test case becoming invalid
-        assertThat(response).hasRows(
+        assertThat(response).hasLines(
             "NestedLoopJoin[INNER | (id = id)]",
                 "  ├ NestedLoopJoin[INNER | (id = id)]",
                 "  │  ├ Collect[doc.t1 | [id, a] | true]",
@@ -1511,7 +1511,7 @@ public class JoinIntegrationTest extends IntegTestCase {
         execute("analyze");
 
         String stmt = "SELECT * FROM (select a from tt1 order by b desc limit 1) i, tt2 WHERE c >= 50";
-        assertThat(execute("explain (costs false) " + stmt)).hasRows(
+        assertThat(execute("explain (costs false) " + stmt)).hasLines(
             "Eval[a, a, b, c]",
             "  └ NestedLoopJoin[CROSS]",
             "    ├ Collect[doc.tt2 | [a, b, c] | (c >= 50)]",

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -139,14 +139,14 @@ public class PgCatalogITest extends IntegTestCase {
     @Test
     public void testPgDescriptionTableIsEmpty() {
         execute("select * from pg_description");
-        assertThat(response).hasRows("");
+        assertThat(response).isEmpty();
         assertThat(response).hasColumns("classoid", "description", "objoid", "objsubid");
     }
 
     @Test
     public void testPgShdescriptionTableIsEmpty() {
         execute("select * from pg_shdescription");
-        assertThat(response).hasRows("");
+        assertThat(response).isEmpty();
         assertThat(response).hasColumns("classoid", "description", "objoid");
     }
 
@@ -316,7 +316,7 @@ public class PgCatalogITest extends IntegTestCase {
     @Test
     public void test_kepserver_regclass_cast_query() throws Exception {
         execute("select nspname from pg_namespace n, pg_class c where c.relnamespace=n.oid and c.oid='kepware'::regclass");
-        assertThat(response).hasRows("");
+        assertThat(response).isEmpty();
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
@@ -76,7 +76,7 @@ public class SubSelectIntegrationTest extends IntegTestCase {
         ));
         execute("refresh table doc.tbl");
         execute("explain (costs false) select i, name from (select ord as i, name from doc.tbl order by name) as t order by i desc limit 20");
-        assertThat(response).hasRows(
+        assertThat(response).hasLines(
             "Rename[i, name] AS t",
             "  └ Fetch[ord AS i, name]",
             "    └ Limit[20::bigint;0]",

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -1754,10 +1754,10 @@ public class TransportSQLActionTest extends IntegTestCase {
         execute("refresh table tbl");
 
         execute("select * from tbl where obj['b'] = 10");
-        assertThat(response).hasRows("");
+        assertThat(response).isEmpty();
 
         execute("select * from (select * from tbl) as t where obj['b'] = 10");
-        assertThat(response).hasRows("");
+        assertThat(response).isEmpty();
     }
 
 

--- a/server/src/test/java/io/crate/integrationtests/ViewsITest.java
+++ b/server/src/test/java/io/crate/integrationtests/ViewsITest.java
@@ -26,6 +26,7 @@ import static io.crate.protocols.postgres.PGErrorStatus.DUPLICATE_TABLE;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.CONFLICT;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.stream.Collectors;
@@ -68,9 +69,12 @@ public class ViewsITest extends IntegTestCase {
         }
         assertThat(execute("select * from v1")).hasRows("1");
         assertThat(execute("select view_definition from information_schema.views")).hasRows(
-                "SELECT *",
-                "FROM \"t1\"",
-                "WHERE \"x\" > 0");
+            """
+            SELECT *
+            FROM "t1"
+            WHERE "x" > 0
+            """
+        );
         execute("drop view v1");
         for (ClusterService clusterService : cluster().getInstances(ClusterService.class)) {
             ViewsMetadata views = clusterService.state().metadata().custom(ViewsMetadata.TYPE);

--- a/server/src/testFixtures/java/io/crate/testing/SQLResponseAssert.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLResponseAssert.java
@@ -39,9 +39,29 @@ public final class SQLResponseAssert extends AbstractAssert<SQLResponseAssert, S
         return this;
     }
 
-    public SQLResponseAssert hasRows(String ... rows) {
+    /**
+     * Like {@link #hasRows(String...)} but if a single row contains newlines, it is treated as multiple lines.
+     **/
+    public SQLResponseAssert hasLines(String ... lines) {
         String result = TestingHelpers.printedTable(actual.rows());
         String[] resultRows = result.split("\n");
+        assertThat(resultRows).containsExactly(lines);
+        return this;
+    }
+
+    /**
+     * Assert that the response contains the given rows
+     * <ul>
+     * <li>Use {@link #hasLines(String...)} to treat newlines in a single row as separate rows.</li>
+     * <li>Use {@link #hasRows(Object[]...)} for exact object matches instead of string formatting</li>
+     * </ul>
+     **/
+    public SQLResponseAssert hasRows(String ... rows) {
+        String[] resultRows = new String[actual.rows().length];
+        for (int i = 0; i < actual.rows().length; i++) {
+            Object[] row = actual.rows()[i];
+            resultRows[i] = TestingHelpers.printRow(row);
+        }
         assertThat(resultRows).containsExactly(rows);
         return this;
     }
@@ -58,6 +78,11 @@ public final class SQLResponseAssert extends AbstractAssert<SQLResponseAssert, S
 
     public SQLResponseAssert hasColumns(String ... names) {
         assertThat(actual.cols()).containsExactly(names);
+        return this;
+    }
+
+    public SQLResponseAssert isEmpty() {
+        assertThat(actual.rows()).isEmpty();
         return this;
     }
 }

--- a/server/src/testFixtures/java/io/crate/testing/TestingHelpers.java
+++ b/server/src/testFixtures/java/io/crate/testing/TestingHelpers.java
@@ -111,14 +111,20 @@ public class TestingHelpers {
     }
 
     public static String printRows(Iterable<Object[]> rows) {
+        StringBuilder sb = new StringBuilder();
+        for (Object[] row : rows) {
+            sb.append(printRow(row));
+            sb.append("\n");
+        }
+        return sb.toString();
+    }
+
+    public static String printRow(Object[] row) {
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         PrintStream out = new PrintStream(os);
-        for (Object[] row : rows) {
-            boolean first = true;
-            for (Object o : row) {
-                first = printObject(out, first, o);
-            }
-            out.print("\n");
+        boolean first = true;
+        for (Object o : row) {
+            first = printObject(out, first, o);
         }
         return os.toString();
     }


### PR DESCRIPTION
Makes it possible to use `hasRows()` even if individual rows contain
newlines themselves.

Adds a `hasLines()` variant for use in cases where the splitting on
all newlines is actually preferable (like for explain)
