### PR TITLE
docs: Add warning note for JOIN regression in 5.4

### DIFF
--- a/docs/appendices/release-notes/5.4.0.rst
+++ b/docs/appendices/release-notes/5.4.0.rst
@@ -35,6 +35,17 @@ Released on 2023-07-11.
 .. contents::
    :local:
 
+Known Issues
+============
+
+- Version 5.4.0 introduced a regression which can cause some ``JOIN`` queries
+  to return no results when the query optimizer re-orders the joined tables.
+  As a workaround, users should apply the following session settings before
+  running such queries to prevent the query optimizer from re-ordering them
+  and therefore produce the correct results::
+
+    SET optimizer_reorder_hash_join = false
+    SET optimizer_reorder_nested_loop_join = false
 
 Breaking Changes
 ================

--- a/docs/appendices/release-notes/5.4.1.rst
+++ b/docs/appendices/release-notes/5.4.1.rst
@@ -41,6 +41,17 @@ Released on 2023-08-04.
 See the :ref:`version_5.4.0` release notes for a full list of changes in the
 5.4 series.
 
+Known Issues
+============
+
+- Version 5.4.0 introduced a regression which can cause some ``JOIN`` queries
+  to return no results when the query optimizer re-orders the joined tables.
+  As a workaround, users should apply the following session settings before
+  running such queries to prevent the query optimizer from re-ordering them
+  and therefore produce the correct results::
+
+    SET optimizer_reorder_hash_join = false
+    SET optimizer_reorder_nested_loop_join = false
 
 Fixes
 =====

--- a/docs/appendices/release-notes/5.4.2.rst
+++ b/docs/appendices/release-notes/5.4.2.rst
@@ -36,6 +36,17 @@ Released on 2023-08-11.
 See the :ref:`version_5.4.0` release notes for a full list of changes in the
 5.4 series.
 
+Known Issues
+============
+
+- Version 5.4.0 introduced a regression which can cause some ``JOIN`` queries
+  to return no results when the query optimizer re-orders the joined tables.
+  As a workaround, users should apply the following session settings before
+  running such queries to prevent the query optimizer from re-ordering them
+  and therefore produce the correct results::
+
+    SET optimizer_reorder_hash_join = false
+    SET optimizer_reorder_nested_loop_join = false
 
 Fixes
 =====


### PR DESCRIPTION
Seems that some queries return no results when optimizer re-orders the joined tables.

Relates: #14583
