### PR TITLE
Fix handling of dual session/global settings in SetSessionPlan

### DIFF
--- a/docs/appendices/release-notes/5.4.1.rst
+++ b/docs/appendices/release-notes/5.4.1.rst
@@ -47,6 +47,10 @@ See the :ref:`version_5.4.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that caused ``SET SESSION`` statements to fail for settings
+  that are both session settings and global settings, like
+  ``statement_timeout``.
+
 - Fixed an issue that caused a ``object_column = {}`` query to not match if the
   object column doesn't have any child columns.
 

--- a/server/src/test/java/io/crate/planner/statement/SetSessionPlanTest.java
+++ b/server/src/test/java/io/crate/planner/statement/SetSessionPlanTest.java
@@ -21,18 +21,71 @@
 
 package io.crate.planner.statement;
 
-import static io.crate.planner.statement.SetSessionPlan.validateSetting;
+import static io.crate.planner.statement.SetSessionPlan.ensureNotGlobalSetting;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
 
-import org.elasticsearch.test.ESTestCase;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
 import org.junit.Test;
 
-public class SetSessionPlanTest extends ESTestCase {
+import io.crate.action.sql.Cursors;
+import io.crate.data.Row;
+import io.crate.data.testing.TestingRowConsumer;
+import io.crate.expression.symbol.Literal;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.RoutingProvider;
+import io.crate.metadata.settings.session.SessionSettingRegistry;
+import io.crate.planner.DependencyCarrier;
+import io.crate.planner.PlannerContext;
+import io.crate.planner.operators.SubQueryResults;
+import io.crate.planner.optimizer.costs.PlanStats;
+import io.crate.protocols.postgres.TransactionState;
+import io.crate.sql.tree.Assignment;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+
+public class SetSessionPlanTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testSetSessionInvalidSetting() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage(
-            "GLOBAL Cluster setting 'stats.operations_log_size' cannot be used with SET SESSION / LOCAL");
-        validateSetting("stats.operations_log_size");
+        assertThatThrownBy(() -> ensureNotGlobalSetting("stats.operations_log_size"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("GLOBAL Cluster setting 'stats.operations_log_size' cannot be used with SET SESSION / LOCAL");
+    }
+
+    @Test
+    public void test_set_session_allows_settings_that_exist_as_both_global_and_session_setting() throws Exception {
+        Assignment<Symbol> assignment = new Assignment<Symbol>(Literal.of("statement_timeout"), Literal.of(10));
+        SetSessionPlan setSessionPlan = new SetSessionPlan(List.of(assignment), new SessionSettingRegistry(Set.of()));
+        TestingRowConsumer consumer = new TestingRowConsumer();
+        NodeContext nodeCtx = new NodeContext(new Functions(Map.of()), () -> List.of());
+        setSessionPlan.execute(
+            mock(DependencyCarrier.class),
+            new PlannerContext(
+                clusterService.state(),
+                new RoutingProvider(1, List.of()),
+                UUID.randomUUID(),
+                CoordinatorTxnCtx.systemTransactionContext(),
+                nodeCtx,
+                -1,
+                Row.EMPTY,
+                new Cursors(),
+                TransactionState.IDLE,
+                mock(PlanStats.class)
+            ),
+            consumer,
+            Row.EMPTY,
+            SubQueryResults.EMPTY
+        );
+        assertThat(consumer.getBucket())
+            .as("Must not raise an exception")
+            .isEmpty();
     }
 }


### PR DESCRIPTION
Closes https://github.com/crate/crate/issues/14511

`statement_timeout` is new in 5.4 -> not backporting to 5.3