### PR TITLE
Clarify difference between DataType valueForInsert and sanitizeValue

### DIFF
--- a/server/src/main/java/io/crate/types/BitStringType.java
+++ b/server/src/main/java/io/crate/types/BitStringType.java
@@ -29,8 +29,6 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import org.jetbrains.annotations.Nullable;
-
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.Query;
@@ -38,6 +36,7 @@ import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.jetbrains.annotations.Nullable;
 
 import com.fasterxml.jackson.core.Base64Variants;
 
@@ -188,11 +187,10 @@ public final class BitStringType extends DataType<BitString> implements Streamer
     }
 
     @Override
-    public BitString valueForInsert(Object value) {
-        if (value == null) {
+    public BitString valueForInsert(BitString bitString) {
+        if (bitString == null) {
             return null;
         }
-        BitString bitString = (BitString) value;
         if (bitString.length() == length) {
             return bitString;
         }

--- a/server/src/main/java/io/crate/types/CharacterType.java
+++ b/server/src/main/java/io/crate/types/CharacterType.java
@@ -29,10 +29,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
-import org.jetbrains.annotations.Nullable;
-
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.jetbrains.annotations.Nullable;
 
 import io.crate.metadata.settings.SessionSettings;
 import io.crate.sql.tree.ColumnDefinition;
@@ -99,26 +98,23 @@ public class CharacterType extends StringType {
     }
 
     @Override
-    public String valueForInsert(Object value) {
+    public String valueForInsert(String value) {
         if (value == null) {
             return null;
         }
-        assert value instanceof String
-            : "valueForInsert must be called only on objects of String type";
-        var string = (String) value;
-        if (string.length() == lengthLimit) {
-            return string;
-        } else if (string.length() < lengthLimit) {
-            return padEnd(string, lengthLimit, ' ');
+        if (value.length() == lengthLimit) {
+            return value;
+        } else if (value.length() < lengthLimit) {
+            return padEnd(value, lengthLimit, ' ');
         } else {
-            if (isBlank(string, lengthLimit, string.length())) {
-                return string.substring(0, lengthLimit);
+            if (isBlank(value, lengthLimit, value.length())) {
+                return value.substring(0, lengthLimit);
             } else {
-                if (string.length() > 20) {
-                    string = string.substring(0, 20) + "...";
+                if (value.length() > 20) {
+                    value = value.substring(0, 20) + "...";
                 }
                 throw new IllegalArgumentException(
-                    "'" + string + "' is too long for the character type of length: " + lengthLimit);
+                    "'" + value + "' is too long for the character type of length: " + lengthLimit);
             }
         }
     }

--- a/server/src/main/java/io/crate/types/DataType.java
+++ b/server/src/main/java/io/crate/types/DataType.java
@@ -137,14 +137,14 @@ public abstract class DataType<T> implements Comparable<DataType<?>>, Writeable,
     }
 
     /**
-     * To prepare a value of the same {@link DataType<T>} for insertion.
+     * Processes the value to honor SQL semantics of the type.
+     * For example a String may get trimmed to the string's length.
      *
      * @param value The value of the {@link DataType<T>}.
-     * @return The prepared for insertion value of the {@link DataType<T>}.
+     * @return The processed value
      */
-    @SuppressWarnings("unchecked")
-    public T valueForInsert(Object value) {
-        return (T) value;
+    public T valueForInsert(T value) {
+        return value;
     }
 
     /**

--- a/server/src/main/java/io/crate/types/NumericType.java
+++ b/server/src/main/java/io/crate/types/NumericType.java
@@ -21,15 +21,6 @@
 
 package io.crate.types;
 
-import io.crate.Streamer;
-import io.crate.common.annotations.VisibleForTesting;
-
-import org.apache.lucene.util.RamUsageEstimator;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
-
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -37,6 +28,15 @@ import java.math.MathContext;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import io.crate.Streamer;
+import io.crate.common.annotations.VisibleForTesting;
 
 public class NumericType extends DataType<BigDecimal> implements Streamer<BigDecimal> {
 
@@ -143,7 +143,7 @@ public class NumericType extends DataType<BigDecimal> implements Streamer<BigDec
     }
 
     @Override
-    public BigDecimal valueForInsert(Object value) {
+    public BigDecimal valueForInsert(BigDecimal value) {
         throw new UnsupportedOperationException(
             getName() + " type cannot be used in insert statements");
     }

--- a/server/src/main/java/io/crate/types/RegprocType.java
+++ b/server/src/main/java/io/crate/types/RegprocType.java
@@ -21,13 +21,13 @@
 
 package io.crate.types;
 
-import io.crate.Streamer;
+import java.io.IOException;
 
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
-import java.io.IOException;
+import io.crate.Streamer;
 
 public class RegprocType extends DataType<Regproc> implements Streamer<Regproc> {
 
@@ -76,7 +76,7 @@ public class RegprocType extends DataType<Regproc> implements Streamer<Regproc> 
     }
 
     @Override
-    public Regproc valueForInsert(Object value) {
+    public Regproc valueForInsert(Regproc value) {
         throw new UnsupportedOperationException(
             getName() + " cannot be used in insert statements.");
     }

--- a/server/src/main/java/io/crate/types/StringType.java
+++ b/server/src/main/java/io/crate/types/StringType.java
@@ -33,8 +33,6 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import org.jetbrains.annotations.Nullable;
-
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.Query;
@@ -48,6 +46,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.jetbrains.annotations.Nullable;
 
 import io.crate.Streamer;
 import io.crate.common.unit.TimeValue;
@@ -259,24 +258,21 @@ public class StringType extends DataType<String> implements Streamer<String> {
     }
 
     @Override
-    public String valueForInsert(Object value) {
+    public String valueForInsert(String value) {
         if (value == null) {
             return null;
         }
-        assert value instanceof String
-            : "valueForInsert must be called only on objects of String type";
-        var string = (String) value;
-        if (unbound() || string.length() <= lengthLimit) {
-            return string;
+        if (unbound() || value.length() <= lengthLimit) {
+            return value;
         } else {
-            if (isBlank(string, lengthLimit, string.length())) {
-                return string.substring(0, lengthLimit);
+            if (isBlank(value, lengthLimit, value.length())) {
+                return value.substring(0, lengthLimit);
             } else {
-                if (string.length() > 20) {
-                    string = string.substring(0, 20) + "...";
+                if (value.length() > 20) {
+                    value = value.substring(0, 20) + "...";
                 }
                 throw new IllegalArgumentException(
-                    "'" + string + "' is too long for the text type of length: " + lengthLimit);
+                    "'" + value + "' is too long for the text type of length: " + lengthLimit);
             }
         }
     }

--- a/server/src/main/java/io/crate/types/TimeTZType.java
+++ b/server/src/main/java/io/crate/types/TimeTZType.java
@@ -21,15 +21,16 @@
 
 package io.crate.types;
 
-import io.crate.Streamer;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
+import static io.crate.types.TimeTZParser.exceptionForInvalidLiteral;
+import static io.crate.types.TimeTZParser.timeTZOf;
 
 import java.io.IOException;
 import java.util.Locale;
 
-import static io.crate.types.TimeTZParser.timeTZOf;
-import static io.crate.types.TimeTZParser.exceptionForInvalidLiteral;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import io.crate.Streamer;
 
 public final class TimeTZType extends DataType<TimeTZ> implements FixedWidthType, Streamer<TimeTZ> {
 
@@ -117,7 +118,7 @@ public final class TimeTZType extends DataType<TimeTZ> implements FixedWidthType
     }
 
     @Override
-    public TimeTZ valueForInsert(Object value) {
+    public TimeTZ valueForInsert(TimeTZ value) {
         throw new UnsupportedOperationException(String.format(
             Locale.ENGLISH,
             "%s cannot be used in insert statements",


### PR DESCRIPTION
- Changes valueForInsert signature from `Object -> T` to `T -> T` to
  enforce that the value type must already fit
- Appends the method documentation

Closes https://github.com/crate/crate/issues/14178
