### PR TITLE
Fix lucene query building for integer types

### DIFF
--- a/.github/styles/Vocab/CrateDB/accept.txt
+++ b/.github/styles/Vocab/CrateDB/accept.txt
@@ -77,6 +77,7 @@ png
 pq
 prepending
 Quadtree
+queryable
 readonly
 realtime
 rebalance

--- a/docs/appendices/release-notes/5.4.3.rst
+++ b/docs/appendices/release-notes/5.4.3.rst
@@ -46,4 +46,6 @@ See the :ref:`version_5.4.0` release notes for a full list of changes in the
 Fixes
 =====
 
-None
+- Fixed an issue that caused query on un-indexed columns to return empty
+  results. The expected behaviour was to have an exception thrown but as part
+  of this fix, un-indexed columns are now queryable.

--- a/server/src/main/java/io/crate/execution/engine/collect/collectors/OptimizeQueryForSearchAfter.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/collectors/OptimizeQueryForSearchAfter.java
@@ -33,6 +33,7 @@ import io.crate.analyze.OrderBy;
 import io.crate.expression.reference.doc.lucene.NullSentinelValues;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.IndexType;
 import io.crate.metadata.Reference;
 import io.crate.types.EqQuery;
 import io.crate.types.StorageSupport;
@@ -82,20 +83,48 @@ public class OptimizeQueryForSearchAfter implements Function<FieldDoc, Query> {
                     BooleanQuery.Builder booleanQuery = new BooleanQuery.Builder();
                     booleanQuery.add(new MatchAllDocsQuery(), BooleanClause.Occur.MUST);
                     if (orderBy.reverseFlags()[i]) {
-                        booleanQuery.add(eqQuery.rangeQuery(columnName, null, value, false, true, ref.hasDocValues()),
-                                         BooleanClause.Occur.MUST_NOT);
+                        booleanQuery.add(
+                            eqQuery.rangeQuery(
+                                columnName,
+                                null,
+                                value,
+                                false,
+                                true,
+                                ref.hasDocValues(),
+                                ref.indexType() != IndexType.NONE),
+                            BooleanClause.Occur.MUST_NOT);
                     } else {
-                        booleanQuery.add(eqQuery.rangeQuery(columnName, value, null, true, false, ref.hasDocValues()),
-                                         BooleanClause.Occur.MUST_NOT);
+                        booleanQuery.add(
+                            eqQuery.rangeQuery(
+                                columnName,
+                                value,
+                                null,
+                                true,
+                                false,
+                                ref.hasDocValues(),
+                                ref.indexType() != IndexType.NONE),
+                            BooleanClause.Occur.MUST_NOT);
                     }
                     orderQuery = booleanQuery.build();
                 } else {
                     if (orderBy.reverseFlags()[i]) {
                         orderQuery = eqQuery.rangeQuery(
-                                columnName, value, null, false, false, ref.hasDocValues());
+                                columnName,
+                                value,
+                                null,
+                                false,
+                                false,
+                                ref.hasDocValues(),
+                                ref.indexType() != IndexType.NONE);
                     } else {
                         orderQuery = eqQuery.rangeQuery(
-                                columnName, null, value, false, false, ref.hasDocValues());
+                            columnName,
+                            null,
+                            value,
+                            false,
+                            false,
+                            ref.hasDocValues(),
+                            ref.indexType() != IndexType.NONE);
                     }
                 }
                 queryBuilder.add(orderQuery, BooleanClause.Occur.MUST);

--- a/server/src/main/java/io/crate/expression/operator/CmpOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/CmpOperator.java
@@ -28,6 +28,7 @@ import org.apache.lucene.search.Query;
 
 import io.crate.data.Input;
 import io.crate.expression.symbol.Literal;
+import io.crate.metadata.IndexType;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
 import io.crate.metadata.TransactionContext;
