### PR TITLE
Migrate RewriteFilterOnOuterJoinToInnerJoin rule to JoinPlan

### DIFF
--- a/server/src/main/java/io/crate/planner/operators/JoinPlan.java
+++ b/server/src/main/java/io/crate/planner/operators/JoinPlan.java
@@ -42,25 +42,32 @@ import io.crate.sql.tree.JoinType;
 public class JoinPlan extends AbstractJoinPlan {
 
     private final boolean isFiltered;
+    private final boolean rewriteFilterOnOuterJoinToInnerJoinDone;
 
     public JoinPlan(LogicalPlan lhs,
                     LogicalPlan rhs,
                     JoinType joinType,
                     @Nullable Symbol joinCondition) {
-        this(lhs, rhs, joinType, joinCondition, false);
+        this(lhs, rhs, joinType, joinCondition, false, false);
     }
 
     public JoinPlan(LogicalPlan lhs,
                     LogicalPlan rhs,
                     JoinType joinType,
                     @Nullable Symbol joinCondition,
-                    boolean isFiltered) {
+                    boolean isFiltered,
+                    boolean rewriteFilterOnOuterJoinToInnerJoinDone) {
         super(lhs, rhs, joinCondition, joinType);
         this.isFiltered = isFiltered;
+        this.rewriteFilterOnOuterJoinToInnerJoinDone = rewriteFilterOnOuterJoinToInnerJoinDone;
     }
 
     public boolean isFiltered() {
         return isFiltered;
+    }
+
+    public boolean isRewriteFilterOnOuterJoinToInnerJoinDone() {
+        return rewriteFilterOnOuterJoinToInnerJoinDone;
     }
 
     @Override
@@ -123,7 +130,8 @@ public class JoinPlan extends AbstractJoinPlan {
             newRhs,
             joinType,
             joinCondition,
-            isFiltered
+            isFiltered,
+            rewriteFilterOnOuterJoinToInnerJoinDone
         );
     }
 
@@ -149,7 +157,8 @@ public class JoinPlan extends AbstractJoinPlan {
             sources.get(1),
             joinType,
             joinCondition,
-            isFiltered
+            isFiltered,
+            rewriteFilterOnOuterJoinToInnerJoinDone
         );
     }
 }

--- a/server/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
+++ b/server/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
@@ -105,7 +105,8 @@ public class JoinPlanBuilder {
             plan.apply(rhs),
             joinType,
             validJoinConditions,
-            isFiltered
+            isFiltered,
+            false
         );
 
         joinPlan = Filter.create(joinPlan, validWhereConditions);
@@ -194,7 +195,8 @@ public class JoinPlanBuilder {
             nextPlan,
             type,
             AndOperator.join(conditions, null),
-            isFiltered
+            isFiltered,
+            false
         );
         return Filter.create(joinPlan, query);
     }

--- a/server/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
@@ -65,7 +65,6 @@ public class NestedLoopJoin extends AbstractJoinPlan {
 
     private final boolean isFiltered;
     private boolean orderByWasPushedDown = false;
-    private boolean rewriteFilterOnOuterJoinToInnerJoinDone = false;
     private final boolean joinConditionOptimised;
     // this can be removed
     private boolean rewriteNestedLoopJoinToHashJoinDone = false;
@@ -87,12 +86,10 @@ public class NestedLoopJoin extends AbstractJoinPlan {
                           @Nullable Symbol joinCondition,
                           boolean isFiltered,
                           boolean orderByWasPushedDown,
-                          boolean rewriteFilterOnOuterJoinToInnerJoinDone,
                           boolean joinConditionOptimised,
                           boolean rewriteEquiJoinToHashJoinDone) {
         this(lhs, rhs, joinType, joinCondition, isFiltered, joinConditionOptimised);
         this.orderByWasPushedDown = orderByWasPushedDown;
-        this.rewriteFilterOnOuterJoinToInnerJoinDone = rewriteFilterOnOuterJoinToInnerJoinDone;
         this.rewriteNestedLoopJoinToHashJoinDone = rewriteEquiJoinToHashJoinDone;
     }
 
@@ -104,9 +101,6 @@ public class NestedLoopJoin extends AbstractJoinPlan {
         return joinConditionOptimised;
     }
 
-    public boolean isRewriteFilterOnOuterJoinToInnerJoinDone() {
-        return rewriteFilterOnOuterJoinToInnerJoinDone;
-    }
 
     public boolean isFiltered() {
         return isFiltered;
@@ -235,7 +229,6 @@ public class NestedLoopJoin extends AbstractJoinPlan {
             joinCondition,
             isFiltered,
             orderByWasPushedDown,
-            rewriteFilterOnOuterJoinToInnerJoinDone,
             joinConditionOptimised,
             rewriteNestedLoopJoinToHashJoinDone
         );
@@ -265,7 +258,6 @@ public class NestedLoopJoin extends AbstractJoinPlan {
             joinCondition,
             isFiltered,
             orderByWasPushedDown,
-            rewriteFilterOnOuterJoinToInnerJoinDone,
             joinConditionOptimised,
             rewriteNestedLoopJoinToHashJoinDone
         );
@@ -301,7 +293,6 @@ public class NestedLoopJoin extends AbstractJoinPlan {
                 joinCondition,
                 isFiltered,
                 orderByWasPushedDown,
-                rewriteFilterOnOuterJoinToInnerJoinDone,
                 joinConditionOptimised,
                 rewriteNestedLoopJoinToHashJoinDone
             )

--- a/server/src/main/java/io/crate/planner/optimizer/rule/EliminateCrossJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/EliminateCrossJoin.java
@@ -178,6 +178,7 @@ public class EliminateCrossJoin implements Rule<JoinPlan> {
                 rightNode,
                 JoinType.INNER,
                 AndOperator.join(criteria, null),
+                false,
                 false
             );
         }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoop.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoop.java
@@ -88,7 +88,6 @@ public class MoveConstantJoinConditionsBeneathNestedLoop implements Rule<NestedL
                 nl.joinCondition(),
                 nl.isFiltered(),
                 nl.orderByWasPushedDown(),
-                nl.isRewriteFilterOnOuterJoinToInnerJoinDone(),
                 true, // Mark joinConditionOptimised = true
                 nl.isRewriteNestedLoopJoinToHashJoinDone()
             );

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathNestedLoop.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathNestedLoop.java
@@ -107,7 +107,6 @@ public final class MoveOrderBeneathNestedLoop implements Rule<Order> {
                     nestedLoop.joinCondition(),
                     nestedLoop.isFiltered(),
                     true,
-                    nestedLoop.isRewriteFilterOnOuterJoinToInnerJoinDone(),
                     false,
                     nestedLoop.isRewriteNestedLoopJoinToHashJoinDone()
                 );

