### PR TITLE
Throw exception when selecting unknown sub columns of object from aliased tables

### DIFF
--- a/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalysisContext.java
+++ b/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalysisContext.java
@@ -42,12 +42,12 @@ public class ExpressionAnalysisContext {
     private boolean hasAggregates;
     private boolean allowEagerNormalize = true;
     private boolean parentIsOrderSensitive = true;
-    private final boolean errorOnUnknownObjectKey;
+    private final SessionSettings sessionSettings;
 
     private Map<String, Window> windows = Map.of();
 
     public ExpressionAnalysisContext(SessionSettings sessionSettings) {
-        this.errorOnUnknownObjectKey = sessionSettings.errorOnUnknownObjectKey();
+        this.sessionSettings = sessionSettings;
     }
 
     void indicateAggregates() {
@@ -83,7 +83,7 @@ public class ExpressionAnalysisContext {
     }
 
     public boolean errorOnUnknownObjectKey() {
-        return errorOnUnknownObjectKey;
+        return sessionSettings.errorOnUnknownObjectKey();
     }
 
     /**

--- a/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -92,6 +92,7 @@ import io.crate.expression.symbol.ScopedSymbol;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
+import io.crate.expression.symbol.ObjectKeyFinder;
 import io.crate.expression.symbol.WindowFunction;
 import io.crate.interval.IntervalParser;
 import io.crate.metadata.CoordinatorTxnCtx;
@@ -163,8 +164,6 @@ import io.crate.types.ArrayType;
 import io.crate.types.BitStringType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
-import io.crate.types.ObjectType;
-import io.crate.types.StringType;
 import io.crate.types.UndefinedType;
 
 /**
@@ -1294,22 +1293,28 @@ public class ExpressionAnalyzer {
                                                 Symbol index,
                                                 SubscriptContext subscriptContext,
                                                 ExpressionAnalysisContext expressionAnalysisContext) {
-        if (index.valueType().id() != StringType.ID) {
+        if (ObjectKeyFinder.find(base, index) || !expressionAnalysisContext.errorOnUnknownObjectKey()) {
             return allocateFunction(
                 SubscriptFunction.NAME,
                 List.of(base, index),
                 expressionAnalysisContext);
         }
-        var baseType = ArrayType.unnest(base.valueType());
-        if (baseType instanceof ObjectType objectType) {
-            if (expressionAnalysisContext.errorOnUnknownObjectKey() == false ||
-                objectType.resolveInnerType(subscriptContext.parts()).id() != UndefinedType.ID) {
-                return allocateFunction(
-                    SubscriptFunction.NAME,
-                    List.of(base, index),
-                    expressionAnalysisContext);
-            }
-        }
+//        if (index.valueType().id() != StringType.ID) {
+//            return allocateFunction(
+//                SubscriptFunction.NAME,
+//                List.of(base, index),
+//                expressionAnalysisContext);
+//        }
+//        var baseType = ArrayType.unnest(base.valueType());
+//        if (baseType instanceof ObjectType objectType) {
+//            if (expressionAnalysisContext.errorOnUnknownObjectKey() == false ||
+//                objectType.resolveInnerType(subscriptContext.parts()).id() != UndefinedType.ID) {
+//                return allocateFunction(
+//                    SubscriptFunction.NAME,
+//                    List.of(base, index),
+//                    expressionAnalysisContext);
+//            }
+//        }
         throw ColumnUnknownException.ofUnknownRelation("Column " + base + "[" + index + "]" + " unknown");
     }
 

--- a/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -721,8 +721,10 @@ public class ExpressionAnalyzer {
                                 );
                             }
                         }
-                        if (base instanceof Reference || base instanceof ScopedSymbol) {
-                            throw e;
+                        if (context.errorOnUnknownObjectKey()) {
+                            if (base instanceof Reference || base instanceof ScopedSymbol) {
+                                throw e;
+                            }
                         }
                         return allocateFunction(
                             SubscriptFunction.NAME,

--- a/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -164,6 +164,7 @@ import io.crate.types.ArrayType;
 import io.crate.types.BitStringType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
+import io.crate.types.StringType;
 import io.crate.types.UndefinedType;
 
 /**
@@ -1293,28 +1294,18 @@ public class ExpressionAnalyzer {
                                                 Symbol index,
                                                 SubscriptContext subscriptContext,
                                                 ExpressionAnalysisContext expressionAnalysisContext) {
-        if (ObjectKeyFinder.find(base, index) || !expressionAnalysisContext.errorOnUnknownObjectKey()) {
+        if (index.valueType().id() != StringType.ID) {
             return allocateFunction(
                 SubscriptFunction.NAME,
                 List.of(base, index),
                 expressionAnalysisContext);
         }
-//        if (index.valueType().id() != StringType.ID) {
-//            return allocateFunction(
-//                SubscriptFunction.NAME,
-//                List.of(base, index),
-//                expressionAnalysisContext);
-//        }
-//        var baseType = ArrayType.unnest(base.valueType());
-//        if (baseType instanceof ObjectType objectType) {
-//            if (expressionAnalysisContext.errorOnUnknownObjectKey() == false ||
-//                objectType.resolveInnerType(subscriptContext.parts()).id() != UndefinedType.ID) {
-//                return allocateFunction(
-//                    SubscriptFunction.NAME,
-//                    List.of(base, index),
-//                    expressionAnalysisContext);
-//            }
-//        }
+        if (new ObjectKeyFinder(subscriptContext).find(base, index) || !expressionAnalysisContext.errorOnUnknownObjectKey()) {
+            return allocateFunction(
+                SubscriptFunction.NAME,
+                List.of(base, index),
+                expressionAnalysisContext);
+        }
         throw ColumnUnknownException.ofUnknownRelation("Column " + base + "[" + index + "]" + " unknown");
     }
 

--- a/server/src/main/java/io/crate/analyze/relations/UnionSelect.java
+++ b/server/src/main/java/io/crate/analyze/relations/UnionSelect.java
@@ -119,6 +119,8 @@ public class UnionSelect implements AnalyzedRelation {
         return isDistinct;
     }
 
+
+    // TODO: instead of UnionObjectType, can simply contain duplicate in List<Symbol> and when there are duplicates, check the precedence or return left obj.
     /**
      * This class helps resolve object output's sub-columns of UnionSelect by allowing to search both left and right tables.
      * Except when resolving the sub-columns, this should be identical to 'left' object.

--- a/server/src/main/java/io/crate/expression/symbol/ObjectKeyFinder.java
+++ b/server/src/main/java/io/crate/expression/symbol/ObjectKeyFinder.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.symbol;
+
+import io.crate.expression.scalar.arithmetic.MapFunction;
+import io.crate.types.ObjectType;
+
+public class ObjectKeyFinder extends SymbolVisitor<Symbol, Boolean> {
+
+    private static final ObjectKeyFinder INSTANCE = new ObjectKeyFinder();
+
+    /**
+     * Returns true if the object key is found.
+     */
+    public static boolean find (Symbol base, Symbol key) {
+        return base.accept(ObjectKeyFinder.INSTANCE, key);
+    }
+    @Override
+    public Boolean visitFunction(Function symbol, Symbol key) {
+        if (symbol.valueType().id() != ObjectType.ID) {
+            return false;
+        }
+        if (MapFunction.NAME.equals(symbol.name())) {
+            return key.equals(symbol.arguments().get(0));
+        }
+        return false;
+    }
+
+    @Override
+    protected Boolean visitSymbol(Symbol symbol, Symbol key) {
+        return false;
+    }
+
+    private ObjectKeyFinder() {
+    }
+}

--- a/server/src/main/java/io/crate/types/ObjectType.java
+++ b/server/src/main/java/io/crate/types/ObjectType.java
@@ -102,7 +102,7 @@ public class ObjectType extends DataType<Map<String, Object>> implements Streame
         this(Map.of());
     }
 
