### PR TITLE
Add join-reordering back to JoinPlanBuilder

### DIFF
--- a/server/src/main/java/io/crate/planner/operators/JoinOrdering.java
+++ b/server/src/main/java/io/crate/planner/operators/JoinOrdering.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.operators;
+
+import com.carrotsearch.hppc.ObjectIntHashMap;
+import io.crate.common.annotations.VisibleForTesting;
+import io.crate.metadata.RelationName;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Utility class which is used by the {@link JoinPlanBuilder} for the building of
+ * the join tree, which helps to find the optimal ordering of the tables.
+ */
+final class JoinOrdering {
+
+    private JoinOrdering() {
+    }
+
+    static Collection<RelationName> getOrderedRelationNames(Collection<RelationName> sourceRelations,
+                                                            Set<? extends Set<RelationName>> explicitJoinConditions,
+                                                            Set<? extends Set<RelationName>> implicitJoinConditions) {
+        if (sourceRelations.size() == 2) {
+            return sourceRelations;
+        }
+        if (explicitJoinConditions.isEmpty() && implicitJoinConditions.isEmpty()) {
+            return sourceRelations;
+        }
+        return orderByJoinConditions(
+            sourceRelations,
+            explicitJoinConditions,
+            implicitJoinConditions);
+    }
+
+    /**
+     * Returns a the relation re-ordered to apply join conditions further down in the tree.
+     * <p>
+     * (Assuming the relations are consumed from left to right to build a tree of two-relations join nodes)
+     *
+     * @param relations               all relations, e.g. [t1, t2, t3, t3]
+     * @param explicitJoinedRelations contains all relation pairs that have an explicit join condition
+     *                                e.g. {{t1, t2}, {t2, t3}}
+     * @param implicitJoinedRelations contains all relations pairs that have an implicit join condition
+     *                                e.g. {{t1, t2}, {t2, t3}}
+     */
+    static Collection<RelationName> orderByJoinConditions(Collection<RelationName> relations,
+                                                          Set<? extends Set<RelationName>> explicitJoinedRelations,
+                                                          Set<? extends Set<RelationName>> implicitJoinedRelations) {
+        List<Set<RelationName>> pairsWithJoinConditions = new ArrayList<>(explicitJoinedRelations);
+        pairsWithJoinConditions.addAll(implicitJoinedRelations);
+
+        ObjectIntHashMap<RelationName> occurrences =
+            getOccurrencesInJoinConditions(relations.size(), explicitJoinedRelations, implicitJoinedRelations);
+
+        Set<RelationName> firstJoinPair = findAndRemoveFirstJoinPair(occurrences, pairsWithJoinConditions);
+        assert firstJoinPair != null : "firstJoinPair should not be null";
+        LinkedHashSet<RelationName> bestOrder = new LinkedHashSet<>(firstJoinPair);
+
+        buildBestOrderByJoinConditions(pairsWithJoinConditions, bestOrder);
+        bestOrder.addAll(relations);
+        return bestOrder;
+    }
+
+    private static ObjectIntHashMap<RelationName> getOccurrencesInJoinConditions(
+        int numberOfRelations,
+        Set<? extends Set<RelationName>> explicitJoinedRelations,
+        Set<? extends Set<RelationName>> implicitJoinedRelations) {
+
+        ObjectIntHashMap<RelationName> occurrences = new ObjectIntHashMap<>(numberOfRelations);
+        explicitJoinedRelations.forEach(o -> o.forEach(qName -> occurrences.putOrAdd(qName, 1, 1)));
+        implicitJoinedRelations.forEach(o -> o.forEach(qName -> occurrences.putOrAdd(qName, 1, 1)));
+        return occurrences;
+    }
+
+    @VisibleForTesting
+    static Set<RelationName> findAndRemoveFirstJoinPair(ObjectIntHashMap<RelationName> occurrences,
+                                                        Collection<Set<RelationName>> joinPairs) {
+        Iterator<Set<RelationName>> setsIterator = joinPairs.iterator();
+        while (setsIterator.hasNext()) {
+            Set<RelationName> set = setsIterator.next();
+            for (RelationName name : set) {
+                int count = occurrences.getOrDefault(name, 0);
+                if (count > 1) {
+                    setsIterator.remove();
+                    return set;
+                }
+            }
+        }
+        return joinPairs.iterator().next();
+    }
+
+    private static void buildBestOrderByJoinConditions(List<Set<RelationName>> sets, LinkedHashSet<RelationName> bestOrder) {
+        Iterator<Set<RelationName>> setsIterator = sets.iterator();
+        while (setsIterator.hasNext()) {
+            Set<RelationName> set = setsIterator.next();
+            for (RelationName name : set) {
+                if (bestOrder.contains(name)) {
+                    bestOrder.addAll(set);
+                    setsIterator.remove();
+                    setsIterator = sets.iterator();
+                    break;
+                }
+            }
+        }
+
+        // Add the rest of the relations to the end of the collection
+        sets.forEach(bestOrder::addAll);
+    }
+}

