### PR TITLE
Fix: NPE when trying to insert `null` as value in a float_vector

### DIFF
--- a/server/src/main/java/io/crate/expression/scalar/cast/ImplicitCastFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/cast/ImplicitCastFunction.java
@@ -136,8 +136,8 @@ public class ImplicitCastFunction extends Scalar<Object, Object> {
             return argument;
         }
 
-        if (argument instanceof Input) {
-            Object value = ((Input<?>) argument).value();
+        if (argument instanceof Input<?> input) {
+            Object value = input.value();
             try {
                 return Literal.ofUnchecked(targetType, targetType.implicitCast(value));
             } catch (ConversionException e) {

--- a/server/src/main/java/io/crate/metadata/ColumnIdent.java
+++ b/server/src/main/java/io/crate/metadata/ColumnIdent.java
@@ -151,8 +151,7 @@ public class ColumnIdent implements Comparable<ColumnIdent>, Accountable {
         if (parent.isTopLevel()) {
             return new ColumnIdent(parent.name, name);
         }
-        ArrayList<String> childPath = new ArrayList<>();
-        childPath.addAll(parent.path);
+        ArrayList<String> childPath = new ArrayList<>(parent.path);
         childPath.add(name);
         return new ColumnIdent(parent.name, childPath);
     }

--- a/server/src/main/java/io/crate/types/FloatVectorType.java
+++ b/server/src/main/java/io/crate/types/FloatVectorType.java
@@ -128,16 +128,21 @@ public class FloatVectorType extends DataType<float[]> implements Streamer<float
     }
 
     @Override
-    public float[] sanitizeValue(Object value) {
+    public float[] sanitizeValue(Object obj) {
         // Value is stored as list in _raw/xcontent/json
-        if (value instanceof List<?> values) {
+        if (obj instanceof List<?> values) {
             float[] result = new float[values.size()];
             for (int i = 0; i < result.length; i++) {
-                result[i] = ((Number) values.get(i)).floatValue();
+                var value = values.get(i);
+                if (value == null) {
+                    throw new UnsupportedOperationException("null values are not allowed for " + NAME);
+                } else {
+                    result[i] = ((Number) value).floatValue();
+                }
             }
             return result;
         }
-        return (float[]) value;
+        return (float[]) obj;
     }
 
     @Override

--- a/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -27,7 +27,6 @@ import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.mapToSortedString;
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_ROUTING_EXCLUDE_GROUP_SETTING;
 import static org.elasticsearch.index.engine.EngineConfig.INDEX_CODEC_SETTING;

--- a/server/src/test/java/io/crate/analyze/InsertAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/InsertAnalyzerTest.java
@@ -21,26 +21,19 @@
 
 package io.crate.analyze;
 
+import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.isAlias;
 import static io.crate.testing.Asserts.isFunction;
 import static io.crate.testing.Asserts.isInputColumn;
 import static io.crate.testing.Asserts.isLiteral;
 import static io.crate.testing.Asserts.isReference;
 import static io.crate.testing.Asserts.toCondition;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-import org.hamcrest.core.Is;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -54,7 +47,6 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.Reference;
 import io.crate.sql.parser.ParsingException;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
-import io.crate.testing.Asserts;
 import io.crate.testing.SQLExecutor;
 import io.crate.types.DataTypes;
 import io.crate.types.StringType;
@@ -109,16 +101,14 @@ public class InsertAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     private void assertCompatibleColumns(AnalyzedInsertStatement statement) {
         List<Symbol> outputSymbols = statement.subQueryRelation().outputs();
-        assertThat(statement.columns().size(), is(outputSymbols.size()));
+        assertThat(statement.columns()).hasSize(outputSymbols.size());
 
         for (int i = 0; i < statement.columns().size(); i++) {
             Symbol subQueryColumn = outputSymbols.get(i);
-            assertThat(subQueryColumn, instanceOf(Symbol.class));
+            assertThat(subQueryColumn).isInstanceOf(Symbol.class);
             var insertColumn = statement.columns().get(i);
-            assertThat(
-                subQueryColumn.valueType().isConvertableTo(insertColumn.valueType(), false),
-                is(true)
-            );
+            assertThat(subQueryColumn.valueType().isConvertableTo(insertColumn.valueType(), false))
+                .isTrue();
         }
     }
 
@@ -126,7 +116,7 @@ public class InsertAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     public void test_nested_primary_key_can_be_used_as_conflict_target_with_subscript_notation() throws Exception {
         AnalyzedInsertStatement insert =
             e.analyze("insert into doc.nested (o) values (?) on conflict (o['id']) do update set x = x + 1");
-        Asserts.assertThat(insert.onDuplicateKeyAssignments())
+        assertThat(insert.onDuplicateKeyAssignments())
             .hasKeySatisfying(toCondition(isReference("x")));
     }
 
@@ -134,7 +124,7 @@ public class InsertAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     public void test_nested_primary_key_can_be_used_as_conflict_target_with_dotted_column_name() throws Exception {
         AnalyzedInsertStatement insert =
             e.analyze("insert into doc.nested (o) values (?) on conflict (\"o.id\") do update set x = x + 1");
-        Asserts.assertThat(insert.onDuplicateKeyAssignments())
+        assertThat(insert.onDuplicateKeyAssignments())
             .hasKeySatisfying(toCondition(isReference("x")));
     }
 
@@ -155,23 +145,27 @@ public class InsertAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testFromQueryWithMissingSubQueryColumn() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        e.analyze("insert into users (" +
-                  "  select id, other_id, name, details, awesome, counters, " +
-                  "       friends " +
-                  "  from users " +
-                  "  where name = 'Trillian'" +
-                  ")");
+        assertThatThrownBy(() ->
+            e.analyze("""
+                insert into users (
+                  select id, other_id, name, details, awesome, counters, friends
+                  from users   where name = 'Trillian')
+                """))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageMatching("Number of target columns .* of insert statement doesn't match number of source columns .*");
 
     }
 
     @Test
     public void testFromQueryWithMissingInsertColumn() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        e.analyze("insert into users (id, other_id, name, details, awesome, counters, friends) (" +
-                  "  select * from users " +
-                  "  where name = 'Trillian'" +
-                  ")");
+        assertThatThrownBy(() ->
+            e.analyze("""
+                insert into users (id, other_id, name, details, awesome, counters, friends) (
+                  select * from users
+                  where name = 'Trillian')
+            """))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageMatching("Number of target columns .* of insert statement doesn't match number of source columns .*");
     }
 
     @Test
@@ -186,11 +180,14 @@ public class InsertAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testFromQueryWithWrongColumnTypes() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        e.analyze("insert into users (id, details, name) (" +
-                  "  select id, name, details from users " +
-                  "  where name = 'Trillian'" +
-                  ")");
+        assertThatThrownBy(() ->
+            e.analyze("""
+                insert into users (id, details, name) (
+                  select id, name, details from users
+                  where name = 'Trillian')
+            """))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("The type 'object' of the insert source 'details' is not convertible to the type 'text' of target column 'name'");
     }
 
     @Test
@@ -219,11 +216,11 @@ public class InsertAnalyzerTest extends CrateDummyClusterServiceUnitTest {
                      "on conflict (id) do update set name = 'Arthur'";
 
         AnalyzedInsertStatement statement = e.analyze(insert);
-        assertThat(statement.onDuplicateKeyAssignments().size(), is(1));
+        assertThat(statement.onDuplicateKeyAssignments()).hasSize(1);
 
         for (var entry : statement.onDuplicateKeyAssignments().entrySet()) {
-            Asserts.assertThat(entry.getKey()).isReference("name");
-            Asserts.assertThat(entry.getValue()).isLiteral("Arthur", StringType.INSTANCE);
+            assertThat(entry.getKey()).isReference("name");
+            assertThat(entry.getValue()).isLiteral("Arthur", StringType.INSTANCE);
         }
     }
 
@@ -234,11 +231,11 @@ public class InsertAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
         AnalyzedInsertStatement statement = e.analyze(insert);
 
-        Assert.assertThat(statement.onDuplicateKeyAssignments().size(), is(1));
+        assertThat(statement.onDuplicateKeyAssignments()).hasSize(1);
 
         for (var entry : statement.onDuplicateKeyAssignments().entrySet()) {
-            Asserts.assertThat(entry.getKey()).isReference("name");
-            Asserts.assertThat(entry.getValue()).isExactlyInstanceOf(ParameterSymbol.class);
+            assertThat(entry.getKey()).isReference("name");
+            assertThat(entry.getValue()).isExactlyInstanceOf(ParameterSymbol.class);
         }
     }
 
