### PR TITLE
Azure Blob Storage: Support endpoint & secondary endpoint params

### DIFF
--- a/docs/appendices/release-notes/5.5.0.rst
+++ b/docs/appendices/release-notes/5.5.0.rst
@@ -149,3 +149,6 @@ Administration and Operations
   the ``AL`` privileges to see entries from other users.
 
 - Added a new :ref:`memory.operation_limit` cluster and session setting.
+
+- Added support for endpoint and secondary endpoint to
+  :ref:`CREATE REPOSITORY for Azure storage <sql-create-repo-azure>`.

--- a/docs/sql/statements/create-repository.rst
+++ b/docs/sql/statements/create-repository.rst
@@ -425,6 +425,35 @@ Parameters
       CrateDB masks this parameter. You cannot query the parameter value from
       the :ref:`sys.repositories <sys-repositories>` table.
 
+.. _sql-create-repo-azure-endpoint:
+
+**endpoint**
+  | *Type:*    ``text``
+
+  The Azure Storage account endpoint.
+
+  .. TIP::
+
+      You can use an `sql-create-repo-azure-endpoint`_ to access Azure Storage
+      instances served on private endpoints.
+
+  .. NOTE::
+
+      ``endpoint`` cannot be used in combination with
+      `sql-create-repo-azure-endpoint_suffix`_.
+
+.. _sql-create-repo-azure-secondary_endpoint:
+
+**secondary_endpoint**
+  | *Type:*    ``text``
+
+  The Azure Storage account secondary endpoint.
+
+  .. NOTE::
+
+      ``secondary_endpoint`` cannot be used if
+      `sql-create-repo-azure-endpoint`_ is not specified.
+
 .. _sql-create-repo-azure-endpoint_suffix:
 
 **endpoint_suffix**
@@ -435,8 +464,8 @@ Parameters
 
   .. TIP::
 
-      You can use an `endpoint suffix`_ to force the use of a specific `Azure
-      service region`_.
+      You can use an `endpoint suffix`_ to force the use of a specific
+      `Azure service region`_.
 
 .. _sql-create-repo-azure-container:
 
@@ -493,7 +522,8 @@ Parameters
 
 **location_mode**
   | *Type:*    ``text``
-  | *Values:*  ``primary_only``, ``secondary_only``
+  | *Values:*  ``primary_only``, ``secondary_only``, ``primary_then_secondary``,
+               ``secondary_then_primary``
   | *Default:* ``primary_only``
 
   The location mode for storing blob data.

--- a/plugins/es-repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureRepository.java
+++ b/plugins/es-repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureRepository.java
@@ -107,6 +107,12 @@ public class AzureRepository extends BlobStoreRepository {
             RetryPolicy.DEFAULT_CLIENT_RETRY_COUNT,
             Setting.Property.NodeScope);
 
+        static final Setting<String> ENDPOINT_SETTING =
+            Setting.simpleString("endpoint", Property.NodeScope);
+
+        static final Setting<String> SECONDARY_ENDPOINT_SETTING =
+            Setting.simpleString("secondary_endpoint", Property.NodeScope);
+
         /**
          * Azure endpoint suffix. Default to core.windows.net (CloudStorageAccount.DEFAULT_DNS).
          */
