### PR TITLE
Fix issue with unmatched return types for CASE

### DIFF
--- a/docs/appendices/release-notes/5.4.4.rst
+++ b/docs/appendices/release-notes/5.4.4.rst
@@ -51,7 +51,7 @@ Fixes
   must be taken to apply the fix and solve the issue.
 
 - Fixed an issue that caused nested accesses to ``ignored`` objects with
-  unknown object keys from returning non ``nulls``. For example::
+  unknown object keys from returning non ``nulls``. e.g.::
 
     SELECT o['a']['unknown'] FROM t;
 
@@ -74,3 +74,16 @@ Fixes
 
 - Fixed an issue that caused ``UPDATE`` statements, invoked immediately after a
   ``DELETE`` statement, which empties a table, to show an error.
+
+- Fixed an issue that caused ``CASE`` expressions to throw
+  ``UnsupportedFeatureException`` when ``null`` values are returned for one or
+  more conditions. e.g.::
+
+    SELECT CASE col1
+             WHEN 'value1' THEN 1
+	         WHEN 'value2' THEN NULL
+	         WHEN 'value3' THEN 3
+	         ELSE NULL
+	       END
+    FROM (select 'value1' as col1) a;
+

--- a/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -1265,7 +1265,9 @@ public class ExpressionAnalyzer {
         var resultTypes = new HashSet<>(results.size() / 2);
         for (int i = 3; i < results.size(); i = i + 2) {
             var type = results.get(i).valueType();
-            resultTypes.add(type);
+            if (type.id() != DataTypes.UNDEFINED.id()) {
+                resultTypes.add(type);
+            }
         }
         if (resultTypes.size() > 1) {
             var errorMessage = new ArrayList<DataType<?>>(results.size() / 2);

--- a/server/src/test/java/io/crate/expression/scalar/conditional/ConditionalFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/conditional/ConditionalFunctionTest.java
@@ -21,6 +21,8 @@
 
 package io.crate.expression.scalar.conditional;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import org.junit.Test;
 
 import io.crate.exceptions.ConversionException;
@@ -64,10 +66,10 @@ public class ConditionalFunctionTest extends ScalarTestCase {
 
     @Test
     public void testNullIfInvalidArgsLength() throws Exception {
-        expectedException.expect(UnsupportedFunctionException.class);
-        expectedException.expectMessage("Unknown function: nullif(1, 2, 3)," +
-                                        " no overload found for matching argument types: (integer, integer, integer).");
-        assertEvaluateNull("nullif(1, 2, 3)");
+        assertThatThrownBy(() -> assertEvaluateNull("nullif(1, 2, 3)"))
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
+            .hasMessageStartingWith("Unknown function: nullif(1, 2, 3)," +
+                                    " no overload found for matching argument types: (integer, integer, integer).");
     }
 
     @Test
@@ -105,19 +107,20 @@ public class ConditionalFunctionTest extends ScalarTestCase {
 
     @Test
     public void testCaseIncompatibleTypes() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("Data types of all result expressions of a CASE statement must be equal, " +
-                                        "found: [text, integer]");
-        assertEvaluate("case name when 'foo' then 'hello foo' when 'bar' then 1 end",
-            "hello foo",
-            Literal.of("foo"), Literal.of("foo"));
+        assertThatThrownBy(() ->
+            assertEvaluate("case name when 'foo' then 'hello foo' when 'bar' then 1 end",
+                "hello foo",
+                Literal.of("foo"), Literal.of("foo")))
+            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .hasMessage("Data types of all result expressions of a CASE statement must be equal, " +
+                        "found: [text, integer]");
     }
 
     @Test
     public void testCaseConditionNotBooleanThrowsIllegalArgumentException() {
-        expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `boolean`");
-        assertEvaluate("case when 'foo' then x else 1 end", "");
+        assertThatThrownBy(() -> assertEvaluate("case when 'foo' then x else 1 end", ""))
+            .isExactlyInstanceOf(ConversionException.class)
+            .hasMessage("Cannot cast `'foo'` of type `text` to type `boolean`");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/conditional/ConditionalFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/conditional/ConditionalFunctionTest.java
@@ -227,4 +227,11 @@ public class ConditionalFunctionTest extends ScalarTestCase {
         assertEvaluate("case when a <= 5 then 0 else 1 / (a - 10) end", 0, Literal.of(4), Literal.of(10));
     }
 
+    @Test
+    public void test_null_in_return_values() throws Exception {
+        assertEvaluateNull("CASE a WHEN 1 THEN 'foo' WHEN 2 THEN null WHEN 3 THEN 'bar' ELSE null END",
+                       Literal.of(4),
+                       Literal.of(4),
+                       Literal.of(4));
+    }
 }


### PR DESCRIPTION
    
    
 -   Previously, `UNDEFINED` type was calculated as a different
     result type, leading to throwing an exception when at least
     one of the CASE clauses is returning null.
    
     Fixes: #14763

-   tests: ConditionalFunctionTest: expectedException -> assertj