--- a/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -1444,12 +1444,13 @@ public class JoinIntegrationTest extends IntegTestCase {
         execute("explain (costs false)" + stmt);
         assertThat(response.rows()[0][0]).isEqualTo(
             """
-                OrderBy[x ASC]
-                  └ HashJoin[(x = x)]
-                    ├ HashJoin[(x = x)]
-                    │  ├ Collect[doc.j1 | [x] | true]
-                    │  └ Collect[doc.j2 | [x] | true]
-                    └ Collect[doc.j3 | [x] | true]"""
+                Eval[x, x, x]
+                  └ OrderBy[x ASC]
+                    └ HashJoin[(x = x)]
+                      ├ HashJoin[(x = x)]
+                      │  ├ Collect[doc.j2 | [x] | true]
+                      │  └ Collect[doc.j3 | [x] | true]
+                      └ Collect[doc.j1 | [x] | true]"""
         );
 
         execute(stmt);

--- a/server/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -648,7 +648,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         Join innerJoin = (Join) outerJoin.right();
 
         assertThat(innerJoin.joinPhase().joinCondition()).isSQL("((INPUT(0) = INPUT(2)) AND (INPUT(1) = INPUT(3)))");
-        assertThat(innerJoin.joinPhase().projections()).hasSize(2);
+        assertThat(innerJoin.joinPhase().projections()).hasSize(1);
         assertThat(innerJoin.joinPhase().projections().get(0)).isExactlyInstanceOf(EvalProjection.class);
 
         assertThat(outerJoin.joinPhase().joinCondition()).isNull();

--- a/server/src/test/java/io/crate/planner/operators/JoinOrderingTest.java
+++ b/server/src/test/java/io/crate/planner/operators/JoinOrderingTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.operators;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Test;
+
+import com.carrotsearch.hppc.ObjectIntHashMap;
+
+import io.crate.metadata.RelationName;
+import io.crate.testing.T3;
+
+public class JoinOrderingTest {
+
+    @Test
+    public void testFindFirstJoinPair() {
+        // SELECT * FROM t1, t2, t3 WHERE t1.id = t2.id AND t2.id = t3.id AND t3.id = t4.id
+        ObjectIntHashMap<RelationName> occurrences = new ObjectIntHashMap<>(4);
+        occurrences.put(T3.T1, 1);
+        occurrences.put(T3.T2, 1);
+        occurrences.put(T3.T3, 3);
+        occurrences.put(T3.T4, 1);
+        ArrayList<Set<RelationName>> joinPairs = new ArrayList<>();
+        joinPairs.add(Set.of(T3.T1, T3.T2));
+        joinPairs.add(Set.of(T3.T2, T3.T3));
+        joinPairs.add(Set.of(T3.T3, T3.T4));
+        assertThat(JoinOrdering.findAndRemoveFirstJoinPair(occurrences, joinPairs), is(Set.of(T3.T2, T3.T3)));
+    }
+
+    @Test
+    public void testFindFirstJoinPairOnlyOneOccurrence() {
+        // SELECT * FROM t1, t2, t3 WHERE t1.id = t2.id AND t3.id = t4.id
+        ObjectIntHashMap<RelationName> occurrences = new ObjectIntHashMap<>(4);
+        occurrences.put(T3.T1, 1);
+        occurrences.put(T3.T2, 1);
+        occurrences.put(T3.T3, 1);
+        occurrences.put(T3.T4, 1);
+        Set<Set<RelationName>> sets = new LinkedHashSet<>();
+        sets.add(Set.of(T3.T1, T3.T2));
+        sets.add(Set.of(T3.T2, T3.T3));
+        sets.add(Set.of(T3.T3, T3.T4));
+        assertThat(JoinOrdering.findAndRemoveFirstJoinPair(occurrences, sets), is(Set.of(T3.T1, T3.T2)));
+    }
+
+    @Test
+    public void testOptimizeJoinNoPresort() throws Exception {
+        Collection<RelationName> qualifiedNames = JoinOrdering.orderByJoinConditions(
+            Arrays.asList(T3.T1, T3.T2, T3.T3),
+            Set.of(new LinkedHashSet<>(List.of(T3.T1, T3.T2))),
+            Set.of(new LinkedHashSet<>(List.of(T3.T2, T3.T3)))
+        );
+        assertThat(qualifiedNames, contains(T3.T1, T3.T2, T3.T3));
+    }
+}


### PR DESCRIPTION
The JoinPlanBuilder can generate invalid queries when the relations are not pre-sorted by occurrence. This adds the ordering routine of the relations back. This fixes the failing test from select4.test from sql-logic in crate-qa. I would like to be on the save side for the upcoming release.

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
