### PR TITLE
Don't wrap exception in RuntimeException in prepareForClientTransmission

### DIFF
--- a/server/src/main/java/io/crate/exceptions/SQLExceptions.java
+++ b/server/src/main/java/io/crate/exceptions/SQLExceptions.java
@@ -53,7 +53,6 @@ import org.elasticsearch.transport.RemoteTransportException;
 import org.jetbrains.annotations.Nullable;
 
 import io.crate.auth.AccessControl;
-import io.crate.common.exceptions.Exceptions;
 import io.crate.metadata.PartitionName;
 import io.crate.sql.parser.ParsingException;
 
@@ -137,7 +136,7 @@ public class SQLExceptions {
             || t instanceof ElasticsearchTimeoutException;
     }
 
-    public static RuntimeException prepareForClientTransmission(AccessControl accessControl, Throwable e) {
+    public static Throwable prepareForClientTransmission(AccessControl accessControl, Throwable e) {
         Throwable unwrappedError = SQLExceptions.unwrap(e);
         e = esToCrateException(unwrappedError);
         try {
@@ -145,7 +144,7 @@ public class SQLExceptions {
         } catch (Exception mpe) {
             e = mpe;
         }
-        return Exceptions.toRuntimeException(e);
+        return e;
     }
 
     private static Throwable esToCrateException(Throwable unwrappedError) {

--- a/server/src/testFixtures/java/io/crate/testing/SQLTransportExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLTransportExecutor.java
@@ -290,7 +290,8 @@ public class SQLTransportExecutor {
         FutureActionListener<SQLResponse, SQLResponse> future = FutureActionListener.newInstance();
         execute(stmt, args, future, session);
         return future.exceptionally(err -> {
-            throw SQLExceptions.prepareForClientTransmission(AccessControl.DISABLED, err);
+            Exceptions.rethrowUnchecked(SQLExceptions.prepareForClientTransmission(AccessControl.DISABLED, err));
+            return null;
         });
     }
 


### PR DESCRIPTION
The components using prepareForClientTransmission can handle a Throwable and
don't need a RuntimeException.

This should lead to better stack traces, e.g. instead of:

    CONTEXT:  io.crate.common.exceptions.Exceptions.toRuntimeException(Exceptions.java:70)
    io.crate.exceptions.SQLExceptions.prepareForClientTransmission(SQLExceptions.java:148)
    io.crate.protocols.postgres.Messages.sendErrorResponse(Messages.java:190)
    io.crate.protocols.postgres.RowCountReceiver.fail(RowCountReceiver.java:72)

Users will get the original trace