### PR TITLE
Added if not exists support to create table as

### DIFF
--- a/docs/appendices/release-notes/5.5.0.rst
+++ b/docs/appendices/release-notes/5.5.0.rst
@@ -87,7 +87,7 @@ SQL Statements
   :ref:`ALTER TABLE DROP COLUMN <sql-alter-table-drop-column>` statement.
 
 - Added support for
-  :ref:`CREATE TABLE IF NOT EXISTS <table-name> AS <other-table>` statement.
+  :ref:`CREATE TABLE IF NOT EXISTS AS <ref-create-table-as>` statement.
 
 SQL Standard and PostgreSQL Compatibility
 -----------------------------------------

--- a/docs/appendices/release-notes/5.5.0.rst
+++ b/docs/appendices/release-notes/5.5.0.rst
@@ -86,6 +86,9 @@ SQL Statements
 - Added support for
   :ref:`ALTER TABLE DROP COLUMN <sql-alter-table-drop-column>` statement.
 
+- Added support for
+  :ref:`CREATE TABLE IF NOT EXISTS <table-name> AS <other-table>` statement.
+
 SQL Standard and PostgreSQL Compatibility
 -----------------------------------------
 

--- a/libs/sql-parser/src/main/antlr/io/crate/sql/parser/antlr/SqlBaseParser.g4
+++ b/libs/sql-parser/src/main/antlr/io/crate/sql/parser/antlr/SqlBaseParser.g4
@@ -570,7 +570,7 @@ createStmt
     : CREATE TABLE (IF NOT EXISTS)? table
         OPEN_ROUND_BRACKET tableElement (COMMA tableElement)* CLOSE_ROUND_BRACKET
          partitionedByOrClusteredInto withProperties?                                #createTable
-    | CREATE TABLE table AS insertSource                                             #createTableAs
+    | CREATE TABLE (IF NOT EXISTS)? table AS insertSource                            #createTableAs
     | CREATE BLOB TABLE table numShards=blobClusteredInto? withProperties?           #createBlobTable
     | CREATE REPOSITORY name=ident TYPE type=ident withProperties?                   #createRepository
     | CREATE SNAPSHOT qname (ALL | TABLE tableWithPartitions) withProperties?        #createSnapshot


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
closes #14834 
Added if not exists support to create table as

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
