### PR TITLE
Fix handling of `empty_obj_column = {}`

### DIFF
--- a/docs/appendices/release-notes/5.3.5.rst
+++ b/docs/appendices/release-notes/5.3.5.rst
@@ -47,6 +47,9 @@ See the :ref:`version_5.3.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that caused a ``object_column = {}`` query to not match if the
+  object column doesn't have any child columns.
+
 - Fixed an issue that caused queries against views to evaluate the view
   definition with the current search path. This could cause issues if the
   search path diverged. The fix only applies to newly created views.

--- a/docs/appendices/release-notes/5.4.1.rst
+++ b/docs/appendices/release-notes/5.4.1.rst
@@ -47,6 +47,9 @@ See the :ref:`version_5.4.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that caused a ``object_column = {}`` query to not match if the
+  object column doesn't have any child columns.
+
 - Fixed an issue that caused queries against views to evaluate the view
   definition with the current search path. This could cause issues if the
   search path diverged. The fix only applies to newly created views.

--- a/server/src/main/java/io/crate/expression/operator/EqOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/EqOperator.java
@@ -303,7 +303,7 @@ public final class EqOperator extends Operator<Object> {
             preFilters++;
             boolBuilder.add(innerQuery, BooleanClause.Occur.MUST);
         }
-        if (preFilters == value.size()) {
+        if (preFilters > 0 && preFilters == value.size()) {
             return boolBuilder.build();
         } else {
             Query genericEqFilter = genericFunctionFilter(eq, context);

--- a/server/src/main/java/io/crate/lucene/GenericFunctionQuery.java
+++ b/server/src/main/java/io/crate/lucene/GenericFunctionQuery.java
@@ -53,7 +53,7 @@ import io.crate.expression.symbol.SymbolVisitors;
  *
  * This query is very slow.
  */
-class GenericFunctionQuery extends Query {
+public class GenericFunctionQuery extends Query {
 
     private final Function function;
     private final LuceneCollectorExpression[] expressions;


### PR DESCRIPTION
Closes https://github.com/crate/crate/issues/14457
