### PR TITLE
 Support float_vector with JDBC

### DIFF
--- a/server/src/main/java/io/crate/protocols/postgres/types/PGArray.java
+++ b/server/src/main/java/io/crate/protocols/postgres/types/PGArray.java
@@ -143,7 +143,7 @@ public class PGArray extends PGType<List<Object>> {
 
         do {
             dimensions++;
-            List arr = (List) array;
+            List<?> arr = (List<?>) array;
             if (arr.isEmpty()) {
                 break;
             }
@@ -176,6 +176,7 @@ public class PGArray extends PGType<List<Object>> {
         return values;
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     byte[] encodeAsUTF8Text(@NotNull List<Object> array) {
         boolean isJson = JsonType.OID == innerType.oid();
@@ -183,8 +184,8 @@ public class PGArray extends PGType<List<Object>> {
         encodedValues.add((byte) '{');
         for (int i = 0; i < array.size(); i++) {
             Object o = array.get(i);
-            if (o instanceof List) { // Nested Array -> recursive call
-                byte[] bytes = encodeAsUTF8Text((List) o);
+            if (o instanceof List list) { // Nested Array -> recursive call
+                byte[] bytes = encodeAsUTF8Text(list);
                 encodedValues.add(bytes);
                 if (i == 0) {
                     encodedValues.add((byte) ',');
@@ -220,6 +221,7 @@ public class PGArray extends PGType<List<Object>> {
         return Arrays.copyOfRange(encodedValues.buffer, 0, encodedValues.elementsCount);
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     List<Object> decodeUTF8Text(byte[] bytes) {
         /*
@@ -240,6 +242,7 @@ public class PGArray extends PGType<List<Object>> {
         return (List<Object>) PgArrayParser.parse(bytes, innerType::decodeUTF8Text);
     }
 
+    @SuppressWarnings("unchecked")
     private int buildDimensions(List<Object> values, List<Integer> dimensionsList, int maxDimensions, int currentDimension) {
         if (values == null) {
             return 1;
@@ -265,6 +268,7 @@ public class PGArray extends PGType<List<Object>> {
         return values.size();
     }
 
+    @SuppressWarnings({"rawtypes", "unchecked"})
     private int writeArrayAsBinary(ByteBuf buffer, List<Object> array, List<Integer> dimensionsList, int currentDimension) {
         int bytesWritten = 0;
 

--- a/server/src/main/java/io/crate/protocols/postgres/types/PGFloatVectorType.java
+++ b/server/src/main/java/io/crate/protocols/postgres/types/PGFloatVectorType.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.protocols.postgres.types;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.jetbrains.annotations.NotNull;
+
+import com.carrotsearch.hppc.ByteArrayList;
+
+import io.crate.protocols.postgres.parser.PgArrayParser;
+import io.crate.types.FloatVectorType;
+import io.netty.buffer.ByteBuf;
+
+/**
+ * Like {@link PGArray#FLOAT4_ARRAY} - including using the same oid - but specialized
+ * to handle float[] used by {@link FloatVectorType}.
+ * It's not registered in {@link io.crate.metadata.pgcatalog.PgTypeTable}.
+ */
+public class PGFloatVectorType extends PGType<float[]> {
+
+
+    public static final PGFloatVectorType INSTANCE = new PGFloatVectorType();
+
+    PGFloatVectorType() {
+        super(PGArray.FLOAT4_ARRAY.oid(), -1, -1, PGArray.FLOAT4_ARRAY.typName());
+    }
+
+    @Override
+    public int typArray() {
+        return 0;
+    }
+
+    @Override
+    public int typElem() {
+        return PGArray.FLOAT4_ARRAY.typElem();
+    }
+
+    @Override
+    public String typeCategory() {
+        return PGArray.FLOAT4_ARRAY.typeCategory();
+    }
+
+    @Override
+    public String type() {
+        return PGArray.FLOAT4_ARRAY.type();
+    }
+
+    @Override
+    public int writeAsBinary(ByteBuf buffer, @NotNull float[] value) {
+        int arrayLength = value.length;
+
+        final int lenIndex = buffer.writerIndex();
+        buffer.writeInt(0);
+        buffer.writeInt(1); // one dimension
+        buffer.writeInt(1); // flags bit 0: 0=no-nulls, 1=has-nulls
+        buffer.writeInt(typElem());
+
+        buffer.writeInt(arrayLength); // upper bound
+        buffer.writeInt(arrayLength); // lower bound
+        int bytesWritten = 4 + 4 + 4 + 8;
+
+        int len = bytesWritten + writeArrayAsBinary(buffer, value);
+        buffer.setInt(lenIndex, len);
+        return INT32_BYTE_SIZE + len; // add also the size of the length itself
+    }
+
+    @Override
+    public float[] readBinaryValue(ByteBuf buffer, int valueLength) {
+        int dimensions = buffer.readInt();
+        assert dimensions == 1 : "float_vector should have only 1 dimension";
+        buffer.readInt(); // flags bit 0: 0=no-nulls, 1=has-nulls
+        buffer.readInt(); // element oid
+        int dimension = buffer.readInt();
+        buffer.readInt();  // lowerBound ignored
+        return readArrayAsBinary(buffer, dimension);
+    }
+
+    @Override
+    byte[] encodeAsUTF8Text(float[] value) {
+        ByteArrayList encodedValues = new ByteArrayList();
+        encodedValues.add((byte) '{');
+        for (int i = 0; i < value.length; i++) {
+            var f = value[i];
+            if (i > 0) {
+                encodedValues.add((byte) ',');
+            }
+            byte[] bytes = RealType.INSTANCE.encodeAsUTF8Text(f);
+            encodedValues.add((byte) '"');
+            encodedValues.add(bytes);
+            encodedValues.add((byte) '"');
+        }
+        encodedValues.add((byte) '}');
+        return Arrays.copyOfRange(encodedValues.buffer, 0, encodedValues.elementsCount);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    float[] decodeUTF8Text(byte[] bytes) {
+        var list = (List<Object>) PgArrayParser.parse(bytes, RealType.INSTANCE::decodeUTF8Text);
+        float[] vector = new float[list.size()];
+        for (int i = 0; i < vector.length; i++) {
+            vector[i] = (float) list.get(i);
+        }
+        return vector;
+    }
+
+    private int writeArrayAsBinary(ByteBuf buffer, @NotNull float[] array) {
+        int bytesWritten = 0;
+        for (float f : array) {
+            bytesWritten += RealType.INSTANCE.writeAsBinary(buffer, f);
+        }
+        return bytesWritten;
+    }
+
+    static float[] readArrayAsBinary(ByteBuf buffer, final int dimension) {
+        float[] array = new float[dimension];
+        for (int i = 0; i < dimension; ++i) {
+            int len = buffer.readInt();
+            array[i] = RealType.INSTANCE.readBinaryValue(buffer, len);
+        }
+        return array;
+    }
+}

--- a/server/src/main/java/io/crate/protocols/postgres/types/PGFloatVectorType.java
+++ b/server/src/main/java/io/crate/protocols/postgres/types/PGFloatVectorType.java
@@ -73,7 +73,7 @@ public class PGFloatVectorType extends PGType<float[]> {
         final int lenIndex = buffer.writerIndex();
         buffer.writeInt(0);
         buffer.writeInt(1); // one dimension
-        buffer.writeInt(1); // flags bit 0: 0=no-nulls, 1=has-nulls
+        buffer.writeInt(0); // flags bit 0: 0=no-nulls, 1=has-nulls
         buffer.writeInt(typElem());
 
         buffer.writeInt(arrayLength); // upper bound

--- a/server/src/main/java/io/crate/protocols/postgres/types/PGTypes.java
+++ b/server/src/main/java/io/crate/protocols/postgres/types/PGTypes.java
@@ -94,7 +94,6 @@ public class PGTypes {
         .put(new ArrayType<>(DataTypes.REGCLASS), PGArray.REGCLASS_ARRAY)
         .put(new ArrayType<>(BitStringType.INSTANCE_ONE), PGArray.BIT_ARRAY)
         .put(DataTypes.OIDVECTOR, PgOidVectorType.INSTANCE)
-        .put(FloatVectorType.INSTANCE_ONE, PGArray.FLOAT4_ARRAY)
         .immutableMap();
 
     private static final IntObjectMap<DataType<?>> PG_TYPES_TO_CRATE_TYPE = new IntObjectHashMap<>();
@@ -184,6 +183,9 @@ public class PGTypes {
 
             case BitStringType.ID:
                 return new BitType(((BitStringType) type).length());
+
+            case FloatVectorType.ID:
+                return PGFloatVectorType.INSTANCE;
 
             default: {
                 PGType<?> pgType = CRATE_TO_PG_TYPES.get(type);

--- a/server/src/main/java/io/crate/types/FloatVectorType.java
+++ b/server/src/main/java/io/crate/types/FloatVectorType.java
@@ -54,7 +54,7 @@ public class FloatVectorType extends DataType<float[]> implements Streamer<float
     public static final FloatVectorType INSTANCE_ONE = new FloatVectorType(1);
     public static final VectorSimilarityFunction SIMILARITY_FUNC = VectorSimilarityFunction.EUCLIDEAN;
 
-    private static final EqQuery<float[]> EQ_QUERY = new EqQuery<float[]>() {
+    private static final EqQuery<float[]> EQ_QUERY = new EqQuery<>() {
 
         @Override
         public Query termQuery(String field, float[] value) {

--- a/server/src/test/java/io/crate/integrationtests/PostgresITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PostgresITest.java
@@ -1185,24 +1185,9 @@ public class PostgresITest extends IntegTestCase {
     }
 
     @Test
-    public void test_foo2() throws Exception {
-        try (Connection conn = DriverManager.getConnection(url(RW), properties)) {
-            conn.createStatement().execute("create table tbl (xs float_vector(2))");
-            PreparedStatement stmt = conn.prepareStatement("insert into tbl (xs) values (?)");
-            stmt.setObject(1, new float[] { 1.2f, 1.3f });
-            stmt.executeUpdate();
-
-            conn.createStatement().execute("refresh table tbl");
-            var resultSet = conn.createStatement().executeQuery("select * from tbl");
-            assertThat(resultSet.next()).isTrue();
-            assertThat(resultSet.getArray(1).getArray()).isEqualTo(new Float[] { 1.2f, 1.3f });
-        }
-    }
-
-    @Test
     public void test_float_vector_jdbc() throws Exception {
         try (Connection conn = DriverManager.getConnection(url(RW), properties)) {
-            conn.createStatement().execute("create table tbl (id int, xs float[])");
+            conn.createStatement().execute("create table tbl (id int, xs float_vector(2))");
             PreparedStatement stmt = conn.prepareStatement("insert into tbl (id, xs) values (?, ?)");
             stmt.setObject(1, 1);
             stmt.setObject(2, new float[] { 1.2f, 1.3f });

--- a/server/src/test/java/io/crate/protocols/postgres/types/PGTypesTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/types/PGTypesTest.java
@@ -47,6 +47,7 @@ import io.crate.types.BitStringType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.FloatType;
+import io.crate.types.FloatVectorType;
 import io.crate.types.LongType;
 import io.crate.types.ObjectType;
 import io.crate.types.RowType;
@@ -191,6 +192,18 @@ public class PGTypesTest extends ESTestCase {
     @Test
     public void test_text_oidvector_streaming_roundtrip() throws Exception {
         var entry = new Entry<>(DataTypes.OIDVECTOR, List.of(1, 2, 3, 4));
+        assertThat(writeAndReadAsText(entry, PGTypes.get(entry.type))).isEqualTo(entry.value);
+    }
+
+    @Test
+    public void test_binary_float_vector_streaming_roundtrip() {
+        var entry = new Entry<>(new FloatVectorType(4), new float[]{1.1f, 2.2f, 3.3f, 4.4f});
+        assertThat(writeAndReadBinary(entry, PGTypes.get(entry.type))).isEqualTo(entry.value);
+    }
+
+    @Test
+    public void test_text_float_vector_streaming_roundtrip() {
+        var entry = new Entry<>(new FloatVectorType(4), new float[]{1.1f, 2.2f, 3.3f, 4.4f});
         assertThat(writeAndReadAsText(entry, PGTypes.get(entry.type))).isEqualTo(entry.value);
     }
 

--- a/server/src/test/java/io/crate/protocols/postgres/types/PGTypesTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/types/PGTypesTest.java
@@ -21,13 +21,10 @@
 
 package io.crate.protocols.postgres.types;
 
+import static io.crate.testing.Asserts.assertThat;
 import static io.crate.types.DataTypes.GEO_POINT;
 import static io.crate.types.DataTypes.GEO_SHAPE;
 import static io.crate.types.DataTypes.PRIMITIVE_TYPES;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -39,7 +36,6 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import org.elasticsearch.test.ESTestCase;
-import org.hamcrest.Matchers;
 import org.joda.time.Period;
 import org.junit.Test;
 
@@ -63,22 +59,24 @@ public class PGTypesTest extends ESTestCase {
 
     @Test
     public void testCrate2PGType() {
-        assertThat(PGTypes.get(DataTypes.STRING), instanceOf(VarCharType.class));
-        assertThat(PGTypes.get(DataTypes.UNTYPED_OBJECT), instanceOf(JsonType.class));
-        assertThat(PGTypes.get(DataTypes.BOOLEAN), instanceOf(BooleanType.class));
-        assertThat(PGTypes.get(DataTypes.SHORT), instanceOf(SmallIntType.class));
-        assertThat(PGTypes.get(DataTypes.INTEGER), instanceOf(IntegerType.class));
-        assertThat(PGTypes.get(DataTypes.LONG), instanceOf(BigIntType.class));
-        assertThat(PGTypes.get(DataTypes.FLOAT), instanceOf(RealType.class));
-        assertThat(PGTypes.get(DataTypes.DOUBLE), instanceOf(DoubleType.class));
-        assertThat(PGTypes.get(DataTypes.DATE), instanceOf(DateType.class));
-        assertThat("Crate IP type is mapped to PG varchar", PGTypes.get(DataTypes.IP),
-            instanceOf(VarCharType.class));
-        assertThat(PGTypes.get(DataTypes.NUMERIC), instanceOf(NumericType.class));
-        assertThat(PGTypes.get(io.crate.types.JsonType.INSTANCE), instanceOf(JsonType.class));
+        assertThat(PGTypes.get(DataTypes.STRING)).isExactlyInstanceOf(VarCharType.class);
+        assertThat(PGTypes.get(DataTypes.UNTYPED_OBJECT)).isExactlyInstanceOf(JsonType.class);
+        assertThat(PGTypes.get(DataTypes.BOOLEAN)).isExactlyInstanceOf(BooleanType.class);
+        assertThat(PGTypes.get(DataTypes.SHORT)).isExactlyInstanceOf(SmallIntType.class);
+        assertThat(PGTypes.get(DataTypes.INTEGER)).isExactlyInstanceOf(IntegerType.class);
+        assertThat(PGTypes.get(DataTypes.LONG)).isExactlyInstanceOf(BigIntType.class);
+        assertThat(PGTypes.get(DataTypes.FLOAT)).isExactlyInstanceOf(RealType.class);
+        assertThat(PGTypes.get(DataTypes.DOUBLE)).isExactlyInstanceOf(DoubleType.class);
+        assertThat(PGTypes.get(DataTypes.DATE)).isExactlyInstanceOf(DateType.class);
+        assertThat(PGTypes.get(DataTypes.IP))
+            .as("Crate IP type is mapped to PG varchar")
+            .isExactlyInstanceOf(VarCharType.class);
+        assertThat(PGTypes.get(DataTypes.NUMERIC)).isExactlyInstanceOf(NumericType.class);
+        assertThat(PGTypes.get(io.crate.types.JsonType.INSTANCE)).isExactlyInstanceOf(JsonType.class);
 
     }
 
+    @SuppressWarnings({"unchecked", "rawtypes"})
     @Test
     public void test_undefined_type_can_stream_non_string_values() {
         PGType pgType = PGTypes.get(DataTypes.UNDEFINED);
@@ -87,55 +85,53 @@ public class PGTypesTest extends ESTestCase {
 
     @Test
     public void testPG2CrateType() {
-        assertThat(PGTypes.fromOID(VarCharType.OID), instanceOf(StringType.class));
-        assertThat(PGTypes.fromOID(JsonType.OID), instanceOf(ObjectType.class));
-        assertThat(PGTypes.fromOID(BooleanType.OID), instanceOf(io.crate.types.BooleanType.class));
-        assertThat(PGTypes.fromOID(SmallIntType.OID), instanceOf(ShortType.class));
-        assertThat(PGTypes.fromOID(IntegerType.OID), instanceOf(io.crate.types.IntegerType.class));
-        assertThat(PGTypes.fromOID(BigIntType.OID), instanceOf(LongType.class));
-        assertThat(PGTypes.fromOID(RealType.OID), instanceOf(FloatType.class));
-        assertThat(PGTypes.fromOID(DoubleType.OID), instanceOf(io.crate.types.DoubleType.class));
-        assertThat(PGTypes.fromOID(NumericType.OID), instanceOf(io.crate.types.NumericType.class));
+        assertThat(PGTypes.fromOID(VarCharType.OID)).isExactlyInstanceOf(StringType.class);
+        assertThat(PGTypes.fromOID(JsonType.OID)).isExactlyInstanceOf(ObjectType.class);
+        assertThat(PGTypes.fromOID(BooleanType.OID)).isExactlyInstanceOf(io.crate.types.BooleanType.class);
+        assertThat(PGTypes.fromOID(SmallIntType.OID)).isExactlyInstanceOf(ShortType.class);
+        assertThat(PGTypes.fromOID(IntegerType.OID)).isExactlyInstanceOf(io.crate.types.IntegerType.class);
+        assertThat(PGTypes.fromOID(BigIntType.OID)).isExactlyInstanceOf(LongType.class);
+        assertThat(PGTypes.fromOID(RealType.OID)).isExactlyInstanceOf(FloatType.class);
+        assertThat(PGTypes.fromOID(DoubleType.OID)).isExactlyInstanceOf(io.crate.types.DoubleType.class);
+        assertThat(PGTypes.fromOID(NumericType.OID)).isExactlyInstanceOf(io.crate.types.NumericType.class);
     }
 
     @Test
     public void testTextOidIsMappedToString() {
-        assertThat(PGTypes.fromOID(25), is(DataTypes.STRING));
-        assertThat(PGTypes.fromOID(1009), is(new ArrayType(DataTypes.STRING)));
+        assertThat(PGTypes.fromOID(25)).isEqualTo(DataTypes.STRING);
+        assertThat(PGTypes.fromOID(1009)).isEqualTo(new ArrayType<>(DataTypes.STRING));
     }
 
     @Test
     public void testCrateCollection2PgType() {
-        for (DataType type : PRIMITIVE_TYPES) {
-            assertThat(PGTypes.get(new ArrayType(type)), instanceOf(PGArray.class));
+        for (DataType<?> type : PRIMITIVE_TYPES) {
+            assertThat(PGTypes.get(new ArrayType<>(type))).isExactlyInstanceOf(PGArray.class);
         }
-
-        assertThat(PGTypes.get(new ArrayType(GEO_POINT)), instanceOf(PGArray.class));
-
-        assertThat(PGTypes.get(new ArrayType(GEO_SHAPE)), instanceOf(PGArray.class));
+        assertThat(PGTypes.get(new ArrayType<>(GEO_POINT))).isExactlyInstanceOf(PGArray.class);
+        assertThat(PGTypes.get(new ArrayType<>(GEO_SHAPE))).isExactlyInstanceOf(PGArray.class);
     }
 
     @Test
     public void testPgArray2CrateType() {
-        assertThat(PGTypes.fromOID(PGArray.CHAR_ARRAY.oid()), instanceOf(ArrayType.class));
-        assertThat(PGTypes.fromOID(PGArray.INT2_ARRAY.oid()), instanceOf(ArrayType.class));
-        assertThat(PGTypes.fromOID(PGArray.INT4_ARRAY.oid()), instanceOf(ArrayType.class));
-        assertThat(PGTypes.fromOID(PGArray.INT8_ARRAY.oid()), instanceOf(ArrayType.class));
-        assertThat(PGTypes.fromOID(PGArray.FLOAT4_ARRAY.oid()), instanceOf(ArrayType.class));
-        assertThat(PGTypes.fromOID(PGArray.FLOAT8_ARRAY.oid()), instanceOf(ArrayType.class));
-        assertThat(PGTypes.fromOID(PGArray.BOOL_ARRAY.oid()), instanceOf(ArrayType.class));
-        assertThat(PGTypes.fromOID(PGArray.TIMESTAMPZ_ARRAY.oid()), instanceOf(ArrayType.class));
-        assertThat(PGTypes.fromOID(PGArray.TIMESTAMP_ARRAY.oid()), instanceOf(ArrayType.class));
-        assertThat(PGTypes.fromOID(PGArray.DATE_ARRAY.oid()), instanceOf(ArrayType.class));
-        assertThat(PGTypes.fromOID(PGArray.VARCHAR_ARRAY.oid()), instanceOf(ArrayType.class));
-        assertThat(PGTypes.fromOID(PGArray.JSON_ARRAY.oid()), instanceOf(ArrayType.class));
+        assertThat(PGTypes.fromOID(PGArray.CHAR_ARRAY.oid())).isExactlyInstanceOf(ArrayType.class);
+        assertThat(PGTypes.fromOID(PGArray.INT2_ARRAY.oid())).isExactlyInstanceOf(ArrayType.class);
+        assertThat(PGTypes.fromOID(PGArray.INT4_ARRAY.oid())).isExactlyInstanceOf(ArrayType.class);
+        assertThat(PGTypes.fromOID(PGArray.INT8_ARRAY.oid())).isExactlyInstanceOf(ArrayType.class);
+        assertThat(PGTypes.fromOID(PGArray.FLOAT4_ARRAY.oid())).isExactlyInstanceOf(ArrayType.class);
+        assertThat(PGTypes.fromOID(PGArray.FLOAT8_ARRAY.oid())).isExactlyInstanceOf(ArrayType.class);
+        assertThat(PGTypes.fromOID(PGArray.BOOL_ARRAY.oid())).isExactlyInstanceOf(ArrayType.class);
+        assertThat(PGTypes.fromOID(PGArray.TIMESTAMPZ_ARRAY.oid())).isExactlyInstanceOf(ArrayType.class);
+        assertThat(PGTypes.fromOID(PGArray.TIMESTAMP_ARRAY.oid())).isExactlyInstanceOf(ArrayType.class);
+        assertThat(PGTypes.fromOID(PGArray.DATE_ARRAY.oid())).isExactlyInstanceOf(ArrayType.class);
+        assertThat(PGTypes.fromOID(PGArray.VARCHAR_ARRAY.oid())).isExactlyInstanceOf(ArrayType.class);
+        assertThat(PGTypes.fromOID(PGArray.JSON_ARRAY.oid())).isExactlyInstanceOf(ArrayType.class);
     }
 
-    private static class Entry {
-        final DataType<?> type;
+    private static class Entry<T> {
+        final DataType<T> type;
         final Object value;
 
-        public Entry(DataType<?> type, Object value) {
+        public Entry(DataType<T> type, Object value) {
             this.type = type;
             this.value = value;
         }
@@ -143,13 +139,13 @@ public class PGTypesTest extends ESTestCase {
 
     @Test
     public void testByteReadWrite() {
-        for (Entry entry : List.of(
-            new Entry(new ArrayType<>(DataTypes.INTEGER), Arrays.asList(10, null, 20)),
-            new Entry(new ArrayType<>(DataTypes.INTEGER), List.of()),
-            new Entry(new ArrayType<>(DataTypes.INTEGER), Arrays.asList(null, null)),
-            new Entry(new ArrayType<>(DataTypes.INTEGER), Arrays.asList(Arrays.asList(10, null, 20), Arrays.asList(1, 2, 3)))
+        for (var entry : List.of(
+            new Entry<>(new ArrayType<>(DataTypes.INTEGER), Arrays.asList(10, null, 20)),
+            new Entry<>(new ArrayType<>(DataTypes.INTEGER), List.of()),
+            new Entry<>(new ArrayType<>(DataTypes.INTEGER), Arrays.asList(null, null)),
+            new Entry<>(new ArrayType<>(DataTypes.INTEGER), Arrays.asList(Arrays.asList(10, null, 20), Arrays.asList(1, 2, 3)))
         )) {
-            PGType pgType = PGTypes.get(entry.type);
+            var pgType = PGTypes.get(entry.type);
             assertEntryOfPgType(entry, pgType);
         }
     }
@@ -157,93 +153,73 @@ public class PGTypesTest extends ESTestCase {
     @Test
     public void test_pgtypes_has_en_entry_for_each_typelem() throws Exception {
         Map<Integer, PGType<?>> typeByOid = StreamSupport.stream(PGTypes.pgTypes().spliterator(), false)
-            .collect(Collectors.toMap(x -> x.oid(), x -> x));
-        for (PGType<?> type : PGTypes.pgTypes()) {
+            .collect(Collectors.toMap(PGType::oid, x -> x));
+        for (var type : PGTypes.pgTypes()) {
             if (type.typElem() == 0) {
                 continue;
             }
-            assertThat(
-                "The element type with oid " + type.typElem() + " must exist for " + type.typName(),
-                typeByOid.get(type.typElem()),
-                Matchers.notNullValue()
-            );
+            assertThat(typeByOid.get(type.typElem()))
+                .as("The element type with oid " + type.typElem() + " must exist for " + type.typName())
+                .isNotNull();
         }
     }
 
 
     @Test
     public void test_period_binary_round_trip_streaming() {
-        Entry entry = new Entry(DataTypes.INTERVAL, new Period(1, 2, 3, 4, 5, 6, 7, 8));
-        assertThat(
-            writeAndReadBinary(entry, IntervalType.INSTANCE),
-            is(entry.value)
-        );
+        var entry = new Entry<>(DataTypes.INTERVAL, new Period(1, 2, 3, 4, 5, 6, 7, 8));
+        assertThat(writeAndReadBinary(entry, IntervalType.INSTANCE)).isEqualTo(entry.value);
     }
 
     @Test
     public void test_period_text_round_trip_streaming() {
-        Entry entry = new Entry(DataTypes.INTERVAL, new Period(1, 2, 3, 4, 5, 6, 7, 8));
-        assertThat(
-            writeAndReadAsText(entry, IntervalType.INSTANCE),
-            is(entry.value)
-        );
+        var entry = new Entry<>(DataTypes.INTERVAL, new Period(1, 2, 3, 4, 5, 6, 7, 8));
+        assertThat(writeAndReadAsText(entry, IntervalType.INSTANCE)).isEqualTo(entry.value);
     }
 
     @Test
     public void testReadWriteVarCharType() {
-        assertEntryOfPgType(new Entry(DataTypes.STRING, "test"), VarCharType.INSTANCE);
+        assertEntryOfPgType(new Entry<>(DataTypes.STRING, "test"), VarCharType.INSTANCE);
     }
 
     @Test
     public void test_binary_oidvector_streaming_roundtrip() throws Exception {
-        Entry entry = new Entry(DataTypes.OIDVECTOR, List.of(1, 2, 3, 4));
-        assertThat(
-            writeAndReadBinary(entry, PGTypes.get(entry.type)),
-            is(entry.value)
-        );
+        var entry = new Entry<>(DataTypes.OIDVECTOR, List.of(1, 2, 3, 4));
+        assertThat(writeAndReadBinary(entry, PGTypes.get(entry.type))).isEqualTo(entry.value);
     }
 
     @Test
     public void test_text_oidvector_streaming_roundtrip() throws Exception {
-        Entry entry = new Entry(DataTypes.OIDVECTOR, List.of(1, 2, 3, 4));
-        assertThat(
-            writeAndReadAsText(entry, PGTypes.get(entry.type)),
-            is(entry.value)
-        );
+        var entry = new Entry<>(DataTypes.OIDVECTOR, List.of(1, 2, 3, 4));
+        assertThat(writeAndReadAsText(entry, PGTypes.get(entry.type))).isEqualTo(entry.value);
     }
 
     @Test
     @SuppressWarnings({"unchecked", "rawtypes"})
     public void test_can_retrieve_pg_type_for_record_array() throws Exception {
         var pgType = PGTypes.get(new ArrayType<>(new RowType(List.of(DataTypes.STRING))));
-        assertThat(pgType.oid(), is(PGArray.EMPTY_RECORD_ARRAY.oid()));
+        assertThat(pgType.oid()).isEqualTo(PGArray.EMPTY_RECORD_ARRAY.oid());
 
         byte[] bytes = ((PGType) pgType).encodeAsUTF8Text(List.of(new Row1("foobar")));
-        assertThat(new String(bytes, StandardCharsets.UTF_8), is("{\"(foobar)\"}"));
+        assertThat(new String(bytes, StandardCharsets.UTF_8)).isEqualTo("{\"(foobar)\"}");
     }
 
-    private void assertEntryOfPgType(Entry entry, PGType pgType) {
-        assertThat(
-            "Binary write/read round-trip for `" + pgType.typName() + "` must not change value",
-            writeAndReadBinary(entry, pgType),
-            is(entry.value)
-        );
+    private <V> void assertEntryOfPgType(Entry<?> entry, PGType<V> pgType) {
+        assertThat(writeAndReadBinary(entry, pgType))
+            .as("Binary write/read round-trip for `" + pgType.typName() + "` must not change value")
+            .isEqualTo(entry.value);
         var streamedValue = writeAndReadAsText(entry, pgType);
-        assertThat(
-            "Text write/read round-trip for `" + pgType.typName() + "` must not change value",
-            streamedValue,
-            is(entry.value)
-        );
+        assertThat(streamedValue)
+            .as("Text write/read round-trip for `" + pgType.typName() + "` must not change value")
+            .isEqualTo(entry.value);
     }
 
     @Test
     public void test_all_types_exposed_via_pg_type_table_can_be_resolved_via_oid() throws Exception {
         for (var type : PGTypes.pgTypes()) {
-            assertThat(
-                "Must be possible to retrieve " + type.typName() + "/" + type.oid() + " via PGTypes.fromOID",
-                PGTypes.fromOID(type.oid()),
-                Matchers.notNullValue()
-            );
+            assertThat(PGTypes.fromOID(type.oid()))
+                .as("Must be possible to retrieve " + type.typName() + "/" + type.oid() + " via PGTypes.fromOID")
+                .isNotNull();
         }
     }
 
@@ -253,16 +229,17 @@ public class PGTypesTest extends ESTestCase {
         BitStringType type = new BitStringType(bitLength);
         Supplier<BitString> dataGenerator = DataTypeTesting.getDataGenerator(type);
         PGType<?> bitType = PGTypes.get(type);
-        Entry entry = new Entry(type, dataGenerator.get());
-        assertThat(writeAndReadBinary(entry, bitType), is(entry.value));
+        Entry<?> entry = new Entry<>(type, dataGenerator.get());
+        assertThat(writeAndReadBinary(entry, bitType)).isEqualTo(entry.value);
     }
 
 
+    @SuppressWarnings("unchecked")
     @Test
     public void test_typsend_and_receive_names_match_postgresql() throws Exception {
         // Some types have `<name>send`, others `<name>_send`
         // Needs to match PostgreSQL because clients may depend on this (concrete example is Postgrex)
-        Set<PGType> withUnderscore = Set.of(
+        Set<PGType<?>> withUnderscore = Set.of(
             TimestampType.INSTANCE,
             BitType.INSTANCE,
             DateType.INSTANCE,
@@ -295,22 +272,22 @@ public class PGTypesTest extends ESTestCase {
         }
     }
 
-
-
-    private Object writeAndReadBinary(Entry entry, PGType pgType) {
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private Object writeAndReadBinary(Entry<?> entry, PGType pgType) {
         ByteBuf buffer = Unpooled.buffer();
         try {
             pgType.writeAsBinary(buffer, entry.value);
             int length = buffer.readInt();
             Object result = pgType.readBinaryValue(buffer, length);
-            assertThat(buffer.readableBytes(), is(0));
+            assertThat(buffer.readableBytes()).isEqualTo(0);
             return result;
         } finally {
             buffer.release();
         }
     }
 
-    private Object writeAndReadAsText(Entry entry, PGType pgType) {
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private Object writeAndReadAsText(Entry<?> entry, PGType pgType) {
         ByteBuf buffer = Unpooled.buffer();
         try {
             pgType.writeAsText(buffer, entry.value);

--- a/server/src/testFixtures/java/io/crate/testing/SQLTransportExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLTransportExecutor.java
@@ -398,8 +398,7 @@ public class SQLTransportExecutor {
         if (arg.getClass().isArray()) {
             arg = Arrays.asList((Object[]) arg);
         }
-        if (arg instanceof Collection) {
-            Collection<?> values = (Collection<?>) arg;
+        if (arg instanceof Collection<?> values) {
             if (values.isEmpty()) {
                 return null; // Can't insert empty list without knowing the type
             }
@@ -431,7 +430,7 @@ public class SQLTransportExecutor {
             ResultSet resultSet = preparedStatement.getResultSet();
             List<Object[]> rows = new ArrayList<>();
             List<String> columnNames = new ArrayList<>(metadata.getColumnCount());
-            DataType[] dataTypes = new DataType[metadata.getColumnCount()];
+            DataType<?>[] dataTypes = new DataType[metadata.getColumnCount()];
             for (int i = 0; i < metadata.getColumnCount(); i++) {
                 columnNames.add(metadata.getColumnName(i + 1));
             }
@@ -639,7 +638,7 @@ public class SQLTransportExecutor {
     }
 
 
-    private static final DataType[] EMPTY_TYPES = new DataType[0];
+    private static final DataType<?>[] EMPTY_TYPES = new DataType[0];
     private static final String[] EMPTY_NAMES = new String[0];
     private static final Object[][] EMPTY_ROWS = new Object[0][];
 
@@ -682,7 +681,7 @@ public class SQLTransportExecutor {
 
         private SQLResponse createSqlResponse() {
             String[] outputNames = new String[outputFields.size()];
-            DataType[] outputTypes = new DataType[outputFields.size()];
+            DataType<?>[] outputTypes = new DataType[outputFields.size()];
 
             for (int i = 0, outputFieldsSize = outputFields.size(); i < outputFieldsSize; i++) {
                 Symbol field = outputFields.get(i);

--- a/server/src/testFixtures/java/io/crate/testing/SQLTransportExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLTransportExecutor.java
@@ -395,8 +395,8 @@ public class SQLTransportExecutor {
         if (arg instanceof Map) {
             return DataTypes.STRING.implicitCast(arg);
         }
-        if (arg.getClass().isArray()) {
-            arg = Arrays.asList((Object[]) arg);
+        if (arg instanceof Object[] values) {
+            arg = Arrays.asList(values);
         }
         if (arg instanceof Collection<?> values) {
             if (values.isEmpty()) {

--- a/server/src/testFixtures/java/io/crate/testing/SQLTransportExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLTransportExecutor.java
@@ -590,7 +590,7 @@ public class SQLTransportExecutor {
             });
             return FutureUtils.get(future, timeout);
         } catch (ElasticsearchTimeoutException e) {
-            LOGGER.error("Timeout on SQL statement: {}", e, stmt);
+            LOGGER.error("Timeout on SQL statement: " + stmt, e);
             throw e;
         }
     }


### PR DESCRIPTION
 -   Migrate PGTypesTest to assertj
 -   Fix warnings in `PGArray/FloatVectorType/SQLTransportExecutor`
 -   Fix logging of error message for timeout

      Previously the original exception was not included.

 -   Support float_vector with JDBC

      Introduce `PGFloatVectorType` as a simplified FLOAT4_ARRAY
      which can handle `float[]` instead of `List<Float>` which is
      used by `FloatVectorType`.

      Follows: #14437
