### PR TITLE
Fix flaky testArrayLengthWithAllSupportedTypes

### DIFF
--- a/server/src/main/java/io/crate/analyze/validator/SemanticSortValidator.java
+++ b/server/src/main/java/io/crate/analyze/validator/SemanticSortValidator.java
@@ -51,7 +51,7 @@ public class SemanticSortValidator {
             DataTypes.REGCLASS,
             DataTypes.REGPROC,
             BitStringType.INSTANCE_ONE,
-            FloatVectorType.INSTANCE
+            FloatVectorType.INSTANCE_ONE
         )
     ).map(x -> x.id()).collect(Collectors.toSet());
 

--- a/server/src/main/java/io/crate/protocols/postgres/types/PGTypes.java
+++ b/server/src/main/java/io/crate/protocols/postgres/types/PGTypes.java
@@ -94,7 +94,7 @@ public class PGTypes {
         .put(new ArrayType<>(DataTypes.REGCLASS), PGArray.REGCLASS_ARRAY)
         .put(new ArrayType<>(BitStringType.INSTANCE_ONE), PGArray.BIT_ARRAY)
         .put(DataTypes.OIDVECTOR, PgOidVectorType.INSTANCE)
-        .put(FloatVectorType.INSTANCE, PGArray.FLOAT4_ARRAY)
+        .put(FloatVectorType.INSTANCE_ONE, PGArray.FLOAT4_ARRAY)
         .immutableMap();
 
     private static final IntObjectMap<DataType<?>> PG_TYPES_TO_CRATE_TYPE = new IntObjectHashMap<>();

--- a/server/src/main/java/io/crate/types/DataTypes.java
+++ b/server/src/main/java/io/crate/types/DataTypes.java
@@ -315,8 +315,10 @@ public final class DataTypes {
             return UNTYPED_OBJECT;
         } else if (value instanceof List list) {
             return valueFromList(list);
-        } else if (value.getClass().isArray()) {
+        } else if (value instanceof Object[]) {
             return valueFromList(Arrays.asList((Object[]) value));
+        } else if (value instanceof float[] values) {
+            return new FloatVectorType(values.length);
         }
         DataType<?> dataType = POJO_TYPE_MAPPING.get(value.getClass());
         if (dataType == null) {
@@ -430,7 +432,7 @@ public final class DataTypes {
         entry(BitStringType.INSTANCE_ONE.getName(), BitStringType.INSTANCE_ONE),
         entry(JsonType.INSTANCE.getName(), JsonType.INSTANCE),
         entry("decimal", NUMERIC),
-        entry(FloatVectorType.INSTANCE.getName(), FloatVectorType.INSTANCE)
+        entry(FloatVectorType.INSTANCE_ONE.getName(), FloatVectorType.INSTANCE_ONE)
     );
 
     public static DataType<?> ofName(String typeName) {
@@ -487,7 +489,7 @@ public final class DataTypes {
         entry("object", UNTYPED_OBJECT),
         entry("nested", UNTYPED_OBJECT),
         entry("interval", DataTypes.INTERVAL),
-        entry(FloatVectorType.INSTANCE.getName(), FloatVectorType.INSTANCE)
+        entry(FloatVectorType.INSTANCE_ONE.getName(), FloatVectorType.INSTANCE_ONE)
     );
 
     private static final Map<Integer, String> TYPE_IDS_TO_MAPPINGS = Map.ofEntries(
@@ -508,7 +510,7 @@ public final class DataTypes {
         entry(GEO_POINT.id(), "geo_point"),
         entry(INTERVAL.id(), "interval"),
         entry(BitStringType.ID, "bit"),
-        entry(FloatVectorType.ID, FloatVectorType.INSTANCE.getName())
+        entry(FloatVectorType.ID, FloatVectorType.INSTANCE_ONE.getName())
     );
 
     @Nullable

--- a/server/src/main/java/io/crate/types/FloatVectorType.java
+++ b/server/src/main/java/io/crate/types/FloatVectorType.java
@@ -51,7 +51,7 @@ public class FloatVectorType extends DataType<float[]> implements Streamer<float
 
     public static final int ID = 28;
     public static final String NAME = "float_vector";
-    public static final FloatVectorType INSTANCE = new FloatVectorType(1);
+    public static final FloatVectorType INSTANCE_ONE = new FloatVectorType(1);
     public static final VectorSimilarityFunction SIMILARITY_FUNC = VectorSimilarityFunction.EUCLIDEAN;
 
     private static final EqQuery<float[]> EQ_QUERY = new EqQuery<float[]>() {

--- a/server/src/main/java/org/elasticsearch/index/mapper/FloatVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FloatVectorFieldMapper.java
@@ -63,7 +63,7 @@ public class FloatVectorFieldMapper extends FieldMapper implements ArrayValueMap
 
         @Override
         public String typeName() {
-            return FloatVectorType.INSTANCE.getName();
+            return FloatVectorType.INSTANCE_ONE.getName();
         }
     }
 
@@ -156,7 +156,7 @@ public class FloatVectorFieldMapper extends FieldMapper implements ArrayValueMap
 
     @Override
     protected String contentType() {
-        return FloatVectorType.INSTANCE.getName();
+        return FloatVectorType.INSTANCE_ONE.getName();
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/indices/IndicesModule.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesModule.java
@@ -101,7 +101,7 @@ public class IndicesModule extends AbstractModule {
         mappers.put(ObjectMapper.CONTENT_TYPE, new ObjectMapper.TypeParser());
         mappers.put(GeoPointFieldMapper.CONTENT_TYPE, new GeoPointFieldMapper.TypeParser());
         mappers.put(BitStringFieldMapper.CONTENT_TYPE, new BitStringFieldMapper.TypeParser());
-        mappers.put(FloatVectorType.INSTANCE.getName(), new FloatVectorFieldMapper.TypeParser());
+        mappers.put(FloatVectorType.INSTANCE_ONE.getName(), new FloatVectorFieldMapper.TypeParser());
         mappers.put(ArrayMapper.CONTENT_TYPE, new ArrayTypeParser());
 
         if (ShapesAvailability.JTS_AVAILABLE && ShapesAvailability.SPATIAL4J_AVAILABLE) {

--- a/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -1744,7 +1744,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
     public void test_can_use_vector_in_create_table() throws Exception {
         BoundCreateTable stmt = analyze("create table tbl (x float_vector)");
         assertThat(stmt.columns()).hasEntrySatisfying(
-            new ColumnIdent("x"), Asserts.isReference("x", FloatVectorType.INSTANCE)
+            new ColumnIdent("x"), Asserts.isReference("x", FloatVectorType.INSTANCE_ONE)
         );
     }
 

--- a/server/src/test/java/io/crate/execution/dml/IndexerTest.java
+++ b/server/src/test/java/io/crate/execution/dml/IndexerTest.java
@@ -633,7 +633,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
                     DataTypes.GEO_POINT,
                     DataTypes.GEO_SHAPE,
                     new BitStringType(1),
-                    FloatVectorType.INSTANCE
+                    FloatVectorType.INSTANCE_ONE
                 ))
             .stream()
             .filter(t -> t.storageSupport() != null)

--- a/server/src/test/java/io/crate/types/DataTypesTest.java
+++ b/server/src/test/java/io/crate/types/DataTypesTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.types;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsNot.not;
@@ -240,5 +241,11 @@ public class DataTypesTest extends ESTestCase {
         } else {
             assertThat(dt.compare(dt.sanitizeValue(val1), dt.sanitizeValue(val2)), is(expected));
         }
+    }
+
+
+    @Test
+    public void test_can_guess_float_vectors() throws Exception {
+        assertThat(DataTypes.guessType(new float[] { 3.14f })).isEqualTo(FloatVectorType.INSTANCE_ONE);
     }
 }


### PR DESCRIPTION
Adds `float[]` handling to DataTypes.guessType

    java.lang.ClassCastException: class [F cannot be cast to class [Ljava.lang.Object; ([F and [Ljava.lang.Object; are in module java.base of loader 'bootstrap')
    	at __randomizedtesting.SeedInfo.seed([21DB1955F204FA18:B8413C463F556749]:0)
    	at io.crate.types.DataTypes.guessType(DataTypes.java:319)
    	at io.crate.execution.dml.DynamicIndexer.guessType(DynamicIndexer.java:154)
    	at io.crate.execution.dml.ObjectIndexer.addNewColumns(ObjectIndexer.java:178)
    	at io.crate.execution.dml.ObjectIndexer.indexValue(ObjectIndexer.java:142)
    	at io.crate.execution.dml.ObjectIndexer.indexValue(ObjectIndexer.java:54)
    	at io.crate.execution.dml.ArrayIndexer.indexValue(ArrayIndexer.java:56)
    	at io.crate.execution.dml.ArrayIndexer.indexValue(ArrayIndexer.java:35)
    	at io.crate.execution.dml.Indexer.index(Indexer.java:580)
    	at io.crate.testing.QueryTester$Builder.indexValue(QueryTester.java:135)
    	at io.crate.testing.QueryTester$Builder.indexValues(QueryTester.java:118)
    	at io.crate.lucene.ArrayLengthQueryTest.testArrayLengthWithAllSupportedTypes(ArrayLengthQueryTest.java:266)
