### PR TITLE
Fix chooseReleaseNotes gradle task for end-of-life branch

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -150,7 +150,18 @@ task chooseReleaseNotes(dependsOn: [':server:getVersion']) {
         def version = project(':server').getVersion.version
         def releaseNotesDir = "$rootDir/blackbox/docs/appendices/release-notes"
         def releaseNotesFile = version.replaceAll('-.*', '') + '.rst'
-        def file = new File(releaseNotesDir + "/" + releaseNotesFile)
+        def file = new File(releaseNotesDir + '/' + releaseNotesFile)
+        if (!file.exists()) { // End of life for a branch
+            def start = version.lastIndexOf('.') + 1
+            def end = version.indexOf('-')
+            if (end == -1) {
+                end = version.length
+            }
+            def hotfixVersion = Integer.parseInt(version.substring(start, end)) - 1
+            releaseNotesFile = version.substring(0, start) + hotfixVersion + '.rst'
+            file = new File(releaseNotesDir + '/' + releaseNotesFile)
+            logger.quiet('Branch is end of life, choosing latest available release notes: ' + releaseNotesFile)
+        }
         if (file.exists()) {
             copy {
                 from("$releaseNotesDir") {


### PR DESCRIPTION
When a branch is end of life, we don't add a future `.rst` release notes file, and therefore the `chooseReleaseNotes` gradle task must use the last release notes available.
