### PR TITLE
Fix SqlExpressions.setErrorOnUnknownObjectKey not being effective

### DIFF
--- a/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalysisContext.java
+++ b/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalysisContext.java
@@ -42,12 +42,12 @@ public class ExpressionAnalysisContext {
     private boolean hasAggregates;
     private boolean allowEagerNormalize = true;
     private boolean parentIsOrderSensitive = true;
-    private final boolean errorOnUnknownObjectKey;
+    private final SessionSettings sessionSettings;
 
     private Map<String, Window> windows = Map.of();
 
     public ExpressionAnalysisContext(SessionSettings sessionSettings) {
-        this.errorOnUnknownObjectKey = sessionSettings.errorOnUnknownObjectKey();
+        this.sessionSettings = sessionSettings;
     }
 
     void indicateAggregates() {
@@ -83,7 +83,7 @@ public class ExpressionAnalysisContext {
     }
 
     public boolean errorOnUnknownObjectKey() {
-        return errorOnUnknownObjectKey;
+        return sessionSettings.errorOnUnknownObjectKey();
     }
 
     /**


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
