### PR TITLE
Remove use of SnapshotId in CreateSnapshotAnalyzer

### DIFF
--- a/server/src/main/java/io/crate/analyze/AnalyzedCreateSnapshot.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedCreateSnapshot.java
@@ -21,34 +21,41 @@
 
 package io.crate.analyze;
 
+import java.util.List;
+import java.util.function.Consumer;
+
 import io.crate.expression.symbol.Symbol;
 import io.crate.sql.tree.Assignment;
 import io.crate.sql.tree.GenericProperties;
 import io.crate.sql.tree.Table;
-import org.elasticsearch.snapshots.Snapshot;
-
-import java.util.List;
-import java.util.function.Consumer;
 
 public class AnalyzedCreateSnapshot implements DDLStatement {
 
     public static final List<String> ALL_INDICES = List.of("*", "-.blob_*");
 
-    private final Snapshot snapshot;
+    private final String repositoryName;
+    private final String snapshotName;
     private final List<Table<Symbol>> tables;
     private final GenericProperties<Symbol> properties;
 
-    AnalyzedCreateSnapshot(Snapshot snapshot,
+    AnalyzedCreateSnapshot(String repositoryName,
+                           String snapshotName,
                            List<Table<Symbol>> tables,
                            GenericProperties<Symbol> properties) {
-        this.snapshot = snapshot;
+        this.repositoryName = repositoryName;
+        this.snapshotName = snapshotName;
         this.tables = tables;
         this.properties = properties;
     }
 
-    public Snapshot snapshot() {
-        return snapshot;
+    public String repositoryName() {
+        return repositoryName;
     }
+
+    public String snapshotName() {
+        return snapshotName;
+    }
+
 
     public GenericProperties<Symbol> properties() {
         return properties;

--- a/server/src/main/java/io/crate/analyze/CreateSnapshotAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/CreateSnapshotAnalyzer.java
@@ -21,6 +21,9 @@
 
 package io.crate.analyze;
 
+import java.util.List;
+import java.util.Locale;
+
 import io.crate.analyze.expressions.ExpressionAnalysisContext;
 import io.crate.analyze.expressions.ExpressionAnalyzer;
 import io.crate.analyze.relations.FieldProvider;
@@ -34,13 +37,6 @@ import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.GenericProperties;
 import io.crate.sql.tree.QualifiedName;
 import io.crate.sql.tree.Table;
-
-import org.elasticsearch.common.UUIDs;
-import org.elasticsearch.snapshots.Snapshot;
-import org.elasticsearch.snapshots.SnapshotId;
-
-import java.util.List;
-import java.util.Locale;
 
 class CreateSnapshotAnalyzer {
 
@@ -64,7 +60,6 @@ class CreateSnapshotAnalyzer {
                 "Snapshot must be specified by \"<repository_name>\".\"<snapshot_name>\""));
 
         String snapshotName = createSnapshot.name().getSuffix();
-        Snapshot snapshot = new Snapshot(repositoryName, new SnapshotId(snapshotName, UUIDs.dirtyUUID().toString()));
 
         var exprCtx = new ExpressionAnalysisContext(txnCtx.sessionSettings());
         var exprAnalyzerWithoutFields = new ExpressionAnalyzer(
@@ -78,7 +73,7 @@ class CreateSnapshotAnalyzer {
         GenericProperties<Symbol> properties = createSnapshot.properties()
             .map(x -> exprAnalyzerWithoutFields.convert(x, exprCtx));
 
-        return new AnalyzedCreateSnapshot(snapshot, tables, properties);
+        return new AnalyzedCreateSnapshot(repositoryName, snapshotName, tables, properties);
     }
 
     private void validateRepository(QualifiedName name) {

--- a/server/src/main/java/io/crate/exceptions/CreateSnapshotException.java
+++ b/server/src/main/java/io/crate/exceptions/CreateSnapshotException.java
@@ -22,15 +22,17 @@
 package io.crate.exceptions;
 
 
-import org.elasticsearch.snapshots.Snapshot;
-
 import java.util.Locale;
 
 public class CreateSnapshotException extends UnhandledServerException implements ClusterScopeException {
 
-    public CreateSnapshotException(Snapshot snapshot, String message) {
-        super(String.format(Locale.ENGLISH, "Error creating snapshot '%s.%s': %s",
-            snapshot.getRepository(), snapshot.getSnapshotId().getName(), message));
+    public CreateSnapshotException(String repositoryName, String snapshotName, String message) {
+        super(
+            String.format(Locale.ENGLISH, "Error creating snapshot '%s.%s': %s",
+            repositoryName,
+            snapshotName,
+            message)
+        );
     }
 
     @Override


### PR DESCRIPTION
Creating a SnapshotId early in the CreateSnapshotAnalyzer is misleading
because the UUID is discarded, and instead the real UUID is assigned in
`SnapshotsService.createSnapshot`
