### PR TITLE
Fix UNION's pruning logic when outputs contain duplicates

### DIFF
--- a/docs/appendices/release-notes/5.4.5.rst
+++ b/docs/appendices/release-notes/5.4.5.rst
@@ -81,6 +81,15 @@ Fixes
   errors or even updating wrong sub-columns when using a sub-column expression
   in the ``ON CONFLICT`` clause.
 
+- Fixed an issue that caused ``UNION`` to return wrong results or throw
+  ``SQLParseException`` when the output columns had identical names which were
+  from tables that were aliased. e.g.::
+
+    SELECT * FROM (SELECT t1.a, t2.a FROM t AS t1, t AS t2) t3 UNION SELECT 1, 1;
+
+  where ``t1.a`` and ``t2.a`` are from aliased tables that also have identical
+  names, ``a``.
+
 - Fixed a regression, introduced in :ref:`version_4.2.0` which caused wrong
   :ref:`HTTP error code <http-error-codes>` to be returned, when some internal
   issue occurred during the creation of execution plan for a query, e.g.: shards

--- a/server/src/main/java/io/crate/planner/operators/GroupHashAggregate.java
+++ b/server/src/main/java/io/crate/planner/operators/GroupHashAggregate.java
@@ -249,7 +249,7 @@ public class GroupHashAggregate extends ForwardingLogicalPlan {
     @Override
     public LogicalPlan pruneOutputsExcept(Collection<Symbol> outputsToKeep) {
         // Keep the same order and avoid introducing an Eval
-        HashSet<Symbol> toKeep = new LinkedHashSet<>();
+        ArrayList<Symbol> toKeep = new ArrayList<>();
         // We cannot prune groupKeys, even if they are not used in the outputs, because it would change the result semantically
         for (Symbol groupKey : groupKeys) {
             SymbolVisitors.intersection(groupKey, source.outputs(), toKeep::add);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes https://github.com/crate/crate/issues/14807, https://github.com/crate/crate/issues/14805. 
Please see the commit and the commit message for details.(Also https://github.com/crate/crate/pull/14816#discussion_r1350732646)

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
