### PR TITLE
Generate new identifiers on snapshot of swapped table

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -63,6 +63,7 @@ import org.elasticsearch.gateway.MetadataStateFormat;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.rest.RestStatus;
+import org.jetbrains.annotations.Nullable;
 
 import com.carrotsearch.hppc.cursors.ObjectCursor;
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
@@ -290,10 +291,12 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
         return getAliasAndIndexLookup().containsKey(index);
     }
 
+    @Nullable
     public IndexMetadata index(String index) {
         return indices.get(index);
     }
 
+    @Nullable
     public IndexMetadata index(Index index) {
         return indicesByUUID.get(index.getUUID());
     }

--- a/server/src/main/java/org/elasticsearch/repositories/IndexMetaDataGenerations.java
+++ b/server/src/main/java/org/elasticsearch/repositories/IndexMetaDataGenerations.java
@@ -27,7 +27,6 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.elasticsearch.cluster.metadata.IndexMetadata;
-import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.snapshots.SnapshotId;
 import org.jetbrains.annotations.Nullable;
 
@@ -104,7 +103,8 @@ public final class IndexMetaDataGenerations {
      * @param newIdentifiers new mappings of index metadata identifier to blob id
      * @return instance with added snapshot
      */
-    public IndexMetaDataGenerations withAddedSnapshot(SnapshotId snapshotId, Map<IndexId, String> newLookup,
+    public IndexMetaDataGenerations withAddedSnapshot(SnapshotId snapshotId,
+                                                      Map<IndexId, String> newLookup,
                                                       Map<String, String> newIdentifiers) {
         final Map<SnapshotId, Map<IndexId, String>> updatedIndexMetaLookup = new HashMap<>(this.lookup);
         final Map<String, String> updatedIndexMetaIdentifiers = new HashMap<>(identifiers);
@@ -162,7 +162,7 @@ public final class IndexMetaDataGenerations {
     }
 
     /**
-     * Compute identifier for {@link IndexMetadata} from its index- and history-uuid as well as its settings-, mapping- and alias-version.
+     * Compute identifier for {@link IndexMetadata} from its name, index- and history-uuid as well as its settings-, mapping- and alias-version.
      * If an index did not see a change in its settings, mappings or aliases between two points in time then the identifier will not change
      * between them either.
      *
@@ -170,29 +170,10 @@ public final class IndexMetaDataGenerations {
      * @return identifier string
      */
     public static String buildUniqueIdentifier(IndexMetadata indexMetadata) {
-        return indexMetadata.getIndexUUID() +
+        return indexMetadata.getIndex().getName() +
+                "-" + indexMetadata.getIndexUUID() +
                 "-" + indexMetadata.getSettings().get(IndexMetadata.SETTING_HISTORY_UUID, IndexMetadata.INDEX_UUID_NA_VALUE) +
                 "-" + indexMetadata.getSettingsVersion() +
                 "-" + indexMetadata.getMappingVersion();
-    }
-
-    /**
-     * Extract the indexUUID from the identifier.
-     * Only works if the identifier was created using {@link #buildUniqueIdentifier(IndexMetadata)}
-     */
-    @Nullable
-    public String getIndexUUID(String indexName) {
-        for (Map<IndexId, String> indices : lookup.values()) {
-            for (var entry : indices.entrySet()) {
-                IndexId key = entry.getKey();
-                String entryIndexName = key.getName();
-                if (entryIndexName.equals(indexName)) {
-                    String identifier = entry.getValue();
-                    assert UUIDs.randomBase64UUID().length() == 22 : "Length of random UUID should be 22";
-                    return identifier.substring(0, 22);
-                }
-            }
-        }
-        return null;
     }
 }

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoryData.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoryData.java
@@ -782,5 +782,4 @@ public final class RepositoryData {
         }
         return uuid;
     }
-
 }

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -1003,15 +1003,10 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 executor.execute(ActionRunnable.run(allMetaListener, () -> {
                         final IndexMetadata indexMetaData = clusterMetadata.index(index.getName());
                         if (writeIndexGens) {
-                            final String identifiers = IndexMetaDataGenerations.buildUniqueIdentifier(indexMetaData);
-
-                            // If the existing IndexMetadataGenerations contain a indexUUID that's different from the current indexMetadata
-                            // the table may have been swapped, in which case we need to reset it, otherwise a subsequent restore
-                            // will try to access files which don't exist.
+                            String identifiers = IndexMetaDataGenerations.buildUniqueIdentifier(indexMetaData);
                             IndexMetaDataGenerations existingIndexMetaGenerations = existingRepositoryData.indexMetaDataGenerations();
-                            String indexUUID = existingIndexMetaGenerations.getIndexUUID(index.getName());
                             String metaUUID = existingIndexMetaGenerations.getIndexMetaBlobId(identifiers);
-                            if (metaUUID == null || (indexUUID != null && !indexUUID.equals(indexMetaData.getIndexUUID()))) {
+                            if (metaUUID == null) {
                                 // We don't yet have this version of the metadata so we write it
                                 metaUUID = UUIDs.base64UUID();
                                 INDEX_METADATA_FORMAT.write(indexMetaData, indexContainer(index), metaUUID, compress);


### PR DESCRIPTION
Follow up to https://github.com/crate/crate/commit/24d7e94b055dc41d90ba9b01a87dc3274d32ef7a (and no changes, because 5.4.4 wasn't released yet)
The fix resulted in snapshots taken before swapping a table to become
unusable.

The reason was that the `index_metadata_identifiers` which are global
per repository-data only pointed to the _new_ metaUUID:

For example, on snapshot 1:

    metaUUID=M1, index=t02, indexId=I1, indexUUID=U1
    metaUUID=M2, index=t01, indexId=I2, indexUUID=U2

    index_metadata_identifiers: {
      U1-_na_-2-1: M1,
      U2-_na_-2-1: M2
    }

On snapshot 2, after swapping t01 and t02:

    Discard metaUUID=M2, newMetaUUID=M3, index=t02, indexId=I1, indexUUID=U2
    Discard metaUUID=M1, newMetaUUID=M4, index=t01, indexId=I2, indexUUID=U1

    index_metadata_identifiers: {
      U1-_na_-2-1: M4,
      U2-_na_-2-1: M3
    }

U1 (now I2) is pointing to M4, which contained M1 (I1) before the swap.
But on the filesystem in the repository was:

    /indices
      /I2
        /meta-M4.dat
        /meta-M2.dat
        /3
        /1
        /2
        /0
      /I1
        /meta-M3.dat
        /meta-M1.dat
        /0
        /3
        /1
        /2

On a restore of the first snapshot (U1, I1) it found `M4` in the
`index_metadata_identifiers`, and tried to look for `/I1/meta-m4.dat` on
the filesystem.

The solution is to generate a new `identifiers` key, so that we have the
following data after the second snapshot:

      index_metadata_identifiers: {
        "U2-U1-2-1": "M3",
        "U2-_na_-2-1": "M2",
        "U1-_na_-2-1": "M1",
        "U1-U2-2-1": "M4"
      }

And the snapshots themselves reference the correct identifier:

    {
      "name": "s2",
      "uuid": "xIhl-ubiTMWxCPRQbXjJng",
      "state": 1,
      "index_metadata_lookup": {
        "I1": "U2-U1-2-1",
        "I2": "U1-U2-2-1"
      },
      "version": "5.5.0"
    },
    {
      "name": "s1",
      "uuid": "TpqnN1x-SoSGO8IE_y8n5Q",
      "state": 1,
      "index_metadata_lookup": {
        "I1": "U1-_na_-2-1",
        "I2": "U2-_na_-2-1"
      },
      "version": "5.5.0"
    }
