### PR TITLE
Fix Lucene query building for array types

### DIFF
--- a/server/src/main/java/io/crate/types/BitStringType.java
+++ b/server/src/main/java/io/crate/types/BitStringType.java
@@ -30,6 +30,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.apache.lucene.document.SortedSetDocValuesField;
+import org.apache.lucene.search.TermInSetQuery;
 import org.jetbrains.annotations.Nullable;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.Term;
@@ -86,6 +87,16 @@ public final class BitStringType extends DataType<BitString> implements Streamer
                                     boolean hasDocValues,
                                     boolean isIndexed) {
                 return null;
+            }
+
+            @Override
+            public Query termsQuery(String field, List<BitString> nonNullValues, boolean hasDocValues, boolean isIndexed) {
+                if (isIndexed) {
+                    return new TermInSetQuery(field, nonNullValues.stream().map(v -> new BytesRef(v.bitSet().toByteArray())).toList());
+                } else {
+                    assert hasDocValues == true : "hasDocValues must be true for BitString types since 'columnstore=false' is not supported.";
+                    return SortedSetDocValuesField.newSlowSetQuery(field, nonNullValues.stream().map(v -> new BytesRef(v.bitSet().toByteArray())).toArray(BytesRef[]::new));
+                }
             }
         }
     ) {

--- a/server/src/main/java/io/crate/types/DoubleType.java
+++ b/server/src/main/java/io/crate/types/DoubleType.java
@@ -24,6 +24,7 @@ package io.crate.types;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.List;
 import java.util.function.Function;
 
 import org.apache.lucene.document.DoublePoint;
@@ -92,6 +93,17 @@ public class DoubleType extends DataType<Double> implements FixedWidthType, Stre
                         field,
                         NumericUtils.doubleToSortableLong(lower),
                         NumericUtils.doubleToSortableLong(upper));
+                }
+                return null;
+            }
+
+            @Override
+            public Query termsQuery(String field, List<Double> nonNullValues, boolean hasDocValues, boolean isIndexed) {
+                if (isIndexed) {
+                    return DoublePoint.newSetQuery(field, nonNullValues);
+                }
+                if (hasDocValues) {
+                    return SortedNumericDocValuesField.newSlowSetQuery(field, nonNullValues.stream().mapToLong(NumericUtils::doubleToSortableLong).toArray());
                 }
                 return null;
             }

--- a/server/src/main/java/io/crate/types/EqQuery.java
+++ b/server/src/main/java/io/crate/types/EqQuery.java
@@ -21,6 +21,8 @@
 
 package io.crate.types;
 
