### PR TITLE
Remove cratedb.version, version and java.version from plugin-descriptor

### DIFF
--- a/extensions/extensionModule.gradle
+++ b/extensions/extensionModule.gradle
@@ -53,12 +53,6 @@ task writePropertiesFile(dependsOn: [':server:getVersion']) {
             from "src/main/resources/"
             into "${buildDir}/tmp"
             include "plugin-descriptor.properties"
-            expand(
-                version: project.version,
-                crateVersion: project(':server').getVersion.shortVersion,
-                jmvCompatibility: project.targetCompatibility,
-                name: project.name
-            )
         }
     }
 }

--- a/extensions/functions/src/main/resources/plugin-descriptor.properties
+++ b/extensions/functions/src/main/resources/plugin-descriptor.properties
@@ -1,7 +1,3 @@
 name=crate-functions
 description="CrateDB extra functions"
-version=${version}
 classname=io.crate.plugin.ExtraFunctionsPlugin
-
-cratedb.version=${crateVersion}
-java.version=${jmvCompatibility}

--- a/extensions/jmx-monitoring/src/main/resources/plugin-descriptor.properties
+++ b/extensions/jmx-monitoring/src/main/resources/plugin-descriptor.properties
@@ -1,7 +1,3 @@
 name=crate-jmx-monitoring
 description="CrateDB JMX plugin"
-version=${version}
 classname=io.crate.plugin.CrateMonitoringPlugin
-
-cratedb.version=${crateVersion}
-java.version=${jmvCompatibility}

--- a/extensions/lang-js/src/main/resources/plugin-descriptor.properties
+++ b/extensions/lang-js/src/main/resources/plugin-descriptor.properties
@@ -1,7 +1,3 @@
 name=crate-lang-js
 description="CrateDB Javascript UDF Plugin"
-version=${version}
 classname=io.crate.plugin.JavaScriptLanguagePlugin
-
-cratedb.version=${crateVersion}
-java.version=${jmvCompatibility}

--- a/plugins/cr8-copy-s3/src/main/resources/plugin-descriptor.properties
+++ b/plugins/cr8-copy-s3/src/main/resources/plugin-descriptor.properties
@@ -1,7 +1,3 @@
 name=cr8-copy-s3
 description="CrateDB S3 Copy Plugin"
-version=${version}
 classname=io.crate.copy.s3.S3CopyPlugin
-
-cratedb.version=${crateVersion}
-java.version=${jmvCompatibility}

--- a/plugins/es-analysis-common/src/main/resources/plugin-descriptor.properties
+++ b/plugins/es-analysis-common/src/main/resources/plugin-descriptor.properties
@@ -1,7 +1,3 @@
 name=es-analysis-common
 description="CrateDB Analyzers"
-version=${version}
 classname=org.elasticsearch.analysis.common.CommonAnalysisPlugin
-
-cratedb.version=${crateVersion}
-java.version=${jmvCompatibility}

--- a/plugins/es-analysis-phonetic/src/main/resources/plugin-descriptor.properties
+++ b/plugins/es-analysis-phonetic/src/main/resources/plugin-descriptor.properties
@@ -1,7 +1,3 @@
 name=es-analysis-phonetic
 description="CrateDB Phonetic Analysis"
-version=${version}
 classname=org.elasticsearch.plugin.analysis.AnalysisPhoneticPlugin
-
-cratedb.version=${crateVersion}
-java.version=${jmvCompatibility}

--- a/plugins/es-repository-azure/src/main/resources/plugin-descriptor.properties
+++ b/plugins/es-repository-azure/src/main/resources/plugin-descriptor.properties
@@ -1,7 +1,3 @@
 name=es-repository-azure
 description="CrateDB Azure Repository Plugin"
-version=${version}
 classname=org.elasticsearch.repositories.azure.AzureRepositoryPlugin
-
-cratedb.version=${crateVersion}
-java.version=${jmvCompatibility}

--- a/server/src/main/java/org/elasticsearch/plugins/PluginsService.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginsService.java
@@ -53,7 +53,6 @@ import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.DocValuesFormat;
 import org.apache.lucene.codecs.PostingsFormat;
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.Version;
 import org.elasticsearch.bootstrap.JarHell;
 import org.elasticsearch.common.component.LifecycleComponent;
 import org.elasticsearch.common.inject.Module;
@@ -102,8 +101,13 @@ public class PluginsService {
         // first we load plugins that are on the classpath. this is for tests and transport clients
         for (Class<? extends Plugin> pluginClass : classpathPlugins) {
             Plugin plugin = loadPlugin(pluginClass, settings, configPath);
-            PluginInfo pluginInfo = new PluginInfo(pluginClass.getName(), "classpath plugin", "NA", Version.CURRENT, "1.8",
-                                                   pluginClass.getName(), Collections.emptyList(), false);
+            PluginInfo pluginInfo = new PluginInfo(
+                pluginClass.getName(),
+                "classpath plugin",
+                pluginClass.getName(),
+                Collections.emptyList(),
+                false
+            );
             if (LOGGER.isTraceEnabled()) {
                 LOGGER.trace("plugin loaded from classpath [{}]", pluginInfo);
             }
@@ -292,17 +296,6 @@ public class PluginsService {
         return plugins;
     }
 
-    /**
-     * Verify the given plugin is compatible with the current Elasticsearch installation.
-     */
-    static void verifyCompatibility(PluginInfo info) {
-        if (info.getElasticsearchVersion().equals(Version.CURRENT) == false) {
-            throw new IllegalArgumentException("Plugin [" + info.getName() + "] was built for Elasticsearch version "
-                + info.getElasticsearchVersion() + " but version " + Version.CURRENT + " is running");
-        }
-        JarHell.checkJavaVersion(info.getName(), info.getJavaVersion());
-    }
-
     static void checkForFailedPluginRemovals(final Path pluginsDirectory) throws IOException {
         /*
          * Check for the existence of a marker file that indicates any plugins are in a garbage state from a failed attempt to remove the
@@ -482,8 +475,6 @@ public class PluginsService {
 
     private Plugin loadBundle(Bundle bundle, Map<String, Plugin> loaded) {
         String name = bundle.plugin.getName();
-
-        verifyCompatibility(bundle.plugin);
 
         // collect loaders of extended plugins
         List<ClassLoader> extendedLoaders = new ArrayList<>();


### PR DESCRIPTION
Motivated by https://github.com/crate/crate/pull/13651

Makes the assembly easiser and given that we don't promote writing
custom plugins much there shouldn't be too much harm in removing the
sanity check. It's very likely that if there is an incompatibility it
would blow up anyway.
