### PR TITLE
Fix for ineffective IS_NULL on sub-cols of ignored objects

### DIFF
--- a/docs/appendices/release-notes/5.4.4.rst
+++ b/docs/appendices/release-notes/5.4.4.rst
@@ -62,6 +62,9 @@ Fixes
   hand side. With this fix, the output object column will contain the
   merged sub-columns of the respective objects of both relations.
 
+- Fixed an issue that caused ``IS NULL`` predicate to be ineffective on
+  sub-columns of ``ignored`` object types.
+
 - Fixed a regression introduced with CrateDB 5.3.1 which caused a
   ``NullPointerException`` when creating a repository on S3 with authentication
   provided by IAM role attached to the EC2 instance running the CrateDB node.

--- a/server/src/main/java/io/crate/expression/predicate/IsNullPredicate.java
+++ b/server/src/main/java/io/crate/expression/predicate/IsNullPredicate.java
@@ -136,7 +136,11 @@ public class IsNullPredicate<T> extends Scalar<Boolean, T> {
             valueType = ArrayType.unnest(valueType);
         }
         StorageSupport<?> storageSupport = valueType.storageSupport();
-        if (storageSupport == null && ref instanceof DynamicReference) {
+        if (ref instanceof DynamicReference) {
+            if (ref.columnPolicy() == ColumnPolicy.IGNORED) {
+                // Not indexed, need to use source lookup
+                return null;
+            }
             return new MatchNoDocsQuery("DynamicReference/type without storageSupport does not exist");
         } else if (canUseFieldsExist) {
             return new FieldExistsQuery(field);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes the following scenario:

```
cr> create table x (o object(ignored));                                                                                                           
CREATE OK, 1 row affected  (0.226 sec)
cr> insert into x values ({a=1});                                                                                                                 
INSERT OK, 1 row affected  (0.031 sec)
cr> select * from x where o['a'] = 1 and o['a'] is null; -- is_null predicate took no effect                                                                                         
+----------+
| o        |
+----------+
| {"a": 1} |
+----------+
SELECT 1 row in set (0.006 sec)
```

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
