### PR TITLE
Fix NPE when inserting null for a float_vector column

### DIFF
--- a/server/src/main/java/io/crate/execution/dml/FloatVectorIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/FloatVectorIndexer.java
@@ -35,6 +35,7 @@ import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.mapper.FloatVectorFieldMapper;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import io.crate.execution.dml.Indexer.ColumnConstraint;
@@ -97,7 +98,7 @@ public class FloatVectorIndexer implements ValueIndexer<float[]> {
                                     FieldType fieldType,
                                     boolean indexed,
                                     boolean hasDocValues,
-                                    float @Nullable [] values,
+                                    float @NotNull [] values,
                                     Consumer<? super IndexableField> addField) {
         if (indexed) {
             addField.accept(new KnnFloatVectorField(fqn, values, fieldType));

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/FloatVectorColumnReference.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/FloatVectorColumnReference.java
@@ -43,7 +43,7 @@ public class FloatVectorColumnReference extends LuceneCollectorExpression<float[
     @Override
     public float[] value() {
         try {
-            if (docValues.advanceExact(doc)) {
+            if (docValues != null && docValues.advanceExact(doc)) {
                 BytesRef bytesRef = docValues.binaryValue();
                 float[] values = new float[bytesRef.length / Float.BYTES];
                 ByteBuffer buffer = ByteBuffer.wrap(bytesRef.bytes, bytesRef.offset, bytesRef.length);

--- a/server/src/test/java/io/crate/integrationtests/PostgresITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PostgresITest.java
@@ -1195,6 +1195,9 @@ public class PostgresITest extends IntegTestCase {
             stmt.setObject(1, 2);
             stmt.setObject(2, new float[] { 2.2f, 2.3f });
             stmt.executeUpdate();
+            stmt.setObject(1, 3);
+            stmt.setObject(2, null);
+            stmt.executeUpdate();
 
             conn.createStatement().execute("refresh table tbl");
             var resultSet = conn.createStatement().executeQuery("select xs from tbl order by id");
@@ -1202,6 +1205,8 @@ public class PostgresITest extends IntegTestCase {
             assertThat(resultSet.getArray(1).getArray()).isEqualTo(new Float[] { 1.2f, 1.3f });
             assertThat(resultSet.next()).isTrue();
             assertThat(resultSet.getArray(1).getArray()).isEqualTo(new Float[] { 2.2f, 2.3f });
+            assertThat(resultSet.next()).isTrue();
+            assertThat(resultSet.getArray(1)).isNull();
         }
     }
 


### PR DESCRIPTION
When `null` value is provided for the array, `getBinaryDocValues()` returns `null`, therefore a check is required when attempting to fetch the float[] value.

Follows: #14437
