### PR TITLE
Rename BatchIterators.partition -> chunks

### DIFF
--- a/libs/dex/src/main/java/io/crate/data/BatchIterators.java
+++ b/libs/dex/src/main/java/io/crate/data/BatchIterators.java
@@ -56,7 +56,7 @@ public class BatchIterators {
     }
 
     /**
-     * Partition the items of a BatchIterator into blocks of {@code size}.
+     * Create chunks of items of a BatchIterator of {@code size}.
      *
      * Example:
      * <pre>
@@ -66,17 +66,17 @@ public class BatchIterators {
      *     partition(inputBi, 2, ArrayList::new, List::add) -> [[1, 2], [3, 4], [5]]
      * }
      * </pre>
-     * @param supplier Used to create the state per partition
-     * @param accumulator Used to add items to the partitions state
-     * @param stateLimiter Used to dynamically adjust the partition size.
+     * @param supplier Used to create the state per chunk
+     * @param accumulator Used to add items to the chunk
+     * @param stateLimiter Used to dynamically adjust the chunk size.
      * @param <T> input item type
      * @param <A> output item type
      */
-    public static <T, A> BatchIterator<A> partition(BatchIterator<T> bi,
-                                                    int size,
-                                                    Supplier<A> supplier,
-                                                    BiConsumer<A, T> accumulator,
-                                                    Predicate<? super A> stateLimiter) {
+    public static <T, A> BatchIterator<A> chunks(BatchIterator<T> bi,
+                                                 int size,
+                                                 Supplier<A> supplier,
+                                                 BiConsumer<A, T> accumulator,
+                                                 Predicate<? super A> stateLimiter) {
         return new MappedForwardingBatchIterator<T, A>() {
 
             private A element = null;

--- a/libs/dex/src/test/java/io/crate/data/BatchIteratorsTest.java
+++ b/libs/dex/src/test/java/io/crate/data/BatchIteratorsTest.java
@@ -49,7 +49,7 @@ public class BatchIteratorsTest {
     @Test
     public void testBatchBySize() {
         var batchIterator = InMemoryBatchIterator.of(() -> IntStream.range(0, 5).iterator(), null, false);
-        BatchIterator<List<Integer>> batchedIt = BatchIterators.partition(batchIterator,
+        BatchIterator<List<Integer>> batchedIt = BatchIterators.chunks(batchIterator,
                                                                           2,
                                                                           ArrayList::new,
                                                                           List::add,
@@ -71,7 +71,7 @@ public class BatchIteratorsTest {
             2,
             null
         );
-        BatchIterator<List<Integer>> batchedIt = BatchIterators.partition(batchIterator, 2, ArrayList::new, List::add, r -> false);
+        BatchIterator<List<Integer>> batchedIt = BatchIterators.chunks(batchIterator, 2, ArrayList::new, List::add, r -> false);
 
         CompletableFuture<List<List<Integer>>> future = batchedIt.toList();
         assertThat(future.get(10, TimeUnit.SECONDS)).isEqualTo(Arrays.asList(
@@ -85,8 +85,13 @@ public class BatchIteratorsTest {
     public void testBatchBySizeWithDynamicLimiter() {
         var batchIterator = InMemoryBatchIterator.of(() -> IntStream.range(0, 5).iterator(), null, false);
         final AtomicInteger rowCount = new AtomicInteger();
-        BatchIterator<List<Integer>> batchedIt = BatchIterators.partition(batchIterator, 2, ArrayList::new, List::add,
-                                                                          r -> rowCount.incrementAndGet() == 3);
+        BatchIterator<List<Integer>> batchedIt = BatchIterators.chunks(
+            batchIterator,
+            2,
+            ArrayList::new,
+            List::add,
+            r -> rowCount.incrementAndGet() == 3
+        );
 
         assertThat(batchedIt.moveNext()).isTrue();
         assertThat(batchedIt.currentElement()).isEqualTo(Arrays.asList(0, 1));

--- a/server/src/main/java/io/crate/execution/engine/fetch/FetchProjector.java
+++ b/server/src/main/java/io/crate/execution/engine/fetch/FetchProjector.java
@@ -67,7 +67,7 @@ public final class FetchProjector {
         EstimateCellsSize estimateRowSize = new EstimateCellsSize(projection.inputTypes());
         return (BatchIterator<Row> source) -> {
             final long maxBucketsSizeInBytes = getBucketsBytesThreshold.getAsLong();
-            BatchIterator<ReaderBuckets> buckets = BatchIterators.partition(
+            BatchIterator<ReaderBuckets> buckets = BatchIterators.chunks(
                 source,
                 projection.getFetchSize(),
                 () -> new ReaderBuckets(fetchRows, projection::getFetchSourceByReader, estimateRowSize, ramAccounting),

--- a/server/src/main/java/io/crate/execution/engine/indexing/ShardDMLExecutor.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/ShardDMLExecutor.java
@@ -35,8 +35,6 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collector;
 
-import org.jetbrains.annotations.Nullable;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
@@ -46,6 +44,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.shard.ShardNotFoundException;
+import org.jetbrains.annotations.Nullable;
 
 import io.crate.common.concurrent.ConcurrencyLimit;
 import io.crate.common.exceptions.Exceptions;
@@ -197,7 +196,7 @@ public class ShardDMLExecutor<TReq extends ShardRequest<TReq, TItem>,
     public CompletableFuture<TResult> apply(BatchIterator<Row> batchIterator) {
         ConcurrencyLimit nodeLimit = nodeLimits.get(localNode);
         var isUsedBytesOverThreshold = new IsUsedBytesOverThreshold(queryCircuitBreaker, nodeLimit);
-        BatchIterator<TReq> reqBatchIterator = BatchIterators.partition(
+        BatchIterator<TReq> reqBatchIterator = BatchIterators.chunks(
             batchIterator,
             bulkSize,
             requestFactory,

--- a/server/src/main/java/io/crate/execution/engine/indexing/ShardingUpsertExecutor.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/ShardingUpsertExecutor.java
@@ -266,7 +266,7 @@ public class ShardingUpsertExecutor
         final ConcurrencyLimit nodeLimit = nodeLimits.get(localNode);
         long startTime = nodeLimit.startSample();
         var isUsedBytesOverThreshold = new IsUsedBytesOverThreshold(queryCircuitBreaker, nodeLimit);
-        var reqBatchIterator = BatchIterators.partition(
+        var reqBatchIterator = BatchIterators.chunks(
             batchIterator,
             bulkSize,
             () -> new ShardedRequests<>(requestFactory, ramAccounting),


### PR DESCRIPTION
`partition` is already used for table partition and window function partitions.
Using a different term helps disambiguate things.
