### PR TITLE
Fix flaky test_cross_join_on_top_of_fetch

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -1511,16 +1511,16 @@ public class JoinIntegrationTest extends IntegTestCase {
         execute("analyze");
 
         String stmt = "SELECT * FROM (select a from tt1 order by b desc limit 1) i, tt2 WHERE c >= 50";
-        assertThat(execute("explain " + stmt)).hasRows(
-            "Eval[a, a, b, c] (rows=33)",
-            "  └ NestedLoopJoin[CROSS] (rows=33)",
-            "    ├ Collect[doc.tt2 | [a, b, c] | (c >= 50)] (rows=33)",
-            "    └ Rename[a] AS i (rows=1)",
-            "      └ Eval[a] (rows=1)",
-            "        └ Fetch[a, b] (rows=1)",
-            "          └ Limit[1::bigint;0] (rows=1)",
-            "            └ OrderBy[b DESC] (rows=100)",
-            "              └ Collect[doc.tt1 | [_fetchid, b] | true] (rows=100)"
+        assertThat(execute("explain (costs false) " + stmt)).hasRows(
+            "Eval[a, a, b, c]",
+            "  └ NestedLoopJoin[CROSS]",
+            "    ├ Collect[doc.tt2 | [a, b, c] | (c >= 50)]",
+            "    └ Rename[a] AS i",
+            "      └ Eval[a]",
+            "        └ Fetch[a, b]",
+            "          └ Limit[1::bigint;0]",
+            "            └ OrderBy[b DESC]",
+            "              └ Collect[doc.tt1 | [_fetchid, b] | true]"
         );
         assertThat(execute(stmt)).hasRowCount(51);
     }


### PR DESCRIPTION
The estimated row counts could change. I suspect that can happen due to a
combination of random sharding, node counts and the random sampling.
Leading to different table stats across runs.

    java.lang.AssertionError:
    Expecting actual:
      ["Eval[a, a, b, c] (rows=18)",
        "  └ NestedLoopJoin[CROSS] (rows=18)",
        "    ├ Collect[doc.tt2 | [a, b, c] | (c >= 50)] (rows=18)",
        "    └ Rename[a] AS i (rows=1)",
        "      └ Eval[a] (rows=1)",
        "        └ Fetch[a, b] (rows=1)",
        "          └ Limit[1::bigint;0] (rows=1)",
        "            └ OrderBy[b DESC] (rows=100)",
        "              └ Collect[doc.tt1 | [_fetchid, b] | true] (rows=100)"]
    to contain exactly (and in same order):
      ["Eval[a, a, b, c] (rows=33)",
        "  └ NestedLoopJoin[CROSS] (rows=33)",
        "    ├ Collect[doc.tt2 | [a, b, c] | (c >= 50)] (rows=33)",
        "    └ Rename[a] AS i (rows=1)",
        "      └ Eval[a] (rows=1)",
        "        └ Fetch[a, b] (rows=1)",
        "          └ Limit[1::bigint;0] (rows=1)",
        "            └ OrderBy[b DESC] (rows=100)",
        "              └ Collect[doc.tt1 | [_fetchid, b] | true] (rows=100)"]
    but some elements were not found:
      ["Eval[a, a, b, c] (rows=33)",
        "  └ NestedLoopJoin[CROSS] (rows=33)",
        "    ├ Collect[doc.tt2 | [a, b, c] | (c >= 50)] (rows=33)"]
    and others were not expected:
      ["Eval[a, a, b, c] (rows=18)",
        "  └ NestedLoopJoin[CROSS] (rows=18)",
        "    ├ Collect[doc.tt2 | [a, b, c] | (c >= 50)] (rows=18)"]

    	at __randomizedtesting.SeedInfo.seed([3D8FC1A4F29FD55E:96681AD68E1635BA]:0)
    	at io.crate.testing.SQLResponseAssert.hasRows(SQLResponseAssert.java:45)
    	at io.crate.integrationtests.JoinIntegrationTest.test_cross_join_on_top_of_fetch(JoinIntegrationTest.java:1514)

Given that the costs don't matter for the test scenario, we can disable
them. The EXPLAIN is only there to make sure the test really involves a
fetch phase.
