### PR TITLE
Null column constraint

### DIFF
--- a/docs/appendices/release-notes/5.6.0.rst
+++ b/docs/appendices/release-notes/5.6.0.rst
@@ -59,7 +59,8 @@ Changes
 SQL Statements
 --------------
 
-None
+- Added support for explicit :ref:`NULL <null_constraint>` column constraint
+  definitions in ``CREATE TABLE`` statements.
 
 SQL Standard and PostgreSQL Compatibility
 -----------------------------------------

--- a/docs/general/ddl/constraints.rst
+++ b/docs/general/ddl/constraints.rst
@@ -14,7 +14,7 @@ The values of a constrained column must comply with the constraint.
 
 .. _constraints-primary-key:
 
-Primary key
+PRIMARY KEY
 ===========
 
 The primary key constraint combines a unique constraint and a not-null
@@ -57,10 +57,29 @@ Or using a alternate syntax::
 
    For further details see :ref:`primary_key_constraint`.
 
+.. _constraints-null:
+
+NULL
+====
+
+Explicitly states that the column can contain ``NULL`` values. This is the default.
+
+Example::
+
+    cr> create table my_table2 (
+    ...   first_column integer primary key,
+    ...   second_column text null
+    ... );
+    CREATE OK, 1 row affected (... sec)
+
+.. SEEALSO::
+
+   - :ref:`null_constraint`
+
 
 .. _constraints-not-null:
 
-Not null
+NOT NULL
 ========
 
 The not null constraint can be used on any table column and it prevents null
@@ -68,20 +87,20 @@ values from being inserted.
 
 Example::
 
