### PR TITLE
Update github PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,13 +3,13 @@
 
 ## Checklist
 
- - [ ] Added an entry in `CHANGES.txt` for user facing changes
+ - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
  - [ ] Updated documentation & `sql_features` table for user facing changes
  - [ ] Touched code is covered by tests
  - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
  - [ ] This does not contain breaking changes, or if it does:
     - It is released within a major release
-    - It is recorded in ``CHANGES.txt``
+    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
     - It was marked as deprecated in an earlier release if possible
     - You've thought about the consequences and other components are adapted
       (E.g. AdminUI)


### PR DESCRIPTION
Update PR template to reference the new release notes scheme, since `CHANGES.txt` has been removed and unreleased changes are written to the `X.X.0.rst` where `X.X.0` is the upcoming minor version.
