### PR TITLE
Fix UNION to recognize ambiguous columns

### DIFF
--- a/docs/appendices/release-notes/5.4.5.rst
+++ b/docs/appendices/release-notes/5.4.5.rst
@@ -46,4 +46,9 @@ See the :ref:`version_5.4.0` release notes for a full list of changes in the
 Fixes
 =====
 
-None
+- Fixed an issue that caused ``UNION`` to throw ``SQLParseExceptions`` instead
+  of ``AmbiguousColumnExceptions``, when 2 or more columns are assigned the
+  same name. e.g.::
+
+    SELECT a FROM (SELECT a, b AS a FROM t UNION SELECT 1, 1) t2;
+    -- selecting 'a' from 't2' is ambiguous since there are 'a' and 'b AS a'

--- a/server/src/main/java/io/crate/analyze/relations/UnionSelect.java
+++ b/server/src/main/java/io/crate/analyze/relations/UnionSelect.java
@@ -89,12 +89,16 @@ public class UnionSelect implements AnalyzedRelation {
 
     @Override
     public Symbol getField(ColumnIdent column, Operation operation, boolean errorOnUnknownObjectKey) throws AmbiguousColumnException, ColumnUnknownException, UnsupportedOperationException {
+        Symbol field = null;
         for (var output : outputs) {
             if (output.column().equals(column)) {
-                return output;
+                if (field != null) {
+                    throw new AmbiguousColumnException(output.column(), output);
+                }
+                field = output;
             }
         }
-        return null;
+        return field;
     }
 
     @Override


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Before fix:
```
cr> create table t (a int, b int);                                                                                                                
CREATE OK, 1 row affected  (1.764 sec)
cr> select a from (select a, b as a from t union select 1, 1) t2;                                                                                 
SQLParseException[Couldn't create execution plan from logical plan because of: Index 1 out of bounds for length 1:
Eval[a] (rows=unknown)
  └ Rename[a, a] AS t2 (rows=unknown)
    └ GroupHashAggregate[a, a] (rows=unknown)
      └ Union[a] (rows=unknown)
        ├ Collect[doc.t | [a] | true] (rows=unknown)
        └ Eval[1, 1] (rows=unknown)
          └ TableFunction[empty_row | [] | true] (rows=unknown)]
```

After fix:
```
cr> select a from (select a, b as a from t union select 1, 1) t2;                                                                                 
AmbiguousColumnException[Column "a" is ambiguous]
```

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
