### PR TITLE
Don't bypass alias for subscript lookup

### DIFF
--- a/docs/appendices/release-notes/5.3.5.rst
+++ b/docs/appendices/release-notes/5.3.5.rst
@@ -47,6 +47,12 @@ See the :ref:`version_5.3.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that could lead to a ``class_cast_exception`` when using a
+  subscript expression on an aliased expression that shadows another column. For
+  example::
+
+    SELECT a['b'] FROM (SELECT UNNEST(a) AS a FROM tbl) t;
+
 - Fixed an issue that caused a ``object_column = {}`` query to not match if the
   object column doesn't have any child columns.
 

--- a/docs/appendices/release-notes/5.4.1.rst
+++ b/docs/appendices/release-notes/5.4.1.rst
@@ -47,6 +47,12 @@ See the :ref:`version_5.4.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that could lead to a ``class_cast_exception`` when using a
+  subscript expression on an aliased expression that shadows another column. For
+  example::
+
+    SELECT a['b'] FROM (SELECT UNNEST(a) AS a FROM tbl) t;
+
 - Fixed an issue that caused ``SET SESSION`` statements to fail for settings
   that are both session settings and global settings, like
   ``statement_timeout``.

--- a/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -2993,4 +2993,29 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         assertThat(analyzed.outputs()).hasSize(1);
         assertThat(analyzed.outputs().get(0)).isVoidReference(new ColumnIdent("o", "unknown_key"), new RelationName(null, "alias"));
     }
+
+    @Test
+    public void test_can_use_subscript_on_aliased_functions_shadowing_columns() throws Exception {
+        var executor = SQLExecutor.builder(clusterService)
+            .addTable("create table t (obj array(object as (x int)))")
+            .build();
+        QueriedSelectRelation relation = executor.analyze(
+            "select obj['x'] from (select unnest(obj) as obj from t) tbl");
+
+        assertThat(relation.outputs()).satisfiesExactly(
+            output -> assertThat(output.valueType()).isEqualTo(DataTypes.INTEGER)
+        );
+    }
+
+    @Test
+    public void test_subscript_on_aliased_object_gets_optimized_to_reference() throws Exception {
+        var executor = SQLExecutor.builder(clusterService)
+            .addTable("create table t (obj array(object as (x int)))")
+            .build();
+        QueriedSelectRelation relation = executor.analyze(
+            "select obj['x'] from (select obj as obj from t) tbl");
+        assertThat(relation.outputs()).satisfiesExactly(
+            output -> assertThat(output.valueType()).isEqualTo(new ArrayType<>(DataTypes.INTEGER))
+        );
+    }
 }


### PR DESCRIPTION
Closes https://github.com/crate/crate/issues/14434

`QueriedSelectRelation.getField` always resolved sub-column lookups via
the source, potentially bypassing an alias.
