### PR TITLE
Don't print implicit casts via Symbol.toString

### DIFF
--- a/server/src/main/java/io/crate/expression/symbol/Function.java
+++ b/server/src/main/java/io/crate/expression/symbol/Function.java
@@ -387,20 +387,18 @@ public class Function implements Symbol, Cloneable {
     private void printCastFunction(StringBuilder builder, Style style) {
         var name = signature.getName().name();
         assert arguments.size() == 2 : "Expecting 2 arguments for function " + name;
-        var targetType = arguments.get(1).valueType();
-        builder
-            .append(name)
-            .append("(")
-            .append(arguments().get(0).toString(style));
         if (name.equalsIgnoreCase(ImplicitCastFunction.NAME)) {
-            builder
-                .append(", ")
-                .append(arguments.get(1).toString(style));
+            builder.append(arguments().get(0).toString(style));
         } else {
-            builder.append(" AS ")
-                .append(targetType.toString());
+            var targetType = arguments.get(1).valueType();
+            builder
+                .append(name)
+                .append("(")
+                .append(arguments().get(0).toString(style))
+                .append(" AS ")
+                .append(targetType.toString())
+                .append(")");
         }
-        builder.append(")");
     }
 
     private void printExtract(StringBuilder builder, Style style) {

--- a/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -1264,7 +1264,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
         Map<String, Object> mappingProperties = (Map<String, Object>) mapping.get("properties");
 
         assertThat(mapToSortedString(mappingProperties)).isEqualTo(
-                   "id={default_expr=_cast(3.5, 'integer'), position=1, type=integer}");
+                   "id={default_expr=3.5, position=1, type=integer}");
     }
 
     @Test
@@ -1293,7 +1293,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
         Map<String, Object> mappingProperties = (Map<String, Object>) mapping.get("properties");
 
         assertThat(mapToSortedString(mappingProperties)).isEqualTo(
-            "arr={inner={default_expr=_cast([1, 2], 'array(bigint)'), position=1, type=long}, type=array}");
+            "arr={inner={default_expr=[1, 2], position=1, type=long}, type=array}");
     }
 
     @Test
@@ -1308,8 +1308,8 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
         Map<String, Object> mappingProperties = (Map<String, Object>) mapping.get("properties");
 
         assertThat(mapToSortedString(mappingProperties)).isEqualTo(
-            "p={default_expr=_cast([0, 0], 'geo_point'), position=1, type=geo_point}, " +
-            "s={default_expr=_cast('LINESTRING (0 0, 1 1)', 'geo_shape'), position=2, tree=geohash, type=geo_shape}");
+            "p={default_expr=[0, 0], position=1, type=geo_point}, " +
+            "s={default_expr='LINESTRING (0 0, 1 1)', position=2, tree=geohash, type=geo_shape}");
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/MetadataToASTNodeResolverTest.java
+++ b/server/src/test/java/io/crate/analyze/MetadataToASTNodeResolverTest.java
@@ -466,7 +466,7 @@ public class MetadataToASTNodeResolverTest extends CrateDummyClusterServiceUnitT
                      "   \"col1\" TEXT,\n" +
                      "   \"col2\" INTEGER DEFAULT 2,\n" +
                      "   \"col3\" TIMESTAMP WITH TIME ZONE DEFAULT current_timestamp(3),\n" +
-                     "   \"col4\" TIMESTAMP WITHOUT TIME ZONE DEFAULT _cast(current_timestamp(3), 'timestamp without time zone')\n" +
+                     "   \"col4\" TIMESTAMP WITHOUT TIME ZONE DEFAULT current_timestamp(3)\n" +
                      ")\n" +
                      "CLUSTERED INTO 4 SHARDS\n" +
                      "WITH (\n" +
@@ -524,7 +524,7 @@ public class MetadataToASTNodeResolverTest extends CrateDummyClusterServiceUnitT
         CreateTable<?> node = MetadataToASTNodeResolver.resolveCreateTable(table);
         assertThat(
             SqlFormatter.formatSql(node),
-            Matchers.containsString("\"g\" GEO_SHAPE GENERATED ALWAYS AS _cast('POLYGON (( 5 5, 30 5, 30 30, 5 30, 5 5 ))', 'geo_shape')")
+            Matchers.containsString("\"g\" GEO_SHAPE GENERATED ALWAYS AS 'POLYGON (( 5 5, 30 5, 30 30, 5 30, 5 5 ))")
         );
     }
 }

