### PR TITLE
Correct float_vector maximum length in docs

### DIFF
--- a/docs/general/ddl/data-types.rst
+++ b/docs/general/ddl/data-types.rst
@@ -234,9 +234,9 @@ are likely to be larger due to additional metadata.
       - variable
       - Each coordinate is stored as a ``DOUBLE PRECISION`` type.
       - A ``GEO_SHAPE`` column can store different kinds of `GeoJSON geometry objects`_.
-    * - ``FLOAT_VECTOR``
-      - variable
-      - Minimum length: 1. Maximum length: 2^31-1
+    * - ``FLOAT_VECTOR(n)``
+      - ``n``
+      - Vector Minimum length: 1. Maximum length: 1024.
       - A vector of floating point numbers.
 
 


### PR DESCRIPTION
    cr> create table tbl (xs float_vector(2048));
    MapperParsingException[Failed to parse mapping: vector numDimensions must be <= FloatVectorValues.MAX_DIMENSIONS (=1024); got 2048]