-    cr> create table my_table2 (
+    cr> create table my_table3 (
     ...   first_column integer primary key,
     ...   second_column text not null
     ... );
     CREATE OK, 1 row affected (... sec)
 
-.. NOTE::
+.. SEEALSO::
 
-   For further details see :ref:`not_null_constraint`.
+   :ref:`not_null_constraint`
 
 
 .. _constraints-check:
 
-Check
+CHECK
 =====
 
 A check constraint allows you to specify that the values in a certain column
@@ -108,6 +127,8 @@ from sensors and you want to ensure that negative values are rejected::
     cr> drop table my_table1pk1;
     DROP OK, 1 row affected (... sec)
     cr> drop table my_table2;
+    DROP OK, 1 row affected (... sec)
+    cr> drop table my_table3;
     DROP OK, 1 row affected (... sec)
     cr> drop table metrics;
     DROP OK, 1 row affected (... sec)

--- a/docs/sql/general/constraints.rst
+++ b/docs/sql/general/constraints.rst
@@ -169,6 +169,25 @@ The supported column constraints are:
 - :ref:`check_constraint`
 
 
+.. _null_constraint:
+
+``NULL``
+--------
+
+The ``NULL`` constraint specifies that a column of a table can also contain
+null values.
+
+The columns that are part of the primary key of a table cannot be declared as
+``NULL``.
+
+A column cannot be declared both as ``NULL`` and ``NOT NULL``.
+
+.. NOTE::
+
+    ``NULL`` constraint is not shown in :ref:`ref-show-create-table`, as is the
+    default for every column.
+
+
 .. _not_null_constraint:
 
 ``NOT NULL``

--- a/docs/sql/statements/alter-table.rst
+++ b/docs/sql/statements/alter-table.rst
@@ -37,6 +37,7 @@ Synopsis
 where ``column_constraint`` is::
 
     { PRIMARY KEY |
+      NULL |
       NOT NULL |
       INDEX { OFF | USING { PLAIN |
                             FULLTEXT [ WITH ( analyzer = analyzer_name ) ]  } |

--- a/docs/sql/statements/create-table.rst
+++ b/docs/sql/statements/create-table.rst
@@ -48,6 +48,7 @@ where ``generated_column_definition`` is::
 where ``column_constraint`` is::
 
     { PRIMARY KEY |
+      NULL |
       NOT NULL |
       INDEX { OFF | USING { PLAIN |
                             FULLTEXT [ WITH ( analyzer = analyzer_name ) ]  }

--- a/libs/sql-parser/src/main/antlr/io/crate/sql/parser/antlr/SqlBaseParser.g4
+++ b/libs/sql-parser/src/main/antlr/io/crate/sql/parser/antlr/SqlBaseParser.g4
@@ -681,6 +681,7 @@ objectTypeDefinition
 columnConstraint
     : PRIMARY_KEY                                                                    #columnConstraintPrimaryKey
     | NOT NULL                                                                       #columnConstraintNotNull
+    | NULL																			 #columnConstraintNull
     | INDEX USING method=ident withProperties?                                       #columnIndexConstraint
     | INDEX OFF                                                                      #columnIndexOff
     | STORAGE withProperties                                                         #columnStorageDefinition

--- a/libs/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
@@ -97,6 +97,7 @@ import io.crate.sql.tree.LongLiteral;
 import io.crate.sql.tree.NaturalJoin;
 import io.crate.sql.tree.Node;
 import io.crate.sql.tree.NotNullColumnConstraint;
+import io.crate.sql.tree.NullColumnConstraint;
 import io.crate.sql.tree.ObjectColumnType;
 import io.crate.sql.tree.PartitionedBy;
 import io.crate.sql.tree.PrimaryKeyColumnConstraint;
@@ -854,6 +855,13 @@ public final class SqlFormatter {
         @Override
         public Void visitNotNullColumnConstraint(NotNullColumnConstraint<?> node, Integer indent) {
             builder.append("NOT NULL");
+            return null;
+        }
+
+        @SuppressWarnings("rawtypes")
+        @Override
+        public Void visitNullColumnConstraint(NullColumnConstraint node, Integer indent) {
+            builder.append("NULL");
             return null;
         }
 

--- a/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -46,6 +46,7 @@ import io.crate.sql.parser.antlr.SqlBaseLexer;
 import io.crate.sql.parser.antlr.SqlBaseParser;
 import io.crate.sql.parser.antlr.SqlBaseParser.BitStringContext;
 import io.crate.sql.parser.antlr.SqlBaseParser.CloseContext;
+import io.crate.sql.parser.antlr.SqlBaseParser.ColumnConstraintNullContext;
 import io.crate.sql.parser.antlr.SqlBaseParser.ConflictTargetContext;
 import io.crate.sql.parser.antlr.SqlBaseParser.DeclareContext;
 import io.crate.sql.parser.antlr.SqlBaseParser.DeclareCursorParamsContext;
@@ -181,6 +182,7 @@ import io.crate.sql.tree.NegativeExpression;
 import io.crate.sql.tree.Node;
 import io.crate.sql.tree.NotExpression;
 import io.crate.sql.tree.NotNullColumnConstraint;
+import io.crate.sql.tree.NullColumnConstraint;
 import io.crate.sql.tree.NullLiteral;
 import io.crate.sql.tree.ObjectColumnType;
 import io.crate.sql.tree.ObjectLiteral;
@@ -1126,6 +1128,12 @@ class AstBuilder extends SqlBaseParserBaseVisitor<Node> {
     @Override
     public Node visitColumnConstraintNotNull(SqlBaseParser.ColumnConstraintNotNullContext context) {
         return new NotNullColumnConstraint<>();
+    }
+
+    
+    @Override
+    public Node visitColumnConstraintNull(ColumnConstraintNullContext ctx) {
+        return new NullColumnConstraint<>();
     }
 
     @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
@@ -355,7 +355,11 @@ public abstract class AstVisitor<R, C> {
     public R visitNotNullColumnConstraint(NotNullColumnConstraint<?> node, C context) {
         return visitNode(node, context);
     }
-
+    
+    public R visitNullColumnConstraint(NullColumnConstraint<?> node, C context) {
+        return visitNode(node, context);
+    }
+    
     public R visitIndexColumnConstraint(IndexColumnConstraint<?> node, C context) {
         return visitNode(node, context);
     }

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/NullColumnConstraint.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/NullColumnConstraint.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.sql.tree;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public class NullColumnConstraint<T> extends ColumnConstraint<T> {
+    private static final String NAME = "NULL";
+
+    @Override
+    public void visit(Consumer<? super T> consumer) {
+    }
+
+    @Override
+    public int hashCode() {
+        return NAME.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        return !(obj == null || getClass() != obj.getClass());
+    }
+
+    @Override
+    public String toString() {
+        return NAME;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitNullColumnConstraint(this, context);
+    }
+
+    @Override
+    public <U> ColumnConstraint<U> map(Function<? super T, ? extends U> mapper) {
+        return new NullColumnConstraint<>();
+    }
+}

--- a/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -630,6 +630,7 @@ public class TestStatementBuilder {
     public void testAlterTableStmtBuilder() {
         printStatement("alter table t add foo integer");
         printStatement("alter table t add foo['1']['2'] integer");
+        printStatement("alter table t add foo integer null");
 
         printStatement("alter table t set (number_of_replicas=4)");
         printStatement("alter table schema.t set (number_of_replicas=4)");
@@ -638,6 +639,7 @@ public class TestStatementBuilder {
 
         printStatement("alter table t add foo integer");
         printStatement("alter table t add column foo integer");
+        printStatement("alter table t add column foo integer null");
         printStatement("alter table t add foo integer primary key");
         printStatement("alter table t add foo string index using fulltext");
         printStatement("alter table t add column foo['x'] integer");
@@ -680,11 +682,14 @@ public class TestStatementBuilder {
     public void testCreateTableStmtBuilder() {
         printStatement("create table if not exists t (id integer primary key, name string)");
         printStatement("create table t (id double precision)");
+        printStatement("create table t (id double precision null)");
         printStatement("create table t (id character varying)");
         printStatement("create table t (id integer primary key, value array(double precision))");
         printStatement("create table t (id integer, value double precision not null)");
         printStatement("create table t (id integer primary key, name string)");
+        printStatement("create table t (id integer primary key, name string null)");
         printStatement("create table t (id integer primary key, name string) clustered into 3 shards");
+        printStatement("create table t (id integer primary key, name string null) clustered into 3 shards");
         printStatement("create table t (id integer primary key, name string) clustered into ? shards");
         printStatement("create table t (id integer primary key, name string) clustered into CAST('123' AS int) shards");
         printStatement("create table t (id integer primary key, name string) clustered by (id)");
@@ -698,6 +703,7 @@ public class TestStatementBuilder {
         printStatement("create table t (id integer primary key, name string) with (number_of_replicas=-4)");
         printStatement("create table t (o object(dynamic) as (i integer, d double))");
         printStatement("create table t (id integer, name string, primary key (id))");
+        printStatement("create table t (id integer, name string null, primary key (id))");
         printStatement("create table t (" +
             "  \"_i\" integer, " +
             "  \"in\" int," +


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Closes: #14633.  

@matriv , you suggested that I implement the following code; however, the test in TestStatmenetBuilder would often fail. 

```
@Override
public Void visitNullColumnConstraint(NullColumnConstraint<?> node, Integer context) {
    return null;
}
```
The reason for the failure was that (1) the parse tree would create a formatted string. Then (2) that string would be parsed to create a second parse tree. Finally, (3) that second parse tree would be turned into a second formatted string. The first parse tree has to match the second parse tree, and the first formatted string must match the second formatted string. I thought of writing a separate test altogether, but I was not sure if other parts of the code require the parse tree to be able to make a round trip. Let me know what you advise. 

Since we want to analyze and fail if a null is being paired with a primary key constraint or a not null constraint, I felt that the Null Constraint must be in the initial parse tree. @hlcianfagna I am not sure, but I think some sort of parsing method would be needed in order to manually take out the occurrences of null with a regex replace. The null can be in many locations and an error would need to be thrown if it is combined with something not allowed (like "Not Null" or "Primary Key"). 

All that being said, I am not sure if my code is the best choice for fixing this issue, and any feedback would be much appreciated. 

Thanks, 


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes (no user facing changes)
 - [x] Updated documentation & `sql_features` table for user facing changes (no user facing changes)
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
