### PR TITLE
Do not throw an error on UPDATE on a table, emptied by DELETE 

### DIFF
--- a/docs/appendices/release-notes/5.4.4.rst
+++ b/docs/appendices/release-notes/5.4.4.rst
@@ -66,3 +66,6 @@ Fixes
 
 - Fixed an issue with missing validation on ``INSERT`` statement, allowing to
   specify duplicate target columns.
+
+- Fixed an issue that caused ``UPDATE`` statements, invoked immediately after a
+  ``DELETE`` statement, which empties a table, to show an error.

--- a/server/src/main/java/io/crate/execution/dml/ShardRequestExecutor.java
+++ b/server/src/main/java/io/crate/execution/dml/ShardRequestExecutor.java
@@ -22,6 +22,7 @@
 package io.crate.execution.dml;
 
 import static io.crate.data.SentinelRow.SENTINEL;
+import static io.crate.execution.engine.indexing.ShardDMLExecutor.maybeRaiseFailure;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -36,21 +37,17 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.lucene.uid.Versions;
 import org.elasticsearch.index.IndexNotFoundException;
-import org.elasticsearch.index.engine.DocumentMissingException;
-import org.elasticsearch.index.engine.VersionConflictEngineException;
 import org.elasticsearch.index.seqno.SequenceNumbers;
 import org.elasticsearch.index.shard.ShardId;
 
 import com.carrotsearch.hppc.IntArrayList;
 
 import io.crate.analyze.where.DocKeys;
-import io.crate.common.exceptions.Exceptions;
 import io.crate.data.InMemoryBatchIterator;
 import io.crate.data.Row;
 import io.crate.data.Row1;
 import io.crate.data.RowConsumer;
 import io.crate.data.RowN;
-import io.crate.exceptions.SQLExceptions;
 import io.crate.execution.support.MultiActionListener;
 import io.crate.execution.support.OneRowActionListener;
 import io.crate.metadata.IndexParts;
@@ -247,13 +244,7 @@ public class ShardRequestExecutor<Req> {
     }
 
     private static <A> void updateOrFail(A acc, ShardResponse response, BiConsumer<A, ShardResponse> f) {
-        Exception exception = response.failure();
-        if (exception != null) {
-            Throwable t = SQLExceptions.unwrap(exception);
-            if (!(t instanceof DocumentMissingException) && !(t instanceof VersionConflictEngineException)) {
-                throw Exceptions.toRuntimeException(t);
-            }
-        }
+        maybeRaiseFailure(response.failure());
         for (int i = 0; i < response.itemIndices().size(); i++) {
             ShardResponse.Failure failure = response.failures().get(i);
             if (failure == null) {

--- a/server/src/main/java/io/crate/execution/engine/indexing/ShardDMLExecutor.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/ShardDMLExecutor.java
@@ -35,6 +35,7 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collector;
 
+import io.crate.exceptions.SQLExceptions;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
@@ -43,6 +44,8 @@ import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.index.engine.DocumentMissingException;
+import org.elasticsearch.index.engine.VersionConflictEngineException;
 import org.elasticsearch.index.shard.ShardNotFoundException;
 import org.jetbrains.annotations.Nullable;
 
@@ -236,17 +239,19 @@ public class ShardDMLExecutor<TReq extends ShardRequest<TReq, TItem>,
         return nodeId;
     }
 
-    private static void maybeRaiseFailure(ShardResponse shardResponse) {
-        Exception failure = shardResponse.failure();
-        if (failure != null) {
-            throw Exceptions.toRuntimeException(failure);
+    public static void maybeRaiseFailure(@Nullable Exception exception) {
+        if (exception != null) {
+            Throwable t = SQLExceptions.unwrap(exception);
+            if (!(t instanceof DocumentMissingException) && !(t instanceof VersionConflictEngineException)) {
+                throw Exceptions.toRuntimeException(t);
+            }
         }
     }
 
     public static final Collector<ShardResponse, long[], Iterable<Row>> ROW_COUNT_COLLECTOR = Collector.of(
         () -> new long[]{0L},
         (acc, response) -> {
-            maybeRaiseFailure(response);
+            maybeRaiseFailure(response.failure());
             acc[0] += response.successRowCount();
         },
         (acc, response) -> {
@@ -259,7 +264,7 @@ public class ShardDMLExecutor<TReq extends ShardRequest<TReq, TItem>,
     public static final Collector<ShardResponse, List<Object[]>, Iterable<Row>> RESULT_ROW_COLLECTOR = Collector.of(
         ArrayList::new,
         (acc, response) -> {
-            maybeRaiseFailure(response);
+            maybeRaiseFailure(response.failure());
             List<Object[]> rows = response.getResultRows();
             if (rows != null) {
                 acc.addAll(rows);


### PR DESCRIPTION
Fixes https://github.com/crate/crate/issues/14707 

Please note, that continue on error which is done in  https://github.com/crate/crate/pull/14719 also fixes DELETE + UPDATE issue but it's more a feature (allow partial failure) and cannot be back ported. 

Prepared a more pin-point, specific for DELETE+UPDATE fix because:
1. It can be backported to 5.4 since its a fix and not a breaking change.
2. As discussed in https://github.com/crate/crate/pull/14719#discussion_r1337222076, once we implement session setting to throw an error https://github.com/crate/crate/issues/12218, this issue will pop up again in that case - UPDATE should not throw an error on the empty table