--- a/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -32,6 +32,7 @@ import static io.crate.testing.Asserts.isLiteral;
 import static io.crate.testing.Asserts.isReference;
 import static io.crate.testing.Asserts.toCondition;
 import static org.assertj.core.api.Assertions.anyOf;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
@@ -1649,7 +1650,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
             .addTable(TableDefinitions.USER_TABLE_DEFINITION)
             .build();
         QueriedSelectRelation stmt = executor.analyze("select * from users where floats ~ 'foo'");
-        assertThat(stmt.where()).isSQL("(_cast(doc.users.floats, 'text') ~ 'foo')");
+        assertThat(stmt.where()).isSQL("(doc.users.floats ~ 'foo')");
     }
 
     @Test
@@ -1658,7 +1659,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
             .addTable(TableDefinitions.USER_TABLE_DEFINITION)
             .build();
         QueriedSelectRelation stmt = executor.analyze("select * from users where floats ~* 'foo'");
-        assertThat(stmt.where()).isSQL("(_cast(doc.users.floats, 'text') ~* 'foo')");
+        assertThat(stmt.where()).isSQL("(doc.users.floats ~* 'foo')");
     }
 
     @Test
@@ -2195,7 +2196,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
             "order by 2, 3");
         assertThat(relation.having()).isNotNull();
         assertThat(relation.having())
-            .isSQL("(NOT (_cast(collect_set(sys.shards.recovery['size']['percent']), 'array(double precision)') = [100.0]))");
+            .isSQL("(NOT (collect_set(sys.shards.recovery['size']['percent']) = [100.0]))");
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -25,6 +25,7 @@ import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.exactlyInstanceOf;
 import static io.crate.testing.Asserts.isLiteral;
 import static io.crate.testing.Asserts.isReference;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
