### PR TITLE
Remove useless maybeInvertPair method

### DIFF
--- a/server/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
+++ b/server/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
@@ -84,7 +84,7 @@ public class JoinPlanBuilder {
             joinType = JoinType.CROSS;
             joinCondition = null;
         } else {
-            joinType = maybeInvertPair(rhsName, joinLhsRhs);
+            joinType = joinLhsRhs.joinType();
             joinCondition = joinLhsRhs.condition();
         }
 
@@ -133,18 +133,6 @@ public class JoinPlanBuilder {
         return joinPlan;
     }
 
-
-    private static JoinType maybeInvertPair(RelationName rhsName, JoinPair pair) {
-        // A matching joinPair for two relations is retrieved using pairByQualifiedNames.remove(setOf(a, b))
-        // This returns a pair for both cases: (a ⋈ b) and (b ⋈ a) -> invert joinType to execute correct join
-        // Note that this can only happen if a re-ordering optimization happened, otherwise the joinPair would always
-        // be in the correct format.
-        if (pair.right().equals(rhsName)) {
-            return pair.joinType();
-        }
-        return pair.joinType().invert();
-    }
-
     private static LogicalPlan joinWithNext(Function<AnalyzedRelation, LogicalPlan> plan,
                                             LogicalPlan source,
                                             AnalyzedRelation nextRel,
@@ -160,7 +148,7 @@ public class JoinPlanBuilder {
         if (joinPair == null) {
             type = JoinType.CROSS;
         } else {
-            type = maybeInvertPair(nextName, joinPair);
+            type = joinPair.joinType();
             if (joinPair.condition() != null) {
                 conditions.add(joinPair.condition());
             }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The JoinPlanBuilder does not do any reordering anymore, therefore maybeInvertPair is useless. Follow-up https://github.com/crate/crate/pull/14685

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
