### PR TITLE
Ensure generated expression type matches it's column type

### DIFF
--- a/server/src/main/java/io/crate/metadata/GeneratedReference.java
+++ b/server/src/main/java/io/crate/metadata/GeneratedReference.java
@@ -124,6 +124,8 @@ public class GeneratedReference implements Reference {
     }
 
     public void generatedExpression(Symbol generatedExpression) {
+        assert generatedExpression == null || generatedExpression.valueType().equals(valueType())
+            : "The type of the generated expression must match the valueType of the `GeneratedReference`";
         this.generatedExpression = generatedExpression;
         if (generatedExpression != null && SymbolVisitors.any(Symbols::isAggregate, generatedExpression)) {
             throw new UnsupportedOperationException("Aggregation functions are not allowed in generated columns: " + generatedExpression);

--- a/server/src/main/java/io/crate/metadata/doc/DocIndexMetadata.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocIndexMetadata.java
@@ -699,7 +699,9 @@ public class DocIndexMetadata {
         for (var generatedReference : generatedColumnReferences) {
             Expression expression = SqlParser.createExpression(generatedReference.formattedGeneratedExpression());
             tableReferenceResolver.references().clear();
-            generatedReference.generatedExpression(exprAnalyzer.convert(expression, analysisCtx));
+            Symbol generatedExpression = exprAnalyzer.convert(expression, analysisCtx)
+                .cast(generatedReference.valueType());
+            generatedReference.generatedExpression(generatedExpression);
             generatedReference.referencedReferences(List.copyOf(tableReferenceResolver.references()));
         }
         return this;


### PR DESCRIPTION
Follow up to https://github.com/crate/crate/pull/14477
Because we no longer include the `_cast` in the formatted generated
expression we could end up with a `GeneratedReference` where it's
valueType didn't match the valueType of its expression symbol.

This led to a `ClassCastException` on some queries. The nightly
benchmarks failed because of that.

Example:

    create table if not exists generated_columns (
        id integer,
        col_0 integer,
        col_1 integer,
        col_2 integer,
        col_sum long generated always as ((col_0 + col_1) + col_2)
    )
    clustered by (id) into 3 shards;

    insert into generated_columns (id, col_0, col_1, col_2, col_sum)
    values
      (1,   1,   2,   3,   6),
      (2,  10,  20,  30,  60),
      (3, 100, 200, 300, 600);

    refresh table generated_columns;
    update generated_columns set col_1 = col_1 + 1;
