### PR TITLE
Add operation memory limit as node & session setting

### DIFF
--- a/docs/admin/system-information.rst
+++ b/docs/admin/system-information.rst
@@ -190,6 +190,7 @@ information about the currently applied cluster settings.
     | settings['memory']                                                                | object       |
     | settings['memory']['allocation']                                                  | object       |
     | settings['memory']['allocation']['type']                                          | text         |
+    | settings['memory']['operation_limit']                                             | integer      |
     | settings['overload_protection']                                                   | object       |
     | settings['overload_protection']['dml']                                            | object       |
     | settings['overload_protection']['dml']['initial_concurrency']                     | integer      |

--- a/docs/appendices/release-notes/5.5.0.rst
+++ b/docs/appendices/release-notes/5.5.0.rst
@@ -109,3 +109,5 @@ Administration and Operations
 
 - Changed permissions on ``sys.jobs`` and ``sys.jobs_log`` to allow users with
   the ``AL`` privileges to see entries from other users.
+
+- Added a new :ref:`memory.operation_limit` cluster and session setting.

--- a/docs/config/cluster.rst
+++ b/docs/config/cluster.rst
@@ -1024,6 +1024,15 @@ be allowed to utilize off heap buffers.
 
     Using ``off-heap`` is considered **experimental**.
 
+.. _memory.operation_limit:
+
+**memory.operation_limit**
+   | *Default:* ``0``
+   | *Runtime:* ``yes``
+
+Default value for the :ref:`memory.operation_limit
+session setting <conf-session-memory-operation-limit>`. Changing the cluster
+setting will only affect new sessions, not existing sessions.
 
 Query circuit breaker
 ---------------------

--- a/docs/config/session.rst
+++ b/docs/config/session.rst
@@ -88,6 +88,25 @@ Supported session settings
   The value is an ``INTERVAL`` with a maximum of ``2147483647`` milliseconds.
   That's roughly 24 days.
 
+.. _conf-session-memory-operation-limit:
+
+**memory.operation_limit**
+   | *Default:* ``0``
+   | *Modifiable:* ``yes``
+
+This is an experimental expert setting defining the maximal amount of memory in
+bytes that an individual operation can consume before triggering an error.
+
+``0`` means unlimited. In that case only the global circuit breaker limits
+apply.
+
+There is no 1:1 mapping from SQL statement to operation. Some SQL statements
+have no corresponding operation. Other SQL statements can have more than one
+operation. You can use the :ref:`sys.operations <sys-operations>` view to get
+some insights, but keep in mind that both, operations which are used to execute
+a query, and their name could change with any release, including hotfix
+releases.
+
 .. _conf-session-enable-hashjoin:
 
 **enable_hashjoin**

--- a/libs/dex/src/main/java/io/crate/data/breaker/BlockBasedRamAccounting.java
+++ b/libs/dex/src/main/java/io/crate/data/breaker/BlockBasedRamAccounting.java
@@ -23,8 +23,6 @@ package io.crate.data.breaker;
 
 import java.util.function.LongConsumer;
 
