### PR TITLE
Add planner/execution support for DROP COLUMN

### DIFF
--- a/server/src/main/java/io/crate/analyze/AlterTableDropColumnAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/AlterTableDropColumnAnalyzer.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import io.crate.analyze.AnalyzedAlterTableDropColumn.DropColumn;
 import io.crate.analyze.expressions.ExpressionAnalysisContext;
 import io.crate.analyze.expressions.ExpressionAnalyzer;
 import io.crate.analyze.relations.DocTableRelation;
@@ -40,7 +41,7 @@ import io.crate.metadata.table.Operation;
 import io.crate.sql.tree.AlterTableDropColumn;
 import io.crate.sql.tree.Expression;
 
-class AlterTableDropColumnAnalyzer {
+public class AlterTableDropColumnAnalyzer {
 
     private final Schemas schemas;
     private final NodeContext nodeCtx;
@@ -71,41 +72,31 @@ class AlterTableDropColumnAnalyzer {
             null
         );
         var expressionContext = new ExpressionAnalysisContext(txnCtx.sessionSettings());
-        List<Reference> dropColumns = new ArrayList<>(alterTable.tableElements().size());
+        List<DropColumn> dropColumns = new ArrayList<>(alterTable.tableElements().size());
 
         for (var dropColumnDefinition : alterTable.tableElements()) {
             Expression name = dropColumnDefinition.name();
             try {
-                dropColumns.add((Reference) expressionAnalyzer.convert(name, expressionContext));
+                var colRefToDrop = (Reference) expressionAnalyzer.convert(name, expressionContext);
+                dropColumns.add(new DropColumn(colRefToDrop, dropColumnDefinition.ifExists()));
             } catch (ColumnUnknownException e) {
                 if (dropColumnDefinition.ifExists() == false) {
                     throw e;
                 }
             }
         }
-        validate(tableInfo, dropColumns);
+        dropColumns = validateDynamic(tableInfo, dropColumns);
+        validateStatic(tableInfo, dropColumns);
 
         return new AnalyzedAlterTableDropColumn(tableInfo, dropColumns);
     }
 
-    private static void validate(DocTableInfo tableInfo, List<Reference> dropColumns) {
-        var generatedColRefs = new HashSet<>();
-        for (var genRef : tableInfo.generatedColumns()) {
-            generatedColRefs.addAll(genRef.referencedReferences());
-        }
-        var leftOverCols = tableInfo.columns().stream().map(Reference::column).collect(Collectors.toSet());
-
+    /** Validate restrictions based on properties that cannot change */
+    private static void validateStatic(DocTableInfo tableInfo, List<DropColumn> dropColumns) {
         for (int i = 0 ; i < dropColumns.size(); i++) {
-            var refToDrop = dropColumns.get(i);
+            var refToDrop = dropColumns.get(i).ref();
             var colToDrop = refToDrop.column();
 
-            for (var indexRef : tableInfo.indexColumns()) {
-                if (indexRef.columns().contains(refToDrop)) {
-                    throw new UnsupportedOperationException("Dropping column: " + colToDrop.sqlFqn() + " which " +
-                                                            "is part of INDEX: " + indexRef.toString() +
-                                                            " is not allowed");
-                }
-            }
             if (tableInfo.primaryKey().contains(colToDrop)) {
                 throw new UnsupportedOperationException("Dropping column: " + colToDrop.sqlFqn() + " which " +
                                                         "is part of the PRIMARY KEY is not allowed");
@@ -120,6 +111,28 @@ class AlterTableDropColumnAnalyzer {
                 throw new UnsupportedOperationException("Dropping column: " + colToDrop.sqlFqn() + " which " +
                                                         "is part of the 'PARTITIONED BY' columns is not allowed");
             }
+        }
+    }
+
+    /** Validate restrictions based on properties that change and need to be rechecked during execution*/
+    public static List<DropColumn> validateDynamic(DocTableInfo tableInfo, List<DropColumn> dropColumns) {
+        var generatedColRefs = new HashSet<>();
+        for (var genRef : tableInfo.generatedColumns()) {
+            generatedColRefs.addAll(genRef.referencedReferences());
+        }
+        var leftOverCols = tableInfo.columns().stream().map(Reference::column).collect(Collectors.toSet());
+        ArrayList<DropColumn> validatedDropCols = new ArrayList<>(dropColumns.size());
+
+        for (int i = 0 ; i < dropColumns.size(); i++) {
+            var refToDrop = dropColumns.get(i).ref();
+            var colToDrop = refToDrop.column();
+
+            for (var indexRef : tableInfo.indexColumns()) {
+                if (indexRef.columns().contains(refToDrop)) {
+                    throw new UnsupportedOperationException("Dropping column: " + colToDrop.sqlFqn() + " which " +
+                                                            "is part of INDEX: " + indexRef + " is not allowed");
+                }
+            }
 
             if (generatedColRefs.contains(refToDrop)) {
                 throw new UnsupportedOperationException(
@@ -127,10 +140,12 @@ class AlterTableDropColumnAnalyzer {
                     "generated column is not allowed");
             }
             leftOverCols.remove(colToDrop);
+            validatedDropCols.add(new DropColumn(refToDrop, dropColumns.get(i).ifExists()));
         }
 
         if (leftOverCols.isEmpty()) {
             throw new UnsupportedOperationException("Dropping all columns of a table is not allowed");
         }
+        return validatedDropCols;
     }
 }

--- a/server/src/main/java/io/crate/analyze/relations/NameFieldProvider.java
+++ b/server/src/main/java/io/crate/analyze/relations/NameFieldProvider.java
@@ -21,15 +21,16 @@
 
 package io.crate.analyze.relations;
 
+import java.util.List;
+import java.util.Locale;
+
+import org.jetbrains.annotations.Nullable;
+
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.table.Operation;
 import io.crate.sql.tree.QualifiedName;
-
-import org.jetbrains.annotations.Nullable;
-import java.util.List;
-import java.util.Locale;
 
 /**
  * Resolves QualifiedNames to Fields considering only one AnalyzedRelation

--- a/server/src/main/java/io/crate/execution/TransportExecutorModule.java
+++ b/server/src/main/java/io/crate/execution/TransportExecutorModule.java
@@ -30,6 +30,7 @@ import io.crate.execution.ddl.tables.TransportAddColumnAction;
 import io.crate.execution.ddl.tables.TransportAlterTableAction;
 import io.crate.execution.ddl.tables.TransportCloseTable;
 import io.crate.execution.ddl.tables.TransportCreateTableAction;
+import io.crate.execution.ddl.tables.TransportDropColumnAction;
 import io.crate.execution.ddl.tables.TransportDropConstraintAction;
 import io.crate.execution.ddl.tables.TransportDropTableAction;
 import io.crate.execution.ddl.tables.TransportOpenCloseTableOrPartitionAction;
@@ -68,6 +69,7 @@ public class TransportExecutorModule extends AbstractModule {
         bind(TransportAlterTableAction.class).asEagerSingleton();
         bind(TransportDropConstraintAction.class).asEagerSingleton();
         bind(TransportAddColumnAction.class).asEagerSingleton();
+        bind(TransportDropColumnAction.class).asEagerSingleton();
         bind(TransportAnalyzeAction.class).asEagerSingleton();
 
         bind(TransportCreatePublicationAction.class).asEagerSingleton();

--- a/server/src/main/java/io/crate/execution/ddl/tables/AlterTableOperation.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/AlterTableOperation.java
@@ -79,6 +79,7 @@ public class AlterTableOperation {
     private final TransportAlterTableAction transportAlterTableAction;
     private final TransportDropConstraintAction transportDropConstraintAction;
     private final TransportAddColumnAction transportAddColumnAction;
+    private final TransportDropColumnAction transportDropColumnAction;
     private final TransportRenameTableAction transportRenameTableAction;
     private final TransportOpenCloseTableOrPartitionAction transportOpenCloseTableOrPartitionAction;
     private final TransportResizeAction transportResizeAction;
@@ -100,6 +101,7 @@ public class AlterTableOperation {
                                TransportAlterTableAction transportAlterTableAction,
                                TransportDropConstraintAction transportDropConstraintAction,
                                TransportAddColumnAction transportAddColumnAction,
+                               TransportDropColumnAction transportDropColumnAction,
                                Sessions sessions,
                                IndexScopedSettings indexScopedSettings,
                                LogicalReplicationService logicalReplicationService) {
@@ -113,6 +115,7 @@ public class AlterTableOperation {
         this.transportCloseTable = transportCloseTable;
         this.transportAlterTableAction = transportAlterTableAction;
         this.transportAddColumnAction = transportAddColumnAction;
+        this.transportDropColumnAction = transportDropColumnAction;
         this.transportDropConstraintAction = transportDropConstraintAction;
         this.sessions = sessions;
         this.indexScopedSettings = indexScopedSettings;
@@ -137,6 +140,10 @@ public class AlterTableOperation {
             });
         }
         return transportAddColumnAction.execute(addColumnRequest).thenApply(resp -> -1L);
+    }
+
+    public CompletableFuture<Long> executeAlterTableDropColumn(DropColumnRequest dropColumnRequest) {
+        return transportDropColumnAction.execute(dropColumnRequest).thenApply(resp -> -1L);
     }
 
     private CompletableFuture<Long> getRowCount(RelationName ident) {

--- a/server/src/main/java/io/crate/execution/ddl/tables/DropColumnRequest.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/DropColumnRequest.java
@@ -21,6 +21,8 @@
 
 package io.crate.execution.ddl.tables;
 
+import static io.crate.analyze.AnalyzedAlterTableDropColumn.DropColumn;
+
 import java.io.IOException;
 import java.util.List;
 
@@ -29,16 +31,15 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.jetbrains.annotations.NotNull;
 
-import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 
 public class DropColumnRequest extends AcknowledgedRequest<DropColumnRequest> {
 
     private final RelationName relationName;
-    private final List<Reference> colsToDrop;
+    private final List<DropColumn> colsToDrop;
 
     public DropColumnRequest(@NotNull RelationName relationName,
-                             @NotNull List<Reference> colsToDrop) {
+                             @NotNull List<DropColumn> colsToDrop) {
         this.relationName = relationName;
         this.colsToDrop = colsToDrop;
     }
@@ -46,14 +47,14 @@ public class DropColumnRequest extends AcknowledgedRequest<DropColumnRequest> {
     public DropColumnRequest(StreamInput in) throws IOException {
         super(in);
         this.relationName = new RelationName(in);
-        this.colsToDrop = in.readList(Reference::fromStream);
+        this.colsToDrop = in.readList(DropColumn::fromStream);
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         relationName.writeTo(out);
-        out.writeCollection(colsToDrop, Reference::toStream);
+        out.writeCollection(colsToDrop, DropColumn::toStream);
     }
 
     @NotNull
@@ -62,7 +63,7 @@ public class DropColumnRequest extends AcknowledgedRequest<DropColumnRequest> {
     }
 
     @NotNull
-    public List<Reference> references() {
+    public List<DropColumn> colsToDrop() {
         return this.colsToDrop;
     }
 }

--- a/server/src/main/java/io/crate/execution/ddl/tables/DropColumnTask.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/DropColumnTask.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.ddl.tables;
+
+import static io.crate.analyze.AnalyzedAlterTableDropColumn.DropColumn;
+import static io.crate.execution.ddl.tables.MappingUtil.createMapping;
+import static io.crate.metadata.cluster.AlterTableClusterStateExecutor.resolveIndices;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
+import org.elasticsearch.cluster.metadata.MappingMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.common.settings.IndexScopedSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.index.mapper.MapperService;
+
+import com.carrotsearch.hppc.IntArrayList;
+
+import io.crate.analyze.AlterTableDropColumnAnalyzer;
+import io.crate.common.CheckedFunction;
+import io.crate.common.collections.Lists2;
+import io.crate.common.collections.Maps;
+import io.crate.exceptions.ColumnUnknownException;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.PartitionName;
+import io.crate.metadata.Reference;
+import io.crate.metadata.cluster.DDLClusterStateHelpers;
+import io.crate.metadata.cluster.DDLClusterStateTaskExecutor;
+import io.crate.metadata.doc.DocTableInfo;
+import io.crate.metadata.doc.DocTableInfoFactory;
+
+public final class DropColumnTask extends DDLClusterStateTaskExecutor<DropColumnRequest> {
+
+    private static final IntArrayList EMPTY_PK_LIST = new IntArrayList();
+
+    private final NodeContext nodeContext;
+    private final CheckedFunction<IndexMetadata, MapperService, IOException> createMapperService;
+
+    public DropColumnTask(NodeContext nodeContext, CheckedFunction<IndexMetadata, MapperService, IOException> createMapperService) {
+        this.nodeContext = nodeContext;
+        this.createMapperService = createMapperService;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public ClusterState execute(ClusterState currentState, DropColumnRequest request) throws Exception {
+        DocTableInfoFactory docTableInfoFactory = new DocTableInfoFactory(nodeContext);
+        DocTableInfo currentTable = docTableInfoFactory.create(request.relationName(), currentState);
+
+        List<DropColumn> normalizedColumns = AlterTableDropColumnAnalyzer.validateDynamic(
+            currentTable, normalizeColumns(request, currentTable));
+
+        if (normalizedColumns.isEmpty()) {
+            return currentState;
+        }
+
+        var refsToDrop = Lists2.map(normalizedColumns,
+                                    dc -> {
+                                        dc.ref().setDropped();
+                                        return dc.ref();
+                                    });
+
+        Metadata.Builder metadataBuilder = Metadata.builder(currentState.metadata());
+        Map<String, Object> mapping = createMapping(
+            MappingUtil.AllocPosition.forTable(currentTable),
+                refsToDrop,
+                EMPTY_PK_LIST,
+                Map.of(),
+                List.of(),
+                null,
+                null,
+                null
+        );
+
+        String templateName = PartitionName.templateName(request.relationName().schema(), request.relationName().name());
+        IndexTemplateMetadata indexTemplateMetadata = currentState.metadata().templates().get(templateName);
+        if (indexTemplateMetadata != null) {
+            // Partitioned table
+            IndexTemplateMetadata newIndexTemplateMetadata = DDLClusterStateHelpers.updateTemplate(
+                indexTemplateMetadata,
+                mapping,
+                Collections.emptyMap(),
+                Settings.EMPTY,
+                IndexScopedSettings.DEFAULT_SCOPED_SETTINGS // Not used if new settings are empty
+            );
+            metadataBuilder.put(newIndexTemplateMetadata);
+        }
+
+        currentState = updateMapping(
+            currentState,
+            metadataBuilder,
+            request.relationName().indexNameOrAlias(),
+            (Map<String, Map<String, Object>>) mapping.get("properties")
+        );
+        // ensure the table can still be parsed into a DocTableInfo to avoid breaking the table.
+        docTableInfoFactory.create(request.relationName(), currentState);
+        return currentState;
+    }
+
+
+    /**
+     * Replace existing references by taking them from the cluster state (so that we get an actual version with assigned OID).
+     * @return NULL if all columns already exist.
+     */
+    static List<DropColumn> normalizeColumns(DropColumnRequest request, DocTableInfo currentTable) {
+        List<DropColumn> dropColumns = new ArrayList<>();
+
+        // Get existing references
+        for (var colToDrop : request.colsToDrop()) {
+            var col = colToDrop.ref().column();
+            Reference ref = currentTable.getReference(col);
+            if (ref == null || ref.isDropped()) {
+                if (colToDrop.ifExists() == false) {
+                    throw new ColumnUnknownException(col, currentTable.ident());
+                }
+            } else {
+                dropColumns.add(new DropColumn(ref, colToDrop.ifExists())); // Actually a column to drop, Get updated reference from the cluster state.
+            }
+        }
+        return dropColumns;
+    }
+
+    private ClusterState updateMapping(ClusterState currentState,
+                                       Metadata.Builder metadataBuilder,
+                                       String indexName,
+                                       Map<String, Map<String, Object>> propertiesMap) throws IOException {
+        Index[] concreteIndices = resolveIndices(currentState, indexName);
+
+        for (Index index : concreteIndices) {
+            final IndexMetadata indexMetadata = currentState.metadata().getIndexSafe(index);
+
+            Map<String, Object> indexMapping = indexMetadata.mapping().sourceAsMap();
+            mergeDeltaIntoExistingMapping(indexMapping, propertiesMap);
+
+            MapperService mapperService = createMapperService.apply(indexMetadata);
+
+            DocumentMapper mapper = mapperService.merge(indexMapping, MapperService.MergeReason.MAPPING_UPDATE);
+
+            IndexMetadata.Builder imBuilder = IndexMetadata.builder(indexMetadata);
+            imBuilder.putMapping(new MappingMetadata(mapper.mappingSource())).mappingVersion(1 + imBuilder.mappingVersion());
+
+            metadataBuilder.put(imBuilder); // implicitly increments metadata version.
+        }
+
+        return ClusterState.builder(currentState).metadata(metadataBuilder).build();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void mergeDeltaIntoExistingMapping(Map<String, Object> existingMapping,
+                                                      Map<String, Map<String, Object>> propertiesMap) {
+
+        Map<String, Object> meta = (Map<String, Object>) existingMapping.get("_meta");
+        if (meta == null) {
+            // existingMapping passed as an empty map in case of partitioned tables as template gets all changes unfiltered.
+            // Create _meta so that we have a base to merge constraints.
+            meta = new HashMap<>();
+            existingMapping.put("_meta", meta);
+        }
+
+        existingMapping.merge(
+            "properties",
+            propertiesMap,
+            (oldMap, newMap) -> {
+                Maps.extendRecursive((Map<String, Object>) oldMap, (Map<String, Object>) newMap);
+                return oldMap;
+            }
+        );
+    }
+}

--- a/server/src/main/java/io/crate/execution/ddl/tables/MappingUtil.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/MappingUtil.java
@@ -203,9 +203,9 @@ public class MappingUtil {
 
     @SuppressWarnings("unchecked")
     public static void mergeConstraints(Map<String, Object> meta,
-                                         List<Reference> references,
-                                         IntArrayList pKeyIndices,
-                                         Map<String, String> checkConstraints) {
+                                        List<Reference> references,
+                                        IntArrayList pKeyIndices,
+                                        Map<String, String> checkConstraints) {
 
         // CHECK
         if (checkConstraints.isEmpty() == false) {

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportDropColumnAction.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportDropColumnAction.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.ddl.tables;
+
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateTaskExecutor;
+import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+import io.crate.execution.ddl.AbstractDDLTransportAction;
+import io.crate.metadata.NodeContext;
+
+@Singleton
+public class TransportDropColumnAction extends AbstractDDLTransportAction<DropColumnRequest, AcknowledgedResponse> {
+
+    private static final String ACTION_NAME = "internal:crate:sql/table/drop_column";
+    private final NodeContext nodeContext;
+    private final IndicesService indicesService;
+
+    @Inject
+    public TransportDropColumnAction(TransportService transportService,
+                                     ClusterService clusterService,
+                                     IndicesService indicesService,
+                                     ThreadPool threadPool,
+                                     NodeContext nodeContext) {
+        super(ACTION_NAME,
+              transportService,
+              clusterService,
+              threadPool,
+              DropColumnRequest::new,
+              AcknowledgedResponse::new,
+              AcknowledgedResponse::new,
+              "drop-column");
+        this.nodeContext = nodeContext;
+        this.indicesService = indicesService;
+    }
+
+    @Override
+    public ClusterStateTaskExecutor<DropColumnRequest> clusterStateTaskExecutor(DropColumnRequest request) {
+        return new DropColumnTask(nodeContext, indicesService::createIndexMapperService);
+    }
+
+
+    @Override
+    public ClusterBlockException checkBlock(DropColumnRequest request, ClusterState state) {
+        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+    }
+}

--- a/server/src/main/java/io/crate/execution/dml/DoubleIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/DoubleIndexer.java
@@ -25,8 +25,6 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.function.Consumer;
 
-import org.jetbrains.annotations.Nullable;
-
 import org.apache.lucene.document.DoubleField;
 import org.apache.lucene.document.DoublePoint;
 import org.apache.lucene.document.Field;
@@ -38,6 +36,7 @@ import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.mapper.FieldNamesFieldMapper;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
+import org.jetbrains.annotations.Nullable;
 
 import io.crate.execution.dml.Indexer.ColumnConstraint;
 import io.crate.execution.dml.Indexer.Synthetic;

--- a/server/src/main/java/io/crate/metadata/GeneratedReference.java
+++ b/server/src/main/java/io/crate/metadata/GeneratedReference.java
@@ -232,6 +232,9 @@ public class GeneratedReference implements Reference {
     }
 
     @Override
+    public void setDropped() {}
+
+    @Override
     public boolean hasDocValues() {
         return ref.hasDocValues();
     }

--- a/server/src/main/java/io/crate/metadata/Reference.java
+++ b/server/src/main/java/io/crate/metadata/Reference.java
@@ -72,6 +72,8 @@ public interface Reference extends Symbol {
 
     boolean isDropped();
 
+    void setDropped();
+
     boolean hasDocValues();
 
     @Nullable

--- a/server/src/main/java/io/crate/metadata/SimpleReference.java
+++ b/server/src/main/java/io/crate/metadata/SimpleReference.java
@@ -56,7 +56,7 @@ public class SimpleReference implements Reference {
 
     protected final int position;
     protected final long oid;
-    protected final boolean isDropped;
+    protected boolean isDropped;
 
     protected final ReferenceIdent ident;
     protected final ColumnPolicy columnPolicy;
@@ -236,6 +236,11 @@ public class SimpleReference implements Reference {
     @Override
     public boolean isDropped() {
         return isDropped;
+    }
+
+    @Override
+    public void setDropped() {
+        this.isDropped = true;
     }
 
     @Nullable

--- a/server/src/main/java/io/crate/metadata/doc/DocIndexMetadata.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocIndexMetadata.java
@@ -478,6 +478,9 @@ public class DocIndexMetadata {
             long oid = ((Number) columnProperties.getOrDefault("oid", COLUMN_OID_UNASSIGNED)).longValue();
 
             boolean isDropped = (Boolean) columnProperties.getOrDefault("dropped", false);
+            if (isDropped) {
+                continue; // skip column
+            }
 
             DataType<?> elementType = ArrayType.unnest(columnDataType);
             if (elementType.equals(DataTypes.GEO_SHAPE)) {

--- a/server/src/main/java/io/crate/planner/Planner.java
+++ b/server/src/main/java/io/crate/planner/Planner.java
@@ -37,6 +37,7 @@ import io.crate.analyze.AnalyzedAlterBlobTable;
 import io.crate.analyze.AnalyzedAlterTable;
 import io.crate.analyze.AnalyzedAlterTableAddColumn;
 import io.crate.analyze.AnalyzedAlterTableDropCheckConstraint;
+import io.crate.analyze.AnalyzedAlterTableDropColumn;
 import io.crate.analyze.AnalyzedAlterTableOpenClose;
 import io.crate.analyze.AnalyzedAlterTableRename;
 import io.crate.analyze.AnalyzedAlterUser;
@@ -102,6 +103,7 @@ import io.crate.planner.node.dcl.GenericDCLPlan;
 import io.crate.planner.node.ddl.AlterBlobTablePlan;
 import io.crate.planner.node.ddl.AlterTableAddColumnPlan;
 import io.crate.planner.node.ddl.AlterTableDropCheckConstraintPlan;
+import io.crate.planner.node.ddl.AlterTableDropColumnPlan;
 import io.crate.planner.node.ddl.AlterTableOpenClosePlan;
 import io.crate.planner.node.ddl.AlterTablePlan;
 import io.crate.planner.node.ddl.AlterTableRenameTablePlan;
@@ -397,6 +399,12 @@ public class Planner extends AnalyzedStatementVisitor<PlannerContext, Plan> {
     public Plan visitAlterTableAddColumn(AnalyzedAlterTableAddColumn alterTableAddColumn,
                                          PlannerContext context) {
         return new AlterTableAddColumnPlan(alterTableAddColumn);
+    }
+
+    @Override
+    public Plan visitAlterTableDropColumn(AnalyzedAlterTableDropColumn alterTableDropColumn,
+                                          PlannerContext context) {
+        return new AlterTableDropColumnPlan(alterTableDropColumn);
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/node/ddl/AlterTableDropColumnPlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/AlterTableDropColumnPlan.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.node.ddl;
+
+import io.crate.analyze.AnalyzedAlterTableDropColumn;
+import io.crate.data.Row;
+import io.crate.data.Row1;
+import io.crate.data.RowConsumer;
+import io.crate.execution.ddl.tables.DropColumnRequest;
+import io.crate.execution.support.OneRowActionListener;
+import io.crate.planner.DependencyCarrier;
+import io.crate.planner.Plan;
+import io.crate.planner.PlannerContext;
+import io.crate.planner.operators.SubQueryResults;
+
+public class AlterTableDropColumnPlan implements Plan {
+
+    private final AnalyzedAlterTableDropColumn alterTable;
+
+    public AlterTableDropColumnPlan(AnalyzedAlterTableDropColumn alterTable) {
+        this.alterTable = alterTable;
+    }
+
+    @Override
+    public StatementType type() {
+        return StatementType.DDL;
+    }
+
+    @Override
+    public void executeOrFail(DependencyCarrier dependencies,
+                              PlannerContext plannerContext,
+                              RowConsumer consumer,
+                              Row params,
+                              SubQueryResults subQueryResults) throws Exception {
+        var dropColumnRequest = new DropColumnRequest(alterTable.table().ident(), alterTable.columns());
+        dependencies.alterTableOperation().executeAlterTableDropColumn(dropColumnRequest)
+            .whenComplete(new OneRowActionListener<>(consumer, rCount -> new Row1(rCount == null ? -1 : rCount)));
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -227,6 +227,7 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
         merged.mappedFieldType = toMerge.mappedFieldType;
         merged.fieldType = toMerge.fieldType;
         merged.copyTo = toMerge.copyTo;
+        merged.isDropped = toMerge.isDropped();
         return merged;
     }
 

--- a/server/src/test/java/io/crate/analyze/AlterTableDropColumnAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/AlterTableDropColumnAnalyzerTest.java
@@ -50,7 +50,7 @@ public class AlterTableDropColumnAnalyzerTest extends CrateDummyClusterServiceUn
 
         AnalyzedAlterTableDropColumn d = e.analyze("ALTER TABLE t DROP COLUMN a");
         assertThat(d.columns()).satisfiesExactly(
-            r -> assertThat(r).isReference("a"));
+            r -> assertThat(r.ref()).isReference("a"));
     }
 
     @Test
@@ -62,8 +62,8 @@ public class AlterTableDropColumnAnalyzerTest extends CrateDummyClusterServiceUn
         AnalyzedAlterTableDropColumn d = e.analyze("ALTER TABLE t DROP COLUMN a, DROP b");
         assertThat(d.table().ident().name()).isEqualTo("t");
         assertThat(d.columns()).satisfiesExactly(
-            r -> assertThat(r).isReference("a"),
-            r -> assertThat(r).isReference("b"));
+            dc -> assertThat(dc.ref()).isReference("a"),
+            dc -> assertThat(dc.ref()).isReference("b"));
     }
 
     @Test
@@ -74,7 +74,7 @@ public class AlterTableDropColumnAnalyzerTest extends CrateDummyClusterServiceUn
 
         AnalyzedAlterTableDropColumn d = e.analyze("ALTER TABLE t DROP COLUMN b");
         assertThat(d.columns()).satisfiesExactly(
-            r -> assertThat(r).isReference("b"));
+            dc -> assertThat(dc.ref()).isReference("b"));
     }
 
     @Test
@@ -86,7 +86,7 @@ public class AlterTableDropColumnAnalyzerTest extends CrateDummyClusterServiceUn
         AnalyzedAlterTableDropColumn d = e.analyze("ALTER TABLE t DROP COLUMN o['oo']['ooa']");
         assertThat(d.table().ident().name()).isEqualTo("t");
         assertThat(d.columns()).satisfiesExactly(
-            r -> assertThat(r).isReference(
+            dc -> assertThat(dc.ref()).isReference(
                 new ColumnIdent("o", List.of("oo", "ooa")), d.table().ident(), DataTypes.INTEGER));
     }
 
@@ -123,14 +123,14 @@ public class AlterTableDropColumnAnalyzerTest extends CrateDummyClusterServiceUn
         AnalyzedAlterTableDropColumn d2 = e.analyze("ALTER TABLE t1 DROP COLUMN b, DROP IF EXISTS d");
         assertThat(d2.table().ident().name()).isEqualTo("t1");
         assertThat(d2.columns()).satisfiesExactly(
-            r -> assertThat(r).isReference("b"));
+            dc -> assertThat(dc.ref()).isReference("b"));
 
         AnalyzedAlterTableDropColumn d3 = e.analyze("ALTER TABLE t2 DROP COLUMN o['oa'], DROP COLUMN IF EXISTS o['ob'], " +
                          "DROP o['oo']['ooa'], DROP IF EXISTS o['oo']['ooc']");
         assertThat(d3.table().ident().name()).isEqualTo("t2");
         assertThat(d3.columns()).satisfiesExactly(
-            r -> assertThat(r).isReference(new ColumnIdent("o", "oa"), d3.table().ident(), DataTypes.INTEGER),
-            r -> assertThat(r).isReference(new ColumnIdent("o", List.of("oo", "ooa")), d3.table().ident(), DataTypes.INTEGER));
+            dc -> assertThat(dc.ref()).isReference(new ColumnIdent("o", "oa"), d3.table().ident(), DataTypes.INTEGER),
+            dc -> assertThat(dc.ref()).isReference(new ColumnIdent("o", List.of("oo", "ooa")), d3.table().ident(), DataTypes.INTEGER));
     }
 
     @Test
@@ -157,7 +157,7 @@ public class AlterTableDropColumnAnalyzerTest extends CrateDummyClusterServiceUn
     @Test
     public void test_drop_clustered_by_column_is_not_allowed() throws Exception {
         e = SQLExecutor.builder(clusterService)
-            .addTable("CREATE TABLE t1 (a int) CLUSTERED BY (a)")
+            .addTable("CREATE TABLE t1 (a int, b int) CLUSTERED BY (a)")
             .addTable("CREATE TABLE t2 (o object AS(oo object AS(ooa int))) CLUSTERED BY (o['oo']['ooa'])")
             .build();
 

--- a/server/src/test/java/io/crate/analyze/DropColumnTest.java
+++ b/server/src/test/java/io/crate/analyze/DropColumnTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.analyze;
+
+import static io.crate.analyze.AnalyzedAlterTableDropColumn.DropColumn;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Test;
+
+import io.crate.expression.symbol.Literal;
+import io.crate.metadata.IndexType;
+import io.crate.metadata.ReferenceIdent;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.RowGranularity;
+import io.crate.metadata.SimpleReference;
+import io.crate.sql.tree.ColumnPolicy;
+import io.crate.types.ArrayType;
+import io.crate.types.DataTypes;
+
+public class DropColumnTest extends ESTestCase {
+
+    @Test
+    public void testStreaming() throws Exception {
+        RelationName relationName = new RelationName("doc", "test");
+        ReferenceIdent referenceIdent = new ReferenceIdent(relationName, "object_column");
+        SimpleReference reference = new SimpleReference(
+            referenceIdent,
+            RowGranularity.DOC,
+            new ArrayType<>(DataTypes.UNTYPED_OBJECT),
+            ColumnPolicy.STRICT,
+            IndexType.FULLTEXT,
+            false,
+            true,
+            0,
+            111,
+            true,
+            Literal.of(Map.of("f", 10)
+            )
+        );
+        boolean ifExists = randomBoolean();
+        DropColumn dropColumn = new DropColumn(reference, ifExists);
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        DropColumn.toStream(out, dropColumn);
+
+        StreamInput in = out.bytes().streamInput();
+        DropColumn dropColumn2 = DropColumn.fromStream(in);
+
+        assertThat(dropColumn2).isEqualTo(dropColumn);
+    }
+
+}

--- a/server/src/test/java/io/crate/execution/ddl/tables/AddColumnTaskTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/tables/AddColumnTaskTest.java
@@ -22,7 +22,6 @@
 package io.crate.execution.ddl.tables;
 
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
 

--- a/server/src/test/java/io/crate/execution/ddl/tables/DropColumnTaskTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/tables/DropColumnTaskTest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.ddl.tables;
+
+import static io.crate.analyze.AnalyzedAlterTableDropColumn.DropColumn;
+import static io.crate.testing.Asserts.assertThat;
+
+import java.util.List;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterState;
+import org.junit.Test;
+
+import io.crate.metadata.ReferenceIdent;
+import io.crate.metadata.RowGranularity;
+import io.crate.metadata.SimpleReference;
+import io.crate.metadata.doc.DocTableInfo;
+import io.crate.metadata.doc.DocTableInfoFactory;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.IndexEnv;
+import io.crate.testing.SQLExecutor;
+import io.crate.types.DataTypes;
+
+public class DropColumnTaskTest extends CrateDummyClusterServiceUnitTest {
+
+    @Test
+    public void test_can_drop_simple_column() throws Exception {
+        var e = SQLExecutor.builder(clusterService)
+            .addTable("create table tbl (x int, y int)")
+            .build();
+        DocTableInfo tbl = e.resolveTableInfo("tbl");
+        try (IndexEnv indexEnv = new IndexEnv(
+            THREAD_POOL,
+            tbl,
+            clusterService.state(),
+            Version.CURRENT,
+            createTempDir()
+        )) {
+            var dropColumnTask = new DropColumnTask(e.nodeCtx, imd -> indexEnv.mapperService());
+            ReferenceIdent refIdent = new ReferenceIdent(tbl.ident(), "y");
+            SimpleReference colToDrop = new SimpleReference(
+                refIdent,
+                RowGranularity.DOC,
+                DataTypes.SHORT, // irrelevant
+                333, // irrelevant
+                null
+            );
+            var request = new DropColumnRequest(tbl.ident(), List.of(new DropColumn(colToDrop, false)));
+            ClusterState newState = dropColumnTask.execute(clusterService.state(), request);
+            DocTableInfo newTable = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState);
+
+            assertThat(newTable.getReference(colToDrop.column())).isNull();
+        }
+    }
+
+    @Test
+    public void test_is_no_op_if_columns_exist() throws Exception {
+        var e = SQLExecutor.builder(clusterService)
+            .addTable("create table tbl (x int, y int)")
+            .build();
+        DocTableInfo tbl = e.resolveTableInfo("tbl");
+        ClusterState state = clusterService.state();
+        try (IndexEnv indexEnv = new IndexEnv(
+            THREAD_POOL,
+            tbl,
+            state,
+            Version.CURRENT,
+            createTempDir()
+        )) {
+            var dropColumnTask = new DropColumnTask(e.nodeCtx, imd -> indexEnv.mapperService());
+            ReferenceIdent refIdent = new ReferenceIdent(tbl.ident(), "z");
+            SimpleReference colToDrop = new SimpleReference(
+                refIdent,
+                RowGranularity.DOC,
+                DataTypes.INTEGER,
+                333, // irrelevant
+                null
+            );
+            var request = new DropColumnRequest(tbl.ident(), List.of(new DropColumn(colToDrop, true)));
+            ClusterState newState = dropColumnTask.execute(state, request);
+            assertThat(newState).isSameAs(state);
+        }
+    }
+}

--- a/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
@@ -24,6 +24,7 @@ package io.crate.integrationtests;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
 import static io.crate.protocols.postgres.PGErrorStatus.DUPLICATE_TABLE;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
+import static io.crate.protocols.postgres.PGErrorStatus.UNDEFINED_COLUMN;
 import static io.crate.protocols.postgres.PGErrorStatus.UNDEFINED_TABLE;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.printedTable;
@@ -392,7 +393,7 @@ public class DDLIntegrationTest extends IntegTestCase {
     }
 
     @Test
-    public void test_alter_table_add_column_succedds_because_check_constaint_refers_to_self_columns() {
+    public void test_alter_table_add_column_succeeds_because_check_constaint_refers_to_self_columns() {
         execute("create table t (id integer primary key, qty integer constraint check_1 check (qty > 0))");
         execute("alter table t add column bazinga integer constraint bazinga_check check(bazinga <> 42)");
         execute("insert into t(id, qty, bazinga) values(0, 1, 100)");
@@ -1147,5 +1148,49 @@ public class DDLIntegrationTest extends IntegTestCase {
             .hasPGError(INTERNAL_ERROR)
             .hasHTTPError(BAD_REQUEST, 4000)
             .hasMessageContaining("Failed CONSTRAINT leaf_check CHECK (\"o1\"['a1']['c1'] > 10)");
+    }
+
+    @Test
+    public void test_alter_table_drop_simple_column() {
+        execute("create table t(id integer primary key, a integer, b integer)");
+        execute("insert into t(id, a, b) values(1, 11, 111)");
+        execute("refresh table t");
+        execute("select * from t");
+        assertThat(response).hasRows("1| 11| 111");
+
+        execute("alter table t drop column a");
+        execute("select * from t");
+        assertThat(response).hasRows("1| 111");
+        Asserts.assertSQLError(() -> execute("select a from t"))
+            .hasPGError(UNDEFINED_COLUMN)
+            .hasHTTPError(NOT_FOUND, 4043)
+            .hasMessageContaining("Column a unknown");
+    }
+
+    @Test
+    public void test_alter_partitioned_table_drop_simple_column() {
+        execute("create table t(id integer primary key, a integer, b integer) partitioned by(id)");
+        execute("insert into t(id, a, b) values(1, 11, 111)");
+        execute("insert into t(id, a, b) values(2, 22, 222)");
+        execute("insert into t(id, a, b) values(3, 33, 333)");
+        execute("refresh table t");
+        execute("select * from t");
+        assertThat(response).hasRows(
+            "1| 11| 111",
+            "2| 22| 222",
+            "3| 33| 333");
+
+        execute("alter table t drop column a");
+        execute("select * from t");
+        assertThat(response).hasRows(
+            "1| 111",
+            "2| 222",
+            "3| 333");
+        execute("select * from t where id = 2");
+        assertThat(response).hasRows("2| 222");
+        Asserts.assertSQLError(() -> execute("select a from t"))
+            .hasPGError(UNDEFINED_COLUMN)
+            .hasHTTPError(NOT_FOUND, 4043)
+            .hasMessageContaining("Column a unknown");
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
@@ -1174,14 +1174,14 @@ public class DDLIntegrationTest extends IntegTestCase {
         execute("insert into t(id, a, b) values(2, 22, 222)");
         execute("insert into t(id, a, b) values(3, 33, 333)");
         execute("refresh table t");
-        execute("select * from t");
+        execute("select * from t order by id");
         assertThat(response).hasRows(
             "1| 11| 111",
             "2| 22| 222",
             "3| 33| 333");
 
         execute("alter table t drop column a");
-        execute("select * from t");
+        execute("select * from t order by id");
         assertThat(response).hasRows(
             "1| 111",
             "2| 222",

--- a/server/src/test/java/io/crate/metadata/ReferenceTest.java
+++ b/server/src/test/java/io/crate/metadata/ReferenceTest.java
@@ -168,6 +168,7 @@ public class ReferenceTest extends CrateDummyClusterServiceUnitTest {
         assertThat(mapping)
             .containsEntry("position", 1)
             .containsEntry("type", "keyword")
+            .doesNotContainKey("dropped")
             .containsEntry("doc_values", "false")
             .hasSize(3);
         IndexMetadata indexMetadata = clusterService.state().metadata().indices().valuesIt().next();
@@ -186,6 +187,7 @@ public class ReferenceTest extends CrateDummyClusterServiceUnitTest {
         assertThat(mapping)
                 .containsEntry("position", 1)
                 .containsEntry("type", "float")
+                .doesNotContainKey("dropped")
                 .containsEntry("doc_values", "false")
                 .hasSize(3);
         IndexMetadata indexMetadata = clusterService.state().metadata().indices().valuesIt().next();
@@ -204,6 +206,7 @@ public class ReferenceTest extends CrateDummyClusterServiceUnitTest {
         assertThat(mapping)
             .containsEntry("position", 1)
             .containsEntry("type", "keyword")
+            .doesNotContainKey("dropped")
             .containsEntry("default_expr", "'foo'")
             .hasSize(3);
         IndexMetadata indexMetadata = clusterService.state().metadata().indices().valuesIt().next();


### PR DESCRIPTION
For now added  only some basic tests.

Will follow up with more tests
 - [ ] try to simulate concurrency (e.g drop a column while it has been used in a new column with a generated expression in between)
 - [ ] dropping parent drops subcols
 - [ ] information_schema,pg_catalog 
 - [ ] check all places that the dropped columns are not "seen" (views, show create table, select _raw, etc)
 - [ ] re-add column with same name