@@ -81,13 +82,37 @@ public final class CmpOperator extends Operator<Object> {
         String field = ref.column().fqn();
         return switch (functionName) {
             case GtOperator.NAME -> eqQuery.rangeQuery(
-                    field, value, null, false, false, ref.hasDocValues());
+                field,
+                value,
+                null,
+                false,
+                false,
+                ref.hasDocValues(),
+                ref.indexType() != IndexType.NONE);
             case GteOperator.NAME -> eqQuery.rangeQuery(
-                    field, value, null, true, false, ref.hasDocValues());
-            case LtOperator.NAME ->
-                    eqQuery.rangeQuery(field, null, value, false, false, ref.hasDocValues());
-            case LteOperator.NAME ->
-                    eqQuery.rangeQuery(field, null, value, false, true, ref.hasDocValues());
+                field,
+                value,
+                null,
+                true,
+                false,
+                ref.hasDocValues(),
+                ref.indexType() != IndexType.NONE);
+            case LtOperator.NAME -> eqQuery.rangeQuery(
+                field,
+                null,
+                value,
+                false,
+                false,
+                ref.hasDocValues(),
+                ref.indexType() != IndexType.NONE);
+            case LteOperator.NAME -> eqQuery.rangeQuery(
+                field,
+                null,
+                value,
+                false,
+                true,
+                ref.hasDocValues(),
+                ref.indexType() != IndexType.NONE);
             default -> throw new IllegalArgumentException(functionName + " is not a supported comparison operator");
         };
     }

--- a/server/src/main/java/io/crate/expression/operator/any/AnyEqOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/any/AnyEqOperator.java
@@ -68,7 +68,7 @@ public final class AnyEqOperator extends AnyOperator {
             return new MatchNoDocsQuery("column does not exist in this index");
         }
         DataType<?> innerType = ArrayType.unnest(probe.valueType());
-        return EqOperator.termsQuery(columnName, innerType, values);
+        return EqOperator.termsQuery(columnName, innerType, values, probe.hasDocValues(), probe.indexType());
     }
 
     @Override
@@ -85,7 +85,12 @@ public final class AnyEqOperator extends AnyOperator {
             // [1, 2] = any(nested_array_ref)
             return arrayLiteralEqAnyArray(any, candidates, probe.value(), context);
         }
