### PR TITLE
RTD: Add configuration file for Read the Docs, which is mandatory now

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -13,12 +13,13 @@ jobs:
         run: |-
           gh api graphql -F contentId=$PR_ID -f query='
             mutation($contentId: ID!) {
-              addProjectNextItem(input: {projectId: "PN_kwDOAD3FaM4ACoUS" contentId: $contentId}) {
-                projectNextItem {
+              addProjectV2ItemById(input: {projectId: "PVT_kwDOAD3FaM4ACoUS" contentId: $contentId}) {
+                item {
                   id
                 }
               }
-            }'
+            }
+            '
         env:
           PR_ID: ${{github.event.pull_request.node_id}}
           GITHUB_TOKEN: ${{ secrets.JENKINS_USER_TOKEN }}

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,16 @@
+---
+version: 2
+
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.11"
+
+python:
+  install:
+  - requirements: docs/requirements.txt
+
+sphinx:
+  builder: html
+  configuration: docs/conf.py
+  fail_on_warning: true

--- a/docs/general/ddl/data-types.rst
+++ b/docs/general/ddl/data-types.rst
@@ -3405,7 +3405,7 @@ However, you cannot use it with any :ref:`scalar functions
 .. _Geohash: https://en.wikipedia.org/wiki/Geohash
 .. _GeoJSON geometry objects: https://tools.ietf.org/html/rfc7946#section-3.1
 .. _GeoJSON: https://geojson.org/
-.. _IEEE 754: https://ieeexplore.ieee.org/document/30711/?arnumber=30711&filter=AND(p_Publication_Number:2355)
+.. _IEEE 754: https://en.wikipedia.org/wiki/IEEE_754
 .. _IP address: https://en.wikipedia.org/wiki/IP_address
 .. _ISO 8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
 .. _ISO 8601 time zone designators: https://en.wikipedia.org/wiki/ISO_8601#Time_zone_designators

--- a/docs/general/ddl/data-types.rst
+++ b/docs/general/ddl/data-types.rst
@@ -2210,10 +2210,10 @@ Example::
     ... ) VALUES (
     ...     'Alice in Wonderland',
     ...     {
-    ...         "age" = '10',
+    ...         "age" = '10'
     ...     }
     ... );
-    SQLParseException[line 8:5: no viable alternative at input 'VALUES (\n    'Alice in Wonderland',\n    {\n        "age" = '10',\n    }']
+    StrictDynamicMappingException[mapping set to strict, dynamic introduction of [age] within [protagonist] is not allowed]
 
 The insert above failed because the ``protagonist`` column defines a ``name``
 column and does not define an ``age`` column.

--- a/docs/interfaces/postgres.rst
+++ b/docs/interfaces/postgres.rst
@@ -568,7 +568,7 @@ CrateDB and we love to hear feedback.
 .. _PostgreSQL Fulltext Search: https://www.postgresql.org/docs/current/static/functions-textsearch.html
 .. _PostgreSQL JDBC connection failover: https://jdbc.postgresql.org/documentation/use/#connection-fail-over
 .. _PostgreSQL JDBC Query docs: https://jdbc.postgresql.org/documentation/query
-.. _PostgreSQL simple query: https://www.postgresql.org/docs/current/static/protocol-flow.html#id-1.10.5.7.4
+.. _PostgreSQL simple query: https://www.postgresql.org/docs/14/static/protocol-flow.html#id-1.10.5.7.4
 .. _PostgreSQL value expressions: https://www.postgresql.org/docs/current/static/sql-expressions.html
 .. _PostgreSQL wire protocol v3: https://www.postgresql.org/docs/current/static/protocol.html
-.. _PostgreSQL cancelling requests: https://www.postgresql.org/docs/current/protocol-flow.html#id-1.10.5.7.10
+.. _PostgreSQL cancelling requests: https://www.postgresql.org/docs/14/protocol-flow.html#id-1.10.5.7.10


### PR DESCRIPTION
## About

Read the Docs now mandates a configuration file, `.readthedocs.yml`.

## Problem

Otherwise, RTD builds will fail.

![image](https://github.com/crate/crate/assets/453543/bed32f28-9a00-4f60-8a64-14774ee7d10d)

-- https://readthedocs.org/projects/crate/builds/22054840/

## Details

This is applicable to both the `4.8` and `3.3` branches.


See commits as several fixes are required to make the build work for `4.8`.