### PR TITLE
 Use SourceParser for upsert document parsing

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/collect/PKLookupOperation.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/PKLookupOperation.java
@@ -36,7 +36,6 @@ import java.util.stream.Stream;
 
 import org.apache.lucene.index.StoredFields;
 import org.apache.lucene.index.Term;
-import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.VersionType;
@@ -66,7 +65,6 @@ import io.crate.expression.reference.doc.lucene.SourceParser;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.TransactionContext;
 import io.crate.planner.operators.PKAndVersion;
-import io.crate.server.xcontent.XContentHelper;
 
 public final class PKLookupOperation {
 
@@ -107,7 +105,7 @@ public final class PKLookupOperation {
             }
             Map<String, Object> sourceMap;
             if (sourceParser == null) {
-                sourceMap = XContentHelper.toMap(visitor.source(), XContentType.JSON);
+                sourceMap = Map.of();
             } else {
                 sourceMap = sourceParser.parse(visitor.source());
             }


### PR DESCRIPTION
The source is only required on upsert requests as in this case update assignments may need reference values but also the complete source is required to write the new updated document.

The main motivation of using the source parser here relates to on-demand source modification when the stored source differs from the needed source e.g. by using oid's instead of column names.

Relates to https://github.com/crate/crate/pull/14697.