### PR TITLE
Generate crate-build.properties on build and update Build/version info

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -68,6 +68,29 @@
           <sha256>54a6ff90ba819f690cd6eee14b572df542f04e24ab647d05d2c7f9efd3eecc2b</sha256>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>io.github.git-commit-id</groupId>
+        <artifactId>git-commit-id-maven-plugin</artifactId>
+        <version>6.0.0</version>
+        <executions>
+          <execution>
+            <id>get-the-git-infos</id>
+            <goals>
+              <goal>revision</goal>
+            </goals>
+            <phase>initialize</phase>
+          </execution>
+        </executions>
+        <configuration>
+          <generateGitPropertiesFile>true</generateGitPropertiesFile>
+          <generateGitPropertiesFilename>${project.build.outputDirectory}/crate-build.properties</generateGitPropertiesFilename>
+          <includeOnlyProperties>
+            <includeOnlyProperty>^git.build.(time|version)$</includeOnlyProperty>
+            <includeOnlyProperty>^git.commit.id.(abbrev|full)$</includeOnlyProperty>
+          </includeOnlyProperties>
+          <commitIdGenerationMode>full</commitIdGenerationMode>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -152,22 +152,6 @@
           </addModules>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>io.github.git-commit-id</groupId>
-        <artifactId>git-commit-id-maven-plugin</artifactId>
-        <version>6.0.0</version>
-        <executions>
-          <execution>
-            <id>get-the-git-infos</id>
-            <goals>
-              <goal>revision</goal>
-            </goals>
-            <phase>initialize</phase>
-          </execution>
-        </executions>
-        <configuration>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
   <reporting>

--- a/server/src/main/java/org/elasticsearch/Build.java
+++ b/server/src/main/java/org/elasticsearch/Build.java
@@ -19,14 +19,14 @@
 
 package org.elasticsearch;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.joda.time.DateTimeZone;
 import org.joda.time.format.ISODateTimeFormat;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Properties;
 
 public final class Build {
 
@@ -42,10 +42,8 @@ public final class Build {
             if (inputStream != null) {
                 props.load(inputStream);
             }
-            hash = props.getProperty("hash", hash);
-            if (hash.length() >= 7) {
-                hashShort = hash.substring(0, 7);
-            }
+            hash = props.getProperty("git.commit.id.full", hash);
+            hashShort = props.getProperty("git.commit.id.abbrev", hashShort);
             String gitTimestampRaw = props.getProperty("timestamp");
             if (gitTimestampRaw != null) {
                 timestamp = ISODateTimeFormat.dateTimeNoMillis().withZone(DateTimeZone.UTC).print(Long.parseLong(gitTimestampRaw));


### PR DESCRIPTION
`select version from sys.nodes` showed `NA` as `build_hash` because the
crate-build.properties generation got lost in the maven migration
