### PR TITLE
Update antlr to 4.13.1

### DIFF
--- a/gradle/version.properties
+++ b/gradle/version.properties
@@ -1,5 +1,5 @@
 # crate and components deps
-antlr=4.12.0
+antlr=4.13.1
 jodatime=2.12.2
 bouncycastle=1.70
 bytebuddy=1.12.19


### PR DESCRIPTION
Hardly any java related changes:

- https://github.com/antlr/antlr4/releases/tag/4.13.0
- https://github.com/antlr/antlr4/releases/tag/4.13.1

Jar file should be smaller. A JDK 21 related warnings suppression.

Motivated by https://github.com/crate/crate/pull/13651, the antlr4 maven
plugin used the newer tooling version, which led to warnings due to
a runtime version mismatch.
