### PR TITLE
Adjust version number in ViewMetadata serialization

### DIFF
--- a/server/src/main/java/io/crate/metadata/view/ViewMetadata.java
+++ b/server/src/main/java/io/crate/metadata/view/ViewMetadata.java
@@ -41,7 +41,7 @@ public record ViewMetadata(
         String owner = in.readOptionalString();
         SearchPath searchPath;
         Version version = in.getVersion();
-        if (version.onOrAfter(Version.V_5_3_4) && !version.equals(Version.V_5_4_0)) {
+        if (version.onOrAfter(Version.V_5_3_5) && !version.equals(Version.V_5_4_0)) {
             searchPath = SearchPath.createSearchPathFrom(in);
         } else {
             searchPath = SearchPath.pathWithPGCatalogAndDoc();
@@ -54,7 +54,7 @@ public record ViewMetadata(
         out.writeString(stmt);
         out.writeOptionalString(owner);
         Version version = out.getVersion();
-        if (version.onOrAfter(Version.V_5_3_4) && !version.equals(Version.V_5_4_0)) {
+        if (version.onOrAfter(Version.V_5_3_5) && !version.equals(Version.V_5_4_0)) {
             searchPath.writeTo(out);
         }
     }

--- a/server/src/test/java/io/crate/metadata/view/ViewMetadataTest.java
+++ b/server/src/test/java/io/crate/metadata/view/ViewMetadataTest.java
@@ -50,6 +50,16 @@ public class ViewMetadataTest {
             assertThat(fromStream.owner()).isEqualTo(viewMetadata.owner());
         }
         try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.setVersion(Version.V_5_3_4);
+            viewMetadata.writeTo(out);
+            StreamInput in = out.bytes().streamInput();
+            in.setVersion(Version.V_5_3_4);
+            ViewMetadata fromStream = ViewMetadata.of(in);
+            assertThat(fromStream.searchPath()).isEqualTo(SearchPath.pathWithPGCatalogAndDoc());
+            assertThat(fromStream.stmt()).isEqualTo(viewMetadata.stmt());
+            assertThat(fromStream.owner()).isEqualTo(viewMetadata.owner());
+        }
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
             out.setVersion(Version.V_5_4_1);
             viewMetadata.writeTo(out);
             StreamInput in = out.bytes().streamInput();


### PR DESCRIPTION
5.3.5 had the search path change, not 5.3.4


I'll apply this change directly in the backport PRs for the previous commit