### PR TITLE
Support `IS NULL` on columns that have column store disabled

### DIFF
--- a/docs/appendices/release-notes/5.4.4.rst
+++ b/docs/appendices/release-notes/5.4.4.rst
@@ -116,3 +116,6 @@ Fixes
 
 - Fixed an issue that caused ``(I)LIKE ANY`` operators to fail with an exception
   when comparing non-string expressions.
+
+- Fixed an issue that caused ``IS NULL`` operators to raise an error if the
+  column had the column store disabled.

--- a/server/src/main/java/io/crate/expression/predicate/IsNullPredicate.java
+++ b/server/src/main/java/io/crate/expression/predicate/IsNullPredicate.java
@@ -27,8 +27,6 @@ import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
 import java.util.Collections;
 import java.util.List;
 
-import org.apache.lucene.document.FieldType;
-import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
@@ -39,6 +37,8 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.index.mapper.FieldNamesFieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.MapperService;
 import org.jetbrains.annotations.Nullable;
 
 import io.crate.data.Input;
@@ -117,9 +117,10 @@ public class IsNullPredicate<T> extends Scalar<Boolean, T> {
     @Nullable
     public static Query refExistsQuery(Reference ref, Context context, boolean countEmptyArrays) {
         String field = ref.storageIdent();
-        FieldType fieldType = context.queryShardContext().getMapperService().getLuceneFieldType(field);
+        MapperService mapperService = context.queryShardContext().getMapperService();
+        MappedFieldType mappedFieldType = mapperService.fieldType(field);
         DataType<?> valueType = ref.valueType();
-        boolean canUseFieldsExist = ref.hasDocValues() || (fieldType != null && !fieldType.omitNorms());
+        boolean canUseFieldsExist = ref.hasDocValues() || (mappedFieldType != null && mappedFieldType.hasNorms());
         if (valueType instanceof ArrayType<?>) {
             if (countEmptyArrays) {
                 if (canUseFieldsExist) {
@@ -173,7 +174,7 @@ public class IsNullPredicate<T> extends Scalar<Boolean, T> {
                     .add(Queries.not(isNullFuncToQuery(ref, context)), Occur.SHOULD)
                     .build();
             }
-            if (fieldType == null || fieldType.indexOptions() == IndexOptions.NONE && !fieldType.stored()) {
+            if (mappedFieldType == null || !mappedFieldType.isSearchable()) {
                 return null;
             } else {
                 return new ConstantScoreQuery(new TermQuery(new Term(FieldNamesFieldMapper.NAME, field)));

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -28,10 +28,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
 
-import org.jetbrains.annotations.Nullable;
-
-import io.crate.server.xcontent.XContentMapValues;
-
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.SortedSetDocValuesField;
@@ -41,6 +37,9 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.jetbrains.annotations.Nullable;
+
+import io.crate.server.xcontent.XContentMapValues;
 
 /**
  * A field mapper for keywords. This mapper accepts strings and indexes them as-is.
@@ -152,14 +151,11 @@ public final class KeywordFieldMapper extends FieldMapper {
 
     public static final class KeywordFieldType extends MappedFieldType {
 
-        boolean hasNorms;
-
         public KeywordFieldType(String name,
                                 boolean isSearchable,
                                 boolean hasDocValues,
                                 boolean hasNorms) {
-            super(name, isSearchable, hasDocValues);
-            this.hasNorms = hasNorms;
+            super(name, isSearchable, hasDocValues, hasNorms);
             setIndexAnalyzer(Lucene.KEYWORD_ANALYZER);
             setSearchAnalyzer(Lucene.KEYWORD_ANALYZER);
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
@@ -31,15 +31,21 @@ public abstract class MappedFieldType {
     private final String name;
     private final boolean docValues;
     private final boolean isIndexed;
+    private final boolean hasNorms;
     private NamedAnalyzer indexAnalyzer;
     private NamedAnalyzer searchAnalyzer;
     private NamedAnalyzer searchQuoteAnalyzer;
     protected boolean hasPositions;
 
     public MappedFieldType(String name, boolean isIndexed, boolean hasDocValues) {
+        this(name, isIndexed, hasDocValues, false);
+    }
+
+    public MappedFieldType(String name, boolean isIndexed, boolean hasDocValues, boolean hasNorms) {
         this.name = Objects.requireNonNull(name);
         this.isIndexed = isIndexed;
         this.docValues = hasDocValues;
+        this.hasNorms = hasNorms;
     }
 
     /** Returns the name of this type, as would be specified in mapping properties */
@@ -47,6 +53,10 @@ public abstract class MappedFieldType {
 
     public String name() {
         return name;
+    }
+
+    public boolean hasNorms() {
+        return hasNorms;
     }
 
     public boolean hasPositions() {

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -33,7 +33,6 @@ import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
-
 import org.jetbrains.annotations.NotNull;
 
 /** A {@link FieldMapper} for full-text fields. */
@@ -191,7 +190,7 @@ public class TextFieldMapper extends FieldMapper {
     public static final class TextFieldType extends MappedFieldType {
 
         public TextFieldType(String name, boolean indexed, boolean hasPositions) {
-            super(name, indexed, false);
+            super(name, indexed, false, true);
             this.hasPositions = hasPositions;
         }
 

--- a/server/src/test/java/io/crate/expression/predicate/FieldExistsQueryTest.java
+++ b/server/src/test/java/io/crate/expression/predicate/FieldExistsQueryTest.java
@@ -33,12 +33,15 @@ import org.elasticsearch.Version;
 import org.junit.Test;
 
 import io.crate.analyze.TableElementsAnalyzer;
+import io.crate.sql.SqlFormatter;
+import io.crate.sql.tree.ColumnPolicy;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.DataTypeTesting;
 import io.crate.testing.QueryTester;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.FloatVectorType;
+import io.crate.types.StorageSupport;
 
 public class FieldExistsQueryTest extends CrateDummyClusterServiceUnitTest {
 
@@ -216,6 +219,40 @@ public class FieldExistsQueryTest extends CrateDummyClusterServiceUnitTest {
 
             results = queryTester.runQuery("xs", "xs is not null");
             assertThat(results).containsExactly(shapes);
+        }
+    }
+
+    @Test
+    public void test_is_null_on_columns_without_doc_values() throws Exception {
+        for (var type : DataTypeTesting.ALL_STORED_TYPES_EXCEPT_ARRAYS) {
+            StorageSupport<?> storageSupport = type.storageSupport();
+            if (storageSupport == null || !storageSupport.supportsDocValuesOff()) {
+                continue;
+            }
+            Supplier<?> dataGenerator = DataTypeTesting.getDataGenerator(type);
+            Object val1 = dataGenerator.get();
+            var extendedType = DataTypeTesting.extendedType(type, val1);
+            String typeDefinition = SqlFormatter.formatSql(extendedType.toColumnType(ColumnPolicy.STRICT, null));
+            String stmt = "create table tbl (id int primary key, x " + typeDefinition + " storage with (columnstore = false))";
+            QueryTester.Builder builder = new QueryTester.Builder(
+                createTempDir(),
+                THREAD_POOL,
+                clusterService,
+                Version.CURRENT,
+                stmt
+            );
+            builder.indexValue("x", val1);
+            builder.indexValue("x", null);
+            try (var queryTester = builder.build()) {
+                assertThat(queryTester.runQuery("x", "x is null"))
+                    .containsExactly(new Object[] { null });
+
+                if (!(type instanceof FloatVectorType)) {
+                    assertThat(queryTester.toQuery("x is null").toString())
+                        .as(type.getName() + " indexes field_names")
+                        .isEqualTo("+*:* -ConstantScore(_field_names:x)");
+                }
+            }
         }
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -28,6 +28,7 @@ import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -83,7 +84,6 @@ import io.crate.testing.UseRandomizedSchema;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.ObjectType;
-import io.crate.types.ObjectType.Builder;
 
 @IntegTestCase.ClusterScope(minNumDataNodes = 2)
 public class TransportSQLActionTest extends IntegTestCase {
@@ -1936,28 +1936,6 @@ public class TransportSQLActionTest extends IntegTestCase {
         );
     }
 
-    /**
-     * Adds innerTypes to object type definitions
-     **/
-    private static DataType<?> extendedType(DataType<?> type, Object value) {
-        if (type.id() == ObjectType.ID) {
-            var entryIt = ((Map<?, ?>) value).entrySet().iterator();
-            Builder builder = ObjectType.builder();
-            while (entryIt.hasNext()) {
-                var entry = entryIt.next();
-                String innerName = (String) entry.getKey();
-                Object innerValue = entry.getValue();
-                DataType<?> innerType = DataTypes.guessType(innerValue);
-                if (innerType.id() == ObjectType.ID && innerValue instanceof Map<?, ?> m && m.containsKey("coordinates")) {
-                    innerType = DataTypes.GEO_SHAPE;
-                }
-                builder.setInnerType(innerName, extendedType(innerType, innerValue));
-            }
-            return builder.build();
-        } else {
-            return type;
-        }
-    }
 
     @Test
     @UseJdbc(0)
@@ -1970,7 +1948,7 @@ public class TransportSQLActionTest extends IntegTestCase {
             }
             Supplier<?> dataGenerator = DataTypeTesting.getDataGenerator(type);
             Object val1 = dataGenerator.get();
-            var extendedType = extendedType(type, val1);
+            var extendedType = DataTypeTesting.extendedType(type, val1);
             String typeDefinition = SqlFormatter.formatSql(extendedType.toColumnType(ColumnPolicy.STRICT, null));
             execute("create table tbl (id int primary key, x " + typeDefinition + ")");
             execute("insert into tbl (id, x) values (?, ?)", new Object[] { 1, val1 });


### PR DESCRIPTION
Subset of https://github.com/crate/crate/pull/14604, focusing on
doc-values.

Before `x IS NULL` resulted in an error with `STORAGE WITH (columnstore =
false)`:

    IllegalStateException[FieldExistsQuery requires that the field indexes doc values, norms or vectors, but field '1' exists and indexes neither of these data structures]