@@ -261,7 +262,15 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testColumnsAreCastedToLiteralType() {
         Function symbol = (Function) executor.asSymbol("doc.t2.i = 1.1");
-        assertThat(symbol).isSQL("(_cast(doc.t2.i, 'double precision') = 1.1)");
+        assertThat(symbol).isSQL("(doc.t2.i = 1.1)");
+        assertThat(symbol).isFunction(
+            EqOperator.NAME,
+            lhs -> {
+                assertThat(lhs).isFunction("_cast");
+                assertThat(lhs.valueType()).isEqualTo(DataTypes.DOUBLE);
+            },
+            rhs -> assertThat(rhs).isLiteral(1.1)
+        );
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/where/NullEliminatorTest.java
+++ b/server/src/test/java/io/crate/analyze/where/NullEliminatorTest.java
@@ -21,7 +21,7 @@
 
 package io.crate.analyze.where;
 
-import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.function.Function;
 
@@ -65,23 +65,22 @@ public class NullEliminatorTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testNullsReplaced() throws Exception {
         sqlExpressions.context().allowEagerNormalize(false);
-        assertReplaced("null and x = null", "(_cast(NULL, 'boolean') AND (x = _cast(NULL, 'integer')))");
+        assertReplaced("null and x = null", "(NULL AND (x = NULL))");
         assertReplaced(
             "null or x = 1 or null",
-            "((_cast(NULL, 'boolean') OR (x = 1)) OR _cast(NULL, 'boolean'))");
+            "((NULL OR (x = 1)) OR NULL)");
         assertReplaced(
             "not(null and x = 1)",
-            "(NOT (_cast(NULL, 'boolean') AND (x = 1)))");
+            "(NOT (NULL AND (x = 1)))");
         assertReplaced(
             "not(null or not(null and x = 1))",
-            "(NOT (_cast(NULL, 'boolean') OR (NOT (_cast(NULL, 'boolean') AND (x = 1)))))");
+            "(NOT (NULL OR (NOT (NULL AND (x = 1)))))");
         assertReplaced(
             "not(null and x = 1) and not(null or x = 2)",
-            "((NOT (_cast(NULL, 'boolean') AND (x = 1))) AND " +
-            "(NOT (_cast(NULL, 'boolean') OR (x = 2))))");
+            "((NOT (NULL AND (x = 1))) AND (NOT (NULL OR (x = 2))))");
         assertReplaced(
             "null or coalesce(null or x = 1, true)",
-            "(_cast(NULL, 'boolean') OR coalesce((_cast(NULL, 'boolean') OR (x = 1)), true))");
+            "(NULL OR coalesce((NULL OR (x = 1)), true))");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
+++ b/server/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
@@ -22,6 +22,7 @@
 package io.crate.expression.symbol.format;
 
 import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -326,9 +327,9 @@ public class SymbolPrinterTest extends CrateDummyClusterServiceUnitTest {
     public void testStyles() {
         Symbol nestedFn = sqlExpressions.asSymbol("abs(sqrt(ln(bar+cast(\"select\" as long)+1+1+1+1+1+1)))");
         assertThat(nestedFn.toString(Style.QUALIFIED)).isEqualTo(
-                   "abs(sqrt(ln(_cast((((((((doc.formatter.bar + cast(doc.formatter.\"select\" AS bigint)) + 1::bigint) + 1::bigint) + 1::bigint) + 1::bigint) + 1::bigint) + 1::bigint), 'double precision'))))");
+                   "abs(sqrt(ln((((((((doc.formatter.bar + cast(doc.formatter.\"select\" AS bigint)) + 1::bigint) + 1::bigint) + 1::bigint) + 1::bigint) + 1::bigint) + 1::bigint))))");
         assertThat(nestedFn.toString(Style.UNQUALIFIED)).isEqualTo(
-                   "abs(sqrt(ln(_cast((((((((bar + cast(\"select\" AS bigint)) + 1::bigint) + 1::bigint) + 1::bigint) + 1::bigint) + 1::bigint) + 1::bigint), 'double precision'))))");
+                   "abs(sqrt(ln((((((((bar + cast(\"select\" AS bigint)) + 1::bigint) + 1::bigint) + 1::bigint) + 1::bigint) + 1::bigint) + 1::bigint))))");
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
@@ -1026,7 +1026,7 @@ public class DDLIntegrationTest extends IntegTestCase {
             """
                 CREATE TABLE IF NOT EXISTS "doc"."tbl" (
                    "id" INTEGER,
-                   "g" GEO_SHAPE GENERATED ALWAYS AS _cast('POLYGON (( 5 5, 30 5, 30 30, 5 30, 5 5 ))', 'geo_shape') INDEX USING QUADTREE WITH (
+                   "g" GEO_SHAPE GENERATED ALWAYS AS 'POLYGON (( 5 5, 30 5, 30 30, 5 30, 5 5 ))' INDEX USING QUADTREE WITH (
                       distance_error_pct = 0.123,
                       precision = '123.0m'
                    )
@@ -1109,7 +1109,7 @@ public class DDLIntegrationTest extends IntegTestCase {
                       "c2" INTEGER
                    ),
                    "int_col" INTEGER NOT NULL,
-                   "long_col" BIGINT GENERATED ALWAYS AS _cast(30, 'bigint'),
+                   "long_col" BIGINT GENERATED ALWAYS AS 30,
                    "analyzed_col" TEXT INDEX USING FULLTEXT WITH (
                       analyzer = 'simple'
                    ),

--- a/server/src/test/java/io/crate/integrationtests/ObjectColumnTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ObjectColumnTest.java
@@ -345,7 +345,7 @@ public class ObjectColumnTest extends IntegTestCase {
             execute("explain select a['u'] = 123 from t", session);
         }
         // make sure that a['u'] is kept as requested.
-        assertThat(printedTable(response.rows())).contains("[(123 = _cast(a['u'], 'integer'))]");
+        assertThat(printedTable(response.rows())).contains("[(123 = a['u'])]");
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
@@ -24,6 +24,7 @@ package io.crate.integrationtests;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Locale;
 
@@ -235,20 +236,22 @@ public class ShowIntegrationTest extends IntegTestCase {
                 ")");
         execute("show create table test_generated_column");
         assertFirstRow().startsWith(
-            "CREATE TABLE IF NOT EXISTS \"doc\".\"test_generated_column\" (\n" +
-            "   \"day1\" TIMESTAMP WITH TIME ZONE GENERATED ALWAYS AS date_trunc('day', \"ts\"),\n" +
-            "   \"day2\" TIMESTAMP WITH TIME ZONE GENERATED ALWAYS AS date_trunc('day', \"ts\") INDEX OFF,\n" +
-            "   \"day3\" TIMESTAMP WITH TIME ZONE GENERATED ALWAYS AS date_trunc('day', \"ts\"),\n" +
-            "   \"day4\" TIMESTAMP WITH TIME ZONE GENERATED ALWAYS AS date_trunc('day', \"ts\"),\n" +
-            "   \"col1\" TIMESTAMP WITH TIME ZONE GENERATED ALWAYS AS \"ts\" + CAST(1 AS bigint),\n" +
-            "   \"col2\" TEXT GENERATED ALWAYS AS _cast((\"ts\" + CAST(1 AS bigint)), 'text'),\n" +
-            "   \"col3\" TEXT GENERATED ALWAYS AS _cast((\"ts\" + CAST(1 AS bigint)), 'text'),\n" +
-            "   \"name\" TEXT GENERATED ALWAYS AS concat(\"user\"['name'], 'foo'),\n" +
-            "   \"ts\" TIMESTAMP WITH TIME ZONE,\n" +
-            "   \"user\" OBJECT(DYNAMIC) AS (\n" +
-            "      \"name\" TEXT\n" +
-            "   )\n" +
-            ")");
+            """
+            CREATE TABLE IF NOT EXISTS "doc"."test_generated_column" (
+               "day1" TIMESTAMP WITH TIME ZONE GENERATED ALWAYS AS date_trunc('day', "ts"),
+               "day2" TIMESTAMP WITH TIME ZONE GENERATED ALWAYS AS date_trunc('day', "ts") INDEX OFF,
+               "day3" TIMESTAMP WITH TIME ZONE GENERATED ALWAYS AS date_trunc('day', "ts"),
+               "day4" TIMESTAMP WITH TIME ZONE GENERATED ALWAYS AS date_trunc('day', "ts"),
+               "col1" TIMESTAMP WITH TIME ZONE GENERATED ALWAYS AS "ts" + CAST(1 AS bigint),
+               "col2" TEXT GENERATED ALWAYS AS "ts" + CAST(1 AS bigint),
+               "col3" TEXT GENERATED ALWAYS AS "ts" + CAST(1 AS bigint),
+               "name" TEXT GENERATED ALWAYS AS concat("user"['name'], 'foo'),
+               "ts" TIMESTAMP WITH TIME ZONE,
+               "user" OBJECT(DYNAMIC) AS (
+                  "name" TEXT
+               )
+            """
+        );
     }
 
     @Test

--- a/server/src/test/java/io/crate/metadata/doc/DocIndexMetadataTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocIndexMetadataTest.java
@@ -1642,7 +1642,7 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
         Reference reference = md.references().get(new ColumnIdent("g"));
         assertThat(reference.valueType()).isEqualTo(DataTypes.GEO_SHAPE);
         GeneratedReference genRef = (GeneratedReference) reference;
-        assertThat(genRef.formattedGeneratedExpression()).isEqualTo("_cast('POLYGON (( 5 5, 30 5, 30 30, 5 30, 5 5 ))', 'geo_shape')");
+        assertThat(genRef.formattedGeneratedExpression()).isEqualTo("'POLYGON (( 5 5, 30 5, 30 30, 5 30, 5 5 ))'");
     }
 
     @Test
@@ -1651,7 +1651,7 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
         Reference reference = md.references().get(new ColumnIdent("g"));
         assertThat(reference.valueType()).isEqualTo(DataTypes.GEO_SHAPE);
         assertThat(reference.defaultExpression().toString(Style.UNQUALIFIED))
-            .isEqualTo("{\"coordinates\"=[[[5.0, 5.0], [5.0, 30.0], [30.0, 30.0], [30.0, 5.0], [5.0, 5.0]]], \"type\"='Polygon'}");
+            .isEqualTo("'POLYGON (( 5 5, 30 5, 30 30, 5 30, 5 5 ))'");
     }
 
     @Test

--- a/server/src/test/java/io/crate/planner/ExplainPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/ExplainPlannerTest.java
@@ -31,7 +31,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.jetbrains.annotations.Nullable;
-
 import org.junit.Before;
 import org.junit.Test;
 
@@ -181,7 +180,7 @@ public class ExplainPlannerTest extends CrateDummyClusterServiceUnitTest {
         ExplainPlan plan = e.plan("EXPLAIN (COSTS FALSE) SELECT * FROM ts1 WHERE ts = 1662740986992");
         var printedPlan = ExplainPlan.printLogicalPlan((LogicalPlan) plan.subPlan(), e.getPlannerContext(clusterService.state()), plan.showCosts());
         assertThat(printedPlan).isEqualTo(
-            "Collect[doc.ts1 | [ts] | (ts = _cast(1662740986992::bigint, 'timestamp without time zone'))]"
+            "Collect[doc.ts1 | [ts] | (ts = 1662740986992::bigint)]"
         );
     }
 

--- a/server/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -127,7 +127,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
 
         LogicalPlan plan = e.logicalPlan("select name from users where _id = 1");
         assertThat(plan).isEqualTo(
-            "Get[doc.users | name | DocKeys{1} | (_cast(_id, 'integer') = 1)]");
+            "Get[doc.users | name | DocKeys{1} | (_id = 1)]");
     }
 
     @Test
@@ -1427,7 +1427,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             .build();
 
         CountPlan plan = e.plan("select count(*) from tbl where 'a' = ANY(xs)");
-        assertThat(plan.countPhase().where()).isSQL("(_cast('a', 'text(1)') = ANY(doc.tbl.xs))");
+        assertThat(plan.countPhase().where()).isSQL("('a' = ANY(doc.tbl.xs))");
     }
 
     @Test

--- a/server/src/test/java/io/crate/planner/UpdatePlannerTest.java
+++ b/server/src/test/java/io/crate/planner/UpdatePlannerTest.java
@@ -27,11 +27,11 @@ import static io.crate.testing.Asserts.isLiteral;
 import static io.crate.testing.Asserts.isReference;
 import static io.crate.testing.Asserts.toCondition;
 import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.List;
@@ -201,7 +201,7 @@ public class UpdatePlannerTest extends CrateDummyClusterServiceUnitTest {
             "Limit[2::bigint;0::bigint] (rows=1)",
             "  └ MultiPhase (rows=1)",
             "    └ HashAggregate[count(id)] (rows=1)",
-            "      └ Collect[doc.users | [id] | (id = ANY(_cast((SELECT unnest([1, 2, 3, 4]) FROM (empty_row)), 'array(bigint)')))] (rows=unknown)",
+            "      └ Collect[doc.users | [id] | (id = ANY((SELECT unnest([1, 2, 3, 4]) FROM (empty_row))))] (rows=unknown)",
             "    └ OrderBy[unnest([1, 2, 3, 4]) ASC] (rows=unknown)",
             "      └ ProjectSet[unnest([1, 2, 3, 4])] (rows=unknown)",
             "        └ TableFunction[empty_row | [] | true] (rows=unknown)");

--- a/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -23,6 +23,7 @@ package io.crate.planner.operators;
 
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.MemoryLimits.assertMaxBytesAllocated;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.List;
@@ -659,7 +660,7 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
             .as("Must not collect `x`")
             .hasOperators(
                 "MultiPhase",
-                "  └ Collect[doc.users | [name] | (id = ANY(_cast((SELECT a FROM (doc.t1)), 'array(bigint)')))]",
+                "  └ Collect[doc.users | [name] | (id = ANY((SELECT a FROM (doc.t1))))]",
                 "  └ Eval[a]",
                 "    └ OrderBy[a ASC]",
                 "      └ Collect[doc.t1 | [a] | (x > 10)]"

--- a/server/src/test/java/io/crate/planner/optimizer/symbol/CollectQueryCastRulesTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/symbol/CollectQueryCastRulesTest.java
@@ -21,13 +21,13 @@
 
 package io.crate.planner.optimizer.symbol;
 
+import static io.crate.testing.Asserts.assertThat;
 import static java.util.Collections.emptyMap;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -48,6 +48,7 @@ import io.crate.expression.operator.Operators;
 import io.crate.expression.operator.any.AnyOperator;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.SelectSymbol;
+import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.doc.DocSchemaInfo;
 import io.crate.metadata.doc.DocTableInfo;
@@ -92,7 +93,7 @@ public class CollectQueryCastRulesTest extends CrateDummyClusterServiceUnitTest 
         plannerContext = SQLExecutor.builder(clusterService).build().getPlannerContext(clusterService.state());
     }
 
-    private void assertCollectQuery(String query, String expected) {
+    private Symbol toQuery(String query) {
         var collect = new Collect(
             tr1,
             Collections.emptyList(),
@@ -116,56 +117,64 @@ public class CollectQueryCastRulesTest extends CrateDummyClusterServiceUnitTest 
             }
 
         );
-        assertThat(((RoutedCollectPhase) plan.collectPhase()).where().toString(), is(expected));
+        return ((RoutedCollectPhase) plan.collectPhase()).where();
     }
 
 
     @Test
     public void test_any_operator_cast_on_left_reference_is_moved_to_cast_on_literal() {
         for (var op : AnyOperator.SUPPORTED_COMPARISONS) {
-            assertCollectQuery(
-                "name " + op + " ANY([1, 2, 2])",
-                "(name " + op + " ANY(_cast([1, 2, 2], 'array(text)')))"
-            );
+            assertThat(toQuery("name " + op + " ANY([1, 2, 2])"))
+                .isFunction("any_" + op,
+                    arg1 -> assertThat(arg1).isReference("name"),
+                    arg2 -> assertThat(arg2).isFunction("_cast")
+                );
         }
         for (var op : List.of("LIKE", "ILIKE")) {
-            assertCollectQuery(
-                "name " + op + " ANY([1, 2, 2])",
-                "(name " + op + " ANY(_cast([1, 2, 2], 'array(text)')))"
-            );
-
-            assertCollectQuery(
-                "name NOT " + op + " ANY([1, 2, 2])",
-                "(name NOT " + op + " ANY(_cast([1, 2, 2], 'array(text)')))"
-            );
+            String lowerOp = op.toLowerCase(Locale.ENGLISH);
+            assertThat(toQuery("name " + op + " ANY([1, 2, 2])"))
+                .isFunction("any_" + lowerOp,
+                    arg1 -> assertThat(arg1).isReference("name"),
+                    arg2 -> assertThat(arg2).isFunction("_cast")
+                );
+            assertThat(toQuery("name NOT " + op + " ANY([1, 2, 2])"))
+                .isFunction("any_not_" + lowerOp,
+                    arg1 -> assertThat(arg1).isReference("name"),
+                    arg2 -> assertThat(arg2).isFunction("_cast")
+                );
         }
     }
 
     @Test
     public void test_any_operator_cast_on_right_reference_is_moved_to_cast_on_literal() {
         for (var op : AnyOperator.SUPPORTED_COMPARISONS) {
-            assertCollectQuery(
-                "'1' " + op + " ANY(d_array)",
-                "(1.0 " + op + " ANY(d_array))"
+            assertThat(toQuery("'1' " + op + " ANY(d_array)")).isFunction(
+                "any_" + op,
+                arg1 -> assertThat(arg1).isLiteral(1.0),
+                arg2 -> assertThat(arg2).isReference("d_array")
             );
         }
         for (var op : List.of("LIKE", "ILIKE")) {
-            assertCollectQuery(
-                "1 " + op + " ANY(text_array)",
-                "(_cast(1, 'text') " + op + " ANY(text_array))"
+            String opLower = op.toLowerCase(Locale.ENGLISH);
+            assertThat(toQuery("1 " + op + " ANY(text_array)")).isFunction(
+                "any_" + opLower,
+                arg1 -> assertThat(arg1).isFunction("_cast"),
+                arg2 -> assertThat(arg2).isReference("text_array")
             );
-            assertCollectQuery(
-                "1 NOT " + op + " ANY(text_array)",
-                "(_cast(1, 'text') NOT " + op + " ANY(text_array))"
+            assertThat(toQuery("1 NOT " + op + " ANY(text_array)")).isFunction(
+                "any_not_" + opLower,
+                arg1 -> assertThat(arg1).isFunction("_cast"),
+                arg2 -> assertThat(arg2).isReference("text_array")
             );
         }
     }
 
     @Test
     public void test_any_operator_cast_on_nested_array_referewence_is_moved_to_cast_on_literal() {
-        assertCollectQuery(
-            "[1.0, 2.0, 3.0] = any(o_array['xs'])",
-            "(_cast([1.0, 2.0, 3.0], 'array(integer)') = ANY(o_array['xs']))"
+        assertThat(toQuery("[1.0, 2.0, 3.0] = any(o_array['xs'])")).isFunction(
+            "any_=",
+            arg1 -> assertThat(arg1).isFunction("_cast"),
+            arg2 -> assertThat(arg2).isReference("o_array['xs']")
         );
     }
 
@@ -187,18 +196,17 @@ public class CollectQueryCastRulesTest extends CrateDummyClusterServiceUnitTest 
         for (var op : Operators.COMPARISON_OPERATORS) {
             op = op.replace(Operator.PREFIX, "");
             if (op.equals(ComparisonExpression.Type.CONTAINED_WITHIN.getValue())) {
-                assertCollectQuery(
-                    "addr " + op + " '192.168.0.1/24'",
-                    "(addr << '192.168.0.1/24')"
-                );
+                assertThat(toQuery("addr " + op + " '192.168.0.1/24'")).isFunction("op_<<");
             } else {
-                assertCollectQuery(
-                    "id " + op + " 1.0",
-                    "(id " + op + " _cast(1.0, 'integer'))"
+                assertThat(toQuery("id " + op + " 1.0")).isFunction(
+                    "op_" + op,
+                    arg1 -> assertThat(arg1).isReference("id"),
+                    arg2 -> assertThat(arg2).isFunction("_cast")
                 );
-                assertCollectQuery(
-                    "1.0 " + op + " id",
-                    "(id " + getSwappedOperator(op) + " _cast(1.0, 'integer'))"
+                assertThat(toQuery("1.0 " + op + " id")).isFunction(
+                    "op_" + getSwappedOperator(op),
+                    arg1 -> assertThat(arg1).isReference("id"),
+                    arg2 -> assertThat(arg2).isFunction("_cast")
                 );
             }
         }
@@ -206,17 +214,19 @@ public class CollectQueryCastRulesTest extends CrateDummyClusterServiceUnitTest 
 
     @Test
     public void test_operator_subscript_on_reference_cast_is_moved_to_literal_cast() {
-        assertCollectQuery(
-            "ts_array[1] = 1129224512000",
-            "(ts_array[1] = _cast(1129224512000::bigint, 'timestamp with time zone'))"
+        assertThat(toQuery("ts_array[1] = 1129224512000")).isFunction(
+            "op_=",
+            arg1 -> assertThat(arg1).isFunction("subscript"),
+            arg2 -> assertThat(arg2).isFunction("_cast")
         );
     }
 
     @Test
     public void test_operator_cast_on_array_length_with_reference_is_moved_to_literal_cast() {
-        assertCollectQuery(
-            "array_length(y_array, 1) < 1.0",
-            "(array_length(y_array, 1) < _cast(1.0, 'integer'))"
+        assertThat(toQuery("array_length(y_array, 1) < 1.0")).isFunction(
+            "op_<",
+            arg1 -> assertThat(arg1).isFunction("array_length"),
+            arg2 -> assertThat(arg2).isFunction("_cast")
         );
     }
 }


### PR DESCRIPTION
Relates to https://github.com/crate/crate/pull/14475
There I'm planning to add a round-trip assertion:

- Format analyzed relation
- Parse and analyze it a second time
- Format it a second time, assert it matches the first formatted version

Currently it would duplicate implicit casts because they initially are
typed to `undefined` until compiled.
