### PR TITLE
Add missing spaces to `RecoveryExpectedNodesSysCheck` message

### DIFF
--- a/server/src/main/java/io/crate/expression/reference/sys/check/node/RecoveryExpectedNodesSysCheck.java
+++ b/server/src/main/java/io/crate/expression/reference/sys/check/node/RecoveryExpectedNodesSysCheck.java
@@ -34,8 +34,8 @@ public class RecoveryExpectedNodesSysCheck extends AbstractSysNodeCheck {
     private final Settings settings;
 
     static final int ID = 1;
-    private static final String DESCRIPTION = "It has been detected that the 'gateway.expected_data_nodes' setting" +
-                                              "(or the deprecated `gateway.recovery_after_nodes` setting) is not" +
+    private static final String DESCRIPTION = "It has been detected that the 'gateway.expected_data_nodes' setting " +
+                                              "(or the deprecated 'gateway.recovery_after_nodes' setting) is not " +
                                               "configured or it does not match the actual number of (data) nodes in the cluster.";
 
     @Inject


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
<img width="825" alt="Screenshot 2023-07-27 at 09 31 33" src="https://github.com/crate/crate/assets/218003/b4405dee-476f-4bc7-be57-2262d971172f">

There are currently missing spaces, and also inconsistent usage of quotes vs. backticks.

## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
