### PR TITLE
Unwrap RuntimeException by default

### DIFF
--- a/server/src/main/java/io/crate/execution/dml/BulkShardResponseListener.java
+++ b/server/src/main/java/io/crate/execution/dml/BulkShardResponseListener.java
@@ -21,19 +21,21 @@
 
 package io.crate.execution.dml;
 
-import com.carrotsearch.hppc.IntCollection;
-import com.carrotsearch.hppc.cursors.IntCursor;
-import io.crate.data.Row1;
-import io.crate.exceptions.SQLExceptions;
-import io.crate.execution.support.MultiActionListener;
-import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.index.engine.DocumentMissingException;
-import org.elasticsearch.index.engine.VersionConflictEngineException;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.index.engine.DocumentMissingException;
+import org.elasticsearch.index.engine.VersionConflictEngineException;
+
+import com.carrotsearch.hppc.IntCollection;
+import com.carrotsearch.hppc.cursors.IntCursor;
+
+import io.crate.data.Row1;
+import io.crate.exceptions.SQLExceptions;
+import io.crate.execution.support.MultiActionListener;
 
 /**
  * Listener to aggregate the responses of multiple (bulk-operation-mode) ShardResponses
@@ -71,7 +73,7 @@ final class BulkShardResponseListener implements ActionListener<ShardResponse> {
         if (failure == null) {
             result.update(response);
         } else {
-            Throwable t = SQLExceptions.unwrap(failure, e -> e instanceof RuntimeException);
+            Throwable t = SQLExceptions.unwrap(failure);
             if (!(t instanceof DocumentMissingException) && !(t instanceof VersionConflictEngineException)) {
                 throw new RuntimeException(t);
             }

--- a/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
+++ b/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
@@ -56,7 +56,6 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.routing.ShardIterator;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.io.stream.NotSerializableExceptionWrapper;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.jetbrains.annotations.Nullable;
 
@@ -655,7 +654,7 @@ public class InsertFromValues implements LogicalPlan {
                 if (throwable == null) {
                     result.complete(compressedResult);
                 } else {
-                    throwable = SQLExceptions.unwrap(throwable, t -> t instanceof RuntimeException);
+                    throwable = SQLExceptions.unwrap(throwable);
                     // we want to report duplicate key exceptions
                     if (!SQLExceptions.isDocumentAlreadyExistsException(throwable) &&
                             (partitionWasDeleted(throwable, request.index())
@@ -731,8 +730,7 @@ public class InsertFromValues implements LogicalPlan {
     }
 
     private static boolean mixedArgumentTypesFailure(Throwable throwable) {
-        return throwable instanceof ClassCastException
-               || throwable instanceof NotSerializableExceptionWrapper;
+        return throwable instanceof ClassCastException;
     }
 
     private static boolean partitionWasDeleted(Throwable throwable, String index) {

--- a/server/src/main/java/io/crate/rest/action/HttpError.java
+++ b/server/src/main/java/io/crate/rest/action/HttpError.java
@@ -25,12 +25,11 @@ import static io.crate.common.exceptions.Exceptions.userFriendlyMessage;
 
 import java.io.IOException;
 
-import org.jetbrains.annotations.Nullable;
-
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.mapper.MapperParsingException;
+import org.jetbrains.annotations.Nullable;
 
 import io.crate.exceptions.AmbiguousColumnAliasException;
 import io.crate.exceptions.AmbiguousColumnException;
@@ -38,7 +37,6 @@ import io.crate.exceptions.AnalyzerInvalidException;
 import io.crate.exceptions.AnalyzerUnknownException;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.exceptions.ColumnValidationException;
-import io.crate.exceptions.CrateException;
 import io.crate.exceptions.DuplicateKeyException;
 import io.crate.exceptions.InvalidArgumentException;
 import io.crate.exceptions.InvalidColumnNameException;
@@ -133,88 +131,84 @@ public class HttpError {
 
     public static HttpError fromThrowable(Throwable throwable) {
         var httpErrorStatus = HttpErrorStatus.UNHANDLED_SERVER_ERROR;
-
         if (throwable instanceof MapperParsingException) {
+            httpErrorStatus = HttpErrorStatus.FIELD_VALIDATION_FAILED;
+        } else if (throwable instanceof MissingPrivilegeException) {
+            httpErrorStatus = HttpErrorStatus.MISSING_USER_PRIVILEGES;
+        } else if (throwable instanceof AmbiguousColumnAliasException) {
+            httpErrorStatus = HttpErrorStatus.COLUMN_ALIAS_IS_AMBIGUOUS;
+        } else if (throwable instanceof AmbiguousColumnException) {
+            httpErrorStatus = HttpErrorStatus.COLUMN_ALIAS_IS_AMBIGUOUS;
+        } else if (throwable instanceof AnalyzerInvalidException) {
+            httpErrorStatus = HttpErrorStatus.STATEMENT_INVALID_ANALYZER_DEFINITION;
+        } else if (throwable instanceof ColumnValidationException) {
+            httpErrorStatus = HttpErrorStatus.FIELD_VALIDATION_FAILED;
+        } else if (throwable instanceof InvalidArgumentException) {
+            httpErrorStatus = HttpErrorStatus.FIELD_VALIDATION_FAILED;
+        } else if (throwable instanceof InvalidColumnNameException) {
+            httpErrorStatus = HttpErrorStatus.COLUMN_NAME_INVALID;
+        } else if (throwable instanceof InvalidRelationName) {
+            httpErrorStatus = HttpErrorStatus.RELATION_INVALID_NAME;
+        } else if (throwable instanceof InvalidSchemaNameException) {
+            httpErrorStatus = HttpErrorStatus.RELATION_INVALID_NAME;
+        } else if (throwable instanceof OperationOnInaccessibleRelationException) {
+            httpErrorStatus = HttpErrorStatus.RELATION_OPERATION_NOT_SUPPORTED;
+        } else if (throwable instanceof RelationValidationException) {
+            httpErrorStatus = HttpErrorStatus.FIELD_VALIDATION_FAILED;
+        } else if (throwable instanceof SQLParseException) {
             httpErrorStatus = HttpErrorStatus.STATEMENT_INVALID_OR_UNSUPPORTED_SYNTAX;
-        } else if (throwable instanceof CrateException) {
-            CrateException crateException = (CrateException) throwable;
-            if (crateException instanceof MissingPrivilegeException) {
-                httpErrorStatus = HttpErrorStatus.MISSING_USER_PRIVILEGES;
-            } else if (crateException instanceof AmbiguousColumnAliasException) {
-                httpErrorStatus = HttpErrorStatus.COLUMN_ALIAS_IS_AMBIGUOUS;
-            } else if (crateException instanceof AmbiguousColumnException) {
-                httpErrorStatus = HttpErrorStatus.COLUMN_ALIAS_IS_AMBIGUOUS;
-            } else if (crateException instanceof AnalyzerInvalidException) {
-                httpErrorStatus = HttpErrorStatus.STATEMENT_INVALID_ANALYZER_DEFINITION;
-            } else if (crateException instanceof ColumnValidationException) {
-                httpErrorStatus = HttpErrorStatus.FIELD_VALIDATION_FAILED;
-            } else if (crateException instanceof InvalidArgumentException) {
-                httpErrorStatus = HttpErrorStatus.FIELD_VALIDATION_FAILED;
-            } else if (crateException instanceof InvalidColumnNameException) {
-                httpErrorStatus = HttpErrorStatus.COLUMN_NAME_INVALID;
-            } else if (crateException instanceof InvalidRelationName) {
-                httpErrorStatus = HttpErrorStatus.RELATION_INVALID_NAME;
-            } else if (crateException instanceof InvalidSchemaNameException) {
-                httpErrorStatus = HttpErrorStatus.RELATION_INVALID_NAME;
-            } else if (crateException instanceof OperationOnInaccessibleRelationException) {
-                httpErrorStatus = HttpErrorStatus.RELATION_OPERATION_NOT_SUPPORTED;
-            } else if (crateException instanceof RelationValidationException) {
-                httpErrorStatus = HttpErrorStatus.FIELD_VALIDATION_FAILED;
-            } else if (crateException instanceof SQLParseException) {
-                httpErrorStatus = HttpErrorStatus.STATEMENT_INVALID_OR_UNSUPPORTED_SYNTAX;
-            } else if (crateException instanceof UnsupportedFeatureException ||
-                       crateException instanceof UnsupportedFunctionException) {
-                httpErrorStatus = HttpErrorStatus.POSSIBLE_FEATURE_NOT_SUPPROTED_YET;
-            } else if (crateException instanceof VersioningValidationException) {
-                httpErrorStatus = HttpErrorStatus.STATEMENT_INVALID_OR_UNSUPPORTED_SYNTAX;
-            } else if (crateException instanceof AnalyzerUnknownException) {
-                httpErrorStatus = HttpErrorStatus.STATEMENT_INVALID_ANALYZER_DEFINITION;
-            } else if (crateException instanceof ColumnUnknownException) {
-                httpErrorStatus = HttpErrorStatus.COLUMN_UNKNOWN;
-            } else if (crateException instanceof PartitionUnknownException) {
-                httpErrorStatus = HttpErrorStatus.PARTITION_UNKNOWN;
-            } else if (crateException instanceof RelationUnknown) {
-                httpErrorStatus = HttpErrorStatus.RELATION_UNKNOWN;
-            } else if (crateException instanceof RelationsUnknown) {
-                httpErrorStatus = HttpErrorStatus.RELATION_UNKNOWN;
-            } else if (crateException instanceof RepositoryUnknownException) {
-                httpErrorStatus = HttpErrorStatus.REPOSITORY_UNKNOWN;
-            } else if (crateException instanceof SchemaUnknownException) {
-                httpErrorStatus = HttpErrorStatus.SCHEMA_UNKNOWN;
-            } else if (crateException instanceof UserDefinedFunctionUnknownException) {
-                httpErrorStatus = HttpErrorStatus.USER_DEFINED_FUNCTION_UNKNOWN;
-            } else if (crateException instanceof UserUnknownException) {
-                httpErrorStatus = HttpErrorStatus.USER_UNKNOWN;
-            } else if (crateException instanceof SnapshotUnknownException) {
-                httpErrorStatus = HttpErrorStatus.SNAPSHOT_UNKNOWN;
-            } else if (crateException instanceof UnauthorizedException) {
-                httpErrorStatus = HttpErrorStatus.USER_NOT_AUTHORIZED_TO_PERFORM_STATEMENT;
-            } else if (crateException instanceof ReadOnlyException) {
-                httpErrorStatus = HttpErrorStatus.ONLY_READ_OPERATION_ALLOWED_ON_THIS_NODE;
-            } else if (crateException instanceof DuplicateKeyException) {
-                httpErrorStatus = HttpErrorStatus.DOCUMENT_WITH_THE_SAME_PRIMARY_KEY_EXISTS_ALREADY;
-            } else if (crateException instanceof PartitionAlreadyExistsException) {
-                httpErrorStatus = HttpErrorStatus.PARTITION_FOR_THE_SAME_VALUE_EXISTS_ALREADY;
-            } else if (crateException instanceof RelationAlreadyExists) {
-                httpErrorStatus = HttpErrorStatus.RELATION_WITH_THE_SAME_NAME_EXISTS_ALREADY;
-            } else if (crateException instanceof RepositoryAlreadyExistsException) {
-                httpErrorStatus = HttpErrorStatus.REPOSITORY_WITH_SAME_NAME_EXISTS_ALREADY;
-            } else if (crateException instanceof SnapshotAlreadyExistsException) {
-                httpErrorStatus = HttpErrorStatus.SNAPSHOT_WITH_SAME_NAME_EXISTS_ALREADY;
-            } else if (crateException instanceof SnapshotNameInvalidException) {
-                httpErrorStatus = HttpErrorStatus.USER_WITH_SAME_NAME_EXISTS_ALREADY;
-            } else if (crateException instanceof UserAlreadyExistsException) {
-                httpErrorStatus = HttpErrorStatus.USER_WITH_SAME_NAME_EXISTS_ALREADY;
-            } else if (crateException instanceof UserDefinedFunctionAlreadyExistsException) {
-                httpErrorStatus = HttpErrorStatus.USER_DEFINED_FUNCTION_WITH_SAME_SIGNATURE_EXISTS_ALREADY;
-            } else if (crateException instanceof JobKilledException) {
-                httpErrorStatus = HttpErrorStatus.QUERY_KILLED_BY_STATEMENT;
-            } else if (crateException instanceof UnavailableShardsException) {
-                httpErrorStatus = HttpErrorStatus.ONE_OR_MORE_SHARDS_NOT_AVAILABLE;
-            }
-            // Missing GroupByOnArrayUnsupportedException, SchemaScopeException, TaskMissing, UnhandledServerException
-            // will be handled as UNHANDLED_SERVER_ERROR
+        } else if (throwable instanceof UnsupportedFeatureException ||
+                    throwable instanceof UnsupportedFunctionException) {
+            httpErrorStatus = HttpErrorStatus.POSSIBLE_FEATURE_NOT_SUPPROTED_YET;
+        } else if (throwable instanceof VersioningValidationException) {
+            httpErrorStatus = HttpErrorStatus.STATEMENT_INVALID_OR_UNSUPPORTED_SYNTAX;
+        } else if (throwable instanceof AnalyzerUnknownException) {
+            httpErrorStatus = HttpErrorStatus.STATEMENT_INVALID_ANALYZER_DEFINITION;
+        } else if (throwable instanceof ColumnUnknownException) {
+            httpErrorStatus = HttpErrorStatus.COLUMN_UNKNOWN;
+        } else if (throwable instanceof PartitionUnknownException) {
+            httpErrorStatus = HttpErrorStatus.PARTITION_UNKNOWN;
+        } else if (throwable instanceof RelationUnknown) {
+            httpErrorStatus = HttpErrorStatus.RELATION_UNKNOWN;
+        } else if (throwable instanceof RelationsUnknown) {
+            httpErrorStatus = HttpErrorStatus.RELATION_UNKNOWN;
+        } else if (throwable instanceof RepositoryUnknownException) {
+            httpErrorStatus = HttpErrorStatus.REPOSITORY_UNKNOWN;
+        } else if (throwable instanceof SchemaUnknownException) {
+            httpErrorStatus = HttpErrorStatus.SCHEMA_UNKNOWN;
+        } else if (throwable instanceof UserDefinedFunctionUnknownException) {
+            httpErrorStatus = HttpErrorStatus.USER_DEFINED_FUNCTION_UNKNOWN;
+        } else if (throwable instanceof UserUnknownException) {
+            httpErrorStatus = HttpErrorStatus.USER_UNKNOWN;
+        } else if (throwable instanceof SnapshotUnknownException) {
+            httpErrorStatus = HttpErrorStatus.SNAPSHOT_UNKNOWN;
+        } else if (throwable instanceof UnauthorizedException) {
+            httpErrorStatus = HttpErrorStatus.USER_NOT_AUTHORIZED_TO_PERFORM_STATEMENT;
+        } else if (throwable instanceof ReadOnlyException) {
+            httpErrorStatus = HttpErrorStatus.ONLY_READ_OPERATION_ALLOWED_ON_THIS_NODE;
+        } else if (throwable instanceof DuplicateKeyException) {
+            httpErrorStatus = HttpErrorStatus.DOCUMENT_WITH_THE_SAME_PRIMARY_KEY_EXISTS_ALREADY;
+        } else if (throwable instanceof PartitionAlreadyExistsException) {
+            httpErrorStatus = HttpErrorStatus.PARTITION_FOR_THE_SAME_VALUE_EXISTS_ALREADY;
+        } else if (throwable instanceof RelationAlreadyExists) {
+            httpErrorStatus = HttpErrorStatus.RELATION_WITH_THE_SAME_NAME_EXISTS_ALREADY;
+        } else if (throwable instanceof RepositoryAlreadyExistsException) {
+            httpErrorStatus = HttpErrorStatus.REPOSITORY_WITH_SAME_NAME_EXISTS_ALREADY;
+        } else if (throwable instanceof SnapshotAlreadyExistsException) {
+            httpErrorStatus = HttpErrorStatus.SNAPSHOT_WITH_SAME_NAME_EXISTS_ALREADY;
+        } else if (throwable instanceof SnapshotNameInvalidException) {
+            httpErrorStatus = HttpErrorStatus.USER_WITH_SAME_NAME_EXISTS_ALREADY;
+        } else if (throwable instanceof UserAlreadyExistsException) {
+            httpErrorStatus = HttpErrorStatus.USER_WITH_SAME_NAME_EXISTS_ALREADY;
+        } else if (throwable instanceof UserDefinedFunctionAlreadyExistsException) {
+            httpErrorStatus = HttpErrorStatus.USER_DEFINED_FUNCTION_WITH_SAME_SIGNATURE_EXISTS_ALREADY;
+        } else if (throwable instanceof JobKilledException) {
+            httpErrorStatus = HttpErrorStatus.QUERY_KILLED_BY_STATEMENT;
+        } else if (throwable instanceof UnavailableShardsException) {
+            httpErrorStatus = HttpErrorStatus.ONE_OR_MORE_SHARDS_NOT_AVAILABLE;
         }
+        // Missing GroupByOnArrayUnsupportedException, SchemaScopeException, TaskMissing, UnhandledServerException
+        // will be handled as UNHANDLED_SERVER_ERROR
         return new HttpError(httpErrorStatus, SQLExceptions.messageOf(throwable), throwable);
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/KillIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/KillIntegrationTest.java
@@ -97,7 +97,7 @@ public class KillIntegrationTest extends IntegTestCase {
             } catch (Throwable exception) {
                 // wrapped in ExecutionException or RuntimeException via Exceptions.toRuntimeExceptions
                 // (E.g. in ShardDMLExecutor.maybeRaiseFailure)
-                exception = SQLExceptions.unwrap(exception, t -> t.getClass() == RuntimeException.class);
+                exception = SQLExceptions.unwrap(exception);
                 assertThat(exception).satisfiesAnyOf(
                     x -> assertThat(x).isExactlyInstanceOf(JobKilledException.class),
                     x -> assertThat(x).isExactlyInstanceOf(InterruptedException.class),

--- a/server/src/test/java/io/crate/integrationtests/MetadataTrackerITest.java
+++ b/server/src/test/java/io/crate/integrationtests/MetadataTrackerITest.java
@@ -378,7 +378,7 @@ public class MetadataTrackerITest extends LogicalReplicationITestCase {
                 try {
                     var response = executeOnSubscriber("INSERT INTO t1 (id) VALUES(4)");
                     rowCount = response.rowCount();
-                } catch (OperationOnInaccessibleRelationException e) {
+                } catch (Throwable e) {
                     throw new AssertionError(e.getMessage());
                 }
                 assertThat(rowCount).isEqualTo(1L);
@@ -390,7 +390,7 @@ public class MetadataTrackerITest extends LogicalReplicationITestCase {
                 try {
                     var response = executeOnSubscriber("INSERT INTO p2 (id, p) VALUES(4, 4)");
                     rowCount = response.rowCount();
-                } catch (OperationOnInaccessibleRelationException e) {
+                } catch (Throwable e) {
                     throw new AssertionError(e.getMessage());
                 }
                 assertThat(rowCount).isEqualTo(1L);

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionClassLifecycleTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionClassLifecycleTest.java
@@ -565,7 +565,7 @@ public class TransportSQLActionClassLifecycleTest extends IntegTestCase {
     public void testCreateTableWithInvalidAnalyzer() throws Exception {
         Asserts.assertSQLError(() -> execute("create table t (content string index using fulltext with (analyzer='foobar'))"))
             .hasPGError(INTERNAL_ERROR)
-            .hasHTTPError(BAD_REQUEST, 4000)
+            .hasHTTPError(BAD_REQUEST, 4003)
             .hasMessageContaining("Failed to parse mapping: analyzer [foobar] not found for field [content]");
     }
 


### PR DESCRIPTION
Follow up to https://github.com/crate/crate/pull/14612
Given that `Exceptions.toRuntimeException`  might wrap an exception in
`RuntimeException`, `unwrap` should by default unwrap it.

Changing that led to sometimes getting a `NotSerializableExceptionWrapper`, which
is also a generic wrapper exception and needs to be unwrapped too.