@@ -248,16 +245,16 @@ public class InsertAnalyzerTest extends CrateDummyClusterServiceUnitTest {
                      "on conflict (id) do update set name = substr(excluded.name, 1, 1)";
 
         AnalyzedInsertStatement statement = e.analyze(insert);
-        Assert.assertThat(statement.onDuplicateKeyAssignments().size(), is(1));
+        assertThat(statement.onDuplicateKeyAssignments()).hasSize(1);
 
         for (var entry : statement.onDuplicateKeyAssignments().entrySet()) {
-            Asserts.assertThat(entry.getKey()).isReference("name");
-            Asserts.assertThat(entry.getValue()).isFunction(SubstrFunction.NAME);
+            assertThat(entry.getKey()).isReference("name");
+            assertThat(entry.getValue()).isFunction(SubstrFunction.NAME);
             Function function = (Function) entry.getValue();
-            assertThat(function.arguments().get(0), instanceOf(InputColumn.class));
+            assertThat(function.arguments().get(0)).isExactlyInstanceOf(InputColumn.class);
             InputColumn inputColumn = (InputColumn) function.arguments().get(0);
-            assertThat(inputColumn.index(), is(1));
-            assertThat(inputColumn.valueType(), instanceOf(StringType.class));
+            assertThat(inputColumn.index()).isEqualTo(1);
+            assertThat(inputColumn.valueType()).isExactlyInstanceOf(StringType.class);
         }
     }
 
