### PR TITLE
WIP: write oid in the source

### DIFF
--- a/server/src/main/java/io/crate/execution/dml/Indexer.java
+++ b/server/src/main/java/io/crate/execution/dml/Indexer.java
@@ -677,7 +677,7 @@ public class Indexer {
                     continue;
                 }
                 ValueIndexer<Object> valueIndexer = (ValueIndexer<Object>) valueIndexers.get(i);
-                xContentBuilder.field(reference.column().leafName());
+                xContentBuilder.field(Long.toString(reference.oid()));
                 valueIndexer.indexValue(
                     reference.valueType().sanitizeValue(value),
                     xContentBuilder,
@@ -697,7 +697,7 @@ public class Indexer {
                 if (value == null) {
                     continue;
                 }
-                xContentBuilder.field(column.leafName());
+                xContentBuilder.field(Long.toString(synthetic.ref().oid()));
                 indexer.indexValue(
                     value,
                     xContentBuilder,

--- a/server/src/main/java/io/crate/execution/dml/ObjectIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/ObjectIndexer.java
@@ -128,7 +128,9 @@ public class ObjectIndexer implements ValueIndexer<Map<String, Object>> {
             var valueIndexer = innerIndexers.get(innerName);
             // valueIndexer is null for partitioned columns
             if (valueIndexer != null) {
-                xContentBuilder.field(innerName);
+                ColumnIdent child = column.getChild(innerName);
+                Reference childRef = getRef.apply(child);
+                xContentBuilder.field(Long.toString(childRef.oid()));
                 valueIndexer.indexValue(
                     type.sanitizeValue(innerValue),
                     xContentBuilder,
@@ -265,10 +267,12 @@ public class ObjectIndexer implements ValueIndexer<Map<String, Object>> {
                 continue;
             }
             if (innerValue == null) {
+                // also todo - but looks like can as as is, only update javadocs
                 xContentBuilder.nullField(innerName);
                 continue;
             }
             if (ref.columnPolicy() == ColumnPolicy.IGNORED) {
+                //todo but looks like can as as is, only update javadocs
                 xContentBuilder.field(innerName, innerValue);
                 continue;
             }
@@ -276,6 +280,8 @@ public class ObjectIndexer implements ValueIndexer<Map<String, Object>> {
             innerValue = type.sanitizeValue(innerValue);
             StorageSupport<?> storageSupport = type.storageSupport();
             if (storageSupport == null) {
+                //todo - figure out indexing but looks like can as as is, only update javadocs
+                // and also scenario when no closing value?
                 xContentBuilder.field(innerName);
                 if (DynamicIndexer.handleEmptyArray(type, innerValue, xContentBuilder)) {
                     continue;

--- a/server/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
@@ -1407,7 +1407,7 @@ public class InsertIntoIntegrationTest extends IntegTestCase {
      * Test that when an error happens on the primary, the record should never be inserted on the replica.
      * Since we cannot force a select statement to be executed on a replica, we repeat this test to increase the chance.
      */
-    @Repeat(iterations = 5)
+  //  @Repeat(iterations = 5)
     @Test
     public void testInsertWithErrorMustNotBeInsertedOnReplica() throws Exception {
         execute("create table test (id integer primary key, name string) with (number_of_replicas=1)");


### PR DESCRIPTION
Next step after https://github.com/crate/crate/pull/14617.

Early draft

TODO: 
 - [ ] use oid (already assigned in mapping) instead of colname
 - [ ] (reads) Change LuceneReferenceResolver/Lucene reading logic to access data by oid instead of column name
 - [ ] (reads) Need to update query building to use oid instead of column name
 - [ ] Primary key lookup? (check PKLookupOperation)
 - [ ] (indexing) Change mapper implementations  to use oid as field name
 - [ ] (indexing) Change source generation to use oid as field name
 - [ ] Change _raw lookup to rewrite oid to name and don’t' include dropped columns
 - [ ] `select _raw` must hide dropped columns

