### PR TITLE
Change (I)LIKE ANY operators signature to allow only string arguments

### DIFF
--- a/docs/appendices/release-notes/5.4.4.rst
+++ b/docs/appendices/release-notes/5.4.4.rst
@@ -113,3 +113,6 @@ Fixes
    ``NullPointerExceptions`` or return invalid results when the left hand side
    argument is a column and the right hand side argument array contains at
    least one ``null``.
+
+- Fixed an issue that caused ``(I)LIKE ANY`` operators to fail with an exception
+  when comparing non-string expressions.

--- a/server/src/main/java/io/crate/expression/operator/LikeOperators.java
+++ b/server/src/main/java/io/crate/expression/operator/LikeOperators.java
@@ -21,8 +21,6 @@
 
 package io.crate.expression.operator;
 
-import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
-
 import java.util.regex.Pattern;
 
 import org.apache.lucene.index.Term;
@@ -36,7 +34,6 @@ import io.crate.expression.operator.any.AnyOperator;
 import io.crate.lucene.match.CrateRegexQuery;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
-import io.crate.types.TypeSignature;
 
 public class LikeOperators {
     public static final String OP_LIKE = "op_like";
@@ -130,10 +127,10 @@ public class LikeOperators {
         module.register(
             Signature.scalar(
                 ANY_LIKE,
-                TypeSignature.parse("E"),
-                TypeSignature.parse("array(E)"),
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.STRING_ARRAY.getTypeSignature(),
                 Operator.RETURN_TYPE.getTypeSignature()
-            ).withTypeVariableConstraints(typeVariable("E")),
+            ),
             (signature, boundSignature) ->
                 new AnyLikeOperator(
                     signature,
@@ -144,10 +141,10 @@ public class LikeOperators {
         module.register(
             Signature.scalar(
                 ANY_NOT_LIKE,
-                TypeSignature.parse("E"),
-                TypeSignature.parse("array(E)"),
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.STRING_ARRAY.getTypeSignature(),
                 Operator.RETURN_TYPE.getTypeSignature()
-            ).withTypeVariableConstraints(typeVariable("E")),
+            ),
             (signature, boundSignature) ->
                 new AnyNotLikeOperator(
                     signature,
@@ -158,10 +155,10 @@ public class LikeOperators {
         module.register(
             Signature.scalar(
                 ANY_ILIKE,
-                TypeSignature.parse("E"),
-                TypeSignature.parse("array(E)"),
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.STRING_ARRAY.getTypeSignature(),
                 Operator.RETURN_TYPE.getTypeSignature()
-            ).withTypeVariableConstraints(typeVariable("E")),
+            ),
             (signature, boundSignature) ->
                 new AnyLikeOperator(
                     signature,
@@ -172,10 +169,10 @@ public class LikeOperators {
         module.register(
             Signature.scalar(
                 ANY_NOT_ILIKE,
-                TypeSignature.parse("E"),
-                TypeSignature.parse("array(E)"),
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.STRING_ARRAY.getTypeSignature(),
                 Operator.RETURN_TYPE.getTypeSignature()
-            ).withTypeVariableConstraints(typeVariable("E")),
+            ),
             (signature, boundSignature) ->
                 new AnyNotLikeOperator(
                     signature,

--- a/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -25,7 +25,6 @@ import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.exactlyInstanceOf;
 import static io.crate.testing.Asserts.isLiteral;
 import static io.crate.testing.Asserts.isReference;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
@@ -315,7 +314,7 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testParameterExpressionInLikeAny() throws Exception {
         Symbol s = expressions.asSymbol("5 LIKE ANY(?)");
-        assertThat(s).isFunction(LikeOperators.ANY_LIKE, isLiteral(5), exactlyInstanceOf(ParameterSymbol.class));
+        assertThat(s).isFunction(LikeOperators.ANY_LIKE, isLiteral("5"), exactlyInstanceOf(ParameterSymbol.class));
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/operator/any/AnyLikeOperatorTest.java
+++ b/server/src/test/java/io/crate/expression/operator/any/AnyLikeOperatorTest.java
@@ -133,4 +133,12 @@ public class AnyLikeOperatorTest extends ScalarTestCase {
         assertNormalize("'BaR' ilike any (['_ar'])", isLiteral(true));
         assertNormalize("'foobar' ilike any (['%O_a%'])", isLiteral(true));
     }
+
+    @Test
+    public void test_non_string_values() {
+        assertNormalize("1 like any ([1, null, 2])", isLiteral(true));
+        assertNormalize("1 not like any ([1])", isLiteral(false));
+        assertNormalize("1 ilike any ([1, null, 2])", isLiteral(true));
+        assertNormalize("1 not ilike any ([1])", isLiteral(false));
+    }
 }

--- a/server/src/test/java/io/crate/planner/optimizer/symbol/CollectQueryCastRulesTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/symbol/CollectQueryCastRulesTest.java
@@ -132,12 +132,12 @@ public class CollectQueryCastRulesTest extends CrateDummyClusterServiceUnitTest 
         }
         for (var op : List.of("LIKE", "ILIKE")) {
             String lowerOp = op.toLowerCase(Locale.ENGLISH);
-            assertThat(toQuery("name " + op + " ANY([1, 2, 2])"))
+            assertThat(toQuery("name " + op + " ANY(d_array)"))
                 .isFunction("any_" + lowerOp,
                     arg1 -> assertThat(arg1).isReference().hasName("name"),
                     arg2 -> assertThat(arg2).isFunction("_cast")
                 );
-            assertThat(toQuery("name NOT " + op + " ANY([1, 2, 2])"))
+            assertThat(toQuery("name NOT " + op + " ANY(d_array)"))
                 .isFunction("any_not_" + lowerOp,
                     arg1 -> assertThat(arg1).isReference().hasName("name"),
                     arg2 -> assertThat(arg2).isFunction("_cast")
@@ -156,12 +156,12 @@ public class CollectQueryCastRulesTest extends CrateDummyClusterServiceUnitTest 
         }
         for (var op : List.of("LIKE", "ILIKE")) {
             String opLower = op.toLowerCase(Locale.ENGLISH);
-            assertThat(toQuery("1 " + op + " ANY(text_array)")).isFunction(
+            assertThat(toQuery("id " + op + " ANY(text_array)")).isFunction(
                 "any_" + opLower,
                 arg1 -> assertThat(arg1).isFunction("_cast"),
                 arg2 -> assertThat(arg2).isReference().hasName("text_array")
             );
-            assertThat(toQuery("1 NOT " + op + " ANY(text_array)")).isFunction(
+            assertThat(toQuery("id NOT " + op + " ANY(text_array)")).isFunction(
                 "any_not_" + opLower,
                 arg1 -> assertThat(arg1).isFunction("_cast"),
                 arg2 -> assertThat(arg2).isReference().hasName("text_array")


### PR DESCRIPTION
Non-string values are supported by the implicit casting logic.

Fixes #14826.
