### PR TITLE
Hide dropped columns in the information_schema.columns table

### DIFF
--- a/server/src/main/java/io/crate/metadata/information/InformationSchemaTableDefinitions.java
+++ b/server/src/main/java/io/crate/metadata/information/InformationSchemaTableDefinitions.java
@@ -67,9 +67,10 @@ public class InformationSchemaTableDefinitions {
         ));
         tableDefinitions.put(InformationColumnsTableInfo.IDENT, new StaticTableDefinition<>(
             informationSchemaIterables::columns,
-            (user, c) -> user.hasAnyPrivilege(Privilege.Clazz.TABLE, c.relation().ident().fqn())
+            (user, c) -> (user.hasAnyPrivilege(Privilege.Clazz.TABLE, c.relation().ident().fqn())
                          // we also need to check for views which have privileges set
-                         || user.hasAnyPrivilege(Privilege.Clazz.VIEW, c.relation().ident().fqn()),
+                         || user.hasAnyPrivilege(Privilege.Clazz.VIEW, c.relation().ident().fqn())
+                         ) && !c.ref().isDropped(),
             InformationColumnsTableInfo.create().expressions()
         ));
         tableDefinitions.put(InformationTableConstraintsTableInfo.IDENT, new StaticTableDefinition<>(


### PR DESCRIPTION
Tested in PG14, dropped columns are not shown there.

```
select attname, attnum, attisdropped
            from pg_attribute
            where attrelid = 't'::regclass
            order by attnum
```
            
shows active columns + system columns like xmin/xmax +
 dropped  columns entries (with names looking like `........pg.dropped.1........`)
 
 and query like 
```
  select column_name, ordinal_position
            from information_schema.columns
            where table_name = 't'
            order by ordinal_position
```
            
shows only active columns.