### PR TITLE
🧹 Remove useless new instances of the CollectorContext

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
@@ -208,7 +208,7 @@ final class DocValuesGroupByOptimizedIterator {
                 (expressions) -> expressions.get(0).value(),
                 (key, cells) -> cells[0] = key,
                 query,
-                new CollectorContext(collectorContext.readerId())
+                collectorContext
             );
         }
 
@@ -247,7 +247,7 @@ final class DocValuesGroupByOptimizedIterator {
                     }
                 },
                 query,
-                new CollectorContext(collectorContext.readerId())
+                collectorContext
             );
         }
 


### PR DESCRIPTION
The existing instance can be used, no reason to create new ones.