-    private ObjectType(Map<String, DataType<?>> innerTypes) {
+    protected ObjectType(Map<String, DataType<?>> innerTypes) {
         this.innerTypes = innerTypes;
     }
 

--- a/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -2886,29 +2886,21 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
 
     @Test
     public void testSubscriptExpressionWithUnknownObjectKeyFromAliasedRelationWithSessionSetting() throws Exception {
-        /*
-         * This is documenting a bug. If this fails, it is a breaking change.
-         * CREATE TABLE e1 (obj_dy object, obj_st object(strict))
-         *
-         * select obj_dy['missing_key'] from (select obj_dy from e1) alias; --> works ------> bug
-         * select obj_st['missing_key'] from (select obj_st from e1) alias; --> works ------> bug (1)
-         * set errorOnUnknownObjectKey = false
-         * select obj_dy['missing_key'] from (select obj_dy from e1) alias; --> works ------> expected
-         * select obj_st['missing_key'] from (select obj_st from e1) alias; --> works ------> bug (depends on (1))
-         */
         var executor = SQLExecutor.builder(clusterService)
             .addTable("CREATE TABLE e1 (obj_dy object, obj_st object(strict))")
             .build();
         executor.getSessionSettings().setErrorOnUnknownObjectKey(true);
-        var analyzed = executor.analyze("select obj_dy['missing_key'] from (select obj_dy from e1) alias");
-        assertThat(analyzed.outputs()).hasSize(1);
-        assertThat(analyzed.outputs().get(0)).isFunction("subscript", isField("obj_dy"), isLiteral("missing_key"));
-        analyzed = executor.analyze("select obj_st['missing_key'] from (select obj_st from e1) alias");
-        assertThat(analyzed.outputs()).hasSize(1);
-        assertThat(analyzed.outputs().get(0)).isFunction("subscript", isField("obj_st"), isLiteral("missing_key"));
+        assertThatThrownBy(
+            () -> executor.analyze("select obj_dy['missing_key'] from (select obj_dy from e1) alias")
+        ).isExactlyInstanceOf(ColumnUnknownException.class)
+            .hasMessage("Column obj_dy['missing_key'] unknown");
+        assertThatThrownBy(
+            () -> executor.analyze("select obj_st['missing_key'] from (select obj_st from e1) alias")
+        ).isExactlyInstanceOf(ColumnUnknownException.class)
+            .hasMessage("Column obj_st['missing_key'] unknown");
 
         executor.getSessionSettings().setErrorOnUnknownObjectKey(false);
-        analyzed = executor.analyze("select obj_dy['missing_key'] from (select obj_dy from e1) alias");
+        var analyzed = executor.analyze("select obj_dy['missing_key'] from (select obj_dy from e1) alias");
         assertThat(analyzed.outputs()).hasSize(1);
         assertThat(analyzed.outputs().get(0)).isVoidReference("obj_dy['missing_key']");
         analyzed = executor.analyze("select obj_st['missing_key'] from (select obj_st from e1) alias");
@@ -2918,38 +2910,24 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
 
     @Test
     public void testSubscriptExpressionFromUnionAll() throws Exception {
-        /*
-         * This is documenting a bug. If this fails, it is a breaking change.
-         * CREATE TABLE c1 (obj object (strict)  as (a int,        c int))
-         * CREATE TABLE c2 (obj object (dynamic) as (       b int, c int))
-         *
-         * select obj['unknown'] from (select obj from c1 union all select obj from c1) alias;  --> works
-         * select obj['unknown'] from (select obj from c2 union all select obj from c2) alias;  --> works
-         * select obj['a']       from (select obj from c1 union all select obj from c2) alias;  --> works
-         * select obj['b']       from (select obj from c1 union all select obj from c2) alias;  --> works
-         * select obj['c']       from (select obj from c1 union all select obj from c2) alias;  --> works
-         * select obj['unknown'] from (select obj from c1 union all select obj from c2) alias;  --> works
-         * set errorOnUnknownObjectKey = false
-         * select obj['unknown'] from (select obj from c1 union all select obj from c1) alias;  --> works
-         * select obj['unknown'] from (select obj from c2 union all select obj from c2) alias;  --> works
-         * select obj['a']       from (select obj from c1 union all select obj from c2) alias;  --> works
-         * select obj['b']       from (select obj from c1 union all select obj from c2) alias;  --> works
-         * select obj['c']       from (select obj from c1 union all select obj from c2) alias;  --> works
-         * select obj['unknown'] from (select obj from c1 union all select obj from c2) alias;  --> works
-         */
-
         var executor = SQLExecutor.builder(clusterService)
             .addTable("CREATE TABLE c1 (obj object (strict)  as (a int,        c int))")
             .addTable("CREATE TABLE c2 (obj object (dynamic) as (       b int, c int))")
             .build();
         executor.getSessionSettings().setErrorOnUnknownObjectKey(true);
-        var analyzed = executor.analyze("select obj['unknown'] from (select obj from c1 union all select obj from c1) alias");
-        assertThat(analyzed.outputs()).hasSize(1);
-        assertThat(analyzed.outputs().get(0)).isFunction("subscript", isField("obj"), isLiteral("unknown"));
-        analyzed = executor.analyze("select obj['unknown'] from (select obj from c2 union all select obj from c2) alias");
-        assertThat(analyzed.outputs()).hasSize(1);
-        assertThat(analyzed.outputs().get(0)).isFunction("subscript", isField("obj"), isLiteral("unknown"));
-        analyzed = executor.analyze("select obj['a'] from (select obj from c1 union all select obj from c2) alias");
+        assertThatThrownBy(
+            () -> executor.analyze("select obj['unknown'] from (select obj from c1 union all select obj from c1) alias")
+        ).isExactlyInstanceOf(ColumnUnknownException.class)
+            .hasMessage("Column obj['unknown'] unknown");
+        assertThatThrownBy(
+            () -> executor.analyze("select obj['unknown'] from (select obj from c1 union all select obj from c1) alias")
+        ).isExactlyInstanceOf(ColumnUnknownException.class)
+            .hasMessage("Column obj['unknown'] unknown");
+        assertThatThrownBy(
+            () -> executor.analyze("select obj['unknown'] from (select obj from c2 union all select obj from c2) alias")
+        ).isExactlyInstanceOf(ColumnUnknownException.class)
+            .hasMessage("Column obj['unknown'] unknown");
+        var analyzed = executor.analyze("select obj['a'] from (select obj from c1 union all select obj from c2) alias");
         assertThat(analyzed.outputs()).hasSize(1);
         assertThat(analyzed.outputs().get(0)).isFunction("subscript", isField("obj"), isLiteral("a"));
         analyzed = executor.analyze("select obj['b'] from (select obj from c1 union all select obj from c2) alias");
@@ -2958,9 +2936,10 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         analyzed = executor.analyze("select obj['c'] from (select obj from c1 union all select obj from c2) alias");
         assertThat(analyzed.outputs()).hasSize(1);
         assertThat(analyzed.outputs().get(0)).isFunction("subscript", isField("obj"), isLiteral("c"));
-        analyzed = executor.analyze("select obj['unknown'] from (select obj from c1 union all select obj from c2) alias");
-        assertThat(analyzed.outputs()).hasSize(1);
-        assertThat(analyzed.outputs().get(0)).isFunction("subscript", isField("obj"), isLiteral("unknown"));
+        assertThatThrownBy(
+            () -> executor.analyze("select obj['unknown'] from (select obj from c1 union all select obj from c2) alias")
+        ).isExactlyInstanceOf(ColumnUnknownException.class)
+            .hasMessage("Column obj['unknown'] unknown");
 
         executor.getSessionSettings().setErrorOnUnknownObjectKey(false);
         analyzed = executor.analyze("select obj['unknown'] from (select obj from c1 union all select obj from c1) alias");

--- a/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -2687,7 +2687,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         executor.getSessionSettings().setErrorOnUnknownObjectKey(true);
         assertThatThrownBy(() -> executor.analyze("SELECT ''::OBJECT['x']"))
             .isExactlyInstanceOf(ColumnUnknownException.class)
-            .hasMessageContaining("The object `{}` does not contain the key `x`");
+            .hasMessageContaining("Column cast('' AS object)['x'] unknown");
         executor.getSessionSettings().setErrorOnUnknownObjectKey(false);
         var analyzed = executor.analyze("SELECT ''::OBJECT['x']");
         assertThat(analyzed.outputs()).hasSize(1);

--- a/server/src/test/java/io/crate/analyze/relations/UnionAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/relations/UnionAnalyzerTest.java
@@ -19,7 +19,7 @@
  * software solely pursuant to the terms of the relevant commercial agreement.
  */
 
-package io.crate.analyze;
+package io.crate.analyze.relations;
 
 import static io.crate.testing.Asserts.isField;
 import static io.crate.testing.Asserts.isLiteral;
@@ -34,7 +34,9 @@ import java.util.Objects;
 import org.junit.Before;
 import org.junit.Test;
 
-import io.crate.analyze.relations.UnionSelect;
+import io.crate.analyze.AnalyzedStatement;
+import io.crate.analyze.QueriedSelectRelation;
+import io.crate.analyze.TableDefinitions;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.Asserts;
@@ -197,7 +199,10 @@ public class UnionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
             ).build();
 
         UnionSelect union = analyze("select obj from v1 union all select obj from v2");
-        ObjectType expectedType = ObjectType.builder().setInnerType("col", DataTypes.STRING).build();
+        UnionSelect.UnionObjectType expectedType = new UnionSelect.UnionObjectType(
+            ObjectType.builder().setInnerType("col", DataTypes.STRING).build(),
+            ObjectType.builder().setInnerType("col", DataTypes.INTEGER).build());
+
         Asserts.assertThat(union.outputs())
             .as("Output type is object(col::text) because text has higher precedence than int")
             .satisfiesExactly(isField("obj", expectedType));

--- a/server/src/test/java/io/crate/expression/scalar/SubscriptFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/SubscriptFunctionTest.java
@@ -111,7 +111,7 @@ public class SubscriptFunctionTest extends ScalarTestCase {
         sqlExpressions.setErrorOnUnknownObjectKey(true);
         assertThatThrownBy(() -> assertEvaluate("{}['y']", null))
             .isExactlyInstanceOf(ColumnUnknownException.class)
-            .hasMessageContaining("The object `{}` does not contain the key `y`");
+            .hasMessageContaining("Column {}['y'] unknown");
         sqlExpressions.setErrorOnUnknownObjectKey(false);
         assertEvaluateNull("{}['y']");
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
When `error_on_unknown_object_key` was introduced, the existing behaviour was kept.
This will now be fixed such that the behaviour will be more consistent when `error_on_unknown_object_key = true`.

For example,
```
cr> create table t (o object);                                                                                                                    
CREATE OK, 1 row affected  (1.624 sec)

cr> select o['unknown'] from t;                                                                                                                   
ColumnUnknownException[Column o['unknown'] unknown]

cr> select o['unknown'] from t as t2; -- should throw like above                                                                                                             
+--------------+
| o['unknown'] |
+--------------+
+--------------+
SELECT 0 rows in set (0.003 sec)
```
This was brought up from https://github.com/crate/crate/pull/14371#discussion_r1262735707.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
