### PR TITLE
Don't add ignored column prefix on tables created with CrateDB < 5.5

### DIFF
--- a/server/src/main/java/io/crate/execution/dml/Indexer.java
+++ b/server/src/main/java/io/crate/execution/dml/Indexer.java
@@ -22,6 +22,7 @@
 
 package io.crate.execution.dml;
 
+import static io.crate.expression.reference.doc.lucene.SourceParser.UNKNOWN_COLUMN_PREFIX;
 import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
 
 import java.io.IOException;
@@ -449,7 +450,9 @@ public class Indexer {
                         table.ident()
                     ));
                 }
-                valueIndexer = new DynamicIndexer(ref.ident(), position, getFieldType, getRef);
+                // Empty arrays are not registered as known references, such they are stored in the source as unknown columns
+                var storageIdentPrefixForEmptyArrays = writeOids ? UNKNOWN_COLUMN_PREFIX : null;
+                valueIndexer = new DynamicIndexer(ref.ident(), position, getFieldType, getRef, storageIdentPrefixForEmptyArrays);
                 position--;
             } else {
                 valueIndexer = ref.valueType().valueIndexer(

--- a/server/src/main/java/io/crate/execution/dml/ObjectIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/ObjectIndexer.java
@@ -62,6 +62,7 @@ public class ObjectIndexer implements ValueIndexer<Map<String, Object>> {
     private final RelationName table;
     private final Reference ref;
     private final Function<String, FieldType> getFieldType;
+    private final boolean prefixUnknownColumns;
 
     /**
      * @param getFieldType  A function to resolve a {@link FieldType} by {@link Reference#storageIdent()}
@@ -75,6 +76,7 @@ public class ObjectIndexer implements ValueIndexer<Map<String, Object>> {
         this.ref = ref;
         this.getFieldType = getFieldType;
         this.getRef = getRef;
+        this.prefixUnknownColumns = ref.oid() != COLUMN_OID_UNASSIGNED;
         this.column = ref.column();
         this.objectType = (ObjectType) ArrayType.unnest(ref.valueType());
         this.innerIndexers = new HashMap<>();
@@ -295,7 +297,9 @@ public class ObjectIndexer implements ValueIndexer<Map<String, Object>> {
             if (!isNewColumn) {
                 continue;
             }
-            innerName = UNKNOWN_COLUMN_PREFIX + innerName;
+            if (prefixUnknownColumns) {
+                innerName = UNKNOWN_COLUMN_PREFIX + innerName;
+            }
             if (innerValue == null) {
                 xContentBuilder.nullField(innerName);
                 continue;


### PR DESCRIPTION
Follow up of 3372b479ff8e05cea9e6f07d2530adfd50fa1006.
