### PR TITLE
Remove deprecation annotation from Tuple; Convert to record

### DIFF
--- a/libs/shared/src/main/java/io/crate/common/collections/Tuple.java
+++ b/libs/shared/src/main/java/io/crate/common/collections/Tuple.java
@@ -22,54 +22,13 @@
 package io.crate.common.collections;
 
 /**
- * @deprecated Use a record instead. Not much more verbose and they allow for
- *             named properties instead of a generic v1 and v2.
+ * Generic tuple for two values.
+ * Consider defining a custom record instead to have meaningful property names.
  */
-@Deprecated
-public class Tuple<V1, V2> {
-
-    public static <V1, V2> Tuple<V1, V2> tuple(V1 v1, V2 v2) {
-        return new Tuple<>(v1, v2);
-    }
-
-    private final V1 v1;
-    private final V2 v2;
-
-    public Tuple(V1 v1, V2 v2) {
-        this.v1 = v1;
-        this.v2 = v2;
-    }
-
-    public V1 v1() {
-        return v1;
-    }
-
-    public V2 v2() {
-        return v2;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        Tuple<?, ?> tuple = (Tuple<?, ?>) o;
-
-        if (v1 != null ? !v1.equals(tuple.v1) : tuple.v1 != null) return false;
-        if (v2 != null ? !v2.equals(tuple.v2) : tuple.v2 != null) return false;
-
-        return true;
-    }
-
-    @Override
-    public int hashCode() {
-        int result = v1 != null ? v1.hashCode() : 0;
-        result = 31 * result + (v2 != null ? v2.hashCode() : 0);
-        return result;
-    }
+public record Tuple<V1, V2>(V1 v1, V2 v2) {
 
     @Override
     public String toString() {
-        return "Tuple [v1=" + v1 + ", v2=" + v2 + "]";
+        return "Tuple{v1=" + v1 + ", v2=" + v2 + "}";
     }
 }

--- a/plugins/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobContainer.java
+++ b/plugins/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobContainer.java
@@ -510,16 +510,16 @@ class S3BlobContainer extends AbstractBlobContainer {
         }
 
         if ((totalSize == 0L) || (totalSize <= partSize)) {
-            return Tuple.tuple(1L, totalSize);
+            return new Tuple<>(1L, totalSize);
         }
 
         final long parts = totalSize / partSize;
         final long remaining = totalSize % partSize;
 
         if (remaining == 0) {
-            return Tuple.tuple(parts, partSize);
+            return new Tuple<>(parts, partSize);
         } else {
-            return Tuple.tuple(parts + 1, remaining);
+            return new Tuple<>((parts + 1), remaining);
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/settings/SettingsUpdater.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/settings/SettingsUpdater.java
@@ -19,20 +19,21 @@
 
 package org.elasticsearch.action.admin.cluster.settings;
 
+import static org.elasticsearch.cluster.ClusterState.builder;
+import static org.elasticsearch.common.settings.AbstractScopedSettings.ARCHIVED_SETTINGS_PREFIX;
+
+import java.util.Map;
+
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.logging.log4j.util.Supplier;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.metadata.Metadata;
-import io.crate.common.collections.Tuple;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 
-import java.util.Map;
-
-import static org.elasticsearch.cluster.ClusterState.builder;
-import static org.elasticsearch.common.settings.AbstractScopedSettings.ARCHIVED_SETTINGS_PREFIX;
+import io.crate.common.collections.Tuple;
 
 /**
  * Updates transient and persistent cluster state settings if there are any changes
@@ -147,7 +148,7 @@ final class SettingsUpdater {
             settingsExcludingExistingArchivedSettings,
             e -> logUnknownSetting(settingsType, e, logger),
             (e, ex) -> logInvalidSetting(settingsType, e, ex, logger));
-        return Tuple.tuple(
+        return new Tuple<>(
             Settings.builder()
                 .put(settingsWithUnknownOrInvalidArchived.filter(k -> k.startsWith(ARCHIVED_SETTINGS_PREFIX) == false))
                 .put(existingArchivedSettings)

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterBootstrapService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterBootstrapService.java
@@ -245,6 +245,6 @@ public class ClusterBootstrapService {
             }
         }
 
-        return Tuple.tuple(selectedNodes, unmatchedRequirements);
+        return new Tuple<>(selectedNodes, unmatchedRequirements);
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/ElasticsearchNodeCommand.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/ElasticsearchNodeCommand.java
@@ -102,7 +102,7 @@ public abstract class ElasticsearchNodeCommand extends EnvironmentAwareCommand {
         if (bestOnDiskState.empty()) {
             throw new ElasticsearchException(CS_MISSING_MSG);
         }
-        return Tuple.tuple(bestOnDiskState.currentTerm, clusterState(env, bestOnDiskState));
+        return new Tuple<>(bestOnDiskState.currentTerm, clusterState(env, bestOnDiskState));
     }
 
     protected void processNodePaths(Terminal terminal, OptionSet options, Environment env) throws IOException, UserException {

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
@@ -267,7 +267,7 @@ public class JoinHelper {
             return;
         }
         final JoinRequest joinRequest = new JoinRequest(transportService.getLocalNode(), term, optionalJoin);
-        final Tuple<DiscoveryNode, JoinRequest> dedupKey = Tuple.tuple(destination, joinRequest);
+        final Tuple<DiscoveryNode, JoinRequest> dedupKey = new Tuple<>(destination, joinRequest);
         if (pendingOutgoingJoins.add(dedupKey)) {
             LOGGER.debug("attempting to join {} with {}", destination, joinRequest);
             transportService.sendRequest(destination, JOIN_ACTION_NAME, joinRequest,

--- a/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
@@ -458,7 +458,7 @@ public class RoutingNodes implements Iterable<RoutingNode> {
         assignedShardsAdd(target);
         addRecovery(target);
         changes.relocationStarted(startedShard, target);
-        return Tuple.tuple(source, target);
+        return new Tuple<>(source, target);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -382,7 +382,7 @@ public class BalancedShardsAllocator implements ShardsAllocator {
                         assignedNode = node;
                     }
                 }
-                Tuple<ModelNode, Decision> nodeResult = Tuple.tuple(node, canAllocate);
+                Tuple<ModelNode, Decision> nodeResult = new Tuple<>(node, canAllocate);
                 if (rebalanceConditionsMet) {
                     betterBalanceNodes.add(nodeResult);
                 } else if (betterWeightThanCurrent) {
@@ -883,7 +883,7 @@ public class BalancedShardsAllocator implements ShardsAllocator {
                 if (explain) {
                     nodeExplanationMap.put(node.getNodeId(),
                         new NodeAllocationResult(node.getRoutingNode().node(), currentDecision, 0));
-                    nodeWeights.add(Tuple.tuple(node.getNodeId(), currentWeight));
+                    nodeWeights.add(new Tuple<>(node.getNodeId(), currentWeight));
                 }
                 if (currentDecision.type() == Type.YES || currentDecision.type() == Type.THROTTLE) {
                     final boolean updateMinNode;

--- a/server/src/main/java/org/elasticsearch/gateway/MetadataStateFormat.java
+++ b/server/src/main/java/org/elasticsearch/gateway/MetadataStateFormat.java
@@ -446,7 +446,7 @@ public abstract class MetadataStateFormat<T> {
                     .map(Object::toString)
                     .collect(Collectors.joining(", ")) + "], concurrent writes?");
         }
-        return Tuple.tuple(state, generation);
+        return new Tuple<>(state, generation);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/gateway/ReplicaShardAllocator.java
+++ b/server/src/main/java/org/elasticsearch/gateway/ReplicaShardAllocator.java
@@ -262,7 +262,7 @@ public abstract class ReplicaShardAllocator extends BaseGatewayShardAllocator {
                 if (explain) {
                     madeDecision = decision;
                 } else {
-                    return Tuple.tuple(decision, null);
+                    return new Tuple<>(decision, null);
                 }
             } else if (madeDecision.type() == Decision.Type.NO && decision.type() == Decision.Type.THROTTLE) {
                 madeDecision = decision;
@@ -271,7 +271,7 @@ public abstract class ReplicaShardAllocator extends BaseGatewayShardAllocator {
                 nodeDecisions.put(node.nodeId(), new NodeAllocationResult(node.node(), null, decision));
             }
         }
-        return Tuple.tuple(madeDecision, nodeDecisions);
+        return new Tuple<>(madeDecision, nodeDecisions);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/seqno/ReplicationTracker.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/ReplicationTracker.java
@@ -247,7 +247,7 @@ public class ReplicationTracker extends AbstractIndexShardComponent implements L
      */
     public synchronized Tuple<Boolean, RetentionLeases> getRetentionLeases(final boolean expireLeases) {
         if (expireLeases == false) {
-            return Tuple.tuple(false, retentionLeases);
+            return new Tuple<>(false, retentionLeases);
         }
         assert primaryMode;
         // the primary calculates the non-expired retention leases and syncs them to replicas
@@ -280,13 +280,13 @@ public class ReplicationTracker extends AbstractIndexShardComponent implements L
         if (expiredLeases == null) {
             // early out as no retention leases have expired
             logger.debug("no retention leases are expired from current retention leases [{}]", retentionLeases);
-            return Tuple.tuple(false, retentionLeases);
+            return new Tuple<>(false, retentionLeases);
         }
         final Collection<RetentionLease> nonExpiredLeases =
                 partitionByExpiration.get(false) != null ? partitionByExpiration.get(false) : Collections.emptyList();
         logger.debug("expiring retention leases [{}] from current retention leases [{}]", expiredLeases, retentionLeases);
         retentionLeases = new RetentionLeases(operationPrimaryTerm, retentionLeases.version() + 1, nonExpiredLeases);
-        return Tuple.tuple(true, retentionLeases);
+        return new Tuple<>(true, retentionLeases);
     }
 
     private long getMinimumReasonableRetainedSeqNo() {

--- a/server/src/main/java/org/elasticsearch/index/shard/GlobalCheckpointListeners.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/GlobalCheckpointListeners.java
@@ -19,12 +19,8 @@
 
 package org.elasticsearch.index.shard;
 
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
-import org.elasticsearch.Assertions;
-import io.crate.common.collections.Tuple;
-import io.crate.common.unit.TimeValue;
-import org.elasticsearch.common.util.concurrent.FutureUtils;
+import static org.elasticsearch.index.seqno.SequenceNumbers.NO_OPS_PERFORMED;
+import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -39,8 +35,13 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
-import static org.elasticsearch.index.seqno.SequenceNumbers.NO_OPS_PERFORMED;
-import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.elasticsearch.Assertions;
+import org.elasticsearch.common.util.concurrent.FutureUtils;
+
+import io.crate.common.collections.Tuple;
+import io.crate.common.unit.TimeValue;
 
 /**
  * Represents a collection of global checkpoint listeners. This collection can be added to, and all listeners present at the time of an
@@ -121,11 +122,11 @@ public class GlobalCheckpointListeners implements Closeable {
             notifyListener(listener, lastKnownGlobalCheckpoint, null);
         } else {
             if (timeout == null) {
-                listeners.put(listener, Tuple.tuple(waitingForGlobalCheckpoint, null));
+                listeners.put(listener, new Tuple<>(waitingForGlobalCheckpoint, null));
             } else {
                 listeners.put(
                     listener,
-                    Tuple.tuple(
+                    new Tuple<>(
                         waitingForGlobalCheckpoint,
                         scheduler.schedule(
                             () -> {

--- a/server/src/main/java/org/elasticsearch/indices/recovery/MultiChunkTransfer.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/MultiChunkTransfer.java
@@ -168,7 +168,7 @@ public abstract class MultiChunkTransfer<Source, Request extends MultiChunkTrans
             if (request.lastChunk()) {
                 currentSource = null;
             }
-            return Tuple.tuple(md, request);
+            return new Tuple<>(md, request);
         } catch (Exception e) {
             handleError(currentSource, e);
             throw e;

--- a/server/src/main/java/org/elasticsearch/monitor/fs/FsProbe.java
+++ b/server/src/main/java/org/elasticsearch/monitor/fs/FsProbe.java
@@ -63,7 +63,7 @@ public class FsProbe {
             Set<Tuple<Integer, Integer>> devicesNumbers = new HashSet<>();
             for (int i = 0; i < dataLocations.length; i++) {
                 if (dataLocations[i].majorDeviceNumber != -1 && dataLocations[i].minorDeviceNumber != -1) {
-                    devicesNumbers.add(Tuple.tuple(dataLocations[i].majorDeviceNumber, dataLocations[i].minorDeviceNumber));
+                    devicesNumbers.add(new Tuple<>(dataLocations[i].majorDeviceNumber, dataLocations[i].minorDeviceNumber));
                 }
             }
             ioStats = ioStats(devicesNumbers, previous);
@@ -77,7 +77,7 @@ public class FsProbe {
             if (previous != null && previous.getIoStats() != null && previous.getIoStats().devicesStats != null) {
                 for (int i = 0; i < previous.getIoStats().devicesStats.length; i++) {
                     FsInfo.DeviceStats deviceStats = previous.getIoStats().devicesStats[i];
-                    deviceMap.put(Tuple.tuple(deviceStats.majorDeviceNumber, deviceStats.minorDeviceNumber), deviceStats);
+                    deviceMap.put(new Tuple<>(deviceStats.majorDeviceNumber, deviceStats.minorDeviceNumber), deviceStats);
                 }
             }
 
@@ -89,7 +89,7 @@ public class FsProbe {
                     String[] fields = line.trim().split("\\s+");
                     final int majorDeviceNumber = Integer.parseInt(fields[0]);
                     final int minorDeviceNumber = Integer.parseInt(fields[1]);
-                    if (!devicesNumbers.contains(Tuple.tuple(majorDeviceNumber, minorDeviceNumber))) {
+                    if (!devicesNumbers.contains(new Tuple<>(majorDeviceNumber, minorDeviceNumber))) {
                         continue;
                     }
                     final String deviceName = fields[2];
@@ -106,7 +106,7 @@ public class FsProbe {
                                     sectorsRead,
                                     writesCompleted,
                                     sectorsWritten,
-                                    deviceMap.get(Tuple.tuple(majorDeviceNumber, minorDeviceNumber)));
+                                    deviceMap.get(new Tuple<>(majorDeviceNumber, minorDeviceNumber)));
                     devicesStats.add(deviceStats);
                 }
             }

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -884,7 +884,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                     entry.version(),
                     state -> stateWithoutSnapshot(state, snapshot),
                     ActionListener.wrap(newRepoData -> {
-                        completeListenersIgnoringException(endAndGetListenersToResolve(snapshot), Tuple.tuple(newRepoData, snapshotInfo));
+                        completeListenersIgnoringException(endAndGetListenersToResolve(snapshot), new Tuple<>(newRepoData, snapshotInfo));
                         LOGGER.info("snapshot [{}] completed with state [{}]", snapshot, snapshotInfo.state());
                         runNextQueuedOperation(newRepoData, repository, true);
                     }, e -> handleFinalizationFailure(e, entry, repositoryData)));
@@ -1010,7 +1010,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
         final SnapshotDeletionsInProgress deletions =
                 currentState.custom(SnapshotDeletionsInProgress.TYPE, SnapshotDeletionsInProgress.EMPTY);
         if (deletions.hasDeletionsInProgress() == false) {
-            return Tuple.tuple(currentState, Collections.emptyList());
+            return new Tuple<>(currentState, Collections.emptyList());
         }
         final SnapshotsInProgress snapshotsInProgress = currentState.custom(SnapshotsInProgress.TYPE);
         assert snapshotsInProgress != null;
@@ -1031,8 +1031,8 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                 newDeletes.add(entry);
             }
         }
-        return Tuple.tuple(changed ? ClusterState.builder(currentState).putCustom(
-                SnapshotDeletionsInProgress.TYPE, SnapshotDeletionsInProgress.of(newDeletes)).build() : currentState, readyDeletions);
+        return new Tuple<>(changed ? ClusterState.builder(currentState).putCustom(
+        SnapshotDeletionsInProgress.TYPE, SnapshotDeletionsInProgress.of(newDeletes)).build() : currentState, readyDeletions);
     }
 
     /**
@@ -2320,7 +2320,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
             }
             nextEntry = queued.pollFirst();
             assert nextEntry != null;
-            final Tuple<SnapshotsInProgress.Entry, Metadata> res = Tuple.tuple(nextEntry, latestKnownMetaData);
+            final Tuple<SnapshotsInProgress.Entry, Metadata> res = new Tuple<>(nextEntry, latestKnownMetaData);
             if (queued.isEmpty()) {
                 snapshotsToFinalize.remove(repository);
             }

--- a/server/src/test/java/io/crate/execution/engine/window/WindowBatchIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/window/WindowBatchIteratorTest.java
@@ -22,7 +22,6 @@
 package io.crate.execution.engine.window;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
-import static io.crate.common.collections.Tuple.tuple;
 import static io.crate.execution.engine.window.WindowFunctionBatchIterator.sortAndComputeWindowFunctions;
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -44,6 +43,7 @@ import org.junit.Test;
 import io.crate.breaker.ConcurrentRamAccounting;
 import io.crate.breaker.RowAccountingWithEstimators;
 import io.crate.common.collections.Lists2;
+import io.crate.common.collections.Tuple;
 import io.crate.data.BatchIterator;
 import io.crate.data.Input;
 import io.crate.data.Row;
@@ -132,7 +132,7 @@ public class WindowBatchIteratorTest {
             new Boolean[]{null},
             args).get(5, TimeUnit.SECONDS).spliterator(), false)
             .collect(toList());
-        var expectedBounds = tuple(0, 10);
+        var expectedBounds = new Tuple<>(0, 10);
         IntStream.range(0, 10).forEach(i -> assertThat(result.get(i), is(new Object[] { i, expectedBounds})));
     }
 
@@ -157,16 +157,16 @@ public class WindowBatchIteratorTest {
         assertThat(
             result,
             contains(
-                $(-1, tuple(0, 1)),
-                $(1, tuple(0, 2)),
-                $(1, tuple(0, 2)),
-                $(2, tuple(0, 2)),
-                $(2, tuple(0, 2)),
-                $(3, tuple(0, 1)),
-                $(4, tuple(0, 1)),
-                $(5, tuple(0, 1)),
-                $(null, tuple(0, 2)),
-                $(null, tuple(0, 2))
+                $(-1, new Tuple<>(0, 1)),
+                $(1, new Tuple<>(0, 2)),
+                $(1, new Tuple<>(0, 2)),
+                $(2, new Tuple<>(0, 2)),
+                $(2, new Tuple<>(0, 2)),
+                $(3, new Tuple<>(0, 1)),
+                $(4, new Tuple<>(0, 1)),
+                $(5, new Tuple<>(0, 1)),
+                $(null, new Tuple<>(0, 2)),
+                $(null, new Tuple<>(0, 2))
             )
         );
     }
@@ -204,16 +204,16 @@ public class WindowBatchIteratorTest {
         assertThat(
             result,
             contains(
-                $(-1, -1, tuple(0, 1)),
-                $(1, 0, tuple(0, 1)),
-                $(1, 1, tuple(0, 2)),
-                $(2, -1, tuple(0, 1)),
-                $(2, 2, tuple(0, 2)),
-                $(3, 3, tuple(0, 1)),
-                $(4, 4, tuple(0, 1)),
-                $(5, 5, tuple(0, 1)),
-                $(null, null, tuple(0, 2)),
-                $(null, null, tuple(0, 2))
+                $(-1, -1, new Tuple<>(0, 1)),
+                $(1, 0, new Tuple<>(0, 1)),
+                $(1, 1, new Tuple<>(0, 2)),
+                $(2, -1, new Tuple<>(0, 1)),
+                $(2, 2, new Tuple<>(0, 2)),
+                $(3, 3, new Tuple<>(0, 1)),
+                $(4, 4, new Tuple<>(0, 1)),
+                $(5, 5, new Tuple<>(0, 1)),
+                $(null, null, new Tuple<>(0, 2)),
+                $(null, null, new Tuple<>(0, 2))
             )
         );
     }
@@ -252,17 +252,17 @@ public class WindowBatchIteratorTest {
         assertThat(
             result,
             contains(
-                $(-1, -1, tuple(0, 1)),
-                $(1, 0, tuple(0, 3)),
-                $(1, 1, tuple(1, 3)),
-                $(1, 1, tuple(1, 3)),
-                $(2, -1, tuple(0, 2)),
-                $(2, 2, tuple(1, 2)),
-                $(3, 3, tuple(0, 1)),
-                $(4, 4, tuple(0, 1)),
-                $(5, 5, tuple(0, 1)),
-                $(null, null, tuple(0, 2)),
-                $(null, null, tuple(0, 2))
+                $(-1, -1, new Tuple<>(0, 1)),
+                $(1, 0, new Tuple<>(0, 3)),
+                $(1, 1, new Tuple<>(1, 3)),
+                $(1, 1, new Tuple<>(1, 3)),
+                $(2, -1, new Tuple<>(0, 2)),
+                $(2, 2, new Tuple<>(1, 2)),
+                $(3, 3, new Tuple<>(0, 1)),
+                $(4, 4, new Tuple<>(0, 1)),
+                $(5, 5, new Tuple<>(0, 1)),
+                $(null, null, new Tuple<>(0, 2)),
+                $(null, null, new Tuple<>(0, 2))
             )
         );
     }
@@ -325,16 +325,16 @@ public class WindowBatchIteratorTest {
         assertThat(
             result,
             contains(
-                $(-1, tuple(0, 1)),
-                $(1, tuple(0, 2)),
-                $(1, tuple(1, 2)),
-                $(2, tuple(0, 2)),
-                $(2, tuple(1, 2)),
-                $(3, tuple(0, 1)),
-                $(4, tuple(0, 1)),
-                $(5, tuple(0, 1)),
-                $(null, tuple(0, 2)),
-                $(null, tuple(1, 2))
+                $(-1, new Tuple<>(0, 1)),
+                $(1, new Tuple<>(0, 2)),
+                $(1, new Tuple<>(1, 2)),
+                $(2, new Tuple<>(0, 2)),
+                $(2, new Tuple<>(1, 2)),
+                $(3, new Tuple<>(0, 1)),
+                $(4, new Tuple<>(0, 1)),
+                $(5, new Tuple<>(0, 1)),
+                $(null, new Tuple<>(0, 2)),
+                $(null, new Tuple<>(1, 2))
             )
         );
     }
@@ -423,7 +423,7 @@ public class WindowBatchIteratorTest {
                                   List<? extends CollectExpression<Row, ?>> expressions,
                                   Boolean ignoreNulls,
                                   Input... args) {
-                return tuple(currentFrame.lowerBound(), currentFrame.upperBoundExclusive());
+                return new Tuple<>(currentFrame.lowerBound(), currentFrame.upperBoundExclusive());
             }
 
             @Override

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/LinearizabilityChecker.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/LinearizabilityChecker.java
@@ -334,7 +334,7 @@ public class LinearizabilityChecker {
         Entry entry = createLinkedEntries(events).next;
         Map<Tuple<EventType, Integer>, Integer> eventToPosition = new HashMap<>();
         for (Event event : events) {
-            eventToPosition.put(Tuple.tuple(event.type, event.id), eventToPosition.size());
+            eventToPosition.put(new Tuple<>(event.type, event.id), eventToPosition.size());
         }
         while (entry != null) {
             if (entry.match != null) {
@@ -349,8 +349,8 @@ public class LinearizabilityChecker {
         String input = String.valueOf(entry.event.value);
         String output = String.valueOf(entry.match.event.value);
         int id = entry.event.id;
-        int beginIndex = eventToPosition.get(Tuple.tuple(EventType.INVOCATION, id));
-        int endIndex = eventToPosition.get(Tuple.tuple(EventType.RESPONSE, id));
+        int beginIndex = eventToPosition.get(new Tuple<>(EventType.INVOCATION, id));
+        int endIndex = eventToPosition.get(new Tuple<>(EventType.RESPONSE, id));
         input = input.substring(0, Math.min(beginIndex + 25, input.length()));
         return Strings.padStart(input, beginIndex + 25, ' ') +
                "   "  + Strings.padStart("", endIndex-beginIndex, 'X') + "   "

--- a/server/src/test/java/org/elasticsearch/cluster/service/MasterServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/service/MasterServiceTests.java
@@ -470,7 +470,7 @@ public class MasterServiceTests extends ESTestCase {
                     tasks.add(new Task(taskId++));
                 }
                 taskGroups.add(tasks);
-                assignments.add(Tuple.tuple(executor, tasks));
+                assignments.add(new Tuple<>(executor, tasks));
             }
         }
 

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -409,13 +409,13 @@ public class IndexShardTests extends IndexShardTestCase {
                     }
                     releasable.close();
                     super.onResponse(releasable);
-                    results.setOnce(threadId, Tuple.tuple(Boolean.TRUE, null));
+                    results.setOnce(threadId, new Tuple<>(Boolean.TRUE, null));
                     allOperationsDone.countDown();
                 }
 
                 @Override
                 public void onFailure(final Exception e) {
-                    results.setOnce(threadId, Tuple.tuple(Boolean.FALSE, e));
+                    results.setOnce(threadId, new Tuple<>(Boolean.FALSE, e));
                     allOperationsDone.countDown();
                 }
             };

--- a/server/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
+++ b/server/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
@@ -3091,9 +3091,9 @@ public class TranslogTests extends ESTestCase {
         final List<Tuple<Long, Long>> seqNos = new ArrayList<>();
         final Map<Long, Long> terms = new HashMap<>();
         for (final Long seqNo : shuffledSeqNos) {
-            seqNos.add(Tuple.tuple(seqNo, terms.computeIfAbsent(seqNo, k -> 0L)));
+            seqNos.add(new Tuple<>(seqNo, terms.computeIfAbsent(seqNo, k -> 0L)));
             Long repeatingTermSeqNo = randomFrom(seqNos.stream().map(Tuple::v1).collect(Collectors.toList()));
-            seqNos.add(Tuple.tuple(repeatingTermSeqNo, terms.get(repeatingTermSeqNo)));
+            seqNos.add(new Tuple<>(repeatingTermSeqNo, terms.get(repeatingTermSeqNo)));
         }
 
         for (final Tuple<Long, Long> tuple : seqNos) {
@@ -3121,7 +3121,7 @@ public class TranslogTests extends ESTestCase {
                         TranslogSnapshot snapshot = reader.newSnapshot();
                         Translog.Operation operation;
                         while ((operation = snapshot.next()) != null) {
-                            generationSeenSeqNos.add(Tuple.tuple(operation.seqNo(), operation.primaryTerm()));
+                            generationSeenSeqNos.add(new Tuple<>(operation.seqNo(), operation.primaryTerm()));
                             opCount++;
                         }
                         assertThat(opCount, equalTo(reader.totalOperations()));
@@ -3142,7 +3142,7 @@ public class TranslogTests extends ESTestCase {
                 assertThat(snapshot.totalOperations(), equalTo(expectedSnapshotOps));
                 Translog.Operation op;
                 while ((op = snapshot.next()) != null) {
-                    assertThat(Tuple.tuple(op.seqNo(), op.primaryTerm()), isIn(seenSeqNos));
+                    assertThat(new Tuple<>(op.seqNo(), op.primaryTerm()), isIn(seenSeqNos));
                     readFromSnapshot++;
                 }
                 readFromSnapshot += snapshot.skippedOperations();

--- a/server/src/test/java/org/elasticsearch/monitor/fs/FsProbeTests.java
+++ b/server/src/test/java/org/elasticsearch/monitor/fs/FsProbeTests.java
@@ -19,11 +19,7 @@
 
 package org.elasticsearch.monitor.fs;
 
-import io.crate.common.collections.Tuple;
-import org.apache.lucene.util.Constants;
-import org.elasticsearch.env.NodeEnvironment;
-import org.elasticsearch.env.NodeEnvironment.NodePath;
-import org.elasticsearch.test.ESTestCase;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.FileStore;
@@ -38,7 +34,12 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.apache.lucene.util.Constants;
+import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.env.NodeEnvironment.NodePath;
+import org.elasticsearch.test.ESTestCase;
+
+import io.crate.common.collections.Tuple;
 
 
 public class FsProbeTests extends ESTestCase {
@@ -169,8 +170,8 @@ public class FsProbeTests extends ESTestCase {
         };
 
         final Set<Tuple<Integer, Integer>> devicesNumbers = new HashSet<>();
-        devicesNumbers.add(Tuple.tuple(253, 0));
-        devicesNumbers.add(Tuple.tuple(253, 2));
+        devicesNumbers.add(new Tuple<>(253, 0));
+        devicesNumbers.add(new Tuple<>(253, 2));
         final FsInfo.IoStats first = probe.ioStats(devicesNumbers, null);
         assertThat(first).isNotNull();
         assertThat(first.devicesStats[0].majorDeviceNumber).isEqualTo(253);

--- a/server/src/testFixtures/java/org/elasticsearch/test/RandomObjects.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/RandomObjects.java
@@ -126,7 +126,7 @@ public final class RandomObjects {
                     throw new UnsupportedOperationException();
             }
         }
-        return Tuple.tuple(originalValues, expectedParsedValues);
+        return new Tuple<>(originalValues, expectedParsedValues);
     }
 
     /**

--- a/server/src/testFixtures/java/org/elasticsearch/test/transport/MockTransport.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/transport/MockTransport.java
@@ -166,7 +166,7 @@ public class MockTransport extends StubbableTransport {
             @Override
             public void sendRequest(long requestId, String action, TransportRequest request, TransportRequestOptions options)
                 throws TransportException {
-                requests.put(requestId, Tuple.tuple(node, action));
+                requests.put(requestId, new Tuple<>(node, action));
                 onSendRequest(requestId, action, request, node);
             }
         };


### PR DESCRIPTION
It is hardly worth replacing some of the existing Tuple use-cases with
dedicated records.

An example is in `readyDeletions` in `SnapshotsService`. The type of the
properties already carries lots of information and it's difficult to
come up with a record with better naming.
