### PR TITLE
Check for unknown object keys before allocating SubscriptFunctions

### DIFF
--- a/docs/appendices/release-notes/5.4.4.rst
+++ b/docs/appendices/release-notes/5.4.4.rst
@@ -104,3 +104,7 @@ Fixes
    query. e.g.:: ``gen_random_text_uuid`` and ``random``. Functions like
    ``NOW`` or ``CURRENT_TIMESTAMP`` are unaffected by this issue.
 
+
+- Fixed an issue that caused querying an unknown object key to return empty
+  result instead of throwing ``ColumnUnknownException`` when the table was
+  aliased.

--- a/server/src/main/java/io/crate/analyze/DataTypeAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/DataTypeAnalyzer.java
@@ -66,6 +66,7 @@ public final class DataTypeAnalyzer extends DefaultTraversalVisitor<DataType<?>,
                 type == null ? DataTypes.UNDEFINED : type.accept(this, context)
             );
         }
+        node.columnPolicy().ifPresent(builder::setColumnPolicy);
         return builder.build();
     }
 

--- a/server/src/main/java/io/crate/analyze/MetadataToASTNodeResolver.java
+++ b/server/src/main/java/io/crate/analyze/MetadataToASTNodeResolver.java
@@ -139,7 +139,6 @@ public class MetadataToASTNodeResolver {
                 }
 
                 final ColumnType<Expression> columnType = ref.valueType().toColumnType(
-                    ref.columnPolicy(),
                     () -> extractColumnDefinitions(ident)
                 );
                 List<ColumnConstraint<Expression>> constraints = new ArrayList<>();

