### PR TITLE
Avoid creation of dependency-reduced-pom.xml in benchmarks

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -49,6 +49,7 @@
                   </excludes>
                 </filter>
               </filters>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
The file is automatically created by default by the `shade` plugin,
so disable it using the config param.
