### PR TITLE
Use SourceParser on primary key lookups

### DIFF
--- a/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
@@ -569,7 +569,7 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
 
     private static Doc getDocument(IndexShard indexShard, String id, long version, long seqNo, long primaryTerm) {
         // when sequence versioning is used, this lookup will throw VersionConflictEngineException
-        Doc doc = PKLookupOperation.lookupDoc(indexShard, id, Versions.MATCH_ANY, VersionType.INTERNAL, seqNo, primaryTerm);
+        Doc doc = PKLookupOperation.lookupDoc(indexShard, id, Versions.MATCH_ANY, VersionType.INTERNAL, seqNo, primaryTerm, null);
         if (doc == null) {
             throw new DocumentMissingException(indexShard.shardId(), Constants.DEFAULT_MAPPING_TYPE, id);
         }

--- a/server/src/main/java/io/crate/execution/engine/collect/PKLookupOperation.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/PKLookupOperation.java
@@ -34,8 +34,6 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.jetbrains.annotations.Nullable;
-
 import org.apache.lucene.index.StoredFields;
 import org.apache.lucene.index.Term;
 import org.elasticsearch.common.xcontent.XContentType;
@@ -49,6 +47,7 @@ import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.ShardNotFoundException;
 import org.elasticsearch.indices.IndicesService;
+import org.jetbrains.annotations.Nullable;
 
 import io.crate.data.BatchIterator;
 import io.crate.data.CompositeBatchIterator;
@@ -63,6 +62,7 @@ import io.crate.execution.engine.pipeline.ProjectorFactory;
 import io.crate.execution.engine.pipeline.Projectors;
 import io.crate.expression.reference.Doc;
 import io.crate.expression.reference.doc.lucene.SourceFieldVisitor;
+import io.crate.expression.reference.doc.lucene.SourceParser;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.TransactionContext;
 import io.crate.planner.operators.PKAndVersion;
@@ -79,7 +79,13 @@ public final class PKLookupOperation {
     }
 
     @Nullable
-    public static Doc lookupDoc(IndexShard shard, String id, long version, VersionType versionType, long seqNo, long primaryTerm) {
+    public static Doc lookupDoc(IndexShard shard,
+                                String id,
+                                long version,
+                                VersionType versionType,
+                                long seqNo,
+                                long primaryTerm,
+                                @Nullable SourceParser sourceParser) {
         Term uidTerm = new Term(IdFieldMapper.NAME, Uid.encodeId(id));
         Engine.Get get = new Engine.Get(id, uidTerm)
             .version(version)
@@ -99,6 +105,12 @@ public final class PKLookupOperation {
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }
+            Map<String, Object> sourceMap;
+            if (sourceParser == null) {
+                sourceMap = XContentHelper.toMap(visitor.source(), XContentType.JSON);
+            } else {
+                sourceMap = sourceParser.parse(visitor.source());
+            }
             return new Doc(
                 docIdAndVersion.docId,
                 shard.shardId().getIndexName(),
@@ -106,7 +118,7 @@ public final class PKLookupOperation {
                 docIdAndVersion.version,
                 docIdAndVersion.seqNo,
                 docIdAndVersion.primaryTerm,
-                XContentHelper.toMap(visitor.source(), XContentType.JSON),
+                sourceMap,
                 () -> visitor.source().utf8ToString()
             );
         }
@@ -120,7 +132,8 @@ public final class PKLookupOperation {
                                      Map<ShardId, List<PKAndVersion>> idsByShard,
                                      Collection<? extends Projection> projections,
                                      boolean requiresScroll,
-                                     Function<Doc, Row> resultToRow) {
+                                     Function<Doc, Row> resultToRow,
+                                     SourceParser sourceParser) {
         ArrayList<BatchIterator<Row>> iterators = new ArrayList<>(idsByShard.size());
         for (Map.Entry<ShardId, List<PKAndVersion>> idsByShardEntry : idsByShard.entrySet()) {
             ShardId shardId = idsByShardEntry.getKey();
@@ -145,7 +158,9 @@ public final class PKLookupOperation {
                     pkAndVersion.version(),
                     VersionType.EXTERNAL,
                     pkAndVersion.seqNo(),
-                    pkAndVersion.primaryTerm()))
+                    pkAndVersion.primaryTerm(),
+                    sourceParser
+                ))
                 .filter(Objects::nonNull)
                 .map(resultToRow);
 

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -1464,8 +1464,9 @@ public class TransportSQLActionTest extends IntegTestCase {
         execute("select _doc, id from locations where id in (2,3) order by id");
         Map<String, Object> _doc1 = (Map<String, Object>) response.rows()[0][0];
         Map<String, Object> _doc2 = (Map<String, Object>) response.rows()[1][0];
-        assertEquals(_doc1.get("id"), "2");
-        assertEquals(_doc2.get("id"), "3");
+        // Ensure complete source is returned for _doc by verifying a non-selected column
+        assertEquals(_doc1.get("name"), "Outer Eastern Rim");
+        assertEquals(_doc2.get("name"), "Galactic Sector QQ7 Active J Gamma");
 
         execute("select name, kind from locations where id in (2,3) order by id");
         assertEquals(printedTable(response.rows()), "Outer Eastern Rim| Galaxy\n" +


### PR DESCRIPTION
By using the source parser, only required columns are parsed instead of parsing the complete source into a map.
It will improve performance on PK lookups slightly as seen in the benchmark. Performance is expected to increase on larger documents while only few columns are selected.

<details>
  <summary>Benchmarks</summary>

```
# Results (server side duration in ms)
V1: 5.5.0-2ffeaaa7e3a3cb1a386b7c49685842f42f810d70
V2: 5.5.0-f42107b17b09d7961c03a2a39f07f9fd32e56a2d

Q: select duration from uservisits where "sourceIP" = '25.193.131.52'
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |        0.440 ±    0.554 |      0.163 |      0.311 |      0.432 |      7.457 |
|   V2    |        0.416 ±    0.471 |      0.161 |      0.303 |      0.409 |      9.111 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -   5.52%                           -   2.31%   
There is a 69.62% probability that the observed difference is not random, and the best estimate of that difference is 5.52%
The test has no statistical significance


System/JVM Metrics (durations in ms, byte-values in MB)
    |    YOUNG GC            |       OLD GC           |      HEAP         |     ALLOC     
    |  cnt      avg      max |  cnt      avg      max |  initial     used |     rate      total
 V1 |    0     0.00     0.00 |    0     0.00     0.00 |      268        0 |  4130.85      18419
 V2 |    0     0.00     0.00 |    0     0.00     0.00 |      268        0 |  3878.19      18359
    
Top allocation frames
  V1
    StreamSpliterators$WrappingSpliterator.initPartialTraversalState() total=16444653392, count=11
    ArrayUtil.growExact(...) total=1619107337, count=34
    ArrayUtil.growNoCopy(...) total=56496920, count=24
    DirectMethodHandle.allocateInstance(Object) total=24599032, count=12
    BufferRecycler.balloc(int) total=20689368, count=6
    ArrayList.grow(int) total=15330192, count=14
    CommonTokenFactory.create(...) total=13160168, count=4
    ReduceOps.makeRef(Collector) total=11284256, count=3
    HashMap.newNode(...) total=9150928, count=7
    HashMap.resize() total=8834248, count=6
  V2
    StreamSpliterators$WrappingSpliterator.initPartialTraversalState() total=16369635264, count=11
    ArrayUtil.growNoCopy(...) total=1603539336, count=28
    BufferRecycler.balloc(int) total=53136128, count=18
    DirectMethodHandle.allocateInstance(Object) total=31617608, count=14
    ArrayUtil.growExact(...) total=24585744, count=14
    ArrayList.grow(int) total=15946992, count=11
    ArrayUtil.growNoCopy(int[], int) total=14318232, count=4
    ArrayList.iterator() total=12753368, count=6
    AbstractByteBuf.duplicate() total=12748296, count=2
    ReduceOps$3.makeSink() total=12377448, count=4

Top frames (by count)
  V1
    ArrayUtil.growExact(...) total=1619107337, count=34
    ArrayUtil.growNoCopy(...) total=56496920, count=24
    ArrayList.grow(int) total=15330192, count=14
    DirectMethodHandle.allocateInstance(Object) total=24599032, count=12
    StreamSpliterators$WrappingSpliterator.initPartialTraversalState() total=16444653392, count=11
    ObjectName.construct(String) total=25264, count=11
    StreamSupport.stream(...) total=4479264, count=11
    SegmentTermsEnumFrame.<init>(...) total=11168, count=8
    HashMap.newNode(...) total=9150928, count=7
    ObjectName.setCanonicalName(...) total=14480, count=7
  V2
    ArrayUtil.growNoCopy(...) total=1603539336, count=28
    BufferRecycler.balloc(int) total=53136128, count=18
    ArrayUtil.growExact(...) total=24585744, count=14
    DirectMethodHandle.allocateInstance(Object) total=31617608, count=14
    StreamSpliterators$WrappingSpliterator.initPartialTraversalState() total=16369635264, count=11
    ArrayList.grow(int) total=15946992, count=11
    ObjectName.construct(String) total=23352, count=10
    SegmentTermsEnumFrame.<init>(...) total=11104, count=8
    StreamSupport.stream(...) total=6388800, count=8
    ArrayList.iterator() total=12753368, count=6

```