### PR TITLE
Restrict column definition with the same name and same type on CREATE TABLE

### DIFF
--- a/docs/appendices/release-notes/5.4.4.rst
+++ b/docs/appendices/release-notes/5.4.4.rst
@@ -60,3 +60,6 @@ Fixes
 - Fixed a regression introduced with CrateDB 5.3.1 which caused a
   ``NullPointerException`` when creating a repository on S3 with authentication
   provided by IAM role attached to the EC2 instance running the CrateDB node.
+
+- Fixed an issue which led to skipping duplicate column check, in
+  ``CREATE TABLE`` statements, if duplicate columns have the same type.

--- a/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -881,7 +881,13 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
 
     @Test
     public void testCreateTableSameColumn() {
+        // Same name, different type.
         assertThatThrownBy(() -> analyze("create table my_table (title string, title integer)"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("column \"title\" specified more than once");
+
+        // Same name, same type.
+        assertThatThrownBy(() -> analyze("create table my_table (title string, title string)"))
             .isExactlyInstanceOf(IllegalArgumentException.class)
             .hasMessage("column \"title\" specified more than once");
     }


### PR DESCRIPTION
Fixes part of https://github.com/crate/crate/issues/14729

On master it's already fixed by https://github.com/crate/crate/pull/14360/.  

Creating a 5.4 fix directly (will only add a test modification to the master later on)

I've verified that INSERT columns validation is not done on master, so will create a separate PR for that