### PR TITLE
Fix java path in distribution script

### DIFF
--- a/app/src/main/dist/bin/crate
+++ b/app/src/main/dist/bin/crate
@@ -164,11 +164,7 @@ if [ "x$CRATE_HEAP_DUMP_PATH" != "x" ]; then
     JAVA_OPTS="$JAVA_OPTS -XX:HeapDumpPath=$CRATE_HEAP_DUMP_PATH"
 fi
 
-if [ "$(uname -s)" = "Darwin" ]; then
-    JAVA="$CRATE_HOME/jdk/Contents/Home/bin/java"
-else
-    JAVA="$CRATE_HOME/jdk/bin/java"
-fi
+JAVA="$CRATE_HOME/jdk/bin/java"
 
 if [ -z "$CRATE_CLASSPATH" ]; then
     echo "ERROR: CRATE_CLASSPATH is not defined or empty" >&2


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The java path was incorrect for os x.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
