### PR TITLE
Hide dropped columns on _raw lookup

### DIFF
--- a/benchmarks/src/main/java/io/crate/execution/engine/collect/collectors/LuceneBatchIteratorBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/execution/engine/collect/collectors/LuceneBatchIteratorBenchmark.java
@@ -45,6 +45,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
@@ -69,7 +70,7 @@ public class LuceneBatchIteratorBenchmark {
         indexSearcher = new IndexSearcher(DirectoryReader.open(iw));
         IntegerColumnReference columnReference = new IntegerColumnReference(columnName);
         columnRefs = Collections.singletonList(columnReference);
-        collectorContext = new CollectorContext(Set.of());
+        collectorContext = new CollectorContext(Set.of(), Function.identity());
     }
 
     @Benchmark

--- a/benchmarks/src/main/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorBenchmark.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.document.Document;
@@ -102,7 +103,7 @@ public class OrderedLuceneBatchIteratorBenchmark {
         iw.commit();
         iw.forceMerge(1, true);
         indexSearcher = new IndexSearcher(DirectoryReader.open(iw, true, true));
-        collectorContext = new CollectorContext(Set.of());
+        collectorContext = new CollectorContext(Set.of(), Function.identity());
         reference = new SimpleReference(
             new ReferenceIdent(new RelationName(Schemas.DOC_SCHEMA_NAME, "dummyTable"), columnName),
             RowGranularity.DOC,

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/CmpByAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/CmpByAggregation.java
@@ -26,6 +26,7 @@ import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Function;
 
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReaderContext;
@@ -172,9 +173,9 @@ public final class CmpByAggregation extends AggregationFunction<CmpByAggregation
             case TimestampType.ID_WITHOUT_TZ:
                 var resultExpression = referenceResolver.getImplementation(aggregationReferences.get(0));
                 if (signature.getName().name().equalsIgnoreCase("min_by")) {
-                    return new MinByLong(searchRef.column().fqn(), searchType, resultExpression, table.droppedColumns());
+                    return new MinByLong(searchRef.column().fqn(), searchType, resultExpression, table.droppedColumns(), table.lookupNameBySourceKey());
                 } else {
-                    return new MaxByLong(searchRef.column().fqn(), searchType, resultExpression, table.droppedColumns());
+                    return new MaxByLong(searchRef.column().fqn(), searchType, resultExpression, table.droppedColumns(), table.lookupNameBySourceKey());
                 }
             default:
                 return null;
@@ -269,8 +270,9 @@ public final class CmpByAggregation extends AggregationFunction<CmpByAggregation
         public MinByLong(String columnName,
                          DataType<?> searchType,
                          LuceneCollectorExpression<?> resultExpression,
-                         Set<ColumnIdent> droppedColumns) {
-            super(Long.MAX_VALUE, columnName, searchType, resultExpression, droppedColumns);
+                         Set<ColumnIdent> droppedColumns,
+                         Function<String, String> lookupNameBySourceKey) {
+            super(Long.MAX_VALUE, columnName, searchType, resultExpression, droppedColumns, lookupNameBySourceKey);
         }
 
         @Override
@@ -284,8 +286,9 @@ public final class CmpByAggregation extends AggregationFunction<CmpByAggregation
         public MaxByLong(String columnName,
                          DataType<?> searchType,
                          LuceneCollectorExpression<?> resultExpression,
-                         Set<ColumnIdent> droppedColumns) {
-            super(Long.MIN_VALUE, columnName, searchType, resultExpression, droppedColumns);
+                         Set<ColumnIdent> droppedColumns,
+                         Function<String, String> lookupNameBySourceKey) {
+            super(Long.MIN_VALUE, columnName, searchType, resultExpression, droppedColumns, lookupNameBySourceKey);
         }
 
         @Override
@@ -305,15 +308,16 @@ public final class CmpByAggregation extends AggregationFunction<CmpByAggregation
         private LeafReaderContext leafReaderContext;
 
         CmpByLong(long sentinelValue,
-                         String columnName,
-                         DataType<?> searchType,
-                         LuceneCollectorExpression<?> resultExpression,
-                         Set<ColumnIdent> droppedColumns) {
+                  String columnName,
+                  DataType<?> searchType,
+                  LuceneCollectorExpression<?> resultExpression,
+                  Set<ColumnIdent> droppedColumns,
+                  Function<String, String> lookupNameBySourceKey) {
             this.sentinelValue = sentinelValue;
             this.columnName = columnName;
             this.searchType = searchType;
             this.resultExpression = resultExpression;
-            resultExpression.startCollect(new CollectorContext(droppedColumns));
+            resultExpression.startCollect(new CollectorContext(droppedColumns, lookupNameBySourceKey));
         }
 
         @Override

--- a/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
@@ -163,7 +163,7 @@ final class DocValuesGroupByOptimizedIterator {
                 collectTask.memoryManager(),
                 collectTask.minNodeVersion(),
                 queryContext.query(),
-                new CollectorContext(sharedShardContext.readerId(), table.droppedColumns())
+                new CollectorContext(sharedShardContext.readerId(), table.droppedColumns(), table.lookupNameBySourceKey())
             );
         } else {
             return GroupByIterator.forManyKeys(
@@ -175,7 +175,7 @@ final class DocValuesGroupByOptimizedIterator {
                 collectTask.memoryManager(),
                 collectTask.minNodeVersion(),
                 queryContext.query(),
-                new CollectorContext(sharedShardContext.readerId(), table.droppedColumns())
+                new CollectorContext(sharedShardContext.readerId(), table.droppedColumns(), table.lookupNameBySourceKey())
             );
         }
     }
@@ -208,7 +208,7 @@ final class DocValuesGroupByOptimizedIterator {
                 (expressions) -> expressions.get(0).value(),
                 (key, cells) -> cells[0] = key,
                 query,
-                new CollectorContext(collectorContext.readerId(), collectorContext.droppedColumns())
+                new CollectorContext(collectorContext.readerId(), collectorContext.droppedColumns(), collectorContext.lookupNameBySourceKey())
             );
         }
 
