### PR TITLE
Ensure tarball artifact uses current version

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -11,8 +11,23 @@
 
   <artifactId>crate-app</artifactId>
 
+  <properties>
+    <timestamp>${maven.build.timestamp}</timestamp>
+    <maven.build.timestamp.format>yyyy-MM-dd-HH-mm</maven.build.timestamp.format>
+    <tarball.version>${project.version}-${timestamp}-${git.commit.id.abbrev}</tarball.version>
+  </properties>
+
+  <profiles>
+    <profile>
+      <id>release</id>
+      <properties>
+        <tarball.version>${project.version}</tarball.version>
+      </properties>
+    </profile>
+  </profiles>
+
   <build>
-    <finalName>crate-${git.commit.id.describe}</finalName>
+    <finalName>crate-${tarball.version}</finalName>
     <plugins>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>

--- a/app/src/assembly/src.xml
+++ b/app/src/assembly/src.xml
@@ -31,7 +31,7 @@
       leading to JarHell. Exclude the latter
       -->
       <excludes>
-        <exclude>crate-${git.commit.id.describe}.jar</exclude>
+        <exclude>crate-${tarball.version}.jar</exclude>
       </excludes>
     </fileSet>
     <fileSet>

--- a/devs/tools/create_tag.sh
+++ b/devs/tools/create_tag.sh
@@ -59,7 +59,7 @@ then
 fi
 
 # install locally so we can get the version
-./mvnw -T 1C clean package -DskipTests=true
+./mvnw -T 1C clean package -DskipTests=true -P release
 checkBuild "Java"
 
 # check for broken docs


### PR DESCRIPTION
Using `git describe` doesn't really work out, as some jobs now think
we're dealing with older versions and fail.

The idea behind using `git describe` was that we'd get `crate-<version>`
for free if there is a tag on the commit.

The problem is that for all other commits it is relative to the previous
tag on the branch.

E.g. for the following

    commit3
    commit2
    commit1
    5.4.0

We'd have `5.4.0-3-<commit3>`
Currently this is even worse, because `5.4.0` was tagged on the 5.4
branch, so we've `5.3.0-...` on master.

Solution:

Use a custom profile for releases that uses
`crate-${project.version}`, and include time and commit abbrev for all
normal builds. (Time to ensure alphabetically ordering in
https://cdn.crate.io/downloads/releases/nightly/ has the latest at the
end)
