### PR TITLE
Fix issue with privileges bypassed for scalar subselects

### DIFF
--- a/docs/appendices/release-notes/5.4.4.rst
+++ b/docs/appendices/release-notes/5.4.4.rst
@@ -104,3 +104,6 @@ Fixes
    query. e.g.:: ``gen_random_text_uuid`` and ``random``. Functions like
    ``NOW`` or ``CURRENT_TIMESTAMP`` are unaffected by this issue.
 
+- Fixed an issue that caused privileges checks to be bypassed when using scalar
+  sub-selects in various clauses of a query: ``SELECT``, ``WHERE``, ``HAVING``,
+  etc.

--- a/server/src/main/java/io/crate/expression/symbol/SymbolVisitors.java
+++ b/server/src/main/java/io/crate/expression/symbol/SymbolVisitors.java
@@ -22,18 +22,27 @@
 package io.crate.expression.symbol;
 
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
+import org.jetbrains.annotations.Nullable;
+
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.WindowDefinition;
+import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
 
-public class SymbolVisitors {
+public final class SymbolVisitors {
+
+    private SymbolVisitors() {}
 
     private static final AnyPredicateVisitor ANY_VISITOR = new AnyPredicateVisitor();
+    private static final ExtractAnalyzedRelationsVisitor EXTRACT_ANALYZED_RELATIONS_VISITOR =
+        new ExtractAnalyzedRelationsVisitor();
 
     public static boolean any(Predicate<? super Symbol> predicate, List<? extends Symbol> symbols) {
         for (int i = 0; i < symbols.size(); i++) {
@@ -69,6 +78,15 @@ public class SymbolVisitors {
      */
     public static <T> void intersection(Symbol needle, Collection<T> haystack, Consumer<T> consumer) {
         needle.accept(new IntersectionVisitor<>(haystack, consumer), null);
+    }
+
+    public static Iterable<AnalyzedRelation> extractAnalyzedRelations(@Nullable Symbol symbol) {
+        if (symbol == null) {
+            return Set.of();
+        }
+        Set<AnalyzedRelation> relations = new HashSet<>();
+        symbol.accept(EXTRACT_ANALYZED_RELATIONS_VISITOR, relations);
+        return relations;
     }
 
     // If `haystack.contains(x)` is true, then `x` has type `T`, and the call to the consumer is safe.
@@ -268,4 +286,13 @@ public class SymbolVisitors {
         }
     }
 
+    private static class ExtractAnalyzedRelationsVisitor
+        extends DefaultTraversalSymbolVisitor<Set<AnalyzedRelation>, Void> {
+
+        @Override
+        public Void visitSelectSymbol(SelectSymbol selectSymbol, Set<AnalyzedRelation> context) {
+            context.add(selectSymbol.relation());
+            return null;
+        }
+    }
 }

--- a/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
+++ b/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
@@ -356,7 +356,7 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
 
     /**
      * Union with order by (and/or limit) results
-     * in a {@link io.crate.analyze.relation.OrderedLimitedRelation}
+     * in a {@link io.crate.analyze.QueriedSelectRelation}
      * which wraps the {@link io.crate.analyze.relations.UnionSelect}
      */
     @Test
@@ -373,6 +373,41 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
                 ") as users_parted order by users_parted.id");
         assertAskedForTable(Privilege.Type.DQL, "doc.users");
         assertAskedForTable(Privilege.Type.DQL, "doc.parted");
+    }
+
+    @Test
+    public void test_select_with_scalar_subselect_in_select() {
+        analyze("SELECT 1, array(SELECT users.id FROM USERS), 2");
+        assertAskedForTable(Privilege.Type.DQL, "doc.users");
+    }
+
+    @Test
+    public void test_select_with_scalar_subselect_in_where() {
+        analyze("SELECT generate_series(1, 10, 1) WHERE EXISTS " +
+                "(SELECT u.a + 10 FROM (SELECT users.id AS a FROM USERS) u)");
+        assertAskedForTable(Privilege.Type.DQL, "doc.users");
+    }
+
+    @Test
+    public void test_select_with_scalar_subselect_in_order_by() {
+        analyze("SELECT generate_series(1, 10, 1) ORDER BY " +
+                "(SELECT u.a + 10 FROM (SELECT users.id AS a FROM USERS) u)");
+        assertAskedForTable(Privilege.Type.DQL, "doc.users");
+    }
+
+    @Test
+    public void test_select_with_scalar_subselect_in_group_by() {
+        analyze("SELECT count(*) FROM (SELECT * FROM GENERATE_SERIES(1,10,1) AS g) gs " +
+                "GROUP BY gs.g + (SELECT u.a + 10 FROM (SELECT users.id AS a FROM USERS) u)");
+        assertAskedForTable(Privilege.Type.DQL, "doc.users");
+    }
+
+    @Test
+    public void test_select_with_scalar_subselect_in_having() {
+        analyze("SELECT count(*) FROM parted GROUP BY id HAVING id > " +
+                "(SELECT u.a + 10 FROM (SELECT users.id AS a FROM USERS) u)");
+        assertAskedForTable(Privilege.Type.DQL, "doc.parted");
+        assertAskedForTable(Privilege.Type.DQL, "doc.users");
     }
 
     @Test


### PR DESCRIPTION
Previously, `SelectSymbols` in a relation's outputs (SELECT clause) and in WHERE clause (scalar subqueries) where not checked for sufficient privileges.

Use a `SymbolVisitor` to extract relations and validate the user's privileges on them.