@@ -247,7 +247,7 @@ final class DocValuesGroupByOptimizedIterator {
                     }
                 },
                 query,
-                new CollectorContext(collectorContext.readerId(), collectorContext.droppedColumns())
+                new CollectorContext(collectorContext.readerId(), collectorContext.droppedColumns(), collectorContext.lookupNameBySourceKey())
             );
         }
 

--- a/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
@@ -165,7 +165,7 @@ final class GroupByOptimizedIterator {
 
         RamAccounting ramAccounting = collectTask.getRamAccounting();
 
-        CollectorContext collectorContext = new CollectorContext(sharedShardContext.readerId(), table.droppedColumns());
+        CollectorContext collectorContext = new CollectorContext(sharedShardContext.readerId(), table.droppedColumns(), table.lookupNameBySourceKey());
         InputRow inputRow = new InputRow(docCtx.topLevelInputs());
 
         LuceneQueryBuilder.Context queryContext = luceneQueryBuilder.convert(

--- a/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
@@ -158,7 +158,7 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
             queryContext.query(),
             queryContext.minScore(),
             Symbols.containsColumn(collectPhase.toCollect(), DocSysColumns.SCORE),
-            new CollectorContext(sharedShardContext.readerId(), table.droppedColumns()),
+            new CollectorContext(sharedShardContext.readerId(), table.droppedColumns(), table.lookupNameBySourceKey()),
             docCtx.topLevelInputs(),
             docCtx.expressions()
         );
@@ -231,7 +231,7 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
             indexService.cache()
         );
         ctx = docInputFactory.extractImplementations(collectTask.txnCtx(), collectPhase);
