### PR TITLE
Improve optimizer logging

### DIFF
--- a/server/src/main/java/io/crate/planner/optimizer/LoadedRules.java
+++ b/server/src/main/java/io/crate/planner/optimizer/LoadedRules.java
@@ -27,7 +27,6 @@ import java.util.Locale;
 
 import org.elasticsearch.common.inject.Singleton;
 
-import io.crate.common.StringUtils;
 import io.crate.common.annotations.VisibleForTesting;
 import io.crate.common.collections.Lists2;
 import io.crate.metadata.settings.CoordinatorSessionSettings;
@@ -39,7 +38,6 @@ import io.crate.types.DataTypes;
 @Singleton
 public class LoadedRules implements SessionSettingProvider {
 
-    private static final String OPTIMIZER_SETTING_PREFIX = "optimizer_";
     public static final List<Class<? extends Rule<?>>> RULES = buildRules();
 
     private static List<Class<? extends Rule<?>>> buildRules() {
@@ -50,13 +48,9 @@ public class LoadedRules implements SessionSettingProvider {
         return Lists2.map(rules, x -> (Class<? extends Rule<?>>) x.getClass());
     }
 
-    public static String buildSessionSettingName(Class<? extends Rule<?>> rule) {
-        return OPTIMIZER_SETTING_PREFIX + StringUtils.camelToSnakeCase(rule.getSimpleName());
-    }
-
     @VisibleForTesting
     static SessionSetting<?> buildRuleSessionSetting(Class<? extends Rule<?>> rule) {
-        var optimizerRuleName = buildSessionSettingName(rule);
+        var optimizerRuleName = Rule.sessionSettingName(rule);
         return new SessionSetting<>(
             optimizerRuleName,
             objects -> {},

--- a/server/src/main/java/io/crate/planner/optimizer/Optimizer.java
+++ b/server/src/main/java/io/crate/planner/optimizer/Optimizer.java
@@ -71,17 +71,12 @@ public class Optimizer {
     }
 
     public static List<Rule<?>> removeExcludedRules(List<Rule<?>> rules, Set<Class<? extends Rule<?>>> excludedRules) {
-        final boolean isTraceEnabled = LOGGER.isTraceEnabled();
         if (excludedRules.isEmpty()) {
             return rules;
         }
         var result = new ArrayList<Rule<?>>(rules.size());
         for (var rule : rules) {
-            if (excludedRules.contains(rule.getClass())) {
-                if (isTraceEnabled) {
-                    LOGGER.trace("Rule '" + rule.getClass().getSimpleName() + "' excluded from execution");
-                }
-            } else {
+            if (excludedRules.contains(rule.getClass()) == false) {
                 result.add(rule);
             }
         }
@@ -130,7 +125,7 @@ public class Optimizer {
         Match<T> match = rule.pattern().accept(node, Captures.empty(), resolvePlan);
         if (match.isPresent()) {
             if (traceEnabled) {
-                LOGGER.trace("Rule '" + rule.getClass().getSimpleName() + "' matched");
+                LOGGER.trace("Rule " + rule.sessionSettingName() + " matched");
             }
             return rule.apply(match.value(), match.captures(), planStats, txnCtx, nodeCtx, resolvePlan);
         }

--- a/server/src/main/java/io/crate/planner/optimizer/Rule.java
+++ b/server/src/main/java/io/crate/planner/optimizer/Rule.java
@@ -23,6 +23,7 @@ package io.crate.planner.optimizer;
 
 import java.util.function.Function;
 
+import io.crate.common.StringUtils;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.planner.operators.LogicalPlan;
@@ -55,5 +56,13 @@ public interface Rule<T> {
      */
     default Version requiredVersion() {
         return Version.V_4_0_0;
+    }
+
+    default String sessionSettingName() {
+        return sessionSettingName(getClass());
+    }
+
+    static String sessionSettingName(Class<?> rule) {
+        return "optimizer_" + StringUtils.camelToSnakeCase(rule.getSimpleName());
     }
 }

--- a/server/src/testFixtures/java/io/crate/testing/SQLTransportExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLTransportExecutor.java
@@ -179,7 +179,7 @@ public class SQLTransportExecutor {
         for (int i = 0; i < numberOfRulesToPick; i++) {
             result.add(String.format(Locale.ENGLISH,
                                      "set %s=false",
-                                     LoadedRules.buildSessionSettingName(ruleCandidates.get(i))));
+                                     Rule.sessionSettingName(ruleCandidates.get(i))));
         }
 
         return result;


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This improves the logging for the iterative optimizer on log level TRACE. This really helps when debugging the optimizer and could be considered as pre-cursor for  https://github.com/crate/crate/issues/14397.

Example:

```
SELECT * FROM t1, t2 WHERE t1.x = t2.y and t1.x > 1;
```
from
```
[2023-08-31T16:37:54,421][TRACE][i.c.p.o.i.IterativeOptimizer] [Alplerspitz] Rule 'MoveFilterBeneathJoin' transformed the logical plan
16:37:54.421 [cratedb[Alplerspitz][netty-worker][T#3]] TRACE io.crate.planner.optimizer.iterative.IterativeOptimizer - Rule 'MoveFilterBeneathJoin' transformed the logical plan
[2023-08-31T16:37:54,422][TRACE][i.c.p.o.i.IterativeOptimizer] [Alplerspitz] Rule 'MoveConstantJoinConditionsBeneathNestedLoop' transformed the logical plan
16:37:54.422 [cratedb[Alplerspitz][netty-worker][T#3]] TRACE io.crate.planner.optimizer.iterative.IterativeOptimizer - Rule 'MoveConstantJoinConditionsBeneathNestedLoop' transformed the logical plan
[2023-08-31T16:37:54,423][TRACE][i.c.p.o.i.IterativeOptimizer] [Alplerspitz] Rule 'RewriteNestedLoopJoinToHashJoin' transformed the logical plan
16:37:54.423 [cratedb[Alplerspitz][netty-worker][T#3]] TRACE io.crate.planner.optimizer.iterative.IterativeOptimizer - Rule 'RewriteNestedLoopJoinToHashJoin' transformed the logical plan
[2023-08-31T16:37:54,423][TRACE][i.c.p.o.i.IterativeOptimizer] [Alplerspitz] Rule 'MergeFilterAndCollect' transformed the logical plan
16:37:54.423 [cratedb[Alplerspitz][netty-worker][T#3]] TRACE io.crate.planner.optimizer.iterative.IterativeOptimizer - Rule 'MergeFilterAndCollect' transformed the logical plan

```

to

```
[2023-08-31T14:27:54,562][TRACE][i.c.p.o.i.IterativeOptimizer] [Monte Susino] Optimize plan: 
 Filter[(x > 1)] (rows=0)
  └ NestedLoopJoin[INNER | (x = y)] (rows=unknown)
    ├ Collect[doc.t1 | [x] | true] (rows=unknown)
    └ Collect[doc.t2 | [y] | true] (rows=unknown)
[2023-08-31T14:27:54,562][TRACE][i.c.p.o.i.IterativeOptimizer] [Monte Susino] Rule optimizer_move_filter_beneath_join transformed the logical plan: 
NestedLoopJoin[INNER | (x = y)] (rows=unknown)
  ├ Filter[(x > 1)] (rows=0)
  │  └ Collect[doc.t1 | [x] | true] (rows=unknown)
  └ Collect[doc.t2 | [y] | true] (rows=unknown)
[2023-08-31T14:27:54,562][TRACE][i.c.p.o.i.IterativeOptimizer] [Monte Susino] Rule optimizer_move_constant_join_conditions_beneath_nested_loop transformed the logical plan: 
NestedLoopJoin[INNER | (x = y)] (rows=unknown)
  ├ Filter[(x > 1)] (rows=0)
  │  └ Collect[doc.t1 | [x] | true] (rows=unknown)
  └ Collect[doc.t2 | [y] | true] (rows=unknown)
[2023-08-31T14:27:54,562][TRACE][i.c.p.o.i.IterativeOptimizer] [Monte Susino] Rule optimizer_rewrite_nested_loop_join_to_hash_join transformed the logical plan: 
HashJoin[(x = y)] (rows=unknown)
  ├ Filter[(x > 1)] (rows=0)
  │  └ Collect[doc.t1 | [x] | true] (rows=unknown)
  └ Collect[doc.t2 | [y] | true] (rows=unknown)
[2023-08-31T14:27:54,562][TRACE][i.c.p.o.i.IterativeOptimizer] [Monte Susino] Rule optimizer_merge_filter_and_collect transformed the logical plan: 
Collect[doc.t1 | [x] | (x > 1)] (rows=unknown)
[2023-08-31T14:27:54,563][TRACE][i.c.p.o.i.IterativeOptimizer] [Monte Susino] Optimize plan: 
 HashJoin[(x = y)] (rows=unknown)
  ├ Collect[doc.t1 | [x] | (x > 1)] (rows=unknown)
  └ Collect[doc.t2 | [y] | true] (rows=unknown)
```


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
