### PR TITLE
Simplify MoveConstantJoinConditionsBeneathNestedLoop Rule

### DIFF
--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -87,7 +87,7 @@ import io.crate.planner.optimizer.rule.MergeAggregateAndCollectToCount;
 import io.crate.planner.optimizer.rule.MergeAggregateRenameAndCollectToCount;
 import io.crate.planner.optimizer.rule.MergeFilterAndCollect;
 import io.crate.planner.optimizer.rule.MergeFilters;
-import io.crate.planner.optimizer.rule.MoveConstantJoinConditionsBeneathNestedLoop;
+import io.crate.planner.optimizer.rule.MoveConstantJoinConditionsToFilter;
 import io.crate.planner.optimizer.rule.MoveFilterBeneathCorrelatedJoin;
 import io.crate.planner.optimizer.rule.MoveFilterBeneathEval;
 import io.crate.planner.optimizer.rule.MoveFilterBeneathGroupBy;
@@ -152,7 +152,7 @@ public class LogicalPlanner {
         new DeduplicateOrder(),
         new OptimizeCollectWhereClauseAccess(),
         new RewriteGroupByKeysLimitToLimitDistinct(),
-        new MoveConstantJoinConditionsBeneathNestedLoop(),
+        new MoveConstantJoinConditionsToFilter(),
         new EliminateCrossJoin(),
         new RewriteJoinPlan(),
         new RewriteNestedLoopJoinToHashJoin()

--- a/server/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
@@ -66,7 +66,6 @@ public class NestedLoopJoin extends AbstractJoinPlan {
     private final boolean isFiltered;
     private boolean orderByWasPushedDown = false;
     private boolean rewriteFilterOnOuterJoinToInnerJoinDone = false;
-    private final boolean joinConditionOptimised;
     // this can be removed
     private boolean rewriteNestedLoopJoinToHashJoinDone = false;
 
@@ -74,11 +73,9 @@ public class NestedLoopJoin extends AbstractJoinPlan {
                    LogicalPlan rhs,
                    JoinType joinType,
                    @Nullable Symbol joinCondition,
-                   boolean isFiltered,
-                   boolean joinConditionOptimised) {
+                   boolean isFiltered) {
         super(lhs, rhs, joinCondition, joinType);
         this.isFiltered = isFiltered || joinCondition != null;
-        this.joinConditionOptimised = joinConditionOptimised;
     }
 
     public NestedLoopJoin(LogicalPlan lhs,
@@ -88,9 +85,8 @@ public class NestedLoopJoin extends AbstractJoinPlan {
                           boolean isFiltered,
                           boolean orderByWasPushedDown,
                           boolean rewriteFilterOnOuterJoinToInnerJoinDone,
-                          boolean joinConditionOptimised,
                           boolean rewriteEquiJoinToHashJoinDone) {
-        this(lhs, rhs, joinType, joinCondition, isFiltered, joinConditionOptimised);
+        this(lhs, rhs, joinType, joinCondition, isFiltered);
         this.orderByWasPushedDown = orderByWasPushedDown;
         this.rewriteFilterOnOuterJoinToInnerJoinDone = rewriteFilterOnOuterJoinToInnerJoinDone;
         this.rewriteNestedLoopJoinToHashJoinDone = rewriteEquiJoinToHashJoinDone;
@@ -98,10 +94,6 @@ public class NestedLoopJoin extends AbstractJoinPlan {
 
     public boolean isRewriteNestedLoopJoinToHashJoinDone() {
         return rewriteNestedLoopJoinToHashJoinDone;
-    }
-
-    public boolean isJoinConditionOptimised() {
-        return joinConditionOptimised;
     }
 
     public boolean isRewriteFilterOnOuterJoinToInnerJoinDone() {
@@ -236,7 +228,6 @@ public class NestedLoopJoin extends AbstractJoinPlan {
             isFiltered,
             orderByWasPushedDown,
             rewriteFilterOnOuterJoinToInnerJoinDone,
-            joinConditionOptimised,
             rewriteNestedLoopJoinToHashJoinDone
         );
     }
@@ -266,7 +257,6 @@ public class NestedLoopJoin extends AbstractJoinPlan {
             isFiltered,
             orderByWasPushedDown,
             rewriteFilterOnOuterJoinToInnerJoinDone,
-            joinConditionOptimised,
             rewriteNestedLoopJoinToHashJoinDone
         );
     }
@@ -302,7 +292,6 @@ public class NestedLoopJoin extends AbstractJoinPlan {
                 isFiltered,
                 orderByWasPushedDown,
                 rewriteFilterOnOuterJoinToInnerJoinDone,
-                joinConditionOptimised,
                 rewriteNestedLoopJoinToHashJoinDone
             )
         );

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathNestedLoop.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathNestedLoop.java
@@ -108,7 +108,6 @@ public final class MoveOrderBeneathNestedLoop implements Rule<Order> {
                     nestedLoop.isFiltered(),
                     true,
                     nestedLoop.isRewriteFilterOnOuterJoinToInnerJoinDone(),
-                    false,
                     nestedLoop.isRewriteNestedLoopJoinToHashJoinDone()
                 );
             }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/ReorderNestedLoopJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/ReorderNestedLoopJoin.java
@@ -71,7 +71,6 @@ public class ReorderNestedLoopJoin implements Rule<NestedLoopJoin> {
                         nestedLoop.isFiltered(),
                         nestedLoop.orderByWasPushedDown(),
                         nestedLoop.isRewriteFilterOnOuterJoinToInnerJoinDone(),
-                        nestedLoop.isJoinConditionOptimised(),
                         nestedLoop.isRewriteNestedLoopJoinToHashJoinDone()
                     ),
                     nestedLoop.outputs());

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoin.java
@@ -260,7 +260,6 @@ public final class RewriteFilterOnOuterJoinToInnerJoin implements Rule<Filter> {
             nl.isFiltered(),
             nl.orderByWasPushedDown(),
             true,
-            nl.isJoinConditionOptimised(),
             nl.isRewriteNestedLoopJoinToHashJoinDone()
         );
         assert newJoin.outputs().equals(nl.outputs()) : "Outputs after rewrite must be the same as before";

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteJoinPlan.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteJoinPlan.java
@@ -77,7 +77,6 @@ public class RewriteJoinPlan implements Rule<JoinPlan> {
                 join.isFiltered(),
                 false,
                 false,
-                false,
                 false
             );
         }

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -170,7 +170,7 @@ public class PgCatalogITest extends IntegTestCase {
             "optimizer_merge_aggregate_rename_and_collect_to_count| true| Indicates if the optimizer rule MergeAggregateRenameAndCollectToCount is activated.| NULL| NULL",
             "optimizer_merge_filter_and_collect| true| Indicates if the optimizer rule MergeFilterAndCollect is activated.| NULL| NULL",
             "optimizer_merge_filters| true| Indicates if the optimizer rule MergeFilters is activated.| NULL| NULL",
-            "optimizer_move_constant_join_conditions_beneath_nested_loop| true| Indicates if the optimizer rule MoveConstantJoinConditionsBeneathNestedLoop is activated.| NULL| NULL",
+            "optimizer_move_constant_join_conditions_to_filter| true| Indicates if the optimizer rule MoveConstantJoinConditionsToFilter is activated.| NULL| NULL",
             "optimizer_move_filter_beneath_correlated_join| true| Indicates if the optimizer rule MoveFilterBeneathCorrelatedJoin is activated.| NULL| NULL",
             "optimizer_move_filter_beneath_eval| true| Indicates if the optimizer rule MoveFilterBeneathEval is activated.| NULL| NULL",
             "optimizer_move_filter_beneath_group_by| true| Indicates if the optimizer rule MoveFilterBeneathGroupBy is activated.| NULL| NULL",

--- a/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
@@ -410,7 +410,7 @@ public class ShowIntegrationTest extends IntegTestCase {
             "optimizer_merge_aggregate_rename_and_collect_to_count| true| Indicates if the optimizer rule MergeAggregateRenameAndCollectToCount is activated.",
             "optimizer_merge_filter_and_collect| true| Indicates if the optimizer rule MergeFilterAndCollect is activated.",
             "optimizer_merge_filters| true| Indicates if the optimizer rule MergeFilters is activated.",
-            "optimizer_move_constant_join_conditions_beneath_nested_loop| true| Indicates if the optimizer rule MoveConstantJoinConditionsBeneathNestedLoop is activated.",
+            "optimizer_move_constant_join_conditions_to_filter| true| Indicates if the optimizer rule MoveConstantJoinConditionsToFilter is activated.",
             "optimizer_move_filter_beneath_correlated_join| true| Indicates if the optimizer rule MoveFilterBeneathCorrelatedJoin is activated.",
             "optimizer_move_filter_beneath_eval| true| Indicates if the optimizer rule MoveFilterBeneathEval is activated.",
             "optimizer_move_filter_beneath_group_by| true| Indicates if the optimizer rule MoveFilterBeneathGroupBy is activated.",

--- a/server/src/test/java/io/crate/planner/operators/RelationNamesInLogicalPlanTest.java
+++ b/server/src/test/java/io/crate/planner/operators/RelationNamesInLogicalPlanTest.java
@@ -97,7 +97,6 @@ public class RelationNamesInLogicalPlanTest extends CrateDummyClusterServiceUnit
                                                 t2Rename,
                                                 JoinType.INNER,
                                                 e.asSymbol("x = y"),
-                                                false,
                                                 false);
         assertThat(nestedLoopJoin.baseTables(), containsInAnyOrder(t1Relation, t2Relation));
         assertThat(nestedLoopJoin.getRelationNames(), containsInAnyOrder(t1RenamedRelationName, t2RenamedRelationName));

--- a/server/src/test/java/io/crate/planner/optimizer/costs/PlanStatsTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/costs/PlanStatsTest.java
@@ -256,7 +256,7 @@ public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
         );
 
         var nestedLoopJoin = new NestedLoopJoin(
-            lhs, rhs, JoinType.INNER, Literal.BOOLEAN_TRUE, false, false, false, false, false);
+            lhs, rhs, JoinType.INNER, Literal.BOOLEAN_TRUE, false, false, false, false);
 
         var memo = new Memo(nestedLoopJoin);
         PlanStats planStats = new PlanStats(nodeContext, txnCtx, tableStats, memo);
