### PR TITLE
Fix flaky testKillUpdateByQuery

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/KillIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/KillIntegrationTest.java
@@ -23,8 +23,6 @@ package io.crate.integrationtests;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.anyOf;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -36,11 +34,10 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
-import org.jetbrains.annotations.Nullable;
-
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.IntegTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.jetbrains.annotations.Nullable;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -98,13 +95,14 @@ public class KillIntegrationTest extends IntegTestCase {
             try {
                 future.get(10, TimeUnit.SECONDS);
             } catch (Throwable exception) {
-                exception = SQLExceptions.unwrap(exception); // wrapped in ExecutionException
-                assertThat(exception,
-                           anyOf(instanceOf(JobKilledException.class),
-                                 instanceOf(InterruptedException.class),
-                                 instanceOf(CancellationException.class),
-                                 instanceOf(TaskMissing.class)
-                                )
+                // wrapped in ExecutionException or RuntimeException via Exceptions.toRuntimeExceptions
+                // (E.g. in ShardDMLExecutor.maybeRaiseFailure)
+                exception = SQLExceptions.unwrap(exception, t -> t.getClass() == RuntimeException.class);
+                assertThat(exception).satisfiesAnyOf(
+                    x -> assertThat(x).isExactlyInstanceOf(JobKilledException.class),
+                    x -> assertThat(x).isExactlyInstanceOf(InterruptedException.class),
+                    x -> assertThat(x).isExactlyInstanceOf(CancellationException.class),
+                    x -> assertThat(x).isExactlyInstanceOf(TaskMissing.class)
                 );
             }
         } finally {


### PR DESCRIPTION
Failed with seed D9DE788C357A9865 (sometimes took up to 10 minutes of
non-stop repeat, but usually much faster)

We sometimes wrap `InterruptedException` in a `RuntimeException`, one
such instance is in ShardDMLExecutor.maybeRaiseFailure

The test case didn't account for that.
The assertj assertions made this more visible:

    org.assertj.core.error.AssertJMultipleFailuresError:
    Multiple Failures (4 failures)
    -- failure 1 --
    Expecting actual throwable to be exactly an instance of:
      io.crate.exceptions.JobKilledException
    but was:
      java.lang.RuntimeException: java.lang.InterruptedException
            at io.crate.common.exceptions.Exceptions.toRuntimeException(Exceptions.java:70)
            at io.crate.execution.engine.indexing.ShardDMLExecutor.maybeRaiseFailure(ShardDMLExecutor.java:243)
            at io.crate.execution.engine.indexing.ShardDMLExecutor.lambda$static$5(ShardDMLExecutor.java:250)
            ...(56 remaining lines not displayed - this can be changed with Assertions.setMaxStackTraceElementsDisplayed)
    at KillIntegrationTest.lambda$assertGotCancelled$0(KillIntegrationTest.java:100)