@@ -265,31 +262,28 @@ public class InsertAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     public void testFromQueryWithOnConflictAndMultiplePKs() {
         String insertStatement = "insert into three_pk (a, b, c) (select 1, 2, 3) on conflict (a, b, c) do update set d = 1";
         AnalyzedInsertStatement statement = e.analyze(insertStatement);
-        assertThat(statement.onDuplicateKeyAssignments().size(), Is.is(1));
-        Asserts.assertThat(statement.onDuplicateKeyAssignments()).hasEntrySatisfying(
+        assertThat(statement.onDuplicateKeyAssignments()).hasSize(1);
+        assertThat(statement.onDuplicateKeyAssignments()).hasEntrySatisfying(
             toCondition(isReference("d")),
             toCondition(isLiteral(1)));
     }
 
     @Test
     public void testFromQueryWithUnknownOnDuplicateKeyValues() throws Exception {
-        try {
+        assertThatThrownBy(() ->
             e.analyze("insert into users (id, name) (select id, name from users) " +
-                      "on conflict (id) do update set name = excluded.does_not_exist");
-            fail("Analyze passed without a failure.");
-        } catch (ColumnUnknownException e) {
-            assertThat(e.getMessage(), containsString("Column does_not_exist unknown"));
-        }
+                      "on conflict (id) do update set name = excluded.does_not_exist"))
+            .isExactlyInstanceOf(ColumnUnknownException.class)
+            .hasMessage("Column does_not_exist unknown");
     }
 
     @Test
     public void testFromQueryWithOnDuplicateKeyPrimaryKeyUpdate() {
-        try {
-            e.analyze("insert into users (id, name) (select 1, 'Arthur') on conflict (id) do update set id = id + 1");
-            fail("Analyze passed without a failure.");
-        } catch (ColumnValidationException e) {
-            assertThat(e.getMessage(), containsString("Updating a primary key is not supported"));
-        }
+        assertThatThrownBy(() ->
+            e.analyze("insert into users (id, name) (select 1, 'Arthur') " +
+                      "on conflict (id) do update set id = id + 1"))
+            .isExactlyInstanceOf(ColumnValidationException.class)
+            .hasMessage("Validation failed for id: Updating a primary key is not supported");
     }
 
     @Test
@@ -297,85 +291,95 @@ public class InsertAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         AnalyzedInsertStatement statement =
             e.analyze("insert into users (id, name) (select 1, 'Jon') on conflict DO NOTHING");
         Map<Reference, Symbol> duplicateKeyAssignments = statement.onDuplicateKeyAssignments();
-        assertThat(statement.isIgnoreDuplicateKeys(), is(true));
-        assertThat(duplicateKeyAssignments, is(notNullValue()));
-        assertThat(duplicateKeyAssignments.size(), is(0));
+        assertThat(statement.isIgnoreDuplicateKeys()).isTrue();
+        assertThat(duplicateKeyAssignments).isNotNull();
+        assertThat(duplicateKeyAssignments).isEmpty();
     }
 
     @Test
     public void testMissingPrimaryKey() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Column `id` is required but is missing from the insert statement");