-        collectorContext = new CollectorContext(sharedShardContext.readerId(), table.droppedColumns());
+        collectorContext = new CollectorContext(sharedShardContext.readerId(), table.droppedColumns(), table.lookupNameBySourceKey());
         int batchSize = collectPhase.shardQueueSize(localNodeId.get());
         if (LOGGER.isTraceEnabled()) {
             LOGGER.trace("[{}][{}] creating LuceneOrderedDocCollector. Expected number of rows to be collected: {}",

--- a/server/src/main/java/io/crate/execution/engine/fetch/FetchCollector.java
+++ b/server/src/main/java/io/crate/execution/engine/fetch/FetchCollector.java
@@ -60,7 +60,8 @@ class FetchCollector {
         this.streamers = streamers;
         this.ramAccounting = ramAccounting;
         this.readerId = readerId;
-        CollectorContext collectorContext = new CollectorContext(readerId, fetchTask.table(readerId).droppedColumns());
+        var table = fetchTask.table(readerId);
+        CollectorContext collectorContext = new CollectorContext(readerId, table.droppedColumns(), table.lookupNameBySourceKey());
         for (LuceneCollectorExpression<?> collectorExpression : this.collectorExpressions) {
             collectorExpression.startCollect(collectorContext);
         }

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/CollectorContext.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/CollectorContext.java
@@ -22,6 +22,7 @@
 package io.crate.expression.reference.doc.lucene;
 
 import java.util.Set;
+import java.util.function.Function;
 
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
@@ -30,16 +31,18 @@ public class CollectorContext {
 
     private final int readerId;
     private final Set<ColumnIdent> droppedColumns;
+    private final Function<String, String> lookupNameBySourceKey;
 
     private SourceLookup sourceLookup;
 
-    public CollectorContext(Set<ColumnIdent> droppedColumns) {
-        this(-1, droppedColumns);
+    public CollectorContext(Set<ColumnIdent> droppedColumns, Function<String, String> lookupNameBySourceKey) {
+        this(-1, droppedColumns, lookupNameBySourceKey);
     }
 
-    public CollectorContext(int readerId, Set<ColumnIdent> droppedColumns) {
+    public CollectorContext(int readerId, Set<ColumnIdent> droppedColumns, Function<String, String> lookupNameBySourceKey) {
         this.readerId = readerId;
         this.droppedColumns = droppedColumns;
+        this.lookupNameBySourceKey = lookupNameBySourceKey;
     }
 
     public int readerId() {
@@ -50,16 +53,20 @@ public class CollectorContext {
         return droppedColumns;
     }
 
+    public Function<String, String> lookupNameBySourceKey() {
+        return lookupNameBySourceKey;
+    }
+
     public SourceLookup sourceLookup() {
         if (sourceLookup == null) {
-            sourceLookup = new SourceLookup(droppedColumns);
+            sourceLookup = new SourceLookup(droppedColumns, lookupNameBySourceKey);
         }
         return sourceLookup;
     }
 
     public SourceLookup sourceLookup(Reference ref) {
         if (sourceLookup == null) {
-            sourceLookup = new SourceLookup(droppedColumns);
+            sourceLookup = new SourceLookup(droppedColumns, lookupNameBySourceKey);
         }
         return sourceLookup.registerRef(ref);
     }

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/SourceLookup.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/SourceLookup.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.RandomAccess;
 import java.util.Set;
+import java.util.function.Function;
 
 import org.elasticsearch.common.bytes.BytesReference;
 
@@ -44,8 +45,8 @@ public final class SourceLookup {
     private Map<String, Object> source;
     private boolean docVisited = false;
 
-    SourceLookup(Set<ColumnIdent> droppedColumns) {
-        sourceParser = new SourceParser(droppedColumns);
+    SourceLookup(Set<ColumnIdent> droppedColumns, Function<String, String> lookupNameBySourceKey) {
+        sourceParser = new SourceParser(droppedColumns, lookupNameBySourceKey);
     }
 
     public void setSegmentAndDocument(ReaderContext context, int doc) {

--- a/server/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
+++ b/server/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
@@ -361,7 +361,7 @@ public class LuceneQueryBuilder {
         @SuppressWarnings("unchecked")
         final Input<Boolean> condition = (Input<Boolean>) ctx.add(function);
         final Collection<? extends LuceneCollectorExpression<?>> expressions = ctx.expressions();
-        final CollectorContext collectorContext = new CollectorContext(context.table.droppedColumns());
+        final CollectorContext collectorContext = new CollectorContext(context.table.droppedColumns(), context.table.lookupNameBySourceKey());
         for (LuceneCollectorExpression<?> expression : expressions) {
             expression.startCollect(collectorContext);
         }

--- a/server/src/main/java/io/crate/statistics/ReservoirSampler.java
+++ b/server/src/main/java/io/crate/statistics/ReservoirSampler.java
@@ -30,7 +30,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
-import java.util.Set;
 import java.util.function.IntFunction;
 
 import org.apache.logging.log4j.LogManager;
@@ -80,7 +79,6 @@ import io.crate.expression.reference.doc.lucene.LuceneCollectorExpression;
 import io.crate.expression.reference.doc.lucene.LuceneReferenceResolver;
 import io.crate.expression.symbol.Symbols;
 import io.crate.lucene.FieldTypeLookup;
-import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
@@ -177,7 +175,6 @@ public final class ReservoirSampler {
         try {
             return getSamples(
                 columns,
-                docTable.droppedColumns(),
                 maxSamples,
                 docTable,
                 random,
@@ -196,7 +193,6 @@ public final class ReservoirSampler {
     }
 
     private Samples getSamples(List<Reference> columns,
-                               Set<ColumnIdent> droppedColumns,
                                int maxSamples,
                                DocTableInfo docTable,
                                Random random,
@@ -233,7 +229,7 @@ public final class ReservoirSampler {
             ctx.add(columns);
             List<Input<?>> inputs = ctx.topLevelInputs();
             List<? extends LuceneCollectorExpression<?>> expressions = ctx.expressions();
-            CollectorContext collectorContext = new CollectorContext(droppedColumns);
+            CollectorContext collectorContext = new CollectorContext(docTable.droppedColumns(), docTable.lookupNameBySourceKey());
             for (LuceneCollectorExpression<?> expression : expressions) {
                 expression.startCollect(collectorContext);
             }

--- a/server/src/test/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIteratorTest.java
@@ -33,6 +33,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.NumericDocValuesField;
@@ -152,7 +153,7 @@ public class DocValuesGroupByOptimizedIteratorTest extends CrateDummyClusterServ
             null,
             null,
             new MatchAllDocsQuery(),
-            new CollectorContext(Set.of())
+            new CollectorContext(Set.of(), Function.identity())
         );
 
         var rowConsumer = new TestingRowConsumer();
@@ -231,7 +232,7 @@ public class DocValuesGroupByOptimizedIteratorTest extends CrateDummyClusterServ
             null,
             null,
             new MatchAllDocsQuery(),
-            new CollectorContext(Set.of())
+            new CollectorContext(Set.of(), Function.identity())
         );
 
         var rowConsumer = new TestingRowConsumer();
@@ -311,7 +312,7 @@ public class DocValuesGroupByOptimizedIteratorTest extends CrateDummyClusterServ
             (expressions) -> expressions.get(0).value(),
             (key, cells) -> cells[0] = key,
             new MatchAllDocsQuery(),
-            new CollectorContext(Set.of())
+            new CollectorContext(Set.of(), Function.identity())
         );
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/collect/GroupByOptimizedIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/GroupByOptimizedIteratorTest.java
@@ -35,6 +35,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.document.Document;
@@ -126,7 +127,7 @@ public class GroupByOptimizedIteratorTest extends CrateDummyClusterServiceUnitTe
             Version.CURRENT,
             new InputRow(Collections.singletonList(inExpr)),
             new MatchAllDocsQuery(),
-            new CollectorContext(Set.of()),
+            new CollectorContext(Set.of(), Function.identity()),
             AggregateMode.ITER_FINAL
         );
     }

--- a/server/src/test/java/io/crate/execution/engine/collect/collectors/LuceneBatchIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/collectors/LuceneBatchIteratorTest.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
 
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.document.Document;
@@ -74,7 +75,7 @@ public class LuceneBatchIteratorTest {
                 new MatchAllDocsQuery(),
                 null,
                 false,
-                new CollectorContext(Set.of()),
+                new CollectorContext(Set.of(), Function.identity()),
                 columnRefs,
                 columnRefs
             )

--- a/server/src/test/java/io/crate/execution/engine/collect/collectors/LuceneOrderedDocCollectorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/collectors/LuceneOrderedDocCollectorTest.java
@@ -31,6 +31,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.StreamSupport;
 
 import org.jetbrains.annotations.Nullable;
@@ -392,7 +393,7 @@ public class LuceneOrderedDocCollectorTest extends RandomizedTest {
             doDocScores,
             2,
             RamAccounting.NO_ACCOUNTING,
-            new CollectorContext(Set.of()),
+            new CollectorContext(Set.of(), Function.identity()),
             f -> null,
             new Sort(SortField.FIELD_SCORE),
             columnReferences,

--- a/server/src/test/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorFactoryTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorFactoryTest.java
@@ -35,6 +35,7 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 
@@ -239,7 +240,7 @@ public class OrderedLuceneBatchIteratorFactoryTest extends ESTestCase {
     }
 
     private LuceneOrderedDocCollector createOrderedCollector(IndexSearcher searcher, int shardId) {
-        CollectorContext collectorContext = new CollectorContext(Set.of());
+        CollectorContext collectorContext = new CollectorContext(Set.of(), Function.identity());
         List<LuceneCollectorExpression<?>> expressions = Collections.singletonList(
             new OrderByCollectorExpression(reference, orderBy, o -> o));
         return new LuceneOrderedDocCollector(

--- a/server/src/test/java/io/crate/expression/reference/doc/DocLevelExpressionsTest.java
+++ b/server/src/test/java/io/crate/expression/reference/doc/DocLevelExpressionsTest.java
@@ -22,6 +22,7 @@
 package io.crate.expression.reference.doc;
 
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.StreamSupport;
 
 import org.apache.lucene.index.DirectoryReader;
@@ -72,7 +73,7 @@ public abstract class DocLevelExpressionsTest extends CrateDummyClusterServiceUn
         insertValues(writer);
         DirectoryReader directoryReader = DirectoryReader.open(writer, true, true);
         readerContext = directoryReader.leaves().get(0);
-        ctx = new CollectorContext(Set.of());
+        ctx = new CollectorContext(Set.of(), Function.identity());
     }
 
     @After

--- a/server/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
@@ -31,7 +31,6 @@ import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.CONFLICT;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.data.Offset.offset;
 

--- a/server/src/testFixtures/java/io/crate/testing/QueryTester.java
+++ b/server/src/testFixtures/java/io/crate/testing/QueryTester.java
@@ -150,7 +150,7 @@ public final class QueryTester implements AutoCloseable {
                 query,
                 null,
                 false,
-                new CollectorContext(table.droppedColumns()),
+                new CollectorContext(table.droppedColumns(), table.lookupNameBySourceKey()),
                 Collections.singletonList(input),
                 ctx.expressions()
             );

--- a/server/src/testFixtures/java/io/crate/types/DataTypeTestCase.java
+++ b/server/src/testFixtures/java/io/crate/types/DataTypeTestCase.java
@@ -163,7 +163,7 @@ public abstract class DataTypeTestCase<T> extends CrateDummyClusterServiceUnitTe
             );
 
             Scorer scorer = weight.scorer(leafReader);
-            CollectorContext collectorContext = new CollectorContext(1, Set.of());
+            CollectorContext collectorContext = new CollectorContext(1, Set.of(), table.lookupNameBySourceKey());
             ReaderContext readerContext = new ReaderContext(leafReader);
             DocIdSetIterator iterator = scorer.iterator();
             int nextDoc = iterator.nextDoc();


### PR DESCRIPTION
We already pass dropped columns to `SourceParser` (https://github.com/crate/crate/commit/432338ca1e18d5ac60557f7ce5c0435e6737fa3e) which already can exclude them but we don't use it for _raw lookups.

For raw we used direct parsing-free lookup.

This change makes _raw lookup go through parsing and such hides dropped columns.

Also, this is a pre-requisite for rewriting OID-s to human readable names.
This would be another reason to do pre-parsing on _raw lookup.