### PR TITLE
Fix FieldExistsQuery on columns with `index off` or `columnstore=false`

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/ArrayFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ArrayFieldType.java
@@ -28,7 +28,10 @@ class ArrayFieldType extends MappedFieldType {
     private final MappedFieldType innerFieldType;
 
     ArrayFieldType(MappedFieldType innerFieldType) {
-        super(innerFieldType.name(), innerFieldType.isSearchable(), innerFieldType.hasDocValues());
+        super(innerFieldType.name(),
+              innerFieldType.isSearchable(),
+              innerFieldType.hasDocValues(),
+              innerFieldType.isNameFieldIndexed());
         this.innerFieldType = innerFieldType;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/BitStringFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BitStringFieldMapper.java
@@ -29,6 +29,7 @@ import java.util.function.Consumer;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.SortedSetDocValuesField;
+import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.util.BytesRef;
@@ -70,6 +71,7 @@ public class BitStringFieldMapper extends FieldMapper {
         static {
             FIELD_TYPE.setOmitNorms(true);
             FIELD_TYPE.setIndexOptions(IndexOptions.DOCS);
+            FIELD_TYPE.setDocValuesType(DocValuesType.SORTED_SET);
             FIELD_TYPE.setTokenized(false);
             FIELD_TYPE.setStored(false);
             FIELD_TYPE.freeze();
@@ -79,7 +81,7 @@ public class BitStringFieldMapper extends FieldMapper {
     static class BitStringFieldType extends MappedFieldType {
 
         BitStringFieldType(String name, boolean isSearchable, boolean hasDocValues) {
-            super(name, isSearchable, hasDocValues);
+            super(name, isSearchable, hasDocValues, !hasDocValues);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
 
+import org.apache.lucene.index.DocValuesType;
 import org.jetbrains.annotations.Nullable;
 
 import io.crate.common.time.IsoLocale;
@@ -63,6 +64,7 @@ public class DateFieldMapper extends FieldMapper {
             FIELD_TYPE.setStoreTermVectors(false);
             FIELD_TYPE.setOmitNorms(false);
             FIELD_TYPE.setIndexOptions(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS);
+            FIELD_TYPE.setDocValuesType(DocValuesType.SORTED_NUMERIC);
         }
     }
 
@@ -137,7 +139,7 @@ public class DateFieldMapper extends FieldMapper {
         private final FormatDateTimeFormatter dateTimeFormatter;
 
         DateFieldType(String name, boolean isSearchable, boolean hasDocValues, FormatDateTimeFormatter formatter) {
-            super(name, isSearchable, hasDocValues);
+            super(name, isSearchable, hasDocValues, false);
             this.dateTimeFormatter = formatter;
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
 
+import org.apache.lucene.index.DocValuesType;
 import org.jetbrains.annotations.Nullable;
 
 import org.apache.lucene.document.Document;
@@ -68,6 +69,9 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
         }
 
         public T docValues(boolean docValues) {
+            if (docValues == false) {
+                fieldType.setDocValuesType(DocValuesType.NONE);
+            }
             this.hasDocValues = docValues;
             return builder;
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldNamesFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldNamesFieldMapper.java
@@ -101,7 +101,7 @@ public class FieldNamesFieldMapper extends MetadataFieldMapper {
         private boolean enabled = Defaults.ENABLED;
 
         public FieldNamesFieldType() {
-            super(Defaults.NAME, true, false);
+            super(Defaults.NAME, true, false, false);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/FloatVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FloatVectorFieldMapper.java
@@ -58,7 +58,7 @@ public class FloatVectorFieldMapper extends FieldMapper implements ArrayValueMap
     static class VectorFieldType extends MappedFieldType {
 
         public VectorFieldType(String name, boolean isIndexed, boolean hasDocValues) {
-            super(name, isIndexed, hasDocValues);
+            super(name, isIndexed, hasDocValues, false);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
+import org.apache.lucene.index.DocValuesType;
 import org.jetbrains.annotations.Nullable;
 
 import org.apache.lucene.document.Document;
@@ -50,6 +51,7 @@ public class GeoPointFieldMapper extends FieldMapper implements ArrayValueMapper
     public static final FieldType FIELD_TYPE = new FieldType();
 
     static {
+        FIELD_TYPE.setDocValuesType(DocValuesType.SORTED_NUMERIC);
         FIELD_TYPE.setStored(false);
         FIELD_TYPE.setTokenized(false);
         FIELD_TYPE.setDimensions(2, Integer.BYTES);
@@ -117,7 +119,7 @@ public class GeoPointFieldMapper extends FieldMapper implements ArrayValueMapper
     public static class GeoPointFieldType extends MappedFieldType {
 
         public GeoPointFieldType(String name, boolean indexed, boolean hasDocValues) {
-            super(name, indexed, hasDocValues);
+            super(name, indexed, hasDocValues, !hasDocValues);
         }
 
         @Override
@@ -144,7 +146,7 @@ public class GeoPointFieldMapper extends FieldMapper implements ArrayValueMapper
         }
         if (fieldType().hasDocValues()) {
             doc.add(new LatLonDocValuesField(fieldType().name(), point.lat(), point.lon()));
-        } else if (fieldType.stored() || fieldType().isSearchable()) {
+        } else if (fieldType.stored() || fieldType().isSearchable()) { // TODO: is this bug?
             createFieldNamesField(context, doc::add);
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeFieldMapper.java
@@ -205,7 +205,7 @@ public class GeoShapeFieldMapper extends FieldMapper {
         private Orientation orientation = Defaults.ORIENTATION;
 
         public GeoShapeFieldType(String name, boolean indexed, boolean hasDocValues) {
-            super(name, indexed, hasDocValues);
+            super(name, indexed, hasDocValues, true);
         }
 
         public GeoShapeFieldType(String name,

--- a/server/src/main/java/org/elasticsearch/index/mapper/IdFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IdFieldMapper.java
@@ -73,7 +73,7 @@ public class IdFieldMapper extends MetadataFieldMapper {
         public static final IdFieldType INSTANCE = new IdFieldType();
 
         private IdFieldType() {
-            super(NAME, true, false);
+            super(NAME, true, false, false);
             setIndexAnalyzer(Lucene.KEYWORD_ANALYZER);
             setSearchAnalyzer(Lucene.KEYWORD_ANALYZER);
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -30,6 +30,7 @@ import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.InetAddressPoint;
 import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.document.StoredField;
+import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Explicit;
@@ -49,6 +50,7 @@ public class IpFieldMapper extends FieldMapper {
         public static final FieldType FIELD_TYPE = new FieldType();
 
         static {
+            FIELD_TYPE.setDocValuesType(DocValuesType.SORTED_SET);
             FIELD_TYPE.setDimensions(1, Integer.BYTES);
             FIELD_TYPE.freeze();
         }
@@ -91,7 +93,7 @@ public class IpFieldMapper extends FieldMapper {
     public static final class IpFieldType extends MappedFieldType {
 
         public IpFieldType(String name, boolean indexed, boolean hasDocValues) {
-            super(name, indexed, hasDocValues);
+            super(name, indexed, hasDocValues, !hasDocValues);
         }
 
         public IpFieldType(String name) {
@@ -141,7 +143,7 @@ public class IpFieldMapper extends FieldMapper {
         }
         if (fieldType().hasDocValues()) {
             onField.accept(new SortedSetDocValuesField(fieldType().name(), new BytesRef(InetAddressPoint.encode(address))));
-        } else if (fieldType.stored() || fieldType().isSearchable()) {
+        } else if (fieldType.stored() || fieldType().isSearchable()) { // bug?
             createFieldNamesField(context, onField);
         }
         if (fieldType.stored()) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
 
+import org.apache.lucene.index.DocValuesType;
 import org.jetbrains.annotations.Nullable;
 
 import io.crate.server.xcontent.XContentMapValues;
@@ -56,6 +57,7 @@ public final class KeywordFieldMapper extends FieldMapper {
             FIELD_TYPE.setTokenized(false);
             FIELD_TYPE.setOmitNorms(true);
             FIELD_TYPE.setIndexOptions(IndexOptions.DOCS);
+            FIELD_TYPE.setDocValuesType(DocValuesType.SORTED_SET);
             FIELD_TYPE.freeze();
         }
 
@@ -156,7 +158,7 @@ public final class KeywordFieldMapper extends FieldMapper {
                                 boolean isSearchable,
                                 boolean hasDocValues,
                                 boolean hasNorms) {
-            super(name, isSearchable, hasDocValues);
+            super(name, isSearchable, hasDocValues, isSearchable && !hasDocValues);
             this.hasNorms = hasNorms;
             setIndexAnalyzer(Lucene.KEYWORD_ANALYZER);
             setSearchAnalyzer(Lucene.KEYWORD_ANALYZER);

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
@@ -31,15 +31,17 @@ public abstract class MappedFieldType {
     private final String name;
     private final boolean docValues;
     private final boolean isIndexed;
+    private final boolean isNameFieldIndexed;
     private NamedAnalyzer indexAnalyzer;
     private NamedAnalyzer searchAnalyzer;
     private NamedAnalyzer searchQuoteAnalyzer;
     protected boolean hasPositions;
 
-    public MappedFieldType(String name, boolean isIndexed, boolean hasDocValues) {
+    public MappedFieldType(String name, boolean isIndexed, boolean hasDocValues, boolean isFieldNameIndexed) {
         this.name = Objects.requireNonNull(name);
         this.isIndexed = isIndexed;
         this.docValues = hasDocValues;
+        this.isNameFieldIndexed = isFieldNameIndexed;
     }
 
     /** Returns the name of this type, as would be specified in mapping properties */
@@ -55,6 +57,10 @@ public abstract class MappedFieldType {
 
     public boolean hasDocValues() {
         return docValues;
+    }
+
+    public boolean isNameFieldIndexed() {
+        return isNameFieldIndexed;
     }
 
     public NamedAnalyzer indexAnalyzer() {

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -34,6 +34,7 @@ import org.apache.lucene.document.IntPoint;
 import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.document.StoredField;
+import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.util.BytesRef;
@@ -49,6 +50,7 @@ public class NumberFieldMapper extends FieldMapper {
     public static final FieldType FIELD_TYPE = new FieldType();
 
     static {
+        FIELD_TYPE.setDocValuesType(DocValuesType.SORTED_NUMERIC);
         FIELD_TYPE.setStored(false);
         FIELD_TYPE.freeze();
     }
@@ -378,7 +380,7 @@ public class NumberFieldMapper extends FieldMapper {
         private final NumberType type;
 
         public NumberFieldType(String name, NumberType type, boolean isSearchable, boolean hasDocValues) {
-            super(name, isSearchable, hasDocValues);
+            super(name, isSearchable, hasDocValues, !hasDocValues);
             this.type = Objects.requireNonNull(type);
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
@@ -85,7 +85,7 @@ public class SourceFieldMapper extends MetadataFieldMapper {
         public static final SourceFieldType INSTANCE = new SourceFieldType();
 
         private SourceFieldType() {
-            super(NAME, false, false);
+            super(NAME, false, false, false);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -189,7 +189,7 @@ public class TextFieldMapper extends FieldMapper {
     public static final class TextFieldType extends MappedFieldType {
 
         public TextFieldType(String name, boolean indexed, boolean hasPositions) {
-            super(name, indexed, false);
+            super(name, indexed, false, false);
             this.hasPositions = hasPositions;
         }
 

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.node;
 
+import static org.elasticsearch.search.SearchModule.INDICES_MAX_CLAUSE_COUNT_PADDING;
+
 import java.io.BufferedWriter;
 import java.io.Closeable;
 import java.io.IOException;
@@ -447,7 +449,7 @@ public class Node implements Closeable {
             IndicesModule indicesModule = new IndicesModule(pluginsService.filterPlugins(MapperPlugin.class));
             modules.add(indicesModule);
 
-            IndexSearcher.setMaxClauseCount(SearchModule.INDICES_MAX_CLAUSE_COUNT_SETTING.get(settings));
+            IndexSearcher.setMaxClauseCount(SearchModule.INDICES_MAX_CLAUSE_COUNT_SETTING.get(settings) + INDICES_MAX_CLAUSE_COUNT_PADDING);
 
             CircuitBreakerService circuitBreakerService = new HierarchyCircuitBreakerService(settings, settingsModule.getClusterSettings());
             resourcesToClose.add(circuitBreakerService);

--- a/server/src/main/java/org/elasticsearch/search/SearchModule.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchModule.java
@@ -24,4 +24,8 @@ import org.elasticsearch.common.settings.Setting;
 public class SearchModule {
     public static final Setting<Integer> INDICES_MAX_CLAUSE_COUNT_SETTING = Setting.intSetting("indices.query.bool.max_clause_count",
             8192, 1, Integer.MAX_VALUE, Setting.Property.NodeScope);
+
+    // Sometimes an extra FieldExistsQuery is added for a null check:
+    // https://github.com/crate/crate/pull/13733/commits/69345c0dcf17eb70be1ca26aa82bec741d3c8d8c
+    public static final int INDICES_MAX_CLAUSE_COUNT_PADDING = 1;
 }

--- a/server/src/test/java/io/crate/execution/engine/collect/collectors/LuceneOrderedDocCollectorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/collectors/LuceneOrderedDocCollectorTest.java
@@ -374,7 +374,7 @@ public class LuceneOrderedDocCollectorTest extends RandomizedTest {
 
     private static void addDoc(IndexWriter w, String name, FieldType fieldType, String value) throws IOException {
         Document doc = new Document();
-        Field field = new Field(name, value, fieldType);
+        Field field = new Field(name, new BytesRef(value), fieldType);
         doc.add(field);
         w.addDocument(doc);
     }

--- a/server/src/test/java/io/crate/integrationtests/LuceneQueryBuilderIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/LuceneQueryBuilderIntegrationTest.java
@@ -324,10 +324,70 @@ public class LuceneQueryBuilderIntegrationTest extends IntegTestCase {
     }
 
     @Test
-    public void testWhereNotEqualAnyWithLargeArray() throws Exception {
+    public void testWhereNotEqualAnyWithLargeArrayForIntegerType() throws Exception {
         // Test overriding of default value 8192 for indices.query.bool.max_clause_count
         execute("create table t1 (id integer) clustered into 2 shards with (number_of_replicas = 0)");
         execute("create table t2 (id integer) clustered into 2 shards with (number_of_replicas = 0)");
+        ensureYellow();
+
+        int bulkSize = NUMBER_OF_BOOLEAN_CLAUSES;
+        Object[][] bulkArgs = new Object[bulkSize][];
+        for (int i = 0; i < bulkSize; i++) {
+            bulkArgs[i] = new Object[]{i};
+        }
+        execute("insert into t1 (id) values (?)", bulkArgs);
+        execute("insert into t2 (id) values (1)");
+        execute("refresh table t1, t2");
+
+        execute("select count(*) from t2 where id != any(select id from t1)");
+        assertThat(response.rows()[0][0]).isEqualTo(1L);
+    }
+
+    @Test
+    public void testWhereNotEqualAnyWithLargeArrayWithIndexOffForIntegerType() throws Exception {
+        // Test overriding of default value 8192 for indices.query.bool.max_clause_count
+        execute("create table t1 (id integer index off) clustered into 2 shards with (number_of_replicas = 0)");
+        execute("create table t2 (id integer index off) clustered into 2 shards with (number_of_replicas = 0)");
+        ensureYellow();
+
+        int bulkSize = NUMBER_OF_BOOLEAN_CLAUSES;
+        Object[][] bulkArgs = new Object[bulkSize][];
+        for (int i = 0; i < bulkSize; i++) {
+            bulkArgs[i] = new Object[]{i};
+        }
+        execute("insert into t1 (id) values (?)", bulkArgs);
+        execute("insert into t2 (id) values (1)");
+        execute("refresh table t1, t2");
+
+        execute("select count(*) from t2 where id != any(select id from t1)");
+        assertThat(response.rows()[0][0]).isEqualTo(1L);
+    }
+
+    @Test
+    public void testWhereNotEqualAnyWithLargeArrayWithColumnStoreOffForIntegerType() throws Exception {
+        // Test overriding of default value 8192 for indices.query.bool.max_clause_count
+        execute("create table t1 (id integer storage with (columnstore = false)) clustered into 2 shards with (number_of_replicas = 0)");
+        execute("create table t2 (id integer storage with (columnstore = false)) clustered into 2 shards with (number_of_replicas = 0)");
+        ensureYellow();
+
+        int bulkSize = NUMBER_OF_BOOLEAN_CLAUSES;
+        Object[][] bulkArgs = new Object[bulkSize][];
+        for (int i = 0; i < bulkSize; i++) {
+            bulkArgs[i] = new Object[]{i};
+        }
+        execute("insert into t1 (id) values (?)", bulkArgs);
+        execute("insert into t2 (id) values (1)");
+        execute("refresh table t1, t2");
+
+        execute("select count(*) from t2 where id != any(select id from t1)");
+        assertThat(response.rows()[0][0]).isEqualTo(1L);
+    }
+
+    @Test
+    public void testWhereNotEqualAnyWithLargeArrayWithIndexAndColumnStoreOffForIntegerType() throws Exception {
+        // Test overriding of default value 8192 for indices.query.bool.max_clause_count
+        execute("create table t1 (id integer index off storage with (columnstore = false)) clustered into 2 shards with (number_of_replicas = 0)");
+        execute("create table t2 (id integer index off storage with (columnstore = false)) clustered into 2 shards with (number_of_replicas = 0)");
         ensureYellow();
 
         int bulkSize = NUMBER_OF_BOOLEAN_CLAUSES;

--- a/server/src/test/java/io/crate/integrationtests/LuceneQueryBuilderIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/LuceneQueryBuilderIntegrationTest.java
@@ -48,7 +48,8 @@ public class LuceneQueryBuilderIntegrationTest extends IntegTestCase {
     protected Settings nodeSettings(int nodeOrdinal) {
         return Settings.builder()
                        .put(super.nodeSettings(nodeOrdinal))
-                       .put(SearchModule.INDICES_MAX_CLAUSE_COUNT_SETTING.getKey(), NUMBER_OF_BOOLEAN_CLAUSES)
+                       .put(SearchModule.INDICES_MAX_CLAUSE_COUNT_SETTING.getKey(),
+                            NUMBER_OF_BOOLEAN_CLAUSES + SearchModule.INDICES_MAX_CLAUSE_COUNT_PADDING)
                        .build();
     }
 

--- a/server/src/test/java/io/crate/lucene/BitStringEqQueryTest.java
+++ b/server/src/test/java/io/crate/lucene/BitStringEqQueryTest.java
@@ -34,11 +34,11 @@ import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.sql.tree.BitString;
 
 public class BitStringEqQueryTest extends LuceneQueryBuilderTest {
-    private static final BitString BIT_STRING = BitString.ofBitString("B'001'");
+    public static final BitString BIT_STRING = BitString.ofBitString("B'001'");
     private static final BytesRef BIT_STRING_IN_BYTES_REF = new BytesRef(BIT_STRING.bitSet().toByteArray());
 
     @Override
-    protected String createStmt() {
+    public String createStmt() {
         // `columnstore = false` is not supported
         return """
                 create table m (

--- a/server/src/test/java/io/crate/lucene/BooleanEqQueryTest.java
+++ b/server/src/test/java/io/crate/lucene/BooleanEqQueryTest.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 
 public class BooleanEqQueryTest extends LuceneQueryBuilderTest {
     @Override
-    protected String createStmt() {
+    public String createStmt() {
         // `columnstore = false` is not supported
         return """
                 create table m (

--- a/server/src/test/java/io/crate/lucene/DoubleEqQueryTest.java
+++ b/server/src/test/java/io/crate/lucene/DoubleEqQueryTest.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 
 public class DoubleEqQueryTest extends LuceneQueryBuilderTest {
     @Override
-    protected String createStmt() {
+    public String createStmt() {
         return """
                 create table m (
                 a1 double,

--- a/server/src/test/java/io/crate/lucene/FloatEqQueryTest.java
+++ b/server/src/test/java/io/crate/lucene/FloatEqQueryTest.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 
 public class FloatEqQueryTest extends LuceneQueryBuilderTest {
     @Override
-    protected String createStmt() {
+    public String createStmt() {
         return """
                 create table m (
                 a1 float,

--- a/server/src/test/java/io/crate/lucene/IntEqQueryTest.java
+++ b/server/src/test/java/io/crate/lucene/IntEqQueryTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 
 public class IntEqQueryTest extends LuceneQueryBuilderTest {
     @Override
-    protected String createStmt() {
+    public String createStmt() {
         return """
                 create table m (
                 a1 int,

--- a/server/src/test/java/io/crate/lucene/IpEqQueryTest.java
+++ b/server/src/test/java/io/crate/lucene/IpEqQueryTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 
 public class IpEqQueryTest extends LuceneQueryBuilderTest {
     @Override
-    protected String createStmt() {
+    public String createStmt() {
         // `columnstore = false` is not supported
         return """
                 create table m (

--- a/server/src/test/java/io/crate/lucene/LongEqQueryTest.java
+++ b/server/src/test/java/io/crate/lucene/LongEqQueryTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 
 public class LongEqQueryTest extends LuceneQueryBuilderTest {
     @Override
-    protected String createStmt() {
+    public String createStmt() {
         return """
                 create table m (
                 a1 long,

--- a/server/src/test/java/io/crate/lucene/StringEqQueryTest.java
+++ b/server/src/test/java/io/crate/lucene/StringEqQueryTest.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 
 public class StringEqQueryTest extends LuceneQueryBuilderTest {
     @Override
-    protected String createStmt() {
+    public String createStmt() {
         return """
                 create table m (
                 a1 text,

--- a/server/src/testFixtures/java/io/crate/testing/QueryTester.java
+++ b/server/src/testFixtures/java/io/crate/testing/QueryTester.java
@@ -27,7 +27,9 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -217,6 +219,10 @@ public final class QueryTester implements AutoCloseable {
 
     public List<Object> runQuery(String resultColumn, String expression, Object ... params) throws Exception {
         Query query = toQuery(expression, params);
+        return runQuery(resultColumn, query);
+    }
+
+    public List<Object> runQuery(String resultColumn, Query query) throws ExecutionException, InterruptedException, TimeoutException {
         LuceneBatchIterator batchIterator = getIterator.apply(ColumnIdent.fromPath(resultColumn), query);
         return BatchIterators.collect(
             batchIterator,


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Follows https://github.com/crate/crate/pull/14527, managing it separately since this exposes bugs.

The first commit adds more variations of the test `testWhereNotEqualAnyWithLargeArray` combining `index off` and `columnstore = false` which exposes below two bugs:

1) `FieldExistsQuery` is counted as 1 more clause resulting in `TooManyClauses` exceptions. (In some cases, it does not due to rewriting)
2) When `columnstore = false`, `FieldExistsQuery` is used and raises exceptions:
```
select a from t where a != any([1,2]); -- where 'a' is an int column with (columnstore = false)                                                                                                       
IllegalStateException[FieldExistsQuery requires that the field indexes doc values, norms or vectors, but field 'a' exists and indexes neither of these data structures]
```

The last two commits address the mentioned issues.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
