### PR TITLE
Fix close handling in FileReadingIterator

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/collect/files/FileReadingIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/files/FileReadingIterator.java
@@ -347,7 +347,6 @@ public class FileReadingIterator implements BatchIterator<FileReadingIterator.Li
         closeReader();
         reset();
         killed = BatchIterator.CLOSED;
-        backOffPolicy.forEachRemaining((delay) -> {});
     }
 
     private void reset() {


### PR DESCRIPTION
    [ERROR] io.crate.integrationtests.CopyFromFailFastITest.test_copy_from_with_fail_fast_with_write_error_on_handler_node -- Time elapsed: 0.238 s <<< ERROR!
    com.carrotsearch.randomizedtesting.UncaughtExceptionError: Captured an uncaught exception in thread: Thread[id=2017, name=cratedb[node_s0][search][T#3], state=RUNNABLE, group=TGRP-CopyFromFailFastITest]
    	at __randomizedtesting.SeedInfo.seed([6D8D154646FAE6FA:65063880B37BFB82]:0)
    Caused by: java.util.NoSuchElementException: Only up to 5 elements
    	at __randomizedtesting.SeedInfo.seed([6D8D154646FAE6FA]:0)
    	at org.elasticsearch.action.bulk.BackoffPolicy$ExponentialBackoffIterator.next(BackoffPolicy.java:167)
    	at org.elasticsearch.action.bulk.BackoffPolicy$ExponentialBackoffIterator.next(BackoffPolicy.java:147)
    	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
    	at io.crate.execution.engine.collect.files.FileReadingIterator.close(FileReadingIterator.java:350)
    	at io.crate.data.MappedForwardingBatchIterator.close(MappedForwardingBatchIterator.java:46)
    	at io.crate.data.MappedForwardingBatchIterator.close(MappedForwardingBatchIterator.java:46)
    	at io.crate.execution.engine.indexing.BatchIteratorBackpressureExecutor.consumeIterator(BatchIteratorBackpressureExecutor.java:202)
    	at io.crate.execution.engine.indexing.BatchIteratorBackpressureExecutor.doResumeConsumption(BatchIteratorBackpressureExecutor.java:232)
    	at io.crate.execution.engine.indexing.BatchIteratorBackpressureExecutor.lambda$resumeConsumption$3(BatchIteratorBackpressureExecutor.java:215)
