### PR TITLE
Remove executeIO from CancellableThreads

### DIFF
--- a/server/src/main/java/io/crate/blob/recovery/BlobRecoveryHandler.java
+++ b/server/src/main/java/io/crate/blob/recovery/BlobRecoveryHandler.java
@@ -196,7 +196,7 @@ public class BlobRecoveryHandler extends RecoverySourceHandler {
                 LOGGER.trace("[{}][{}] start to transfer file var/{} to {}",
                              request.shardId().getIndexName(), request.shardId().id(), digest,
                              request.targetNode().getName());
-                cancellableThreads.executeIO(
+                cancellableThreads.execute(
                     new TransferFileRunnable(blobShard.blobContainer().getFile(digest),
                         lastException, latch)
                 );

--- a/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
@@ -248,7 +248,7 @@ public class PeerRecoveryTargetService implements IndexEventListener {
         RecoveryResponseHandler responseHandler = new RecoveryResponseHandler(startRequest, timer);
 
         try {
-            cancellableThreads.executeIO(() ->
+            cancellableThreads.execute(() ->
                 // we still execute under cancelableThreads here to ensure we interrupt any blocking call to the network if any
                 // on the underlying transport. It's unclear if we need this here at all after moving to async execution but
                 // the issues that a missing call to this could cause are sneaky and hard to debug. If we don't need it on this


### PR DESCRIPTION
The places where it was used don't raise a checked IOException
