### PR TITLE
Increase limit for float vectors to 2048

### DIFF
--- a/docs/general/ddl/data-types.rst
+++ b/docs/general/ddl/data-types.rst
@@ -236,7 +236,7 @@ are likely to be larger due to additional metadata.
       - A ``GEO_SHAPE`` column can store different kinds of `GeoJSON geometry objects`_.
     * - ``FLOAT_VECTOR(n)``
       - ``n``
-      - Vector Minimum length: 1. Maximum length: 1024.
+      - Vector Minimum length: 1. Maximum length: 2048.
       - A vector of floating point numbers.
 
 

--- a/server/src/main/java/io/crate/execution/dml/FloatVectorIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/FloatVectorIndexer.java
@@ -53,8 +53,8 @@ public class FloatVectorIndexer implements ValueIndexer<float[]> {
 
     public FloatVectorIndexer(Reference ref, @Nullable FieldType fieldType) {
         if (fieldType == null) {
-            fieldType = new FieldType(FloatVectorFieldMapper.Defaults.FIELD_TYPE);
-            fieldType.setVectorAttributes(
+            fieldType = FloatVectorFieldMapper.Defaults.withVectorAttributes(
+                FloatVectorFieldMapper.Defaults.FIELD_TYPE,
                 ref.valueType().characterMaximumLength(),
                 VectorEncoding.FLOAT32,
                 FloatVectorType.SIMILARITY_FUNC

--- a/server/src/test/java/io/crate/execution/dml/FloatVectorIndexerTest.java
+++ b/server/src/test/java/io/crate/execution/dml/FloatVectorIndexerTest.java
@@ -49,5 +49,21 @@ public class FloatVectorIndexerTest {
         assertThat(floatVectorIndexer.fieldType).isNotNull();
         assertThat(floatVectorIndexer.fieldType.vectorDimension()).isEqualTo(4);
     }
-}
 
+    @Test
+    public void test_indexer_with_2048_dimensions() throws Exception {
+        FloatVectorType type = new FloatVectorType(2048);
+        RelationName tableName = new RelationName("doc", "tbl");
+        Reference ref = new SimpleReference(
+            new ReferenceIdent(tableName, "x"),
+            RowGranularity.DOC,
+            type,
+            1,
+            null
+        );
+        FloatVectorIndexer floatVectorIndexer = new FloatVectorIndexer(ref, null);
+        assertThat(floatVectorIndexer.fieldType).isNotNull();
+        assertThat(floatVectorIndexer.fieldType.vectorDimension()).isEqualTo(2048);
+    }
+
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This increases the limit of float vector from 1024 to 2048.
The previous limit was based on what Lucene provided but current
discussions and current benchmarks indicate that 2048 will also
be ok and the next Lucene version will have 2048 as default.

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
