### PR TITLE
Store and read column OID instead of the column name

### DIFF
--- a/extensions/functions/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregation.java
+++ b/extensions/functions/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregation.java
@@ -27,10 +27,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
-import org.jetbrains.annotations.Nullable;
-
-import com.carrotsearch.hppc.BitMixer;
-
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.util.BytesRef;
@@ -44,6 +40,9 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.index.fielddata.FieldData;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.search.DocValueFormat;
+import org.jetbrains.annotations.Nullable;
+
+import com.carrotsearch.hppc.BitMixer;
 
 import io.crate.Streamer;
 import io.crate.common.annotations.VisibleForTesting;
@@ -184,7 +183,7 @@ public class HyperLogLogDistinctAggregation extends AggregationFunction<HyperLog
             case TimestampType.ID_WITH_TZ:
             case TimestampType.ID_WITHOUT_TZ:
                 return new SortedNumericDocValueAggregator<>(
-                    reference.column().fqn(),
+                    reference.storageIdent(),
                     (ramAccounting, memoryManager, minNodeVersion) -> {
                         var state = new HllState(dataType, minNodeVersion.onOrAfter(Version.V_4_1_0));
                         var precision = optionalParams.size() == 1 ? (Integer) optionalParams.get(0).value() : HyperLogLogPlusPlus.DEFAULT_PRECISION;
@@ -197,7 +196,7 @@ public class HyperLogLogDistinctAggregation extends AggregationFunction<HyperLog
                 );
             case DoubleType.ID:
                 return new SortedNumericDocValueAggregator<>(
-                    reference.column().fqn(),
+                    reference.storageIdent(),
                     (ramAccounting, memoryManager, minNodeVersion) -> {
                         var state = new HllState(dataType, minNodeVersion.onOrAfter(Version.V_4_1_0));
                         var precision = optionalParams.size() == 1 ? (Integer) optionalParams.get(0).value() : HyperLogLogPlusPlus.DEFAULT_PRECISION;
@@ -216,7 +215,7 @@ public class HyperLogLogDistinctAggregation extends AggregationFunction<HyperLog
                 );
             case FloatType.ID:
                 return new SortedNumericDocValueAggregator<>(
-                    reference.column().fqn(),
+                    reference.storageIdent(),
                     (ramAccounting, memoryManager, minNodeVersion) -> {
                         var state = new HllState(dataType, minNodeVersion.onOrAfter(Version.V_4_1_0));
                         var precision = optionalParams.size() == 1 ? (Integer) optionalParams.get(0).value() : HyperLogLogPlusPlus.DEFAULT_PRECISION;
@@ -235,7 +234,7 @@ public class HyperLogLogDistinctAggregation extends AggregationFunction<HyperLog
             case StringType.ID:
             case CharacterType.ID:
                 var precision = optionalParams.size() == 1 ? (Integer) optionalParams.get(0).value() : HyperLogLogPlusPlus.DEFAULT_PRECISION;
-                return new HllAggregator(reference.column().fqn(), dataType, precision) {
+                return new HllAggregator(reference.storageIdent(), dataType, precision) {
                     @Override
                     public void apply(RamAccounting ramAccounting, int doc, HllState state) throws IOException {
                         if (super.values.advanceExact(doc) && super.values.docValueCount() == 1) {
@@ -250,7 +249,7 @@ public class HyperLogLogDistinctAggregation extends AggregationFunction<HyperLog
                 };
             case IpType.ID:
                 var ipPrecision = optionalParams.size() == 1 ? (Integer) optionalParams.get(0).value() : HyperLogLogPlusPlus.DEFAULT_PRECISION;
-                return new HllAggregator(reference.column().fqn(), dataType, ipPrecision) {
+                return new HllAggregator(reference.storageIdent(), dataType, ipPrecision) {
                     @Override
                     public void apply(RamAccounting ramAccounting, int doc, HllState state) throws IOException {
                         if (super.values.advanceExact(doc) && super.values.docValueCount() == 1) {

--- a/server/src/main/java/io/crate/execution/ddl/tables/MappingUtil.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/MappingUtil.java
@@ -116,7 +116,7 @@ public final class MappingUtil {
         Map<String, Object> indices = new HashMap<>();
         for (Reference column : columns) {
             if (column instanceof IndexReference indexRef && !indexRef.columns().isEmpty()) {
-                indices.put(column.column().name(), Map.of());
+                indices.put(column.storageIdent(), Map.of());
             }
         }
         if (indices.isEmpty() == false) {

--- a/server/src/main/java/io/crate/execution/dml/ArrayIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/ArrayIndexer.java
@@ -25,13 +25,14 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import org.apache.lucene.index.IndexableField;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.jetbrains.annotations.Nullable;
 
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
-import org.jetbrains.annotations.Nullable;
 
 public class ArrayIndexer<T> implements ValueIndexer<List<T>> {
 
@@ -77,5 +78,10 @@ public class ArrayIndexer<T> implements ValueIndexer<List<T>> {
                 }
             }
         }
+    }
+
+    @Override
+    public void updateTargets(Function<ColumnIdent, Reference> getRef) {
+        innerIndexer.updateTargets(getRef);
     }
 }

--- a/server/src/main/java/io/crate/execution/dml/BitStringIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/BitStringIndexer.java
@@ -51,7 +51,7 @@ public class BitStringIndexer implements ValueIndexer<BitString> {
 
     public BitStringIndexer(Reference ref, FieldType fieldType) {
         this.ref = ref;
-        this.name = ref.column().fqn();
+        this.name = ref.storageIdent();
         this.fieldType = fieldType == null
             ? BitStringFieldMapper.Defaults.FIELD_TYPE
             : fieldType;

--- a/server/src/main/java/io/crate/execution/dml/BooleanIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/BooleanIndexer.java
@@ -47,7 +47,7 @@ public class BooleanIndexer implements ValueIndexer<Boolean> {
 
     public BooleanIndexer(Reference ref, FieldType fieldType) {
         this.ref = ref;
-        this.name = ref.column().fqn();
+        this.name = ref.storageIdent();
         this.fieldType = fieldType == null ? BooleanFieldMapper.Defaults.FIELD_TYPE : fieldType;
     }
 

--- a/server/src/main/java/io/crate/execution/dml/DoubleIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/DoubleIndexer.java
@@ -53,7 +53,7 @@ public class DoubleIndexer implements ValueIndexer<Number> {
     public DoubleIndexer(Reference ref, @Nullable FieldType fieldType) {
         this.ref = ref;
         this.fieldType = fieldType == null ? NumberFieldMapper.FIELD_TYPE : fieldType;
-        this.name = ref.column().fqn();
+        this.name = ref.storageIdent();
     }
 
     @Override

--- a/server/src/main/java/io/crate/execution/dml/DynamicIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/DynamicIndexer.java
@@ -21,6 +21,8 @@
 
 package io.crate.execution.dml;
 
+import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
+
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
@@ -30,6 +32,7 @@ import java.util.function.Function;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.IndexableField;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.jetbrains.annotations.Nullable;
 
 import io.crate.execution.dml.Indexer.ColumnConstraint;
 import io.crate.execution.dml.Indexer.Synthetic;
@@ -50,22 +53,19 @@ import io.crate.types.IntegerType;
 import io.crate.types.ShortType;
 import io.crate.types.StorageSupport;
 import io.crate.types.UndefinedType;
-import org.jetbrains.annotations.Nullable;
-
-import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
 
 public final class DynamicIndexer implements ValueIndexer<Object> {
 
     private final ReferenceIdent refIdent;
-    private final Function<ColumnIdent, FieldType> getFieldType;
-    private final Function<ColumnIdent, Reference> getRef;
+    private final Function<String, FieldType> getFieldType;
+    private Function<ColumnIdent, Reference> getRef;
     private final int position;
     private DataType<?> type = null;
     private ValueIndexer<Object> indexer;
 
     public DynamicIndexer(ReferenceIdent refIdent,
                           int position,
-                          Function<ColumnIdent, FieldType> getFieldType,
+                          Function<String, FieldType> getFieldType,
                           Function<ColumnIdent, Reference> getRef) {
         this.refIdent = refIdent;
         this.getFieldType = getFieldType;

--- a/server/src/main/java/io/crate/execution/dml/FloatIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/FloatIndexer.java
@@ -50,7 +50,7 @@ public class FloatIndexer implements ValueIndexer<Float> {
 
     public FloatIndexer(Reference ref, FieldType fieldType) {
         this.ref = ref;
-        this.name = ref.column().fqn();
+        this.name = ref.storageIdent();
         this.fieldType = fieldType;
     }
 

--- a/server/src/main/java/io/crate/execution/dml/FloatVectorIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/FloatVectorIndexer.java
@@ -61,7 +61,7 @@ public class FloatVectorIndexer implements ValueIndexer<float[]> {
             );
         }
         this.ref = ref;
-        this.name = ref.column().fqn();
+        this.name = ref.storageIdent();
         this.fieldType = fieldType;
     }
 

--- a/server/src/main/java/io/crate/execution/dml/FulltextIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/FulltextIndexer.java
@@ -56,7 +56,7 @@ public class FulltextIndexer implements ValueIndexer<String> {
         if (value == null) {
             return;
         }
-        String name = ref.column().fqn();
+        String name = ref.storageIdent();
         if (fieldType.indexOptions() != IndexOptions.NONE || fieldType.stored()) {
             Field field = new Field(name, value, fieldType);
             addField.accept(field);

--- a/server/src/main/java/io/crate/execution/dml/GeoPointIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/GeoPointIndexer.java
@@ -50,7 +50,7 @@ public class GeoPointIndexer implements ValueIndexer<Point> {
 
     public GeoPointIndexer(Reference ref, FieldType fieldType) {
         this.ref = ref;
-        this.name = ref.column().fqn();
+        this.name = ref.storageIdent();
         this.fieldType = fieldType == null ? GeoShapeFieldMapper.FIELD_TYPE : fieldType;
     }
 

--- a/server/src/main/java/io/crate/execution/dml/GeoShapeIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/GeoShapeIndexer.java
@@ -49,7 +49,7 @@ public class GeoShapeIndexer implements ValueIndexer<Map<String, Object>> {
     public GeoShapeIndexer(Reference ref, FieldType fieldType) {
         assert ref instanceof GeoReference : "GeoShapeIndexer requires GeoReference";
         this.ref = (GeoReference) ref;
-        this.name = ref.column().fqn();
+        this.name = ref.storageIdent();
         this.strategy = new RecursivePrefixTreeStrategy(this.ref.prefixTree(), name);
         Double distanceErrorPct = this.ref.distanceErrorPct();
         if (distanceErrorPct != null) {

--- a/server/src/main/java/io/crate/execution/dml/Indexer.java
+++ b/server/src/main/java/io/crate/execution/dml/Indexer.java
@@ -22,6 +22,8 @@
 
 package io.crate.execution.dml;
 
+import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -83,8 +85,6 @@ import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.ObjectType;
 
-import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
-
 /**
  * <p>
  *  Component to create a {@link ParsedDocument} from a {@link IndexItem}
@@ -127,7 +127,14 @@ public class Indexer {
     private final BytesStreamOutput stream;
     private final boolean writeOids;
 
-    record IndexColumn(ColumnIdent name, FieldType fieldType, List<Input<?>> inputs) {
+    /**
+     * Function to resolve a field type based on the columns {@link Reference#storageIdent()}.
+     */
+    private final Function<String, FieldType> getFieldType;
+
+    private final Map<ColumnIdent, Reference> newColumns = new HashMap<>();
+
+    record IndexColumn(Reference reference, FieldType fieldType, List<Input<?>> inputs) {
     }
 
     static class RefResolver implements ReferenceResolver<CollectExpression<IndexItem, Object>> {
@@ -358,12 +365,15 @@ public class Indexer {
         }
     }
 
+    /**
+     * @param getFieldType  A function to resolve a {@link FieldType} by {@link Reference#storageIdent()}
+     */
     @SuppressWarnings("unchecked")
     public Indexer(String indexName,
                    DocTableInfo table,
                    TransactionContext txnCtx,
                    NodeContext nodeCtx,
-                   Function<ColumnIdent, FieldType> getFieldType,
+                   Function<String, FieldType> getFieldType,
                    List<Reference> targetColumns,
                    Symbol[] returnValues) {
         this.symbolEval = new SymbolEvaluator(txnCtx, nodeCtx, SubQueryResults.EMPTY);
@@ -371,6 +381,8 @@ public class Indexer {
         this.synthetics = new HashMap<>();
         this.stream = new BytesStreamOutput();
         this.writeOids = table.versionCreated().onOrAfter(Version.V_5_5_0);
+        this.getFieldType = getFieldType;
+        Function<ColumnIdent, Reference> getRef = table::getReference;
         PartitionName partitionName = table.isPartitioned()
             ? PartitionName.fromIndexOrTemplate(indexName)
             : null;
@@ -380,7 +392,6 @@ public class Indexer {
             txnCtx,
             referenceResolver
         );
-        Function<ColumnIdent, Reference> getRef = table::getReference;
         this.valueIndexers = new ArrayList<>(targetColumns.size());
         int position = -1;
         for (var ref : targetColumns) {
@@ -493,7 +504,7 @@ public class Indexer {
         this.indexColumns = new ArrayList<>(table.indexColumns().size());
         for (var ref : table.indexColumns()) {
             ArrayList<Input<?>> indexInputs = new ArrayList<>(ref.columns().size());
-            FieldType fieldType = getFieldType.apply(ref.column());
+            FieldType fieldType = getFieldType.apply(ref.storageIdent());
 
             for (var sourceRef : ref.columns()) {
                 Reference reference = table.getReference(sourceRef.column());
@@ -503,7 +514,7 @@ public class Indexer {
                 indexInputs.add(input);
             }
             if (fieldType.indexOptions() != IndexOptions.NONE) {
-                indexColumns.add(new IndexColumn(ref.column(), fieldType, indexInputs));
+                indexColumns.add(new IndexColumn(ref, fieldType, indexInputs));
             }
         }
         if (returnValues == null) {
@@ -518,20 +529,51 @@ public class Indexer {
     }
 
     /**
-     * @param addedColumns has columns collected by {@link #collectSchemaUpdates(IndexItem) and with assigned OID0-s
+     * Trigger resolving of columns and update indexers if needed.
+     * Should be only triggered when new columns were detected by {@link #collectSchemaUpdates(IndexItem)
+     * and added to the cluster state
+     *
+     * @param getRef A function that returns a reference for a given column ident based on the current cluster state
      */
-    public void updateTargets(List<Reference> addedColumns) {
-        // Store by ident for fast replacement.
-        Map<ColumnIdent, Reference> addedColumnsByIdent = new HashMap<>();
-        for (Reference ref: addedColumns) {
-            addedColumnsByIdent.put(ref.column(), ref);
+    public void updateTargets(Function<ColumnIdent, Reference> getRef) {
+        var it = columns.iterator();
+        var idx = 0;
+        while (it.hasNext()) {
+            var oldRef = it.next();
+            if (oldRef.oid() == COLUMN_OID_UNASSIGNED) {
+                // try to resolve the column again, new reference may have been added to or dropped of the table or
+                // the reference may be invalid
+                Reference newRef = getRef.apply(oldRef.column());
+                if (newRef == null) {
+                    // column was dropped or new column is invalid
+                    it.remove();
+                    valueIndexers.remove(idx);
+                    // don't increase idx, since we removed the current element
+                    continue;
+                }
+                if (oldRef.equals(newRef) == false) {
+                    columns.set(idx, newRef);
+                    valueIndexers.set(idx, newRef.valueType().valueIndexer(
+                            newRef.ident().tableIdent(),
+                            newRef,
+                            getFieldType,
+                            getRef
+                    ));
+                }
+            } else {
+                valueIndexers.get(idx).updateTargets(getRef);
+            }
+            idx++;
         }
 
-        for (int i = 0; i < columns.size(); i++) {
-            Reference referenceWithOid = addedColumnsByIdent.get(columns.get(i).column());
-            if (referenceWithOid != null) {
-                columns.set(i, referenceWithOid);
+        for (var entry : synthetics.entrySet()) {
+            ColumnIdent column = entry.getKey();
+            if (!column.isRoot()) {
+                continue;
             }
+            Synthetic synthetic = entry.getValue();
+            ValueIndexer<Object> indexer = synthetic.indexer();
+            indexer.updateTargets(getRef);
         }
     }
 
@@ -648,9 +690,6 @@ public class Indexer {
             Object[] values = item.insertValues();
             for (int i = 0; i < values.length; i++) {
                 Reference reference = columns.get(i);
-                    // It's possible to have target references without OID after doing a mapping update:
-                    // Empty arrays, arrays with only null values and columns added dynamically into IGNORED object doesn't result in schema update.
-                    assert assertExistingOid(reference) : "All target columns must have assigned OID on indexing.";
 
                 Object value = reference.valueType().valueForInsert(values[i]);
                 ColumnConstraint check = columnConstraints.get(reference.column());
@@ -664,7 +703,7 @@ public class Indexer {
                     continue;
                 }
                 ValueIndexer<Object> valueIndexer = (ValueIndexer<Object>) valueIndexers.get(i);
-                xContentBuilder.field(reference.column().leafName());
+                xContentBuilder.field(reference.storageIdentLeafName());
                 valueIndexer.indexValue(
                     reference.valueType().sanitizeValue(value),
                     xContentBuilder,
@@ -684,7 +723,7 @@ public class Indexer {
                 if (value == null) {
                     continue;
                 }
-                xContentBuilder.field(column.leafName());
+                xContentBuilder.field(synthetic.ref.storageIdentLeafName());
                 indexer.indexValue(
                     value,
                     xContentBuilder,
@@ -696,7 +735,7 @@ public class Indexer {
             xContentBuilder.endObject();
 
             for (var indexColumn : indexColumns) {
-                String fqn = indexColumn.name.fqn();
+                String fqn = indexColumn.reference.storageIdent();
                 for (var input : indexColumn.inputs) {
                     Object value = input.value();
                     if (value == null) {

--- a/server/src/main/java/io/crate/execution/dml/IntIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/IntIndexer.java
@@ -50,7 +50,7 @@ public class IntIndexer implements ValueIndexer<Number> {
 
     public IntIndexer(Reference ref, @Nullable FieldType fieldType) {
         this.ref = ref;
-        this.name = ref.column().fqn();
+        this.name = ref.storageIdent();
         this.fieldType = fieldType == null ? NumberFieldMapper.FIELD_TYPE : fieldType;
     }
 

--- a/server/src/main/java/io/crate/execution/dml/IpIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/IpIndexer.java
@@ -51,7 +51,7 @@ public class IpIndexer implements ValueIndexer<String> {
 
     public IpIndexer(Reference ref, FieldType fieldType) {
         this.ref = ref;
-        this.name = ref.column().fqn();
+        this.name = ref.storageIdent();
         this.fieldType = fieldType;
     }
 

--- a/server/src/main/java/io/crate/execution/dml/LongIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/LongIndexer.java
@@ -50,7 +50,7 @@ public class LongIndexer implements ValueIndexer<Long> {
     public LongIndexer(Reference ref, @Nullable FieldType fieldType) {
         this.ref = ref;
         this.fieldType = fieldType == null ? NumberFieldMapper.FIELD_TYPE : fieldType;
-        this.name = ref.column().fqn();
+        this.name = ref.storageIdent();
     }
 
     @Override

--- a/server/src/main/java/io/crate/execution/dml/RawIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/RawIndexer.java
@@ -52,7 +52,8 @@ public class RawIndexer {
     private final DocTableInfo table;
     private final TransactionContext txnCtx;
     private final NodeContext nodeCtx;
-    private final Function<ColumnIdent, FieldType> getFieldType;
+    private final Function<ColumnIdent, Reference> getRef;
+    private final Function<String, FieldType> getFieldType;
     private final Symbol[] returnValues;
 
     private final Map<Set<String>, Indexer> indexers = new HashMap<>();
@@ -66,13 +67,14 @@ public class RawIndexer {
                       DocTableInfo table,
                       TransactionContext txnCtx,
                       NodeContext nodeCtx,
-                      Function<ColumnIdent, FieldType> getFieldType,
+                      Function<String, FieldType> getFieldType,
                       Symbol[] returnValues,
                       @NotNull List<Reference> nonDeterministicSynthetics) {
         this.indexName = indexName;
         this.table = table;
         this.txnCtx = txnCtx;
         this.nodeCtx = nodeCtx;
+        this.getRef = table::getReference;
         this.getFieldType = getFieldType;
         this.returnValues = returnValues;
         this.nonDeterministicSynthetics = nonDeterministicSynthetics;
@@ -143,6 +145,12 @@ public class RawIndexer {
         );
 
         return currentRowIndexer.collectSchemaUpdates(currentItem);
+    }
+
+    public void updateTargets(Function<ColumnIdent, Reference> getRef) {
+        for (var indexer : indexers.values()) {
+            indexer.updateTargets(getRef);
+        }
     }
 
     /**

--- a/server/src/main/java/io/crate/execution/dml/RawIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/RawIndexer.java
@@ -30,12 +30,13 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 
-import io.crate.execution.dml.upsert.ShardUpsertRequest;
 import org.apache.lucene.document.FieldType;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.mapper.ParsedDocument;
+import org.jetbrains.annotations.NotNull;
 
 import io.crate.exceptions.ConversionException;
+import io.crate.execution.dml.upsert.ShardUpsertRequest;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.NodeContext;
@@ -44,7 +45,6 @@ import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.server.xcontent.XContentHelper;
 import io.crate.types.DataType;
-import org.jetbrains.annotations.NotNull;
 
 public class RawIndexer {
 

--- a/server/src/main/java/io/crate/execution/dml/StringIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/StringIndexer.java
@@ -57,7 +57,7 @@ public class StringIndexer implements ValueIndexer<String> {
                            Map<ColumnIdent, Indexer.Synthetic> synthetics,
                            Map<ColumnIdent, Indexer.ColumnConstraint> toValidate) throws IOException {
         xcontentBuilder.value(value);
-        String name = ref.column().fqn();
+        String name = ref.storageIdent();
         BytesRef binaryValue = new BytesRef(value);
         if (fieldType.indexOptions() != IndexOptions.NONE || fieldType.stored()) {
             Field field = new Field(name, binaryValue, fieldType);

--- a/server/src/main/java/io/crate/execution/dml/ValueIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/ValueIndexer.java
@@ -24,11 +24,11 @@ package io.crate.execution.dml;
 import java.io.IOException;
 import java.util.Map;
 import java.util.function.Consumer;
-
-import org.jetbrains.annotations.Nullable;
+import java.util.function.Function;
 
 import org.apache.lucene.index.IndexableField;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.jetbrains.annotations.Nullable;
 
 import io.crate.execution.dml.Indexer.ColumnConstraint;
 import io.crate.metadata.ColumnIdent;
@@ -56,6 +56,15 @@ public interface ValueIndexer<T> {
     default void collectSchemaUpdates(@Nullable T value,
                                       Consumer<? super Reference> onDynamicColumn,
                                       Map<ColumnIdent, Indexer.Synthetic> synthetics) throws IOException {}
+
+    /**
+     * Update value indexer of inner columns.
+     * Should be only triggered when new columns were detected by {@link #collectSchemaUpdates(Object, Consumer, Map)
+     * and added to the cluster state
+     *
+     * @param getRef A function that returns a reference for a given column ident based on the current cluster state
+     */
+    default void updateTargets(Function<ColumnIdent, Reference> getRef) {}
 
     void indexValue(
         @Nullable T value,

--- a/server/src/main/java/io/crate/execution/dml/upsert/UpdateToInsert.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/UpdateToInsert.java
@@ -118,6 +118,7 @@ public final class UpdateToInsert {
     private final List<Reference> updateColumns;
     private final ArrayList<Reference> columns;
 
+
     record Values(Doc doc, Object[] excludedValues) {
     }
 
@@ -207,6 +208,7 @@ public final class UpdateToInsert {
             ? 0
             : table.primaryKey().size();
         String[] primaryKeys = new String[pkSize];
+
 
         Iterator<Reference> it = columns.iterator();
         for (int i = 0; it.hasNext(); i++) {

--- a/server/src/main/java/io/crate/execution/dml/upsert/UpdateToInsert.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/UpdateToInsert.java
@@ -149,7 +149,7 @@ public final class UpdateToInsert {
                           TransactionContext txnCtx,
                           DocTableInfo table,
                           String[] updateColumns,
-                          @Nullable Reference[] insertColumns) {
+                          @Nullable List<Reference> insertColumns) {
         var refResolver = new DocRefResolver(table.partitionedBy());
         this.table = table;
         this.eval = new Evaluator(nodeCtx, txnCtx, refResolver);
@@ -157,9 +157,7 @@ public final class UpdateToInsert {
         this.columns = new ArrayList<>();
         boolean errorOnUnknownObjectKey = txnCtx.sessionSettings().errorOnUnknownObjectKey();
         if (insertColumns != null) {
-            for (Reference insertColumn : insertColumns) {
-                this.columns.add(insertColumn);
-            }
+            this.columns.addAll(insertColumns);
         }
         for (var ref : table.columns()) {
             // The Indexer later on injects the generated column values

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregation.java
@@ -164,18 +164,18 @@ public class ArbitraryAggregation extends AggregationFunction<Object, Object> {
             case TimestampType.ID_WITH_TZ:
             case TimestampType.ID_WITHOUT_TZ:
                 return new LongArbitraryDocValueAggregator<>(
-                    arg.column().fqn(),
+                    arg.storageIdent(),
                     dataType
                 );
             case FloatType.ID:
-                return new FloatArbitraryDocValueAggregator(arg.column().fqn());
+                return new FloatArbitraryDocValueAggregator(arg.storageIdent());
             case DoubleType.ID:
-                return new DoubleArbitraryDocValueAggregator(arg.column().fqn());
+                return new DoubleArbitraryDocValueAggregator(arg.storageIdent());
             case IpType.ID:
-                return new ArbitraryIPDocValueAggregator(arg.column().fqn());
+                return new ArbitraryIPDocValueAggregator(arg.storageIdent());
             case StringType.ID:
                 return new ArbitraryBinaryDocValueAggregator<>(
-                    arg.column().fqn(),
+                    arg.storageIdent(),
                     dataType
                 );
             default:

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/CmpByAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/CmpByAggregation.java
@@ -171,14 +171,14 @@ public final class CmpByAggregation extends AggregationFunction<CmpByAggregation
                 var resultExpression = referenceResolver.getImplementation(aggregationReferences.get(0));
                 if (signature.getName().name().equalsIgnoreCase("min_by")) {
                     return new MinByLong(
-                        searchRef.column().fqn(),
+                        searchRef.storageIdent(),
                         searchType,
                         resultExpression,
                         new CollectorContext(table.droppedColumns(), table.lookupNameBySourceKey())
                     );
                 } else {
                     return new MaxByLong(
-                        searchRef.column().fqn(),
+                        searchRef.storageIdent(),
                         searchType,
                         resultExpression,
                         new CollectorContext(table.droppedColumns(), table.lookupNameBySourceKey())

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/CountAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/CountAggregation.java
@@ -263,7 +263,7 @@ public class CountAggregation extends AggregationFunction<MutableLong, Long> {
             case DoubleType.ID:
             case GeoPointType.ID:
                 return new SortedNumericDocValueAggregator<>(
-                    ref.column().fqn(),
+                    ref.storageIdent(),
                     (ramAccounting, memoryManager, minNodeVersion) -> {
                         ramAccounting.addBytes(LongStateType.INSTANCE.fixedSize());
                         return new MutableLong(0L);
@@ -274,7 +274,7 @@ public class CountAggregation extends AggregationFunction<MutableLong, Long> {
             case StringType.ID:
             case BitStringType.ID:
                 return new BinaryDocValueAggregator<>(
-                    ref.column().fqn(),
+                    ref.storageIdent(),
                     (ramAccounting, memoryManager, minNodeVersion) -> {
                         ramAccounting.addBytes(LongStateType.INSTANCE.fixedSize());
                         return new MutableLong(0L);

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregation.java
@@ -317,7 +317,7 @@ public class GeometricMeanAggregation extends AggregationFunction<GeometricMeanA
             case TimestampType.ID_WITH_TZ:
             case TimestampType.ID_WITHOUT_TZ:
                 return new SortedNumericDocValueAggregator<>(
-                    reference.column().fqn(),
+                    reference.storageIdent(),
                     (ramAccounting, memoryManager, minNodeVersion) -> {
                         ramAccounting.addBytes(GeometricMeanStateType.INSTANCE.fixedSize());
                         return new GeometricMeanState();
@@ -326,7 +326,7 @@ public class GeometricMeanAggregation extends AggregationFunction<GeometricMeanA
                 );
             case FloatType.ID:
                 return new SortedNumericDocValueAggregator<>(
-                    reference.column().fqn(),
+                    reference.storageIdent(),
                     (ramAccounting, memoryManager, minNodeVersion) -> {
                         ramAccounting.addBytes(GeometricMeanStateType.INSTANCE.fixedSize());
                         return new GeometricMeanState();
@@ -338,7 +338,7 @@ public class GeometricMeanAggregation extends AggregationFunction<GeometricMeanA
                 );
             case DoubleType.ID:
                 return new SortedNumericDocValueAggregator<>(
-                    reference.column().fqn(),
+                    reference.storageIdent(),
                     (ramAccounting, memoryManager, minNodeVersion) -> {
                         ramAccounting.addBytes(GeometricMeanStateType.INSTANCE.fixedSize());
                         return new GeometricMeanState();

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
@@ -230,12 +230,12 @@ public abstract class MaximumAggregation extends AggregationFunction<Object, Obj
                 case LongType.ID:
                 case TimestampType.ID_WITH_TZ:
                 case TimestampType.ID_WITHOUT_TZ:
-                    return new LongMax(reference.column().fqn(), arg);
+                    return new LongMax(reference.storageIdent(), arg);
 
                 case FloatType.ID:
-                    return new FloatMax(reference.column().fqn());
+                    return new FloatMax(reference.storageIdent());
                 case DoubleType.ID:
-                    return new DoubleMax(reference.column().fqn());
+                    return new DoubleMax(reference.storageIdent());
 
                 default:
                     return null;

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/MinimumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/MinimumAggregation.java
@@ -264,12 +264,12 @@ public abstract class MinimumAggregation extends AggregationFunction<Object, Obj
                 case LongType.ID:
                 case TimestampType.ID_WITH_TZ:
                 case TimestampType.ID_WITHOUT_TZ:
-                    return new LongMin(reference.column().fqn(), arg);
+                    return new LongMin(reference.storageIdent(), arg);
 
                 case FloatType.ID:
-                    return new FloatMin(reference.column().fqn());
+                    return new FloatMin(reference.storageIdent());
                 case DoubleType.ID:
-                    return new DoubleMin(reference.column().fqn());
+                    return new DoubleMin(reference.storageIdent());
 
                 default:
                     return null;

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/NumericSumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/NumericSumAggregation.java
@@ -186,9 +186,9 @@ public class NumericSumAggregation extends AggregationFunction<BigDecimal, BigDe
         }
         return switch (reference.valueType().id()) {
             case ByteType.ID, ShortType.ID, IntegerType.ID, LongType.ID ->
-                new SumLong(returnType, reference.column().fqn());
-            case FloatType.ID -> new SumFloat(returnType, reference.column().fqn());
-            case DoubleType.ID -> new SumDouble(returnType, reference.column().fqn());
+                new SumLong(returnType, reference.storageIdent());
+            case FloatType.ID -> new SumFloat(returnType, reference.storageIdent());
+            case DoubleType.ID -> new SumDouble(returnType, reference.storageIdent());
             default -> null;
         };
     }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationAggregation.java
@@ -239,7 +239,7 @@ public class StandardDeviationAggregation extends AggregationFunction<StandardDe
             case TimestampType.ID_WITH_TZ:
             case TimestampType.ID_WITHOUT_TZ:
                 return new SortedNumericDocValueAggregator<>(
-                    reference.column().fqn(),
+                    reference.storageIdent(),
                     (ramAccounting, memoryManager, minNodeVersion) -> {
                         ramAccounting.addBytes(StdDevStateType.INSTANCE.fixedSize());
                         return new StandardDeviation();
@@ -248,7 +248,7 @@ public class StandardDeviationAggregation extends AggregationFunction<StandardDe
                 );
             case FloatType.ID:
                 return new SortedNumericDocValueAggregator<>(
-                    reference.column().fqn(),
+                    reference.storageIdent(),
                     (ramAccounting, memoryManager, minNodeVersion) -> {
                         ramAccounting.addBytes(StdDevStateType.INSTANCE.fixedSize());
                         return new StandardDeviation();
@@ -260,7 +260,7 @@ public class StandardDeviationAggregation extends AggregationFunction<StandardDe
                 );
             case DoubleType.ID:
                 return new SortedNumericDocValueAggregator<>(
-                    reference.column().fqn(),
+                    reference.storageIdent(),
                     (ramAccounting, memoryManager, minNodeVersion) -> {
                         ramAccounting.addBytes(StdDevStateType.INSTANCE.fixedSize());
                         return new StandardDeviation();

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/SumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/SumAggregation.java
@@ -201,12 +201,12 @@ public class SumAggregation<T extends Number> extends AggregationFunction<T, T> 
             case ShortType.ID:
             case IntegerType.ID:
             case LongType.ID:
-                return new SumLong(reference.column().fqn());
+                return new SumLong(reference.storageIdent());
 
             case FloatType.ID:
-                return new SumFloat(reference.column().fqn());
+                return new SumFloat(reference.storageIdent());
             case DoubleType.ID:
-                return new SumDouble(reference.column().fqn());
+                return new SumDouble(reference.storageIdent());
 
             default:
                 return null;

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
@@ -239,7 +239,7 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
             case TimestampType.ID_WITH_TZ:
             case TimestampType.ID_WITHOUT_TZ:
                 return new SortedNumericDocValueAggregator<>(
-                    reference.column().fqn(),
+                    reference.storageIdent(),
                     (ramAccounting, memoryManager, minNodeVersion) -> {
                         ramAccounting.addBytes(VarianceStateType.INSTANCE.fixedSize());
                         return new Variance();
@@ -248,7 +248,7 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
                 );
             case FloatType.ID:
                 return new SortedNumericDocValueAggregator<>(
-                    reference.column().fqn(),
+                    reference.storageIdent(),
                     (ramAccounting, memoryManager, minNodeVersion) -> {
                         ramAccounting.addBytes(VarianceStateType.INSTANCE.fixedSize());
                         return new Variance();
@@ -260,7 +260,7 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
                 );
             case DoubleType.ID:
                 return new SortedNumericDocValueAggregator<>(
-                    reference.column().fqn(),
+                    reference.storageIdent(),
                     (ramAccounting, memoryManager, minNodeVersion) -> {
                         ramAccounting.addBytes(VarianceStateType.INSTANCE.fixedSize());
                         return new Variance();

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/AverageAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/AverageAggregation.java
@@ -319,7 +319,7 @@ public class AverageAggregation extends AggregationFunction<AverageAggregation.A
             case IntegerType.ID:
             case LongType.ID:
                 return new SortedNumericDocValueAggregator<>(
-                    reference.column().fqn(),
+                    reference.storageIdent(),
                     (ramAccounting, memoryManager, minNodeVersion) -> {
                         ramAccounting.addBytes(AverageStateType.INSTANCE.fixedSize());
                         return new AverageState();
@@ -330,7 +330,7 @@ public class AverageAggregation extends AggregationFunction<AverageAggregation.A
                 );
             case FloatType.ID:
                 return new SortedNumericDocValueAggregator<>(
-                    reference.column().fqn(),
+                    reference.storageIdent(),
                     (ramAccounting, memoryManager, minNodeVersion) -> {
                         ramAccounting.addBytes(AverageStateType.INSTANCE.fixedSize());
                         return new AverageState();
@@ -342,7 +342,7 @@ public class AverageAggregation extends AggregationFunction<AverageAggregation.A
                 );
             case DoubleType.ID:
                 return new SortedNumericDocValueAggregator<>(
-                    reference.column().fqn(),
+                    reference.storageIdent(),
                     (ramAccounting, memoryManager, minNodeVersion) -> {
                         ramAccounting.addBytes(AverageStateType.INSTANCE.fixedSize());
                         return new AverageState();

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/numeric/NumericAverageAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/numeric/NumericAverageAggregation.java
@@ -202,9 +202,9 @@ public class NumericAverageAggregation extends AggregationFunction<NumericAverag
         var argumentTypes = Symbols.typeView(aggregationReferences);
         return switch (argumentTypes.get(0).id()) {
             case ByteType.ID, ShortType.ID, IntegerType.ID, LongType.ID ->
-                new AvgLong(reference.column().fqn());
-            case FloatType.ID -> new AvgFloat(returnType, reference.column().fqn());
-            case DoubleType.ID -> new AvgDouble(returnType, reference.column().fqn());
+                new AvgLong(reference.storageIdent());
+            case FloatType.ID -> new AvgFloat(returnType, reference.storageIdent());
+            case DoubleType.ID -> new AvgDouble(returnType, reference.storageIdent());
             default -> null;
         };
     }

--- a/server/src/main/java/io/crate/execution/engine/collect/collectors/OptimizeQueryForSearchAfter.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/collectors/OptimizeQueryForSearchAfter.java
@@ -75,27 +75,27 @@ public class OptimizeQueryForSearchAfter implements Function<FieldDoc, Query> {
                     // no filter needed
                     continue;
                 }
-                String columnName = columnIdent.fqn();
+                String storageIdent = ref.storageIdent();
                 Query orderQuery;
                 // nulls already gone, so they should be excluded
                 if (nullsFirst) {
                     BooleanQuery.Builder booleanQuery = new BooleanQuery.Builder();
                     booleanQuery.add(new MatchAllDocsQuery(), BooleanClause.Occur.MUST);
                     if (orderBy.reverseFlags()[i]) {
-                        booleanQuery.add(eqQuery.rangeQuery(columnName, null, value, false, true, ref.hasDocValues()),
+                        booleanQuery.add(eqQuery.rangeQuery(storageIdent, null, value, false, true, ref.hasDocValues()),
                                          BooleanClause.Occur.MUST_NOT);
                     } else {
-                        booleanQuery.add(eqQuery.rangeQuery(columnName, value, null, true, false, ref.hasDocValues()),
+                        booleanQuery.add(eqQuery.rangeQuery(storageIdent, value, null, true, false, ref.hasDocValues()),
                                          BooleanClause.Occur.MUST_NOT);
                     }
                     orderQuery = booleanQuery.build();
                 } else {
                     if (orderBy.reverseFlags()[i]) {
                         orderQuery = eqQuery.rangeQuery(
-                                columnName, value, null, false, false, ref.hasDocValues());
+                                storageIdent, value, null, false, false, ref.hasDocValues());
                     } else {
                         orderQuery = eqQuery.rangeQuery(
-                                columnName, null, value, false, false, ref.hasDocValues());
+                                storageIdent, null, value, false, false, ref.hasDocValues());
                     }
                 }
                 queryBuilder.add(orderQuery, BooleanClause.Occur.MUST);

--- a/server/src/main/java/io/crate/execution/engine/sort/SortSymbolVisitor.java
+++ b/server/src/main/java/io/crate/execution/engine/sort/SortSymbolVisitor.java
@@ -144,7 +144,7 @@ public class SortSymbolVisitor extends SymbolVisitor<SortSymbolVisitor.SortSymbo
             return customSortField(ref.toString(), ref, context);
         }
 
-        MappedFieldType fieldType = fieldTypeLookup.get(columnIdent.fqn());
+        MappedFieldType fieldType = fieldTypeLookup.get(ref.storageIdent());
         if (fieldType == null) {
             FieldComparatorSource fieldComparatorSource = new NullFieldComparatorSource(NullSentinelValues.nullSentinelForScoreDoc(
                 ref.valueType(),
@@ -152,7 +152,7 @@ public class SortSymbolVisitor extends SymbolVisitor<SortSymbolVisitor.SortSymbo
                 context.nullFirst
             ));
             return new SortField(
-                columnIdent.fqn(),
+                ref.storageIdent(),
                 fieldComparatorSource,
                 context.reverseFlag);
         } else if (ref.valueType().equals(DataTypes.IP)
@@ -172,7 +172,7 @@ public class SortSymbolVisitor extends SymbolVisitor<SortSymbolVisitor.SortSymbo
     static SortField mappedSortField(Reference symbol,
                                      boolean reverse,
                                      NullValueOrder nullValueOrder) {
-        String fieldName = symbol.column().fqn();
+        String fieldName = symbol.storageIdent();
         MultiValueMode sortMode = reverse ? MultiValueMode.MAX : MultiValueMode.MIN;
         switch (symbol.valueType().id()) {
             case StringType.ID, CharacterType.ID -> {

--- a/server/src/main/java/io/crate/expression/eval/EvaluatingNormalizer.java
+++ b/server/src/main/java/io/crate/expression/eval/EvaluatingNormalizer.java
@@ -21,6 +21,8 @@
 
 package io.crate.expression.eval;
 
+import static io.crate.expression.predicate.MatchPredicate.TEXT_MATCH;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -28,13 +30,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import io.crate.analyze.relations.FieldResolver;
 import io.crate.data.Input;
@@ -56,8 +57,6 @@ import io.crate.metadata.Reference;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.TransactionContext;
 import io.crate.types.DataTypes;
-
-import static io.crate.expression.predicate.MatchPredicate.TEXT_MATCH;
 
 
 /**
@@ -142,7 +141,7 @@ public class EvaluatingNormalizer {
                 for (Map.Entry<Symbol, Symbol> entry : fieldBoostMap.entrySet()) {
                     Symbol resolved = entry.getKey().accept(this, null);
                     if (resolved instanceof Reference ref) {
-                        columnBoostMapArgs.add(Literal.of(ref.column().fqn()));
+                        columnBoostMapArgs.add(Literal.of(ref.storageIdent()));
                         columnBoostMapArgs.add(entry.getValue());
                     } else {
                         return matchPredicate;

--- a/server/src/main/java/io/crate/expression/operator/CIDROperator.java
+++ b/server/src/main/java/io/crate/expression/operator/CIDROperator.java
@@ -133,7 +133,7 @@ public final class CIDROperator {
                 return new MatchNoDocsQuery("column does not exist in this index");
             }
             InetAddresses.InetAddressPrefixLength cidr = InetAddresses.parseCidr(cidrStr);
-            return InetAddressPoint.newPrefixQuery(ref.column().fqn(), cidr.inetAddress(), cidr.prefixLen());
+            return InetAddressPoint.newPrefixQuery(ref.storageIdent(), cidr.inetAddress(), cidr.prefixLen());
         }
     }
 }

--- a/server/src/main/java/io/crate/expression/operator/CmpOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/CmpOperator.java
@@ -78,7 +78,7 @@ public final class CmpOperator extends Operator<Object> {
             // For types that do not support EqQuery, a `x [>, >=, <, <=] <value>` is always considered a no-match
             return new MatchNoDocsQuery("column does not exist in this index");
         }
-        String field = ref.column().fqn();
+        String field = ref.storageIdent();
         return switch (functionName) {
             case GtOperator.NAME -> eqQuery.rangeQuery(
                     field, value, null, false, false, ref.hasDocValues());

--- a/server/src/main/java/io/crate/expression/operator/LikeOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/LikeOperator.java
@@ -84,7 +84,7 @@ public class LikeOperator extends Operator<String> {
         Object value = literal.value();
         assert value instanceof String
             : "LikeOperator is registered for string types. Value must be a string";
-        return caseSensitivity.likeQuery(ref.column().fqn(), (String) value, ref.indexType() != IndexType.NONE);
+        return caseSensitivity.likeQuery(ref.storageIdent(), (String) value, ref.indexType() != IndexType.NONE);
     }
 
     private static class CompiledLike extends Scalar<Boolean, String> {

--- a/server/src/main/java/io/crate/expression/operator/RegexpMatchCaseInsensitiveOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/RegexpMatchCaseInsensitiveOperator.java
@@ -77,7 +77,7 @@ public class RegexpMatchCaseInsensitiveOperator extends Operator<String> {
     public Query toQuery(Reference ref, Literal<?> literal) {
         String pattern = (String) literal.value();
         return new CrateRegexQuery(
-            new Term(ref.column().fqn(), pattern),
+            new Term(ref.storageIdent(), pattern),
             Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE
         );
     }

--- a/server/src/main/java/io/crate/expression/operator/RegexpMatchOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/RegexpMatchOperator.java
@@ -88,7 +88,7 @@ public class RegexpMatchOperator extends Operator<String> {
     @Override
     public Query toQuery(Reference ref, Literal<?> literal) {
         String pattern = (String) literal.value();
-        Term term = new Term(ref.column().fqn(), pattern);
+        Term term = new Term(ref.storageIdent(), pattern);
         if (RegexpFlags.isPcrePattern(pattern)) {
             return new CrateRegexQuery(term);
         } else {

--- a/server/src/main/java/io/crate/expression/operator/any/AnyEqOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/any/AnyEqOperator.java
@@ -61,7 +61,7 @@ public final class AnyEqOperator extends AnyOperator {
 
     @Override
     protected Query refMatchesAnyArrayLiteral(Function any, Reference probe, Literal<?> candidates, Context context) {
-        String columnName = probe.column().fqn();
+        String columnName = probe.storageIdent();
         List<?> values = (List<?>) candidates.value();
         MappedFieldType fieldType = context.getFieldTypeOrNull(columnName);
         if (fieldType == null) {
@@ -73,7 +73,7 @@ public final class AnyEqOperator extends AnyOperator {
 
     @Override
     protected Query literalMatchesAnyArrayRef(Function any, Literal<?> probe, Reference candidates, Context context) {
-        MappedFieldType fieldType = context.getFieldTypeOrNull(candidates.column().fqn());
+        MappedFieldType fieldType = context.getFieldTypeOrNull(candidates.storageIdent());
         if (fieldType == null) {
             if (ArrayType.unnest(candidates.valueType()).id() == ObjectType.ID) {
                 // {x=10} = any(objects)
@@ -85,7 +85,7 @@ public final class AnyEqOperator extends AnyOperator {
             // [1, 2] = any(nested_array_ref)
             return arrayLiteralEqAnyArray(any, candidates, probe.value(), context);
         }
-        return EqOperator.fromPrimitive(ArrayType.unnest(candidates.valueType()), candidates.column().fqn(), probe.value());
+        return EqOperator.fromPrimitive(ArrayType.unnest(candidates.valueType()), candidates.storageIdent(), probe.value());
     }
 
     private static Query arrayLiteralEqAnyArray(Function function,
@@ -95,7 +95,7 @@ public final class AnyEqOperator extends AnyOperator {
         ArrayList<Object> terms = new ArrayList<>();
         gatherLeafs((Iterable<?>) candidate, terms::add);
         Query termsQuery = EqOperator.termsQuery(
-            candidates.column().fqn(),
+            candidates.storageIdent(),
             ArrayType.unnest(candidates.valueType()),
             terms
         );

--- a/server/src/main/java/io/crate/expression/operator/any/AnyLikeOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/any/AnyLikeOperator.java
@@ -65,7 +65,7 @@ public final class AnyLikeOperator extends AnyOperator {
     @Override
     protected Query refMatchesAnyArrayLiteral(Function any, Reference probe, Literal<?> candidates, Context context) {
         // col like ANY (['a', 'b']) --> or(like(col, 'a'), like(col, 'b'))
-        String fqn = probe.column().fqn();
+        String fqn = probe.storageIdent();
         BooleanQuery.Builder booleanQuery = new BooleanQuery.Builder();
         booleanQuery.setMinimumNumberShouldMatch(1);
         Iterable<?> values = (Iterable<?>) candidates.value();
@@ -81,6 +81,6 @@ public final class AnyLikeOperator extends AnyOperator {
 
     @Override
     protected Query literalMatchesAnyArrayRef(Function any, Literal<?> probe, Reference candidates, Context context) {
-        return caseSensitivity.likeQuery(candidates.column().fqn(), (String) probe.value(), candidates.indexType() != IndexType.NONE);
+        return caseSensitivity.likeQuery(candidates.storageIdent(), (String) probe.value(), candidates.indexType() != IndexType.NONE);
     }
 }

--- a/server/src/main/java/io/crate/expression/operator/any/AnyNeqOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/any/AnyNeqOperator.java
@@ -57,7 +57,7 @@ public final class AnyNeqOperator extends AnyOperator {
     @Override
     protected Query refMatchesAnyArrayLiteral(Function any, Reference probe, Literal<?> candidates, Context context) {
         //  col != ANY ([1,2,3]) --> not(col=1 and col=2 and col=3)
-        String columnName = probe.column().fqn();
+        String columnName = probe.storageIdent();
         MappedFieldType fieldType = context.getFieldTypeOrNull(columnName);
         if (fieldType == null) {
             return new MatchNoDocsQuery("column does not exist in this index");
@@ -78,7 +78,7 @@ public final class AnyNeqOperator extends AnyOperator {
     @SuppressWarnings({"unchecked", "rawtypes"})
     protected Query literalMatchesAnyArrayRef(Function any, Literal<?> probe, Reference candidates, Context context) {
         // 1 != any ( col ) -->  gt 1 or lt 1
-        String columnName = candidates.column().fqn();
+        String columnName = candidates.storageIdent();
 
         MappedFieldType fieldType = context.getFieldTypeOrNull(columnName);
         if (fieldType == null) {

--- a/server/src/main/java/io/crate/expression/operator/any/AnyNotLikeOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/any/AnyNotLikeOperator.java
@@ -64,7 +64,7 @@ public final class AnyNotLikeOperator extends AnyOperator {
     @Override
     protected Query refMatchesAnyArrayLiteral(Function any, Reference probe, Literal<?> candidates, Context context) {
         // col not like ANY (['a', 'b']) --> not(and(like(col, 'a'), like(col, 'b')))
-        String columnName = probe.column().fqn();
+        String columnName = probe.storageIdent();
         BooleanQuery.Builder andLikeQueries = new BooleanQuery.Builder();
         Iterable<?> values = (Iterable<?>) candidates.value();
         for (Object value : values) {
@@ -85,7 +85,7 @@ public final class AnyNotLikeOperator extends AnyOperator {
         String notLike = negateWildcard(regexString);
 
         return new RegexpQuery(new Term(
-            candidates.column().fqn(),
+            candidates.storageIdent(),
             notLike),
             RegexpFlag.COMPLEMENT.value()
         );

--- a/server/src/main/java/io/crate/expression/predicate/IsNullPredicate.java
+++ b/server/src/main/java/io/crate/expression/predicate/IsNullPredicate.java
@@ -116,7 +116,7 @@ public class IsNullPredicate<T> extends Scalar<Boolean, T> {
 
     @Nullable
     public static Query refExistsQuery(Reference ref, Context context, boolean countEmptyArrays) {
-        String field = ref.column().fqn();
+        String field = ref.storageIdent();
         FieldType fieldType = context.queryShardContext().getMapperService().getLuceneFieldType(field);
         DataType<?> valueType = ref.valueType();
         boolean canUseFieldsExist = ref.hasDocValues() || (fieldType != null && !fieldType.omitNorms());

--- a/server/src/main/java/io/crate/expression/reference/DocRefResolver.java
+++ b/server/src/main/java/io/crate/expression/reference/DocRefResolver.java
@@ -119,6 +119,7 @@ public final class DocRefResolver implements ReferenceResolver<CollectExpression
                         return replaceArraysWithNull(value, ref.valueType(), e);
                     }
                 });
+
         }
     }
 

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/LuceneReferenceResolver.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/LuceneReferenceResolver.java
@@ -155,8 +155,9 @@ public class LuceneReferenceResolver implements ReferenceResolver<LuceneCollecto
         return result;
     }
 
-    private static LuceneCollectorExpression<?> typeSpecializedExpression(final FieldTypeLookup fieldTypeLookup, final Reference ref) {
-        final String fqn = ref.column().fqn();
+    private static LuceneCollectorExpression<?> typeSpecializedExpression(final FieldTypeLookup fieldTypeLookup,
+                                                                          final Reference ref) {
+        final String fqn = ref.storageIdent();
         final MappedFieldType fieldType = fieldTypeLookup.get(fqn);
         if (fieldType == null) {
             return NO_FIELD_TYPES_IDS.contains(unnest(ref.valueType()).id()) || isIgnoredDynamicReference(ref)

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/SourceLookup.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/SourceLookup.java
@@ -77,6 +77,11 @@ public final class SourceLookup {
         return fieldsVisitor.source();
     }
 
+    public void source(Map<String, Object> source) {
+        this.source = source;
+        docVisited = true;
+    }
+
     private void ensureSourceParsed() {
         if (source == null) {
             ensureDocVisited();

--- a/server/src/main/java/io/crate/expression/scalar/KnnMatch.java
+++ b/server/src/main/java/io/crate/expression/scalar/KnnMatch.java
@@ -81,7 +81,7 @@ public class KnnMatch extends Scalar<Boolean, Object> {
             Object target = targetLiteral.value();
             Object k = kLiteral.value();
             if (target instanceof float[] && k instanceof Integer) {
-                return new KnnFloatVectorQuery(ref.column().fqn(), (float[]) target, (int) k);
+                return new KnnFloatVectorQuery(ref.storageIdent(), (float[]) target, (int) k);
             }
             return null;
         }

--- a/server/src/main/java/io/crate/expression/scalar/NullOrEmptyFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/NullOrEmptyFunction.java
@@ -115,7 +115,7 @@ public final class NullOrEmptyFunction extends Scalar<Boolean, Object> {
             }
             return Queries.not(booleanQuery.build());
         } else if (valueType instanceof ArrayType<?> && ref.hasDocValues()) {
-            return Queries.not(new FieldExistsQuery(ref.column().fqn()));
+            return Queries.not(new FieldExistsQuery(ref.storageIdent()));
         }
         return null;
     }

--- a/server/src/main/java/io/crate/expression/scalar/NumTermsPerDocQuery.java
+++ b/server/src/main/java/io/crate/expression/scalar/NumTermsPerDocQuery.java
@@ -66,7 +66,7 @@ public class NumTermsPerDocQuery extends Query {
 
     public static NumTermsPerDocQuery forRef(Reference ref, IntPredicate valueCountIsMatch) {
         return new NumTermsPerDocQuery(
-            ref.column().fqn(),
+            ref.storageIdent(),
             leafReaderContext -> getNumTermsPerDocFunction(leafReaderContext.reader(), ref.column().fqn(), ref.valueType()),
             valueCountIsMatch
         );

--- a/server/src/main/java/io/crate/expression/scalar/SubscriptFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/SubscriptFunction.java
@@ -242,7 +242,7 @@ public class SubscriptFunction extends Scalar<Object, Object[]> {
             if (preFilterQueryBuilder == null) {
                 return null;
             }
-            MappedFieldType fieldType = context.getFieldTypeOrNull(ref.column().fqn());
+            MappedFieldType fieldType = context.getFieldTypeOrNull(ref.storageIdent());
             DataType<?> innerType = ArrayType.unnest(ref.valueType());
             if (fieldType == null) {
                 if (innerType.id() == ObjectType.ID) {
@@ -258,7 +258,7 @@ public class SubscriptFunction extends Scalar<Object, Object[]> {
             }
             BooleanQuery.Builder builder = new BooleanQuery.Builder();
             builder.add(
-                preFilterQueryBuilder.buildQuery(ref.column().fqn(), eqQuery, cmpLiteral.value(), ref.hasDocValues()),
+                preFilterQueryBuilder.buildQuery(ref.storageIdent(), eqQuery, cmpLiteral.value(), ref.hasDocValues()),
                 BooleanClause.Occur.MUST);
             builder.add(LuceneQueryBuilder.genericFunctionFilter(parent, context), BooleanClause.Occur.FILTER);
             return builder.build();

--- a/server/src/main/java/io/crate/expression/scalar/geo/DistanceFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/geo/DistanceFunction.java
@@ -150,7 +150,7 @@ public class DistanceFunction extends Scalar<Double, Point> {
         Double distance = DataTypes.DOUBLE.implicitCast(parentRhs.value());
         String parentName = parent.name();
         Point pointValue = (Point) pointLiteral.value();
-        String fieldName = pointRef.column().fqn();
+        String fieldName = pointRef.storageIdent();
         return esV5DistanceQuery(parent, context, parentName, fieldName, distance, pointValue);
     }
 

--- a/server/src/main/java/io/crate/expression/scalar/geo/WithinFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/geo/WithinFunction.java
@@ -49,7 +49,6 @@ import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.geo.GeoJSONUtils;
 import io.crate.lucene.LuceneQueryBuilder.Context;
-import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
 import io.crate.metadata.Scalar;
@@ -204,10 +203,10 @@ public class WithinFunction extends Scalar<Boolean, Object> {
             geometry = JtsSpatialContext.GEO.getShapeFactory().getGeometryFrom(shape);
         }
 
-        return getPolygonQuery(ref.column(), geometry);
+        return getPolygonQuery(ref.storageIdent(), geometry);
     }
 
-    private static Query getPolygonQuery(ColumnIdent column, Geometry geometry) {
+    private static Query getPolygonQuery(String column, Geometry geometry) {
         Coordinate[] coordinates = geometry.getCoordinates();
         // close the polygon shape if startpoint != endpoint
         if (!CoordinateArrays.isRing(coordinates)) {
@@ -221,6 +220,6 @@ public class WithinFunction extends Scalar<Boolean, Object> {
             lats[i] = coordinates[i].y;
             lons[i] = coordinates[i].x;
         }
-        return LatLonPoint.newPolygonQuery(column.fqn(), new Polygon(lats, lons));
+        return LatLonPoint.newPolygonQuery(column, new Polygon(lats, lons));
     }
 }

--- a/server/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
+++ b/server/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
@@ -316,7 +316,7 @@ public class LuceneQueryBuilder {
                 if (ref.indexType() == IndexType.NONE) {
                     return new MatchNoDocsQuery("column does not exist in this index");
                 }
-                return new TermQuery(new Term(ref.column().fqn(), new BytesRef("T")));
+                return new TermQuery(new Term(ref.storageIdent(), new BytesRef("T")));
             }
             return super.visitReference(ref, context);
         }

--- a/server/src/main/java/io/crate/metadata/IndexReference.java
+++ b/server/src/main/java/io/crate/metadata/IndexReference.java
@@ -110,7 +110,7 @@ public class IndexReference extends SimpleReference {
                 // This code handles outdated shards case.
                 return new IndexReference(position, oid, isDropped, ident, indexType, columns, analyzer);
             }
-            List<Reference> sources = references.values().stream().filter(ref -> sourceNames.contains(ref.column().fqn())).collect(Collectors.toList());
+            List<Reference> sources = references.values().stream().filter(ref -> sourceNames.contains(ref.storageIdent())).collect(Collectors.toList());
             return new IndexReference(position, oid, isDropped, ident, indexType, sources, analyzer);
         }
     }
@@ -245,7 +245,7 @@ public class IndexReference extends SimpleReference {
         mapping.put("type", "text");
 
         if (columns.isEmpty() == false) {
-            mapping.put("sources", columns.stream().map(ref -> ref.column().fqn()).toList());
+            mapping.put("sources", columns.stream().map(Reference::storageIdent).toList());
         }
 
         return mapping;

--- a/server/src/main/java/io/crate/metadata/Reference.java
+++ b/server/src/main/java/io/crate/metadata/Reference.java
@@ -21,6 +21,8 @@
 
 package io.crate.metadata;
 
+import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -84,6 +86,22 @@ public interface Reference extends Symbol {
     Reference getRelocated(ReferenceIdent referenceIdent);
 
     Reference applyColumnOid(LongSupplier oidSupplier);
+
+    /**
+     * Return the identifier of this column used inside the storage engine
+     */
+    default String storageIdent() {
+        return oid() == COLUMN_OID_UNASSIGNED ? column().fqn() : Long.toString(oid());
+    }
+
+    /**
+     * Return the identifier of this column used inside the storage engine.
+     * Compared to {@link #storageIdent()}, this will return the columns leaf name instead of the FQN
+     * if no OID is assigned.
+     */
+    default String storageIdentLeafName() {
+        return oid() == COLUMN_OID_UNASSIGNED ? column().leafName() : Long.toString(oid());
+    }
 
     /**
      * Creates the {@link IndexMetadata} mapping representation of the Column.

--- a/server/src/main/java/io/crate/metadata/doc/DocIndexMetadata.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocIndexMetadata.java
@@ -546,7 +546,8 @@ public class DocIndexMetadata {
                     }
                 }
                 // is it an index?
-                if (indicesMap.containsKey(newIdent.fqn())) {
+                var indicesKey = oid == COLUMN_OID_UNASSIGNED ? newIdent.fqn() : Long.toString(oid);
+                if (indicesMap.containsKey(indicesKey)) {
                     List<String> sources = Maps.get(columnProperties, "sources");
                     if (sources != null) {
                         IndexReference.Builder builder = getOrCreateIndexBuilder(newIdent);

--- a/server/src/main/java/io/crate/planner/statement/CopyToPlan.java
+++ b/server/src/main/java/io/crate/planner/statement/CopyToPlan.java
@@ -53,6 +53,7 @@ import io.crate.execution.dsl.projection.WriterProjection;
 import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
 import io.crate.execution.engine.JobLauncher;
 import io.crate.execution.engine.NodeOperationTreeGenerator;
+import io.crate.expression.scalar.cast.CastMode;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.RefVisitor;
 import io.crate.expression.symbol.Symbol;
@@ -224,7 +225,7 @@ public final class CopyToPlan implements Plan {
             }
             columnsDefined = true;
         } else {
-            Reference sourceRef;
+            Symbol toCollect;
             if (table.isPartitioned() && partitions.isEmpty()) {
                 // table is partitioned, insert partitioned columns into the output
                 overwrites = new HashMap<>();
@@ -234,14 +235,18 @@ public final class CopyToPlan implements Plan {
                     }
                 }
                 if (overwrites.size() > 0) {
-                    sourceRef = table.getReference(DocSysColumns.DOC);
+                    toCollect = table.getReference(DocSysColumns.DOC);
                 } else {
-                    sourceRef = table.getReference(DocSysColumns.RAW);
+                    var docRef = table.getReference(DocSysColumns.DOC);
+                    assert docRef != null : "_doc reference must be resolvable";
+                    toCollect = docRef.cast(DataTypes.STRING, CastMode.EXPLICIT);
                 }
             } else {
-                sourceRef = table.getReference(DocSysColumns.RAW);
+                var docRef = table.getReference(DocSysColumns.DOC);
+                assert docRef != null : "_doc reference must be resolvable";
+                toCollect = docRef.cast(DataTypes.STRING, CastMode.EXPLICIT);
             }
-            outputs = List.of(sourceRef);
+            outputs = List.of(toCollect);
         }
 
         Settings settings = Settings.builder().put(copyTo.properties().map(eval)).build();

--- a/server/src/main/java/io/crate/types/ArrayType.java
+++ b/server/src/main/java/io/crate/types/ArrayType.java
@@ -96,7 +96,7 @@ public class ArrayType<T> extends DataType<List<T>> {
 
                 @Override
                 public ValueIndexer<T> valueIndexer(RelationName table, Reference ref,
-                                                    Function<ColumnIdent, FieldType> getFieldType,
+                                                    Function<String, FieldType> getFieldType,
                                                     Function<ColumnIdent, Reference> getRef) {
                     return new ArrayIndexer<>(
                         innerStorage.valueIndexer(table, ref, getFieldType, getRef));

--- a/server/src/main/java/io/crate/types/BitStringType.java
+++ b/server/src/main/java/io/crate/types/BitStringType.java
@@ -88,9 +88,9 @@ public final class BitStringType extends DataType<BitString> implements Streamer
         @Override
         public ValueIndexer<BitString> valueIndexer(RelationName table,
                                                     Reference ref,
-                                                    Function<ColumnIdent, FieldType> getFieldType,
+                                                    Function<String, FieldType> getFieldType,
                                                     Function<ColumnIdent, Reference> getRef) {
-            return new BitStringIndexer(ref, getFieldType.apply(ref.column()));
+            return new BitStringIndexer(ref, getFieldType.apply(ref.storageIdent()));
         }
     };
 

--- a/server/src/main/java/io/crate/types/BooleanType.java
+++ b/server/src/main/java/io/crate/types/BooleanType.java
@@ -82,9 +82,9 @@ public class BooleanType extends DataType<Boolean> implements Streamer<Boolean>,
         @Override
         public ValueIndexer<Boolean> valueIndexer(RelationName table,
                                                   Reference ref,
-                                                  Function<ColumnIdent, FieldType> getFieldType,
+                                                  Function<String, FieldType> getFieldType,
                                                   Function<ColumnIdent, Reference> getRef) {
-            return new BooleanIndexer(ref, getFieldType.apply(ref.column()));
+            return new BooleanIndexer(ref, getFieldType.apply(ref.storageIdent()));
         }
     };
 

--- a/server/src/main/java/io/crate/types/ByteType.java
+++ b/server/src/main/java/io/crate/types/ByteType.java
@@ -49,9 +49,9 @@ public class ByteType extends DataType<Byte> implements Streamer<Byte>, FixedWid
         @Override
         public ValueIndexer<Number> valueIndexer(RelationName table,
                                                  Reference ref,
-                                                 Function<ColumnIdent, FieldType> getFieldType,
+                                                 Function<String, FieldType> getFieldType,
                                                  Function<ColumnIdent, Reference> getRef) {
-            return new IntIndexer(ref, getFieldType.apply(ref.column()));
+            return new IntIndexer(ref, getFieldType.apply(ref.storageIdent()));
         }
     };
 

--- a/server/src/main/java/io/crate/types/DataType.java
+++ b/server/src/main/java/io/crate/types/DataType.java
@@ -249,7 +249,7 @@ public abstract class DataType<T> implements Comparable<DataType<?>>, Writeable,
     @Nullable
     public final ValueIndexer<? super T> valueIndexer(RelationName table,
                                                       Reference ref,
-                                                      Function<ColumnIdent, FieldType> getFieldType,
+                                                      Function<String, FieldType> getFieldType,
                                                       Function<ColumnIdent, Reference> getRef) {
         StorageSupport<? super T> storageSupport = storageSupportSafe();
         return storageSupport.valueIndexer(table, ref, getFieldType, getRef);

--- a/server/src/main/java/io/crate/types/DoubleType.java
+++ b/server/src/main/java/io/crate/types/DoubleType.java
@@ -96,9 +96,9 @@ public class DoubleType extends DataType<Double> implements FixedWidthType, Stre
         @Override
         public ValueIndexer<Number> valueIndexer(RelationName table,
                                                  Reference ref,
-                                                 Function<ColumnIdent, FieldType> getFieldType,
+                                                 Function<String, FieldType> getFieldType,
                                                  Function<ColumnIdent, Reference> getRef) {
-            return new DoubleIndexer(ref, getFieldType.apply(ref.column()));
+            return new DoubleIndexer(ref, getFieldType.apply(ref.storageIdent()));
         }
     };
 

--- a/server/src/main/java/io/crate/types/FloatType.java
+++ b/server/src/main/java/io/crate/types/FloatType.java
@@ -96,9 +96,9 @@ public class FloatType extends DataType<Float> implements Streamer<Float>, Fixed
         @Override
         public ValueIndexer<Float> valueIndexer(RelationName table,
                                                 Reference ref,
-                                                Function<ColumnIdent, FieldType> getFieldType,
+                                                Function<String, FieldType> getFieldType,
                                                 Function<ColumnIdent, Reference> getRef) {
-            return new FloatIndexer(ref, getFieldType.apply(ref.column()));
+            return new FloatIndexer(ref, getFieldType.apply(ref.storageIdent()));
         }
     };
 

--- a/server/src/main/java/io/crate/types/FloatVectorType.java
+++ b/server/src/main/java/io/crate/types/FloatVectorType.java
@@ -81,9 +81,9 @@ public class FloatVectorType extends DataType<float[]> implements Streamer<float
         @Override
         public ValueIndexer<? super float[]> valueIndexer(RelationName table,
                                                           Reference ref,
-                                                          Function<ColumnIdent, FieldType> getFieldType,
+                                                          Function<String, FieldType> getFieldType,
                                                           Function<ColumnIdent, Reference> getRef) {
-            return new FloatVectorIndexer(ref, getFieldType.apply(ref.column()));
+            return new FloatVectorIndexer(ref, getFieldType.apply(ref.storageIdent()));
         }
     };
 

--- a/server/src/main/java/io/crate/types/GeoPointType.java
+++ b/server/src/main/java/io/crate/types/GeoPointType.java
@@ -52,9 +52,9 @@ public class GeoPointType extends DataType<Point> implements Streamer<Point>, Fi
         @Override
         public ValueIndexer<Point> valueIndexer(RelationName table,
                                                 Reference ref,
-                                                Function<ColumnIdent, FieldType> getFieldType,
+                                                Function<String, FieldType> getFieldType,
                                                 Function<ColumnIdent, Reference> getRef) {
-            return new GeoPointIndexer(ref, getFieldType.apply(ref.column()));
+            return new GeoPointIndexer(ref, getFieldType.apply(ref.storageIdent()));
         }
     };
 

--- a/server/src/main/java/io/crate/types/GeoShapeType.java
+++ b/server/src/main/java/io/crate/types/GeoShapeType.java
@@ -52,9 +52,9 @@ public class GeoShapeType extends DataType<Map<String, Object>> implements Strea
         @Override
         public ValueIndexer<Map<String, Object>> valueIndexer(RelationName table,
                                                               Reference ref,
-                                                              Function<ColumnIdent, FieldType> getFieldType,
+                                                              Function<String, FieldType> getFieldType,
                                                               Function<ColumnIdent, Reference> getRef) {
-            return new GeoShapeIndexer(ref, getFieldType.apply(ref.column()));
+            return new GeoShapeIndexer(ref, getFieldType.apply(ref.storageIdent()));
         }
     };
 

--- a/server/src/main/java/io/crate/types/IntegerType.java
+++ b/server/src/main/java/io/crate/types/IntegerType.java
@@ -47,9 +47,9 @@ public class IntegerType extends DataType<Integer> implements Streamer<Integer>,
         @Override
         public ValueIndexer<Number> valueIndexer(RelationName table,
                                                  Reference ref,
-                                                 Function<ColumnIdent, FieldType> getFieldType,
+                                                 Function<String, FieldType> getFieldType,
                                                  Function<ColumnIdent, Reference> getRef) {
-            return new IntIndexer(ref, getFieldType.apply(ref.column()));
+            return new IntIndexer(ref, getFieldType.apply(ref.storageIdent()));
         }
     };
 

--- a/server/src/main/java/io/crate/types/IpType.java
+++ b/server/src/main/java/io/crate/types/IpType.java
@@ -86,9 +86,9 @@ public class IpType extends DataType<String> implements Streamer<String> {
         @Override
         public ValueIndexer<String> valueIndexer(RelationName table,
                                                  Reference ref,
-                                                 Function<ColumnIdent, FieldType> getFieldType,
+                                                 Function<String, FieldType> getFieldType,
                                                  Function<ColumnIdent, Reference> getRef) {
-            return new IpIndexer(ref, getFieldType.apply(ref.column()));
+            return new IpIndexer(ref, getFieldType.apply(ref.storageIdent()));
         }
     };
 

--- a/server/src/main/java/io/crate/types/LongType.java
+++ b/server/src/main/java/io/crate/types/LongType.java
@@ -52,9 +52,9 @@ public class LongType extends DataType<Long> implements FixedWidthType, Streamer
         @Override
         public ValueIndexer<Long> valueIndexer(RelationName table,
                                                Reference ref,
-                                               Function<ColumnIdent, FieldType> getFieldType,
+                                               Function<String, FieldType> getFieldType,
                                                Function<ColumnIdent, Reference> getRef) {
-            return new LongIndexer(ref, getFieldType.apply(ref.column()));
+            return new LongIndexer(ref, getFieldType.apply(ref.storageIdent()));
         }
     };
 

--- a/server/src/main/java/io/crate/types/ObjectType.java
+++ b/server/src/main/java/io/crate/types/ObjectType.java
@@ -72,7 +72,7 @@ public class ObjectType extends DataType<Map<String, Object>> implements Streame
         @Override
         public ValueIndexer<Map<String, Object>> valueIndexer(RelationName table,
                                                               Reference ref,
-                                                              Function<ColumnIdent, FieldType> getFieldType,
+                                                              Function<String, FieldType> getFieldType,
                                                               Function<ColumnIdent, Reference> getRef) {
             return new ObjectIndexer(table, ref, getFieldType, getRef);
         }

--- a/server/src/main/java/io/crate/types/ShortType.java
+++ b/server/src/main/java/io/crate/types/ShortType.java
@@ -47,9 +47,9 @@ public class ShortType extends DataType<Short> implements Streamer<Short>, Fixed
         @Override
         public ValueIndexer<Number> valueIndexer(RelationName table,
                                                  Reference ref,
-                                                 Function<ColumnIdent, FieldType> getFieldType,
+                                                 Function<String, FieldType> getFieldType,
                                                  Function<ColumnIdent, Reference> getRef) {
-            return new IntIndexer(ref, getFieldType.apply(ref.column()));
+            return new IntIndexer(ref, getFieldType.apply(ref.storageIdent()));
         }
     };
 

--- a/server/src/main/java/io/crate/types/StorageSupport.java
+++ b/server/src/main/java/io/crate/types/StorageSupport.java
@@ -64,7 +64,7 @@ public abstract class StorageSupport<T> {
     public abstract ValueIndexer<? super T> valueIndexer(
         RelationName table,
         Reference ref,
-        Function<ColumnIdent, FieldType> getFieldType,
+        Function<String, FieldType> getFieldType,
         Function<ColumnIdent, Reference> getRef);
 
 

--- a/server/src/main/java/io/crate/types/StringType.java
+++ b/server/src/main/java/io/crate/types/StringType.java
@@ -104,9 +104,9 @@ public class StringType extends DataType<String> implements Streamer<String> {
         @SuppressWarnings({"rawtypes", "unchecked"})
         public ValueIndexer<Object> valueIndexer(RelationName table,
                                                  Reference ref,
-                                                 Function<ColumnIdent, FieldType> getFieldType,
+                                                 Function<String, FieldType> getFieldType,
                                                  Function<ColumnIdent, Reference> getRef) {
-            FieldType fieldType = getFieldType.apply(ref.column());
+            FieldType fieldType = getFieldType.apply(ref.storageIdent());
             if (fieldType == null) {
                 return (ValueIndexer) new StringIndexer(ref, fieldType);
             }

--- a/server/src/main/java/io/crate/types/TimestampType.java
+++ b/server/src/main/java/io/crate/types/TimestampType.java
@@ -73,9 +73,9 @@ public final class TimestampType extends DataType<Long>
         @Override
         public ValueIndexer<Long> valueIndexer(RelationName table,
                                                Reference ref,
-                                               Function<ColumnIdent, FieldType> getFieldType,
+                                               Function<String, FieldType> getFieldType,
                                                Function<ColumnIdent, Reference> getRef) {
-            return new LongIndexer(ref, getFieldType.apply(ref.column()));
+            return new LongIndexer(ref, getFieldType.apply(ref.storageIdent()));
         }
     };
 

--- a/server/src/main/java/io/crate/types/UncheckedObjectType.java
+++ b/server/src/main/java/io/crate/types/UncheckedObjectType.java
@@ -52,7 +52,7 @@ public class UncheckedObjectType extends DataType<Map<Object, Object>> implement
         @Override
         public ValueIndexer<Map<Object, Object>> valueIndexer(RelationName table,
                                                               Reference ref,
-                                                              Function<ColumnIdent, FieldType> getFieldType,
+                                                              Function<String, FieldType> getFieldType,
                                                               Function<ColumnIdent, Reference> getRef) {
             throw new UnsupportedOperationException("Unimplemented method 'valueIndexer'");
         }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -68,6 +68,8 @@ import org.elasticsearch.rest.RestStatus;
 import com.carrotsearch.hppc.cursors.ObjectCursor;
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 
+import io.crate.common.annotations.VisibleForTesting;
+
 public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, ToXContentFragment {
 
     private static final Logger LOGGER = LogManager.getLogger(Metadata.class);
@@ -594,7 +596,8 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
     private static class ColumnOidSupplier implements LongSupplier {
         private long columnOID;
 
-        private ColumnOidSupplier(long columnOID) {
+        @VisibleForTesting
+        public ColumnOidSupplier(long columnOID) {
             this.columnOID = columnOID;
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/ArrayMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ArrayMapper.java
@@ -119,7 +119,7 @@ public class ArrayMapper extends FieldMapper implements ArrayValueMapperParser {
             return new ArrayMapper(
                 name,
                 position,
-                columnOID,
+                innerMapper.columnOID(),
                 isDropped,
                 defaultExpression,
                 innerFieldType,

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentFieldMappers.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentFieldMappers.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.index.mapper;
 
+import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -33,7 +35,8 @@ public final class DocumentFieldMappers implements Iterable<Mapper> {
     public DocumentFieldMappers(Collection<FieldMapper> mappers) {
         Map<String, Mapper> fieldMappers = new HashMap<>();
         for (FieldMapper mapper : mappers) {
-            fieldMappers.put(mapper.name(), mapper);
+            var name = mapper.columnOID() == COLUMN_OID_UNASSIGNED ? mapper.name() : Long.toString(mapper.columnOID());
+            fieldMappers.put(name, mapper);
         }
         this.fieldMappers = Collections.unmodifiableMap(fieldMappers);
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -139,13 +139,13 @@ public class DocumentMapper implements ToXContentFragment {
         this.fieldMappers = new DocumentFieldMappers(newFieldMappers);
         Map<String, ObjectMapper> builder = new HashMap<>();
         for (ObjectMapper objectMapper : newObjectMappers) {
-            for (var objectProperty : objectMapper.getMappers().keySet()) {
-                if (containsInvalidWhitespaceCharacters(objectProperty)) {
+            for (var mapper : objectMapper.getMappers().values()) {
+                if (containsInvalidWhitespaceCharacters(mapper.simpleName())) {
                     throw new InvalidArgumentException(
                         String.format(
                             Locale.ENGLISH,
                             "Column name '%s' contains illegal whitespace character",
-                            objectProperty
+                            mapper.simpleName()
                         )
                     );
                 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.index.mapper;
 
+import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -27,8 +29,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
 
-import org.jetbrains.annotations.Nullable;
-
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
@@ -36,8 +36,7 @@ import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.mapper.FieldNamesFieldMapper.FieldNamesFieldType;
-
-import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
+import org.jetbrains.annotations.Nullable;
 
 public abstract class FieldMapper extends Mapper implements Cloneable {
 
@@ -86,6 +85,9 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
         }
 
         protected String buildFullName(BuilderContext context) {
+            if (columnOID != COLUMN_OID_UNASSIGNED) {
+                return Long.toString(columnOID);
+            }
             return context.path().pathAsText(name);
         }
 
@@ -111,9 +113,8 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
                           FieldType fieldType,
                           MappedFieldType mappedFieldType,
                           CopyTo copyTo) {
-        super(simpleName);
+        super(simpleName, columnOID);
         this.position = position;
-        this.columnOID = columnOID;
         this.isDropped = isDropped;
         this.defaultExpression = defaultExpression;
         if (mappedFieldType.name().isEmpty()) {
@@ -127,10 +128,6 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
 
     public int position() {
         return position;
-    }
-
-    public long columnOID() {
-        return columnOID;
     }
 
     public boolean isDropped() {

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.index.mapper;
 
+import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -42,7 +44,8 @@ class FieldTypeLookup implements Iterable<MappedFieldType> {
     FieldTypeLookup(Collection<FieldMapper> fieldMappers) {
         for (FieldMapper fieldMapper : fieldMappers) {
             MappedFieldType fieldType = fieldMapper.fieldType();
-            fullNameToFieldType.put(fieldType.name(), fieldType);
+            var name = fieldMapper.columnOID == COLUMN_OID_UNASSIGNED ? fieldType.name() : Long.toString(fieldMapper.columnOID);
+            fullNameToFieldType.put(name, fieldType);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
@@ -19,14 +19,14 @@
 
 package org.elasticsearch.index.mapper;
 
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+
 import org.elasticsearch.cluster.metadata.ColumnPositionResolver;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.index.analysis.IndexAnalyzers;
-
-import java.util.Map;
-import java.util.Objects;
-import java.util.function.Function;
 
 public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
 
@@ -142,15 +142,24 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
 
     protected boolean isDropped;
 
-    protected Mapper(String simpleName) {
+    protected Mapper(String simpleName, long columnOID) {
         Objects.requireNonNull(simpleName);
         this.simpleName = simpleName;
+        this.columnOID = columnOID;
     }
 
     /** Returns the simple name, which identifies this mapper against other mappers at the same level in the mappers hierarchy
      * TODO: make this protected once Mapper and FieldMapper are merged together */
     public final String simpleName() {
         return simpleName;
+    }
+
+    /**
+     * Returns the column's (field) OID this mapper is used for.
+     * If no OID was assigned, {@link org.elasticsearch.cluster.metadata.Metadata#COLUMN_OID_UNASSIGNED} is returned.
+     */
+    public long columnOID() {
+        return columnOID;
     }
 
     /** Returns the canonical name which uniquely identifies the mapper against other mappers in a type. */

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.mapper;
 
 import static java.util.Collections.emptyMap;
+import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -298,7 +299,8 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
                 // first time through the loops
                 fullPathObjectMappers = new HashMap<>(this.fullPathObjectMappers);
             }
-            fullPathObjectMappers.put(objectMapper.fullPath(), objectMapper);
+            var path = objectMapper.columnOID() == COLUMN_OID_UNASSIGNED ? objectMapper.fullPath() : Long.toString(objectMapper.columnOID());
+            fullPathObjectMappers.put(path, objectMapper);
         }
 
         if (reason == MergeReason.MAPPING_UPDATE) {

--- a/server/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
+++ b/server/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
@@ -40,20 +40,6 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import io.crate.metadata.ColumnIdent;
-import io.crate.metadata.IndexType;
-import io.crate.metadata.NodeContext;
-import io.crate.metadata.PartitionName;
-import io.crate.metadata.Reference;
-import io.crate.metadata.ReferenceIdent;
-import io.crate.metadata.RelationName;
-import io.crate.metadata.RowGranularity;
-import io.crate.metadata.Schemas;
-import io.crate.metadata.SearchPath;
-import io.crate.metadata.SimpleReference;
-import io.crate.sql.tree.ColumnPolicy;
-import org.jetbrains.annotations.Nullable;
-
 import org.elasticsearch.Version;
 import org.elasticsearch.action.support.replication.TransportWriteAction;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
@@ -78,6 +64,7 @@ import org.elasticsearch.test.VersionUtils;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
+import org.jetbrains.annotations.Nullable;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -93,10 +80,22 @@ import io.crate.execution.dml.ShardResponse;
 import io.crate.execution.dml.upsert.ShardUpsertRequest.DuplicateKeyAction;
 import io.crate.execution.jobs.TasksService;
 import io.crate.expression.symbol.DynamicReference;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.IndexType;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.PartitionName;
+import io.crate.metadata.Reference;
+import io.crate.metadata.ReferenceIdent;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.RowGranularity;
+import io.crate.metadata.Schemas;
+import io.crate.metadata.SearchPath;
+import io.crate.metadata.SimpleReference;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.settings.SessionSettings;
 import io.crate.metadata.table.Operation;
 import io.crate.netty.NettyBootstrap;
+import io.crate.sql.tree.ColumnPolicy;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.types.DataTypes;
 
@@ -184,8 +183,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
         when(tableInfo.versionCreated()).thenReturn(Version.CURRENT);
         when(schemas.getTableInfo(any(RelationName.class), eq(Operation.INSERT))).thenReturn(tableInfo);
 
-        when(tableInfo.getReference(new ColumnIdent("dynamic_long_col"))).thenReturn(
-            new SimpleReference(
+        var dynamicLongColRef = new SimpleReference(
                 new ReferenceIdent(TABLE_IDENT,"dynamic_long_col"),
                 RowGranularity.DOC,
                 DataTypes.LONG,
@@ -197,7 +195,9 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
                 1,
                 false,
                 null
-            ));
+        );
+        when(tableInfo.getReference(new ColumnIdent("dynamic_long_col"))).thenReturn(dynamicLongColRef);
+        when(tableInfo.iterator()).thenReturn(List.<Reference>of(ID_REF, dynamicLongColRef).iterator());
 
         transportShardUpsertAction = new TestingTransportShardUpsertAction(
             mock(ThreadPool.class),

--- a/server/src/test/java/io/crate/execution/dml/upsert/UpdateToInsertTest.java
+++ b/server/src/test/java/io/crate/execution/dml/upsert/UpdateToInsertTest.java
@@ -23,10 +23,10 @@ package io.crate.execution.dml.upsert;
 
 
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -264,7 +264,7 @@ public class UpdateToInsertTest extends CrateDummyClusterServiceUnitTest {
             new CoordinatorTxnCtx(e.getSessionSettings()),
             table,
             updateColumns,
-            insertColumns
+            Arrays.asList(insertColumns)
         );
         assertThat(updateToInsert.columns())
             .as("Start References of columns() must match insertColumns")
@@ -309,7 +309,7 @@ public class UpdateToInsertTest extends CrateDummyClusterServiceUnitTest {
             new CoordinatorTxnCtx(e.getSessionSettings()),
             table,
             updateColumns,
-            insertColumns
+            Arrays.asList(insertColumns)
         );
         Map<String, Object> source = Map.of("x", 1, "y", 2, "z", 3);
         Doc doc = doc(table.concreteIndices()[0], source);
@@ -353,7 +353,7 @@ public class UpdateToInsertTest extends CrateDummyClusterServiceUnitTest {
             new CoordinatorTxnCtx(e.getSessionSettings()),
             table,
             updateColumns,
-            insertColumns
+            Arrays.asList(insertColumns)
         );
         Map<String, Object> source = Map.of(
             "x", 1,
@@ -394,7 +394,7 @@ public class UpdateToInsertTest extends CrateDummyClusterServiceUnitTest {
             new CoordinatorTxnCtx(e.getSessionSettings()),
             table,
             updateColumns,
-            insertColumns
+            Arrays.asList(insertColumns)
         );
         Map<String, Object> source = Map.of(
             "x", 1,

--- a/server/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
@@ -57,6 +57,7 @@ import com.carrotsearch.randomizedtesting.LifecycleScope;
 import io.crate.testing.Asserts;
 import io.crate.testing.SQLResponse;
 import io.crate.testing.UseJdbc;
+import io.crate.testing.UseNewCluster;
 
 @IntegTestCase.ClusterScope(numDataNodes = 2)
 public class CopyIntegrationTest extends SQLHttpIntegrationTest {
@@ -876,6 +877,7 @@ public class CopyIntegrationTest extends SQLHttpIntegrationTest {
         );
     }
 
+    @UseNewCluster
     @Test
     public void test_copy_excludes_partitioned_values_from_source() throws Exception {
         execute("create table tbl (x int, p int) partitioned by (p)");
@@ -895,7 +897,7 @@ public class CopyIntegrationTest extends SQLHttpIntegrationTest {
             execute("refresh table tbl");
             execute("SELECT _raw, * FROM tbl");
             assertThat(response).hasRows(
-                "{\"x\":10}| 10| 1"
+                "{\"1\":10}| 10| 1"
             );
         }
 
@@ -915,7 +917,7 @@ public class CopyIntegrationTest extends SQLHttpIntegrationTest {
             execute("refresh table tbl2");
             execute("SELECT _raw, * FROM tbl2");
             assertThat(response).hasRows(
-                "{\"x\":10,\"o\":{}}| 10| {p=1}"
+                "{\"3\":10,\"4\":{}}| 10| {p=1}"
             );
         }
     }

--- a/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
@@ -211,9 +211,10 @@ public class DDLIntegrationTest extends IntegTestCase {
             "\"dynamic\":\"strict\"," +
             "\"_meta\":{}," +
             "\"properties\":{" +
+            "\"id\":{\"type\":\"integer\",\"position\":1,\"oid\":1}," +
             "\"col1\":{\"type\":\"keyword\",\"position\":2,\"default_expr\":\"'foo'\",\"oid\":2}," +
-            "\"col2\":{\"type\":\"array\",\"inner\":{\"type\":\"integer\",\"position\":3,\"default_expr\":\"[1, 2]\",\"oid\":3}}," +
-            "\"id\":{\"type\":\"integer\",\"position\":1,\"oid\":1}}}}";
+            "\"col2\":{\"type\":\"array\",\"inner\":{\"type\":\"integer\",\"position\":3,\"default_expr\":\"[1, 2]\",\"oid\":3}}" +
+            "}}}";
         assertThat(getIndexMapping("test")).isEqualTo(expectedMapping);
         execute("insert into test(id) values(1)");
         execute("refresh table test");
@@ -331,11 +332,11 @@ public class DDLIntegrationTest extends IntegTestCase {
 
         String expectedMapping = "{\"default\":{" +
             "\"dynamic\":\"strict\",\"" +
-            "_meta\":{\"indices\":{\"title_desc_fulltext\":{}}}," +
+            "_meta\":{\"indices\":{\"3\":{}}}," +
             "\"properties\":{" +
-            "\"description\":{\"type\":\"keyword\",\"position\":2,\"oid\":2}," +
             "\"title\":{\"type\":\"keyword\",\"position\":1,\"oid\":1}," +
-            "\"title_desc_fulltext\":{\"type\":\"text\",\"position\":3,\"oid\":3,\"analyzer\":\"stop\",\"sources\":[\"title\",\"description\"]}}}}";
+            "\"description\":{\"type\":\"keyword\",\"position\":2,\"oid\":2}," +
+            "\"title_desc_fulltext\":{\"type\":\"text\",\"position\":3,\"oid\":3,\"analyzer\":\"stop\",\"sources\":[\"1\",\"2\"]}}}}";
         assertEquals(expectedMapping, getIndexMapping("novels"));
 
         String title = "So Long, and Thanks for All the Fish";
@@ -896,8 +897,8 @@ public class DDLIntegrationTest extends IntegTestCase {
                                  "\"_meta\":{" +
                                  "\"generated_columns\":{\"day\":\"date_trunc('day', ts)\"}}," +
                                  "\"properties\":{" +
-                                 "\"day\":{\"type\":\"date\",\"position\":2,\"oid\":2,\"format\":\"epoch_millis||strict_date_optional_time\"}," +
-                                 "\"ts\":{\"type\":\"date\",\"position\":1,\"oid\":1,\"format\":\"epoch_millis||strict_date_optional_time\"}" +
+                                 "\"ts\":{\"type\":\"date\",\"position\":1,\"oid\":1,\"format\":\"epoch_millis||strict_date_optional_time\"}," +
+                                 "\"day\":{\"type\":\"date\",\"position\":2,\"oid\":2,\"format\":\"epoch_millis||strict_date_optional_time\"}" +
                                  "}}}";
 
         assertEquals(expectedMapping, getIndexMapping("test"));
@@ -919,9 +920,9 @@ public class DDLIntegrationTest extends IntegTestCase {
                                  "\"day\":\"date_trunc('day', ts)\"," +
                                  "\"added\":\"date_trunc('day', ts)\"}}," +
                                  "\"properties\":{" +
-                                 "\"added\":{\"type\":\"date\",\"position\":3,\"oid\":3,\"format\":\"epoch_millis||strict_date_optional_time\"}," +
+                                 "\"ts\":{\"type\":\"date\",\"position\":1,\"oid\":1,\"format\":\"epoch_millis||strict_date_optional_time\"}," +
                                  "\"day\":{\"type\":\"date\",\"position\":2,\"oid\":2,\"format\":\"epoch_millis||strict_date_optional_time\"}," +
-                                 "\"ts\":{\"type\":\"date\",\"position\":1,\"oid\":1,\"format\":\"epoch_millis||strict_date_optional_time\"}" +
+                                 "\"added\":{\"type\":\"date\",\"position\":3,\"oid\":3,\"format\":\"epoch_millis||strict_date_optional_time\"}" +
                                  "}}}";
 
         assertEquals(expectedMapping, getIndexMapping("test"));

--- a/server/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
@@ -478,7 +478,7 @@ public class InsertIntoIntegrationTest extends IntegTestCase {
 
     @Test
     public void testInsertFromQueryWithSysColumn() throws Exception {
-        execute("create table target (name string, a string, b string, docid int) " +
+        execute("create table target (name string, a string, docid int) " +
                 "clustered into 1 shards with (number_of_replicas = 0)");
         execute("create table source (name string) clustered into 1 shards with (number_of_replicas = 0)");
         ensureYellow();
@@ -486,14 +486,13 @@ public class InsertIntoIntegrationTest extends IntegTestCase {
         execute("insert into source (name) values ('yalla')");
         execute("refresh table source");
 
-        execute("insert into target (name, a, b, docid) (select name, _raw, _id, _docid from source)");
+        execute("insert into target (name, a, docid) (select name, _id, _docid from source)");
         execute("refresh table target");
 
-        execute("select name, a, b, docid from target");
+        execute("select name, a, docid from target");
         assertThat(response.rows()[0][0]).isEqualTo("yalla");
-        assertThat(response.rows()[0][1]).isEqualTo("{\"name\":\"yalla\"}");
-        assertThat(response.rows()[0][2]).isNotNull();
-        assertThat(response.rows()[0][3]).isEqualTo(0);
+        assertThat(response.rows()[0][1]).isNotNull();
+        assertThat(response.rows()[0][2]).isEqualTo(0);
     }
 
     @Test
@@ -1372,8 +1371,8 @@ public class InsertIntoIntegrationTest extends IntegTestCase {
         execute("select data_type from information_schema.columns where table_name='dyn_ts' and column_name='ts'");
         assertThat(response.rows()[0][0]).isEqualTo("text");
 
-        execute("select _raw from dyn_ts where id = 0");
-        assertThat((String) response.rows()[0][0]).isEqualTo("{\"id\":0,\"ts\":\"2015-01-01\"}");
+        execute("select _doc from dyn_ts where id = 0");
+        assertThat(printedTable(response.rows())).isEqualTo("{id=0, ts=2015-01-01}\n");
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
@@ -427,10 +427,8 @@ public class SQLTypeMappingTest extends IntegTestCase {
             "id| smallint",
             "tags| text_array"
         );
-        assertThat((String) execute("select _raw from arr").rows()[0][0]).isEqualToIgnoringWhitespace(
-            """
-            {"id":1,"tags":["wow","much","wow"],"new":[]}
-            """
+        assertThat(execute("select _doc from arr")).hasRows(
+            "{id=1, new=[], tags=[wow, much, wow]}"
         );
     }
 
@@ -447,10 +445,8 @@ public class SQLTypeMappingTest extends IntegTestCase {
             "id| smallint",
             "tags| text_array"
         );
-        assertThat((String) execute("select _raw from arr").rows()[0][0]).isEqualToIgnoringWhitespace(
-            """
-            {"id":2,"tags":["wow","much","wow"],"new":[null]}
-            """
+        assertThat(execute("select _doc from arr")).hasRows(
+            "{id=2, new=[null], tags=[wow, much, wow]}"
         );
     }
 

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionClassLifecycleTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionClassLifecycleTest.java
@@ -52,6 +52,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 import org.apache.lucene.util.Constants;
 import org.elasticsearch.Build;
@@ -68,6 +69,10 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import io.crate.execution.engine.collect.stats.JobsLogService;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.Schemas;
+import io.crate.metadata.doc.DocTableInfo;
 import io.crate.testing.Asserts;
 import io.crate.testing.SQLResponse;
 import io.crate.testing.SQLTransportExecutor;
@@ -110,14 +115,22 @@ public class TransportSQLActionClassLifecycleTest extends IntegTestCase {
     public void testSelectRaw() throws Exception {
         new Setup(sqlExecutor).groupBySetup();
         SQLResponse response = execute("select _raw from characters order by name desc limit 1");
+
+        var schemas = cluster().getDataNodeInstance(Schemas.class);
+        DocTableInfo table = schemas.getTableInfo(new RelationName(sqlExecutor.getCurrentSchema(), "characters"));
+        Function<String, String> mapName = s -> {
+            var ref = table.getReference(ColumnIdent.fromPath(s));
+            return ref.storageIdent();
+        };
+
         Object raw = response.rows()[0][0];
         Map<String, Object> rawMap = JsonXContent.JSON_XCONTENT.createParser(
             NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, (String) raw).map();
 
-        assertThat(rawMap.get("race"), is("Human"));
-        assertThat(rawMap.get("gender"), is("female"));
-        assertThat(rawMap.get("age"), is(32));
-        assertThat(rawMap.get("name"), is("Trillian"));
+        assertThat(rawMap.get(mapName.apply("race")), is("Human"));
+        assertThat(rawMap.get(mapName.apply("gender")), is("female"));
+        assertThat(rawMap.get(mapName.apply("age")), is(32));
+        assertThat(rawMap.get(mapName.apply("name")), is("Trillian"));
     }
 
     @Test
@@ -126,14 +139,21 @@ public class TransportSQLActionClassLifecycleTest extends IntegTestCase {
         SQLResponse response = execute("select name, _raw from characters " +
                                        "group by _raw, name order by name desc limit 1");
 
+        var schemas = cluster().getDataNodeInstance(Schemas.class);
+        DocTableInfo table = schemas.getTableInfo(new RelationName(sqlExecutor.getCurrentSchema(), "characters"));
+        Function<String, String> mapName = s -> {
+            var ref = table.getReference(ColumnIdent.fromPath(s));
+            return ref.storageIdent();
+        };
+
         Object raw = response.rows()[0][1];
         Map<String, Object> rawMap = JsonXContent.JSON_XCONTENT.createParser(
             NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, (String) raw).map();
 
-        assertThat(rawMap.get("race"), is("Human"));
-        assertThat(rawMap.get("gender"), is("female"));
-        assertThat(rawMap.get("age"), is(32));
-        assertThat(rawMap.get("name"), is("Trillian"));
+        assertThat(rawMap.get(mapName.apply("race")), is("Human"));
+        assertThat(rawMap.get(mapName.apply("gender")), is("female"));
+        assertThat(rawMap.get(mapName.apply("age")), is(32));
+        assertThat(rawMap.get(mapName.apply("name")), is("Trillian"));
     }
 
     @Test

--- a/server/src/test/java/io/crate/metadata/IndexReferenceTest.java
+++ b/server/src/test/java/io/crate/metadata/IndexReferenceTest.java
@@ -72,10 +72,12 @@ public class IndexReferenceTest extends CrateDummyClusterServiceUnitTest {
 
         DocTableInfo table = e.resolveTableInfo("tbl");
         IndexReference reference = table.indexColumn(new ColumnIdent("title_desc_fulltext"));
+        var titleRef = table.getReference(new ColumnIdent("title"));
+        var descRef = table.getReference(new ColumnIdent("description"));
 
         Map<String, Object> mapping = reference.toMapping(reference.position());
         assertThat(mapping)
-            .containsEntry("sources", List.of("title", "description"))
+            .containsEntry("sources", List.of(titleRef.storageIdent(), descRef.storageIdent()))
             .containsEntry("oid", 3L)
             .containsEntry("analyzer", "stop");
         IndexMetadata indexMetadata = clusterService.state().metadata().indices().valuesIt().next();

--- a/server/src/testFixtures/java/io/crate/types/DataTypeTestCase.java
+++ b/server/src/testFixtures/java/io/crate/types/DataTypeTestCase.java
@@ -100,7 +100,7 @@ public abstract class DataTypeTestCase<T> extends CrateDummyClusterServiceUnitTe
             ValueIndexer<? super T> valueIndexer = storageSupport.valueIndexer(
                 table.ident(),
                 reference,
-                column -> mapperService.getLuceneFieldType(column.fqn()),
+                mapperService::getLuceneFieldType,
                 table::getReference
             );
 
@@ -108,7 +108,7 @@ public abstract class DataTypeTestCase<T> extends CrateDummyClusterServiceUnitTe
             try (XContentBuilder xContentBuilder = XContentFactory.json(new BytesStreamOutput())) {
                 List<IndexableField> fields = new ArrayList<>();
                 xContentBuilder.startObject()
-                    .field(reference.column().fqn());
+                    .field(reference.storageIdent());
                 valueIndexer.indexValue(
                     value,
                     xContentBuilder,
@@ -128,7 +128,7 @@ public abstract class DataTypeTestCase<T> extends CrateDummyClusterServiceUnitTe
                     BytesReference.bytes(xContentBuilder),
                     XContentType.JSON
                 ));
-                IndexableField[] fieldsFromMapper = parsedDocument.doc().getFields("x");
+                IndexableField[] fieldsFromMapper = parsedDocument.doc().getFields(reference.storageIdent());
                 assertThat(fieldsFromMapper).hasSize(fields.size());
                 for (int i = 0; i < fields.size(); i++) {
                     var field1 = fields.get(i);


### PR DESCRIPTION
Use the column's OID inside the stored source and lucene fields instead of the columns name:
 - write the source map using the OID
 - use the OID as the Lucene field's name
 - lookup Lucene fieldmappers by the columns OID (be able to parse a raw document containing only OID's such as documents stored inside the translog)
 - lookup reference resolver by OID
 - convert the OID back to the columns name on reading objects/raw-doc

The first 3 commits are prerequisites but only needed for the last commit.