-import io.crate.data.breaker.RamAccounting;
-
 /**
  * A RamAccounting implementation that reserves blocks of memory up-front.
  * This implementation should be used from a single thread only.

--- a/server/src/main/java/io/crate/analyze/relations/StatementAnalysisContext.java
+++ b/server/src/main/java/io/crate/analyze/relations/StatementAnalysisContext.java
@@ -117,7 +117,8 @@ public class StatementAnalysisContext {
                     searchPath,
                     sessionSettings.hashJoinsEnabled(),
                     sessionSettings.excludedOptimizerRules(),
-                    sessionSettings.errorOnUnknownObjectKey()
+                    sessionSettings.errorOnUnknownObjectKey(),
+                    sessionSettings.memoryLimitInBytes()
                 )),
             parentOutputColumns
         );

--- a/server/src/main/java/io/crate/execution/engine/collect/stats/RamAccountingQueue.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/stats/RamAccountingQueue.java
@@ -21,19 +21,19 @@
 
 package io.crate.execution.engine.collect.stats;
 
-import io.crate.breaker.ConcurrentRamAccounting;
-import io.crate.data.breaker.RamAccounting;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Queue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.ToLongFunction;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.Queue;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.ToLongFunction;
+import io.crate.breaker.ConcurrentRamAccounting;
+import io.crate.data.breaker.RamAccounting;
 
 public final class RamAccountingQueue<T> implements Queue<T> {
 
@@ -52,7 +52,9 @@ public final class RamAccountingQueue<T> implements Queue<T> {
         // create a non-breaking (thread-safe) instance as this component will check the breaker limits by itself
         this.ramAccounting = new ConcurrentRamAccounting(
             breaker::addWithoutBreaking,
-            bytes -> breaker.addWithoutBreaking(- bytes)
+            bytes -> breaker.addWithoutBreaking(- bytes),
+            breaker.getName(),
+            0
         );
         this.exceeded = new AtomicBoolean(false);
     }

--- a/server/src/main/java/io/crate/metadata/settings/CoordinatorSessionSettings.java
+++ b/server/src/main/java/io/crate/metadata/settings/CoordinatorSessionSettings.java
@@ -49,11 +49,19 @@ public class CoordinatorSessionSettings extends SessionSettings {
     private TimeValue statementTimeout;
 
     public CoordinatorSessionSettings(User authenticatedUser, String ... searchPath) {
-        this(authenticatedUser, authenticatedUser, SearchPath.createSearchPathFrom(searchPath), true, Set.of(), true);
+        this(authenticatedUser, authenticatedUser, searchPath);
     }
 
     public CoordinatorSessionSettings(User authenticatedUser, User sessionUser, String ... searchPath) {
-        this(authenticatedUser, sessionUser, SearchPath.createSearchPathFrom(searchPath), true, Set.of(), true);
+        this(
+            authenticatedUser,
+            sessionUser,
+            SearchPath.createSearchPathFrom(searchPath),
+            true,
+            Set.of(),
+            true,
+            0
+        );
     }
 
     public CoordinatorSessionSettings(User authenticatedUser,
@@ -61,13 +69,15 @@ public class CoordinatorSessionSettings extends SessionSettings {
                                       SearchPath searchPath,
                                       boolean hashJoinsEnabled,
                                       Set<Class<? extends Rule<?>>> excludedOptimizerRules,
-                                      boolean errorOnUnknownObjectKey) {
-        super(authenticatedUser.name(), searchPath, hashJoinsEnabled, errorOnUnknownObjectKey);
+                                      boolean errorOnUnknownObjectKey,
+                                      int memoryLimit) {
+        super(authenticatedUser.name(), searchPath, hashJoinsEnabled, errorOnUnknownObjectKey, memoryLimit);
         this.authenticatedUser = authenticatedUser;
         this.sessionUser = sessionUser;
         this.excludedOptimizerRules = new HashSet<>(excludedOptimizerRules);
         this.dateStyle = DEFAULT_DATE_STYLE;
         this.statementTimeout = TimeValue.ZERO;
+        this.memoryLimit = memoryLimit;
     }
 
     public User sessionUser() {
@@ -131,5 +141,9 @@ public class CoordinatorSessionSettings extends SessionSettings {
 
     public void statementTimeout(TimeValue statementTimeout) {
         this.statementTimeout = statementTimeout;
+    }
+
+    public void memoryLimit(int memoryLimit) {
+        this.memoryLimit = memoryLimit;
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -431,6 +431,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
         AnalyzerSettings.CUSTOM_ANALYSIS_SETTING_GROUP,
         Sessions.NODE_READ_ONLY_SETTING,
         Sessions.STATEMENT_TIMEOUT,
+        Sessions.MEMORY_LIMIT,
         PostgresNetty.PSQL_ENABLED_SETTING,
         PostgresNetty.PSQL_PORT_SETTING,
         AuthSettings.AUTH_HOST_BASED_ENABLED_SETTING,

--- a/server/src/test/java/io/crate/breaker/ConcurrentRamAccountingTest.java
+++ b/server/src/test/java/io/crate/breaker/ConcurrentRamAccountingTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.breaker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.junit.jupiter.api.Test;
+
+public class ConcurrentRamAccountingTest {
+
+    @Test
+    void test_raises_circuit_breaking_exception_if_limit_is_exceeded() {
+        AtomicLong usedBytes = new AtomicLong();
+        var ramAccounting = new ConcurrentRamAccounting(usedBytes::addAndGet, ignore -> {}, "dummy", 20);
+        ramAccounting.addBytes(19);
+        assertThatThrownBy(() -> ramAccounting.addBytes(5))
+            .isExactlyInstanceOf(CircuitBreakingException.class)
+            .hasMessage("\"dummy\" reached operation memory limit. Used: 24b, Limit: 20b");
+
+        assertThat(usedBytes).as("value is not reserved if above limit").hasValue(19);
+        assertThat(ramAccounting.totalBytes()).isEqualTo(19);
+    }
+}
+

--- a/server/src/test/java/io/crate/breaker/RowAccountingWithEstimatorsTest.java
+++ b/server/src/test/java/io/crate/breaker/RowAccountingWithEstimatorsTest.java
@@ -48,7 +48,8 @@ public class RowAccountingWithEstimatorsTest extends ESTestCase {
                 new MemoryCircuitBreaker(
                     new ByteSizeValue(10, ByteSizeUnit.BYTES),
                     1.01,
-                    LogManager.getLogger(RowAccountingWithEstimatorsTest.class))
+                    LogManager.getLogger(RowAccountingWithEstimatorsTest.class)),
+                0
             ));
 
         assertThatThrownBy(() -> RowGenerator.range(0, 3).forEach(rowAccounting::accountForAndMaybeBreak))
@@ -62,7 +63,8 @@ public class RowAccountingWithEstimatorsTest extends ESTestCase {
             ConcurrentRamAccounting.forCircuitBreaker(
                 "test",
                 new MemoryCircuitBreaker(
-                    new ByteSizeValue(10, ByteSizeUnit.BYTES), 1.01, LogManager.getLogger(RowAccountingWithEstimatorsTest.class))
+                    new ByteSizeValue(10, ByteSizeUnit.BYTES), 1.01, LogManager.getLogger(RowAccountingWithEstimatorsTest.class)),
+                0
             ), 0);
 
         assertThatThrownBy(
@@ -77,7 +79,8 @@ public class RowAccountingWithEstimatorsTest extends ESTestCase {
             ConcurrentRamAccounting.forCircuitBreaker(
                 "test",
                 new MemoryCircuitBreaker(
-                    new ByteSizeValue(10, ByteSizeUnit.BYTES), 1.01, LogManager.getLogger(RowAccountingWithEstimatorsTest.class))
+                    new ByteSizeValue(10, ByteSizeUnit.BYTES), 1.01, LogManager.getLogger(RowAccountingWithEstimatorsTest.class)),
+                0
             ),
             2);
 

--- a/server/src/test/java/io/crate/execution/engine/distribution/merge/RamAccountingPageIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/distribution/merge/RamAccountingPageIteratorTest.java
@@ -149,7 +149,9 @@ public class RamAccountingPageIteratorTest extends ESTestCase {
                     new MemoryCircuitBreaker(
                         new ByteSizeValue(197, ByteSizeUnit.BYTES),
                         1,
-                        LogManager.getLogger(RowAccountingWithEstimatorsTest.class)))));
+                        LogManager.getLogger(RowAccountingWithEstimatorsTest.class)), 0
+                )
+            ));
         assertThatThrownBy(() -> pagingIterator.merge(Arrays.asList(
                 new KeyIterable<>(0, Collections.singletonList(TEST_ROWS[0])),
                 new KeyIterable<>(1, Collections.singletonList(TEST_ROWS[1])))))

--- a/server/src/test/java/io/crate/execution/engine/fetch/FetchTaskTest.java
+++ b/server/src/test/java/io/crate/execution/engine/fetch/FetchTaskTest.java
@@ -21,8 +21,8 @@
 
 package io.crate.execution.engine.fetch;
 
-import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.createReference;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
@@ -74,6 +74,7 @@ public class FetchTaskTest extends CrateDummyClusterServiceUnitTest {
                 new TreeMap<>(),
                 new HashMap<>(),
                 List.of()),
+            0,
             "dummy",
             new SharedShardContexts(mock(IndicesService.class), UnaryOperator.identity()),
             clusterService.state().metadata(),
@@ -122,6 +123,7 @@ public class FetchTaskTest extends CrateDummyClusterServiceUnitTest {
                 ibb.build(),
                 tableIndices,
                 List.of(createReference("i1", new ColumnIdent("x"), DataTypes.STRING))),
+            0,
             "dummy",
             sharedShardContexts,
             metadata,

--- a/server/src/test/java/io/crate/execution/engine/fetch/NodeFetchResponseTest.java
+++ b/server/src/test/java/io/crate/execution/engine/fetch/NodeFetchResponseTest.java
@@ -99,7 +99,10 @@ public class NodeFetchResponseTest extends ESTestCase {
                 new MemoryCircuitBreaker(
                     new ByteSizeValue(2, ByteSizeUnit.BYTES),
                     1.0,
-                    LogManager.getLogger(NodeFetchResponseTest.class))));
+                    LogManager.getLogger(NodeFetchResponseTest.class)),
+                0
+            )
+        );
 
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/sort/SortingLimitAndOffsetProjectorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/sort/SortingLimitAndOffsetProjectorTest.java
@@ -136,7 +136,7 @@ public class SortingLimitAndOffsetProjectorTest extends ESTestCase {
         RowCellsAccountingWithEstimators rowAccounting =
             new RowCellsAccountingWithEstimators(
                 List.of(DataTypes.INTEGER, DataTypes.BOOLEAN),
-                ConcurrentRamAccounting.forCircuitBreaker("testContext", circuitBreaker),
+                ConcurrentRamAccounting.forCircuitBreaker("testContext", circuitBreaker, 0),
                 0);
 
         Projector projector = getProjector(rowAccounting, 1, 100_000, LimitAndOffset.NO_OFFSET, FIRST_CELL_ORDERING);

--- a/server/src/test/java/io/crate/execution/engine/sort/SortingProjectorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/sort/SortingProjectorTest.java
@@ -115,7 +115,7 @@ public class SortingProjectorTest extends ESTestCase {
         RowCellsAccountingWithEstimators rowAccounting =
             new RowCellsAccountingWithEstimators(
                 List.of(DataTypes.INTEGER, DataTypes.BOOLEAN),
-                ConcurrentRamAccounting.forCircuitBreaker("testContext", circuitBreaker),
+                ConcurrentRamAccounting.forCircuitBreaker("testContext", circuitBreaker, 0),
                 0);
 
         Projector projector = createProjector(rowAccounting, 1, 0);

--- a/server/src/test/java/io/crate/execution/engine/window/WindowBatchIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/window/WindowBatchIteratorTest.java
@@ -341,7 +341,7 @@ public class WindowBatchIteratorTest {
 
     @Test
     public void testWindowBatchIteratorAccountsUsedMemory() {
-        RamAccounting ramAccounting = ConcurrentRamAccounting.forCircuitBreaker("test", new NoopCircuitBreaker("dummy"));
+        RamAccounting ramAccounting = ConcurrentRamAccounting.forCircuitBreaker("test", new NoopCircuitBreaker("dummy"), 0);
         BatchIterator<Row> iterator = WindowFunctionBatchIterator.of(
             TestingBatchIterators.range(0, 10),
             new RowAccountingWithEstimators(List.of(DataTypes.INTEGER), ramAccounting, 32),

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -562,7 +562,7 @@ public class InformationSchemaTest extends IntegTestCase {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertThat(response.rowCount()).isEqualTo(959);
+        assertThat(response.rowCount()).isEqualTo(960);
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -163,6 +163,7 @@ public class PgCatalogITest extends IntegTestCase {
             "enable_hashjoin| false| Considers using the Hash Join instead of the Nested Loop Join implementation.| NULL| NULL",
             "error_on_unknown_object_key| true| Raises or suppresses ObjectKeyUnknownException when querying nonexistent keys to dynamic objects.| NULL| NULL",
             "max_index_keys| 32| Shows the maximum number of index keys.| NULL| NULL",
+            "memory.operation_limit| 0| Memory limit in bytes for an individual operation. 0 by-passes the operation limit, relying entirely on the global circuit breaker limits| NULL| NULL",
             "optimizer_deduplicate_order| true| Indicates if the optimizer rule DeduplicateOrder is activated.| NULL| NULL",
             "optimizer_merge_aggregate_and_collect_to_count| true| Indicates if the optimizer rule MergeAggregateAndCollectToCount is activated.| NULL| NULL",
             "optimizer_merge_aggregate_rename_and_collect_to_count| true| Indicates if the optimizer rule MergeAggregateRenameAndCollectToCount is activated.| NULL| NULL",

--- a/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
@@ -404,6 +404,7 @@ public class ShowIntegrationTest extends IntegTestCase {
             "enable_hashjoin| true| Considers using the Hash Join instead of the Nested Loop Join implementation.",
             "error_on_unknown_object_key| true| Raises or suppresses ObjectKeyUnknownException when querying nonexistent keys to dynamic objects.",
             "max_index_keys| 32| Shows the maximum number of index keys.",
+            "memory.operation_limit| 0| Memory limit in bytes for an individual operation. 0 by-passes the operation limit, relying entirely on the global circuit breaker limits",
             "optimizer_deduplicate_order| true| Indicates if the optimizer rule DeduplicateOrder is activated.",
             "optimizer_merge_aggregate_and_collect_to_count| true| Indicates if the optimizer rule MergeAggregateAndCollectToCount is activated.",
             "optimizer_merge_aggregate_rename_and_collect_to_count| true| Indicates if the optimizer rule MergeAggregateRenameAndCollectToCount is activated.",

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -2198,4 +2198,16 @@ public class TransportSQLActionTest extends IntegTestCase {
             .toList();
         assertThat(sorted).containsExactlyElementsOf(resultOrder);
     }
+
+    @Test
+    public void test_operation_limit_cancels_query_if_using_too_much_memory() throws Exception {
+        try (var session = sqlExecutor.newSession()) {
+            execute("set session memory.operation_limit = 2", session);
+            assertThat(session.sessionSettings().memoryLimitInBytes()).isEqualTo(2);
+
+            Asserts.assertSQLError(() -> execute("select distinct name from sys.nodes", session))
+                .hasMessageContaining("\"collect: 0\" reached operation memory limit.")
+                .hasMessageEndingWith("Limit: 2b");
+        }
+    }
 }

--- a/server/src/test/java/io/crate/metadata/settings/SessionSettingsTest.java
+++ b/server/src/test/java/io/crate/metadata/settings/SessionSettingsTest.java
@@ -21,7 +21,8 @@
 
 package io.crate.metadata.settings;
 
-import static org.junit.Assert.assertEquals;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 
@@ -35,24 +36,24 @@ public class SessionSettingsTest {
 
     @Test
     public void testSessionSettingsStreaming() throws IOException {
-        SessionSettings s1 = new SessionSettings("user", SearchPath.createSearchPathFrom("crate"), true, false);
+        SessionSettings s1 = new SessionSettings("user", SearchPath.createSearchPathFrom("crate"), true, false, 20);
         BytesStreamOutput out = new BytesStreamOutput();
         s1.writeTo(out);
 
         SessionSettings s2 = new SessionSettings(out.bytes().streamInput());
-        assertEquals(s1, s2);
+        assertThat(s1).isEqualTo(s2);
     }
 
     @Test
     public void testSessionSettingsStreamingFrom4_6_0() throws IOException {
-        SessionSettings s1 = new SessionSettings("user", SearchPath.createSearchPathFrom("crate"), true, false);
+        SessionSettings s1 = new SessionSettings("user", SearchPath.createSearchPathFrom("crate"), true, false, 10);
         BytesStreamOutput out = new BytesStreamOutput();
         out.setVersion(Version.V_4_6_0);
         s1.writeTo(out);
         var in = out.bytes().streamInput();
         in.setVersion(Version.V_4_6_0);
         SessionSettings actual = new SessionSettings(in);
-        SessionSettings expected = new SessionSettings("user", SearchPath.createSearchPathFrom("crate"), true, true);
-        assertEquals(expected, actual);
+        SessionSettings expected = new SessionSettings("user", SearchPath.createSearchPathFrom("crate"), true, true, 0);
+        assertThat(actual).isEqualTo(expected);
     }
 }

--- a/server/src/test/java/io/crate/planner/optimizer/OptimizerRuleSessionSettingProviderTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/OptimizerRuleSessionSettingProviderTest.java
@@ -68,7 +68,8 @@ public class OptimizerRuleSessionSettingProviderTest {
             searchPath,
             true,
             Set.of(MergeFilters.class),
-            true
+            true,
+            0
         );
 
         assertThat(sessionSetting.getValue(mergefilterSettings), is("false"));

--- a/server/src/test/java/io/crate/planner/optimizer/OptimizerTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/OptimizerTest.java
@@ -45,7 +45,8 @@ public class OptimizerTest {
             SearchPath.pathWithPGCatalogAndDoc(),
             true,
             Set.of(MergeFilters.class),
-            true
+            true,
+            0
         );
 
         List<Rule<?>> rules = Optimizer.removeExcludedRules(List.of(new MergeFilters()),


### PR DESCRIPTION
Adds a new memory limit which is (currently) applied on a per phase level.

Extends `ConcurrentRamAccounting` because it is typically used between a
`CircuitBreaker` and one or more `BlockBasedRamAccounting` instances.

Closes https://github.com/crate/crate/issues/13956
