### PR TITLE
Replace regex based system column validation with manual loop

### DIFF
--- a/server/src/test/java/io/crate/metadata/ColumnIdentTest.java
+++ b/server/src/test/java/io/crate/metadata/ColumnIdentTest.java
@@ -115,6 +115,8 @@ public class ColumnIdentTest {
         ColumnIdent.validateColumnName("_Name");
         ColumnIdent.validateColumnName("_name_");
         ColumnIdent.validateColumnName("__name");
+        ColumnIdent.validateColumnName("____name");
+        ColumnIdent.validateColumnName("_name__");
         ColumnIdent.validateColumnName("_name1");
         ColumnIdent.validateColumnName("'index'");
         ColumnIdent.validateColumnName("ident'index");


### PR DESCRIPTION
Micro optimization:

    Benchmark                                                  (name)  Mode  Cnt     Score    Error  Units
    ColumnIdentBenchmark.measureIsSystemColumn                  _name  avgt    6     3.031 ±  0.007  ns/op
    ColumnIdentBenchmark.measureIsSystemColumn                 __name  avgt    6     0.991 ±  0.022  ns/op
    ColumnIdentBenchmark.measureIsSystemColumn         _system_column  avgt    6     7.275 ±  0.177  ns/op
    ColumnIdentBenchmark.measureIsSystemColumn     _no_system_column_  avgt    6     8.005 ±  0.109  ns/op
    ColumnIdentBenchmark.measureIsSystemColumnOld               _name  avgt    6    77.019 ±  1.211  ns/op
    ColumnIdentBenchmark.measureIsSystemColumnOld              __name  avgt    6    41.822 ±  0.186  ns/op
    ColumnIdentBenchmark.measureIsSystemColumnOld      _system_column  avgt    6    82.040 ±  3.363  ns/op
    ColumnIdentBenchmark.measureIsSystemColumnOld  _no_system_column_  avgt    6  1351.230 ± 12.000  ns/op


Ran into this while working on https://github.com/crate/crate/pull/14653, where it stood out in a profile:

![image](https://github.com/crate/crate/assets/38700/18ffe112-4dd6-49ac-a592-ad7eb20d9a94)


Benchmark was:

```java
@BenchmarkMode(Mode.AverageTime)
@OutputTimeUnit(TimeUnit.NANOSECONDS)
@State(Scope.Benchmark)
@Warmup(iterations = 2)
@Fork(value = 2)
@Measurement(iterations = 3)
public class ColumnIdentBenchmark {

    private static final Pattern UNDERSCORE_PATTERN = Pattern.compile("^_([a-z][_a-z]*)*[a-z]$");

    @Param({ "_name", "__name", "_system_column", "_no_system_column_" })
    public String name;

    @Benchmark
    public boolean measureIsSystemColumn() {
        return ColumnIdent.isSystemColumn(name);
    }

    @Benchmark
    public boolean measureIsSystemColumnOld() {
        return UNDERSCORE_PATTERN.matcher(name).matches();
    }
}
```