--- a/server/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
@@ -262,7 +262,6 @@ public class TableElementsAnalyzer implements FieldProvider<Reference> {
                     refIdent,
                     rowGranularity,
                     type,
-                    columnPolicy,
                     indexType,
                     nullable,
                     hasDocValues,
@@ -278,7 +277,6 @@ public class TableElementsAnalyzer implements FieldProvider<Reference> {
                 ref = new GeoReference(
                     refIdent,
                     type,
-                    columnPolicy,
                     indexType,
                     nullable,
                     position,
@@ -293,7 +291,6 @@ public class TableElementsAnalyzer implements FieldProvider<Reference> {
                     refIdent,
                     rowGranularity,
                     type,
-                    columnPolicy,
                     indexType,
                     nullable,
                     hasDocValues,
@@ -344,7 +341,8 @@ public class TableElementsAnalyzer implements FieldProvider<Reference> {
             }
         }
         var columnBuilder = columns.get(columnIdent);
-        var dynamicReference = new DynamicReference(new ReferenceIdent(tableName, columnIdent), RowGranularity.DOC, -1);
+        var dynamicReference = new DynamicReference(new ReferenceIdent(tableName, columnIdent), RowGranularity.DOC, -1,
+                                                    ColumnPolicy.DYNAMIC);
         if (columnBuilder == null) {
             if (resolveMissing) {
                 return dynamicReference;
@@ -469,7 +467,7 @@ public class TableElementsAnalyzer implements FieldProvider<Reference> {
                     parentBuilder.builtReference = parentRef;
                     columns.put(parent, parentBuilder);
                 } else {
-                    columns.put(parent, new RefBuilder(parent, ObjectType.UNTYPED));
+                    columns.put(parent, new RefBuilder(parent, ObjectType.DYNAMIC_OBJECT));
                 }
             }
             Reference reference = table.getReference(columnName);

--- a/server/src/main/java/io/crate/analyze/UpdateAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/UpdateAnalyzer.java
@@ -203,7 +203,6 @@ public final class UpdateAnalyzer {
                             targetCol.ident(),
                             targetCol.granularity(),
                             ((ArrayType<?>) targetCol.valueType()).innerType(),
-                            targetCol.columnPolicy(),
                             targetCol.indexType(),
                             targetCol.isNullable(),
                             targetCol.hasDocValues(),

--- a/server/src/main/java/io/crate/analyze/relations/AliasedAnalyzedRelation.java
+++ b/server/src/main/java/io/crate/analyze/relations/AliasedAnalyzedRelation.java
@@ -31,6 +31,7 @@ import org.jetbrains.annotations.Nullable;
 
 import io.crate.exceptions.AmbiguousColumnException;
 import io.crate.exceptions.ColumnUnknownException;
+import io.crate.expression.symbol.DynamicReference;
 import io.crate.expression.symbol.ScopedSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
@@ -121,8 +122,14 @@ public class AliasedAnalyzedRelation implements AnalyzedRelation, FieldResolver 
             return new VoidReference(
                 new ReferenceIdent(alias, voidReference.column()),
                 voidReference.granularity(),
-                voidReference.columnPolicy(),
                 voidReference.position());
+        }
+        if (field instanceof DynamicReference dynamicReference) {
+            return new DynamicReference(
+                new ReferenceIdent(alias, dynamicReference.column()),
+                dynamicReference.granularity(),
+                dynamicReference.position(),
+                dynamicReference.columnPolicy());
         }
         ScopedSymbol scopedSymbol = new ScopedSymbol(alias, column, field.valueType());
 

--- a/server/src/main/java/io/crate/execution/dml/DynamicIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/DynamicIndexer.java
@@ -40,7 +40,6 @@ import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.SimpleReference;
-import io.crate.sql.tree.ColumnPolicy;
 import io.crate.types.ArrayType;
 import io.crate.types.ByteType;
 import io.crate.types.DataType;
@@ -96,7 +95,6 @@ public final class DynamicIndexer implements ValueIndexer<Object> {
                 refIdent,
                 RowGranularity.DOC,
                 type,
-                ColumnPolicy.DYNAMIC,
                 IndexType.PLAIN,
                 nullable,
                 storageSupport.docValuesDefault(),

--- a/server/src/main/java/io/crate/execution/dml/ObjectIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/ObjectIndexer.java
@@ -163,7 +163,8 @@ public class ObjectIndexer implements ValueIndexer<Map<String, Object>> {
                 xContentBuilder.nullField(innerName);
                 continue;
             }
-            if (ref.columnPolicy() == ColumnPolicy.STRICT) {
+            final var columnPolicy = ref.columnPolicy();
+            if (columnPolicy == ColumnPolicy.STRICT) {
                 throw new IllegalArgumentException(String.format(
                     Locale.ENGLISH,
                     "Cannot add column `%s` to strict object `%s`",
@@ -171,7 +172,7 @@ public class ObjectIndexer implements ValueIndexer<Map<String, Object>> {
                     ref.column()
                 ));
             }
-            if (ref.columnPolicy() == ColumnPolicy.IGNORED) {
+            if (columnPolicy == ColumnPolicy.IGNORED) {
                 xContentBuilder.field(innerName, innerValue);
                 continue;
             }
@@ -193,7 +194,6 @@ public class ObjectIndexer implements ValueIndexer<Map<String, Object>> {
                 new ReferenceIdent(table, column.getChild(innerName)),
                 RowGranularity.DOC,
                 type,
-                ref.columnPolicy(),
                 IndexType.PLAIN,
                 nullable,
                 storageSupport.docValuesDefault(),

--- a/server/src/main/java/io/crate/expression/symbol/SymbolType.java
+++ b/server/src/main/java/io/crate/expression/symbol/SymbolType.java
@@ -59,7 +59,6 @@ public enum SymbolType {
         throw new UnsupportedEncodingException("FetchStub is not streamable");
     }),
     VOID_REFERENCE(VoidReference::new);
-
     public static final List<SymbolType> VALUES = List.of(values());
 
     private final Writeable.Reader<Symbol> reader;

--- a/server/src/main/java/io/crate/expression/symbol/Symbols.java
+++ b/server/src/main/java/io/crate/expression/symbol/Symbols.java
@@ -42,7 +42,6 @@ import io.crate.metadata.FunctionType;
 import io.crate.metadata.GeneratedReference;
 import io.crate.metadata.Reference;
 import io.crate.sql.tree.ColumnDefinition;
-import io.crate.sql.tree.ColumnPolicy;
 import io.crate.sql.tree.Expression;
 import io.crate.types.DataType;
 import io.crate.types.TypeSignature;
@@ -266,9 +265,7 @@ public class Symbols {
             pathFromSymbol(symbol).sqlFqn(), // allow ObjectTypes to return col name in subscript notation
             null,
             null,
-            symbol.valueType().toColumnType(
-                symbol instanceof Reference reference ? reference.columnPolicy() : ColumnPolicy.DYNAMIC,
-                null),
+            symbol.valueType().toColumnType(null),
             List.of());
     }
 }

--- a/server/src/main/java/io/crate/expression/symbol/VoidReference.java
+++ b/server/src/main/java/io/crate/expression/symbol/VoidReference.java
@@ -42,14 +42,7 @@ public class VoidReference extends DynamicReference {
     public VoidReference(ReferenceIdent ident,
                          RowGranularity granularity,
                          int position) {
-        super(ident, granularity, position);
-    }
-
-    public VoidReference(ReferenceIdent ident,
-                         RowGranularity granularity,
-                         ColumnPolicy columnPolicy,
-                         int position) {
-        super(ident, granularity, columnPolicy, position);
+        super(ident, granularity, position, ColumnPolicy.DYNAMIC);
     }
 
     @Override

--- a/server/src/main/java/io/crate/metadata/GeneratedReference.java
+++ b/server/src/main/java/io/crate/metadata/GeneratedReference.java
@@ -92,7 +92,6 @@ public class GeneratedReference implements Reference {
                     ref.ident(),
                     ref.granularity(),
                     ref.valueType(),
-                    ref.columnPolicy(),
                     ref.indexType(),
                     ref.isNullable(),
                     ref.hasDocValues(),
@@ -201,13 +200,13 @@ public class GeneratedReference implements Reference {
     }
 
     @Override
-    public ColumnPolicy columnPolicy() {
-        return ref.columnPolicy();
+    public boolean isNullable() {
+        return ref.isNullable();
     }
 
     @Override
-    public boolean isNullable() {
-        return ref.isNullable();
+    public ColumnPolicy columnPolicy() {
+        return ref.columnPolicy();
     }
 
     @Override

--- a/server/src/main/java/io/crate/metadata/GeoReference.java
+++ b/server/src/main/java/io/crate/metadata/GeoReference.java
@@ -40,7 +40,6 @@ import org.jetbrains.annotations.Nullable;
 import io.crate.common.collections.Maps;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolType;
-import io.crate.sql.tree.ColumnPolicy;
 import io.crate.types.DataType;
 
 public class GeoReference extends SimpleReference {
@@ -60,7 +59,6 @@ public class GeoReference extends SimpleReference {
 
     public GeoReference(ReferenceIdent ident,
                         DataType<?> type,
-                        ColumnPolicy columnPolicy,
                         IndexType indexType,
                         boolean nullable,
                         int position,
@@ -70,14 +68,13 @@ public class GeoReference extends SimpleReference {
                         Integer treeLevels,
                         Double distanceErrorPct) {
         super(ident,
-            RowGranularity.DOC, // Only primitive types columns can be used in PARTITIONED BY clause
-            type,
-            columnPolicy,
-            indexType,
-            nullable,
-            false, //Geo shapes don't have doc values
-            position,
-            defaultExpression
+              RowGranularity.DOC, // Only primitive types columns can be used in PARTITIONED BY clause
+              type,
+              indexType,
+              nullable,
+              false, //Geo shapes don't have doc values
+              position,
+              defaultExpression
         );
         this.geoTree = Objects.requireNonNullElse(geoTree, DEFAULT_TREE);
         this.precision = precision;
@@ -161,7 +158,6 @@ public class GeoReference extends SimpleReference {
         return new GeoReference(
             newIdent,
             type,
-            columnPolicy,
             indexType,
             nullable,
             position,

--- a/server/src/main/java/io/crate/metadata/IndexReference.java
+++ b/server/src/main/java/io/crate/metadata/IndexReference.java
@@ -37,7 +37,6 @@ import org.jetbrains.annotations.Nullable;
 
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolType;
-import io.crate.sql.tree.ColumnPolicy;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 
@@ -121,7 +120,7 @@ public class IndexReference extends SimpleReference {
                    IndexType indexType,
                    List<Reference> columns,
                    @Nullable String analyzer) {
-        super(ident, RowGranularity.DOC, DataTypes.STRING, ColumnPolicy.DYNAMIC, indexType, false, false, position, null);
+        super(ident, RowGranularity.DOC, DataTypes.STRING, indexType, false, false, position, null);
         this.columns = columns;
         this.analyzer = analyzer;
     }
@@ -129,7 +128,6 @@ public class IndexReference extends SimpleReference {
     public IndexReference(ReferenceIdent ident,
                           RowGranularity granularity,
                           DataType<?> type,
-                          ColumnPolicy columnPolicy,
                           IndexType indexType,
                           boolean nullable,
                           boolean hasDocValues,
@@ -140,7 +138,6 @@ public class IndexReference extends SimpleReference {
         super(ident,
               granularity,
               type,
-              columnPolicy,
               indexType,
               nullable,
               hasDocValues,
@@ -202,7 +199,6 @@ public class IndexReference extends SimpleReference {
             newIdent,
             granularity,
             type,
-            columnPolicy,
             indexType,
             nullable,
             hasDocValues,

--- a/server/src/main/java/io/crate/metadata/Reference.java
+++ b/server/src/main/java/io/crate/metadata/Reference.java
@@ -56,9 +56,9 @@ public interface Reference extends Symbol {
 
     IndexType indexType();
 
-    ColumnPolicy columnPolicy();
-
     boolean isNullable();
+
+    ColumnPolicy columnPolicy();
 
     RowGranularity granularity();
 

--- a/server/src/main/java/io/crate/metadata/SystemTable.java
+++ b/server/src/main/java/io/crate/metadata/SystemTable.java
@@ -287,7 +287,6 @@ public final class SystemTable<T> implements TableInfo {
                         new ReferenceIdent(name, column.column),
                         RowGranularity.DOC,
                         column.type,
-                        ColumnPolicy.DYNAMIC,
                         IndexType.PLAIN,
                         column.isNullable,
                         false,
@@ -302,9 +301,8 @@ public final class SystemTable<T> implements TableInfo {
                         var ref = new DynamicReference(
                             new ReferenceIdent(name, wanted),
                             RowGranularity.DOC,
-                            ColumnPolicy.DYNAMIC,
-                            position
-                        );
+                            position,
+                            ColumnPolicy.DYNAMIC);
                         ref.valueType(leafType);
                         return ref;
                     });

--- a/server/src/main/java/io/crate/metadata/doc/DocIndexMetadata.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocIndexMetadata.java
@@ -222,7 +222,6 @@ public class DocIndexMetadata {
             refIdent(column),
             granularity(column),
             type,
-            columnPolicy,
             indexType,
             nullable,
             hasDocValues,
@@ -256,7 +255,6 @@ public class DocIndexMetadata {
         Reference info = new GeoReference(
             refIdent(column),
             type,
-            ColumnPolicy.DYNAMIC,
             IndexType.PLAIN,
             nullable,
             position,
@@ -305,6 +303,7 @@ public class DocIndexMetadata {
         String typeName = (String) columnProperties.get("type");
 
         if (typeName == null || ObjectType.NAME.equals(typeName)) {
+            ColumnPolicy columnPolicy = ColumnPolicies.decodeMappingValue(columnProperties.get("dynamic"));
             Map<String, Object> innerProperties = (Map<String, Object>) columnProperties.get("properties");
             if (innerProperties != null) {
                 List<InnerObjectType> children = new ArrayList<>();
@@ -318,9 +317,9 @@ public class DocIndexMetadata {
                 for (var child : children) {
                     builder.setInnerType(child.name, child.type);
                 }
-                type = builder.build();
+                type = builder.setColumnPolicy(columnPolicy).build();
             } else {
-                type = Objects.requireNonNullElse(DataTypes.ofMappingName(typeName), DataTypes.NOT_SUPPORTED);
+                type = ObjectType.builder().setColumnPolicy(columnPolicy).build();
             }
         } else if (typeName.equalsIgnoreCase("array")) {
             Map<String, Object> innerProperties = Maps.get(columnProperties, "inner");
@@ -503,7 +502,6 @@ public class DocIndexMetadata {
                             refIdent(newIdent),
                             granularity(newIdent),
                             columnDataType,
-                            ColumnPolicy.DYNAMIC,
                             columnIndexType,
                             nullable,
                             hasDocValues,

--- a/server/src/main/java/io/crate/metadata/doc/DocSysColumns.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocSysColumns.java
@@ -37,6 +37,7 @@ import io.crate.metadata.SimpleReference;
 import io.crate.sql.tree.ColumnPolicy;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
+import io.crate.types.ObjectType;
 
 public class DocSysColumns {
 
@@ -76,7 +77,7 @@ public class DocSysColumns {
     public static final ColumnIdent DOCID = new ColumnIdent(Names.DOCID);
 
     public static final Map<ColumnIdent, DataType<?>> COLUMN_IDENTS = Map.of(
-        DOC, DataTypes.UNTYPED_OBJECT,
+        DOC, ObjectType.builder().setColumnPolicy(ColumnPolicy.IGNORED).build(),
         FETCHID, DataTypes.LONG,
         ID, DataTypes.STRING,
         RAW, DataTypes.STRING,
@@ -94,15 +95,15 @@ public class DocSysColumns {
     );
 
     private static Reference newInfo(RelationName table, ColumnIdent column, DataType<?> dataType, int position) {
-        return new SimpleReference(new ReferenceIdent(table, column),
-                             RowGranularity.DOC,
-                             dataType,
-                             ColumnPolicy.STRICT,
-                             IndexType.PLAIN,
-                             false,
-                             false,
-                             position,
-                             null
+        return new SimpleReference(
+            new ReferenceIdent(table, column),
+            RowGranularity.DOC,
+            dataType,
+            IndexType.PLAIN,
+            false,
+            false,
+            position,
+            null
         );
     }
 

--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
@@ -432,34 +432,33 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
             }
         }
         switch (parentPolicy) {
-            case DYNAMIC:
+            case DYNAMIC -> {
                 if (!forWrite) {
                     if (!errorOnUnknownObjectKey) {
                         return new VoidReference(new ReferenceIdent(ident(), ident), rowGranularity(), position);
                     }
                     return null;
                 }
-                break;
-            case STRICT:
+            }
+            case STRICT -> {
                 if (forWrite) {
                     throw new ColumnUnknownException(ident, ident());
                 }
                 return null;
-            case IGNORED:
-                parentIsIgnored = true;
-                break;
-            default:
-                break;
+            }
+            case IGNORED -> parentIsIgnored = true;
+            default -> {
+            }
         }
         if (parentIsIgnored) {
             return new DynamicReference(
                 new ReferenceIdent(ident(), ident),
                 rowGranularity(),
-                ColumnPolicy.IGNORED,
-                position
-            );
+                position,
+                ColumnPolicy.IGNORED);
         }
-        return new DynamicReference(new ReferenceIdent(ident(), ident), rowGranularity(), position);
+        return new DynamicReference(new ReferenceIdent(ident(), ident), rowGranularity(), position,
+                                    ColumnPolicy.DYNAMIC);
     }
 
     @NotNull

--- a/server/src/main/java/io/crate/metadata/table/ColumnPolicies.java
+++ b/server/src/main/java/io/crate/metadata/table/ColumnPolicies.java
@@ -23,6 +23,9 @@ package io.crate.metadata.table;
 
 import io.crate.sql.tree.ColumnPolicy;
 import io.crate.common.Booleans;
+import io.crate.types.ArrayType;
+import io.crate.types.DataType;
+import io.crate.types.ObjectType;
 
 import static io.crate.sql.tree.ColumnPolicy.DYNAMIC;
 import static io.crate.sql.tree.ColumnPolicy.IGNORED;
@@ -64,5 +67,12 @@ public final class ColumnPolicies {
             default:
                 throw new AssertionError("Illegal columnPolicy: " + columnPolicy);
         }
+    }
+
+    public static ColumnPolicy of(DataType<?> dataType) {
+        if (ArrayType.unnest(dataType) instanceof ObjectType objectType) {
+            return objectType.columnPolicy();
+        }
+        return DYNAMIC;
     }
 }

--- a/server/src/main/java/io/crate/metadata/table/TableInfo.java
+++ b/server/src/main/java/io/crate/metadata/table/TableInfo.java
@@ -74,7 +74,6 @@ public interface TableInfo extends RelationInfo {
                 ref.ident(),
                 ref.granularity(),
                 readType,
-                ref.columnPolicy(),
                 ref.indexType(),
                 ref.isNullable(),
                 ref.hasDocValues(),

--- a/server/src/main/java/io/crate/metadata/upgrade/MetadataIndexUpgrader.java
+++ b/server/src/main/java/io/crate/metadata/upgrade/MetadataIndexUpgrader.java
@@ -33,7 +33,6 @@ import org.jetbrains.annotations.Nullable;
 import io.crate.common.collections.Maps;
 import io.crate.server.xcontent.XContentHelper;
 import io.crate.types.ArrayType;
-import io.crate.types.DataTypes;
 import io.crate.types.ObjectType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -155,13 +154,13 @@ public class MetadataIndexUpgrader implements BiFunction<IndexMetadata, IndexTem
             if (ArrayType.NAME.equals(type)) {
                 Map<String, Object> innerMapping = Maps.get(columnProperties, "inner");
                 String innerType = Maps.get(innerMapping, "type");
-                if (innerType == null || ObjectType.UNTYPED.equals(DataTypes.ofMappingName(innerType))) {
+                if (innerType == null || ObjectType.NAME.equals(innerType)) {
                     updated |= addIndexColumnSources(rootMapping, innerMapping, columnFQN);
                 }
             } else {
                 // ObjectMapper has logic to skip type if object has "properties" field (i.e has nested sub-column).
                 // Hence, type could be null and it indicates that it's an object column.
-                if (type == null || ObjectType.UNTYPED.equals(DataTypes.ofMappingName(type))) {
+                if (type == null || ObjectType.NAME.equals(type)) {
                     updated |= addIndexColumnSources(rootMapping, columnProperties, columnFQN);
                 }
             }

--- a/server/src/main/java/io/crate/types/ArrayType.java
+++ b/server/src/main/java/io/crate/types/ArrayType.java
@@ -58,7 +58,6 @@ import io.crate.protocols.postgres.parser.PgArrayParser;
 import io.crate.protocols.postgres.parser.PgArrayParsingException;
 import io.crate.sql.tree.CollectionColumnType;
 import io.crate.sql.tree.ColumnDefinition;
-import io.crate.sql.tree.ColumnPolicy;
 import io.crate.sql.tree.ColumnType;
 import io.crate.sql.tree.Expression;
 
@@ -401,9 +400,8 @@ public class ArrayType<T> extends DataType<List<T>> {
     }
 
     @Override
-    public ColumnType<Expression> toColumnType(ColumnPolicy columnPolicy,
-                                               @Nullable Supplier<List<ColumnDefinition<Expression>>> convertChildColumn) {
-        return new CollectionColumnType<>(innerType.toColumnType(columnPolicy, convertChildColumn));
+    public ColumnType<Expression> toColumnType(@Nullable Supplier<List<ColumnDefinition<Expression>>> convertChildColumn) {
+        return new CollectionColumnType<>(innerType.toColumnType(convertChildColumn));
     }
 
     @Override

--- a/server/src/main/java/io/crate/types/BitStringType.java
+++ b/server/src/main/java/io/crate/types/BitStringType.java
@@ -50,7 +50,6 @@ import io.crate.metadata.RelationName;
 import io.crate.metadata.settings.SessionSettings;
 import io.crate.sql.tree.BitString;
 import io.crate.sql.tree.ColumnDefinition;
-import io.crate.sql.tree.ColumnPolicy;
 import io.crate.sql.tree.ColumnType;
 import io.crate.sql.tree.Expression;
 
@@ -261,8 +260,7 @@ public final class BitStringType extends DataType<BitString> implements Streamer
     }
 
     @Override
-    public ColumnType<Expression> toColumnType(ColumnPolicy columnPolicy,
-                                               @Nullable Supplier<List<ColumnDefinition<Expression>>> convertChildColumn) {
+    public ColumnType<Expression> toColumnType(@Nullable Supplier<List<ColumnDefinition<Expression>>> convertChildColumn) {
         return new ColumnType<>(getName(), List.of(length));
     }
 

--- a/server/src/main/java/io/crate/types/CharacterType.java
+++ b/server/src/main/java/io/crate/types/CharacterType.java
@@ -36,7 +36,6 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 
 import io.crate.metadata.settings.SessionSettings;
 import io.crate.sql.tree.ColumnDefinition;
-import io.crate.sql.tree.ColumnPolicy;
 import io.crate.sql.tree.ColumnType;
 import io.crate.sql.tree.Expression;
 
@@ -151,8 +150,7 @@ public class CharacterType extends StringType {
     }
 
     @Override
-    public ColumnType<Expression> toColumnType(ColumnPolicy columnPolicy,
-                                               @Nullable Supplier<List<ColumnDefinition<Expression>>> convertChildColumn) {
+    public ColumnType<Expression> toColumnType(@Nullable Supplier<List<ColumnDefinition<Expression>>> convertChildColumn) {
         return new ColumnType<>(NAME, List.of(lengthLimit));
     }
 

--- a/server/src/main/java/io/crate/types/DataType.java
+++ b/server/src/main/java/io/crate/types/DataType.java
@@ -44,7 +44,6 @@ import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.settings.SessionSettings;
 import io.crate.sql.tree.ColumnDefinition;
-import io.crate.sql.tree.ColumnPolicy;
 import io.crate.sql.tree.ColumnType;
 import io.crate.sql.tree.Expression;
 
@@ -255,8 +254,7 @@ public abstract class DataType<T> implements Comparable<DataType<?>>, Writeable,
     }
 
 
-    public ColumnType<Expression> toColumnType(ColumnPolicy columnPolicy,
-                                               @Nullable Supplier<List<ColumnDefinition<Expression>>> convertChildColumn) {
+    public ColumnType<Expression> toColumnType(@Nullable Supplier<List<ColumnDefinition<Expression>>> convertChildColumn) {
         assert getTypeParameters().isEmpty()
             : "If the type parameters aren't empty, `" + getClass().getSimpleName() + "` must override `toColumnType`";
         return new ColumnType<>(getName());

--- a/server/src/main/java/io/crate/types/DataTypes.java
+++ b/server/src/main/java/io/crate/types/DataTypes.java
@@ -100,7 +100,7 @@ public final class DataTypes {
 
     public static final IntervalType INTERVAL = IntervalType.INSTANCE;
 
-    public static final ObjectType UNTYPED_OBJECT = ObjectType.UNTYPED;
+    public static final ObjectType UNTYPED_OBJECT = ObjectType.DYNAMIC_OBJECT;
 
     public static final RegprocType REGPROC = RegprocType.INSTANCE;
     public static final RegclassType REGCLASS = RegclassType.INSTANCE;
@@ -520,6 +520,8 @@ public final class DataTypes {
 
     @Nullable
     public static DataType<?> ofMappingName(String name) {
+        // NOTE: ObjectType returned by the mapping name 'object' is the default object,
+        // which is ObjectType.DYNAMIC_OBJECT with ColumnPolicy.DYNAMIC.
         return MAPPING_NAMES_TO_TYPES.get(name);
     }
 

--- a/server/src/main/java/io/crate/types/FloatVectorType.java
+++ b/server/src/main/java/io/crate/types/FloatVectorType.java
@@ -43,7 +43,6 @@ import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 import io.crate.sql.tree.ColumnDefinition;
-import io.crate.sql.tree.ColumnPolicy;
 import io.crate.sql.tree.ColumnType;
 import io.crate.sql.tree.Expression;
 
@@ -175,8 +174,7 @@ public class FloatVectorType extends DataType<float[]> implements Streamer<float
     }
 
     @Override
-    public ColumnType<Expression> toColumnType(ColumnPolicy columnPolicy,
-                                               @Nullable Supplier<List<ColumnDefinition<Expression>>> convertChildColumn) {
+    public ColumnType<Expression> toColumnType(@Nullable Supplier<List<ColumnDefinition<Expression>>> convertChildColumn) {
         return new ColumnType<>(getName(), List.of(dimensions));
     }
 

--- a/server/src/main/java/io/crate/types/StringType.java
+++ b/server/src/main/java/io/crate/types/StringType.java
@@ -60,7 +60,6 @@ import io.crate.metadata.RelationName;
 import io.crate.metadata.settings.SessionSettings;
 import io.crate.sql.tree.BitString;
 import io.crate.sql.tree.ColumnDefinition;
-import io.crate.sql.tree.ColumnPolicy;
 import io.crate.sql.tree.ColumnType;
 import io.crate.sql.tree.Expression;
 
@@ -352,8 +351,7 @@ public class StringType extends DataType<String> implements Streamer<String> {
     }
 
     @Override
-    public ColumnType<Expression> toColumnType(ColumnPolicy columnPolicy,
-                                               @Nullable Supplier<List<ColumnDefinition<Expression>>> convertChildColumn) {
+    public ColumnType<Expression> toColumnType(@Nullable Supplier<List<ColumnDefinition<Expression>>> convertChildColumn) {
         if (unbound()) {
             return new ColumnType<>(getName());
         } else {

--- a/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -69,7 +69,6 @@ import io.crate.metadata.SimpleReference;
 import io.crate.metadata.settings.CoordinatorSessionSettings;
 import io.crate.metadata.table.TableInfo;
 import io.crate.sql.parser.SqlParser;
-import io.crate.sql.tree.ColumnPolicy;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.testing.SqlExpressions;
@@ -447,13 +446,12 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     public void testAnalyzeArraySliceFunctionCall() {
         ReferenceIdent arrayRefIdent = new ReferenceIdent(new RelationName("doc", "tarr"), "xs");
         SimpleReference arrayRef = new SimpleReference(arrayRefIdent,
-                                           RowGranularity.DOC,
-                                           DataTypes.INTEGER_ARRAY,
-                                           ColumnPolicy.DYNAMIC,
-                                           IndexType.PLAIN,
-                                           true,
-                                           true,
-                                           1, null);
+                                                       RowGranularity.DOC,
+                                                       DataTypes.INTEGER_ARRAY,
+                                                       IndexType.PLAIN,
+                                                       true,
+                                                       true,
+                                                       1, null);
         CoordinatorTxnCtx txnCtx = CoordinatorTxnCtx.systemTransactionContext();
         ExpressionAnalysisContext localContext = new ExpressionAnalysisContext(txnCtx.sessionSettings());
         Symbol function = ExpressionAnalyzer.allocateFunction(

--- a/server/src/test/java/io/crate/breaker/MapSizeEstimatorTest.java
+++ b/server/src/test/java/io/crate/breaker/MapSizeEstimatorTest.java
@@ -37,7 +37,7 @@ public class MapSizeEstimatorTest {
     public void test_map_size_estimate_depends_on_actual_instance_size() {
         Map<String, Object> map = Map.of("x", 10, "y", 20);
         assertThat(
-            ObjectType.UNTYPED.valueBytes(map),
+            ObjectType.DYNAMIC_OBJECT.valueBytes(map),
             is(RamUsageEstimator.sizeOfMap(map))
         );
     }

--- a/server/src/test/java/io/crate/execution/ddl/tables/AddColumnTaskTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/tables/AddColumnTaskTest.java
@@ -43,7 +43,6 @@ import io.crate.metadata.RowGranularity;
 import io.crate.metadata.SimpleReference;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.doc.DocTableInfoFactory;
-import io.crate.sql.tree.ColumnPolicy;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.IndexEnv;
 import io.crate.testing.SQLExecutor;
@@ -108,7 +107,6 @@ public class AddColumnTaskTest extends CrateDummyClusterServiceUnitTest {
             Reference geoShapeArrayRef = new GeoReference(
                 shapesIdent,
                 new ArrayType<>(DataTypes.GEO_SHAPE),
-                ColumnPolicy.DYNAMIC,
                 IndexType.PLAIN,
                 true,
                 2,
@@ -123,7 +121,6 @@ public class AddColumnTaskTest extends CrateDummyClusterServiceUnitTest {
             Reference geoPointArrayRef = new GeoReference(
                 pointsIdent,
                 new ArrayType<>(DataTypes.GEO_POINT),
-                ColumnPolicy.DYNAMIC,
                 IndexType.PLAIN,
                 true,
                 3,

--- a/server/src/test/java/io/crate/execution/dml/IndexerTest.java
+++ b/server/src/test/java/io/crate/execution/dml/IndexerTest.java
@@ -73,6 +73,7 @@ import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.doc.DocTableInfoFactory;
 import io.crate.server.xcontent.XContentHelper;
 import io.crate.sql.tree.BitString;
+import io.crate.sql.tree.ColumnPolicy;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.DataTypeTesting;
 import io.crate.testing.IndexEnv;
@@ -759,8 +760,8 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
                     new DynamicReference(
                         new ReferenceIdent(table.ident(), "y"),
                         RowGranularity.DOC,
-                        -1
-                    )
+                        -1,
+                        ColumnPolicy.DYNAMIC)
                 ),
                 null
             );
@@ -1113,7 +1114,8 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
             .build();
         DocTableInfo table = executor.resolveTableInfo("tbl");
         Reference x = table.getReference(new ColumnIdent("x"));
-        Reference y = new DynamicReference(new ReferenceIdent(table.ident(), "y"), RowGranularity.DOC, 2);
+        Reference y = new DynamicReference(new ReferenceIdent(table.ident(), "y"), RowGranularity.DOC, 2,
+                                           ColumnPolicy.DYNAMIC);
         Indexer indexer = new Indexer(
             table.ident().indexNameOrAlias(),
             table,

--- a/server/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
+++ b/server/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
@@ -94,6 +94,7 @@ import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.settings.SessionSettings;
 import io.crate.metadata.table.Operation;
 import io.crate.netty.NettyBootstrap;
+import io.crate.sql.tree.ColumnPolicy;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.types.DataTypes;
 
@@ -315,8 +316,8 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
         DynamicReference dynamicRefConvertedToSimpleRef = new DynamicReference(
             new ReferenceIdent(TABLE_IDENT, new ColumnIdent("dynamic_long_col")),
             RowGranularity.DOC,
-            0
-        );
+            0,
+            ColumnPolicy.DYNAMIC);
         ShardId shardId = new ShardId(TABLE_IDENT.indexNameOrAlias(), charactersIndexUUID, 0);
         ShardUpsertRequest request = new ShardUpsertRequest.Builder(
             DUMMY_SESSION_INFO,

--- a/server/src/test/java/io/crate/execution/dsl/projection/SourceIndexWriterProjectionSerializationTest.java
+++ b/server/src/test/java/io/crate/execution/dsl/projection/SourceIndexWriterProjectionSerializationTest.java
@@ -45,7 +45,7 @@ import io.crate.metadata.RowGranularity;
 import io.crate.metadata.SimpleReference;
 import io.crate.sql.tree.ColumnPolicy;
 import io.crate.types.ArrayType;
-import io.crate.types.DataTypes;
+import io.crate.types.ObjectType;
 
 public class SourceIndexWriterProjectionSerializationTest {
 
@@ -53,12 +53,11 @@ public class SourceIndexWriterProjectionSerializationTest {
     public void testSerializationFailFast() throws IOException {
         RelationName relationName = new RelationName("doc", "test");
         ReferenceIdent referenceIdent = new ReferenceIdent(relationName, "object_column");
-        var dataType = new ArrayType<>(DataTypes.UNTYPED_OBJECT);
+        var dataType = new ArrayType<>(ObjectType.builder().setColumnPolicy(ColumnPolicy.STRICT).build());
         SimpleReference reference = new SimpleReference(
             referenceIdent,
             RowGranularity.DOC,
             dataType,
-            ColumnPolicy.STRICT,
             IndexType.FULLTEXT,
             false,
             true,
@@ -111,12 +110,11 @@ public class SourceIndexWriterProjectionSerializationTest {
     public void testSerializationValidationFlag() throws IOException {
         RelationName relationName = new RelationName("doc", "test");
         ReferenceIdent referenceIdent = new ReferenceIdent(relationName, "object_column");
-        var dataType = new ArrayType<>(DataTypes.UNTYPED_OBJECT);
+        var dataType = new ArrayType<>(ObjectType.builder().setColumnPolicy(ColumnPolicy.STRICT).build());
         SimpleReference reference = new SimpleReference(
             referenceIdent,
             RowGranularity.DOC,
             dataType,
-            ColumnPolicy.STRICT,
             IndexType.FULLTEXT,
             false,
             true,

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/CountAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/CountAggregationTest.java
@@ -51,7 +51,6 @@ import io.crate.metadata.SimpleReference;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.operation.aggregation.AggregationTestCase;
 import io.crate.sql.tree.BitString;
-import io.crate.sql.tree.ColumnPolicy;
 import io.crate.types.BitStringType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -124,7 +123,6 @@ public class CountAggregationTest extends AggregationTestCase {
             new ReferenceIdent(null, new ColumnIdent("top_level_object", "not_null_subcol")),
             RowGranularity.DOC,
             childType,
-            ColumnPolicy.DYNAMIC,
             IndexType.PLAIN,
             true,
             true,
@@ -134,7 +132,6 @@ public class CountAggregationTest extends AggregationTestCase {
             new ReferenceIdent(null, new ColumnIdent("top_level_object")),
             RowGranularity.DOC,
             ObjectType.builder().setInnerType(notNullImmediateChild.column().leafName(), notNullImmediateChild.valueType()).build(),
-            ColumnPolicy.DYNAMIC,
             IndexType.PLAIN,
             true,
             true,
@@ -172,7 +169,6 @@ public class CountAggregationTest extends AggregationTestCase {
                 new ColumnIdent("top_level_object", List.of("second_level_object", "not_null_subcol"))),
             RowGranularity.DOC,
             DataTypes.STRING,
-            ColumnPolicy.DYNAMIC,
             IndexType.PLAIN,
             true,
             true,
@@ -182,7 +178,6 @@ public class CountAggregationTest extends AggregationTestCase {
             new ReferenceIdent(null, new ColumnIdent("top_level_object", "second_level_object")),
             RowGranularity.DOC,
             ObjectType.builder().setInnerType(notNullGrandChild.column().leafName(), notNullGrandChild.valueType()).build(),
-            ColumnPolicy.DYNAMIC,
             IndexType.PLAIN,
             true,
             true,
@@ -193,7 +188,6 @@ public class CountAggregationTest extends AggregationTestCase {
             new ReferenceIdent(null, new ColumnIdent("top_level_object")),
             RowGranularity.DOC,
             ObjectType.builder().setInnerType(immediateChild.column().leafName(), immediateChild.valueType()).build(),
-            ColumnPolicy.DYNAMIC,
             IndexType.PLAIN,
             true,
             true,
@@ -222,7 +216,7 @@ public class CountAggregationTest extends AggregationTestCase {
         SimpleReference countedObject = new SimpleReference(
             new ReferenceIdent(null, new ColumnIdent("top_level_object")),
             RowGranularity.DOC,
-            ObjectType.UNTYPED,
+            ObjectType.DYNAMIC_OBJECT,
             0,
             null
         );
@@ -256,7 +250,7 @@ public class CountAggregationTest extends AggregationTestCase {
         SimpleReference countedObject = new SimpleReference(
             new ReferenceIdent(null, new ColumnIdent("top_level_object")),
             RowGranularity.DOC,
-            ObjectType.UNTYPED,
+            ObjectType.DYNAMIC_OBJECT,
             0,
             null
         );
@@ -301,7 +295,6 @@ public class CountAggregationTest extends AggregationTestCase {
                 new ColumnIdent("top_level_object", List.of("second_level_object", "not_null_subcol1"))),
             RowGranularity.DOC,
             DataTypes.STRING,
-            ColumnPolicy.DYNAMIC,
             IndexType.PLAIN,
             true,
             true,
@@ -313,7 +306,6 @@ public class CountAggregationTest extends AggregationTestCase {
                 new ColumnIdent("top_level_object", List.of("second_level_object", "not_null_subcol2"))),
             RowGranularity.DOC,
             DataTypes.BYTE,
-            ColumnPolicy.DYNAMIC,
             IndexType.PLAIN,
             true,
             true,
@@ -326,7 +318,6 @@ public class CountAggregationTest extends AggregationTestCase {
                 .setInnerType(notNullGrandChild1.column().leafName(), notNullGrandChild1.valueType())
                 .setInnerType(notNullGrandChild2.column().leafName(), notNullGrandChild2.valueType())
                 .build(),
-            ColumnPolicy.DYNAMIC,
             IndexType.PLAIN,
             true,
             true,
@@ -337,7 +328,6 @@ public class CountAggregationTest extends AggregationTestCase {
             new ReferenceIdent(null, new ColumnIdent("top_level_object", "not_null_subcol")),
             RowGranularity.DOC,
             DataTypes.IP,
-            ColumnPolicy.DYNAMIC,
             IndexType.PLAIN,
             true,
             true,
@@ -350,7 +340,6 @@ public class CountAggregationTest extends AggregationTestCase {
                 .setInnerType(immediateChild.column().leafName(), immediateChild.valueType())
                 .setInnerType(notNullImmediateChild.column().leafName(), notNullImmediateChild.valueType())
                 .build(),
-            ColumnPolicy.DYNAMIC,
             IndexType.PLAIN,
             true,
             true,

--- a/server/src/test/java/io/crate/execution/engine/collect/DocValuesAggregatesTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/DocValuesAggregatesTest.java
@@ -164,7 +164,6 @@ public class DocValuesAggregatesTest extends CrateDummyClusterServiceUnitTest {
                 xRef.ident(),
                 xRef.granularity(),
                 xRef.valueType(),
-                xRef.columnPolicy(),
                 xRef.indexType(),
                 xRef.isNullable(),
                 false,
@@ -201,7 +200,7 @@ public class DocValuesAggregatesTest extends CrateDummyClusterServiceUnitTest {
         return new Aggregation(
             CountAggregation.SIGNATURE,
             CountAggregation.SIGNATURE.getReturnType().createType(),
-            List.of(new InputColumn(inputCol, ObjectType.UNTYPED))
+            List.of(new InputColumn(inputCol, ObjectType.DYNAMIC_OBJECT))
         );
     }
 

--- a/server/src/test/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIteratorTest.java
@@ -65,7 +65,6 @@ import io.crate.metadata.RowGranularity;
 import io.crate.metadata.SimpleReference;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.functions.Signature;
-import io.crate.sql.tree.ColumnPolicy;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.types.DataTypes;
 
@@ -116,7 +115,6 @@ public class DocValuesGroupByOptimizedIteratorTest extends CrateDummyClusterServ
                 new ReferenceIdent(RelationName.fromIndexName("test"), "z"),
                 RowGranularity.DOC,
                 DataTypes.LONG,
-                ColumnPolicy.DYNAMIC,
                 IndexType.PLAIN,
                 true,
                 true,
@@ -134,7 +132,6 @@ public class DocValuesGroupByOptimizedIteratorTest extends CrateDummyClusterServ
                 new ReferenceIdent(RelationName.fromIndexName("test"), "y"),
                 RowGranularity.DOC,
                 DataTypes.LONG,
-                ColumnPolicy.DYNAMIC,
                 IndexType.PLAIN,
                 true,
                 true,
@@ -175,7 +172,6 @@ public class DocValuesGroupByOptimizedIteratorTest extends CrateDummyClusterServ
                     "z"),
                 RowGranularity.DOC,
                 DataTypes.LONG,
-                ColumnPolicy.DYNAMIC,
                 IndexType.PLAIN,
                 true,
                 true,
@@ -191,7 +187,6 @@ public class DocValuesGroupByOptimizedIteratorTest extends CrateDummyClusterServ
                 new ReferenceIdent(RelationName.fromIndexName("test"), "x"),
                 RowGranularity.DOC,
                 DataTypes.STRING,
-                ColumnPolicy.DYNAMIC,
                 IndexType.PLAIN,
                 true,
                 true,
@@ -202,7 +197,6 @@ public class DocValuesGroupByOptimizedIteratorTest extends CrateDummyClusterServ
                 new ReferenceIdent(RelationName.fromIndexName("test"), "y"),
                 RowGranularity.DOC,
                 DataTypes.LONG,
-                ColumnPolicy.DYNAMIC,
                 IndexType.PLAIN,
                 true,
                 true,

--- a/server/src/test/java/io/crate/execution/engine/collect/collectors/OptimizeQueryForSearchAfterTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/collectors/OptimizeQueryForSearchAfterTest.java
@@ -39,7 +39,6 @@ import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.SimpleReference;
-import io.crate.sql.tree.ColumnPolicy;
 import io.crate.types.DataTypes;
 
 public class OptimizeQueryForSearchAfterTest {
@@ -60,7 +59,7 @@ public class OptimizeQueryForSearchAfterTest {
     public void test_short_range_query_with_and_without_docvalues() {
         ReferenceIdent referenceIdent = new ReferenceIdent(new RelationName("doc", "dummy"), "x");
         OrderBy orderBy = new OrderBy(List.of(
-                new SimpleReference(referenceIdent, RowGranularity.DOC, DataTypes.SHORT, ColumnPolicy.DYNAMIC,
+                new SimpleReference(referenceIdent, RowGranularity.DOC, DataTypes.SHORT,
                                     IndexType.PLAIN, true, true, 1, null)
         ));
         var optimize = new OptimizeQueryForSearchAfter(orderBy);
@@ -74,7 +73,7 @@ public class OptimizeQueryForSearchAfterTest {
                 x -> assertThat(x.getQuery()).isExactlyInstanceOf(IndexOrDocValuesQuery.class));
 
         orderBy = new OrderBy(List.of(
-                new SimpleReference(referenceIdent, RowGranularity.DOC, DataTypes.SHORT, ColumnPolicy.DYNAMIC,
+                new SimpleReference(referenceIdent, RowGranularity.DOC, DataTypes.SHORT,
                                     IndexType.PLAIN, true, false, 1, null)
         ));
         optimize = new OptimizeQueryForSearchAfter(orderBy);

--- a/server/src/test/java/io/crate/executor/transport/task/elasticsearch/DocRefResolverTest.java
+++ b/server/src/test/java/io/crate/executor/transport/task/elasticsearch/DocRefResolverTest.java
@@ -129,10 +129,10 @@ public class DocRefResolverTest extends ESTestCase {
         collectExpression.setNextRow(doc);
         assertThat(collectExpression.value()).isNull();
 
-        ObjectType ot = new ObjectType.Builder()
-            .setInnerType("oo", new ObjectType.Builder()
-                                        .setInnerType("oox", DataTypes.NUMERIC)
-                                        .setInnerType("ooy", DataTypes.NUMERIC).build())
+        ObjectType ot = ObjectType.builder()
+            .setInnerType("oo", ObjectType.builder()
+                .setInnerType("oox", DataTypes.NUMERIC)
+                .setInnerType("ooy", DataTypes.NUMERIC).build())
             .build();
         Reference o = new SimpleReference(
             new ReferenceIdent(

--- a/server/src/test/java/io/crate/expression/reference/doc/lucene/LuceneReferenceResolverTest.java
+++ b/server/src/test/java/io/crate/expression/reference/doc/lucene/LuceneReferenceResolverTest.java
@@ -84,7 +84,7 @@ public class LuceneReferenceResolverTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void test_ignored_dynamic_references_are_resolved_using_sourcelookup() {
         Reference ignored = new DynamicReference(
-            new ReferenceIdent(RELATION_NAME, "a", List.of("b")), RowGranularity.DOC, ColumnPolicy.IGNORED, 0);
+                new ReferenceIdent(RELATION_NAME, "a", List.of("b")), RowGranularity.DOC, 0, ColumnPolicy.DYNAMIC);
 
         assertThat(LUCENE_REFERENCE_RESOLVER.getImplementation(ignored))
             .isExactlyInstanceOf(DocCollectorExpression.ChildDocCollectorExpression.class);

--- a/server/src/test/java/io/crate/expression/reference/doc/lucene/SourceParserTest.java
+++ b/server/src/test/java/io/crate/expression/reference/doc/lucene/SourceParserTest.java
@@ -82,9 +82,9 @@ public class SourceParserTest extends ESTestCase {
         boolean xFirst = randomBoolean();
         if (xFirst) {
             sourceParser.register(x, DataTypes.INTEGER);
-            sourceParser.register(obj, ObjectType.UNTYPED);
+            sourceParser.register(obj, ObjectType.DYNAMIC_OBJECT);
         } else {
-            sourceParser.register(obj, ObjectType.UNTYPED);
+            sourceParser.register(obj, ObjectType.DYNAMIC_OBJECT);
             sourceParser.register(x, DataTypes.INTEGER);
         }
 
@@ -261,7 +261,7 @@ public class SourceParserTest extends ESTestCase {
     @Test
     public void test_convert_empty_or_null_arrays_added_dynamically_to_nulls() {
         SourceParser sourceParser = new SourceParser();
-        var type = ObjectType.UNTYPED;
+        var type = ObjectType.DYNAMIC_OBJECT;
         sourceParser.register(new ColumnIdent("_doc", List.of("x")), type);
         var result = sourceParser.parse(
             new BytesArray(

--- a/server/src/test/java/io/crate/expression/symbol/SymbolsTest.java
+++ b/server/src/test/java/io/crate/expression/symbol/SymbolsTest.java
@@ -65,6 +65,6 @@ public class SymbolsTest extends CrateDummyClusterServiceUnitTest {
             .addTable("create table tbl (x int)")
             .build();
         Symbol symbol = e.asSymbol("x + 10 > 100");
-        assertThat(symbol.ramBytesUsed()).isEqualTo(920L);
+        assertThat(symbol.ramBytesUsed()).isEqualTo(912L);
     }
 }

--- a/server/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
+++ b/server/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
@@ -52,6 +52,7 @@ import io.crate.metadata.SimpleReference;
 import io.crate.metadata.doc.DocSchemaInfo;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.functions.Signature;
+import io.crate.sql.tree.ColumnPolicy;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.testing.SqlExpressions;
@@ -181,10 +182,10 @@ public class SymbolPrinterTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testDynamicReference() {
         Reference r = new DynamicReference(
-            new ReferenceIdent(new RelationName("schema", "table"),
+                new ReferenceIdent(new RelationName("schema", "table"),
                                new ColumnIdent("column", Arrays.asList("path", "nested"))),
-            RowGranularity.DOC,
-            0);
+                RowGranularity.DOC,
+                0, ColumnPolicy.DYNAMIC);
         assertPrint(r, "schema.\"table\".\"column\"['path']['nested']");
     }
 

--- a/server/src/test/java/io/crate/integrationtests/SysSnapshotsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysSnapshotsTest.java
@@ -34,6 +34,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import io.crate.sql.tree.ColumnPolicy;
 import io.crate.testing.UseJdbc;
 import io.crate.testing.UseRandomizedSchema;
 import io.crate.types.ArrayType;
@@ -91,11 +92,13 @@ public class SysSnapshotsTest extends IntegTestCase {
             StringType.INSTANCE,
             TimestampType.INSTANCE_WITH_TZ,
             StringType.INSTANCE,
-            new ArrayType<>(ObjectType.builder()
-                .setInnerType("values", stringArray)
-                .setInnerType("table_schema", StringType.INSTANCE)
-                .setInnerType("table_name", StringType.INSTANCE)
-                .build()
+            new ArrayType<>(
+                ObjectType.builder()
+                    .setColumnPolicy(ColumnPolicy.DYNAMIC)
+                    .setInnerType("values", stringArray)
+                    .setInnerType("table_schema", StringType.INSTANCE)
+                    .setInnerType("table_name", StringType.INSTANCE)
+                    .build()
             ),
             stringArray,
             StringType.INSTANCE

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -28,7 +28,6 @@ import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -73,7 +72,6 @@ import io.crate.analyze.validator.SemanticSortValidator;
 import io.crate.common.collections.Lists2;
 import io.crate.exceptions.SQLExceptions;
 import io.crate.sql.SqlFormatter;
-import io.crate.sql.tree.ColumnPolicy;
 import io.crate.testing.Asserts;
 import io.crate.testing.DataTypeTesting;
 import io.crate.testing.UseJdbc;
@@ -1972,7 +1970,7 @@ public class TransportSQLActionTest extends IntegTestCase {
             Supplier<?> dataGenerator = DataTypeTesting.getDataGenerator(type);
             Object val1 = dataGenerator.get();
             var extendedType = extendedType(type, val1);
-            String typeDefinition = SqlFormatter.formatSql(extendedType.toColumnType(ColumnPolicy.STRICT, null));
+            String typeDefinition = SqlFormatter.formatSql(extendedType.toColumnType(null));
             execute("create table tbl (id int primary key, x " + typeDefinition + ")");
             execute("insert into tbl (id, x) values (?, ?)", new Object[] { 1, val1 });
             execute("refresh table tbl");
@@ -1993,9 +1991,9 @@ public class TransportSQLActionTest extends IntegTestCase {
             var resp2 = execute("select _doc['x'], x, _raw FROM tbl where id = ?", new Object[] { 1 });
             assertThat(resp2.rows()[0][0]).usingComparator((DataType<Object>) type).isEqualTo(resp1.rows()[0][0]);
             assertThat(resp2.rows()[0][1]).usingComparator((DataType<Object>) type).isEqualTo(resp1.rows()[0][1]);
-            assertThat(ObjectType.UNTYPED.sanitizeValue(resp2.rows()[0][2]))
-                .usingComparator(ObjectType.UNTYPED)
-                .isEqualTo(ObjectType.UNTYPED.sanitizeValue(resp1.rows()[0][2]));
+            assertThat(ObjectType.DYNAMIC_OBJECT.sanitizeValue(resp2.rows()[0][2]))
+                .usingComparator(ObjectType.DYNAMIC_OBJECT)
+                .isEqualTo(ObjectType.DYNAMIC_OBJECT.sanitizeValue(resp1.rows()[0][2]));
 
             if (SemanticSortValidator.SUPPORTED_TYPES.contains(type.id())) {
                 // should use doc-values/query-without-fetch execution path due to order + limit

--- a/server/src/test/java/io/crate/metadata/GeoReferenceTest.java
+++ b/server/src/test/java/io/crate/metadata/GeoReferenceTest.java
@@ -24,7 +24,6 @@ package io.crate.metadata;
 
 import static io.crate.testing.Asserts.assertThat;
 
-import io.crate.sql.tree.ColumnPolicy;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.test.ESTestCase;
@@ -41,7 +40,6 @@ public class GeoReferenceTest extends ESTestCase {
         GeoReference geoReferenceInfo = new GeoReference(
             referenceIdent,
             DataTypes.GEO_SHAPE,
-            ColumnPolicy.DYNAMIC,
             IndexType.PLAIN,
             true,
             1,
@@ -62,7 +60,6 @@ public class GeoReferenceTest extends ESTestCase {
         GeoReference geoReferenceInfo3 = new GeoReference(
             referenceIdent,
             DataTypes.GEO_SHAPE,
-            ColumnPolicy.DYNAMIC,
             IndexType.PLAIN,
             false,
             2,

--- a/server/src/test/java/io/crate/metadata/ReferenceTest.java
+++ b/server/src/test/java/io/crate/metadata/ReferenceTest.java
@@ -41,6 +41,7 @@ import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.types.ArrayType;
 import io.crate.types.DataTypes;
+import io.crate.types.ObjectType;
 
 public class ReferenceTest extends CrateDummyClusterServiceUnitTest {
 
@@ -69,12 +70,11 @@ public class ReferenceTest extends CrateDummyClusterServiceUnitTest {
     public void testStreaming() throws Exception {
         RelationName relationName = new RelationName("doc", "test");
         ReferenceIdent referenceIdent = new ReferenceIdent(relationName, "object_column");
-        var dataType = new ArrayType<>(DataTypes.UNTYPED_OBJECT);
+        var dataType = new ArrayType<>(ObjectType.builder().setColumnPolicy(ColumnPolicy.STRICT).build());
         SimpleReference reference = new SimpleReference(
             referenceIdent,
             RowGranularity.DOC,
             dataType,
-            ColumnPolicy.STRICT,
             IndexType.FULLTEXT,
             false,
             true,
@@ -101,7 +101,6 @@ public class ReferenceTest extends CrateDummyClusterServiceUnitTest {
             referenceIdent,
             RowGranularity.DOC,
             dataType,
-            ColumnPolicy.STRICT,
             IndexType.FULLTEXT,
             false,
             true,

--- a/server/src/test/java/io/crate/metadata/doc/DocIndexMetadataTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocIndexMetadataTest.java
@@ -1361,6 +1361,7 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
                         .setInnerType("size", DataTypes.DOUBLE)
                         .setInnerType("numbers", DataTypes.INTEGER_ARRAY)
                         .setInnerType("quote", DataTypes.STRING)
+                        .setColumnPolicy(ColumnPolicy.STRICT)
                         .build()));
         assertThat(md.references().get(ColumnIdent.fromPath("tags")).columnPolicy()).isEqualTo(
             ColumnPolicy.STRICT);

--- a/server/src/test/java/io/crate/metadata/doc/DocTableInfoTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocTableInfoTest.java
@@ -51,6 +51,7 @@ import io.crate.sql.tree.ColumnPolicy;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.types.DataTypes;
+import io.crate.types.ObjectType;
 
 public class DocTableInfoTest extends CrateDummyClusterServiceUnitTest {
 
@@ -124,8 +125,7 @@ public class DocTableInfoTest extends CrateDummyClusterServiceUnitTest {
         SimpleReference strictParent = new SimpleReference(
             foobarIdent,
             RowGranularity.DOC,
-            DataTypes.UNTYPED_OBJECT,
-            ColumnPolicy.STRICT,
+            ObjectType.builder().setColumnPolicy(ColumnPolicy.STRICT).build(),
             IndexType.PLAIN,
             true,
             false,

--- a/server/src/test/java/io/crate/planner/InsertPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/InsertPlannerTest.java
@@ -65,7 +65,6 @@ import io.crate.planner.node.dql.Collect;
 import io.crate.planner.node.dql.QueryThenFetch;
 import io.crate.planner.node.dql.join.Join;
 import io.crate.planner.operators.InsertFromValues;
-import io.crate.sql.tree.ColumnPolicy;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.Asserts;
 import io.crate.testing.SQLExecutor;
@@ -386,7 +385,6 @@ public class InsertPlannerTest extends CrateDummyClusterServiceUnitTest {
             new ReferenceIdent(new RelationName(Schemas.DOC_SCHEMA_NAME, "parted_pks"), "date"),
             RowGranularity.PARTITION,
             DataTypes.TIMESTAMPZ,
-            ColumnPolicy.DYNAMIC,
             IndexType.PLAIN,
             false,
             true,

--- a/server/src/test/java/io/crate/planner/node/ddl/UpdateSettingsPlanTest.java
+++ b/server/src/test/java/io/crate/planner/node/ddl/UpdateSettingsPlanTest.java
@@ -94,7 +94,7 @@ public class UpdateSettingsPlanTest extends ESTestCase {
     @Test
     public void testUpdateObjectWithParameter() throws Exception {
         List<Assignment<Symbol>> settings = List.of(
-            new Assignment<>(Literal.of("stats"), List.of(new ParameterSymbol(0, ObjectType.UNTYPED))));
+            new Assignment<>(Literal.of("stats"), List.of(new ParameterSymbol(0, ObjectType.DYNAMIC_OBJECT))));
 
         Map<String, Object> param = MapBuilder.<String, Object>newMapBuilder()
             .put("enabled", true)

--- a/server/src/test/java/io/crate/planner/optimizer/symbol/rule/SimplifyEqualsOperationOnIdenticalReferencesTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/symbol/rule/SimplifyEqualsOperationOnIdenticalReferencesTest.java
@@ -49,7 +49,6 @@ import io.crate.metadata.SimpleReference;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Match;
 import io.crate.planner.optimizer.symbol.FunctionSymbolResolver;
-import io.crate.sql.tree.ColumnPolicy;
 import io.crate.testing.TestingHelpers;
 import io.crate.types.DataTypes;
 
@@ -75,7 +74,6 @@ public class SimplifyEqualsOperationOnIdenticalReferencesTest {
         new ReferenceIdent(new RelationName(null, "dummy"), "col"),
         RowGranularity.DOC,
         DataTypes.INTEGER,
-        ColumnPolicy.DYNAMIC,
         IndexType.PLAIN,
         true,
         false,
@@ -86,7 +84,6 @@ public class SimplifyEqualsOperationOnIdenticalReferencesTest {
         new ReferenceIdent(new RelationName(null, "dummy"), "col"),
         RowGranularity.DOC,
         DataTypes.INTEGER,
-        ColumnPolicy.DYNAMIC,
         IndexType.PLAIN,
         false,
         false,

--- a/server/src/test/java/io/crate/types/ObjectTypeTest.java
+++ b/server/src/test/java/io/crate/types/ObjectTypeTest.java
@@ -191,7 +191,7 @@ public class ObjectTypeTest extends ESTestCase {
 
     @Test
     public void test_raises_conversion_exception_on_string_parsing_errors() throws Exception {
-        assertThatThrownBy(() -> ObjectType.UNTYPED.implicitCast("foo"))
+        assertThatThrownBy(() -> ObjectType.DYNAMIC_OBJECT.implicitCast("foo"))
             .isExactlyInstanceOf(ConversionException.class)
             .hasMessage("Cannot cast value `foo` to type `object`");
     }

--- a/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
+++ b/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
@@ -126,7 +126,6 @@ import io.crate.metadata.functions.Signature;
 import io.crate.metadata.settings.CoordinatorSessionSettings;
 import io.crate.planner.distribution.DistributionInfo;
 import io.crate.sql.tree.BitString;
-import io.crate.sql.tree.ColumnPolicy;
 import io.crate.types.ArrayType;
 import io.crate.types.BitStringType;
 import io.crate.types.DataType;
@@ -313,7 +312,6 @@ public abstract class AggregationTestCase extends ESTestCase {
                     ident,
                     RowGranularity.DOC,
                     argumentTypes.get(i),
-                    ColumnPolicy.DYNAMIC,
                     IndexType.PLAIN,
                     true,
                     true,
@@ -618,7 +616,6 @@ public abstract class AggregationTestCase extends ESTestCase {
                     new ReferenceIdent(new RelationName(null, "dummy"), Integer.toString(i)),
                     RowGranularity.DOC,
                     dataTypes.get(i),
-                    ColumnPolicy.DYNAMIC,
                     IndexType.PLAIN,
                     true,
                     true,

--- a/server/src/testFixtures/java/io/crate/testing/ReferenceAssert.java
+++ b/server/src/testFixtures/java/io/crate/testing/ReferenceAssert.java
@@ -24,6 +24,7 @@ package io.crate.testing;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
+import io.crate.sql.tree.ColumnPolicy;
 import io.crate.types.DataType;
 import org.assertj.core.api.AbstractAssert;
 
@@ -39,6 +40,13 @@ public class ReferenceAssert extends AbstractAssert<ReferenceAssert, Reference> 
         assertThat(actual.column().sqlFqn())
             .as("sqlFqn")
             .isEqualTo(expectedName);
+        return this;
+    }
+
+    public ReferenceAssert hasColumnPolicy(ColumnPolicy columnPolicy) {
+        assertThat(actual.columnPolicy())
+            .as("columnPolicy")
+            .isEqualTo(columnPolicy);
         return this;
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
2nd attempt to https://github.com/crate/crate/pull/14485 (to address https://github.com/crate/crate/pull/14371#discussion_r1262735707).

Fixes:
```
cr> create table t (o object);                                                                                                                    
CREATE OK, 1 row affected  (1.624 sec)

cr> select o['unknown'] from t;                                                                                                                   
ColumnUnknownException[Column o['unknown'] unknown]

cr> select o['unknown'] from t as t2; -- should throw like above                                                                                                             
+--------------+
| o['unknown'] |
+--------------+
+--------------+
SELECT 0 rows in set (0.003 sec)
```

limiting the scope, considering `References` as the bases of subscript expressions and string literals as the indexes.

The approach is to add more checks before allocating `SubscriptFunctions` when analyzing `SubscriptExpressions`.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
