### PR TITLE
2 phase indexing

### DIFF
--- a/server/src/main/java/io/crate/execution/ddl/tables/AddColumnResponse.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/AddColumnResponse.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.ddl.tables;
+
+import io.crate.metadata.Reference;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class AddColumnResponse extends AcknowledgedResponse {
+
+    private final List<Reference> addedColumns;
+
+    public AddColumnResponse(boolean acknowledged, List<Reference> addedColumns) {
+        super(acknowledged);
+        this.addedColumns = addedColumns;
+    }
+
+    public AddColumnResponse(StreamInput in) throws IOException {
+        super(in);
+        if (in.getVersion().onOrAfter(Version.V_5_5_0)) {
+            addedColumns = in.readList(Reference::fromStream);
+        } else {
+            addedColumns = new ArrayList<>();
+        }
+    }
+
+    public List<Reference> addedColumns() {
+        return addedColumns;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        if (out.getVersion().onOrAfter(Version.V_5_5_0)) {
+            out.writeCollection(addedColumns, Reference::toStream);
+        }
+    }
+}

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportAddColumnAction.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportAddColumnAction.java
@@ -21,23 +21,28 @@
 
 package io.crate.execution.ddl.tables;
 
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
+import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
-import io.crate.execution.ddl.AbstractDDLTransportAction;
 import io.crate.metadata.NodeContext;
 
+import java.io.IOException;
+
 @Singleton
