### PR TITLE
Move benchmark module to separate profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,5 +63,8 @@ sandbox/crate2/repo/
 **/gen/
 target/
 *.factorypath
+
+# Maven
 .mvn/wrapper/maven-wrapper.jar
 pom.xml.versionsBackup
+benchmarks/dependency-reduced-pom.xml

--- a/devs/docs/benchmarks.rst
+++ b/devs/docs/benchmarks.rst
@@ -4,7 +4,7 @@ Benchmarks
 
 Microbenchmarks are written using `JMH`_. To execute them, first build the JAR::
 
-    $ ./mvnw -T 1C package -DskipTests=true
+    $ ./mvnw package -DskipTests=true -P benchmark
 
 Then run the JAR::
 

--- a/pom.xml
+++ b/pom.xml
@@ -224,6 +224,15 @@
     <versions.jmh>1.37</versions.jmh>
   </properties>
 
+  <profiles>
+    <profile>
+      <id>benchmark</id>
+      <modules>
+        <module>benchmarks</module>
+      </modules>
+    </profile>
+  </profiles>
+
   <modules>
     <module>libs/shared</module>
     <module>libs/dex</module>
@@ -246,6 +255,5 @@
     <module>extensions/jmx-monitoring</module>
     <module>jlink-jdk</module>
     <module>app</module>
-    <module>benchmarks</module>
   </modules>
 </project>


### PR DESCRIPTION
For the common tasks (run tests, build package) it is not required.
