### PR TITLE
Fix flaky testNullOperators

### DIFF
--- a/server/src/main/java/io/crate/execution/dml/FloatVectorIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/FloatVectorIndexer.java
@@ -31,8 +31,10 @@ import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.KnnFloatVectorField;
 import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.mapper.FloatVectorFieldMapper;
 import org.jetbrains.annotations.Nullable;
 
 import io.crate.execution.dml.Indexer.ColumnConstraint;
@@ -40,14 +42,23 @@ import io.crate.execution.dml.Indexer.Synthetic;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.IndexType;
 import io.crate.metadata.Reference;
+import io.crate.types.FloatVectorType;
 
 public class FloatVectorIndexer implements ValueIndexer<float[]> {
 
-    private final FieldType fieldType;
+    final FieldType fieldType;
     private final String name;
     private final Reference ref;
 
-    public FloatVectorIndexer(Reference ref, FieldType fieldType) {
+    public FloatVectorIndexer(Reference ref, @Nullable FieldType fieldType) {
+        if (fieldType == null) {
+            fieldType = new FieldType(FloatVectorFieldMapper.Defaults.FIELD_TYPE);
+            fieldType.setVectorAttributes(
+                ref.valueType().characterMaximumLength(),
+                VectorEncoding.FLOAT32,
+                FloatVectorType.SIMILARITY_FUNC
+            );
+        }
         this.ref = ref;
         this.name = ref.column().fqn();
         this.fieldType = fieldType;

--- a/server/src/main/java/io/crate/types/StorageSupport.java
+++ b/server/src/main/java/io/crate/types/StorageSupport.java
@@ -24,9 +24,8 @@ package io.crate.types;
 
 import java.util.function.Function;
 
-import org.jetbrains.annotations.Nullable;
-
 import org.apache.lucene.document.FieldType;
+import org.jetbrains.annotations.Nullable;
 
 import io.crate.execution.dml.ValueIndexer;
 import io.crate.metadata.ColumnIdent;
@@ -58,6 +57,10 @@ public abstract class StorageSupport<T> {
     }
 
 
+    /**
+     * @param getFieldType returns a {@link FieldType} for the column or null in
+     *                     case the column gets dynamically created.
+     */
     public abstract ValueIndexer<? super T> valueIndexer(
         RelationName table,
         Reference ref,

--- a/server/src/test/java/io/crate/execution/dml/FloatVectorIndexerTest.java
+++ b/server/src/test/java/io/crate/execution/dml/FloatVectorIndexerTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.dml;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import io.crate.metadata.Reference;
+import io.crate.metadata.ReferenceIdent;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.RowGranularity;
+import io.crate.metadata.SimpleReference;
+import io.crate.types.FloatVectorType;
+
+public class FloatVectorIndexerTest {
+
+    @Test
+    public void test_indexer_has_default_fieldtype() throws Exception {
+        FloatVectorType type = new FloatVectorType(4);
+        RelationName tableName = new RelationName("doc", "tbl");
+        Reference ref = new SimpleReference(
+            new ReferenceIdent(tableName, "x"),
+            RowGranularity.DOC,
+            type,
+            1,
+            null
+        );
+        FloatVectorIndexer floatVectorIndexer = new FloatVectorIndexer(ref, null);
+        assertThat(floatVectorIndexer.fieldType).isNotNull();
+        assertThat(floatVectorIndexer.fieldType.vectorDimension()).isEqualTo(4);
+    }
+}
+

--- a/server/src/test/java/io/crate/integrationtests/LuceneQueryBuilderIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/LuceneQueryBuilderIntegrationTest.java
@@ -330,7 +330,8 @@ public class LuceneQueryBuilderIntegrationTest extends IntegTestCase {
         Supplier<?> dataGenerator = DataTypeTesting.getDataGenerator(type);
 
         Object[][] bulkArgs = $$($(dataGenerator.get()), $(dataGenerator.get()), new Object[]{null});
-        execute("insert into t1 (c) values (?)", bulkArgs);
+        long[] rowCounts = execute("insert into t1 (c) values (?)", bulkArgs);
+        assertThat(rowCounts).containsExactly(1, 1, 1);
         execute("refresh table t1");
 
         execute("select count(*) from t1 where c is null");


### PR DESCRIPTION
Failed with seed `62BD5BF8C2991E89:C8C5473C94CBEEC0`

The type randomized to object, and the value generator created a
`float[]` array, leading to creating a dynamic float_vector for the
child column.

The value indexing for the dynamic float_vector failed because the
`fieldType` was null.

Not a user facing bug because only the test layer can provide `float[]`
values. Via HTTP and pgwire the serialization leads to `List<Float>`
values and the type guessing assumes it is a float array.
