### PR TITLE
Ensure correct order of hash symbols used in HashJoin plans

### DIFF
--- a/docs/appendices/release-notes/5.4.3.rst
+++ b/docs/appendices/release-notes/5.4.3.rst
@@ -46,4 +46,6 @@ See the :ref:`version_5.4.0` release notes for a full list of changes in the
 Fixes
 =====
 
-None
+- Fixed a regression introduced with CrateDB 5.0.0 which can cause that some
+  nested join queries using the hash-join algorithm will return empty results
+  after table statistics have been collected and the join order is optimized.

--- a/server/src/main/java/io/crate/planner/operators/HashJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/HashJoin.java
@@ -99,21 +99,37 @@ public class HashJoin extends JoinPlan {
 
         SubQueryAndParamBinder paramBinder = new SubQueryAndParamBinder(params, subQueryResults);
         var hashSymbols = HashJoinConditionSymbolsExtractor.extract(joinCondition);
-        // First extract the symbols that belong to rhs
+        /* It is important here to process the hashSymbols in order as there values are used for building the
+         *  hash codes. For example:
+         *
+         *      join-condition:     t1.a = t2.c AND t1.b = t2.d
+         *      left hashSymbols:   [t1.a, t1.b]
+         *      right hashSymbols:  [t2.c, t2.d]
+         *
+         *      with rows:          left ->     [1, 3]
+         *                          right ->    [1, 3]
+         *
+         * if the order is not guaranteed, one side may use [3, 1] for hash code generation which yields different results
+         *
+         */
         var rhsHashSymbols = new ArrayList<Symbol>();
-        for (var relationName : rhs.getRelationNames()) {
-            var symbols = hashSymbols.remove(relationName);
-            if (symbols != null) {
-                for (var symbol : symbols) {
+        var lhsHashSymbols = new ArrayList<Symbol>();
+        var rightRelationNames = rhs.getRelationNames();
+        var leftRelationNames = lhs.getRelationNames();
+        for (var entry : hashSymbols.entrySet()) {
+            var relationName = entry.getKey();
+            var symbols = entry.getValue();
+            if (symbols == null) {
+                continue;
+            }
+            if (rightRelationNames.contains(relationName)) {
+                for (Symbol symbol : symbols) {
                     rhsHashSymbols.add(paramBinder.apply(symbol));
                 }
-            }
-        }
-        // All leftover extracted symbols belong to the lhs
-        var lhsHashSymbols = new ArrayList<Symbol>();
-        for (var symbols : hashSymbols.values()) {
-            for (Symbol symbol : symbols) {
-                lhsHashSymbols.add(paramBinder.apply(symbol));
+            } else if (leftRelationNames.contains(relationName)) {
+                for (Symbol symbol : symbols) {
+                    lhsHashSymbols.add(paramBinder.apply(symbol));
+                }
             }
         }
 

--- a/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -48,6 +48,7 @@ import io.crate.statistics.Stats;
 import io.crate.statistics.TableStats;
 import io.crate.testing.Asserts;
 import io.crate.testing.UseHashJoins;
+import io.crate.testing.UseJdbc;
 import io.crate.testing.UseRandomizedOptimizerRules;
 import io.crate.testing.UseRandomizedSchema;
 import io.crate.types.DataTypes;
@@ -1523,5 +1524,42 @@ public class JoinIntegrationTest extends IntegTestCase {
             "              └ Collect[doc.tt1 | [_fetchid, b] | true]"
         );
         assertThat(execute(stmt)).hasRowCount(51);
+    }
+
+    /**
+     * Verifies a bug in the HashJoinPhase building code resulting in hashing symbols being in the wrong order
+     * and such it's generated hash-code won't match anymore.
+     *
+     * https://github.com/crate/crate/issues/14583
+     */
+    @UseJdbc(1)
+    @UseHashJoins(1)
+    @UseRandomizedSchema(random = false)
+    @UseRandomizedOptimizerRules(0)
+    @Test
+    public void test_ensure_hash_symbols_match_after_hash_join_is_reordered() {
+        execute("create table doc.t1(a int, b int)");
+        execute("create table doc.t2(c int, d int)");
+        execute("create table doc.t3(e int, f int)");
+
+        execute("insert into doc.t1(a,b) values(1,2)");
+        execute("insert into doc.t2(c,d) values (1,3),(5,6)");
+        execute("insert into doc.t3(e,f) values (3,2)");
+        refresh();
+        execute("analyze");
+
+        var stmt = "SELECT t3.e FROM t1 JOIN t3 ON t1.b = t3.f JOIN t2 ON t1.a = t2.c WHERE t2.d =t3.e";
+        assertThat(execute("explain " + stmt)).hasLines(
+                "Eval[e] (rows=0)",
+                "  └ Eval[b, a, e, f, c, d] (rows=0)",
+                "    └ HashJoin[((a = c) AND (d = e))] (rows=0)",
+                "      ├ Collect[doc.t2 | [c, d] | true] (rows=2)",
+                "      └ HashJoin[(b = f)] (rows=1)",
+                "        ├ Collect[doc.t1 | [b, a] | true] (rows=1)",
+                "        └ Collect[doc.t3 | [e, f] | true] (rows=1)"
+        );
+
+        execute(stmt);
+        assertThat(response).hasRows("3");
     }
 }


### PR DESCRIPTION
The hash symbols extracted from the join condition must stay in the same order for both, left and right inputs to generate a matching hash code (used for matching the rows).
In this case, the symbols were mixed up as they were processed based on unordered relation names.
    
Fixes #14583.