### PR TITLE
Fix SourceLookUp for nested access to ignored objects

### DIFF
--- a/docs/appendices/release-notes/5.4.4.rst
+++ b/docs/appendices/release-notes/5.4.4.rst
@@ -46,6 +46,13 @@ See the :ref:`version_5.4.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that caused nested accesses to ``ignored`` objects with
+  unknown object keys from returning non ``nulls``. For example::
+
+    SELECT o['a']['unknown'] FROM t;
+
+  returning the value for ``o['a']`` instead of a ``null``.
+
 - Fixed a regression introduced with CrateDB 5.3.1 which caused a
   ``NullPointerException`` when creating a repository on S3 with authentication
   provided by IAM role attached to the EC2 instance running the CrateDB node.

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/SourceLookup.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/SourceLookup.java
@@ -115,6 +115,9 @@ public final class SourceLookup {
                 }
                 return newList;
             } else {
+                if (i + 1 != path.size()) {
+                    return null;
+                }
                 break;
             }
         }

--- a/server/src/test/java/io/crate/expression/reference/doc/lucene/SourceLookupTest.java
+++ b/server/src/test/java/io/crate/expression/reference/doc/lucene/SourceLookupTest.java
@@ -59,4 +59,10 @@ public class SourceLookupTest {
         Object o = SourceLookup.extractValue(m, singletonList("x"), 0);
         assertThat((Collection<Integer>) o).containsExactly(10, 20);
     }
+
+    @Test
+    public void test_extractValue_from_object_with_unknown_subscript_returns_null() {
+        Map<String, Map<String, Integer>> m = singletonMap("x", singletonMap("a", 1)); // such that x['a'] = 1
+        assertThat(SourceLookup.extractValue(m, Arrays.asList("x", "a", "a"), 0)).isNull(); // x['a']['a'] should return null
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes the following scenarios:
```
cr> create table t (o object(ignored));                                                                                                           
CREATE OK, 1 row affected  (0.151 sec)
cr> insert into t values ({a=1});                                                                                                                 
INSERT OK, 1 row affected  (0.010 sec)
cr> select o['a']['unknown'] from t;                                                                                                              
+-------------------+
| o['a']['unknown'] |
+-------------------+
|                 1 |  -- should be null
+-------------------+
SELECT 1 row in set (0.003 sec)
```

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
