### PR TITLE
Fix test_jmx on java > 11

### DIFF
--- a/blackbox/test_jmx.py
+++ b/blackbox/test_jmx.py
@@ -82,6 +82,9 @@ class JmxClient:
         with Popen(
             [
                 'java',
+                '--add-exports', 'java.rmi/sun.rmi.server=ALL-UNNAMED',
+                '--add-exports', 'java.rmi/sun.rmi.transport=ALL-UNNAMED',
+                '--add-exports', 'java.rmi/sun.rmi.transport.tcp=ALL-UNNAMED',
                 '-jar', self.jmx_path,
                 'mx',
                 '-s', f'localhost:{self.jmx_port}',


### PR DESCRIPTION
Need to add exports to avoid errors like:

    java.lang.IllegalAccessError: class org.gridkit.jvmtool.JmxConnectionInfo (in unnamed module @0x7a5d012c) cannot access class sun.rmi.server.UnicastRef
