### PR TITLE
Add an annotation to start up a new cluster for a test case 

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
@@ -53,20 +53,18 @@ import io.crate.metadata.Schemas;
 import io.crate.protocols.postgres.PGErrorStatus;
 import io.crate.testing.Asserts;
 import io.crate.testing.TestingHelpers;
+import io.crate.testing.UseNewCluster;
 import io.crate.testing.UseRandomizedOptimizerRules;
 import io.crate.testing.UseRandomizedSchema;
 import io.netty.handler.codec.http.HttpResponseStatus;
 
-
-/**
- * Using TEST scope to reset OID after each test run otherwise OID assertions are non-deterministic.
- */
 @UseRandomizedOptimizerRules(0)
-@IntegTestCase.ClusterScope(scope = IntegTestCase.Scope.TEST)
+@IntegTestCase.ClusterScope()
 @UseRandomizedSchema(random = false)
 public class DDLIntegrationTest extends IntegTestCase {
 
     @Test
+    @UseNewCluster
     public void testCreateTable() throws Exception {
         execute("create table test (col1 integer primary key, col2 string) " +
                 "clustered into 5 shards with (number_of_replicas = 1, \"write.wait_for_active_shards\"=1)");
@@ -143,6 +141,7 @@ public class DDLIntegrationTest extends IntegTestCase {
     }
 
     @Test
+    @UseNewCluster
     public void testCreateTableWithReplicasAndShards() throws Exception {
         execute("create table test (col1 integer primary key, col2 string)" +
                 "clustered by (col1) into 10 shards with (number_of_replicas=2, \"write.wait_for_active_shards\"=1)");
@@ -168,6 +167,7 @@ public class DDLIntegrationTest extends IntegTestCase {
     }
 
     @Test
+    @UseNewCluster
     public void testCreateTableWithStrictColumnPolicy() throws Exception {
         execute("create table test (col1 integer primary key, col2 string) " +
                 "clustered into 5 shards " +
@@ -192,6 +192,7 @@ public class DDLIntegrationTest extends IntegTestCase {
     }
 
     @Test
+    @UseNewCluster
     public void testCreateGeoShapeExplicitIndex() throws Exception {
         execute("create table test (col1 geo_shape INDEX using QUADTREE with (precision='1m', distance_error_pct='0.25'))");
         ensureYellow();
@@ -203,6 +204,7 @@ public class DDLIntegrationTest extends IntegTestCase {
     }
 
     @Test
+    @UseNewCluster
     public void testCreateColumnWithDefaultExpression() throws Exception {
         execute("create table test (id int, col1 text default 'foo', col2 int[] default [1,2])");
         String expectedMapping = "{\"default\":{" +
@@ -220,6 +222,7 @@ public class DDLIntegrationTest extends IntegTestCase {
     }
 
     @Test
+    @UseNewCluster
     public void testCreateGeoShape() throws Exception {
         execute("create table test (col1 geo_shape)");
         ensureYellow();
@@ -320,6 +323,7 @@ public class DDLIntegrationTest extends IntegTestCase {
     }
 
     @Test
+    @UseNewCluster
     public void testCreateTableWithCompositeIndex() throws Exception {
         execute("create table novels (title string, description string, " +
                 "index title_desc_fulltext using fulltext(title, description) " +
@@ -589,6 +593,7 @@ public class DDLIntegrationTest extends IntegTestCase {
     }
 
     @Test
+    @UseNewCluster
     public void testAlterTableAddObjectColumnToExistingObject() throws IOException {
         execute("create table t (o object as (x string)) " +
                 "clustered into 1 shards " +
@@ -879,6 +884,7 @@ public class DDLIntegrationTest extends IntegTestCase {
     }
 
     @Test
+    @UseNewCluster
     public void testCreateTableWithGeneratedColumn() throws Exception {
         execute(
             "create table test (" +
@@ -898,6 +904,7 @@ public class DDLIntegrationTest extends IntegTestCase {
     }
 
     @Test
+    @UseNewCluster
     public void testAddGeneratedColumnToTableWithExistingGeneratedColumns() throws Exception {
         execute(
             "create table test (" +

--- a/server/src/test/java/io/crate/integrationtests/DynamicMappingUpdateITest.java
+++ b/server/src/test/java/io/crate/integrationtests/DynamicMappingUpdateITest.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
+import io.crate.testing.UseNewCluster;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.test.IntegTestCase;
 import org.jetbrains.annotations.Nullable;
@@ -50,10 +51,6 @@ import io.crate.types.DataTypes;
 import io.crate.types.ObjectType;
 
 
-/**
- * Using TEST scope to reset OID after each test run otherwise OID assertions are non-deterministic.
- */
-@IntegTestCase.ClusterScope(scope = IntegTestCase.Scope.TEST)
 @UseRandomizedSchema(random = false)
 public class DynamicMappingUpdateITest extends IntegTestCase {
 
@@ -61,12 +58,14 @@ public class DynamicMappingUpdateITest extends IntegTestCase {
     public TemporaryFolder folder = new TemporaryFolder();
 
     @Test
+    @UseNewCluster
     public void test_concurrent_statements_that_add_columns_result_in_dynamic_mapping_updates() throws InterruptedException, IOException {
         execute("create table t (a int, b object as (x int))");
         execute_concurrent_statements_that_add_columns_result_in_dynamic_mapping_updates();
     }
 
     @Test
+    @UseNewCluster
     public void test_concurrent_statements_that_add_columns_to_partitioned_table_result_in_dynamic_mapping_updates() throws InterruptedException, IOException {
         execute("create table t (a int, b object as (x int)) partitioned by (a)");
         execute_concurrent_statements_that_add_columns_result_in_dynamic_mapping_updates();

--- a/server/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
@@ -89,14 +89,12 @@ import io.crate.testing.Asserts;
 import io.crate.testing.SQLResponse;
 import io.crate.testing.TestingHelpers;
 import io.crate.testing.UseJdbc;
+import io.crate.testing.UseNewCluster;
 import io.crate.testing.UseRandomizedOptimizerRules;
 import io.crate.testing.UseRandomizedSchema;
 
-/**
- * Using TEST scope to reset OID after each test run otherwise OID assertions are non-deterministic.
- */
 @UseRandomizedOptimizerRules(0)
-@IntegTestCase.ClusterScope(numDataNodes = 2, numClientNodes = 2, scope = IntegTestCase.Scope.TEST)
+@IntegTestCase.ClusterScope(numDataNodes = 2, numClientNodes = 2)
 public class PartitionedTableIntegrationTest extends IntegTestCase {
 
     private Setup setup = new Setup(sqlExecutor);
@@ -1733,6 +1731,7 @@ public class PartitionedTableIntegrationTest extends IntegTestCase {
 
     @Test
     @UseRandomizedSchema(random = false)
+    @UseNewCluster
     public void testAlterTableAddColumnOnPartitionedTable() throws Exception {
         execute("create table t (id int primary key, date timestamp with time zone primary key) " +
                 "partitioned by (date) " +

--- a/server/src/testFixtures/java/io/crate/testing/UseNewCluster.java
+++ b/server/src/testFixtures/java/io/crate/testing/UseNewCluster.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.testing;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Can be applied to a method to ensure that it starts a new cluster with a clean state.
+ * By default, data is wiped per method but metdata is shared.
+ * This annotation can be used for getting deterministic OID-s.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Inherited
+public @interface UseNewCluster {
+}

--- a/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
@@ -217,6 +217,7 @@ import io.crate.test.integration.SystemPropsTestLoggingListener;
 import io.crate.testing.SQLResponse;
 import io.crate.testing.SQLTransportExecutor;
 import io.crate.testing.TestExecutionConfig;
+import io.crate.testing.UseNewCluster;
 import io.crate.testing.UseHashJoins;
 import io.crate.testing.UseJdbc;
 import io.crate.testing.UseRandomizedOptimizerRules;
@@ -1100,6 +1101,10 @@ public abstract class IntegTestCase extends ESTestCase {
     }
 
     private Scope getCurrentClusterScope() {
+        UseNewCluster createNewCluster = getTestAnnotation(UseNewCluster.class);
+        if (createNewCluster != null) {
+            return Scope.TEST;
+        }
         return getCurrentClusterScope(this.getClass());
     }
 


### PR DESCRIPTION
Supersedes https://github.com/crate/crate/pull/14670 (which was too aggressive anyway because it tried to add new task submission after each test)

In order to keep OID-s deterministic per specific test without having to start up a new cluster for all tests (even where it's not needed)

Optimizes Some test suites which currently use new cluster for all tests and prepares a ground for deterministic assertions of `select _raw` once we have OID-s written to the source.
