### PR TITLE
Documentation: Make link checker ignore "codeproject.com", it went down

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,6 +24,7 @@ exclude_patterns = ['out/**', 'tmp/**', 'eggs/**', 'requirements.txt', 'README.r
 extensions.append('crate.sphinx.csv')
 
 linkcheck_ignore = [
-    'https://www.iso.org/obp/ui/.*'  # Breaks accessibility via JS ¯\_(ツ)_/¯
+    'https://www.iso.org/obp/ui/.*',  # Breaks accessibility via JS ¯\_(ツ)_/¯
+    'https://www.codeproject.com/',   # Went down on 2023-09-28
 ]
 linkcheck_retries = 3


### PR DESCRIPTION
## About

@mkleen reported that the link checker stalls on https://www.codeproject.com/Articles/33052/Visual-Representation-of-SQL-Joins, because the site is currently down.

This patch makes the link checker ignore the site.
