### PR TITLE
Remove top-most-left-relation from NestedLoop Join

### DIFF
--- a/server/src/main/java/io/crate/planner/operators/Collect.java
+++ b/server/src/main/java/io/crate/planner/operators/Collect.java
@@ -310,8 +310,8 @@ public class Collect implements LogicalPlan {
     }
 
     @Override
-    public Set<RelationName> getRelationNames() {
-        return Set.of(relation.relationName());
+    public List<RelationName> getRelationNames() {
+        return List.of(relation.relationName());
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/CorrelatedJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/CorrelatedJoin.java
@@ -188,7 +188,7 @@ public class CorrelatedJoin implements LogicalPlan {
     }
 
     @Override
-    public Set<RelationName> getRelationNames() {
+    public List<RelationName> getRelationNames() {
         return inputPlan.getRelationNames();
     }
 

--- a/server/src/main/java/io/crate/planner/operators/Count.java
+++ b/server/src/main/java/io/crate/planner/operators/Count.java
@@ -140,8 +140,8 @@ public class Count implements LogicalPlan {
     }
 
     @Override
-    public Set<RelationName> getRelationNames() {
-        return Set.of(tableRelation.relationName());
+    public List<RelationName> getRelationNames() {
+        return List.of(tableRelation.relationName());
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/ForwardingLogicalPlan.java
+++ b/server/src/main/java/io/crate/planner/operators/ForwardingLogicalPlan.java
@@ -24,7 +24,6 @@ package io.crate.planner.operators;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.expression.symbol.SelectSymbol;
@@ -65,7 +64,7 @@ public abstract class ForwardingLogicalPlan implements LogicalPlan {
     }
 
     @Override
-    public Set<RelationName> getRelationNames() {
+    public List<RelationName> getRelationNames() {
         return source.getRelationNames();
     }
 

--- a/server/src/main/java/io/crate/planner/operators/Get.java
+++ b/server/src/main/java/io/crate/planner/operators/Get.java
@@ -204,8 +204,8 @@ public class Get implements LogicalPlan {
     }
 
     @Override
-    public Set<RelationName> getRelationNames() {
-        return Set.of(tableRelation.relationName());
+    public List<RelationName> getRelationNames() {
+        return List.of(tableRelation.relationName());
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/HashJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/HashJoin.java
@@ -39,7 +39,6 @@ import org.jetbrains.annotations.Nullable;
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.common.collections.Lists2;
-import io.crate.common.collections.Sets;
 import io.crate.data.Row;
 import io.crate.execution.dsl.phases.HashJoinPhase;
 import io.crate.execution.dsl.phases.MergePhase;
@@ -220,8 +219,8 @@ public class HashJoin extends JoinPlan {
     }
 
     @Override
-    public Set<RelationName> getRelationNames() {
-        return Sets.union(lhs.getRelationNames(), rhs.getRelationNames());
+    public List<RelationName> getRelationNames() {
+        return Lists2.concatUnique(lhs.getRelationNames(), rhs.getRelationNames());
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/Insert.java
+++ b/server/src/main/java/io/crate/planner/operators/Insert.java
@@ -120,8 +120,8 @@ public class Insert implements LogicalPlan {
     }
 
     @Override
-    public Set<RelationName> getRelationNames() {
-        return Set.of();
+    public List<RelationName> getRelationNames() {
+        return List.of();
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
+++ b/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
@@ -832,8 +832,8 @@ public class InsertFromValues implements LogicalPlan {
     }
 
     @Override
-    public Set<RelationName> getRelationNames() {
-        return Set.of();
+    public List<RelationName> getRelationNames() {
+        return List.of();
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
+++ b/server/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
@@ -127,7 +127,6 @@ public class JoinPlanBuilder {
             joinType,
             validJoinConditions,
             isFiltered,
-            lhs,
             false);
 
         joinPlan = Filter.create(joinPlan, validWhereConditions);
@@ -244,7 +243,6 @@ public class JoinPlanBuilder {
             type,
             AndOperator.join(conditions, null),
             isFiltered,
-            leftRelation,
             false);
         return Filter.create(joinPlan, query);
     }

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlan.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlan.java
@@ -219,7 +219,11 @@ public interface LogicalPlan extends Plan {
         return StatementType.SELECT;
     }
 
-    Set<RelationName> getRelationNames();
+    /**
+     *
+     * @return RelationNames of the sources in order from left to right without duplicates
+     */
+    List<RelationName> getRelationNames();
 
     default void print(PrintContext printContext) {
         printContext

--- a/server/src/main/java/io/crate/planner/operators/Rename.java
+++ b/server/src/main/java/io/crate/planner/operators/Rename.java
@@ -214,8 +214,8 @@ public final class Rename extends ForwardingLogicalPlan implements FieldResolver
     }
 
     @Override
-    public Set<RelationName> getRelationNames() {
-        return Set.of(name);
+    public List<RelationName> getRelationNames() {
+        return List.of(name);
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/TableFunction.java
+++ b/server/src/main/java/io/crate/planner/operators/TableFunction.java
@@ -125,8 +125,8 @@ public final class TableFunction implements LogicalPlan {
     }
 
     @Override
-    public Set<RelationName> getRelationNames() {
-        return Set.of(relation.relationName());
+    public List<RelationName> getRelationNames() {
+        return List.of(relation.relationName());
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/Union.java
+++ b/server/src/main/java/io/crate/planner/operators/Union.java
@@ -39,7 +39,6 @@ import io.crate.analyze.OrderBy;
 import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.common.collections.Lists2;
 import io.crate.common.collections.Maps;
-import io.crate.common.collections.Sets;
 import io.crate.data.Row;
 import io.crate.execution.dsl.phases.MergePhase;
 import io.crate.execution.dsl.projection.EvalProjection;
@@ -188,8 +187,8 @@ public class Union implements LogicalPlan {
     }
 
     @Override
-    public Set<RelationName> getRelationNames() {
-        return Sets.union(lhs.getRelationNames(), rhs.getRelationNames());
+    public List<RelationName> getRelationNames() {
+        return Lists2.concatUnique(lhs.getRelationNames(), rhs.getRelationNames());
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/GroupReference.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/GroupReference.java
@@ -51,14 +51,14 @@ public class GroupReference implements LogicalPlan {
 
     private final int groupId;
     private final List<Symbol> outputs;
-    private final Set<RelationName> relationNames;
+    private final List<RelationName> relationNames;
     private static final String ERROR_MESSAGE =
         "Operation is not supported in GroupReference, it needs to be resolved to it's referenced LogicalPlan";
 
     public GroupReference(int groupId, List<Symbol> outputs, Collection<RelationName> relationNames) {
         this.groupId = groupId;
         this.outputs = List.copyOf(outputs);
-        this.relationNames = Set.copyOf(relationNames);
+        this.relationNames = List.copyOf(relationNames);
     }
 
     public int groupId() {
@@ -91,7 +91,7 @@ public class GroupReference implements LogicalPlan {
     }
 
     @Override
-    public Set<RelationName> getRelationNames() {
+    public List<RelationName> getRelationNames() {
         return relationNames;
     }
 

--- a/server/src/main/java/io/crate/planner/optimizer/rule/FilterOnJoinsUtil.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/FilterOnJoinsUtil.java
@@ -31,6 +31,8 @@ import io.crate.planner.operators.JoinPlan;
 import io.crate.planner.operators.LogicalPlan;
 
 import org.jetbrains.annotations.Nullable;
+
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -58,8 +60,8 @@ final class FilterOnJoinsUtil {
         }
         LogicalPlan lhs = join.lhs();
         LogicalPlan rhs = join.rhs();
-        Symbol queryForLhs = splitQuery.remove(lhs.getRelationNames());
-        Symbol queryForRhs = splitQuery.remove(rhs.getRelationNames());
+        Symbol queryForLhs = splitQuery.remove(new HashSet<>(lhs.getRelationNames()));
+        Symbol queryForRhs = splitQuery.remove(new HashSet<>(rhs.getRelationNames()));
         LogicalPlan newLhs = getNewSource(queryForLhs, lhs);
         LogicalPlan newRhs = getNewSource(queryForRhs, rhs);
         LogicalPlan newJoin = join.replaceSources(List.of(newLhs, newRhs));

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoop.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoop.java
@@ -87,7 +87,6 @@ public class MoveConstantJoinConditionsBeneathNestedLoop implements Rule<NestedL
                 nl.joinType(),
                 nl.joinCondition(),
                 nl.isFiltered(),
-                nl.topMostLeftRelation(),
                 nl.orderByWasPushedDown(),
                 nl.isRewriteFilterOnOuterJoinToInnerJoinDone(),
                 true, // Mark joinConditionOptimised = true
@@ -97,8 +96,8 @@ public class MoveConstantJoinConditionsBeneathNestedLoop implements Rule<NestedL
             // Push constant join condition down to source
             var lhs = resolvePlan.apply(nl.lhs());
             var rhs = resolvePlan.apply(nl.rhs());
-            var queryForLhs = constantConditions.remove(lhs.getRelationNames());
-            var queryForRhs = constantConditions.remove(rhs.getRelationNames());
+            var queryForLhs = constantConditions.remove(new HashSet<>(lhs.getRelationNames()));
+            var queryForRhs = constantConditions.remove(new HashSet<>(rhs.getRelationNames()));
             var newLhs = getNewSource(queryForLhs, lhs);
             var newRhs = getNewSource(queryForRhs, rhs);
             return new HashJoin(

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathCorrelatedJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathCorrelatedJoin.java
@@ -25,6 +25,7 @@ import static io.crate.planner.operators.JoinPlanBuilder.extractCorrelatedSubQue
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 import static io.crate.planner.optimizer.matcher.Patterns.source;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.function.Function;
 
@@ -68,7 +69,7 @@ public final class MoveFilterBeneathCorrelatedJoin implements Rule<Filter> {
         var splitQuery = QuerySplitter.split(filter.query());
         assert join.sources().size() == 1 : "CorrelatedJoin operator must have 1 children, the input plan";
         var inputPlan = join.sources().get(0);
-        var inputQuery = splitQuery.remove(inputPlan.getRelationNames());
+        var inputQuery = splitQuery.remove(new HashSet<>(inputPlan.getRelationNames()));
         if (inputQuery == null) {
             return null;
         }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathNestedLoop.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathNestedLoop.java
@@ -96,8 +96,9 @@ public final class MoveOrderBeneathNestedLoop implements Rule<Order> {
             RefVisitor.visitRefs(orderExpr, gatherRelationsFromRef);
         }
         if (relationsInOrderBy.size() == 1) {
-            RelationName relationInOrderBy = relationsInOrderBy.iterator().next();
-            if (relationInOrderBy == nestedLoop.topMostLeftRelation().relationName()) {
+            var relationInOrderBy = relationsInOrderBy.iterator().next();
+            var topMostLeftRelation = nestedLoop.getRelationNames().get(0);
+            if (relationInOrderBy.equals(topMostLeftRelation)) {
                 LogicalPlan lhs = nestedLoop.sources().get(0);
                 LogicalPlan newLhs = order.replaceSources(List.of(lhs));
                 return new NestedLoopJoin(
@@ -106,7 +107,6 @@ public final class MoveOrderBeneathNestedLoop implements Rule<Order> {
                     nestedLoop.joinType(),
                     nestedLoop.joinCondition(),
                     nestedLoop.isFiltered(),
-                    nestedLoop.topMostLeftRelation(),
                     true,
                     nestedLoop.isRewriteFilterOnOuterJoinToInnerJoinDone(),
                     false,

--- a/server/src/main/java/io/crate/planner/optimizer/rule/ReorderNestedLoopJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/ReorderNestedLoopJoin.java
@@ -69,7 +69,6 @@ public class ReorderNestedLoopJoin implements Rule<NestedLoopJoin> {
                         nestedLoop.joinType().invert(),
                         nestedLoop.joinCondition(),
                         nestedLoop.isFiltered(),
-                        nestedLoop.topMostLeftRelation(),
                         nestedLoop.orderByWasPushedDown(),
                         nestedLoop.isRewriteFilterOnOuterJoinToInnerJoinDone(),
                         nestedLoop.isJoinConditionOptimised(),

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoin.java
@@ -25,6 +25,7 @@ import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 import static io.crate.planner.optimizer.matcher.Patterns.source;
 import static io.crate.planner.optimizer.rule.FilterOnJoinsUtil.getNewSource;
 
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
@@ -133,8 +134,8 @@ public final class RewriteFilterOnOuterJoinToInnerJoin implements Rule<Filter> {
         var sources = Lists2.map(nl.sources(), resolvePlan);
         LogicalPlan lhs = sources.get(0);
         LogicalPlan rhs = sources.get(1);
-        Set<RelationName> leftName = lhs.getRelationNames();
-        Set<RelationName> rightName = rhs.getRelationNames();
+        Set<RelationName> leftName = new HashSet<>(lhs.getRelationNames());
+        Set<RelationName> rightName = new HashSet<>(rhs.getRelationNames());
 
         Symbol leftQuery = splitQueries.remove(leftName);
         Symbol rightQuery = splitQueries.remove(rightName);
@@ -257,7 +258,6 @@ public final class RewriteFilterOnOuterJoinToInnerJoin implements Rule<Filter> {
             newJoinIsInnerJoin ? JoinType.INNER : nl.joinType(),
             nl.joinCondition(),
             nl.isFiltered(),
-            nl.topMostLeftRelation(),
             nl.orderByWasPushedDown(),
             true,
             nl.isJoinConditionOptimised(),

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteNestedLoopJoinToHashJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteNestedLoopJoinToHashJoin.java
@@ -69,7 +69,6 @@ public class RewriteNestedLoopJoinToHashJoin implements Rule<NestedLoopJoin> {
                 nl.joinType(),
                 nl.joinCondition(),
                 nl.isFiltered(),
-                nl.topMostLeftRelation(),
                 nl.orderByWasPushedDown(),
                 nl.isRewriteFilterOnOuterJoinToInnerJoinDone(),
                 nl.isJoinConditionOptimised(),

--- a/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -24,7 +24,6 @@ package io.crate.integrationtests;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;

--- a/server/src/test/java/io/crate/planner/operators/RelationNamesInLogicalPlanTest.java
+++ b/server/src/test/java/io/crate/planner/operators/RelationNamesInLogicalPlanTest.java
@@ -98,7 +98,6 @@ public class RelationNamesInLogicalPlanTest extends CrateDummyClusterServiceUnit
                                                 JoinType.INNER,
                                                 e.asSymbol("x = y"),
                                                 false,
-                                                t1Relation,
                                                 false);
         assertThat(nestedLoopJoin.baseTables(), containsInAnyOrder(t1Relation, t2Relation));
         assertThat(nestedLoopJoin.getRelationNames(), containsInAnyOrder(t1RenamedRelationName, t2RenamedRelationName));

--- a/server/src/test/java/io/crate/planner/optimizer/costs/PlanStatsTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/costs/PlanStatsTest.java
@@ -256,7 +256,7 @@ public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
         );
 
         var nestedLoopJoin = new NestedLoopJoin(
-            lhs, rhs, JoinType.INNER, Literal.BOOLEAN_TRUE, false, relation, false, false, false, false);
+            lhs, rhs, JoinType.INNER, Literal.BOOLEAN_TRUE, false, false, false, false, false);
 
         var memo = new Memo(nestedLoopJoin);
         PlanStats planStats = new PlanStats(nodeContext, txnCtx, tableStats, memo);
@@ -267,13 +267,13 @@ public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
 
         var joinCondition = e.asSymbol("x = y");
         nestedLoopJoin = new NestedLoopJoin(
-            lhs, rhs, JoinType.INNER, joinCondition, false, relation, false, false, false, false);
+            lhs, rhs, JoinType.INNER, joinCondition, false, false, false, false, false);
         result = planStats.get(nestedLoopJoin);
         assertThat(result.numDocs()).isEqualTo(1L);
         assertThat(result.sizeInBytes()).isEqualTo(32L);
 
         nestedLoopJoin = new NestedLoopJoin(
-            lhs, rhs, JoinType.CROSS, x, false, relation, false, false, false, false);
+            lhs, rhs, JoinType.CROSS, x, false, false, false, false, false);
 
         memo = new Memo(nestedLoopJoin);
         planStats = new PlanStats(nodeContext, txnCtx, tableStats, memo);

--- a/server/src/test/java/io/crate/planner/optimizer/iterative/MemoTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/iterative/MemoTest.java
@@ -342,8 +342,8 @@ public class MemoTest {
         }
 
         @Override
-        public Set<RelationName> getRelationNames() {
-            return Set.of();
+        public List<RelationName> getRelationNames() {
+            return List.of();
         }
     }
 }

--- a/server/src/test/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoopTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoopTest.java
@@ -76,7 +76,7 @@ public class MoveConstantJoinConditionsBeneathNestedLoopTest extends CrateDummyC
         var nonConstantPart = sqlExpressions.asSymbol("doc.t1.x = doc.t2.y");
         var constantPart = sqlExpressions.asSymbol("doc.t2.b = 'abc'");
 
-        NestedLoopJoin nl = new NestedLoopJoin(c1, c2, JoinType.INNER, joinCondition, false, t1, false, false, false, false);
+        NestedLoopJoin nl = new NestedLoopJoin(c1, c2, JoinType.INNER, joinCondition, false, false, false, false, false);
         var rule = new MoveConstantJoinConditionsBeneathNestedLoop();
         Match<NestedLoopJoin> match = rule.pattern().accept(nl, Captures.empty());
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The top-most-left relation in NestedLoop Join can become invalid when the underlying Logical Plans are reordered.
Therefore this pr removes the top-most-left relation and replaces the functionality with the following steps:

- Convert Relationnames in Logical Plans from Sets to Lists to preserve the position of the underlying relations. 
  The top-most-left relation is then represented by the first element from the relation names from the Logical Plan.
- Adapt the optimizer rules to use the relation names instead of the top-most-left-relation.


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