-public class TransportAddColumnAction extends AbstractDDLTransportAction<AddColumnRequest, AcknowledgedResponse> {
+public class TransportAddColumnAction extends TransportMasterNodeAction<AddColumnRequest, AcknowledgedResponse> {
 
     private static final String ACTION_NAME = "internal:crate:sql/table/add_column";
     private final NodeContext nodeContext;
@@ -49,23 +54,45 @@ public class TransportAddColumnAction extends AbstractDDLTransportAction<AddColu
                                     IndicesService indicesService,
                                     ThreadPool threadPool,
                                     NodeContext nodeContext) {
-        super(ACTION_NAME,
+        super(
+            ACTION_NAME,
             transportService,
             clusterService,
             threadPool,
-            AddColumnRequest::new,
-            AcknowledgedResponse::new,
-            AcknowledgedResponse::new,
-            "add-column");
+            AddColumnRequest::new
+        );
         this.nodeContext = nodeContext;
         this.indicesService = indicesService;
     }
 
     @Override
-    public ClusterStateTaskExecutor<AddColumnRequest> clusterStateTaskExecutor(AddColumnRequest request) {
-        return new AddColumnTask(nodeContext, indicesService::createIndexMapperService);
+    protected String executor() {
+        return ThreadPool.Names.SAME;
     }
 
+    @Override
+    protected AcknowledgedResponse read(StreamInput in) throws IOException {
+        return new AddColumnResponse(in);
+    }
+
+    @Override
+    protected void masterOperation(AddColumnRequest request, ClusterState state, ActionListener<AcknowledgedResponse> listener) throws Exception {
+        AddColumnTask addColumnTask = new AddColumnTask(nodeContext, indicesService::createIndexMapperService);
+
+        clusterService.submitStateUpdateTask("add-column",
+            new AckedClusterStateUpdateTask<>(Priority.HIGH, request, listener) {
+
+                @Override
+                public ClusterState execute(ClusterState currentState) throws Exception {
+                    return addColumnTask.execute(currentState, request);
+                }
+
+                @Override
+                protected AcknowledgedResponse newResponse(boolean acknowledged) {
+                    return new AddColumnResponse(acknowledged, addColumnTask.addedColumns());
+                }
+            });
+    }
 
     @Override
     public ClusterBlockException checkBlock(AddColumnRequest request, ClusterState state) {

--- a/server/src/main/java/io/crate/execution/dml/ArrayIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/ArrayIndexer.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
+import org.jetbrains.annotations.Nullable;
 
 public class ArrayIndexer<T> implements ValueIndexer<List<T>> {
 
@@ -44,7 +45,6 @@ public class ArrayIndexer<T> implements ValueIndexer<List<T>> {
     public void indexValue(List<T> values,
                            XContentBuilder xContentBuilder,
                            Consumer<? super IndexableField> addField,
-                           Consumer<? super Reference> onDynamicColumn,
                            Map<ColumnIdent, Indexer.Synthetic> synthetics,
                            Map<ColumnIdent, Indexer.ColumnConstraint> toValidate) throws IOException {
         xContentBuilder.startArray();
@@ -57,7 +57,6 @@ public class ArrayIndexer<T> implements ValueIndexer<List<T>> {
                         value,
                         xContentBuilder,
                         addField,
-                        onDynamicColumn,
                         synthetics,
                         toValidate
                     );
@@ -65,5 +64,18 @@ public class ArrayIndexer<T> implements ValueIndexer<List<T>> {
             }
         }
         xContentBuilder.endArray();
+    }
+
+    @Override
+    public void collectSchemaUpdates(@Nullable List<T> values,
+                                     Consumer<? super Reference> onDynamicColumn,
+                                     Map<ColumnIdent, Indexer.Synthetic> synthetics) throws IOException {
+        if (values != null) {
+            for (T value : values) {
+                if (value != null) {
+                    innerIndexer.collectSchemaUpdates(value, onDynamicColumn, synthetics);
+                }
+            }
+        }
     }
 }

--- a/server/src/main/java/io/crate/execution/dml/BitStringIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/BitStringIndexer.java
@@ -61,7 +61,6 @@ public class BitStringIndexer implements ValueIndexer<BitString> {
     public void indexValue(BitString value,
                            XContentBuilder xcontentBuilder,
                            Consumer<? super IndexableField> addField,
-                           Consumer<? super Reference> onDynamicColumn,
                            Map<ColumnIdent, Synthetic> synthetics,
                            Map<ColumnIdent, ColumnConstraint> toValidate) throws IOException {
         BitSet bitSet = value.bitSet();

--- a/server/src/main/java/io/crate/execution/dml/BooleanIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/BooleanIndexer.java
@@ -55,7 +55,6 @@ public class BooleanIndexer implements ValueIndexer<Boolean> {
     public void indexValue(Boolean value,
                            XContentBuilder xContentBuilder,
                            Consumer<? super IndexableField> addField,
-                           Consumer<? super Reference> onDynamicColumn,
                            Map<ColumnIdent, Synthetic> synthetics,
                            Map<ColumnIdent, ColumnConstraint> toValidate) throws IOException {
         xContentBuilder.value(value);

--- a/server/src/main/java/io/crate/execution/dml/DoubleIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/DoubleIndexer.java
@@ -60,7 +60,6 @@ public class DoubleIndexer implements ValueIndexer<Number> {
     public void indexValue(Number value,
                            XContentBuilder xcontentBuilder,
                            Consumer<? super IndexableField> addField,
-                           Consumer<? super Reference> onDynamicColumn,
                            Map<ColumnIdent, Synthetic> synthetics,
                            Map<ColumnIdent, ColumnConstraint> toValidate) throws IOException {
         xcontentBuilder.value(value);

--- a/server/src/main/java/io/crate/execution/dml/FloatIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/FloatIndexer.java
@@ -58,7 +58,6 @@ public class FloatIndexer implements ValueIndexer<Float> {
     public void indexValue(Float value,
                            XContentBuilder xcontentBuilder,
                            Consumer<? super IndexableField> addField,
-                           Consumer<? super Reference> onDynamicColumn,
                            Map<ColumnIdent, Synthetic> synthetics,
                            Map<ColumnIdent, ColumnConstraint> toValidate) throws IOException {
         xcontentBuilder.value(value);

--- a/server/src/main/java/io/crate/execution/dml/FloatVectorIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/FloatVectorIndexer.java
@@ -68,7 +68,6 @@ public class FloatVectorIndexer implements ValueIndexer<float[]> {
     public void indexValue(float @Nullable [] values,
                            XContentBuilder xcontentBuilder,
                            Consumer<? super IndexableField> addField,
-                           Consumer<? super Reference> onDynamicColumn,
                            Map<ColumnIdent, Synthetic> synthetics,
                            Map<ColumnIdent, ColumnConstraint> toValidate) throws IOException {
         if (values == null) {

--- a/server/src/main/java/io/crate/execution/dml/FulltextIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/FulltextIndexer.java
@@ -50,7 +50,6 @@ public class FulltextIndexer implements ValueIndexer<String> {
     public void indexValue(String value,
                            XContentBuilder xcontentBuilder,
                            Consumer<? super IndexableField> addField,
-                           Consumer<? super Reference> onDynamicColumn,
                            Map<ColumnIdent, Indexer.Synthetic> synthetics,
                            Map<ColumnIdent, Indexer.ColumnConstraint> toValidate) throws IOException {
         xcontentBuilder.value(value);

--- a/server/src/main/java/io/crate/execution/dml/GeoPointIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/GeoPointIndexer.java
@@ -58,7 +58,6 @@ public class GeoPointIndexer implements ValueIndexer<Point> {
     public void indexValue(Point point,
                            XContentBuilder xcontentBuilder,
                            Consumer<? super IndexableField> addField,
-                           Consumer<? super Reference> onDynamicColumn,
                            Map<ColumnIdent, Synthetic> synthetics,
                            Map<ColumnIdent, ColumnConstraint> toValidate) throws IOException {
 

--- a/server/src/main/java/io/crate/execution/dml/GeoShapeIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/GeoShapeIndexer.java
@@ -62,7 +62,6 @@ public class GeoShapeIndexer implements ValueIndexer<Map<String, Object>> {
     public void indexValue(Map<String, Object> value,
                            XContentBuilder xcontentBuilder,
                            Consumer<? super IndexableField> addField,
-                           Consumer<? super Reference> onDynamicColumn,
                            Map<ColumnIdent, Synthetic> synthetics,
                            Map<ColumnIdent, ColumnConstraint> toValidate) throws IOException {
         xcontentBuilder.map(value);

--- a/server/src/main/java/io/crate/execution/dml/Indexer.java
+++ b/server/src/main/java/io/crate/execution/dml/Indexer.java
@@ -42,6 +42,7 @@ import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -81,6 +82,8 @@ import io.crate.sql.tree.ColumnPolicy;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.ObjectType;
+
+import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
 
 /**
  * <p>
@@ -122,6 +125,7 @@ public class Indexer {
     private final List<Input<?>> returnValueInputs;
     private final List<Synthetic> undeterministic = new ArrayList<>();
     private final BytesStreamOutput stream;
+    private final boolean writeOids;
 
     record IndexColumn(ColumnIdent name, FieldType fieldType, List<Input<?>> inputs) {
     }
@@ -366,6 +370,7 @@ public class Indexer {
         this.columns = targetColumns;
         this.synthetics = new HashMap<>();
         this.stream = new BytesStreamOutput();
+        this.writeOids = table.versionCreated().onOrAfter(Version.V_5_5_0);
         PartitionName partitionName = table.isPartitioned()
             ? PartitionName.fromIndexOrTemplate(indexName)
             : null;
@@ -512,6 +517,24 @@ public class Indexer {
         this.expressions = ctxForRefs.expressions();
     }
 
+    /**
+     * @param addedColumns has columns collected by {@link #collectSchemaUpdates(IndexItem) and with assigned OID0-s
+     */
+    public void updateTargets(List<Reference> addedColumns) {
+        // Store by ident for fast replacement.
+        Map<ColumnIdent, Reference> addedColumnsByIdent = new HashMap<>();
+        for (Reference ref: addedColumns) {
+            addedColumnsByIdent.put(ref.column(), ref);
+        }
+
+        for (int i = 0; i < columns.size(); i++) {
+            Reference referenceWithOid = addedColumnsByIdent.get(columns.get(i).column());
+            if (referenceWithOid != null) {
+                columns.set(i, referenceWithOid);
+            }
+        }
+    }
+
     private static void addNotNullConstraints(List<TableConstraint> tableConstraints,
                                               Map<ColumnIdent, ColumnConstraint> columnConstraints,
                                               DocTableInfo table,
@@ -553,6 +576,7 @@ public class Indexer {
             }
         }
     }
+
 
     /**
      * Looks for new columns in the values of the given IndexItem and returns them.
@@ -624,6 +648,10 @@ public class Indexer {
             Object[] values = item.insertValues();
             for (int i = 0; i < values.length; i++) {
                 Reference reference = columns.get(i);
+                    // It's possible to have target references without OID after doing a mapping update:
+                    // Empty arrays, arrays with only null values and columns added dynamically into IGNORED object doesn't result in schema update.
+                    assert assertExistingOid(reference) : "All target columns must have assigned OID on indexing.";
+
                 Object value = reference.valueType().valueForInsert(values[i]);
                 ColumnConstraint check = columnConstraints.get(reference.column());
                 if (check != null) {
@@ -833,5 +861,12 @@ public class Indexer {
             }
         }
         return result;
+    }
+
+    private boolean assertExistingOid(Reference ref) {
+        if (writeOids && ref instanceof DynamicReference == false) {
+            return ref.oid() != COLUMN_OID_UNASSIGNED;
+        }
+        return true;
     }
 }

--- a/server/src/main/java/io/crate/execution/dml/IntIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/IntIndexer.java
@@ -58,7 +58,6 @@ public class IntIndexer implements ValueIndexer<Number> {
     public void indexValue(Number value,
                            XContentBuilder xContentBuilder,
                            Consumer<? super IndexableField> addField,
-                           Consumer<? super Reference> onDynamicColumn,
                            Map<ColumnIdent, Indexer.Synthetic> synthetics,
                            Map<ColumnIdent, Indexer.ColumnConstraint> toValidate) throws IOException {
         xContentBuilder.value(value);

--- a/server/src/main/java/io/crate/execution/dml/IpIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/IpIndexer.java
@@ -59,7 +59,6 @@ public class IpIndexer implements ValueIndexer<String> {
     public void indexValue(String value,
                            XContentBuilder xContentBuilder,
                            Consumer<? super IndexableField> addField,
-                           Consumer<? super Reference> onDynamicColumn,
                            Map<ColumnIdent, Synthetic> synthetics,
                            Map<ColumnIdent, ColumnConstraint> toValidate) throws IOException {
         xContentBuilder.value(value);

--- a/server/src/main/java/io/crate/execution/dml/LongIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/LongIndexer.java
@@ -57,7 +57,6 @@ public class LongIndexer implements ValueIndexer<Long> {
     public void indexValue(Long value,
                            XContentBuilder xcontentBuilder,
                            Consumer<? super IndexableField> addField,
-                           Consumer<? super Reference> onDynamicColumn,
                            Map<ColumnIdent, Indexer.Synthetic> synthetics,
                            Map<ColumnIdent, Indexer.ColumnConstraint> toValidate) throws IOException {
         xcontentBuilder.value(value);

--- a/server/src/main/java/io/crate/execution/dml/ObjectIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/ObjectIndexer.java
@@ -102,7 +102,6 @@ public class ObjectIndexer implements ValueIndexer<Map<String, Object>> {
     public void indexValue(@Nullable Map<String, Object> value,
                            XContentBuilder xContentBuilder,
                            Consumer<? super IndexableField> addField,
-                           Consumer<? super Reference> onDynamicColumn,
                            Map<ColumnIdent, Indexer.Synthetic> synthetics,
                            Map<ColumnIdent, Indexer.ColumnConstraint> checks) throws IOException {
         xContentBuilder.startObject();
@@ -134,25 +133,54 @@ public class ObjectIndexer implements ValueIndexer<Map<String, Object>> {
                     type.sanitizeValue(innerValue),
                     xContentBuilder,
                     addField,
-                    onDynamicColumn,
                     synthetics,
                     checks
                 );
             }
         }
+
         if (value != null) {
-            addNewColumns(value, xContentBuilder, addField, onDynamicColumn, synthetics, checks);
+            indexUnknownColumns(value, xContentBuilder);
         }
         xContentBuilder.endObject();
     }
 
+    @Override
+    public void collectSchemaUpdates(@Nullable Map<String, Object> value,
+                                     Consumer<? super Reference> onDynamicColumn,
+                                     Map<ColumnIdent, Indexer.Synthetic> synthetics) throws IOException {
+        for (var entry : innerTypes.entrySet()) {
+            String innerName = entry.getKey();
+            DataType<?> type = entry.getValue();
+            ColumnIdent innerColumn = column.getChild(innerName);
+            Object innerValue = null;
+            if (value == null || value.containsKey(innerName) == false) {
+                Synthetic synthetic = synthetics.get(innerColumn);
+                if (synthetic != null) {
+                    innerValue = synthetic.input().value();
+                }
+            } else {
+                innerValue = value.get(innerName);
+            }
+            var valueIndexer = innerIndexers.get(innerName);
+            // valueIndexer is null for partitioned columns
+            if (valueIndexer != null) {
+                valueIndexer.collectSchemaUpdates(
+                    type.sanitizeValue(innerValue),
+                    onDynamicColumn,
+                    synthetics
+                );
+            }
+        }
+        if (value != null) {
+            addNewColumns(value, onDynamicColumn, synthetics);
+        }
+    }
+
     @SuppressWarnings("unchecked")
     private void addNewColumns(Map<String, Object> value,
-                               XContentBuilder xContentBuilder,
-                               Consumer<? super IndexableField> addField,
                                Consumer<? super Reference> onDynamicColumn,
-                               Map<ColumnIdent, Indexer.Synthetic> synthetics,
-                               Map<ColumnIdent, Indexer.ColumnConstraint> checks) throws IOException {
+                               Map<ColumnIdent, Synthetic> synthetics) throws IOException {
         int position = -1;
         for (var entry : value.entrySet()) {
             String innerName = entry.getKey();
@@ -162,7 +190,6 @@ public class ObjectIndexer implements ValueIndexer<Map<String, Object>> {
                 continue;
             }
             if (innerValue == null) {
-                xContentBuilder.nullField(innerName);
                 continue;
             }
             if (ref.columnPolicy() == ColumnPolicy.STRICT) {
@@ -174,15 +201,13 @@ public class ObjectIndexer implements ValueIndexer<Map<String, Object>> {
                 ));
             }
             if (ref.columnPolicy() == ColumnPolicy.IGNORED) {
-                xContentBuilder.field(innerName, innerValue);
                 continue;
             }
             var type = DynamicIndexer.guessType(innerValue);
             innerValue = type.sanitizeValue(innerValue);
             StorageSupport<?> storageSupport = type.storageSupport();
             if (storageSupport == null) {
-                xContentBuilder.field(innerName);
-                if (DynamicIndexer.handleEmptyArray(type, innerValue, xContentBuilder)) {
+                if (DynamicIndexer.handleEmptyArray(type, innerValue, null)) {
                     continue;
                 }
                 throw new IllegalArgumentException(
@@ -214,15 +239,52 @@ public class ObjectIndexer implements ValueIndexer<Map<String, Object>> {
             );
             innerIndexers.put(innerName, valueIndexer);
             innerTypes.put(innerName, type);
-            xContentBuilder.field(innerName);
-            valueIndexer.indexValue(
+            valueIndexer.collectSchemaUpdates(
                 innerValue,
-                xContentBuilder,
-                addField,
                 onDynamicColumn,
-                synthetics,
-                checks
+                synthetics
             );
         }
+    }
+
+    /**
+     * Writes keys and values for which there are no columns after {@link #collectSchemaUpdates(Map, Consumer, Map) to the xContentBuilder.
+     *
+     * There are no columns for:
+     * <ul>
+     *  <li>OBJECT (IGNORED)</li>
+     *  <li>Empty arrays, or arrays with only null values</li>
+     * </ul>
+     */
+    private void indexUnknownColumns(Map<String, Object> value, XContentBuilder xContentBuilder) throws IOException {
+        for (var entry : value.entrySet()) {
+            String innerName = entry.getKey();
+            Object innerValue = entry.getValue();
+            boolean isNewColumn = !innerTypes.containsKey(innerName);
+            if (!isNewColumn) {
+                continue;
+            }
+            if (innerValue == null) {
+                xContentBuilder.nullField(innerName);
+                continue;
+            }
+            if (ref.columnPolicy() == ColumnPolicy.IGNORED) {
+                xContentBuilder.field(innerName, innerValue);
+                continue;
+            }
+            var type = DynamicIndexer.guessType(innerValue);
+            innerValue = type.sanitizeValue(innerValue);
+            StorageSupport<?> storageSupport = type.storageSupport();
+            if (storageSupport == null) {
+                xContentBuilder.field(innerName);
+                if (DynamicIndexer.handleEmptyArray(type, innerValue, xContentBuilder)) {
+                    continue;
+                }
+                throw new IllegalArgumentException(
+                    "Cannot create columns of type " + type.getName() + " dynamically. " +
+                        "Storage is not supported for this type");
+            }
+        }
+
     }
 }

--- a/server/src/main/java/io/crate/execution/dml/StringIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/StringIndexer.java
@@ -54,7 +54,6 @@ public class StringIndexer implements ValueIndexer<String> {
     public void indexValue(String value,
                            XContentBuilder xcontentBuilder,
                            Consumer<? super IndexableField> addField,
-                           Consumer<? super Reference> onDynamicColumn,
                            Map<ColumnIdent, Indexer.Synthetic> synthetics,
                            Map<ColumnIdent, Indexer.ColumnConstraint> toValidate) throws IOException {
         xcontentBuilder.value(value);

--- a/server/src/main/java/io/crate/execution/dml/ValueIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/ValueIndexer.java
@@ -50,11 +50,17 @@ import io.crate.metadata.Reference;
  **/
 public interface ValueIndexer<T> {
 
+    /**
+     * Only {@link ObjectIndexer}, {@link ArrayIndexer} and {@link DynamicIndexer} can create new columns.
+     */
+    default void collectSchemaUpdates(@Nullable T value,
+                                      Consumer<? super Reference> onDynamicColumn,
+                                      Map<ColumnIdent, Indexer.Synthetic> synthetics) throws IOException {}
+
     void indexValue(
         @Nullable T value,
         XContentBuilder xcontentBuilder,
         Consumer<? super IndexableField> addField,
-        Consumer<? super Reference> onDynamicColumn,
         Map<ColumnIdent, Indexer.Synthetic> synthetics,
         Map<ColumnIdent, ColumnConstraint> toValidate
     ) throws IOException;

--- a/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
@@ -32,6 +32,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
+import io.crate.execution.ddl.tables.AddColumnResponse;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.jetbrains.annotations.Nullable;
 
 import org.apache.lucene.document.FieldType;
@@ -174,7 +176,7 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
             assert request.insertColumns() == null || insertColumns.subList(0, request.insertColumns().length).equals(Arrays.asList(request.insertColumns()))
                 : "updateToInsert.columns() must be a superset of insertColumns where the start is an exact overlap. It may only add new columns at the end";
         } else {
-            insertColumns = List.of(request.insertColumns());
+            insertColumns = Arrays.asList(request.insertColumns());
         }
         Indexer indexer = new Indexer(
             indexName,
@@ -522,6 +524,7 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
         final long startTime = System.nanoTime();
 
         List<Reference> newColumns = indexer.collectSchemaUpdates(item);
+        AcknowledgedResponse response = null;
         if (!newColumns.isEmpty()) {
             var addColumnRequest = new AddColumnRequest(
                 RelationName.fromIndexName(indexShard.shardId().getIndexName()),
@@ -529,7 +532,11 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
                 Map.of(),
                 new IntArrayList(0)
             );
-            addColumnAction.execute(addColumnRequest).get();
+            response = addColumnAction.execute(addColumnRequest).get();
+        }
+
+        if (response instanceof AddColumnResponse addColumnResponse) {
+            indexer.updateTargets(addColumnResponse.addedColumns());
         }
 
         ParsedDocument parsedDoc = indexer.index(item);

--- a/server/src/main/java/io/crate/metadata/SimpleReference.java
+++ b/server/src/main/java/io/crate/metadata/SimpleReference.java
@@ -262,6 +262,8 @@ public class SimpleReference implements Reference {
         mapping.put("position", position);
         if (oid == COLUMN_OID_UNASSIGNED && columnOidSupplier != null) {
             mapping.put("oid", columnOidSupplier.nextOid());
+        } else if (oid != COLUMN_OID_UNASSIGNED) {
+            mapping.put("oid", oid);
         }
         if (isDropped) {
             mapping.put("dropped", true);

--- a/server/src/main/java/io/crate/metadata/doc/DocIndexMetadata.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocIndexMetadata.java
@@ -547,6 +547,7 @@ public class DocIndexMetadata {
                         IndexReference.Builder builder = getOrCreateIndexBuilder(newIdent);
                         builder.indexType(columnIndexType)
                             .position(position)
+                            .oid(oid)
                             .analyzer((String) columnProperties.get("analyzer"))
                             .sources(sources);
                     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -88,8 +88,7 @@ final class DocumentParser {
             context.sourceToParse().id(),
             context.doc(),
             context.sourceToParse().source(),
-            createDynamicUpdate(mapping, docMapper, context.getDynamicMappers()),
-            List.of()
+            createDynamicUpdate(mapping, docMapper, context.getDynamicMappers())
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/ParsedDocument.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ParsedDocument.java
@@ -19,13 +19,9 @@
 
 package org.elasticsearch.index.mapper;
 
-import java.util.List;
-
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.elasticsearch.common.bytes.BytesReference;
-
-import io.crate.metadata.Reference;
 
 /**
  * The result of parsing a document.
@@ -43,22 +39,18 @@ public class ParsedDocument {
 
     private final Mapping dynamicMappingsUpdate;
 
-    private final List<Reference> newColumns;
-
     public ParsedDocument(Field version,
                           SequenceIDFields seqID,
                           String id,
                           Document document,
                           BytesReference source,
-                          Mapping dynamicMappingsUpdate,
-                          List<Reference> newColumns) {
+                          Mapping dynamicMappingsUpdate) {
         this.version = version;
         this.seqID = seqID;
         this.id = id;
         this.document = document;
         this.source = source;
         this.dynamicMappingsUpdate = dynamicMappingsUpdate;
-        this.newColumns = newColumns;
     }
 
     public String id() {
@@ -104,9 +96,5 @@ public class ParsedDocument {
     @Override
     public String toString() {
         return "Document id[" + id + "] doc [" + document + ']';
-    }
-
-    public List<Reference> newColumns() {
-        return newColumns;
     }
 }

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -985,6 +985,7 @@ public class Node implements Closeable {
         // start after transport service so the local disco is known
         discovery.start(); // start before cluster service so that it can set initial state on ClusterApplierService
         clusterService.start();
+
         assert clusterService.localNode().equals(localNodeFactory.getNode())
             : "clusterService has a different local node than the factory provided";
         transportService.acceptIncomingRequests();

--- a/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -25,15 +25,14 @@ import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.exactlyInstanceOf;
 import static io.crate.testing.Asserts.isLiteral;
 import static io.crate.testing.Asserts.isReference;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import io.crate.metadata.ColumnIdent;
 import org.joda.time.Period;
 import org.joda.time.PeriodType;
 import org.junit.Before;
@@ -62,15 +61,10 @@ import io.crate.expression.symbol.ParameterSymbol;
 import io.crate.expression.symbol.ScopedSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.IndexType;
-import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RelationName;
-import io.crate.metadata.RowGranularity;
-import io.crate.metadata.SimpleReference;
 import io.crate.metadata.settings.CoordinatorSessionSettings;
 import io.crate.metadata.table.TableInfo;
 import io.crate.sql.parser.SqlParser;
-import io.crate.sql.tree.ColumnPolicy;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.testing.SqlExpressions;
@@ -446,34 +440,16 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testAnalyzeArraySliceFunctionCall() {
-        ReferenceIdent arrayRefIdent = new ReferenceIdent(new RelationName("doc", "tarr"), "xs");
-        SimpleReference arrayRef = new SimpleReference(
-            arrayRefIdent,
-            RowGranularity.DOC,
-            DataTypes.INTEGER_ARRAY,
-            ColumnPolicy.DYNAMIC,
-            IndexType.PLAIN,
-            true,
-            true,
-            1,
-            COLUMN_OID_UNASSIGNED,
-            false,
-            null
-        );
-        CoordinatorTxnCtx txnCtx = CoordinatorTxnCtx.systemTransactionContext();
-        ExpressionAnalysisContext localContext = new ExpressionAnalysisContext(txnCtx.sessionSettings());
-        Symbol function = ExpressionAnalyzer.allocateFunction(
+        assertThat(executor.asSymbol("tarr.xs[1:3]")).isFunction(
             ArraySliceFunction.NAME,
-            List.of(arrayRef, Literal.of(1), Literal.of(3)),
-            null,
-            localContext,
-            txnCtx,
-            expressions.nodeCtx
+            arg1 -> assertThat(arg1)
+                    .isReference()
+                    .hasColumnIdent(new ColumnIdent("xs"))
+                    .hasTableIdent(new RelationName("doc", "tarr"))
+                .hasType(DataTypes.INTEGER_ARRAY),
+            arg2 -> assertThat(arg2).isLiteral(1),
+            arg3 -> assertThat(arg3).isLiteral(3)
         );
-
-        var result = executor.asSymbol("tarr.xs[1:3]");
-
-        assertThat(result).isEqualTo(function);
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/ddl/tables/AddColumnResponseTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/tables/AddColumnResponseTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.ddl.tables;
+
+import io.crate.metadata.Reference;
+import io.crate.metadata.ReferenceIdent;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.RowGranularity;
+import io.crate.metadata.SimpleReference;
+import io.crate.metadata.Schemas;
+import io.crate.sql.tree.QualifiedName;
+import io.crate.types.DataTypes;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AddColumnResponseTest {
+
+    @Test
+    public void test_bwc_streaming() throws Exception {
+        RelationName rel = RelationName.of(QualifiedName.of("t1"), Schemas.DOC_SCHEMA_NAME);
+
+        Reference ref1 = new SimpleReference(
+            new ReferenceIdent(rel, "col_1"),
+            RowGranularity.DOC,
+            DataTypes.STRING,
+            1,
+            null
+        );
+        Reference ref2 = new SimpleReference(
+            new ReferenceIdent(rel, "col_2"),
+            RowGranularity.DOC,
+            DataTypes.INTEGER,
+            2,
+            null
+        );
+        List<Reference> refs = List.of(ref1, ref2);
+
+        AddColumnResponse response = new AddColumnResponse(true, refs);
+
+        // 5.5 -> 5.4
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.setVersion(Version.V_5_4_0);
+            response.writeTo(out);
+            StreamInput in = out.bytes().streamInput();
+            // 5.5 sends AddColumnResponse and 5.4 can read it as an AcknowledgedResponse.
+            AcknowledgedResponse fromStream = new AcknowledgedResponse(in);
+            assertThat(fromStream.isAcknowledged()).isTrue();
+        }
+
+        // 5.4 -> 5.5
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            AcknowledgedResponse acknowledgedResponse = new AcknowledgedResponse(true);
+            acknowledgedResponse.writeTo(out);
+            StreamInput in = out.bytes().streamInput();
+            in.setVersion(Version.V_5_4_0);
+            // 5.4 sends AcknowledgedResponse and 5.5 can read it as an AddColumnResponse with empty columns list.
+            AddColumnResponse fromStream = new AddColumnResponse(in);
+            assertThat(fromStream.isAcknowledged()).isTrue();
+            assertThat(fromStream.addedColumns()).isEmpty();
+        }
+
+        // 5.5 -> 5.5
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.setVersion(Version.V_5_5_0);
+            response.writeTo(out);
+            StreamInput in = out.bytes().streamInput();
+            in.setVersion(Version.V_5_5_0);
+            AddColumnResponse fromStream = new AddColumnResponse(in);
+            assertThat(fromStream.isAcknowledged()).isTrue();
+            assertThat(fromStream.addedColumns()).isEqualTo(refs);
+        }
+    }
+
+}

--- a/server/src/test/java/io/crate/execution/ddl/tables/AddColumnTaskTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/tables/AddColumnTaskTest.java
@@ -35,6 +35,7 @@ import org.junit.Test;
 
 import com.carrotsearch.hppc.IntArrayList;
 
+import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.GeoReference;
 import io.crate.metadata.IndexType;
 import io.crate.metadata.Reference;
@@ -323,6 +324,77 @@ public class AddColumnTaskTest extends CrateDummyClusterServiceUnitTest {
             assertThatThrownBy(() -> addColumnTask.execute(state, request))
                 .isExactlyInstanceOf(MapperParsingException.class)
                 .hasMessageContaining("nested arrays are not supported");
+        }
+    }
+
+    @Test
+    public void test_collect_new_columns() throws Exception {
+        var e = SQLExecutor.builder(clusterService)
+            .addTable("create table tbl (x int, o object) with (column_policy='dynamic')")
+            .build();
+        DocTableInfo table = e.resolveTableInfo("tbl");
+        ClusterState state = clusterService.state();
+
+        try (IndexEnv indexEnv = new IndexEnv(
+            THREAD_POOL,
+            table,
+            state,
+            Version.CURRENT,
+            createTempDir()
+        )) {
+            var addColumnTask = new AddColumnTask(e.nodeCtx, imd -> indexEnv.mapperService());
+            SimpleReference nonObjectRef = new SimpleReference(
+                new ReferenceIdent(table.ident(), "int_col"),
+                RowGranularity.DOC,
+                DataTypes.INTEGER,
+                3,
+                null
+            );
+            SimpleReference oxRef = new SimpleReference(
+                new ReferenceIdent(table.ident(), "o", List.of("x")),
+                RowGranularity.DOC,
+                DataTypes.INTEGER,
+                4,
+                null
+            );
+            SimpleReference oyRef = new SimpleReference(
+                new ReferenceIdent(table.ident(), "o", List.of("y")),
+                RowGranularity.DOC,
+                DataTypes.INTEGER,
+                5,
+                null
+            );
+            List<Reference> columns = List.of(nonObjectRef, oxRef, oyRef);
+            var request = new AddColumnRequest(
+                table.ident(),
+                columns,
+                Map.of(),
+                new IntArrayList()
+            );
+
+            addColumnTask.execute(state, request);
+            List<Reference> addedColumns = addColumnTask.addedColumns();
+            assertThat(addedColumns).hasSize(3);
+            assertThat(addedColumns).satisfiesExactly(
+                ref -> assertThat(ref)
+                    .isReference()
+                    .hasColumnIdent(new ColumnIdent("int_col"))
+                    .hasTableIdent(table.ident())
+                    .hasType(DataTypes.INTEGER)
+                    .hasOid(3L),
+                ref -> assertThat(ref)
+                    .isReference()
+                    .hasColumnIdent(new ColumnIdent("o", List.of("x")))
+                    .hasTableIdent(table.ident())
+                    .hasType(DataTypes.INTEGER)
+                    .hasOid(4L),
+                ref -> assertThat(ref)
+                    .isReference()
+                    .hasColumnIdent(new ColumnIdent("o", List.of("y")))
+                    .hasTableIdent(table.ident())
+                    .hasType(DataTypes.INTEGER)
+                    .hasOid(5L)
+            );
         }
     }
 }

--- a/server/src/test/java/io/crate/execution/ddl/tables/AddColumnTaskTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/tables/AddColumnTaskTest.java
@@ -91,8 +91,7 @@ public class AddColumnTaskTest extends CrateDummyClusterServiceUnitTest {
             DocTableInfo newTable = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState);
 
             Reference addedColumn = newTable.getReference(newColumn.column());
-            // TODO: Update TestingHelpers to assign OID-s so that expression .addTable("create table tbl (x int, o object)") actually shifts the OID.
-            // Need to create a clone of request column to imitate the expected OID. Currently it's 2 and will be 3 once ^ is implemented.
+            // Need to create a clone of request column to imitate the expected OID.
             Reference newColumnWithOid = new SimpleReference(
                 newColumn.ident(),
                 newColumn.granularity(),
@@ -102,7 +101,7 @@ public class AddColumnTaskTest extends CrateDummyClusterServiceUnitTest {
                 newColumn.isNullable(),
                 newColumn.hasDocValues(),
                 newColumn.position(),
-                2,
+                3,
                 false,
                 newColumn.defaultExpression()
             );

--- a/server/src/test/java/io/crate/execution/dml/IndexerTest.java
+++ b/server/src/test/java/io/crate/execution/dml/IndexerTest.java
@@ -23,7 +23,6 @@ package io.crate.execution.dml;
 
 import static io.crate.metadata.doc.mappers.array.ArrayMapperTest.mapper;
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;

--- a/server/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
+++ b/server/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
@@ -40,6 +40,18 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.IndexType;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.PartitionName;
+import io.crate.metadata.Reference;
+import io.crate.metadata.ReferenceIdent;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.RowGranularity;
+import io.crate.metadata.Schemas;
+import io.crate.metadata.SearchPath;
+import io.crate.metadata.SimpleReference;
+import io.crate.sql.tree.ColumnPolicy;
 import org.jetbrains.annotations.Nullable;
 
 import org.elasticsearch.Version;
@@ -80,16 +92,6 @@ import io.crate.execution.dml.ShardResponse;
 import io.crate.execution.dml.upsert.ShardUpsertRequest.DuplicateKeyAction;
 import io.crate.execution.jobs.TasksService;
 import io.crate.expression.symbol.DynamicReference;
-import io.crate.metadata.ColumnIdent;
-import io.crate.metadata.NodeContext;
-import io.crate.metadata.PartitionName;
-import io.crate.metadata.Reference;
-import io.crate.metadata.ReferenceIdent;
-import io.crate.metadata.RelationName;
-import io.crate.metadata.RowGranularity;
-import io.crate.metadata.Schemas;
-import io.crate.metadata.SearchPath;
-import io.crate.metadata.SimpleReference;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.settings.SessionSettings;
 import io.crate.metadata.table.Operation;
@@ -102,7 +104,18 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
     private static final RelationName TABLE_IDENT = new RelationName(Schemas.DOC_SCHEMA_NAME, "characters");
     private static final String PARTITION_INDEX = new PartitionName(TABLE_IDENT, List.of("1395874800000")).asIndexName();
     private static final SimpleReference ID_REF = new SimpleReference(
-        new ReferenceIdent(TABLE_IDENT, "id"), RowGranularity.DOC, DataTypes.SHORT, 0, null);
+        new ReferenceIdent(TABLE_IDENT, "id"),
+        RowGranularity.DOC,
+        DataTypes.SHORT,
+        ColumnPolicy.DYNAMIC,
+        IndexType.PLAIN,
+        true,
+        false,
+        1,
+        1,
+        false,
+        null
+    );
 
     private static final SessionSettings DUMMY_SESSION_INFO = new SessionSettings(
         "dummyUser",
@@ -168,6 +181,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
         DocTableInfo tableInfo = mock(DocTableInfo.class);
         Schemas schemas = mock(Schemas.class);
         when(tableInfo.columns()).thenReturn(Collections.<Reference>emptyList());
+        when(tableInfo.versionCreated()).thenReturn(Version.CURRENT);
         when(schemas.getTableInfo(any(RelationName.class), eq(Operation.INSERT))).thenReturn(tableInfo);
 
         when(tableInfo.getReference(new ColumnIdent("dynamic_long_col"))).thenReturn(
@@ -175,8 +189,15 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
                 new ReferenceIdent(TABLE_IDENT,"dynamic_long_col"),
                 RowGranularity.DOC,
                 DataTypes.LONG,
-                0,
-                null));
+                ColumnPolicy.DYNAMIC,
+                IndexType.PLAIN,
+                true,
+                false,
+                1,
+                1,
+                false,
+                null
+            ));
 
         transportShardUpsertAction = new TestingTransportShardUpsertAction(
             mock(ThreadPool.class),

--- a/server/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
@@ -1918,4 +1918,19 @@ public class InsertIntoIntegrationTest extends IntegTestCase {
             assertThat(PartitionName.templateName(indexName)).isNotEqualTo(tableTemplateName);
         }
     }
+
+    @Test
+    public void test_generated_expression_updates_schema() {
+        execute("create table t (" +
+            "id int," +
+            "details object generated always as {\"a1\" = {\"b1\" = 'test'}}," +
+            "nested_gen object as (a int, gen object generated always as {\"a2\" = {\"b2\" = 'test2'}})) " +
+            "with (number_of_replicas=0, column_policy='dynamic')");
+        execute("insert into t (id, nested_gen) values (1, {\"a\" = 1})");
+        refresh();
+        execute("select * from t");
+        assertThat(response).hasRows(
+            "1| {a1={b1=test}}| {a=1, gen={a2={b2=test2}}}"
+        );
+    }
 }

--- a/server/src/test/java/io/crate/metadata/IndexReferenceTest.java
+++ b/server/src/test/java/io/crate/metadata/IndexReferenceTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.metadata;
 
+import static io.crate.metadata.ReferenceTest.columnMapping;
 import static io.crate.testing.Asserts.assertThat;
 
 import java.util.List;
@@ -31,7 +32,6 @@ import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.junit.Test;
 
-import io.crate.common.collections.Maps;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
@@ -73,13 +73,15 @@ public class IndexReferenceTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo table = e.resolveTableInfo("tbl");
         IndexReference reference = table.indexColumn(new ColumnIdent("title_desc_fulltext"));
 
-        // TODO: Assign OID in TestingHelpers
         Map<String, Object> mapping = reference.toMapping(reference.position(), null);
         assertThat(mapping)
             .containsEntry("sources", List.of("title", "description"))
+            .containsEntry("oid", 3L)
             .containsEntry("analyzer", "stop");
         IndexMetadata indexMetadata = clusterService.state().metadata().indices().valuesIt().next();
         Map<String, Object> sourceAsMap = indexMetadata.mapping().sourceAsMap();
-        assertThat(Maps.getByPath(sourceAsMap, "properties.title_desc_fulltext")).isEqualTo(mapping);
+        assertThat(columnMapping(sourceAsMap, "properties.title_desc_fulltext")).isEqualTo(mapping);
     }
+
+
 }

--- a/server/src/test/java/io/crate/planner/InsertPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/InsertPlannerTest.java
@@ -391,7 +391,7 @@ public class InsertPlannerTest extends CrateDummyClusterServiceUnitTest {
             false,
             true,
             3,
-            0,
+            3,
             false,
             null)));
     }

--- a/server/src/test/java/org/elasticsearch/gateway/GatewayIndexStateIT.java
+++ b/server/src/test/java/org/elasticsearch/gateway/GatewayIndexStateIT.java
@@ -505,6 +505,9 @@ public class GatewayIndexStateIT extends IntegTestCase {
         logger.info("--> starting one node");
         cluster().startNode();
         var tableName = getFqn("test");
+        // Cannot crete table with SQL since intentional invalid value of analyzer wouldn't pass validation.
+        // When index created directly, OID is not assigned.
+        // It's asserted on indexing, thus explicitly adding OID to the mapping.
         client().admin().indices().create(
             new CreateIndexRequest(
                 tableName,
@@ -519,6 +522,7 @@ public class GatewayIndexStateIT extends IntegTestCase {
                 "        \"field1\": {\n" +
                 "          \"type\": \"text\",\n" +
                 "          \"position\": 1,\n" +
+                "          \"oid\": 1,\n" +
                 "          \"analyzer\": \"test\"\n" +
                 "        }\n" +
                 "      }\n" +

--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -4900,8 +4900,7 @@ public class InternalEngineTests extends EngineTestCase {
                 id,
                 document,
                 source,
-                null,
-                List.of()
+                null
             );
 
             final Engine.Index index = new Engine.Index(

--- a/server/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
+++ b/server/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
@@ -2975,7 +2975,7 @@ public class TranslogTests extends ESTestCase {
         document.add(seqID.seqNo);
         document.add(seqID.seqNoDocValue);
         document.add(seqID.primaryTerm);
-        ParsedDocument doc = new ParsedDocument(versionField, seqID, "1", document, B_1, null, List.of());
+        ParsedDocument doc = new ParsedDocument(versionField, seqID, "1", document, B_1, null);
 
         Engine.Index eIndex = new Engine.Index(newUid(doc), doc, randomSeqNum, randomPrimaryTerm,
             1, VersionType.INTERNAL, Origin.PRIMARY, 0, 0, false, SequenceNumbers.UNASSIGNED_SEQ_NO, 0);

--- a/server/src/test/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
@@ -415,7 +415,7 @@ public class RecoverySourceHandlerTests extends ESTestCase {
         document.add(seqID.primaryTerm);
         final BytesReference source = new BytesArray(new byte[] { 1 });
         final ParsedDocument doc =
-            new ParsedDocument(versionField, seqID, id, document, source, null, List.of());
+            new ParsedDocument(versionField, seqID, id, document, source, null);
         return new Engine.Index(
             new Term("_id", Uid.encodeId(doc.id())), doc, UNASSIGNED_SEQ_NO, 0,
             Versions.MATCH_ANY, VersionType.INTERNAL, PRIMARY, System.nanoTime(), -1, false, UNASSIGNED_SEQ_NO, 0);

--- a/server/src/testFixtures/java/io/crate/testing/TestingHelpers.java
+++ b/server/src/testFixtures/java/io/crate/testing/TestingHelpers.java
@@ -49,6 +49,7 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.inject.ModulesBuilder;
 import org.elasticsearch.common.settings.Settings;
@@ -419,7 +420,11 @@ public class TestingHelpers {
     }
 
     public static Map<String, Object> toMapping(BoundCreateTable boundCreateTable) {
-        // TODO: Add MetadataBuilder parameter to this method, so that analyzers test code and SQlExecutor.addTable can also assign oid.
+        // TODO: Assign oid in analyzer tests.
+        return toMapping(null, boundCreateTable);
+    }
+
+    public static Map<String, Object> toMapping(Metadata.ColumnOidSupplier columnOidSupplier, BoundCreateTable boundCreateTable) {
         IntArrayList pKeysIndices = boundCreateTable.primaryKeysIndices();
 
         var policy = (String) boundCreateTable.tableParameter().mappings().get(ColumnPolicies.ES_MAPPING_NAME);
@@ -433,7 +438,7 @@ public class TestingHelpers {
             boundCreateTable.partitionedBy(),
             tableColumnPolicy,
             boundCreateTable.routingColumn().equals(DocSysColumns.ID) ? null : boundCreateTable.routingColumn().fqn(),
-            null
+            columnOidSupplier
         );
 
     }

--- a/server/src/testFixtures/java/io/crate/types/DataTypeTestCase.java
+++ b/server/src/testFixtures/java/io/crate/types/DataTypeTestCase.java
@@ -113,7 +113,6 @@ public abstract class DataTypeTestCase<T> extends CrateDummyClusterServiceUnitTe
                     value,
                     xContentBuilder,
                     fields::add,
-                    ref -> {},
                     Map.of(),
                     Map.of()
                 );

--- a/server/src/testFixtures/java/org/elasticsearch/index/engine/EngineTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/index/engine/EngineTestCase.java
@@ -361,7 +361,7 @@ public abstract class EngineTestCase extends ESTestCase {
         } else {
             document.add(new StoredField(SourceFieldMapper.NAME, ref.bytes, ref.offset, ref.length));
         }
-        return new ParsedDocument(versionField, seqID, id, document, source, mappingUpdate, List.of());
+        return new ParsedDocument(versionField, seqID, id, document, source, mappingUpdate);
     }
 
     /**
@@ -383,7 +383,7 @@ public abstract class EngineTestCase extends ESTestCase {
                 seqID.tombstoneField.setLongValue(1);
                 doc.add(seqID.tombstoneField);
                 return new ParsedDocument(
-                    versionField, seqID, id, doc, new BytesArray("{}"), null, List.of());
+                    versionField, seqID, id, doc, new BytesArray("{}"), null);
             }
 
             @Override
@@ -400,7 +400,7 @@ public abstract class EngineTestCase extends ESTestCase {
                 BytesRef byteRef = new BytesRef(reason);
                 doc.add(new StoredField(SourceFieldMapper.NAME, byteRef.bytes, byteRef.offset, byteRef.length));
                 return new ParsedDocument(
-                    versionField, seqID, null, doc, null, null, List.of());
+                    versionField, seqID, null, doc, null, null);
             }
         };
     }


### PR DESCRIPTION
This is a pre-requisite for using column OID-s instead of names in the _source.

Phase 1: Collect new columns and do a schema update. Don't create a Lucene document with source at this point.
Phase 2: Update Indexer targets using new `AddColumnResponse`. 


Actually writing OID in the source to be followed in https://github.com/crate/crate/pull/14636

Supersedes https://github.com/crate/crate/pull/14617 (same but resolved conflicts after last drop-column rebase (replaced test assertions to use new ReferenceAssert, introduced in https://github.com/crate/crate/pull/14632 and https://github.com/crate/crate/pull/14634) + squashed already reviewed commits for the phase 1)
