### PR TITLE
Documentation: Fix markup of a few bullet lists

### DIFF
--- a/docs/config/node.rst
+++ b/docs/config/node.rst
@@ -876,9 +876,11 @@ Legacy
   5.0.0.
 
   The following table functions are affected by this setting:
+
   - :ref:`unnest <unnest>`
   - :ref:`regexp_matches <table-functions-regexp-matches>`
   - :ref:`generate_series <table-functions-generate-series>`
+
   When the setting is set and a single column is expected to be returned,
   the returned column will be named ``col1``, ``groups``, or ``col1``
   respectively.

--- a/docs/general/builtins/aggregation.rst
+++ b/docs/general/builtins/aggregation.rst
@@ -699,10 +699,10 @@ of the algorithm is defined by a single compression parameter which has a
 constant value of ``100``. However, there are a few guidelines to keep in mind
 in this implementation:
 
-    - Extreme percentiles (e.g. 99%) are more accurate
-    - For small sets percentiles are highly accurate
-    - It's difficult to generalize the exact level of accuracy, as it depends
-      on your data distribution and volume of data being aggregated
+- Extreme percentiles (e.g. 99%) are more accurate.
+- For small sets, percentiles are highly accurate.
+- It is difficult to generalize the exact level of accuracy, as it depends
+  on your data distribution and volume of data being aggregated.
 
 
 .. _aggregation-sum:
@@ -831,11 +831,11 @@ Example::
 Limitations
 ===========
 
- - ``DISTINCT`` is not supported with aggregations on :ref:`sql_joins`.
+- ``DISTINCT`` is not supported with aggregations on :ref:`sql_joins`.
 
- - Aggregate functions can only be applied to columns with a :ref:`plain index
-   <sql_ddl_index_plain>`, which is the default for all :ref:`primitive type
-   <data-types-primitive>` columns.
+- Aggregate functions can only be applied to columns with a :ref:`plain index
+  <sql_ddl_index_plain>`, which is the default for all :ref:`primitive type
+  <data-types-primitive>` columns.
 
 
 .. _Aggregate function: https://en.wikipedia.org/wiki/Aggregate_function

--- a/docs/general/builtins/table-functions.rst
+++ b/docs/general/builtins/table-functions.rst
@@ -240,8 +240,8 @@ with parentheses, but without grouping, use ``(?...)``.
 For example matching the regular expression ``([Aa](.+)z)`` against
 ``alcatraz``, results in these groups:
 
- * group 1: ``alcatraz`` (from first to last parenthesis or whole pattern)
- * group 2: ``lcatra`` (beginning at second parenthesis)
+- group 1: ``alcatraz`` (from first to last parenthesis or whole pattern)
+- group 2: ``lcatra`` (beginning at second parenthesis)
 
 The ``regexp_matches`` :ref:`function <gloss-function>` will return all groups
 as a ``text`` array::

--- a/docs/general/ddl/create-table.rst
+++ b/docs/general/ddl/create-table.rst
@@ -154,24 +154,24 @@ about naming.
 Additionally, table and schema names are restricted in terms of characters and
 length. They:
 
-  - may not contain one of the following characters: ``\ / * ? " < > |
-    <whitespace> , # .``
+- may not contain one of the following characters: ``\ / * ? " < > |
+  <whitespace> , # .``
 
-  - should not exceed 255 bytes when encoded with ``utf-8`` (this
-    limit applies on the optionally schema-qualified table name)
+- should not exceed 255 bytes when encoded with ``utf-8`` (this
+  limit applies on the optionally schema-qualified table name)
 
 Column names are restricted in terms of patterns:
 
-  - Columns are not allowed to contain a dot (``.``), since this conflicts
-    with internal path definitions.
+- Columns are not allowed to contain a dot (``.``), since this conflicts
+  with internal path definitions.
 
-  - Columns that conflict with the naming scheme of
-    :ref:`virtual system columns <sql_administration_system_columns>` are
-    restricted.
+- Columns that conflict with the naming scheme of
+  :ref:`virtual system columns <sql_administration_system_columns>` are
+  restricted.
 
-  - Character sequences that conform to the
-    :ref:`subscript notation <sql_dql_object_arrays>` (e.g. ``col['id']``) are
-    not allowed.
+- Character sequences that conform to the
+  :ref:`subscript notation <sql_dql_object_arrays>` (e.g. ``col['id']``) are
+  not allowed.
 
 
 .. _ddl-create-table-configuration:

--- a/docs/general/ddl/fulltext-indices.rst
+++ b/docs/general/ddl/fulltext-indices.rst
@@ -25,11 +25,11 @@ Index definition
 In CrateDB, every column's data is indexed using the ``plain`` index method by
 default. Currently there are three choices related to index definition:
 
-  - `Disable indexing`_
+- `Disable indexing`_
 
-  - `Plain index (Default)`_
+- `Plain index (Default)`_
 
-  - `Fulltext index with analyzer`_
+- `Fulltext index with analyzer`_
 
 .. WARNING::
 

--- a/docs/general/dql/geo.rst
+++ b/docs/general/dql/geo.rst
@@ -221,11 +221,11 @@ Exact queries
 *Exact* queries are done using the following :ref:`scalar functions
 <scalar-functions>`:
 
- * :ref:`scalar-intersects`
+- :ref:`scalar-intersects`
 
- * :ref:`scalar-within`
+- :ref:`scalar-within`
 
- * :ref:`scalar-distance`
+- :ref:`scalar-distance`
 
 They are exact, but this comes at the price of performance.
 

--- a/docs/general/dql/joins.rst
+++ b/docs/general/dql/joins.rst
@@ -263,12 +263,12 @@ relation once scanning the second relation has finished.
 This optimisation cannot be applied unless the join is an ``INNER`` join and
 the join condition satisfies the following rules:
 
-  - Contains at least one ``EQUAL`` :ref:`operator <gloss-operator>`
+- Contains at least one ``EQUAL`` :ref:`operator <gloss-operator>`
 
-  - Contains no ``OR`` operator
+- Contains no ``OR`` operator
 
-  - Every argument of a ``EQUAL`` operator can only references fields from one
-    relation
+- Every argument of a ``EQUAL`` operator can only references fields from one
+  relation
 
 The `hash join`_ algorithm is faster but has a bigger memory footprint. As such
 it can explicitly be disabled on demand when memory is scarce using the session


### PR DESCRIPTION
## About

It is just about fixing a few spots of reStructuredText markup.


## Problem Example

For example, when getting the indentation wrong, it designates a blockquote, so regular bullet lists start looking like this.

![image](https://github.com/crate/crate/assets/453543/4921efc1-d1e2-413b-8f3f-3c41efbf5fed)

-- https://crate.io/docs/crate/reference/en/5.4/general/dql/geo.html