--- a/server/src/main/java/io/crate/planner/optimizer/rule/ReorderNestedLoopJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/ReorderNestedLoopJoin.java
@@ -70,7 +70,6 @@ public class ReorderNestedLoopJoin implements Rule<NestedLoopJoin> {
                         nestedLoop.joinCondition(),
                         nestedLoop.isFiltered(),
                         nestedLoop.orderByWasPushedDown(),
-                        nestedLoop.isRewriteFilterOnOuterJoinToInnerJoinDone(),
                         nestedLoop.isJoinConditionOptimised(),
                         nestedLoop.isRewriteNestedLoopJoinToHashJoinDone()
                     ),

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoin.java
@@ -41,11 +41,11 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.TransactionContext;
+import io.crate.planner.operators.JoinPlan;
 import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.sql.tree.JoinType;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
-import io.crate.planner.operators.NestedLoopJoin;
 import io.crate.planner.optimizer.Rule;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
@@ -62,7 +62,7 @@ import io.crate.planner.optimizer.matcher.Pattern;
  * <pre>
  *     Filter (lhs.x = 1 AND rhs.x = 2)
  *       |
- *     NestedLoop (outerJoin)
+ *     Outer-Join
  *       /  \
  *     LHS  RHS
  * </pre>
@@ -72,7 +72,7 @@ import io.crate.planner.optimizer.matcher.Pattern;
  * <pre>
  *     Filter
  *       |
- *     NestedLoop (innerJoin)
+ *     Inner-Join
  *       /      \
  *   Filter      Filter
  * (lhs.x = 1)    (rhs.x = 2)
