### PR TITLE
Fix: Disallow `plain` for composite indices

### DIFF
--- a/docs/appendices/release-notes/5.4.2.rst
+++ b/docs/appendices/release-notes/5.4.2.rst
@@ -47,4 +47,6 @@ See the :ref:`version_5.4.0` release notes for a full list of changes in the
 Fixes
 =====
 
-None
+- Disallowed usage of ``plain`` index method for
+  :ref:`composite indices <sql-ddl-composite-index>`. Previously, when ``plain``
+  was used, it was silently converted, internally, to `fulltext.

--- a/docs/general/ddl/fulltext-indices.rst
+++ b/docs/general/ddl/fulltext-indices.rst
@@ -175,6 +175,11 @@ Composite indices can include nested columns within object columns as well::
     ... );
     CREATE OK, 1 row affected (... sec)
 
+.. NOTE::
+
+    Only ``fulltext`` index method is supported for composite indices.
+
+
 .. _sql-ddl-custom-analyzer:
 
 .. _create_custom_analyzer:

--- a/server/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
@@ -673,6 +673,10 @@ public class TableElementsAnalyzer implements FieldProvider<Reference> {
             builder.indexProperties = indexDefinition.properties().map(toSymbol);
             builder.indexSources = Lists2.map(indexDefinition.columns(), toSymbol);
             builder.indexType = IndexType.of(builder.indexMethod);
+            if (builder.indexSources.size() > 1 && builder.indexType != IndexType.FULLTEXT) {
+                throw new IllegalArgumentException("Cannot use 'plain' index method for composite index: " + name +
+                                                   ", only 'fulltext' is allowed");
+            }
             return null;
         }
 

--- a/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -462,6 +462,13 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
     }
 
     @Test
+    public void test_cannot_use_plain_index_on_multiple_columns() {
+        assertThatThrownBy(() -> e.analyze("create table t (a int, b int, index pl_a_b using plain (a, b))"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Cannot use 'plain' index method for composite index: pl_a_b, only 'fulltext' is allowed");
+    }
+
+    @Test
     @SuppressWarnings("unchecked")
     public void testCreateTableWithArray() {
         BoundCreateTable analysis = analyze(

--- a/server/src/test/java/io/crate/analyze/MetadataToASTNodeResolverTest.java
+++ b/server/src/test/java/io/crate/analyze/MetadataToASTNodeResolverTest.java
@@ -341,8 +341,7 @@ public class MetadataToASTNodeResolverTest extends CrateDummyClusterServiceUnitT
                       " )," +
                       " index col_d_a_ft using fulltext (col_d['a']) with (" +
                       "  analyzer= 'custom_analyzer'" +
-                      " )," +
-                      " index col_a_col_b_plain using plain (col_a, col_b)" +
+                      " )" +
                       ") " +
                       "clustered into 5 shards " +
                       "with (" +
@@ -368,9 +367,6 @@ public class MetadataToASTNodeResolverTest extends CrateDummyClusterServiceUnitT
                      "   ),\n" +
                      "   INDEX \"col_d_a_ft\" USING FULLTEXT (\"col_d\"['a']) WITH (\n" +
                      "      analyzer = 'custom_analyzer'\n" +
-                     "   ),\n" +
-                     "   INDEX \"col_a_col_b_plain\" USING FULLTEXT (\"col_a\", \"col_b\") WITH (\n" +
-                     "      analyzer = 'keyword'\n" +
                      "   )\n" +
                      ")\n" +
                      "CLUSTERED INTO 5 SHARDS\n" +


### PR DESCRIPTION
Previously, if `plain` was used it was silently converted to `fulltext`, which can be confusing for users.

Fixes: #14532
