### PR TITLE
Allow reset of cluster `archived.*` settings

### DIFF
--- a/docs/appendices/release-notes/5.3.5.rst
+++ b/docs/appendices/release-notes/5.3.5.rst
@@ -47,6 +47,9 @@ See the :ref:`version_5.3.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Allowed user to :ref:`RESET<ref-set>` cluster settings with ``archived.``
+  prefix.
+
 - Fixed an issue that could lead to a ``class_cast_exception`` when using a
   subscript expression on an aliased expression that shadows another column. For
   example::

--- a/docs/appendices/release-notes/5.4.1.rst
+++ b/docs/appendices/release-notes/5.4.1.rst
@@ -47,6 +47,9 @@ See the :ref:`version_5.4.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Allowed user to :ref:`RESET<ref-set>` cluster settings with ``archived.``
+  prefix.
+
 - Fixed an issue that could lead to a ``class_cast_exception`` when using a
   subscript expression on an aliased expression that shadows another column. For
   example::

--- a/server/src/main/java/io/crate/metadata/settings/CrateSettings.java
+++ b/server/src/main/java/io/crate/metadata/settings/CrateSettings.java
@@ -21,7 +21,9 @@
 
 package io.crate.metadata.settings;
 
+import static org.elasticsearch.common.settings.AbstractScopedSettings.ARCHIVED_SETTINGS_PREFIX;
 import static org.elasticsearch.common.settings.AbstractScopedSettings.LOGGER_SETTINGS_PREFIX;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -93,12 +95,16 @@ public final class CrateSettings {
 
     public static boolean isValidSetting(String name) {
         return isLoggingSetting(name) ||
+               isArchivedSetting(name) ||
                EXPOSED_SETTING_NAMES.contains(name) ||
                EXPOSED_SETTING_NAMES.stream().noneMatch(s -> s.startsWith(name + ".")) == false;
     }
 
     public static List<String> settingNamesByPrefix(String prefix) {
         if (isLoggingSetting(prefix)) {
+            return Collections.singletonList(prefix);
+        }
+        if (isArchivedSetting(prefix)) {
             return Collections.singletonList(prefix);
         }
         List<String> filteredList = new ArrayList<>();
@@ -146,5 +152,8 @@ public final class CrateSettings {
     private static boolean isLoggingSetting(String name) {
         return name.startsWith(LOGGER_SETTINGS_PREFIX);
     }
+
+    private static boolean isArchivedSetting(String name) {
+        return name.startsWith(ARCHIVED_SETTINGS_PREFIX);
     }
 }

--- a/server/src/main/java/io/crate/metadata/settings/CrateSettings.java
+++ b/server/src/main/java/io/crate/metadata/settings/CrateSettings.java
@@ -21,6 +21,7 @@
 
 package io.crate.metadata.settings;
 
+import static org.elasticsearch.common.settings.AbstractScopedSettings.LOGGER_SETTINGS_PREFIX;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -143,6 +144,7 @@ public final class CrateSettings {
     }
 
     private static boolean isLoggingSetting(String name) {
-        return name.startsWith("logger.");
+        return name.startsWith(LOGGER_SETTINGS_PREFIX);
+    }
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/logging/LogConfigurator.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/LogConfigurator.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.common.logging;
 
+import static org.elasticsearch.common.settings.AbstractScopedSettings.LOGGER_SETTINGS_PREFIX;
+
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LoggerContext;
@@ -264,7 +266,7 @@ public class LogConfigurator {
             // do not set a log level for a logger named level (from the default log setting)
             .filter(s -> s.getKey().equals(Loggers.LOG_DEFAULT_LEVEL_SETTING.getKey()) == false).forEach(s -> {
                 final Level level = s.get(settings);
-                Loggers.setLevel(LogManager.getLogger(s.getKey().substring("logger.".length())), level);
+                Loggers.setLevel(LogManager.getLogger(s.getKey().substring(LOGGER_SETTINGS_PREFIX.length())), level);
             });
     }
 

--- a/server/src/main/java/org/elasticsearch/common/logging/Loggers.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/Loggers.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.common.logging;
 
+import static org.elasticsearch.common.settings.AbstractScopedSettings.LOGGER_SETTINGS_PREFIX;
 import static org.elasticsearch.common.util.CollectionUtils.asArrayList;
 
 import java.util.Map;
@@ -40,15 +41,16 @@ import io.crate.types.DataTypes;
 /**
  * A set of utilities around Logging.
  */
-public class Loggers {
-
+public final class Loggers {
     public static final String SPACE = " ";
+
+    private Loggers() {}
 
     public static final Setting<Level> LOG_DEFAULT_LEVEL_SETTING =
         new Setting<>("logger.level", Level.INFO.name(), Level::valueOf, DataTypes.STRING, Setting.Property.NodeScope);
     public static final Setting.AffixSetting<Level> LOG_LEVEL_SETTING = Setting.prefixKeySetting(
-        "logger.",
-        (key) -> new Setting<>(key, Level.INFO.name(), Level::valueOf, DataTypes.STRING, Setting.Property.Dynamic, Setting.Property.NodeScope)
+        LOGGER_SETTINGS_PREFIX,
+        key -> new Setting<>(key, Level.INFO.name(), Level::valueOf, DataTypes.STRING, Setting.Property.Dynamic, Setting.Property.NodeScope)
     );
 
     public static Logger getLogger(Class<?> clazz, ShardId shardId, String... prefixes) {
@@ -73,8 +75,8 @@ public class Loggers {
 
     public static Logger getLogger(Logger parentLogger, String s) {
         String prefix = null;
-        if (parentLogger instanceof PrefixLogger) {
-            prefix = ((PrefixLogger)parentLogger).prefix();
+        if (parentLogger instanceof PrefixLogger prefixLogger) {
+            prefix = prefixLogger.prefix();
         }
         return ESLoggerFactory.getLogger(prefix, parentLogger.getName() + s);
     }

--- a/server/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/AbstractScopedSettings.java
@@ -52,6 +52,7 @@ import java.util.stream.Collectors;
  */
 public abstract class AbstractScopedSettings {
     public static final String ARCHIVED_SETTINGS_PREFIX = "archived.";
+    public static final String LOGGER_SETTINGS_PREFIX = "logger.";
     private static final Pattern KEY_PATTERN = Pattern.compile("^(?:[-\\w]+[.])*[-\\w]+$");
     private static final Pattern GROUP_KEY_PATTERN = Pattern.compile("^(?:[-\\w]+[.])+$");
     private static final Pattern AFFIX_KEY_PATTERN = Pattern.compile("^(?:[-\\w]+[.])+[*](?:[.][-\\w]+)+$");

--- a/server/src/test/java/io/crate/integrationtests/SysClusterSettingsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysClusterSettingsTest.java
@@ -25,22 +25,27 @@ import static io.crate.testing.Asserts.assertThat;
 import static org.elasticsearch.indices.recovery.RecoverySettings.INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING;
 
 import java.lang.reflect.Field;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
 import org.elasticsearch.cluster.ClusterInfoService;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.MemorySizeValue;
 import org.elasticsearch.gateway.GatewayService;
 import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
+import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.IntegTestCase;
 import org.junit.After;
 import org.junit.Test;
 
+import io.crate.common.collections.Lists2;
 import io.crate.common.unit.TimeValue;
 import io.crate.execution.engine.collect.stats.JobsLogService;
 import io.crate.execution.engine.indexing.ShardingUpsertExecutor;
+import io.crate.types.DataTypes;
 import io.crate.udc.service.UDCService;
 
 @IntegTestCase.ClusterScope
@@ -51,6 +56,11 @@ public class SysClusterSettingsTest extends IntegTestCase {
         Settings.Builder builder = Settings.builder().put(super.nodeSettings(nodeOrdinal));
         builder.put(ShardingUpsertExecutor.BULK_REQUEST_TIMEOUT_SETTING.getKey(), "42s");
         return builder.build();
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Lists2.concat(super.nodePlugins(), TestPluginWithArchivedSetting.class);
     }
 
     @After
@@ -198,6 +208,21 @@ public class SysClusterSettingsTest extends IntegTestCase {
         assertThat(f1.get(clusterService)).isEqualTo(TimeValue.timeValueSeconds(45));
     }
 
+    @Test
+    public void test_archived_setting_can_be_reset() throws Exception {
+        execute("set global transient \"archived.cluster.routing.allocation.disk.watermark.low\"=\"70%\"");
+        var clusterService = cluster().getMasterNodeInstance(ClusterService.class);
+        assertThat(clusterService.getClusterSettings().get("archived.cluster.routing.allocation.disk.watermark.low"))
+            .isNotNull();
+        assertThat(clusterService.state().metadata().settings().get("archived.cluster.routing.allocation.disk.watermark.low"))
+            .isEqualTo("70%");
+
+        execute("reset global \"archived.cluster.routing.allocation.disk.watermark.low\"");
+        clusterService = cluster().getMasterNodeInstance(ClusterService.class);
+        assertThat(clusterService.state().metadata().settings().get("archived.cluster.routing.allocation.disk.watermark.low"))
+            .isNull();
+    }
+
     private void assertSettingsDefault(Setting<?> esSetting) {
         assertSettingsValue(esSetting.getKey(), esSetting.getDefault(Settings.EMPTY));
     }
@@ -210,5 +235,28 @@ public class SysClusterSettingsTest extends IntegTestCase {
             settingMap = (Map<String, Object>) settingMap.get(settingPath.get(i));
         }
         assertThat(settingMap.get(settingPath.get(settingPath.size() - 1))).isEqualTo(expectedValue);
+    }
+
+    public static class TestPluginWithArchivedSetting extends Plugin {
+
+        public TestPluginWithArchivedSetting() {}
+
+        @Override
+        public Settings additionalSettings() {
+            return Settings.builder()
+                .put("archived.cluster.routing.allocation.disk.watermark.low", "80%")
+                .build();
+        }
+
+        @Override
+        public List<Setting<?>> getSettings() {
+            return List.of(
+                new Setting<>("archived.cluster.routing.allocation.disk.watermark.low", "85%",
+                              s -> s,
+                              value -> {},
+                              DataTypes.STRING,
+                              Setting.Property.Dynamic, Setting.Property.NodeScope, Setting.Property.Exposed)
+            );
+        }
     }
 }


### PR DESCRIPTION
 -  Extract `logger.` prefix to a constant.
   
 -  Seems that due to validation there is scenario where a cluster setting
    can be marked as invalid and it turn prefixed with `archived.`, which
    then prevents any cluster setting to be set without a full cluster
    restart. Allow to `RESET` such settings while the cluster is still
    running to avoid the restart, and be able to set any cluster setting
    again.
    
    Fixes: #14459

