### PR TITLE
Fix COPY FROM into a table having non-deterministic generated columns to have constant values on primary and replica

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
@@ -1133,4 +1133,35 @@ public class CopyIntegrationTest extends SQLHttpIntegrationTest {
                 ")"
             );
     }
+
+    @Test
+    public void test_generated_non_deterministic_value_is_consistent_on_primary_and_replica() throws Exception {
+        execute("""
+            create table tbl (x int, created generated always as now())
+            clustered into 1 shards
+            with (number_of_replicas = 1)
+            """
+        );
+        Path path = tmpFileWithLines(Arrays.asList(
+            "{\"x\": 1}"
+        ));
+        execute("copy tbl from ? with (shared=true)", new Object[] { path.toUri().toString() + "*.json"});
+
+        execute("refresh table tbl");
+        execute("select x, created from tbl");
+
+        // (int) response.rows()[0][0] used to be null because replica
+        // used regular Indexer instead of RawIndexer
+        // with values ["{\"x\": 1}"][some_long_timestamp], ie tried to write String value into int column.
+
+        int x = (int) response.rows()[0][0];
+        long created = (long) response.rows()[0][1];
+
+        // some iterations to ensure it hits both primary and replica
+        for (int i = 0; i < 30; i++) {
+            execute("select x, created from tbl").rows();
+            assertThat(response.rows()[0][0]).isEqualTo(x);
+            assertThat(response.rows()[0][1]).isEqualTo(created);
+        }
+    }
 }


### PR DESCRIPTION
Not backporting, it's a recent regression (test passes on 5.4 branch). 

Follow up to https://github.com/crate/crate/pull/14683

There were 2 issues:
1. `RawIndexer` was not used on replica if table had non-deterministic generated columns. See first commit
2. `RawIndexer` was not adding non-deterministic synthetics to its indexer. See second commit.