@@ -267,13 +267,13 @@ public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
 
         var joinCondition = e.asSymbol("x = y");
         nestedLoopJoin = new NestedLoopJoin(
-            lhs, rhs, JoinType.INNER, joinCondition, false, false, false, false, false);
+            lhs, rhs, JoinType.INNER, joinCondition, false, false, false, false);
         result = planStats.get(nestedLoopJoin);
         assertThat(result.numDocs()).isEqualTo(1L);
         assertThat(result.sizeInBytes()).isEqualTo(32L);
 
         nestedLoopJoin = new NestedLoopJoin(
-            lhs, rhs, JoinType.CROSS, x, false, false, false, false, false);
+            lhs, rhs, JoinType.CROSS, x, false, false, false, false);
 
         memo = new Memo(nestedLoopJoin);
         planStats = new PlanStats(nodeContext, txnCtx, tableStats, memo);

--- a/server/src/test/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsToFilterTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsToFilterTest.java
@@ -21,14 +21,12 @@
 
 package io.crate.planner.optimizer.rule;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static io.crate.testing.Asserts.assertThat;
 
 import java.util.Collections;
 import java.util.Map;
 import java.util.function.Function;
 
-import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -39,8 +37,7 @@ import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.RelationName;
 import io.crate.planner.operators.Collect;
 import io.crate.planner.operators.Filter;
