### PR TITLE
added hasOid method to ReferenceAssert

### DIFF
--- a/server/src/testFixtures/java/io/crate/testing/ReferenceAssert.java
+++ b/server/src/testFixtures/java/io/crate/testing/ReferenceAssert.java
@@ -35,6 +35,13 @@ public class ReferenceAssert extends AbstractAssert<ReferenceAssert, Reference> 
         super(reference, ReferenceAssert.class);
     }
 
+    public ReferenceAssert hasOid(long expectedOid) {
+        assertThat(actual.oid())
+            .as("oid")
+            .isEqualTo(expectedOid);
+        return this;
+    }
+
     public ReferenceAssert hasName(String expectedName) {
         assertThat(actual.column().sqlFqn())
             .as("sqlFqn")


### PR DESCRIPTION
Follow up for https://github.com/crate/crate/pull/14632 - on drop-column branch we also need `hadOid`.
