### PR TITLE
Fix LIKE operators to fall back to generic query if not indexed

### DIFF
--- a/docs/appendices/release-notes/5.4.1.rst
+++ b/docs/appendices/release-notes/5.4.1.rst
@@ -116,6 +116,16 @@ Fixes
 - Fixed an issue that caused ``LIKE``/``ILIKE`` operators on ``INDEX OFF``
   columns to return empty results.
 
+- Fixed an issue that caused ``LIKE ANY``/``ILIKE ANY`` operators to accept
+  only left arguments as patterns. Both arguments can now be patterns, e.g. ::
+
+    SELECT 'a' LIKE ANY(['a%']);
+    +-------+
+    | false |
+    +-------+
+    | FALSE | -- true will be returned after the fix
+    +-------+
+
 - Fixed an issue which caused ``INSERT INTO ... SELECT ...`` statements to
   leave behind empty partitions if ``NULL`` or ``CHECK`` constraint on
   partitioned by column failed.

--- a/docs/appendices/release-notes/5.4.1.rst
+++ b/docs/appendices/release-notes/5.4.1.rst
@@ -113,6 +113,9 @@ Fixes
 - Fixed an issue which caused arrays in ``IGNORED`` objects to be converted to
   nulls.
 
+- Fixed an issue that caused ``LIKE``/``ILIKE`` operators on ``INDEX OFF``
+  columns to return empty results.
+
 - Fixed an issue which caused ``INSERT INTO ... SELECT ...`` statements to
   leave behind empty partitions if ``NULL`` or ``CHECK`` constraint on
   partitioned by column failed.

--- a/docs/general/dql/selects.rst
+++ b/docs/general/dql/selects.rst
@@ -563,6 +563,23 @@ operator::
     +---------------------+------------------------------+
     SELECT 1 row in set (... sec)
 
+For ``LIKE ANY`` operators, the patterns can be provided on either sides::
+
+    cr> select name from locations where name ILIKE ANY(['al%', 'ar%']) order
+    ... by name asc;
+    +---------------------+
+    | name                |
+    +---------------------+
+    | Aldebaran           |
+    | Algol               |
+    | Allosimanius Syneca |
+    | Alpha Centauri      |
+    | Altair              |
+    | Argabuthon          |
+    | Arkintoofle Minor   |
+    +---------------------+
+    SELECT 7 rows in set (... sec)
+
 This query passes a literal array value to the ``ANY`` operator::
 
     cr> select name, inhabitants['interests'] from locations

--- a/server/src/main/java/io/crate/expression/operator/LikeOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/LikeOperator.java
@@ -30,6 +30,7 @@ import io.crate.data.Input;
 import io.crate.expression.operator.LikeOperators.CaseSensitivity;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.IndexType;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
 import io.crate.metadata.Scalar;
