### PR TITLE
docs: Clarify `plain` type for composite indices

### DIFF
--- a/docs/general/ddl/fulltext-indices.rst
+++ b/docs/general/ddl/fulltext-indices.rst
@@ -323,3 +323,21 @@ and will override the tokenizer with ``mypattern``.
     DROP OK, 1 row affected (... sec)
     cr> drop ANALYZER e2;
     DROP OK, 1 row affected (... sec)
+    cr> drop TABLE table_a;
+    DROP OK, 1 row affected (... sec)
+    cr> drop TABLE table_b1;
+    DROP OK, 1 row affected (... sec)
+    cr> drop TABLE table_b2;
+    DROP OK, 1 row affected (... sec)
+    cr> drop TABLE table_c;
+    DROP OK, 1 row affected (... sec)
+    cr> drop TABLE table_d;
+    DROP OK, 1 row affected (... sec)
+    cr> drop TABLE table_e;
+    DROP OK, 1 row affected (... sec)
+    cr> drop TABLE table_f;
+    DROP OK, 1 row affected (... sec)
+    cr> drop TABLE documents_a;
+    DROP OK, 1 row affected (... sec)
+    cr> drop TABLE documents_b;
+    DROP OK, 1 row affected (... sec)

--- a/docs/general/ddl/fulltext-indices.rst
+++ b/docs/general/ddl/fulltext-indices.rst
@@ -175,6 +175,11 @@ Composite indices can include nested columns within object columns as well::
     ... );
     CREATE OK, 1 row affected (... sec)
 
+.. NOTE::
+
+    If ``plain`` index method is used, this internally translates to
+    ``fulltext with (analyzer = 'keyword')``.
+
 .. _sql-ddl-custom-analyzer:
 
 .. _create_custom_analyzer:
@@ -313,7 +318,7 @@ and will override the tokenizer with ``mypattern``.
    detailed information on the available analyzers.
 
 
-.. hide: Drop created custom analyzers::
+.. hide: Drop created tables and custom analyzers::
 
     cr> drop ANALYZER myanalyzer;
     DROP OK, 1 row affected (... sec)


### PR DESCRIPTION
Also. drop created tables for fulltext-indices.rst

Fixes: #14532


