### PR TITLE
Don't use a symlink path for selecting current release notes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -143,12 +143,10 @@ ext {
 
 def rootDir = project.parent.projectDir
 
-// For releases choose the file under the release_notes structure
-// and for all other builds choose CHANGES.txt which contains the unreleased changes
 task chooseReleaseNotes(dependsOn: [':server:getVersion']) {
     doLast {
         def version = project(':server').getVersion.version
-        def releaseNotesDir = "$rootDir/blackbox/docs/appendices/release-notes"
+        def releaseNotesDir = "$rootDir/docs/appendices/release-notes"
         def releaseNotesFile = version.replaceAll('-.*', '') + '.rst'
         def file = new File(releaseNotesDir + '/' + releaseNotesFile)
         if (!file.exists()) { // End of life for a branch


### PR DESCRIPTION
Symlinks created on *nix systems and commited into git won't work under windows and such will break building the windows distribution.

See related jenkins failure https://jenkins.crate.io/job/CrateDB/job/Release/job/tarball/job/release_crate_tarball_x64_windows/50/.