@@ -148,6 +154,8 @@ public class AzureRepository extends BlobStoreRepository {
                        COMPRESS_SETTING,
                        // client specific repository settings
                        Repository.MAX_RETRIES_SETTING,
+                       Repository.ENDPOINT_SETTING,
+                       Repository.SECONDARY_ENDPOINT_SETTING,
                        Repository.ENDPOINT_SUFFIX_SETTING,
                        Repository.TIMEOUT_SETTING,
                        Repository.PROXY_TYPE_SETTING,

--- a/plugins/es-repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureStorageService.java
+++ b/plugins/es-repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureStorageService.java
@@ -34,8 +34,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
 
-import org.jetbrains.annotations.Nullable;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
@@ -45,6 +43,7 @@ import org.elasticsearch.common.blobstore.support.PlainBlobMetadata;
 import org.elasticsearch.common.settings.SettingsException;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.jetbrains.annotations.Nullable;
 
 import com.microsoft.azure.storage.AccessCondition;
 import com.microsoft.azure.storage.CloudStorageAccount;
@@ -70,6 +69,7 @@ public class AzureStorageService {
     private static final Logger LOGGER = LogManager.getLogger(AzureStorageService.class);
 
     public static final ByteSizeValue MIN_CHUNK_SIZE = new ByteSizeValue(1, ByteSizeUnit.BYTES);
+
     /**
      * {@link com.microsoft.azure.storage.blob.BlobConstants#MAX_SINGLE_UPLOAD_BLOB_SIZE_IN_BYTES}
      */
@@ -110,6 +110,9 @@ public class AzureStorageService {
             }
             client.getDefaultRequestOptions().setTimeoutIntervalInMs((int) timeout);
         }
+
+        client.getDefaultRequestOptions().setLocationMode(azureStorageSettings.getLocationMode());
+
         // We define a default exponential retry policy
         client.getDefaultRequestOptions()
                 .setRetryPolicyFactory(new RetryExponentialRetry(RetryPolicy.DEFAULT_CLIENT_BACKOFF, azureStorageSettings.getMaxRetries()));

--- a/plugins/es-repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureBlobStoreContainerTests.java
+++ b/plugins/es-repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureBlobStoreContainerTests.java
@@ -26,6 +26,8 @@ import org.elasticsearch.common.blobstore.BlobStore;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.repositories.ESBlobStoreContainerTestCase;
 
+import com.microsoft.azure.storage.LocationMode;
+
 import io.crate.common.unit.TimeValue;
 
 public class AzureBlobStoreContainerTests extends ESBlobStoreContainerTestCase {
@@ -43,6 +45,21 @@ public class AzureBlobStoreContainerTests extends ESBlobStoreContainerTestCase {
         String account = randomAlphaOfLength(randomIntBetween(1, 10)).toLowerCase(Locale.ROOT);
         String key = randomAlphaOfLength(randomIntBetween(10, 20)).toLowerCase(Locale.ROOT);
         String endpointSuffix = randomAlphaOfLength(randomIntBetween(1, 10)).toLowerCase(Locale.ROOT);
-        return new AzureStorageSettings(account, key, endpointSuffix, TimeValue.timeValueMinutes(-1), 3, null, null);
+        String endpoint = "https://storage1.privatelink.blob.core.windows.net";
+        String secondaryEndpoint = "https://storage2.privatelink.blob.core.windows.net";
+        return new AzureStorageSettings(
+            account,
+            key,
+            endpoint,
+            secondaryEndpoint,
+            endpointSuffix,
+            TimeValue.timeValueMinutes(-1),
+            3,
+            null,
+            randomFrom(
+                LocationMode.PRIMARY_ONLY,
+                LocationMode.SECONDARY_ONLY,
+                LocationMode.PRIMARY_THEN_SECONDARY,
+                LocationMode.SECONDARY_THEN_PRIMARY));
     }
 }

--- a/plugins/es-repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureStorageServiceMock.java
+++ b/plugins/es-repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureStorageServiceMock.java
@@ -19,8 +19,6 @@
 
 package org.elasticsearch.repositories.azure;
 
-import static com.microsoft.azure.storage.StorageException.translateClientException;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;


### PR DESCRIPTION
## About

This patch adds support for private endpoints to the Azure Storage subsystem.

## References
```
@pytest.mark.skip(reason="CrateDB does not support custom endpoints for Azure Blob Storage")
```
-- https://github.com/crate-workbench/cratedb-retention/blob/0dfe1cb1f5/tests/test_cli.py#L314-L319

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
