### PR TITLE
Allow setting `standard_conforming_strings` to `on`

### DIFF
--- a/docs/appendices/release-notes/5.5.0.rst
+++ b/docs/appendices/release-notes/5.5.0.rst
@@ -81,7 +81,9 @@ SQL Statements
 SQL Standard and PostgreSQL Compatibility
 -----------------------------------------
 
-None
+- Allowed statements that set
+  :ref:`standard_conforming_strings session setting<conf-session-standard_conforming_strings>`
+  to the default value (``on``).
 
 Data Types
 ----------

--- a/libs/shared/src/main/java/io/crate/common/Booleans.java
+++ b/libs/shared/src/main/java/io/crate/common/Booleans.java
@@ -139,7 +139,7 @@ public final class Booleans {
         int len = input.size();
         boolean[] array = new boolean[len];
         for (int i = 0; i < len; i++) {
-            array[i] = (Boolean) Objects.requireNonNull(input.get(i));
+            array[i] = Objects.requireNonNull(input.get(i));
         }
         return array;
     }

--- a/server/src/main/java/io/crate/metadata/settings/session/SessionSettingRegistry.java
+++ b/server/src/main/java/io/crate/metadata/settings/session/SessionSettingRegistry.java
@@ -56,7 +56,7 @@ public class SessionSettingRegistry {
     static final String STANDARD_CONFORMING_STRINGS = "standard_conforming_strings";
     static final String ERROR_ON_UNKNOWN_OBJECT_KEY = "error_on_unknown_object_key";
     static final String DATE_STYLE_KEY = "datestyle";
-    static final SessionSetting<String> APPLICATION_NAME = new SessionSetting<String>(
+    static final SessionSetting<String> APPLICATION_NAME = new SessionSetting<>(
         "application_name",
         inputs -> {},
         inputs -> DataTypes.STRING.implicitCast(inputs[0]),
@@ -66,8 +66,8 @@ public class SessionSettingRegistry {
         "Optional application name. Can be set by a client to identify the application which created the connection",
         DataTypes.STRING
     );
-    static final SessionSetting<String> DATE_STYLE = new SessionSetting<String>(
-        "datestyle",
+    static final SessionSetting<String> DATE_STYLE = new SessionSetting<>(
+        DATE_STYLE_KEY,
         inputs -> validateDateStyleFrom(objectsToStringArray(inputs)),
         inputs -> DEFAULT_DATE_STYLE,
         CoordinatorSessionSettings::setDateStyle,
@@ -77,7 +77,7 @@ public class SessionSettingRegistry {
         DataTypes.STRING
     );
 
-    static final SessionSetting<TimeValue> STATEMENT_TIMEOUT = new SessionSetting<TimeValue>(
+    static final SessionSetting<TimeValue> STATEMENT_TIMEOUT = new SessionSetting<>(
         "statement_timeout",
         inputs -> {},
         inputs -> {
@@ -109,9 +109,7 @@ public class SessionSettingRegistry {
     static final SessionSetting<Integer> MEMORY_LIMIT = new SessionSetting<>(
         Sessions.MEMORY_LIMIT.getKey(),
         input -> {},
-        inputs -> {
-            return DataTypes.INTEGER.implicitCast(inputs[0]);
-        },
+        inputs -> DataTypes.INTEGER.implicitCast(inputs[0]),
         CoordinatorSessionSettings::memoryLimit,
         settings -> Integer.toString(settings.memoryLimitInBytes()),
         () -> "0",
@@ -259,22 +257,24 @@ public class SessionSettingRegistry {
                 // date format style
                 case "ISO":
                     break;
-                case "SQL":
-                case "POSTGRES":
-                case "GERMAN":
-                    throw new IllegalArgumentException("Invalid value for parameter \"datestyle\": \"" + dateStyle + "\". Valid values include: [\"ISO\"].");
+                case "SQL",
+                     "POSTGRES",
+                      "GERMAN":
+                    throw new IllegalArgumentException("Invalid value for parameter \"" + DATE_STYLE + "\": \"" +
+                                                        dateStyle + "\". Valid values include: [\"ISO\"].");
                 // date order style
-                case "MDY":
-                case "NONEURO":
-                case "NONEUROPEAN":
-                case "US":
-                case "DMY":
-                case "EURO":
-                case "EUROPEAN":
-                case "YMD":
+                case "MDY",
+                     "NONEURO",
+                     "NONEUROPEAN",
+                     "US",
+                     "DMY",
+                     "EURO",
+                     "EUROPEAN",
+                     "YMD":
                     break;
                 default:
-                    throw new IllegalArgumentException("Invalid value for parameter \"datestyle\": \"" + dateStyle + "\". Valid values include: [\"ISO\"].");
+                    throw new IllegalArgumentException("Invalid value for parameter \"" + DATE_STYLE + "\": \"" +
+                                                       dateStyle + "\". Valid values include: [\"ISO\"].");
             }
         }
     }

--- a/server/src/test/java/io/crate/metadata/settings/session/SessionSettingRegistryTest.java
+++ b/server/src/test/java/io/crate/metadata/settings/session/SessionSettingRegistryTest.java
@@ -35,6 +35,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
 
 import io.crate.analyze.SymbolEvaluator;
@@ -81,11 +82,21 @@ public class SessionSettingRegistryTest extends ESTestCase {
     }
 
     @Test
-    public void test_standard_confirming_strings_session_setting_cannot_be_changed() {
+    public void test_standard_confirming_strings_session_setting_cannot_be_set_to_false() {
         SessionSetting<?> setting = new SessionSettingRegistry(Set.of(new LoadedRules())).settings().get(SessionSettingRegistry.STANDARD_CONFORMING_STRINGS);
-        assertThatThrownBy(() -> setting.apply(sessionSettings, generateInput("no"), eval))
+        var value = generateInput(randomFrom("no", "false", "0", "no"));
+        assertThatThrownBy(() -> setting.apply(SESSION_SETTINGS, value, EVAL))
             .isExactlyInstanceOf(UnsupportedOperationException.class)
             .hasMessage("\"standard_conforming_strings\" cannot be changed.");
+    }
+
+    @Test
+    public void test_standard_confirming_strings_session_setting_invalid_values() {
+        SessionSetting<?> setting = new SessionSettingRegistry(Set.of(new LoadedRules())).settings().get(SessionSettingRegistry.STANDARD_CONFORMING_STRINGS);
+        var value = generateInput("invalid");
+        assertThatThrownBy(() -> setting.apply(SESSION_SETTINGS, value, EVAL))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Can't convert \"invalid\" to boolean");
     }
 
     @Test


### PR DESCRIPTION
 - Allow setting `standard_conforming_strings` to `on`  - Allow to set the value to the default    
   boolean `true`, to facilitate integration with external tools, e.g.: `ompgsql`.
    
   Closes: #14560

- Minor code improvements
