### PR TITLE
Add max_identifier_length read-only session setting

### DIFF
--- a/docs/appendices/release-notes/5.5.0.rst
+++ b/docs/appendices/release-notes/5.5.0.rst
@@ -87,6 +87,8 @@ SQL Standard and PostgreSQL Compatibility
 - Allowed statements that set
   :ref:`standard_conforming_strings session setting<conf-session-standard_conforming_strings>`
   to the default value (``on``).
+ 
+- Added a new read-only session setting ``max_identifier_length``.
 
 Data Types
 ----------

--- a/docs/config/session.rst
+++ b/docs/config/session.rst
@@ -164,6 +164,14 @@ releases.
      The session setting has no effect in CrateDB and exists for compatibility
      with ``PostgreSQL``.
 
+.. _conf-session-max_identifier_length:
+
+**max_identifier_length**
+  | *Default:* ``255``
+  | *Modifiable:* ``no``
+
+  Shows the maximum length of identifiers in bytes.
+
 .. _conf-session-server_version_num:
 
 **server_version_num**

--- a/server/src/main/java/io/crate/metadata/settings/session/SessionSettingRegistry.java
+++ b/server/src/main/java/io/crate/metadata/settings/session/SessionSettingRegistry.java
@@ -46,12 +46,15 @@ import io.crate.protocols.postgres.PostgresWireProtocol;
 import io.crate.types.BooleanType;
 import io.crate.types.DataTypes;
 
+import org.elasticsearch.cluster.metadata.MetadataCreateIndexService;
+
 @Singleton
 public class SessionSettingRegistry {
 
     private static final String SEARCH_PATH_KEY = "search_path";
     public static final String HASH_JOIN_KEY = "enable_hashjoin";
     static final String MAX_INDEX_KEYS = "max_index_keys";
+    static final String MAX_IDENTIFIER_LENGTH = "max_identifier_length";
     static final String SERVER_VERSION_NUM = "server_version_num";
     static final String SERVER_VERSION = "server_version";
     static final String STANDARD_CONFORMING_STRINGS = "standard_conforming_strings";
@@ -158,6 +161,18 @@ public class SessionSettingRegistry {
                      s -> String.valueOf(32),
                      () -> String.valueOf(32),
                      "Shows the maximum number of index keys.",
+                     DataTypes.INTEGER))
+            .put(MAX_IDENTIFIER_LENGTH,
+                 new SessionSetting<>(
+                     MAX_IDENTIFIER_LENGTH,
+                     objects -> {},
+                     Function.identity(),
+                     (s, v) -> {
+                         throw new UnsupportedOperationException("\"" + MAX_IDENTIFIER_LENGTH + "\" cannot be changed.");
+                     },
+                     s -> String.valueOf(MetadataCreateIndexService.MAX_INDEX_NAME_BYTES),
+                     () -> String.valueOf(MetadataCreateIndexService.MAX_INDEX_NAME_BYTES),
+                     "Shows the maximum length of identifiers in bytes.",
                      DataTypes.INTEGER))
             .put(SERVER_VERSION_NUM,
                  new SessionSetting<>(

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -162,6 +162,7 @@ public class PgCatalogITest extends IntegTestCase {
             "datestyle| ISO| Display format for date and time values.| NULL| NULL",
             "enable_hashjoin| false| Considers using the Hash Join instead of the Nested Loop Join implementation.| NULL| NULL",
             "error_on_unknown_object_key| true| Raises or suppresses ObjectKeyUnknownException when querying nonexistent keys to dynamic objects.| NULL| NULL",
+            "max_identifier_length| 255| Shows the maximum length of identifiers in bytes.| NULL| NULL",
             "max_index_keys| 32| Shows the maximum number of index keys.| NULL| NULL",
             "memory.operation_limit| 0| Memory limit in bytes for an individual operation. 0 by-passes the operation limit, relying entirely on the global circuit breaker limits| NULL| NULL",
             "optimizer_deduplicate_order| true| Indicates if the optimizer rule DeduplicateOrder is activated.| NULL| NULL",

--- a/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
@@ -402,6 +402,7 @@ public class ShowIntegrationTest extends IntegTestCase {
             "datestyle| ISO| Display format for date and time values.",
             "enable_hashjoin| true| Considers using the Hash Join instead of the Nested Loop Join implementation.",
             "error_on_unknown_object_key| true| Raises or suppresses ObjectKeyUnknownException when querying nonexistent keys to dynamic objects.",
+            "max_identifier_length| 255| Shows the maximum length of identifiers in bytes.",
             "max_index_keys| 32| Shows the maximum number of index keys.",
             "memory.operation_limit| 0| Memory limit in bytes for an individual operation. 0 by-passes the operation limit, relying entirely on the global circuit breaker limits",
             "optimizer_deduplicate_order| true| Indicates if the optimizer rule DeduplicateOrder is activated.",

--- a/server/src/test/java/io/crate/metadata/settings/session/SessionSettingRegistryTest.java
+++ b/server/src/test/java/io/crate/metadata/settings/session/SessionSettingRegistryTest.java
@@ -66,6 +66,14 @@ public class SessionSettingRegistryTest extends ESTestCase {
     }
 
     @Test
+    public void test_max_identifier_length_session_setting_cannot_be_changed() {
+        SessionSetting<?> setting = new SessionSettingRegistry(Set.of(new LoadedRules())).settings().get(SessionSettingRegistry.MAX_IDENTIFIER_LENGTH);
+        assertThatThrownBy(() -> setting.apply(SESSION_SETTINGS, generateInput("255"), EVAL))
+            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .hasMessage("\"max_identifier_length\" cannot be changed.");
+    }
+
+    @Test
     public void test_server_version_num_session_setting_cannot_be_changed() {
         SessionSetting<?> setting = new SessionSettingRegistry(Set.of(new LoadedRules())).settings().get(SessionSettingRegistry.SERVER_VERSION_NUM);
         assertThatThrownBy(() -> setting.apply(SESSION_SETTINGS, generateInput("100000"), EVAL))


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Closes: #14743

## Checklist

 - [X] Added an entry in `CHANGES.txt` for user facing changes
 - [X] Updated documentation & `sql_features` table for user facing changes
 - [X] Touched code is covered by tests
 - [X] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [X] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