@@ -96,7 +97,7 @@ public class LikeOperator extends Operator<String> {
         Object value = literal.value();
         assert value instanceof String
             : "LikeOperator is registered for string types. Value must be a string";
-        return caseSensitivity.likeQuery(ref.column().fqn(), (String) value);
+        return caseSensitivity.likeQuery(ref.column().fqn(), (String) value, ref.indexType() != IndexType.NONE);
     }
 
     private static class CompiledLike extends Scalar<Boolean, String> {

--- a/server/src/main/java/io/crate/expression/operator/any/AnyLikeOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/any/AnyLikeOperator.java
@@ -57,7 +57,9 @@ public final class AnyLikeOperator extends AnyOperator {
 
     @Override
     boolean matches(Object probe, Object candidate) {
-        return LikeOperators.matches((String) candidate, (String) probe, caseSensitivity);
+        // Accept both sides of arguments to be patterns
+        return LikeOperators.matches((String) probe, (String) candidate, caseSensitivity) ||
+               LikeOperators.matches((String) candidate, (String) probe, caseSensitivity);
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/operator/any/AnyNotLikeOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/any/AnyNotLikeOperator.java
@@ -56,7 +56,9 @@ public final class AnyNotLikeOperator extends AnyOperator {
 
     @Override
     boolean matches(Object probe, Object candidate) {
-        return !LikeOperators.matches((String) candidate, (String) probe, caseSensitivity);
+        // Accept both sides of arguments to be patterns
+        return !LikeOperators.matches((String) probe, (String) candidate, caseSensitivity) &&
+               !LikeOperators.matches((String) candidate, (String) probe, caseSensitivity);
     }
 
     @Override

--- a/server/src/test/java/io/crate/expression/operator/any/AnyLikeOperatorTest.java
+++ b/server/src/test/java/io/crate/expression/operator/any/AnyLikeOperatorTest.java
@@ -123,4 +123,14 @@ public class AnyLikeOperatorTest extends ScalarTestCase {
         assertEvaluate("not 'A' like any (['A', 'B'])", false);
         assertEvaluate("not 'A' ilike any (['a', 'b'])", false);
     }
+
+    @Test
+    public void test_patterns_on_right_arg() {
+        assertNormalize("'foobar' like any (['%bar'])", isLiteral(true));
+        assertNormalize("'bar' like any (['_ar'])", isLiteral(true));
+        assertNormalize("'foobar' like any (['%o_a%'])", isLiteral(true));
+        assertNormalize("'fOobAR' ilike any (['%BaR'])", isLiteral(true));
+        assertNormalize("'BaR' ilike any (['_ar'])", isLiteral(true));
+        assertNormalize("'foobar' ilike any (['%O_a%'])", isLiteral(true));
+    }
 }

--- a/server/src/test/java/io/crate/expression/operator/any/AnyNotLikeOperatorTest.java
+++ b/server/src/test/java/io/crate/expression/operator/any/AnyNotLikeOperatorTest.java
@@ -131,4 +131,14 @@ public class AnyNotLikeOperatorTest extends ScalarTestCase {
         assertEvaluate("not 'A' not like any (['A', 'B'])", false);
         assertEvaluate("not 'A' not ilike any (['a', 'B'])", false);
     }
+
+    @Test
+    public void test_patterns_on_right_arg() {
+        assertNormalize("'foobar' not like any (['%barr'])", isLiteral(true));
+        assertNormalize("'bar' not like any (['_ar'])", isLiteral(false));
+        assertNormalize("'foobar' not like any (['%o_a%'])", isLiteral(false));
+        assertNormalize("'fOobAR' not ilike any (['%BaR'])", isLiteral(false));
+        assertNormalize("'BaR' not ilike any (['z_ar'])", isLiteral(true));
+        assertNormalize("'foobar' not ilike any (['%O_a%'])", isLiteral(false));
+    }
 }

--- a/server/src/test/java/io/crate/lucene/LikeQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/LikeQueryBuilderTest.java
@@ -131,4 +131,18 @@ public class LikeQueryBuilderTest extends LuceneQueryBuilderTest {
         assertThat(query).hasToString("(text_no_index ILIKE '%abc%')");
         assertThat(query).isExactlyInstanceOf(GenericFunctionQuery.class);
     }
+
+    @Test
+    public void test_not_like_any_on_index_off_column_falls_back_to_generic_query() {
+        Query query = convert("text_no_index not LIKE any(['%abc%'])");
+        assertThat(query).hasToString("(text_no_index NOT LIKE ANY(['%abc%']))");
+        assertThat(query).isExactlyInstanceOf(GenericFunctionQuery.class);
+    }
+
+    @Test
+    public void test_ilike_any_on_index_off_column_falls_back_to_generic_query() {
+        Query query = convert("text_no_index ILIKE any(['%abc%'])");
+        assertThat(query).hasToString("(text_no_index ILIKE ANY(['%abc%']))");
+        assertThat(query).isExactlyInstanceOf(GenericFunctionQuery.class);
+    }
 }

--- a/server/src/test/java/io/crate/lucene/LikeQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/LikeQueryBuilderTest.java
@@ -117,4 +117,18 @@ public class LikeQueryBuilderTest extends LuceneQueryBuilderTest {
         assertThat(query).hasToString("vchar_name:Trillian*");
         assertThat(query).isExactlyInstanceOf(WildcardQuery.class);
     }
+
+    @Test
+    public void test_like_on_index_off_column_falls_back_to_generic_query() {
+        Query query = convert("text_no_index LIKE '%abc%'");
+        assertThat(query).hasToString("(text_no_index LIKE '%abc%')");
+        assertThat(query).isExactlyInstanceOf(GenericFunctionQuery.class);
+    }
+
+    @Test
+    public void test_ilike_on_index_off_column_falls_back_to_generic_query() {
+        Query query = convert("text_no_index ILIKE '%abc%'");
+        assertThat(query).hasToString("(text_no_index ILIKE '%abc%')");
+        assertThat(query).isExactlyInstanceOf(GenericFunctionQuery.class);
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Reported [here](https://github.com/crate/crate/issues/14407#issuecomment-1652053328).
Please see the commit for details.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
