### PR TITLE
Adapt vector dimension limit in codec to field mapping

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/PerFieldMappingPostingFormatCodec.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/PerFieldMappingPostingFormatCodec.java
@@ -32,11 +32,11 @@ import org.apache.lucene.codecs.lucene95.Lucene95Codec;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
 import org.elasticsearch.common.lucene.Lucene;
+import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 
 import io.crate.lucene.codec.CustomLucene90DocValuesFormat;
-import io.crate.types.FloatVectorType;
 
 
 /**
@@ -78,6 +78,8 @@ public class PerFieldMappingPostingFormatCodec extends Lucene95Codec {
 
     @Override
     public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
+        var fieldMapper = (FieldMapper) mapperService.getFieldMapper(field);
+        var vectorDimension = fieldMapper.indexableFieldType().vectorDimension();
         var format = super.getKnnVectorsFormatForField(field);
         return new KnnVectorsFormat(format.getName()) {
 
@@ -93,7 +95,7 @@ public class PerFieldMappingPostingFormatCodec extends Lucene95Codec {
 
             @Override
             public int getMaxDimensions(String fieldName) {
-                return FloatVectorType.MAX_DIMENSIONS;
+                return vectorDimension;
             }
         };
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
 
+import org.apache.lucene.index.IndexableFieldType;
 import org.jetbrains.annotations.Nullable;
 
 import org.apache.lucene.document.Document;
@@ -136,6 +137,10 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
     @Override
     public String typeName() {
         return mappedFieldType.typeName();
+    }
+
+    public IndexableFieldType indexableFieldType() {
+        return fieldType;
     }
 
     public MappedFieldType fieldType() {

--- a/server/src/main/java/org/elasticsearch/index/mapper/FloatVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FloatVectorFieldMapper.java
@@ -77,6 +77,11 @@ public class FloatVectorFieldMapper extends FieldMapper implements ArrayValueMap
 
         @Override
         public Mapper build(BuilderContext context) {
+            if (dimensions > FloatVectorType.MAX_DIMENSIONS) {
+                throw new IllegalArgumentException("vector numDimensions must be less than + " +
+                                                   FloatVectorType.MAX_DIMENSIONS + " got " +
+                                                   dimensions);
+            }
             fieldType.setVectorAttributes(
                 dimensions,
                 VectorEncoding.FLOAT32,

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -379,6 +379,10 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
         return mapper;
     }
 
+    public Mapper getFieldMapper(String field) {
+        return documentMapper().mappers().getMapper(field);
+    }
+
     /**
      * Returns the {@link MappedFieldType} for the give fullName.
      *


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This adapts the maximum vector dimension in the codec to the value configured in the field mapping. The limit is used in the IndexChain to evaluate the size of the field:

https://github.com/apache/lucene/blob/main/lucene/core/src/java/org/apache/lucene/index/IndexingChain.java#L624-L629

Follow-up https://github.com/crate/crate/commit/5febe532d1ba0e866d380fc403ad0de8312f206e

## Checklist

 - [x] Added an entry in `CHANGES.txt` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in ``CHANGES.txt``
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
