### PR TITLE
check flakiness on master

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/DynamicMappingUpdateITest.java
+++ b/server/src/test/java/io/crate/integrationtests/DynamicMappingUpdateITest.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
+import com.carrotsearch.randomizedtesting.annotations.Repeat;
 import io.crate.testing.UseNewCluster;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.test.IntegTestCase;
@@ -59,6 +60,7 @@ public class DynamicMappingUpdateITest extends IntegTestCase {
 
     @Test
     @UseNewCluster
+    @Repeat(iterations = 500)
     public void test_concurrent_statements_that_add_columns_result_in_dynamic_mapping_updates() throws InterruptedException, IOException {
         execute("create table t (a int, b object as (x int))");
         execute_concurrent_statements_that_add_columns_result_in_dynamic_mapping_updates();


### PR DESCRIPTION
`test_concurrent_statements_that_add_columns_result_in_dynamic_mapping_updates` is flaky on another PR and not sure whether flakiness already exists on master


If passes here, then most likely https://github.com/crate/crate/pull/14850/commits/659f0321847c268eb5b6e9d0bbc260e392832125 is problematic

