### PR TITLE
Fix Lucene query building for remaining types implementing `EqQuery`

### DIFF
--- a/server/src/main/java/io/crate/expression/operator/EqOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/EqOperator.java
@@ -68,7 +68,6 @@ import io.crate.metadata.functions.Signature;
 import io.crate.sql.tree.BitString;
 import io.crate.types.ArrayType;
 import io.crate.types.BitStringType;
-import io.crate.types.BooleanType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.DoubleType;
@@ -136,21 +135,6 @@ public final class EqOperator extends Operator<Object> {
             return new MatchNoDocsQuery("`" + fqn + "` = null is always null");
         }
         DataType<?> dataType = ref.valueType();
-        if (dataType.id() != ObjectType.ID && dataType.id() != ArrayType.ID && ref.indexType() == IndexType.NONE) {
-            // gradually allowing un-indexed columns to be searchable: https://github.com/crate/crate/issues/14407
-            var typeId = dataType.id();
-            if (typeId != IntegerType.ID &&
-                typeId != StringType.ID &&
-                typeId != BitStringType.ID &&
-                typeId != LongType.ID &&
-                typeId != DoubleType.ID &&
-                typeId != FloatType.ID &&
-                typeId != IpType.ID &&
-                typeId != BooleanType.ID) {
-                throw new IllegalArgumentException(
-                    "Cannot search on field [" + fqn + "] since it is not indexed.");
-            }
-        }
         return switch (dataType.id()) {
             case ObjectType.ID -> refEqObject(
                 function,

--- a/server/src/main/java/io/crate/expression/operator/EqOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/EqOperator.java
@@ -137,11 +137,13 @@ public final class EqOperator extends Operator<Object> {
         DataType<?> dataType = ref.valueType();
         if (dataType.id() != ObjectType.ID && dataType.id() != ArrayType.ID && ref.indexType() == IndexType.NONE) {
             // gradually allowing un-indexed columns to be searchable: https://github.com/crate/crate/issues/14407
-            if (dataType.id() != IntegerType.ID &&
-                dataType.id() != StringType.ID &&
-                dataType.id() != BitStringType.ID &&
-                dataType.id() != LongType.ID &&
-                dataType.id() != DoubleType.ID) {
+            var typeId = dataType.id();
+            if (typeId != IntegerType.ID &&
+                typeId != StringType.ID &&
+                typeId != BitStringType.ID &&
+                typeId != LongType.ID &&
+                typeId != DoubleType.ID &&
+                typeId != FloatType.ID) {
                 throw new IllegalArgumentException(
                     "Cannot search on field [" + fqn + "] since it is not indexed.");
             }

--- a/server/src/main/java/io/crate/expression/operator/EqOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/EqOperator.java
@@ -137,7 +137,9 @@ public final class EqOperator extends Operator<Object> {
         DataType<?> dataType = ref.valueType();
         if (dataType.id() != ObjectType.ID && dataType.id() != ArrayType.ID && ref.indexType() == IndexType.NONE) {
             // gradually allowing un-indexed columns to be searchable: https://github.com/crate/crate/issues/14407
-            if (dataType.id() != IntegerType.ID && dataType.id() != StringType.ID) {
+            if (dataType.id() != IntegerType.ID &&
+                dataType.id() != StringType.ID &&
+                dataType.id() != BitStringType.ID) {
                 throw new IllegalArgumentException(
                     "Cannot search on field [" + fqn + "] since it is not indexed.");
             }

--- a/server/src/main/java/io/crate/expression/operator/EqOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/EqOperator.java
@@ -143,7 +143,8 @@ public final class EqOperator extends Operator<Object> {
                 typeId != BitStringType.ID &&
                 typeId != LongType.ID &&
                 typeId != DoubleType.ID &&
-                typeId != FloatType.ID) {
+                typeId != FloatType.ID &&
+                typeId != IpType.ID) {
                 throw new IllegalArgumentException(
                     "Cannot search on field [" + fqn + "] since it is not indexed.");
             }

--- a/server/src/main/java/io/crate/expression/operator/EqOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/EqOperator.java
@@ -140,7 +140,8 @@ public final class EqOperator extends Operator<Object> {
             if (dataType.id() != IntegerType.ID &&
                 dataType.id() != StringType.ID &&
                 dataType.id() != BitStringType.ID &&
-                dataType.id() != LongType.ID) {
+                dataType.id() != LongType.ID &&
+                dataType.id() != DoubleType.ID) {
                 throw new IllegalArgumentException(
                     "Cannot search on field [" + fqn + "] since it is not indexed.");
             }

--- a/server/src/main/java/io/crate/expression/operator/EqOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/EqOperator.java
@@ -139,7 +139,8 @@ public final class EqOperator extends Operator<Object> {
             // gradually allowing un-indexed columns to be searchable: https://github.com/crate/crate/issues/14407
             if (dataType.id() != IntegerType.ID &&
                 dataType.id() != StringType.ID &&
-                dataType.id() != BitStringType.ID) {
+                dataType.id() != BitStringType.ID &&
+                dataType.id() != LongType.ID) {
                 throw new IllegalArgumentException(
                     "Cannot search on field [" + fqn + "] since it is not indexed.");
             }

--- a/server/src/main/java/io/crate/expression/operator/EqOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/EqOperator.java
@@ -68,6 +68,7 @@ import io.crate.metadata.functions.Signature;
 import io.crate.sql.tree.BitString;
 import io.crate.types.ArrayType;
 import io.crate.types.BitStringType;
+import io.crate.types.BooleanType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.DoubleType;
@@ -144,7 +145,8 @@ public final class EqOperator extends Operator<Object> {
                 typeId != LongType.ID &&
                 typeId != DoubleType.ID &&
                 typeId != FloatType.ID &&
-                typeId != IpType.ID) {
+                typeId != IpType.ID &&
+                typeId != BooleanType.ID) {
                 throw new IllegalArgumentException(
                     "Cannot search on field [" + fqn + "] since it is not indexed.");
             }

--- a/server/src/main/java/io/crate/types/BitStringType.java
+++ b/server/src/main/java/io/crate/types/BitStringType.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import org.apache.lucene.document.SortedSetDocValuesField;
 import org.jetbrains.annotations.Nullable;
 
 import org.apache.lucene.document.FieldType;
@@ -70,7 +71,12 @@ public final class BitStringType extends DataType<BitString> implements Streamer
 
             @Override
             public Query termQuery(String field, BitString value, boolean hasDocValues, boolean isIndexed) {
-                return new TermQuery(new Term(field, new BytesRef(value.bitSet().toByteArray())));
+                if (isIndexed) {
+                    return new TermQuery(new Term(field, new BytesRef(value.bitSet().toByteArray())));
+                } else {
+                    assert hasDocValues == true : "hasDocValues must be true for BitString types since 'columnstore=false' is not supported.";
+                    return SortedSetDocValuesField.newSlowExactQuery(field, new BytesRef(value.bitSet().toByteArray()));
+                }
             }
 
             @Override

--- a/server/src/main/java/io/crate/types/DoubleType.java
+++ b/server/src/main/java/io/crate/types/DoubleType.java
@@ -29,7 +29,6 @@ import java.util.function.Function;
 import org.apache.lucene.document.DoublePoint;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.SortedNumericDocValuesField;
-import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.NumericUtils;
 import org.apache.lucene.util.RamUsageEstimator;
@@ -56,7 +55,13 @@ public class DoubleType extends DataType<Double> implements FixedWidthType, Stre
 
             @Override
             public Query termQuery(String field, Double value, boolean hasDocValues, boolean isIndexed) {
-                return DoublePoint.newExactQuery(field, value);
+                if (isIndexed) {
+                    return DoublePoint.newExactQuery(field, value);
+                }
+                if (hasDocValues) {
+                    return SortedNumericDocValuesField.newSlowExactQuery(field, NumericUtils.doubleToSortableLong(value));
+                }
+                return null;
             }
 
             @Override
@@ -80,16 +85,16 @@ public class DoubleType extends DataType<Double> implements FixedWidthType, Stre
                 } else {
                     upper = includeUpper ? upperTerm : DoublePoint.nextDown(upperTerm);
                 }
-                Query indexQuery = DoublePoint.newRangeQuery(field, lower, upper);
-                if (hasDocValues) {
-                    Query dvQuery = SortedNumericDocValuesField.newSlowRangeQuery(
-                            field,
-                            NumericUtils.doubleToSortableLong(lower),
-                            NumericUtils.doubleToSortableLong(upper)
-                    );
-                    return new IndexOrDocValuesQuery(indexQuery, dvQuery);
+                if (isIndexed) {
+                    return DoublePoint.newRangeQuery(field, lower, upper);
                 }
-                return indexQuery;
+                if (hasDocValues) {
+                    return SortedNumericDocValuesField.newSlowRangeQuery(
+                        field,
+                        NumericUtils.doubleToSortableLong(lower),
+                        NumericUtils.doubleToSortableLong(upper));
+                }
+                return null;
             }
         }
     ) {

--- a/server/src/main/java/io/crate/types/FloatType.java
+++ b/server/src/main/java/io/crate/types/FloatType.java
@@ -29,7 +29,6 @@ import java.util.function.Function;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.FloatPoint;
 import org.apache.lucene.document.SortedNumericDocValuesField;
-import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.NumericUtils;
 import org.apache.lucene.util.RamUsageEstimator;
@@ -56,7 +55,13 @@ public class FloatType extends DataType<Float> implements Streamer<Float>, Fixed
 
             @Override
             public Query termQuery(String field, Float value, boolean hasDocValues, boolean isIndexed) {
-                return FloatPoint.newExactQuery(field, value);
+                if (isIndexed) {
+                    return FloatPoint.newExactQuery(field, value);
+                }
+                if (hasDocValues) {
+                    return SortedNumericDocValuesField.newSlowExactQuery(field, NumericUtils.floatToSortableInt(value));
+                }
+                return null;
             }
 
             @Override
@@ -80,16 +85,16 @@ public class FloatType extends DataType<Float> implements Streamer<Float>, Fixed
                 } else {
                     upper = includeUpper ? upperTerm : FloatPoint.nextDown(upperTerm);
                 }
-
-                Query indexQuery = FloatPoint.newRangeQuery(field, lower, upper);
-                if (hasDocValues) {
-                    Query dvQuery = SortedNumericDocValuesField
-                            .newSlowRangeQuery(field,
-                                               NumericUtils.floatToSortableInt(lower),
-                                               NumericUtils.floatToSortableInt(upper));
-                    return new IndexOrDocValuesQuery(indexQuery, dvQuery);
+                if (isIndexed) {
+                    return FloatPoint.newRangeQuery(field, lower, upper);
                 }
-                return indexQuery;
+                if (hasDocValues) {
+                    return SortedNumericDocValuesField.newSlowRangeQuery(
+                        field,
+                        NumericUtils.floatToSortableInt(lower),
+                        NumericUtils.floatToSortableInt(upper));
+                }
+                return null;
             }
         }
     ) {

--- a/server/src/main/java/io/crate/types/IpType.java
+++ b/server/src/main/java/io/crate/types/IpType.java
@@ -27,7 +27,9 @@ import java.util.function.Function;
 
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.InetAddressPoint;
+import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -52,7 +54,13 @@ public class IpType extends DataType<String> implements Streamer<String> {
 
             @Override
             public Query termQuery(String field, String value, boolean hasDocValues, boolean isIndexed) {
-                return InetAddressPoint.newExactQuery(field, InetAddresses.forString(value));
+                if (isIndexed) {
+                    return InetAddressPoint.newExactQuery(field, InetAddresses.forString(value));
+                } else {
+                    assert hasDocValues == true : "hasDocValues must be true for Ip types since 'columnstore=false' is not supported.";
+                    return SortedSetDocValuesField.newSlowExactQuery(
+                        field, new BytesRef(InetAddressPoint.encode(InetAddresses.forString(value))));
+                }
             }
 
             @Override
@@ -63,23 +71,33 @@ public class IpType extends DataType<String> implements Streamer<String> {
                                     boolean includeUpper,
                                     boolean hasDocValues,
                                     boolean isIndexed) {
-                InetAddress lower;
+                InetAddress inclusiveLower;
                 if (lowerTerm == null) {
-                    lower = InetAddressPoint.MIN_VALUE;
+                    inclusiveLower = InetAddressPoint.MIN_VALUE;
                 } else {
                     var lowerAddress = InetAddresses.forString(lowerTerm);
-                    lower = includeLower ? lowerAddress : InetAddressPoint.nextUp(lowerAddress);
+                    inclusiveLower = includeLower ? lowerAddress : InetAddressPoint.nextUp(lowerAddress);
                 }
 
-                InetAddress upper;
+                InetAddress inclusiveUpper;
                 if (upperTerm == null) {
-                    upper = InetAddressPoint.MAX_VALUE;
+                    inclusiveUpper = InetAddressPoint.MAX_VALUE;
                 } else {
                     var upperAddress = InetAddresses.forString(upperTerm);
-                    upper = includeUpper ? upperAddress : InetAddressPoint.nextDown(upperAddress);
+                    inclusiveUpper = includeUpper ? upperAddress : InetAddressPoint.nextDown(upperAddress);
                 }
 
-                return InetAddressPoint.newRangeQuery(field, lower, upper);
+                if (isIndexed) {
+                    return InetAddressPoint.newRangeQuery(field, inclusiveLower, inclusiveUpper);
+                } else {
+                    assert hasDocValues == true : "hasDocValues must be true for Ip types since 'columnstore=false' is not supported.";
+                    return SortedSetDocValuesField.newSlowRangeQuery(
+                        field,
+                        new BytesRef(InetAddressPoint.encode(inclusiveLower)),
+                        new BytesRef(InetAddressPoint.encode(inclusiveUpper)),
+                        true,
+                        true);
+                }
             }
         }
     ) {

--- a/server/src/test/java/io/crate/lucene/BitStringEqQueryTest.java
+++ b/server/src/test/java/io/crate/lucene/BitStringEqQueryTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.lucene;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.util.BytesRef;
+import org.junit.Test;
+
+import io.crate.exceptions.UnsupportedFunctionException;
+import io.crate.sql.tree.BitString;
+
+public class BitStringEqQueryTest extends LuceneQueryBuilderTest {
+    private static final BitString BIT_STRING = BitString.ofBitString("B'001'");
+    private static final BytesRef BIT_STRING_IN_BYTES_REF = new BytesRef(BIT_STRING.bitSet().toByteArray());
+    
+    @Override
+    protected String createStmt() {
+        // `columnstore = false` is not supported
+        return """
+                create table m (
+                a1 bit(3),
+                a2 bit(3) index off
+            )
+            """;
+    }
+
+    @Test
+    public void test_BitStringEqQuery_termQuery() {
+        Query query = convert("a1 = " + BIT_STRING);
+        assertThat(query).isExactlyInstanceOf(TermQuery.class);
+        Term term = ((TermQuery) query).getTerm();
+        assertThat(term.field()).endsWith("a1");
+        assertThat(term.bytes()).isEqualTo(BIT_STRING_IN_BYTES_REF);
+
+        query = convert("a2 = " + BIT_STRING);
+        // SortedSetDocValuesRangeQuery.class is not public
+        assertThat(query.getClass().getName()).endsWith("SortedSetDocValuesRangeQuery");
+        assertThat(query).hasToString("a2:[" + BIT_STRING_IN_BYTES_REF + " TO " + BIT_STRING_IN_BYTES_REF + "]");
+    }
+
+    @Test
+    public void test_BitStringEqQuery_rangeQuery() {
+        assertThatThrownBy(
+            () -> convert("a1 < " + BIT_STRING))
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
+            .hasMessageStartingWith("Unknown function: (doc.m.a1 < B'001'), no overload found for matching argument types: (bit, bit).");
+
+        assertThatThrownBy(
+            () -> convert("a2 >= " + BIT_STRING))
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
+            .hasMessageStartingWith("Unknown function: (doc.m.a2 >= B'001'), no overload found for matching argument types: (bit, bit).");
+    }
+}

--- a/server/src/test/java/io/crate/lucene/BitStringEqQueryTest.java
+++ b/server/src/test/java/io/crate/lucene/BitStringEqQueryTest.java
@@ -36,7 +36,7 @@ import io.crate.sql.tree.BitString;
 public class BitStringEqQueryTest extends LuceneQueryBuilderTest {
     private static final BitString BIT_STRING = BitString.ofBitString("B'001'");
     private static final BytesRef BIT_STRING_IN_BYTES_REF = new BytesRef(BIT_STRING.bitSet().toByteArray());
-    
+
     @Override
     protected String createStmt() {
         // `columnstore = false` is not supported

--- a/server/src/test/java/io/crate/lucene/BooleanEqQueryTest.java
+++ b/server/src/test/java/io/crate/lucene/BooleanEqQueryTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.lucene;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.TermRangeQuery;
+import org.junit.Test;
+
+public class BooleanEqQueryTest extends LuceneQueryBuilderTest {
+    @Override
+    protected String createStmt() {
+        // `columnstore = false` is not supported
+        return """
+                create table m (
+                a1 boolean,
+                a2 boolean index off
+            )
+            """;
+    }
+
+    @Test
+    public void test_BooleanEqQuery_termQuery() {
+        Query query = convert("a1 = true");
+        assertThat(query).isExactlyInstanceOf(TermQuery.class);
+        assertThat(query).hasToString("a1:T");
+
+        query = convert("a2 = true");
+        // SortedNumericDocValuesRangeQuery.class is not public
+        assertThat(query.getClass().getName()).endsWith("SortedNumericDocValuesRangeQuery");
+        assertThat(query).hasToString("a2:[1 TO 1]");
+    }
+
+    @Test
+    public void test_BooleanEqQuery_rangeQuery() {
+        Query query = convert("a1 >= true");
+        assertThat(query).isExactlyInstanceOf(TermRangeQuery.class);
+        assertThat(query).hasToString("a1:[T TO T}");
+
+        query = convert("a2 >= true");
+        // SortedNumericDocValuesRangeQuery.class is not public
+        assertThat(query.getClass().getName()).endsWith("SortedNumericDocValuesRangeQuery");
+        assertThat(query).hasToString("a2:[1 TO 1]");
+
+        query = convert("a2 <= true");
+        // SortedNumericDocValuesRangeQuery.class is not public
+        assertThat(query.getClass().getName()).endsWith("SortedNumericDocValuesRangeQuery");
+        assertThat(query).hasToString("a2:[0 TO 1]");
+    }
+}

--- a/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -33,7 +33,6 @@ import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.FieldExistsQuery;
-import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.PointInSetQuery;
@@ -637,8 +636,9 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
                 .isExactlyInstanceOf(BooleanQuery.class);
         BooleanQuery booleanQuery = (BooleanQuery) query;
         assertThat(booleanQuery.clauses()).satisfiesExactly(
-                x -> assertThat(x.getQuery()).isExactlyInstanceOf(IndexOrDocValuesQuery.class),
-                x -> assertThat(x.getQuery()).isExactlyInstanceOf(IndexOrDocValuesQuery.class)
+            // the query class is anonymous
+            x -> assertThat(x.getQuery().getClass().getName()).endsWith("LongPoint$1"),
+            x -> assertThat(x.getQuery().getClass().getName()).endsWith("LongPoint$1")
         );
 
         query = convert("10 != ANY(x_array_no_docvalues)");
@@ -647,8 +647,9 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
                 .isExactlyInstanceOf(BooleanQuery.class);
         booleanQuery = (BooleanQuery) query;
         assertThat(booleanQuery.clauses()).satisfiesExactly(
-                x -> assertThat(x.getQuery()).isNotInstanceOf(IndexOrDocValuesQuery.class),
-                x -> assertThat(x.getQuery()).isNotInstanceOf(IndexOrDocValuesQuery.class)
+            // the query class is anonymous
+            x -> assertThat(x.getQuery().getClass().getName()).doesNotEndWith("LongPoint$1"),
+            x -> assertThat(x.getQuery().getClass().getName()).doesNotEndWith("LongPoint$1")
         );
     }
 

--- a/server/src/test/java/io/crate/lucene/DoubleEqQueryTest.java
+++ b/server/src/test/java/io/crate/lucene/DoubleEqQueryTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.lucene;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.lucene.document.DoublePoint;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.util.NumericUtils;
+import org.junit.Test;
+
+public class DoubleEqQueryTest extends LuceneQueryBuilderTest {
+    @Override
+    protected String createStmt() {
+        return """
+                create table m (
+                a1 double,
+                a2 double index off,
+                a3 double storage with (columnstore = false),
+                a4 double index off storage with (columnstore = false)
+            )
+            """;
+    }
+
+    @Test
+    public void test_DoubleEqQuery_termQuery() {
+        Query query = convert("a1 = 1.1");
+        assertThat(query.getClass().getName()).endsWith("DoublePoint$1"); // the query class is anonymous
+        assertThat(query).hasToString("a1:[1.1 TO 1.1]");
+
+        query = convert("a2 = 1.1");
+        // SortedNumericDocValuesRangeQuery.class is not public
+        assertThat(query.getClass().getName()).endsWith("SortedNumericDocValuesRangeQuery");
+        long l = NumericUtils.doubleToSortableLong(1.1);
+        assertThat(query).hasToString("a2:[" + l + " TO " + l + "]");
+
+        query = convert("a3 = 1.1");
+        assertThat(query.getClass().getName()).endsWith("DoublePoint$1"); // the query class is anonymous
+        assertThat(query).hasToString("a3:[1.1 TO 1.1]");
+
+        query = convert("a4 = 1.1");
+        assertThat(query).isExactlyInstanceOf(GenericFunctionQuery.class);
+        assertThat(query).hasToString("(a4 = 1.1)");
+    }
+
+    @Test
+    public void test_DoubleEqQuery_rangeQuery() {
+        Query query = convert("a1 > 1.1");
+        assertThat(query.getClass().getName()).endsWith("DoublePoint$1"); // the query class is anonymous
+        assertThat(query).hasToString("a1:[1.1000000000000003 TO Infinity]");
+
+        query = convert("a2 < 1.1");
+        // SortedNumericDocValuesRangeQuery.class is not public
+        assertThat(query.getClass().getName()).endsWith("SortedNumericDocValuesRangeQuery");
+        long l = NumericUtils.doubleToSortableLong(Double.NEGATIVE_INFINITY);
+        long l2 = NumericUtils.doubleToSortableLong(DoublePoint.nextDown(1.1));
+        assertThat(query).hasToString("a2:[" + l + " TO " + l2 + "]");
+
+        query = convert("a3 >= 1.1");
+        assertThat(query.getClass().getName()).endsWith("DoublePoint$1"); // the query class is anonymous
+        assertThat(query).hasToString("a3:[1.1 TO Infinity]");
+
+        query = convert("a4 <= 1.1");
+        assertThat(query).isExactlyInstanceOf(GenericFunctionQuery.class);
+        assertThat(query).hasToString("(a4 <= 1.1)");
+    }
+}

--- a/server/src/test/java/io/crate/lucene/FloatEqQueryTest.java
+++ b/server/src/test/java/io/crate/lucene/FloatEqQueryTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.lucene;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.lucene.document.FloatPoint;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.util.NumericUtils;
+import org.junit.Test;
+
+public class FloatEqQueryTest extends LuceneQueryBuilderTest {
+    @Override
+    protected String createStmt() {
+        return """
+                create table m (
+                a1 float,
+                a2 float index off,
+                a3 float storage with (columnstore = false),
+                a4 float index off storage with (columnstore = false)
+            )
+            """;
+    }
+
+    @Test
+    public void test_FloatEqQuery_termQuery() {
+        Query query = convert("a1 = 1.1");
+        assertThat(query.getClass().getName()).endsWith("FloatPoint$1"); // the query class is anonymous
+        assertThat(query).hasToString("a1:[1.1 TO 1.1]");
+
+        query = convert("a2 = 1.1");
+        // SortedNumericDocValuesRangeQuery.class is not public
+        assertThat(query.getClass().getName()).endsWith("SortedNumericDocValuesRangeQuery");
+        long l = NumericUtils.floatToSortableInt(1.1f);
+        assertThat(query).hasToString("a2:[" + l + " TO " + l + "]");
+
+        query = convert("a3 = 1.1");
+        assertThat(query.getClass().getName()).endsWith("FloatPoint$1"); // the query class is anonymous
+        assertThat(query).hasToString("a3:[1.1 TO 1.1]");
+
+        query = convert("a4 = 1.1");
+        assertThat(query).isExactlyInstanceOf(GenericFunctionQuery.class);
+        assertThat(query).hasToString("(a4 = 1.1)");
+    }
+
+    @Test
+    public void test_FloatEqQuery_rangeQuery() {
+        Query query = convert("a1 > 1.1");
+        assertThat(query.getClass().getName()).endsWith("FloatPoint$1"); // the query class is anonymous
+        assertThat(query).hasToString("a1:[1.1000001 TO Infinity]");
+
+        query = convert("a2 < 1.1");
+        // SortedNumericDocValuesRangeQuery.class is not public
+        assertThat(query.getClass().getName()).endsWith("SortedNumericDocValuesRangeQuery");
+        long l = NumericUtils.floatToSortableInt(Float.NEGATIVE_INFINITY);
+        long l2 = NumericUtils.floatToSortableInt(FloatPoint.nextDown(1.1f));
+        assertThat(query).hasToString("a2:[" + l + " TO " + l2 + "]");
+
+        query = convert("a3 >= 1.1");
+        assertThat(query.getClass().getName()).endsWith("FloatPoint$1"); // the query class is anonymous
+        assertThat(query).hasToString("a3:[1.1 TO Infinity]");
+
+        query = convert("a4 <= 1.1");
+        assertThat(query).isExactlyInstanceOf(GenericFunctionQuery.class);
+        assertThat(query).hasToString("(a4 <= 1.1)");
+    }
+}

--- a/server/src/test/java/io/crate/lucene/IpEqQueryTest.java
+++ b/server/src/test/java/io/crate/lucene/IpEqQueryTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.lucene;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.lucene.search.Query;
+import org.junit.Test;
+
+public class IpEqQueryTest extends LuceneQueryBuilderTest {
+    @Override
+    protected String createStmt() {
+        // `columnstore = false` is not supported
+        return """
+                create table m (
+                a1 ip,
+                a2 ip index off
+            )
+            """;
+    }
+
+    @Test
+    public void test_IpEqQuery_termQuery() {
+        Query query = convert("a1 = '1.1.1.1'");
+        assertThat(query.getClass().getName()).endsWith("InetAddressPoint$1"); // the query class is anonymous
+        assertThat(query).hasToString("a1:[1.1.1.1 TO 1.1.1.1]");
+
+        query = convert("a2 = '1.1.1.1'");
+        // SortedSetDocValuesRangeQuery.class is not public
+        assertThat(query.getClass().getName()).endsWith("SortedSetDocValuesRangeQuery");
+        assertThat(query).hasToString("a2:[[0 0 0 0 0 0 0 0 0 0 ff ff 1 1 1 1] TO [0 0 0 0 0 0 0 0 0 0 ff ff 1 1 1 1]]");
+    }
+
+    @Test
+    public void test_IpEqQuery_rangeQuery() {
+        Query query = convert("a1 >= '1.1.1.1'");
+        assertThat(query.getClass().getName()).endsWith("InetAddressPoint$1"); // the query class is anonymous
+        assertThat(query).hasToString("a1:[1.1.1.1 TO ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff]");
+
+        query = convert("a2 < '1.1.1.1'");
+        // SortedSetDocValuesRangeQuery.class is not public
+        assertThat(query.getClass().getName()).endsWith("SortedSetDocValuesRangeQuery");
+        assertThat(query).hasToString("a2:[[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0] TO [0 0 0 0 0 0 0 0 0 0 ff ff 1 1 1 0]]");
+    }
+}

--- a/server/src/test/java/io/crate/lucene/LongEqQueryTest.java
+++ b/server/src/test/java/io/crate/lucene/LongEqQueryTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.lucene;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.lucene.search.Query;
+import org.junit.Test;
+
+public class LongEqQueryTest extends LuceneQueryBuilderTest {
+    @Override
+    protected String createStmt() {
+        return """
+                create table m (
+                a1 long,
+                a2 long index off,
+                a3 long storage with (columnstore = false),
+                a4 long index off storage with (columnstore = false)
+            )
+            """;
+    }
+
+    @Test
+    public void test_LongEqQuery_termQuery() {
+        Query query = convert("a1 = 1");
+        assertThat(query.getClass().getName()).endsWith("LongPoint$1"); // the query class is anonymous
+        assertThat(query).hasToString("a1:[1 TO 1]");
+
+        query = convert("a2 = 1");
+        // SortedNumericDocValuesRangeQuery.class is not public
+        assertThat(query.getClass().getName()).endsWith("SortedNumericDocValuesRangeQuery");
+        assertThat(query).hasToString("a2:[1 TO 1]");
+
+        query = convert("a3 = 1");
+        assertThat(query.getClass().getName()).endsWith("LongPoint$1"); // the query class is anonymous
+        assertThat(query).hasToString("a3:[1 TO 1]");
+
+        query = convert("a4 = 1");
+        assertThat(query).isExactlyInstanceOf(GenericFunctionQuery.class);
+        assertThat(query).hasToString("(a4 = 1::bigint)");
+    }
+
+    @Test
+    public void test_LongEqQuery_rangeQuery() {
+        Query query = convert("a1 > 1");
+        assertThat(query.getClass().getName()).endsWith("LongPoint$1"); // the query class is anonymous
+        assertThat(query).hasToString("a1:[2 TO 9223372036854775807]");
+
+        query = convert("a2 < 1");
+        // SortedNumericDocValuesRangeQuery.class is not public
+        assertThat(query.getClass().getName()).endsWith("SortedNumericDocValuesRangeQuery");
+        assertThat(query).hasToString("a2:[-9223372036854775808 TO 0]");
+
+        query = convert("a3 >= 1");
+        assertThat(query.getClass().getName()).endsWith("LongPoint$1"); // the query class is anonymous
+        assertThat(query).hasToString("a3:[1 TO 9223372036854775807]");
+
+        query = convert("a4 <= 1");
+        assertThat(query).isExactlyInstanceOf(GenericFunctionQuery.class);
+        assertThat(query).hasToString("(a4 <= 1::bigint)");
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Follows https://github.com/crate/crate/pull/14552

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
