### PR TITLE
Fix flaky test_types_with_storage_can_be_inserted_and_queried

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -1991,9 +1991,11 @@ public class TransportSQLActionTest extends IntegTestCase {
             }
 
             var resp2 = execute("select _doc['x'], x, _raw FROM tbl where id = ?", new Object[] { 1 });
-            assertThat(resp2.rows()[0])
-                .as("primary key lookup output must match regular select output for type " + type)
-                .contains(resp1.rows()[0]);
+            assertThat(resp2.rows()[0][0]).usingComparator((DataType<Object>) type).isEqualTo(resp1.rows()[0][0]);
+            assertThat(resp2.rows()[0][1]).usingComparator((DataType<Object>) type).isEqualTo(resp1.rows()[0][1]);
+            assertThat(ObjectType.UNTYPED.sanitizeValue(resp2.rows()[0][2]))
+                .usingComparator(ObjectType.UNTYPED)
+                .isEqualTo(ObjectType.UNTYPED.sanitizeValue(resp1.rows()[0][2]));
 
             if (SemanticSortValidator.SUPPORTED_TYPES.contains(type.id())) {
                 // should use doc-values/query-without-fetch execution path due to order + limit


### PR DESCRIPTION
Follow up to https://github.com/crate/crate/pull/14437

Test failed if an object randomized to have a child float_vector due to
floating arithmetic:

    java.lang.AssertionError: [primary key lookup output must match regular select output for type object]
    Expecting Object[]:
      [{"x"=[0.21486431f]}, {"x"=[0.21486431f]}, "{"id":1,"x":{"x":[0.21486431]}}"]
    to contain:
      [{"x"=[0.21486431f]}, {"x"=[0.21486431f]}, "{"id":1,"x":{"x":[0.21486431]}}"]
    but could not find the following object(s):
      [{"x"=[0.21486431f]}, {"x"=[0.21486431f]}]

    at __randomizedtesting.SeedInfo.seed([EB5282A23639810D:CE4C7FDEE862F3B3]:0)
    at io.crate.integrationtests.TransportSQLActionTest.test_types_with_storage_can_be_inserted_and_queried(TransportSQLActionTest.java:1996)
