### PR TITLE
Make MoveFilterBeneathJoin operate on any Join again

### DIFF
--- a/server/src/main/java/io/crate/planner/optimizer/rule/FilterOnJoinsUtil.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/FilterOnJoinsUtil.java
@@ -27,8 +27,8 @@ import io.crate.common.collections.Sets;
 import io.crate.expression.operator.AndOperator;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.RelationName;
+import io.crate.planner.operators.AbstractJoinPlan;
 import io.crate.planner.operators.Filter;
-import io.crate.planner.operators.JoinPlan;
 import io.crate.planner.operators.LogicalPlan;
 
 import org.jetbrains.annotations.Nullable;
@@ -47,7 +47,7 @@ final class FilterOnJoinsUtil {
         return splitQuery == null ? source : new Filter(source, splitQuery);
     }
 
-    static LogicalPlan moveQueryBelowJoin(Symbol query, JoinPlan join) {
+    static LogicalPlan moveQueryBelowJoin(Symbol query, AbstractJoinPlan join) {
         if (!WhereClause.canMatch(query)) {
             return join.replaceSources(List.of(
                 getNewSource(query, join.lhs()),

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathJoin.java
@@ -23,7 +23,7 @@ package io.crate.planner.optimizer.rule;
 
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
-import io.crate.planner.operators.JoinPlan;
+import io.crate.planner.operators.AbstractJoinPlan;
 import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
@@ -40,14 +40,14 @@ import java.util.function.Function;
 
 public final class MoveFilterBeneathJoin implements Rule<Filter> {
 
-    private final Capture<JoinPlan> joinCapture;
+    private final Capture<AbstractJoinPlan> joinCapture;
     private final Pattern<Filter> pattern;
 
     public MoveFilterBeneathJoin() {
         this.joinCapture = new Capture<>();
         this.pattern = typeOf(Filter.class)
             .with(source(),
-                  typeOf(JoinPlan.class)
+                  typeOf(AbstractJoinPlan.class)
                       .capturedAs(joinCapture)
                       // Can't apply this on OUTER JOINs as outer join actively produce new null rows
                       // We need to run the filter on top of these null rows to produce the correct results
@@ -67,7 +67,7 @@ public final class MoveFilterBeneathJoin implements Rule<Filter> {
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {
-        JoinPlan join = captures.get(joinCapture);
+        AbstractJoinPlan join = captures.get(joinCapture);
         return moveQueryBelowJoin(filter.query(), join);
     }
 }


### PR DESCRIPTION
Make MoveFilterBeneathJoin operate on AbstractJoinPlan to make it applicable for JoinPlan, NestedLoop and HashJoin again. This is a follow-up for https://github.com/crate/crate/commit/1cb03b79e0c5b4d49b24ec8fefaa45642bf3db33 where JoinPlan became a concrete Instance instead of an Interface.

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