@@ -101,14 +101,14 @@ import io.crate.planner.optimizer.matcher.Pattern;
  */
 public final class RewriteFilterOnOuterJoinToInnerJoin implements Rule<Filter> {
 
-    private final Capture<NestedLoopJoin> nlCapture;
+    private final Capture<JoinPlan> nlCapture;
     private final Pattern<Filter> pattern;
 
     public RewriteFilterOnOuterJoinToInnerJoin() {
         this.nlCapture = new Capture<>();
         this.pattern = typeOf(Filter.class)
-                .with(source(), typeOf(NestedLoopJoin.class).capturedAs(nlCapture)
-                    .with(nl -> nl.joinType().isOuter() && !nl.isRewriteFilterOnOuterJoinToInnerJoinDone())
+                .with(source(), typeOf(JoinPlan.class).capturedAs(nlCapture)
+                    .with(j -> j.joinType().isOuter() && !j.isRewriteFilterOnOuterJoinToInnerJoinDone())
                 );
     }
 
@@ -125,13 +125,13 @@ public final class RewriteFilterOnOuterJoinToInnerJoin implements Rule<Filter> {
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {
         final var symbolEvaluator = new NullSymbolEvaluator(txnCtx, nodeCtx);
-        NestedLoopJoin nl = captures.get(nlCapture);
+        JoinPlan join = captures.get(nlCapture);
         Symbol query = filter.query();
         Map<Set<RelationName>, Symbol> splitQueries = QuerySplitter.split(query);
         if (splitQueries.size() == 1 && splitQueries.keySet().iterator().next().size() > 1) {
             return null;
         }
-        var sources = Lists2.map(nl.sources(), resolvePlan);
+        var sources = Lists2.map(join.sources(), resolvePlan);
         LogicalPlan lhs = sources.get(0);
         LogicalPlan rhs = sources.get(1);
         Set<RelationName> leftName = new HashSet<>(lhs.getRelationNames());
@@ -143,7 +143,7 @@ public final class RewriteFilterOnOuterJoinToInnerJoin implements Rule<Filter> {
         final LogicalPlan newLhs;
         final LogicalPlan newRhs;
         final boolean newJoinIsInnerJoin;
-        switch (nl.joinType()) {
+        switch (join.joinType()) {
             case LEFT:
                 /* LEFT OUTER JOIN -> NULL rows are generated for the RHS if the join-condition doesn't match
                  *
@@ -247,23 +247,20 @@ public final class RewriteFilterOnOuterJoinToInnerJoin implements Rule<Filter> {
                 break;
             default:
                 throw new UnsupportedOperationException(
-                    "The Rule to rewrite filter+outer-joins to inner joins must not be run on joins of type=" + nl.joinType());
+                    "The Rule to rewrite filter+outer-joins to inner joins must not be run on joins of type=" + join.joinType());
         }
         if (newLhs == lhs && newRhs == rhs) {
             return null;
         }
-        NestedLoopJoin newJoin = new NestedLoopJoin(
+        JoinPlan newJoin = new JoinPlan(
             newLhs,
             newRhs,
-            newJoinIsInnerJoin ? JoinType.INNER : nl.joinType(),
-            nl.joinCondition(),
-            nl.isFiltered(),
-            nl.orderByWasPushedDown(),
-            true,
-            nl.isJoinConditionOptimised(),
-            nl.isRewriteNestedLoopJoinToHashJoinDone()
+            newJoinIsInnerJoin ? JoinType.INNER : join.joinType(),
+            join.joinCondition(),
+            join.isFiltered(),
+            true
         );
-        assert newJoin.outputs().equals(nl.outputs()) : "Outputs after rewrite must be the same as before";
+        assert newJoin.outputs().equals(join.outputs()) : "Outputs after rewrite must be the same as before";
         return splitQueries.isEmpty() ? newJoin : new Filter(newJoin, AndOperator.join(splitQueries.values()));
     }
 

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteJoinPlan.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteJoinPlan.java
@@ -70,7 +70,6 @@ public class RewriteJoinPlan implements Rule<JoinPlan> {
                 join.isFiltered(),
                 false,
                 false,
-                false,
                 false
             );
         }

--- a/server/src/test/java/io/crate/planner/optimizer/costs/PlanStatsTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/costs/PlanStatsTest.java
@@ -256,7 +256,7 @@ public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
         );
 
         var nestedLoopJoin = new NestedLoopJoin(
-            lhs, rhs, JoinType.INNER, Literal.BOOLEAN_TRUE, false, false, false, false, false);
+            lhs, rhs, JoinType.INNER, Literal.BOOLEAN_TRUE, false, false, false, false);
 
         var memo = new Memo(nestedLoopJoin);
         PlanStats planStats = new PlanStats(nodeContext, txnCtx, tableStats, memo);
@@ -267,13 +267,13 @@ public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
 
         var joinCondition = e.asSymbol("x = y");
         nestedLoopJoin = new NestedLoopJoin(
-            lhs, rhs, JoinType.INNER, joinCondition, false, false, false, false, false);
+            lhs, rhs, JoinType.INNER, joinCondition, false, false, false, false);
         result = planStats.get(nestedLoopJoin);
         assertThat(result.numDocs()).isEqualTo(1L);
         assertThat(result.sizeInBytes()).isEqualTo(32L);
 
         nestedLoopJoin = new NestedLoopJoin(
-            lhs, rhs, JoinType.CROSS, x, false, false, false, false, false);
+            lhs, rhs, JoinType.CROSS, x, false, false, false, false);
 
         memo = new Memo(nestedLoopJoin);
         planStats = new PlanStats(nodeContext, txnCtx, tableStats, memo);

--- a/server/src/test/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoopTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoopTest.java
@@ -76,7 +76,7 @@ public class MoveConstantJoinConditionsBeneathNestedLoopTest extends CrateDummyC
         var nonConstantPart = sqlExpressions.asSymbol("doc.t1.x = doc.t2.y");
         var constantPart = sqlExpressions.asSymbol("doc.t2.b = 'abc'");
 
-        NestedLoopJoin nl = new NestedLoopJoin(c1, c2, JoinType.INNER, joinCondition, false, false, false, false, false);
+        NestedLoopJoin nl = new NestedLoopJoin(c1, c2, JoinType.INNER, joinCondition, false, false, false, false);
         var rule = new MoveConstantJoinConditionsBeneathNestedLoop();
         Match<NestedLoopJoin> match = rule.pattern().accept(nl, Captures.empty());
 


### PR DESCRIPTION
This migrates the Rule RewriteFilterOnOuterJoinToInnerJoin from NestedLoopJoin to JoinPlan. This makes sense because the Rule is not related to NestedLoopJoin and also it helps with Join-Reordering because the current CrossJoin Elimination operates on inner-joins which also operates on JoinPlan.

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] Added an entry in `CHANGES.txt` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
