### PR TITLE
tests: Fix flaky create_azure_snapshot_and_restore_with_secondary_endpoint

### DIFF
--- a/plugins/es-repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureSnapshotIntegrationTest.java
+++ b/plugins/es-repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureSnapshotIntegrationTest.java
@@ -30,7 +30,6 @@ import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Collection;
 
-import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.IntegTestCase;
 import org.junit.After;
@@ -166,11 +165,11 @@ public class AzureSnapshotIntegrationTest extends IntegTestCase {
 
     private String httpServerUrl() {
         InetSocketAddress address = httpServer.getAddress();
-        return "http://" + InetAddresses.toUriString(address.getAddress()) + ":" + address.getPort();
+        return "http://" + address.getAddress().getCanonicalHostName() + ":" + address.getPort();
     }
 
     private String invalidHttpServerUrl() {
         InetSocketAddress address = httpServer.getAddress();
-        return "http://dummy.invalid:" + address.getPort();
+        return "http://invalid." + address.getAddress().getCanonicalHostName() + ":" + address.getPort();
     }
 }


### PR DESCRIPTION
Use host name instead of address, since the secondary endpoint must be
a prefix + the valid endpoint, and when this is an ip address
(`127.0.0.1`) instead of `localhost`, it seems to fail. Switching to
`localhost`, requires that the secondary endpoint is a subdomain of
`localhost`, therefore: `invalid.localhost` for the relevant test.
