### PR TITLE
Propagate unwrapped exception in test layer / SQLTransportExecutor

### DIFF
--- a/server/src/testFixtures/java/io/crate/testing/SQLTransportExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLTransportExecutor.java
@@ -235,17 +235,17 @@ public class SQLTransportExecutor {
                 cause = ex;
             }
             throw new ElasticsearchTimeoutException("Timeout while running `" + stmt + "`", cause);
-        } catch (RuntimeException e) {
-            var cause = e.getCause();
+        } catch (Throwable t) {
             // ActionListener.onFailure takes `Exception` as argument instead of `Throwable`.
             // That requires us to wrap Throwable; That Throwable may be an AssertionError.
             //
             // Wrapping the exception can hide parts of the stacktrace that are interesting
             // to figure out the root cause of an error, so we prefer the cause here
-            if (e.getClass() == RuntimeException.class && cause != null) {
-                Exceptions.rethrowUnchecked(cause);
-            }
-            throw e;
+            t = SQLExceptions.unwrap(t);
+            Exceptions.rethrowUnchecked(t);
+
+            // unreachable
+            return null;
         }
     }
 


### PR DESCRIPTION
Follow up to https://github.com/crate/crate/pull/14613
It caused some test failures like in:

test_subscription_to_multiple_publications_should_not_stop_on_a_single_publication_drop

    org.elasticsearch.common.io.stream.NotSerializableExceptionWrapper: operation_on_inaccessible_relation_exception: The relation "doc.t2" doesn't allow INSERT operations, because it is included in a logical replication subscription.
    	at __randomizedtesting.SeedInfo.seed([FDDDEC244B2347D:210B2D11294A3A6F]:0)
    	at io.crate.metadata.table.Operation.blockedRaiseException(Operation.java:138)
    	at io.crate.metadata.Schemas.getTableInfo(Schemas.java:296)
    	at io.crate.execution.dml.upsert.TransportShardUpsertAction.processRequestItems(TransportShardUpsertAction.java:147)
    	at io.crate.execution.dml.upsert.TransportShardUpsertAction.processRequestItems(TransportShardUpsertAction.java:101)
    	at io.crate.execution.dml.TransportShardAction$1.call(TransportShardAction.java:121)
    	at io.crate.execution.dml.TransportShardAction$1.call(TransportShardAction.java:118)
    	at io.crate.execution.dml.TransportShardAction.wrapOperationInKillable(TransportShardAction.java:146)
    	at io.crate.execution.dml.TransportShardAction.lambda$shardOperationOnPrimary$1(TransportShardAction.java:124)
    	at org.elasticsearch.action.ActionListener.completeWith(ActionListener.java:240)
    	at io.crate.execution.dml.TransportShardAction.shardOperationOnPrimary(TransportShardAction.java:114)
    	at io.crate.execution.dml.TransportShardAction.shardOperationOnPrimary(TransportShardAction.java:63)
    	at org.elasticsearch.action.support.replication.TransportReplicationAction$PrimaryShardReference.perform(TransportReplicationAction.java:927)
    	at org.elasticsearch.action.support.replication.ReplicationOperation.execute(ReplicationOperation.java:126)
    	at org.elasticsearch.action.support.replication.TransportReplicationAction$AsyncPrimaryAction.runWithPrimaryShardReference(TransportReplicationAction.java:428)
    	at org.elasticsearch.action.support.replication.TransportReplicationAction$AsyncPrimaryAction.lambda$doRun$0(TransportReplicationAction.java:346)
    	at org.elasticsearch.action.ActionListener$2.onResponse(ActionListener.java:99)
    	at org.elasticsearch.index.shard.IndexShard.lambda$wrapPrimaryOperationPermitListener$21(IndexShard.java:2721)
    	at org.elasticsearch.action.ActionListener$3.onResponse(ActionListener.java:127)
    	at org.elasticsearch.index.shard.IndexShardOperationPermits.acquire(IndexShardOperationPermits.java:292)
    	at org.elasticsearch.index.shard.IndexShardOperationPermits.acquire(IndexShardOperationPermits.java:242)
    	at org.elasticsearch.index.shard.IndexShard.acquirePrimaryOperationPermit(IndexShard.java:2695)
    	at org.elasticsearch.action.support.replication.TransportReplicationAction.acquirePrimaryOperationPermit(TransportReplicationAction.java:868)
    	at org.elasticsearch.action.support.replication.TransportReplicationAction$AsyncPrimaryAction.doRun(TransportReplicationAction.java:342)
    	at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37)
    	at org.elasticsearch.action.support.replication.TransportReplicationAction.handlePrimaryRequest(TransportReplicationAction.java:308)
    	at org.elasticsearch.transport.RequestHandlerRegistry.processMessageReceived(RequestHandlerRegistry.java:59)

I think this should fix it. We use the same propagation logic already in
the JDBC test code path.
