### PR TITLE
Fix file not found errors on restore after snapshot of swapped tables

### DIFF
--- a/docs/appendices/release-notes/5.4.4.rst
+++ b/docs/appendices/release-notes/5.4.4.rst
@@ -46,6 +46,10 @@ See the :ref:`version_5.4.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that led to file not found errors when trying to restore a
+  snapshot that was taken after a table had been swapped. A new snapshot
+  must be taken to apply the fix and solve the issue.
+
 - Fixed an issue that caused nested accesses to ``ignored`` objects with
   unknown object keys from returning non ``nulls``. For example::
 

--- a/server/src/main/java/org/elasticsearch/repositories/IndexMetaDataGenerations.java
+++ b/server/src/main/java/org/elasticsearch/repositories/IndexMetaDataGenerations.java
@@ -19,9 +19,6 @@
 
 package org.elasticsearch.repositories;
 
-import org.elasticsearch.cluster.metadata.IndexMetadata;
-import org.elasticsearch.snapshots.SnapshotId;
-
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -29,6 +26,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.snapshots.SnapshotId;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -172,6 +172,27 @@ public final class IndexMetaDataGenerations {
     public static String buildUniqueIdentifier(IndexMetadata indexMetadata) {
         return indexMetadata.getIndexUUID() +
                 "-" + indexMetadata.getSettings().get(IndexMetadata.SETTING_HISTORY_UUID, IndexMetadata.INDEX_UUID_NA_VALUE) +
-                "-" + indexMetadata.getSettingsVersion() + "-" + indexMetadata.getMappingVersion();
+                "-" + indexMetadata.getSettingsVersion() +
+                "-" + indexMetadata.getMappingVersion();
+    }
+
+    /**
+     * Extract the indexUUID from the identifier.
+     * Only works if the identifier was created using {@link #buildUniqueIdentifier(IndexMetadata)}
+     */
+    @Nullable
+    public String getIndexUUID(String indexName) {
+        for (Map<IndexId, String> indices : lookup.values()) {
+            for (var entry : indices.entrySet()) {
+                IndexId key = entry.getKey();
+                String entryIndexName = key.getName();
+                if (entryIndexName.equals(indexName)) {
+                    String identifier = entry.getValue();
+                    assert UUIDs.randomBase64UUID().length() == 22 : "Length of random UUID should be 22";
+                    return identifier.substring(0, 22);
+                }
+            }
+        }
+        return null;
     }
 }

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -945,8 +945,9 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         // If there are older version nodes in the cluster, we don't need to run this cleanup as it will have already happened
         // when writing the index-${N} to each shard directory.
         final boolean writeShardGens = SnapshotsService.useShardGenerations(repositoryMetaVersion);
-        final Consumer<Exception> onUpdateFailure =
-            e -> listener.onFailure(new SnapshotException(metadata.name(), snapshotId, "failed to update snapshot in repository", e));
+        final Consumer<Exception> onUpdateFailure = e -> {
+            listener.onFailure(new SnapshotException(metadata.name(), snapshotId, "failed to update snapshot in repository", e));
+        };
 
         final Executor executor = threadPool.executor(ThreadPool.Names.SNAPSHOT);
         final boolean writeIndexGens = SnapshotsService.useIndexGenerations(repositoryMetaVersion);
@@ -1003,8 +1004,14 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                         final IndexMetadata indexMetaData = clusterMetadata.index(index.getName());
                         if (writeIndexGens) {
                             final String identifiers = IndexMetaDataGenerations.buildUniqueIdentifier(indexMetaData);
-                            String metaUUID = existingRepositoryData.indexMetaDataGenerations().getIndexMetaBlobId(identifiers);
-                            if (metaUUID == null) {
+
+                            // If the existing IndexMetadataGenerations contain a indexUUID that's different from the current indexMetadata
+                            // the table may have been swapped, in which case we need to reset it, otherwise a subsequent restore
+                            // will try to access files which don't exist.
+                            IndexMetaDataGenerations existingIndexMetaGenerations = existingRepositoryData.indexMetaDataGenerations();
+                            String indexUUID = existingIndexMetaGenerations.getIndexUUID(index.getName());
+                            String metaUUID = existingIndexMetaGenerations.getIndexMetaBlobId(identifiers);
+                            if (metaUUID == null || (indexUUID != null && !indexUUID.equals(indexMetaData.getIndexUUID()))) {
                                 // We don't yet have this version of the metadata so we write it
                                 metaUUID = UUIDs.base64UUID();
                                 INDEX_METADATA_FORMAT.write(indexMetaData, indexContainer(index), metaUUID, compress);
@@ -1682,9 +1689,15 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
     }
 
     @Override
-    public void snapshotShard(Store store, MapperService mapperService, SnapshotId snapshotId, IndexId indexId,
-                              IndexCommit snapshotIndexCommit, String shardStateIdentifier, IndexShardSnapshotStatus snapshotStatus,
-                              Version repositoryMetaVersion, ActionListener<String> listener) {
+    public void snapshotShard(Store store,
+                              MapperService mapperService,
+                              SnapshotId snapshotId,
+                              IndexId indexId,
+                              IndexCommit snapshotIndexCommit,
+                              String shardStateIdentifier,
+                              IndexShardSnapshotStatus snapshotStatus,
+                              Version repositoryMetaVersion,
+                              ActionListener<String> listener) {
         final ShardId shardId = store.shardId();
         final long startTime = threadPool.absoluteTimeInMillis();
         try {
@@ -1858,7 +1871,8 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 // now create and write the commit point
                 LOGGER.trace("[{}] [{}] writing shard snapshot file", shardId, snapshotId);
                 try {
-                    INDEX_SHARD_SNAPSHOT_FORMAT.write(new BlobStoreIndexShardSnapshot(snapshotId.getName(),
+                    INDEX_SHARD_SNAPSHOT_FORMAT.write(new BlobStoreIndexShardSnapshot(
+                            snapshotId.getName(),
                             lastSnapshotStatus.getIndexVersion(),
                             indexCommitPointFiles,
                             lastSnapshotStatus.getStartTime(),

--- a/server/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
@@ -804,6 +804,62 @@ public class SnapshotRestoreIntegrationTest extends IntegTestCase {
             "empty_parted2");
     }
 
+    @Test
+    public void test_can_restore_snapshots_taken_interleaved_with_swap_table() throws Exception {
+        execute("CREATE TABLE t01 as SELECT a, random() b FROM generate_series(1, 10, 1) as t(a)");
+        execute("CREATE TABLE t02 as SELECT a, random() b FROM generate_series(10, 20, 1) as t(a)");
+        execute("CREATE SNAPSHOT my_repo.s1 ALL WITH (wait_for_completion=true)");
+        execute("ALTER CLUSTER SWAP TABLE t01 TO t02");
+        execute("CREATE SNAPSHOT my_repo.s2 ALL WITH (wait_for_completion=true)");
+        execute("DROP TABLE t01");
+        execute("DROP TABLE t02");
+        execute("RESTORE SNAPSHOT my_repo.s2 ALL");
+        execute("refresh table t01");
+        assertThat(execute("select a from t01 order by a limit 3")).hasRows(
+            "10",
+            "11",
+            "12"
+        );
+    }
+
+    @Test
+    public void test_can_restore_snapshots_after_swapped_table_back_and_forth() throws Exception {
+        execute("CREATE TABLE t01 AS SELECT a, random() b FROM generate_series(1, 10, 1) as t(a)");
+        execute("CREATE TABLE t02 AS SELECT a, random() b FROM generate_series(10, 20, 1) as t(a)");
+        execute("CREATE SNAPSHOT my_repo.s1 ALL WITH (wait_for_completion=true)");
+        execute("ALTER CLUSTER SWAP TABLE t01 TO t02");
+        execute("ALTER CLUSTER SWAP TABLE t02 TO t01");
+        execute("CREATE SNAPSHOT my_repo.s2 ALL WITH (wait_for_completion=true)");
+        execute("DROP TABLE t01");
+        execute("DROP TABLE t02");
+        execute("RESTORE SNAPSHOT my_repo.s2 ALL");
+        execute("refresh table t01");
+        assertThat(execute("select a from t01 order by a limit 3")).hasRows(
+            "1",
+            "2",
+            "3"
+        );
+    }
+
+    @Test
+    public void test_can_restore_snapshot_after_swap_table_with_drop_source() throws Exception {
+        execute("CREATE TABLE t01 AS SELECT a, random() b FROM generate_series(1, 10, 1) as t(a)");
+        execute("CREATE TABLE t02 AS SELECT a, random() b FROM generate_series(10, 20, 1) as t(a)");
+        execute("CREATE SNAPSHOT my_repo.s1 ALL WITH (wait_for_completion=true)");
+
+        execute("ALTER CLUSTER SWAP TABLE t01 TO t02 WITH (drop_source = true)");
+
+        execute("CREATE SNAPSHOT my_repo.s2 ALL WITH (wait_for_completion=true)");
+        execute("DROP TABLE t02");
+        execute("RESTORE SNAPSHOT my_repo.s2 ALL");
+        execute("refresh table t02");
+        assertThat(execute("select a from t02 order by a limit 3")).hasRows(
+            "1",
+            "2",
+            "3"
+        );
+    }
+
     private void createSnapshotWithTablesAndMetadata() throws Exception {
         createTable("my_table", false);
         // creates custom metadata


### PR DESCRIPTION
The repositoryData layout is keyed by indexName.
That means swapping a table can lead to mixing up associations.

For example, with two tables snapshotted before a swap:

    t1 -> <dataForT1>
    t2 -> <dataForT2>

After swapping a table, the RepositoryData in the snapshot remains the
same.

A new snapshot for the new `t1` (former t2) would then try to use
`<dataForT1>`, which contains identifiers that lead to the
`IndexMetaData` blobs of the original t2, which cannot be used for the
new `t1`.
