### PR TITLE
gha: Update vale-action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,8 +37,9 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Run vale
-        uses: errata-ai/vale-action@3160f4797e8eed7775c76cb2563bdee5455b6d21
+        uses: errata-ai/vale-action@v2.0.1
         with:
           files: docs/
+          version: 2.26.0
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Started to fail on other PRs, likely due to runner image changes:

```
/node_modules/undici/lib/global.js:26
  return globalThis[globalDispatcher]
  ^

ReferenceError: globalThis is not defined
    at getGlobalDispatcher (/node_modules/undici/lib/global.js:26:3)
    at Object.<anonymous> (/node_modules/undici/lib/global.js:9:5)
    at Module._compile (internal/modules/cjs/loader.js:778:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:[10](https://github.com/crate/crate/actions/runs/6454164142/job/17519134396?pr=14819#step:4:11))
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:[12](https://github.com/crate/crate/actions/runs/6454164142/job/17519134396?pr=14819#step:4:13))
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
    at Module.require (internal/modules/cjs/loader.js:692:[17](https://github.com/crate/crate/actions/runs/6454164142/job/17519134396?pr=14819#step:4:18))
    at require (internal/modules/cjs/helpers.js:25:[18](https://github.com/crate/crate/actions/runs/6454164142/job/17519134396?pr=14819#step:4:19))
    at Object.<anonymous> (/node_modules/undici/index.js:18:54)
```
