### PR TITLE
Fix sphinx build, avoid use system's sphinx-build

### DIFF
--- a/blackbox/bin/sphinx
+++ b/blackbox/bin/sphinx
@@ -26,7 +26,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 DOCS_DIR=$DIR/../docs
 PATH=$DIR/.venv/bin:$PATH
 
-if ! command -v sphinx-build || [ ! -d "$DIR/.venv" ]; then
+if [ ! -d "$DIR/.venv" ] || [ ! -f "$DIR/.venv/bin/sphinx-build" ]; then
   "$DIR/bootstrap.sh"
 fi
 


### PR DESCRIPTION
Check if `.venv` exists, then if `sphinx-build` exists within `.venv` and don't test if `sphinx-build` command is available in the path, as in Jenkins runners, there might be an old version of `sphinx-build` installed and available in user's PATH already.
