### PR TITLE
Reset Column OID after each test

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
@@ -57,12 +57,8 @@ import io.crate.testing.UseRandomizedOptimizerRules;
 import io.crate.testing.UseRandomizedSchema;
 import io.netty.handler.codec.http.HttpResponseStatus;
 
-
-/**
- * Using TEST scope to reset OID after each test run otherwise OID assertions are non-deterministic.
- */
 @UseRandomizedOptimizerRules(0)
-@IntegTestCase.ClusterScope(scope = IntegTestCase.Scope.TEST)
+@IntegTestCase.ClusterScope()
 @UseRandomizedSchema(random = false)
 public class DDLIntegrationTest extends IntegTestCase {
 


### PR DESCRIPTION
In order to keep OID-s deterministic per test without having to start up a new cluster per test.

Optimizes `DDLIntegrationTest` which currently uses new cluster for all tests and prepares a ground for deterministic assertions of `select _raw` once we have OID-s written to the source.

