### PR TITLE
Assign OID's to all references by a dedicated logic

### DIFF
--- a/server/src/main/java/io/crate/execution/ddl/tables/TableCreator.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TableCreator.java
@@ -111,8 +111,7 @@ public class TableCreator {
                 createTable.getCheckConstraints(),
                 createTable.partitionedBy(),
                 tableColumnPolicy,
-                routingColumn,
-                null // 5.3 requests don't expect OID in mapping
+                routingColumn
             );
             createTableRequest = templateName == null
                 ? new CreateTableRequest(

--- a/server/src/main/java/io/crate/metadata/GeneratedReference.java
+++ b/server/src/main/java/io/crate/metadata/GeneratedReference.java
@@ -21,6 +21,8 @@
 
 package io.crate.metadata;
 
+import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -282,6 +284,18 @@ public class GeneratedReference implements Reference {
     }
 
     @Override
+    public Reference applyColumnOid(Metadata.ColumnOidSupplier oidSupplier) {
+        if (ref.oid() != COLUMN_OID_UNASSIGNED) {
+            return this;
+        }
+        return new GeneratedReference(
+                ref.applyColumnOid(oidSupplier),
+                formattedGeneratedExpression,
+                generatedExpression
+        );
+    }
+
+    @Override
     public long ramBytesUsed() {
         return SHALLOW_SIZE
             + ref.ramBytesUsed()
@@ -291,7 +305,7 @@ public class GeneratedReference implements Reference {
     }
 
     @Override
-    public Map<String, Object> toMapping(int position, @Nullable Metadata.ColumnOidSupplier columnOidSupplier) {
-        return ref.toMapping(position, columnOidSupplier);
+    public Map<String, Object> toMapping(int position) {
+        return ref.toMapping(position);
     }
 }

--- a/server/src/main/java/io/crate/metadata/GeoReference.java
+++ b/server/src/main/java/io/crate/metadata/GeoReference.java
@@ -21,6 +21,8 @@
 
 package io.crate.metadata;
 
+import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
+
 import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
@@ -181,8 +183,30 @@ public class GeoReference extends SimpleReference {
     }
 
     @Override
-    public Map<String, Object> toMapping(int position, @Nullable Metadata.ColumnOidSupplier columnOidSupplier) {
-        Map<String, Object> mapping = super.toMapping(position, columnOidSupplier);
+    public Reference applyColumnOid(Metadata.ColumnOidSupplier oidSupplier) {
+        if (oid != COLUMN_OID_UNASSIGNED) {
+            return this;
+        }
+        return new GeoReference(
+                ident,
+                type,
+                columnPolicy,
+                indexType,
+                nullable,
+                position,
+                oidSupplier.nextOid(),
+                isDropped,
+                defaultExpression,
+                geoTree,
+                precision,
+                treeLevels,
+                distanceErrorPct
+        );
+    }
+
+    @Override
+    public Map<String, Object> toMapping(int position) {
+        Map<String, Object> mapping = super.toMapping(position);
         Maps.putNonNull(mapping, "tree", geoTree);
         Maps.putNonNull(mapping, "precision", precision);
         Maps.putNonNull(mapping, "tree_levels", treeLevels);

--- a/server/src/main/java/io/crate/metadata/IndexReference.java
+++ b/server/src/main/java/io/crate/metadata/IndexReference.java
@@ -22,6 +22,7 @@
 package io.crate.metadata;
 
 import static java.util.Objects.requireNonNull;
+import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -236,8 +237,8 @@ public class IndexReference extends SimpleReference {
     }
 
     @Override
-    public Map<String, Object> toMapping(int position, @Nullable Metadata.ColumnOidSupplier columnOidSupplier) {
-        Map<String, Object> mapping = super.toMapping(position, columnOidSupplier);
+    public Map<String, Object> toMapping(int position) {
+        Map<String, Object> mapping = super.toMapping(position);
         if (analyzer != null) {
             mapping.put("analyzer", analyzer);
         }
@@ -248,5 +249,45 @@ public class IndexReference extends SimpleReference {
         }
 
         return mapping;
+    }
+
+    @Override
+    public Reference applyColumnOid(Metadata.ColumnOidSupplier oidSupplier) {
+        if (oid != COLUMN_OID_UNASSIGNED) {
+            return this;
+        }
+        return new IndexReference(
+                ident,
+                granularity,
+                type,
+                columnPolicy,
+                indexType,
+                nullable,
+                hasDocValues,
+                position,
+                oidSupplier.nextOid(),
+                isDropped,
+                defaultExpression,
+                columns,
+                analyzer
+        );
+    }
+
+    public IndexReference updateColumns(List<Reference> newColumns) {
+        return new IndexReference(
+                ident,
+                granularity,
+                type,
+                columnPolicy,
+                indexType,
+                nullable,
+                hasDocValues,
+                position,
+                oid,
+                isDropped,
+                defaultExpression,
+                newColumns,
+                analyzer
+        );
     }
 }

--- a/server/src/main/java/io/crate/metadata/Reference.java
+++ b/server/src/main/java/io/crate/metadata/Reference.java
@@ -83,6 +83,8 @@ public interface Reference extends Symbol {
 
     Reference getRelocated(ReferenceIdent referenceIdent);
 
+    Reference applyColumnOid(Metadata.ColumnOidSupplier oidSupplier);
+
     /**
      * Creates the {@link IndexMetadata} mapping representation of the Column.
      * <p>
@@ -91,7 +93,7 @@ public interface Reference extends Symbol {
      *
      * @param position position to use in the mapping
      */
-    Map<String, Object> toMapping(int position, @Nullable Metadata.ColumnOidSupplier columnOidSupplier);
+    Map<String, Object> toMapping(int position);
 
     static void toStream(StreamOutput out, Reference ref) throws IOException {
         out.writeVInt(ref.symbolType().ordinal());

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -67,6 +67,8 @@ import org.elasticsearch.rest.RestStatus;
 import com.carrotsearch.hppc.cursors.ObjectCursor;
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 
+import io.crate.common.annotations.VisibleForTesting;
+
 public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, ToXContentFragment {
 
     private static final Logger LOGGER = LogManager.getLogger(Metadata.class);
@@ -593,7 +595,8 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
     public static class ColumnOidSupplier {
         private long columnOID;
 
-        private ColumnOidSupplier(long columnOID) {
+        @VisibleForTesting
+        public ColumnOidSupplier(long columnOID) {
             this.columnOID = columnOID;
         }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -93,9 +93,11 @@ import org.jetbrains.annotations.Nullable;
 
 import io.crate.execution.ddl.tables.CreateTableRequest;
 import io.crate.execution.ddl.tables.MappingUtil;
+import io.crate.metadata.DocReferences;
 import io.crate.metadata.IndexParts;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.PartitionName;
+import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.doc.DocTableInfoFactory;
 
@@ -337,15 +339,19 @@ public class MetadataCreateIndexService {
                     if (createTableRequest == null) {
                         mapping = new HashMap<>(); // resize doesn't change mapping, will be merged below as is.
                     } else {
+                        List<Reference> references = DocReferences.applyOid(
+                                createTableRequest.references(),
+                                metadataBuilder.columnOidSupplier()
+                        );
+
                         mapping = MappingUtil.createMapping(
                             MappingUtil.AllocPosition.forNewTable(),
-                            createTableRequest.references(),
+                            references,
                             createTableRequest.pKeyIndices(),
                             createTableRequest.checkConstraints(),
                             createTableRequest.partitionedBy(),
                             createTableRequest.tableColumnPolicy(),
-                            createTableRequest.routingColumn(),
-                            metadataBuilder.columnOidSupplier()
+                            createTableRequest.routingColumn()
                         );
                     }
                 } else {

--- a/server/src/test/java/io/crate/metadata/IndexReferenceTest.java
+++ b/server/src/test/java/io/crate/metadata/IndexReferenceTest.java
@@ -73,7 +73,7 @@ public class IndexReferenceTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo table = e.resolveTableInfo("tbl");
         IndexReference reference = table.indexColumn(new ColumnIdent("title_desc_fulltext"));
 
-        Map<String, Object> mapping = reference.toMapping(reference.position(), null);
+        Map<String, Object> mapping = reference.toMapping(reference.position());
         assertThat(mapping)
             .containsEntry("sources", List.of("title", "description"))
             .containsEntry("oid", 3L)

--- a/server/src/test/java/io/crate/metadata/ReferenceTest.java
+++ b/server/src/test/java/io/crate/metadata/ReferenceTest.java
@@ -143,7 +143,7 @@ public class ReferenceTest extends CrateDummyClusterServiceUnitTest {
             .build();
         DocTableInfo table = e.resolveTableInfo("tbl");
         Reference reference = table.getReference(new ColumnIdent("xs"));
-        Map<String, Object> mapping = reference.toMapping(reference.position(), null);
+        Map<String, Object> mapping = reference.toMapping(reference.position());
         assertThat(mapping)
             .containsEntry("length_limit", 40)
             .containsEntry("position", 1)
@@ -163,7 +163,7 @@ public class ReferenceTest extends CrateDummyClusterServiceUnitTest {
             .build();
         DocTableInfo table = e.resolveTableInfo("tbl");
         Reference reference = table.getReference(new ColumnIdent("xs"));
-        Map<String, Object> mapping = reference.toMapping(reference.position(), null);
+        Map<String, Object> mapping = reference.toMapping(reference.position());
         assertThat(mapping)
             .containsEntry("position", 1)
             .containsEntry("oid", 1L)
@@ -183,7 +183,7 @@ public class ReferenceTest extends CrateDummyClusterServiceUnitTest {
                 .build();
         DocTableInfo table = e.resolveTableInfo("tbl");
         Reference reference = table.getReference(new ColumnIdent("xs"));
-        Map<String, Object> mapping = reference.toMapping(reference.position(), null);
+        Map<String, Object> mapping = reference.toMapping(reference.position());
         assertThat(mapping)
             .containsEntry("position", 1)
             .containsEntry("oid", 1L)
@@ -203,7 +203,7 @@ public class ReferenceTest extends CrateDummyClusterServiceUnitTest {
             .build();
         DocTableInfo table = e.resolveTableInfo("tbl");
         Reference reference = table.getReference(new ColumnIdent("xs"));
-        Map<String, Object> mapping = reference.toMapping(reference.position(), null);
+        Map<String, Object> mapping = reference.toMapping(reference.position());
         assertThat(mapping)
             .containsEntry("position", 1)
             .containsEntry("oid", 1L)

--- a/server/src/testFixtures/java/io/crate/testing/TestingHelpers.java
+++ b/server/src/testFixtures/java/io/crate/testing/TestingHelpers.java
@@ -76,6 +76,7 @@ import io.crate.expression.predicate.PredicateModule;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.tablefunctions.TableFunctionModule;
 import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.DocReferences;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
@@ -430,15 +431,24 @@ public class TestingHelpers {
         var policy = (String) boundCreateTable.tableParameter().mappings().get(ColumnPolicies.ES_MAPPING_NAME);
         var tableColumnPolicy = policy != null ? ColumnPolicies.decodeMappingValue(policy) : ColumnPolicy.STRICT;
 
+        List<Reference> references;
+        if (columnOidSupplier != null) {
+            references = DocReferences.applyOid(
+                    boundCreateTable.columns().values(),
+                    columnOidSupplier
+            );
+        } else {
+            references = new ArrayList<>(boundCreateTable.columns().values());
+        }
+
         return createMapping(
             MappingUtil.AllocPosition.forNewTable(),
-            new ArrayList<>(boundCreateTable.columns().values()),
+            references,
             pKeysIndices,
             boundCreateTable.getCheckConstraints(),
             boundCreateTable.partitionedBy(),
             tableColumnPolicy,
-            boundCreateTable.routingColumn().equals(DocSysColumns.ID) ? null : boundCreateTable.routingColumn().fqn(),
-            columnOidSupplier
+            boundCreateTable.routingColumn().equals(DocSysColumns.ID) ? null : boundCreateTable.routingColumn().fqn()
         );
 
     }


### PR DESCRIPTION
IndexReferences refer to other references. When assigning OID's to each references, these referred references must also be updated.
