### PR TITLE
Remove projectName from launch.json entries

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,6 @@
             "cwd": "${workspaceFolder}/app",
             "vmArgs": "-Xms2G -Xmx2G",
             "mainClass": "io.crate.bootstrap.CrateDB",
-            "projectName": "app",
             "console": "integratedTerminal"
         },
         {
@@ -20,7 +19,6 @@
             "cwd": "${workspaceFolder}/app",
             "vmArgs": "-Xms2G -Xmx2G",
             "mainClass": "io.crate.bootstrap.CrateDB",
-            "projectName": "app",
             "console": "integratedTerminal"
         },
         {
@@ -31,7 +29,6 @@
             "cwd": "${workspaceFolder}/app",
             "vmArgs": "-Xms2G -Xmx2G",
             "mainClass": "io.crate.bootstrap.CrateDB",
-            "projectName": "app",
             "console": "integratedTerminal",
             "noDebug": true
         },
@@ -41,7 +38,6 @@
             "name": "Attach to CrateDB",
             "hostName": "127.0.0.1",
             "port": 5005,
-            "projectName": "app",
             "cwd": "${workspaceFolder}/app"
         }
     ]


### PR DESCRIPTION
Since the maven migration it leads to errors:

    Failed to resolve classpath: The project 'app' is not a valid java project.
