### PR TITLE
Fix a typo in the CREATE REPOSITORY documentation

### DIFF
--- a/docs/sql/statements/create-repository.rst
+++ b/docs/sql/statements/create-repository.rst
@@ -175,7 +175,7 @@ Parameters
   | *Type:*    ``text``
   | *Required*
 
-  An absolute or relative path to the directory where CreateDB will store
+  An absolute or relative path to the directory where CrateDB will store
   snapshots. If the path is relative, CrateDB will append it to the first entry
   in the :ref:`path.repo <path.repo>` setting.
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Just a CrateDB typo (CreateDB)