-import io.crate.planner.operators.HashJoin;
-import io.crate.planner.operators.NestedLoopJoin;
+import io.crate.planner.operators.JoinPlan;
 import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Match;
@@ -50,7 +47,7 @@ import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SqlExpressions;
 import io.crate.testing.T3;
 
-public class MoveConstantJoinConditionsBeneathNestedLoopTest extends CrateDummyClusterServiceUnitTest {
+public class MoveConstantJoinConditionsToFilterTest extends CrateDummyClusterServiceUnitTest {
 
     private SqlExpressions sqlExpressions;
     private Map<RelationName, AnalyzedRelation> sources;
@@ -64,7 +61,7 @@ public class MoveConstantJoinConditionsBeneathNestedLoopTest extends CrateDummyC
     }
 
     @Test
-    public void test_optimize_nestedloopjoin_to_hashjoin_when_constant_can_be_pused_down() {
+    public void test_extract_constant_join_conditions_into_a_filter() {
         var t1 = (AbstractTableRelation<?>) sources.get(T3.T1);
         var t2 = (AbstractTableRelation<?>) sources.get(T3.T2);
 
@@ -76,24 +73,24 @@ public class MoveConstantJoinConditionsBeneathNestedLoopTest extends CrateDummyC
         var nonConstantPart = sqlExpressions.asSymbol("doc.t1.x = doc.t2.y");
         var constantPart = sqlExpressions.asSymbol("doc.t2.b = 'abc'");
 
-        NestedLoopJoin nl = new NestedLoopJoin(c1, c2, JoinType.INNER, joinCondition, false, false, false, false, false);
-        var rule = new MoveConstantJoinConditionsBeneathNestedLoop();
-        Match<NestedLoopJoin> match = rule.pattern().accept(nl, Captures.empty());
+        var join = new JoinPlan(c1, c2, JoinType.INNER, joinCondition, false);
+        var rule = new MoveConstantJoinConditionsToFilter();
+        Match<JoinPlan> match = rule.pattern().accept(join, Captures.empty());
 
-        assertThat(match.isPresent(), Matchers.is(true));
-        assertThat(match.value(), Matchers.is(nl));
+        assertThat(match.isPresent()).isTrue();
+        assertThat(match.value()).isEqualTo(join);
 
-        HashJoin result = (HashJoin) rule.apply(match.value(),
+        Filter result = (Filter) rule.apply(match.value(),
                                                 match.captures(),
                                                 planStats,
                                                 CoordinatorTxnCtx.systemTransactionContext(),
                                                 sqlExpressions.nodeCtx,
                                                 Function.identity());
 
-        assertThat(result.joinCondition(), is(nonConstantPart));
-        assertThat(result.lhs(), is(c1));
-        Filter filter = (Filter) result.rhs();
-        assertThat(filter.source(), is(c2));
-        assertThat(filter.query(), is(constantPart));
+        assertThat(result.query()).isEqualTo(constantPart);
+        JoinPlan joinWithoutConstantConditions = (JoinPlan) result.source();
+        assertThat(joinWithoutConstantConditions.joinCondition()).isEqualTo(nonConstantPart);
+        assertThat(joinWithoutConstantConditions.lhs()).isEqualTo(c1);
+        assertThat(joinWithoutConstantConditions.lhs()).isEqualTo(c1);
     }
 }


### PR DESCRIPTION
This simplifies the MoveConstantJoinConditionsBeneathNestedLoop rule by moving the constant join conditions into a filter on top of the join. This makes the rule logic simpler and has the same effect in combination with the push filter rules. It also allows to operate on JoinPlan instead of NestedLoopJoin which makes the rule more generic. All the previous use-cases and tests are valid and passing.

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
