### PR TITLE
Fix uri comparsion on macOS at FileReadingCollectorTest

### DIFF
--- a/server/src/test/java/io/crate/execution/engine/collect/files/FileReadingCollectorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/files/FileReadingCollectorTest.java
@@ -63,10 +63,10 @@ public class FileReadingCollectorTest extends ESTestCase {
     private static String line1 = "{\"name\": \"Arthur\", \"id\": 4, \"details\": {\"age\": 38}}";
     private static String line2 = "{\"id\": 5, \"name\": \"Trillian\", \"details\": {\"age\": 33}}";
 
-    private static LineCursor[] expectedResult(File file) {
+    private static LineCursor[] expectedResult(File file) throws Exception {
         return new LineCursor[] {
-            new LineCursor(file.toURI(), 1, line1, null),
-            new LineCursor(file.toURI(), 2, line2, null)
+            new LineCursor(file.toPath().toRealPath().toUri(), 1, line1, null),
+            new LineCursor(file.toPath().toRealPath().toUri(), 2, line2, null)
         };
     }
 


### PR DESCRIPTION
On MacOS, `/var` is symlinked to `/private/var`. While using file path globbing, the `LocalFsFileInput` will convert the given URI to a Path intermediate. This will resolve the symlink and such a URI starting with `/var` will be converted to `/private/var`. This will break conversion in the test runs as they expect the giving original URI.
Fixing this by using an intermediate URI->Path->URI conversion for the expected file URI's at the `FileReadingCollectorTest`.

Follow up of https://github.com/crate/crate/commit/ee4adb63eec.

