### PR TITLE
Don't use JDK19 API just yet

### DIFF
--- a/server/src/main/java/io/crate/statistics/TransportAnalyzeAction.java
+++ b/server/src/main/java/io/crate/statistics/TransportAnalyzeAction.java
@@ -195,7 +195,7 @@ public final class TransportAnalyzeAction {
     static Stats createTableStats(Samples samples, List<Reference> primitiveColumns) {
         List<Row> records = samples.records;
         List<Object> columnValues = new ArrayList<>(records.size());
-        Map<ColumnIdent, ColumnStats<?>> statsByColumn = HashMap.newHashMap(primitiveColumns.size());
+        Map<ColumnIdent, ColumnStats<?>> statsByColumn = new HashMap<>();
         for (int i = 0; i < primitiveColumns.size(); i++) {
             Reference primitiveColumn = primitiveColumns.get(i);
             columnValues.clear();


### PR DESCRIPTION
Follow up of https://github.com/crate/crate/commit/3cf974002a77e13e1065f811dc43d1971f057f82

Given that our gradle version doesn't work with JDK19, some tools have
problems when using JDK19+ APIs

E.g. eclipse.jdt.ls won't work.
If using JDK19 to run it (or if setting the language level to 19/20) it
will run into buildSrc:validatePlugins class level mismatch errors