+import java.util.List;
+
 import org.apache.lucene.search.Query;
 
 /**
@@ -45,4 +47,6 @@ public interface EqQuery<T> {
                      boolean includeUpper,
                      boolean hasDocValues,
                      boolean isIndexed);
+
+    Query termsQuery(String field, List<T> nonNullValues, boolean hasDocValues, boolean isIndexed);
 }

--- a/server/src/main/java/io/crate/types/FloatType.java
+++ b/server/src/main/java/io/crate/types/FloatType.java
@@ -24,6 +24,7 @@ package io.crate.types;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.List;
 import java.util.function.Function;
 
 import org.apache.lucene.document.FieldType;
@@ -92,6 +93,17 @@ public class FloatType extends DataType<Float> implements Streamer<Float>, Fixed
                         field,
                         NumericUtils.floatToSortableInt(lower),
                         NumericUtils.floatToSortableInt(upper));
+                }
+                return null;
+            }
+
+            @Override
+            public Query termsQuery(String field, List<Float> nonNullValues, boolean hasDocValues, boolean isIndexed) {
+                if (isIndexed) {
+                    return FloatPoint.newSetQuery(field, nonNullValues);
+                }
+                if (hasDocValues) {
+                    return SortedNumericDocValuesField.newSlowSetQuery(field, nonNullValues.stream().mapToLong(NumericUtils::floatToSortableInt).toArray());
                 }
                 return null;
             }

--- a/server/src/main/java/io/crate/types/FloatVectorType.java
+++ b/server/src/main/java/io/crate/types/FloatVectorType.java
@@ -72,6 +72,11 @@ public class FloatVectorType extends DataType<float[]> implements Streamer<float
                                 boolean isIndexed) {
             return null;
         }
+
+        @Override
+        public Query termsQuery(String field, List<float[]> nonNullValues, boolean hasDocValues, boolean isIndexed) {
+            return null;
+        }
     };
 
     private static final StorageSupport<? super float[]> STORAGE_SUPPORT = new StorageSupport<>(

--- a/server/src/main/java/io/crate/types/IntEqQuery.java
+++ b/server/src/main/java/io/crate/types/IntEqQuery.java
@@ -21,6 +21,8 @@
 
 package io.crate.types;
 
+import java.util.List;
+
 import org.apache.lucene.document.IntPoint;
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.search.Query;
@@ -59,6 +61,17 @@ public class IntEqQuery implements EqQuery<Number> {
         }
         if (hasDocValues) {
             return SortedNumericDocValuesField.newSlowRangeQuery(field, lower, upper);
+        }
+        return null;
+    }
+
+    @Override
+    public Query termsQuery(String field, List<Number> nonNullValues, boolean hasDocValues, boolean isIndexed) {
+        if (isIndexed) {
+            return IntPoint.newSetQuery(field, nonNullValues.stream().mapToInt(Number::intValue).toArray());
+        }
+        if (hasDocValues) {
+            return SortedNumericDocValuesField.newSlowSetQuery(field, nonNullValues.stream().mapToLong(Number::longValue).toArray());
         }
         return null;
     }

--- a/server/src/main/java/io/crate/types/LongEqQuery.java
+++ b/server/src/main/java/io/crate/types/LongEqQuery.java
@@ -21,6 +21,8 @@
 
 package io.crate.types;
 
+import java.util.List;
+
 import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.search.Query;
@@ -57,6 +59,17 @@ public class LongEqQuery implements EqQuery<Long> {
         }
         if (hasDocValues) {
             return SortedNumericDocValuesField.newSlowRangeQuery(field, lower, upper);
+        }
+        return null;
+    }
+
+    @Override
+    public Query termsQuery(String field, List<Long> nonNullValues, boolean hasDocValues, boolean isIndexed) {
+        if (isIndexed) {
+            return LongPoint.newSetQuery(field, nonNullValues);
+        }
+        if (hasDocValues) {
+            return SortedNumericDocValuesField.newSlowSetQuery(field, nonNullValues.stream().mapToLong(Long::longValue).toArray());
         }
         return null;
     }

--- a/server/src/main/java/io/crate/types/StorageSupport.java
+++ b/server/src/main/java/io/crate/types/StorageSupport.java
@@ -73,6 +73,7 @@ public abstract class StorageSupport<T> {
         return supportsDocValuesOff;
     }
 
+    @Nullable
     public EqQuery<T> eqQuery() {
         return eqQuery;
     }

--- a/server/src/main/java/io/crate/types/StringType.java
+++ b/server/src/main/java/io/crate/types/StringType.java
@@ -34,6 +34,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.apache.lucene.document.SortedSetDocValuesField;
+import org.apache.lucene.search.TermInSetQuery;
 import org.jetbrains.annotations.Nullable;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.Term;
@@ -113,6 +114,17 @@ public class StringType extends DataType<String> implements Streamer<String> {
                         includeLower,
                         includeUpper
                     );
+                }
+                return null;
+            }
+
+            @Override
+            public Query termsQuery(String field, List<Object> nonNullValues, boolean hasDocValues, boolean isIndexed) {
+                if (isIndexed) {
+                    return new TermInSetQuery(field, nonNullValues.stream().map(BytesRefs::toBytesRef).toList());
+                }
+                if (hasDocValues) {
+                    return SortedSetDocValuesField.newSlowSetQuery(field, nonNullValues.stream().map(BytesRefs::toBytesRef).toArray(BytesRef[]::new));
                 }
                 return null;
             }

--- a/server/src/test/java/io/crate/lucene/FloatEqQueryTest.java
+++ b/server/src/test/java/io/crate/lucene/FloatEqQueryTest.java
@@ -24,6 +24,8 @@ package io.crate.lucene;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.lucene.document.FloatPoint;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.NumericUtils;
 import org.junit.Test;
@@ -36,7 +38,11 @@ public class FloatEqQueryTest extends LuceneQueryBuilderTest {
                 a1 float,
                 a2 float index off,
                 a3 float storage with (columnstore = false),
-                a4 float index off storage with (columnstore = false)
+                a4 float index off storage with (columnstore = false),
+                arr1 array(float),
+                arr2 array(float) index off,
+                arr3 array(float) storage with (columnstore = false),
+                arr4 array(float) index off storage with (columnstore = false)
             )
             """;
     }
@@ -82,5 +88,35 @@ public class FloatEqQueryTest extends LuceneQueryBuilderTest {
         query = convert("a4 <= 1.1");
         assertThat(query).isExactlyInstanceOf(GenericFunctionQuery.class);
         assertThat(query).hasToString("(a4 <= 1.1)");
+    }
+
+    @Test
+    public void test_FloatEqQuery_termsQuery() {
+        Query query = convert("arr1 = [1.1]");
+        assertThat(query).isExactlyInstanceOf(BooleanQuery.class);
+        BooleanClause clause = ((BooleanQuery) query).clauses().get(0);
+        query = clause.getQuery();
+        assertThat(query.getClass().getName()).endsWith("FloatPoint$3"); // the query class is anonymous
+        assertThat(query).hasToString("arr1:{1.1}");
+
+        query = convert("arr2 = [1.1]");
+        assertThat(query).isExactlyInstanceOf(BooleanQuery.class);
+        clause = ((BooleanQuery) query).clauses().get(0);
+        query = clause.getQuery();
+        // SortedNumericDocValuesRangeQuery.class is not public
+        assertThat(query.getClass().getName()).endsWith("SortedNumericDocValuesSetQuery");
+        long l = NumericUtils.floatToSortableInt(1.1f);
+        assertThat(query).hasToString("arr2: [" + l + "]");
+
+        query = convert("arr3 = [1.1]");
+        assertThat(query).isExactlyInstanceOf(BooleanQuery.class);
+        clause = ((BooleanQuery) query).clauses().get(0);
+        query = clause.getQuery();
+        assertThat(query.getClass().getName()).endsWith("FloatPoint$3"); // the query class is anonymous
+        assertThat(query).hasToString("arr3:{1.1}");
+
+        query = convert("arr4 = [1.1]");
+        assertThat(query).isExactlyInstanceOf(GenericFunctionQuery.class);
+        assertThat(query).hasToString("(arr4 = [1.1])");
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes the following scenario(the first part of https://github.com/crate/crate/pull/14856#issuecomment-1757931824):
```
cr> create table tbl (a int, b int index off, c int index off storage with (columnstore = false));                                                
CREATE OK, 1 row affected  (0.128 sec)
cr> insert into tbl values (1, 1, 1);                                                                                                             
INSERT OK, 1 row affected  (0.009 sec)
cr> select * from tbl where a = any([1]);                                                                                                         
+---+---+---+
| a | b | c |
+---+---+---+
| 1 | 1 | 1 |
+---+---+---+
SELECT 1 row in set (0.085 sec)
cr> select * from tbl where b = any([1]);                                                                                                         
+---+---+---+
| a | b | c |
+---+---+---+
+---+---+---+
SELECT 0 rows in set (0.003 sec)
cr> select * from tbl where c = any([1]);                                                                                                         
+---+---+---+
| a | b | c |
+---+---+---+
+---+---+---+
SELECT 0 rows in set (0.004 sec)
```

Created `EqQuery.termsQuery` referring to previous commits to `fix-lucene-query-builder` regarding `EqQuery.termQuery` (since `termsQuery` is basically `termQuery` with a collection of values) as well as the tests.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
