### PR TITLE
Introduce maven profile to run server tests

### DIFF
--- a/devs/docs/tests.rst
+++ b/devs/docs/tests.rst
@@ -19,6 +19,11 @@ For example::
 
     $ ./mvnw test -pl server
 
+To run tests for `server` module and build any dependency module beforehand, but
+skip running tests on those modules, you can run::
+
+    $ ./mvnw -Pserver test
+
 Run tests using multiple forks::
 
     $ ./mvnw test -DforkCount=4

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,9 @@
               junit.jupiter.execution.parallel.enabled = true
             </configurationParameters>
           </properties>
+          <!-- by default is false but is set to true by `serverTest` profile to avoid running tests
+               for modules on which `server` module depends on, when running `mvn -Pserver test` -->
+          <skip>${skipRunTests}</skip>
         </configuration>
       </plugin>
       <plugin>
@@ -192,6 +195,9 @@
     <maven.compiler.source>20</maven.compiler.source>
     <maven.compiler.target>20</maven.compiler.target>
 
+    <!-- see surefire plugin configuration for explanation -->
+    <skipRunTests>false</skipRunTests>
+
     <versions.jdk>21</versions.jdk>
     <versions.annotations>24.0.1</versions.annotations>
     <versions.log4j>2.20.0</versions.log4j>
@@ -253,4 +259,16 @@
     <module>app</module>
     <module>benchmarks</module>
   </modules>
+
+  <profiles>
+    <profile>
+      <id>server</id>
+      <properties>
+        <skipRunTests>true</skipRunTests>
+      </properties>
+      <modules>
+        <module>server</module>
+      </modules>
+    </profile>
+  </profiles>
 </project>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -20,6 +20,13 @@
   <build>
     <plugins>
       <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <!-- override setting from parent pom -->
+          <skip>false</skip>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <version>3.3.0</version>


### PR DESCRIPTION
Use `mvn -Pserver test` to build the dependencies as needed,
but only run tests for `server` module.