-        return EqOperator.fromPrimitive(ArrayType.unnest(candidates.valueType()), candidates.column().fqn(), probe.value());
+        return EqOperator.fromPrimitive(
+            ArrayType.unnest(candidates.valueType()),
+            candidates.column().fqn(),
+            probe.value(),
+            candidates.hasDocValues(),
+            candidates.indexType());
     }
 
     private static Query arrayLiteralEqAnyArray(Function function,
@@ -97,8 +102,9 @@ public final class AnyEqOperator extends AnyOperator {
         Query termsQuery = EqOperator.termsQuery(
             candidates.column().fqn(),
             ArrayType.unnest(candidates.valueType()),
-            terms
-        );
+            terms,
+            candidates.hasDocValues(),
+            candidates.indexType());
         Query genericFunctionFilter = LuceneQueryBuilder.genericFunctionFilter(function, context);
         if (termsQuery == null) {
             return genericFunctionFilter;

--- a/server/src/main/java/io/crate/expression/operator/any/AnyNeqOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/any/AnyNeqOperator.java
@@ -34,6 +34,7 @@ import io.crate.expression.predicate.IsNullPredicate;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.lucene.LuceneQueryBuilder.Context;
+import io.crate.metadata.IndexType;
 import io.crate.metadata.Reference;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
@@ -65,7 +66,16 @@ public final class AnyNeqOperator extends AnyOperator {
 
         BooleanQuery.Builder andBuilder = new BooleanQuery.Builder();
         for (Object value : (Iterable<?>) candidates.value()) {
-            andBuilder.add(EqOperator.fromPrimitive(probe.valueType(), probe.column().fqn(), value), BooleanClause.Occur.MUST);
+            var fromPrimitive = EqOperator.fromPrimitive(
+                probe.valueType(),
+                probe.column().fqn(),
+                value,
+                probe.hasDocValues(),
+                probe.indexType());
+            if (fromPrimitive == null) {
+                return null;
+            }
+            andBuilder.add(fromPrimitive, BooleanClause.Occur.MUST);
         }
         Query exists = IsNullPredicate.refExistsQuery(probe, context, false);
         return new BooleanQuery.Builder()
@@ -96,11 +106,24 @@ public final class AnyNeqOperator extends AnyOperator {
         BooleanQuery.Builder query = new BooleanQuery.Builder();
         query.setMinimumNumberShouldMatch(1);
         query.add(
-            eqQuery.rangeQuery(columnName, value, null, false, false, candidates.hasDocValues()),
+            eqQuery.rangeQuery(
+                columnName, value,
+                null,
+                false,
+                false,
+                candidates.hasDocValues(),
+                candidates.indexType() != IndexType.NONE),
             BooleanClause.Occur.SHOULD
         );
         query.add(
-            eqQuery.rangeQuery(columnName, null, value, false, false, candidates.hasDocValues()),
+            eqQuery.rangeQuery(
+                columnName,
+                null,
+                value,
+                false,
+                false,
+                candidates.hasDocValues(),
+                candidates.indexType() != IndexType.NONE),
             BooleanClause.Occur.SHOULD
         );
         return query.build();

--- a/server/src/main/java/io/crate/expression/scalar/SubscriptFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/SubscriptFunction.java
@@ -47,6 +47,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.lucene.LuceneQueryBuilder;
 import io.crate.lucene.LuceneQueryBuilder.Context;
+import io.crate.metadata.IndexType;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
 import io.crate.metadata.Scalar;
@@ -211,19 +212,20 @@ public class SubscriptFunction extends Scalar<Object, Object[]> {
     }
 
     private interface PreFilterQueryBuilder {
-        Query buildQuery(String field, EqQuery<Object> eqQuery, Object value, boolean hasDocValues);
+        Query buildQuery(String field, EqQuery<Object> eqQuery, Object value, boolean hasDocValues, boolean isIndexed);
     }
 
     private static final Map<String, PreFilterQueryBuilder> PRE_FILTER_QUERY_BUILDER_BY_OP = Map.of(
-        EqOperator.NAME, (field, eqQuery, value, haDocValues) -> eqQuery.termQuery(field, value),
-        GteOperator.NAME, (field, eqQuery, value, hasDocValues) ->
-                eqQuery.rangeQuery(field, value, null, true, false, hasDocValues),
-        GtOperator.NAME, (field, eqQuery, value, hasDocValues) ->
-                eqQuery.rangeQuery(field, value, null, false, false, hasDocValues),
-        LteOperator.NAME, (field, eqQuery, value, hasDocValues) ->
-                eqQuery.rangeQuery(field, null, value, false, true, hasDocValues),
-        LtOperator.NAME, (field, eqQuery, value, hasDocValues) ->
-                eqQuery.rangeQuery(field, null, value, false, false, hasDocValues)
+        EqOperator.NAME, (field, eqQuery, value, haDocValues, isIndexed) ->
+            eqQuery.termQuery(field, value, haDocValues, isIndexed),
+        GteOperator.NAME, (field, eqQuery, value, hasDocValues, isIndexed) ->
+                eqQuery.rangeQuery(field, value, null, true, false, hasDocValues, isIndexed),
+        GtOperator.NAME, (field, eqQuery, value, hasDocValues, isIndexed) ->
+                eqQuery.rangeQuery(field, value, null, false, false, hasDocValues, isIndexed),
+        LteOperator.NAME, (field, eqQuery, value, hasDocValues, isIndexed) ->
+                eqQuery.rangeQuery(field, null, value, false, true, hasDocValues, isIndexed),
+        LtOperator.NAME, (field, eqQuery, value, hasDocValues, isIndexed) ->
+                eqQuery.rangeQuery(field, null, value, false, false, hasDocValues, isIndexed)
     );
 
     @Override
@@ -258,7 +260,7 @@ public class SubscriptFunction extends Scalar<Object, Object[]> {
             }
             BooleanQuery.Builder builder = new BooleanQuery.Builder();
             builder.add(
-                preFilterQueryBuilder.buildQuery(ref.column().fqn(), eqQuery, cmpLiteral.value(), ref.hasDocValues()),
+                preFilterQueryBuilder.buildQuery(ref.column().fqn(), eqQuery, cmpLiteral.value(), ref.hasDocValues(), ref.indexType() != IndexType.NONE),
                 BooleanClause.Occur.MUST);
             builder.add(LuceneQueryBuilder.genericFunctionFilter(parent, context), BooleanClause.Occur.FILTER);
             return builder.build();

--- a/server/src/main/java/io/crate/types/BitStringType.java
+++ b/server/src/main/java/io/crate/types/BitStringType.java
@@ -69,7 +69,7 @@ public final class BitStringType extends DataType<BitString> implements Streamer
         new EqQuery<BitString>() {
 
             @Override
-            public Query termQuery(String field, BitString value) {
+            public Query termQuery(String field, BitString value, boolean hasDocValues, boolean isIndexed) {
                 return new TermQuery(new Term(field, new BytesRef(value.bitSet().toByteArray())));
             }
 
@@ -79,7 +79,8 @@ public final class BitStringType extends DataType<BitString> implements Streamer
                                     BitString upperTerm,
                                     boolean includeLower,
                                     boolean includeUpper,
-                                    boolean hasDocValues) {
+                                    boolean hasDocValues,
+                                    boolean isIndexed) {
                 return null;
             }
         }

--- a/server/src/main/java/io/crate/types/BooleanType.java
+++ b/server/src/main/java/io/crate/types/BooleanType.java
@@ -57,7 +57,7 @@ public class BooleanType extends DataType<Boolean> implements Streamer<Boolean>,
         }
 
         @Override
-        public Query termQuery(String field, Boolean value) {
+        public Query termQuery(String field, Boolean value, boolean hasDocValues, boolean isIndexed) {
             return new TermQuery(new Term(field, indexedValue(value)));
         }
 
@@ -67,7 +67,8 @@ public class BooleanType extends DataType<Boolean> implements Streamer<Boolean>,
                                 Boolean upperTerm,
                                 boolean includeLower,
                                 boolean includeUpper,
-                                boolean hasDocValues) {
+                                boolean hasDocValues,
+                                boolean isIndexed) {
             return new TermRangeQuery(
                 field, indexedValue(lowerTerm), indexedValue(upperTerm), includeLower, includeUpper);
         }

--- a/server/src/main/java/io/crate/types/DoubleType.java
+++ b/server/src/main/java/io/crate/types/DoubleType.java
@@ -55,7 +55,7 @@ public class DoubleType extends DataType<Double> implements FixedWidthType, Stre
         new EqQuery<Double>() {
 
             @Override
-            public Query termQuery(String field, Double value) {
+            public Query termQuery(String field, Double value, boolean hasDocValues, boolean isIndexed) {
                 return DoublePoint.newExactQuery(field, value);
             }
 
@@ -65,7 +65,8 @@ public class DoubleType extends DataType<Double> implements FixedWidthType, Stre
                                     Double upperTerm,
                                     boolean includeLower,
                                     boolean includeUpper,
-                                    boolean hasDocValues) {
+                                    boolean hasDocValues,
+                                    boolean isIndexed) {
                 double lower;
                 if (lowerTerm == null) {
                     lower = Double.NEGATIVE_INFINITY;

--- a/server/src/main/java/io/crate/types/EqQuery.java
+++ b/server/src/main/java/io/crate/types/EqQuery.java
@@ -28,12 +28,21 @@ import org.apache.lucene.search.Query;
  **/
 public interface EqQuery<T> {
 
-    Query termQuery(String field, T value);
+    // NOTE: cannot utilize IndexOrDocValuesQuery since it is counted as 2 clauses
+    // (one for indexQuery and the other for dvQuery) causing TooManyClauses exception
+    // when exceeding the limit (indices.query.bool.max_clause_count).
+    // https://github.com/crate/crate/pull/14527#discussion_r1295569395
+    Query termQuery(String field, T value, boolean hasDocValues, boolean isIndexed);
 
+    // NOTE: cannot utilize IndexOrDocValuesQuery since it is counted as 2 clauses
+    // (one for indexQuery and the other for dvQuery) causing TooManyClauses exception
+    // when exceeding the limit (indices.query.bool.max_clause_count).
+    // https://github.com/crate/crate/pull/14527#discussion_r1295569395
     Query rangeQuery(String field,
                      T lowerTerm,
                      T upperTerm,
                      boolean includeLower,
                      boolean includeUpper,
-                     boolean hasDocValues);
+                     boolean hasDocValues,
+                     boolean isIndexed);
 }

--- a/server/src/main/java/io/crate/types/FloatType.java
+++ b/server/src/main/java/io/crate/types/FloatType.java
@@ -55,7 +55,7 @@ public class FloatType extends DataType<Float> implements Streamer<Float>, Fixed
         new EqQuery<Float>() {
 
             @Override
-            public Query termQuery(String field, Float value) {
+            public Query termQuery(String field, Float value, boolean hasDocValues, boolean isIndexed) {
                 return FloatPoint.newExactQuery(field, value);
             }
 
@@ -65,7 +65,8 @@ public class FloatType extends DataType<Float> implements Streamer<Float>, Fixed
                                     Float upperTerm,
                                     boolean includeLower,
                                     boolean includeUpper,
-                                    boolean hasDocValues) {
+                                    boolean hasDocValues,
+                                    boolean isIndexed) {
                 float lower;
                 if (lowerTerm == null) {
                     lower = Float.NEGATIVE_INFINITY;

--- a/server/src/main/java/io/crate/types/FloatVectorType.java
+++ b/server/src/main/java/io/crate/types/FloatVectorType.java
@@ -57,7 +57,7 @@ public class FloatVectorType extends DataType<float[]> implements Streamer<float
     private static final EqQuery<float[]> EQ_QUERY = new EqQuery<float[]>() {
 
         @Override
-        public Query termQuery(String field, float[] value) {
+        public Query termQuery(String field, float[] value, boolean hasDocValues, boolean isIndexed) {
             return null;
         }
 
@@ -67,7 +67,8 @@ public class FloatVectorType extends DataType<float[]> implements Streamer<float
                                 float[] upperTerm,
                                 boolean includeLower,
                                 boolean includeUpper,
-                                boolean hasDocValues) {
+                                boolean hasDocValues,
+                                boolean isIndexed) {
             return null;
         }
     };

--- a/server/src/main/java/io/crate/types/IntEqQuery.java
+++ b/server/src/main/java/io/crate/types/IntEqQuery.java
@@ -23,14 +23,19 @@ package io.crate.types;
 
 import org.apache.lucene.document.IntPoint;
 import org.apache.lucene.document.SortedNumericDocValuesField;
-import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.Query;
 
 public class IntEqQuery implements EqQuery<Number> {
 
     @Override
-    public Query termQuery(String field, Number value) {
-        return IntPoint.newExactQuery(field, value.intValue());
+    public Query termQuery(String field, Number value, boolean hasDocValues, boolean isIndexed) {
+        if (isIndexed) {
+            return IntPoint.newExactQuery(field, value.intValue());
+        }
+        if (hasDocValues) {
+            return SortedNumericDocValuesField.newSlowExactQuery(field, value.intValue());
+        }
+        return null;
     }
 
     @Override
@@ -39,7 +44,8 @@ public class IntEqQuery implements EqQuery<Number> {
                             Number upperTerm,
                             boolean includeLower,
                             boolean includeUpper,
-                            boolean hasDocValues) {
+                            boolean hasDocValues,
+                            boolean isIndexed) {
         int lower = Integer.MIN_VALUE;
         if (lowerTerm != null) {
             lower = includeLower ? lowerTerm.intValue() : lowerTerm.intValue() + 1;
@@ -48,11 +54,12 @@ public class IntEqQuery implements EqQuery<Number> {
         if (upperTerm != null) {
             upper = includeUpper ? upperTerm.intValue() : upperTerm.intValue() - 1;
         }
-        Query indexquery = IntPoint.newRangeQuery(field, lower, upper);
-        if (hasDocValues) {
-            return new IndexOrDocValuesQuery(
-                    indexquery, SortedNumericDocValuesField.newSlowRangeQuery(field, lower, upper));
+        if (isIndexed) {
+            return IntPoint.newRangeQuery(field, lower, upper);
         }
-        return indexquery;
+        if (hasDocValues) {
+            return SortedNumericDocValuesField.newSlowRangeQuery(field, lower, upper);
+        }
+        return null;
     }
 }

--- a/server/src/main/java/io/crate/types/IpType.java
+++ b/server/src/main/java/io/crate/types/IpType.java
@@ -51,7 +51,7 @@ public class IpType extends DataType<String> implements Streamer<String> {
         new EqQuery<String>() {
 
             @Override
-            public Query termQuery(String field, String value) {
+            public Query termQuery(String field, String value, boolean hasDocValues, boolean isIndexed) {
                 return InetAddressPoint.newExactQuery(field, InetAddresses.forString(value));
             }
 
@@ -61,7 +61,8 @@ public class IpType extends DataType<String> implements Streamer<String> {
                                     String upperTerm,
                                     boolean includeLower,
                                     boolean includeUpper,
-                                    boolean hasDocValues) {
+                                    boolean hasDocValues,
+                                    boolean isIndexed) {
                 InetAddress lower;
                 if (lowerTerm == null) {
                     lower = InetAddressPoint.MIN_VALUE;

--- a/server/src/main/java/io/crate/types/LongEqQuery.java
+++ b/server/src/main/java/io/crate/types/LongEqQuery.java
@@ -29,7 +29,7 @@ import org.apache.lucene.search.Query;
 public class LongEqQuery implements EqQuery<Long> {
 
     @Override
-    public Query termQuery(String field, Long value) {
+    public Query termQuery(String field, Long value, boolean hasDocValues, boolean isIndexed) {
         return LongPoint.newExactQuery(field, value);
     }
 
@@ -39,7 +39,8 @@ public class LongEqQuery implements EqQuery<Long> {
                             Long upperTerm,
                             boolean includeLower,
                             boolean includeUpper,
-                            boolean hasDocValues) {
+                            boolean hasDocValues,
+                            boolean isIndexed) {
         long lower = lowerTerm == null
             ? Long.MIN_VALUE
             : (includeLower ? lowerTerm : lowerTerm + 1);

--- a/server/src/main/java/io/crate/types/StringType.java
+++ b/server/src/main/java/io/crate/types/StringType.java
@@ -78,7 +78,7 @@ public class StringType extends DataType<String> implements Streamer<String> {
         new EqQuery<Object>() {
 
             @Override
-            public Query termQuery(String field, Object value) {
+            public Query termQuery(String field, Object value, boolean hasDocValues, boolean isIndexed) {
                 return new TermQuery(new Term(field, BytesRefs.toBytesRef(value)));
             }
 
@@ -88,7 +88,8 @@ public class StringType extends DataType<String> implements Streamer<String> {
                                     Object upperTerm,
                                     boolean includeLower,
                                     boolean includeUpper,
-                                    boolean hasDocValues) {
+                                    boolean hasDocValues,
+                                    boolean isIndexed) {
                 return new TermRangeQuery(
                     field,
                     BytesRefs.toBytesRef(lowerTerm),

--- a/server/src/test/java/io/crate/execution/engine/collect/collectors/OptimizeQueryForSearchAfterTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/collectors/OptimizeQueryForSearchAfterTest.java
@@ -71,7 +71,7 @@ public class OptimizeQueryForSearchAfterTest {
                 .isExactlyInstanceOf(BooleanQuery.class);
         BooleanQuery booleanQuery = (BooleanQuery) query;
         assertThat(booleanQuery.clauses()).satisfiesExactly(
-                x -> assertThat(x.getQuery()).isExactlyInstanceOf(IndexOrDocValuesQuery.class));
+                x -> assertThat(x.getQuery().getClass().getName()).endsWith("IntPoint$1")); // the query class is anonymous
 
         orderBy = new OrderBy(List.of(
                 new SimpleReference(referenceIdent, RowGranularity.DOC, DataTypes.SHORT, ColumnPolicy.DYNAMIC,

--- a/server/src/test/java/io/crate/expression/operator/EqOperatorTest.java
+++ b/server/src/test/java/io/crate/expression/operator/EqOperatorTest.java
@@ -34,6 +34,7 @@ import org.junit.Test;
 
 import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.lucene.GenericFunctionQuery;
+import io.crate.metadata.IndexType;
 import io.crate.metadata.doc.DocSysColumns;
 import io.crate.testing.Asserts;
 import io.crate.testing.DataTypeTesting;
@@ -141,7 +142,13 @@ public class EqOperatorTest extends ScalarTestCase {
 
     @Test
     public void test_terms_query_on__id_encodes_ids() throws Exception {
-        Query query = EqOperator.termsQuery(DocSysColumns.ID.name(), DataTypes.STRING, List.of("foo", "bar"));
+        Query query = EqOperator.termsQuery(DocSysColumns.ID.name(), DataTypes.STRING, List.of("foo", "bar"), true, IndexType.PLAIN);
+        assertThat(query).hasToString("_id:([7e 8a] [ff 62 61 72])");
+        query = EqOperator.termsQuery(DocSysColumns.ID.name(), DataTypes.STRING, List.of("foo", "bar"), false, IndexType.PLAIN);
+        assertThat(query).hasToString("_id:([7e 8a] [ff 62 61 72])");
+        query = EqOperator.termsQuery(DocSysColumns.ID.name(), DataTypes.STRING, List.of("foo", "bar"), true, IndexType.NONE);
+        assertThat(query).hasToString("_id:([7e 8a] [ff 62 61 72])");
+        query = EqOperator.termsQuery(DocSysColumns.ID.name(), DataTypes.STRING, List.of("foo", "bar"), false, IndexType.NONE);
         assertThat(query).hasToString("_id:([7e 8a] [ff 62 61 72])");
     }
 

--- a/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -630,18 +630,6 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
     }
 
     @Test
-    public void test_comparison_with_and_without_docvalues() {
-        Query query = convert("x > 10");
-        assertThat(query)
-                .hasToString("x:[11 TO 2147483647]")
-                .isExactlyInstanceOf(IndexOrDocValuesQuery.class);
-        query = convert("x_no_docvalues > 10");
-        assertThat(query)
-                .hasToString("x_no_docvalues:[11 TO 2147483647]")
-                .isNotInstanceOf(IndexOrDocValuesQuery.class);
-    }
-
-    @Test
     public void test_array_not_any_with_and_without_docvalues() {
         Query query = convert("10 != ANY(y_array)");
         assertThat(query)
@@ -668,5 +656,11 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
     public void test_arr_eq_empty_array_literal_is_optimized() {
         Query query = convert("y_array = []");
         assertThat(query).hasToString("+NumTermsPerDoc: y_array +(y_array = [])");
+    }
+
+    @Test
+    public void test_eq_object_with_undefined_key() {
+        Query query = convert("obj = {x=1, y=2, z=3}"); // z undefined
+        assertThat(query).hasToString("+obj.x:[1 TO 1] +obj.y:[2 TO 2] #(obj = {\"x\"=1, \"y\"=2, \"z\"=3})");
     }
 }

--- a/server/src/test/java/io/crate/lucene/IntEqQueryTest.java
+++ b/server/src/test/java/io/crate/lucene/IntEqQueryTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.lucene;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.lucene.search.Query;
+import org.junit.Test;
+
+public class IntEqQueryTest extends LuceneQueryBuilderTest {
+    @Override
+    protected String createStmt() {
+        return """
+                create table m (
+                a1 int,
+                a2 int index off,
+                a3 int storage with (columnstore = false),
+                a4 int index off storage with (columnstore = false)
+            )
+            """;
+    }
+
+    @Test
+    public void test_IntEqQuery_termQuery() {
+        Query query = convert("a1 = 1");
+        assertThat(query.getClass().getName()).endsWith("IntPoint$1"); // the query class is anonymous
+        assertThat(query).hasToString("a1:[1 TO 1]");
+
+        query = convert("a2 = 1");
+        // SortedNumericDocValuesRangeQuery.class is not public
+        assertThat(query.getClass().getName()).endsWith("SortedNumericDocValuesRangeQuery");
+        assertThat(query).hasToString("a2:[1 TO 1]");
+
+        query = convert("a3 = 1");
+        assertThat(query.getClass().getName()).endsWith("IntPoint$1"); // the query class is anonymous
+        assertThat(query).hasToString("a3:[1 TO 1]");
+
+        query = convert("a4 = 1");
+        assertThat(query).isExactlyInstanceOf(GenericFunctionQuery.class);
+        assertThat(query).hasToString("(a4 = 1)");
+    }
+
+    @Test
+    public void test_IntEqQuery_rangeQuery() {
+        Query query = convert("a1 > 1");
+        assertThat(query.getClass().getName()).endsWith("IntPoint$1"); // the query class is anonymous
+        assertThat(query).hasToString("a1:[2 TO 2147483647]");
+
+        query = convert("a2 < 1");
+        // SortedNumericDocValuesRangeQuery.class is not public
+        assertThat(query.getClass().getName()).endsWith("SortedNumericDocValuesRangeQuery");
+        assertThat(query).hasToString("a2:[-2147483648 TO 0]");
+
+        query = convert("a3 >= 1");
+        assertThat(query.getClass().getName()).endsWith("IntPoint$1"); // the query class is anonymous
+        assertThat(query).hasToString("a3:[1 TO 2147483647]");
+
+        query = convert("a4 <= 1");
+        assertThat(query).isExactlyInstanceOf(GenericFunctionQuery.class);
+        assertThat(query).hasToString("(a4 <= 1)");
+    }
+}

--- a/server/src/test/java/io/crate/lucene/LuceneQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/LuceneQueryBuilderTest.java
@@ -49,33 +49,7 @@ public abstract class LuceneQueryBuilderTest extends CrateDummyClusterServiceUni
             THREAD_POOL,
             clusterService,
             indexVersion(),
-            "create table users (" +
-            " name string," +
-            " tags string index using fulltext not null," +
-            " content string index using fulltext," +
-            " text_no_index text index off storage with (columnstore = false)," +
-            " x integer not null," +
-            " x_no_docvalues int storage with (columnstore = false)," +
-            " f float," +
-            " d double," +
-            " obj object as (" +
-            "     x integer," +
-            "     y integer" +
-            " )," +
-            " obj_ignored object (ignored), " +
-            " d_array array(double)," +
-            " y_array array(long)," +
-            " x_array_no_docvalues array(int) storage with (columnstore = false)," +
-            " o_array array(object as (xs array(integer)))," +
-            " ts_array array(timestamp with time zone)," +
-            " shape geo_shape," +
-            " point geo_point," +
-            " ts timestamp with time zone," +
-            " addr ip," +
-            " vchar_name varchar(40)," +
-            " byte_col byte, " +
-            " bool_col boolean " +
-            ")"
+            createStmt()
         );
         queryTester = builder.build();
     }
@@ -95,6 +69,36 @@ public abstract class LuceneQueryBuilderTest extends CrateDummyClusterServiceUni
 
     protected Query convert(Symbol expression) {
         return queryTester.toQuery(expression);
+    }
+
+    protected String createStmt() {
+        return "create table users (" +
+               " name string," +
+               " tags string index using fulltext not null," +
+               " content string index using fulltext," +
+               " text_no_index text index off storage with (columnstore = false)," +
+               " x integer not null," +
+               " x_no_docvalues int storage with (columnstore = false)," +
+               " f float," +
+               " d double," +
+               " obj object as (" +
+               "     x integer," +
+               "     y integer" +
+               " )," +
+               " obj_ignored object (ignored), " +
+               " d_array array(double)," +
+               " y_array array(long)," +
+               " x_array_no_docvalues array(int) storage with (columnstore = false)," +
+               " o_array array(object as (xs array(integer)))," +
+               " ts_array array(timestamp with time zone)," +
+               " shape geo_shape," +
+               " point geo_point," +
+               " ts timestamp with time zone," +
+               " addr ip," +
+               " vchar_name varchar(40)," +
+               " byte_col byte, " +
+               " bool_col boolean " +
+               ")";
     }
 
     private Version indexVersion() {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes https://github.com/crate/crate/issues/14407 for integer types.
The core of this PR is the changes in `IntEqQuery` and `IntEqQueryTest`.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
