### PR TITLE
Fix surefire test output

### DIFF
--- a/.idea/google-java-format.xml
+++ b/.idea/google-java-format.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GoogleJavaFormatSettings">
+    <option name="enabled" value="false" />
+  </component>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
         <version>3.1.2</version>
         <configuration>
           <parallel>suites</parallel>
+          <redirectTestOutputToFile>true</redirectTestOutputToFile>
           <includes>
             <include>**/Test*.java</include>
             <include>**/*IT.java</include>


### PR DESCRIPTION
-   Revert change to disable redirect of test output to file
    
    It was changed accidentally, and as a results the output is
    currently poluted with all the CrateDB node logs.
    
    Follows: 60b03a9add2ad2cae01f41314894724150c86a09

-  Disable google-java-format Intellij plugin
    
   Since we have our custom checkstyle, if enabled it
   overrides it and formats the code differently.
