### PR TITLE
Fix ordering of hash symbols to guarantee correct execution in hash join

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -48,6 +48,7 @@ import io.crate.statistics.Stats;
 import io.crate.statistics.TableStats;
 import io.crate.testing.Asserts;
 import io.crate.testing.UseHashJoins;
+import io.crate.testing.UseJdbc;
 import io.crate.testing.UseRandomizedOptimizerRules;
 import io.crate.testing.UseRandomizedSchema;
 import io.crate.types.DataTypes;
@@ -895,6 +896,7 @@ public class JoinIntegrationTest extends IntegTestCase {
         assertThat(response).hasRows("1| 1| 2");
     }
 
+    @UseJdbc(0)
     @Test
     @UseHashJoins(1)
     public void testInnerEquiJoinUsingHashJoin() {
@@ -1524,4 +1526,27 @@ public class JoinIntegrationTest extends IntegTestCase {
         );
         assertThat(execute(stmt)).hasRowCount(51);
     }
+
+    /*
+     * https://github.com/crate/crate/issues/14583
+     */
+    @Test
+    @UseRandomizedSchema(random = false)
+    @UseRandomizedOptimizerRules(value = 0)
+    public void test_hash_join_reordering_does_work() throws Exception {
+        execute("create table doc.t1(a int, b int)");
+        execute("create table doc.t2(c int, d int)");
+        execute("create table doc.t3(e int, f int)");
+
+        execute("insert into doc.t1(a,b) values(1,2)");
+        execute("insert into doc.t2(c,d) values (1,3),(5,6)");
+        execute("insert into doc.t3(e,f) values (3,2)");
+
+        execute("refresh table doc.t1, doc.t2, doc.t3");
+        execute("analyze");
+
+        execute("SELECT t3.e FROM t1 JOIN t3 ON t1.b = t3.f JOIN t2 ON t1.a = t2.c WHERE t2.d =t3.e");
+        assertThat(response).hasRows("3");
+    }
+
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Resolves https://github.com/crate/crate/issues/14583 currently only as starting point for a discussion.

If the `rhsHashSymbols` are not ordered the top hash-join will yield an empty result:

```
SELECT t3.e FROM t1 JOIN t3 ON t1.b = t3.f JOIN t2 ON t1.a = t2.c WHERE t2.d =t3.e"
```
```
Eval[e] (rows=0)
  └ Eval[b, a, e, f, c, d] (rows=0)
    └ HashJoin[((a = c) AND (d = e))] (rows=0) <- result will be empty
      ├ Collect[doc.t2 | [c, d] | true] (rows=2)
      └ HashJoin[(b = f)] (rows=1)
        ├ Collect[doc.t1 | [b, a] | true] (rows=1)
        └ Collect[doc.t3 | [e, f] | true] (rows=1)
```

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
