### PR TITLE
Add test case for duplicate column definition

### DIFF
--- a/docs/appendices/release-notes/5.4.4.rst
+++ b/docs/appendices/release-notes/5.4.4.rst
@@ -61,5 +61,8 @@ Fixes
   ``NullPointerException`` when creating a repository on S3 with authentication
   provided by IAM role attached to the EC2 instance running the CrateDB node.
 
+- Fixed an issue which led to skipping duplicate column check, in
+  ``CREATE TABLE`` statements, if duplicate columns have the same type.
+
 - Fixed an issue with missing validation on ``INSERT`` statement, allowing to
   specify duplicate target columns.

--- a/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -876,7 +876,13 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
 
     @Test
     public void testCreateTableSameColumn() {
+        // Same name, different type.
         assertThatThrownBy(() -> analyze("create table my_table (title string, title integer)"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("column \"title\" specified more than once");
+
+        // Same name, same type.
+        assertThatThrownBy(() -> analyze("create table my_table (title string, title string)"))
             .isExactlyInstanceOf(IllegalArgumentException.class)
             .hasMessage("column \"title\" specified more than once");
     }


### PR DESCRIPTION
Ported only change entry and test case from https://github.com/crate/crate/commit/6085d2d3cb1585c4566061ecbd291d3057c65a05

Validation of same name/same type case is already covered on master in https://github.com/crate/crate/commit/42b4051dd1ce53a139efcad14ca01443b2fa8f58