-        e.analyze("insert into users (name) (select name from users)");
+        assertThatThrownBy(() -> e.analyze("insert into users (name) (select name from users)"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Column `id` is required but is missing from the insert statement");
     }
 
     @Test
     public void testTargetColumnsMustMatchSourceColumnsEvenWithGeneratedColumns() throws Exception {
-        /**
+        /*
          * We want the copy case (insert into target (select * from source)) to work so there is no special logic
          * to exclude generated columns from the target
          */
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Number of target columns (id, firstname, lastname, name) " +
-                                        "of insert statement doesn't match number of source columns (id, firstname, lastname)");
-        e.analyze("insert into users_generated (select id, firstname, lastname from users_generated)");
+        assertThatThrownBy(
+            () -> e.analyze("insert into users_generated (select id, firstname, lastname from users_generated)"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Number of target columns (id, firstname, lastname, name) " +
+                        "of insert statement doesn't match number of source columns (id, firstname, lastname)");
     }
 
     @Test
     public void testFromQueryWithInvalidConflictTarget() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Conflict target (name) did not match the primary key columns ([id])");
-        e.analyze("insert into users (id, name) (select 1, 'Arthur') on conflict (name) do update set name = excluded.name");
+        assertThatThrownBy(
+            () -> e.analyze("insert into users (id, name) (select 1, 'Arthur') on conflict (name) do update set name = excluded.name"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Conflict target (name) did not match the primary key columns ([id])");
     }
 
     @Test
     public void testFromQueryWithConflictTargetNotMatchingPK() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Number of conflict targets ([\"id\", \"id2\"]) did not match the number of primary key columns ([id])");
-        e.analyze("insert into users (id, name) (select 1, 'Arthur') on conflict (id, id2) do update set name = excluded.name");
+        assertThatThrownBy(
+            () -> e.analyze("insert into users (id, name) (select 1, 'Arthur') on conflict (id, id2) do update set name = excluded.name"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Number of conflict targets ([\"id\", \"id2\"]) did not match the number of primary key columns ([id])");
     }
 
     @Test
     public void testInsertFromValuesWithConflictTargetNotMatchingMultiplePKs() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Number of conflict targets ([\"a\", \"b\"]) did not match the number of primary key columns ([a, b, c])");
-        e.analyze("insert into three_pk (a, b, c) (select 1, 2, 3) " +
-                  "on conflict (a, b) do update set d = 1");
+        assertThatThrownBy(
+            () -> e.analyze("insert into three_pk (a, b, c) (select 1, 2, 3) " +
+                  "on conflict (a, b) do update set d = 1"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Number of conflict targets ([\"a\", \"b\"]) did not match the number of primary key columns ([a, b, c])");
     }
 
     @Test
     public void testFromQueryWithMissingConflictTarget() {
-        expectedException.expect(ParsingException.class);
-        expectedException.expectMessage("line 1:66: mismatched input 'update' expecting 'NOTHING'");
-        e.analyze("insert into users (id, name) (select 1, 'Arthur') on conflict do update set name = excluded.name");
+        assertThatThrownBy(
+            () -> e.analyze("insert into users (id, name) (select 1, 'Arthur') on conflict do update set name = excluded.name"))
+            .isExactlyInstanceOf(ParsingException.class)
+            .hasMessage("line 1:66: mismatched input 'update' expecting 'NOTHING'");
+
     }
 
     @Test
     public void testFromQueryWithInvalidConflictTargetDoNothing() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Conflict target (name) did not match the primary key columns ([id])");
-        e.analyze("insert into users (id, name) (select 1, 'Arthur') on conflict (name) DO NOTHING");
+        assertThatThrownBy(
+            () -> e.analyze("insert into users (id, name) (select 1, 'Arthur') on conflict (name) DO NOTHING"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Conflict target (name) did not match the primary key columns ([id])");
     }
 
     @Test
     public void test_query_with_column_that_does_not_exist_as_on_conflict_target() {
-        expectedException.expect(ColumnUnknownException.class);
-        e.analyze("insert into users (id, name) (select 1, 'Arthur') on conflict (invalid_col) DO NOTHING");
+        assertThatThrownBy(
+            () -> e.analyze("insert into users (id, name) (select 1, 'Arthur') on conflict (invalid_col) DO NOTHING"))
+            .isExactlyInstanceOf(ColumnUnknownException.class);
     }
 
     @Test
     public void testFromQueryWithConflictTargetDoNothingNotMatchingPK() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Number of conflict targets ([\"id\", \"id2\"]) did not match the number of primary key columns ([id])");
-        e.analyze("insert into users (id, name) (select 1, 'Arthur') on conflict (id, id2) DO NOTHING");
+        assertThatThrownBy(
+            () -> e.analyze("insert into users (id, name) (select 1, 'Arthur') on conflict (id, id2) DO NOTHING"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Number of conflict targets ([\"id\", \"id2\"]) did not match the number of primary key columns ([id])");
     }
 
     @Test
     public void testInsertFromValuesWithConflictTargetDoNothingNotMatchingMultiplePKs() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Number of conflict targets ([\"a\", \"b\"]) did not match the number of primary key columns ([a, b, c])");
-        e.analyze("insert into three_pk (a, b, c) (select 1, 2, 3) " +
-                  "on conflict (a, b) DO NOTHING");
+        assertThatThrownBy(
+            () -> e.analyze("insert into three_pk (a, b, c) (select 1, 2, 3) " +
+                  "on conflict (a, b) DO NOTHING"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Number of conflict targets ([\"a\", \"b\"]) did not match the number of primary key columns ([a, b, c])");
     }
 
     @Test
@@ -384,32 +388,33 @@ public class InsertAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         assertCompatibleColumns(statement);
 
         List<Symbol> pkSymbols = statement.primaryKeySymbols();
-        assertThat(pkSymbols, hasSize(2));
-        Asserts.assertThat(pkSymbols.get(0)).isInputColumn(0);
-        Asserts.assertThat(pkSymbols.get(1)).isLiteral("crate");
+        assertThat(pkSymbols).hasSize(2);
+        assertThat(pkSymbols.get(0)).isInputColumn(0);
+        assertThat(pkSymbols.get(1)).isLiteral("crate");
     }
 
     @Test
     public void test_insert_from_query_with_missing_clustered_by_column() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Column `id` is required but is missing from the insert statement");
-        e.analyze("insert into users_clustered_by_only (name) (select 'user')");
+        assertThatThrownBy(
+            () -> e.analyze("insert into users_clustered_by_only (name) (select 'user')"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Column `id` is required but is missing from the insert statement");
     }
 
     @Test
     public void test_insert_from_query_fails_when_source_and_target_types_are_incompatible() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage(
-            "The type 'bigint' of the insert source 'id' " +
-            "is not convertible to the type 'object' of target column 'details'");
-        e.analyze("insert into users (id, name, details) (select id, name, id from users)");
+        assertThatThrownBy(
+            () -> e.analyze("insert into users (id, name, details) (select id, name, id from users)"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("The type 'bigint' of the insert source 'id' " +
+                        "is not convertible to the type 'object' of target column 'details'");
     }
 
     @Test
     public void test_unnest_with_json_str_can_insert_into_object_column() {
         AnalyzedInsertStatement stmt = e.analyze(
             "insert into users (id, address) (select * from unnest([1], ['{\"postcode\":12345}']))");
-        Asserts.assertThat(stmt.subQueryRelation().outputs())
+        assertThat(stmt.subQueryRelation().outputs())
             .satisfiesExactly(
                 isReference("col1"),
                 isReference("col2", DataTypes.STRING)); // Planner adds a cast projection; text is okay here
@@ -419,21 +424,21 @@ public class InsertAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     public void test_insert_with_id_in_returning_clause() throws Exception {
         AnalyzedInsertStatement stmt =
             e.analyze("insert into users(id, name) values(1, 'max') returning id");
-        Asserts.assertThat(stmt.outputs()).satisfiesExactly(isReference("id"));
+        assertThat(stmt.outputs()).satisfiesExactly(isReference("id"));
     }
 
     @Test
     public void test_insert_with_docid_in_returning_clause() throws Exception {
         AnalyzedInsertStatement stmt =
             e.analyze("insert into users(id, name) values(1, 'max') returning _doc");
-        Asserts.assertThat(stmt.outputs()).satisfiesExactly(isReference("_doc"));
+        assertThat(stmt.outputs()).satisfiesExactly(isReference("_doc"));
     }
 
     @Test
     public void test_insert_with_id_renamed_in_returning_clause() throws Exception {
         AnalyzedInsertStatement stmt =
             e.analyze("insert into users(id, name) values(1, 'max') returning id as foo");
-        Asserts.assertThat(stmt.outputs())
+        assertThat(stmt.outputs())
             .satisfiesExactly(isAlias("foo", isReference("id")));
     }
 
@@ -441,7 +446,7 @@ public class InsertAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     public void test_insert_with_function_in_returning_clause() throws Exception {
         AnalyzedInsertStatement stmt =
             e.analyze("insert into users(id, name) values(1, 'max') returning id + 1 as foo");
-        Asserts.assertThat(stmt.outputs())
+        assertThat(stmt.outputs())
             .satisfiesExactly(isAlias("foo", isFunction("add")));
     }
 
@@ -449,7 +454,7 @@ public class InsertAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     public void test_insert_with_returning_all_columns() throws Exception {
         AnalyzedInsertStatement stmt =
             e.analyze("insert into users(id, name) values(1, 'max') returning *");
-        assertThat(stmt.outputs().size(), is(17));
+        assertThat(stmt.outputs()).hasSize(17);
     }
 
     @Test
@@ -462,8 +467,10 @@ public class InsertAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void test_quoted_on_conflict_columns_are_treated_case_sensitive() throws Exception {
-        expectedException.expect(ColumnUnknownException.class);
-        e.analyze("insert into users (id, name) (select 1, 'Arthur') on conflict (\"ID\") do update set NAME = excluded.name");
+        assertThatThrownBy(() ->
+            e.analyze("insert into users (id, name) (select 1, 'Arthur') " +
+                      "on conflict (\"ID\") do update set NAME = excluded.name"))
+            .isExactlyInstanceOf(ColumnUnknownException.class);
     }
 
     @Test
@@ -475,7 +482,7 @@ public class InsertAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void test_insert_from_values_with_mixed_type_used_target_column_type() throws Exception {
         AnalyzedInsertStatement stmt = e.analyze("insert into users (id, name) values (1, '1'), (2, 2)");
-        Asserts.assertThat(stmt.subQueryRelation().outputs())
+        assertThat(stmt.subQueryRelation().outputs())
             .satisfiesExactly(
                 isReference("col1", DataTypes.LONG),
                 isReference("col2", DataTypes.STRING));
@@ -484,10 +491,10 @@ public class InsertAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void test_pk_col_generated_from_col_with_default() throws Exception {
         AnalyzedInsertStatement stmt = e.analyze("insert into doc.pk_generated_default(col1) values (1)");
-        Asserts.assertThat(stmt.subQueryRelation().outputs())
+        assertThat(stmt.subQueryRelation().outputs())
             .satisfiesExactly(
                 isReference("col1", DataTypes.INTEGER));
-        Asserts.assertThat(stmt.primaryKeySymbols()).satisfiesExactly(
+        assertThat(stmt.primaryKeySymbols()).satisfiesExactly(
             isInputColumn(0),
             isFunction("subtract",
                        isFunction("multiply",

--- a/server/src/test/java/io/crate/types/DataTypesTest.java
+++ b/server/src/test/java/io/crate/types/DataTypesTest.java
@@ -21,11 +21,8 @@
 
 package io.crate.types;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.core.IsNot.not;
-import static org.junit.Assert.assertThat;
+import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Comparator;
 import java.util.List;
@@ -58,16 +55,16 @@ public class DataTypesTest extends ESTestCase {
         Map emptyMap = Map.of();
         DataType objectType = DataTypes.UNTYPED_OBJECT;
 
-        assertThat(objectType.compare(testMap, testMapCopy), is(0));
-        assertThat(objectType.compare(testMapCopy, testMap), is(0));
+        assertThat(objectType.compare(testMap, testMapCopy)).isEqualTo(0);
+        assertThat(objectType.compare(testMapCopy, testMap)).isEqualTo(0);
 
         // first number of argument is checked
-        assertThat(objectType.compare(testMap, emptyMap), is(1));
-        assertThat(objectType.compare(emptyMap, testMap), is(-1));
+        assertThat(objectType.compare(testMap, emptyMap)).isEqualTo(1);
+        assertThat(objectType.compare(emptyMap, testMap)).isEqualTo(-1);
 
         // then values
-        assertThat(objectType.compare(testMap, testCompareMap), is(-1));
-        assertThat(objectType.compare(testCompareMap, testMap), is(1));
+        assertThat(objectType.compare(testMap, testCompareMap)).isEqualTo(-1);
+        assertThat(objectType.compare(testCompareMap, testMap)).isEqualTo(1);
     }
 
     @Test
@@ -134,71 +131,71 @@ public class DataTypesTest extends ESTestCase {
 
     @Test
     public void testSmallIntIsAliasedToShort() {
-        assertThat(DataTypes.ofName("smallint"), is(DataTypes.SHORT));
+        assertThat(DataTypes.ofName("smallint")).isEqualTo(DataTypes.SHORT);
     }
 
     @Test
     public void testInt2IsAliasedToShort() {
-        assertThat(DataTypes.ofName("int2"), is(DataTypes.SHORT));
+        assertThat(DataTypes.ofName("int2")).isEqualTo(DataTypes.SHORT);
     }
 
     @Test
     public void test_varchar_is_aliased_to_string() throws Exception {
-        assertThat(DataTypes.ofName("varchar"), is(DataTypes.STRING));
+        assertThat(DataTypes.ofName("varchar")).isEqualTo(DataTypes.STRING);
     }
 
     @Test
     public void testInt4IsAliasedToInteger() {
-        assertThat(DataTypes.ofName("int4"), is(DataTypes.INTEGER));
+        assertThat(DataTypes.ofName("int4")).isEqualTo(DataTypes.INTEGER);
     }
 
     @Test
     public void testBigIntIsAliasedToLong() {
-        assertThat(DataTypes.ofName("bigint"), is(DataTypes.LONG));
+        assertThat(DataTypes.ofName("bigint")).isEqualTo(DataTypes.LONG);
     }
 
     @Test
     public void testInt8IsAliasedToLong() {
-        assertThat(DataTypes.ofName("int8"), is(DataTypes.LONG));
+        assertThat(DataTypes.ofName("int8")).isEqualTo(DataTypes.LONG);
     }
 
     @Test
     public void testFloat4IsAliasedToReal() {
-        assertThat(DataTypes.ofName("float4"), is(DataTypes.FLOAT));
+        assertThat(DataTypes.ofName("float4")).isEqualTo(DataTypes.FLOAT);
     }
 
     @Test
     public void testFloat8IsAliasedToDouble() {
-        assertThat(DataTypes.ofName("float8"), is(DataTypes.DOUBLE));
+        assertThat(DataTypes.ofName("float8")).isEqualTo(DataTypes.DOUBLE);
     }
 
     @Test
     public void testDecimalIsAliasedToNumeric() {
-        assertThat(DataTypes.ofName("decimal"), is(DataTypes.NUMERIC));
+        assertThat(DataTypes.ofName("decimal")).isEqualTo(DataTypes.NUMERIC);
     }
 
     @Test
     public void test_is_same_type_on_primitive_types() {
-        assertThat(DataTypes.isCompatibleType(DataTypes.STRING, DataTypes.STRING), is(true));
-        assertThat(DataTypes.isCompatibleType(DataTypes.INTEGER, DataTypes.DOUBLE), is(false));
+        assertThat(DataTypes.isCompatibleType(DataTypes.STRING, DataTypes.STRING)).isEqualTo(true);
+        assertThat(DataTypes.isCompatibleType(DataTypes.INTEGER, DataTypes.DOUBLE)).isEqualTo(false);
     }
 
     @Test
     public void test_is_same_type_on_complex_types() {
-        assertThat(DataTypes.isCompatibleType(DataTypes.UNTYPED_OBJECT, DataTypes.BIGINT_ARRAY), is(false));
-        assertThat(DataTypes.isCompatibleType(DataTypes.UNTYPED_OBJECT, DataTypes.GEO_POINT), is(false));
+        assertThat(DataTypes.isCompatibleType(DataTypes.UNTYPED_OBJECT, DataTypes.BIGINT_ARRAY)).isEqualTo(false);
+        assertThat(DataTypes.isCompatibleType(DataTypes.UNTYPED_OBJECT, DataTypes.GEO_POINT)).isEqualTo(false);
     }
 
     @Test
     public void test_is_same_type_on_primitive_and_complex_types() {
-        assertThat(DataTypes.isCompatibleType(DataTypes.STRING_ARRAY, DataTypes.STRING), is(false));
-        assertThat(DataTypes.isCompatibleType(DataTypes.UNTYPED_OBJECT, DataTypes.DOUBLE), is(false));
+        assertThat(DataTypes.isCompatibleType(DataTypes.STRING_ARRAY, DataTypes.STRING)).isEqualTo(false);
+        assertThat(DataTypes.isCompatibleType(DataTypes.UNTYPED_OBJECT, DataTypes.DOUBLE)).isEqualTo(false);
     }
 
     @Test
     public void test_is_same_type_on_array_types_of_the_same_dimension() {
-        assertThat(DataTypes.isCompatibleType(DataTypes.STRING_ARRAY, DataTypes.STRING_ARRAY), is(true));
-        assertThat(DataTypes.isCompatibleType(DataTypes.STRING_ARRAY, DataTypes.BIGINT_ARRAY), is(false));
+        assertThat(DataTypes.isCompatibleType(DataTypes.STRING_ARRAY, DataTypes.STRING_ARRAY)).isEqualTo(true);
+        assertThat(DataTypes.isCompatibleType(DataTypes.STRING_ARRAY, DataTypes.BIGINT_ARRAY)).isEqualTo(false);
     }
 
     @Test
@@ -206,25 +203,24 @@ public class DataTypesTest extends ESTestCase {
         assertThat(
             DataTypes.isCompatibleType(
                 new ArrayType<>(DataTypes.STRING_ARRAY),
-                DataTypes.STRING_ARRAY),
-            is(false));
+                DataTypes.STRING_ARRAY)).isFalse();
     }
 
     @Test
     public void test_resolve_text_data_type_with_length_limit() {
-        assertThat(DataTypes.of("varchar", List.of(1)), is(StringType.of(1)));
+        assertThat(DataTypes.of("varchar", List.of(1))).isEqualTo(StringType.of(1));
     }
 
     @Test
     public void test_resolve_data_type_that_does_not_support_parameters_throws_exception() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("The 'integer' type doesn't support type parameters.");
-        DataTypes.of("integer", List.of(1));
+        assertThatThrownBy(() -> DataTypes.of("integer", List.of(1)))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("The 'integer' type doesn't support type parameters.");
     }
 
     private static void assertCompareValueTo(Object val1, Object val2, int expected) {
         DataType<?> type = DataTypes.guessType(Objects.requireNonNullElse(val1, val2));
-        assertThat(type, not(instanceOf(DataTypes.UNDEFINED.getClass())));
+        assertThat(type).isNotInstanceOf(DataTypes.UNDEFINED.getClass());
         assertCompareValueTo(type, val1, val2, expected);
     }
 
@@ -235,11 +231,9 @@ public class DataTypesTest extends ESTestCase {
                 Comparator.nullsFirst(dt).compare(
                     dt.sanitizeValue(val1),
                     dt.sanitizeValue(val2)
-                ),
-                is(expected)
-            );
+                )).isEqualTo(expected);
         } else {
-            assertThat(dt.compare(dt.sanitizeValue(val1), dt.sanitizeValue(val2)), is(expected));
+            assertThat(dt.compare(dt.sanitizeValue(val1), dt.sanitizeValue(val2))).isEqualTo(expected);
         }
     }
 

--- a/server/src/test/java/io/crate/types/FloatVectorTypeTest.java
+++ b/server/src/test/java/io/crate/types/FloatVectorTypeTest.java
@@ -21,10 +21,28 @@
 
 package io.crate.types;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.ArrayList;
+
+import org.junit.Test;
+
 public class FloatVectorTypeTest extends DataTypeTestCase<float[]> {
 
     @Override
     public DataType<float[]> getType() {
         return new FloatVectorType(4);
+    }
+
+    @Test
+    public void test_cannot_insert_nulls_into_float_vector() {
+        var floatVectorType = new FloatVectorType(3);
+        var insertValues = new ArrayList<>(3); // List.of() doesn't allow nulls
+        insertValues.add(1.1);
+        insertValues.add(null);
+        insertValues.add(2.2);
+        assertThatThrownBy(() -> floatVectorType.sanitizeValue(insertValues))
+            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .hasMessage("null values are not allowed for float_vector");
     }
 }


### PR DESCRIPTION
- Check and throw a nice error message instead of NPE.
   Chose `UnsupportedOperationException`  to not get it caught and converted into a cast exception:
  ```
  Caused by: io.crate.exceptions.ConversionException: Cannot cast `[NULL]` of type `undefined_array` to type `float_vector`
        at io.crate.expression.scalar.cast.ImplicitCastFunction.normalizeSymbol(ImplicitCastFunction.java:146)
  ```
    
-  Minor code improvements

-  tests: Migrate InsertAnalyzerTest & DataTypesTest to assertj



