### PR TITLE
Fix URL constructor deprecations

### DIFF
--- a/plugins/es-repository-url/src/main/java/org/elasticsearch/common/blobstore/url/URLBlobContainer.java
+++ b/plugins/es-repository-url/src/main/java/org/elasticsearch/common/blobstore/url/URLBlobContainer.java
@@ -23,6 +23,7 @@ import java.io.BufferedInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.NoSuchFileException;
 import java.util.List;
@@ -109,7 +110,12 @@ public class URLBlobContainer extends AbstractBlobContainer {
 
     @Override
     public InputStream readBlob(String name) throws IOException {
-        URL url = new URL(path, name);
+        URL url;
+        try {
+            url = path.toURI().resolve(name).toURL();
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
         try {
             return new BufferedInputStream(url.openStream(), blobStore.bufferSizeInBytes());
         } catch (FileNotFoundException fnfe) {

--- a/plugins/es-repository-url/src/main/java/org/elasticsearch/repositories/url/URLRepository.java
+++ b/plugins/es-repository-url/src/main/java/org/elasticsearch/repositories/url/URLRepository.java
@@ -19,6 +19,15 @@
 
 package org.elasticsearch.repositories.url;
 
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.metadata.RepositoryMetadata;
@@ -37,14 +46,6 @@ import org.elasticsearch.repositories.RepositoryException;
 import org.elasticsearch.repositories.blobstore.BlobStoreRepository;
 
 import io.crate.types.DataTypes;
-
-import java.net.MalformedURLException;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.function.Function;
 
 /**
  * Read-only URL-based implementation of the BlobStoreRepository
@@ -68,11 +69,11 @@ public class URLRepository extends BlobStoreRepository {
     public static final Setting<List<URIPattern>> ALLOWED_URLS_SETTING =
         Setting.listSetting("repositories.url.allowed_urls", Collections.emptyList(), URIPattern::new, DataTypes.STRING_ARRAY, Property.NodeScope);
 
-    public static final Setting<URL> URL_SETTING = new Setting<>("url", "http:", URLRepository::parseURL, DataTypes.STRING, Property.NodeScope);
+    public static final Setting<URL> URL_SETTING = new Setting<>("url", "http:///", URLRepository::parseURL, DataTypes.STRING, Property.NodeScope);
 
     public static final Setting<URL> REPOSITORIES_URL_SETTING = new Setting<>(
         "repositories.url.url",
-        (s) -> s.get("repositories.uri.url", "http:"),
+        (s) -> s.get("repositories.uri.url", "http:///"),
         URLRepository::parseURL,
         DataTypes.STRING,
         Property.NodeScope
@@ -178,8 +179,8 @@ public class URLRepository extends BlobStoreRepository {
 
     private static URL parseURL(String s) {
         try {
-            return new URL(s);
-        } catch (MalformedURLException e) {
+            return new URI(s).toURL();
+        } catch (URISyntaxException | MalformedURLException e) {
             throw new IllegalArgumentException("Unable to parse URL repository setting", e);
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,8 @@
             <bundledSignatures>
               <bundledSignature>jdk-unsafe</bundledSignature>
               <bundledSignature>jdk-deprecated</bundledSignature>
+              <bundledSignature>jdk-non-portable</bundledSignature>
+              <bundledSignature>jdk-reflection</bundledSignature>
             </bundledSignatures>
             <signaturesFiles>
               <signaturesFile>

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,7 @@
             <failOnUnsupportedJava>false</failOnUnsupportedJava>
             <bundledSignatures>
               <bundledSignature>jdk-unsafe</bundledSignature>
+              <bundledSignature>jdk-deprecated</bundledSignature>
             </bundledSignatures>
             <signaturesFiles>
               <signaturesFile>


### PR DESCRIPTION
Adds `jdk-deprecated` signatures to the forbiddenapis check and handles
the deprecations.

We had this before https://github.com/crate/crate/pull/13651, but I
removed it in the PR because maven runs forbidden APIs via the
toolchains JDK, so it included Java 18, 19 and 20 deprecations. Before
we only got deprecations up to Java 17 because that's what the Github
workflow used.
