### PR TITLE
Remove suppressions file config from checkstyle.xml

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -56,9 +56,6 @@
         <property name="eachLine" value="true"/>
     </module>
 
-    <module name="SuppressionFilter">
-        <property name="file" value="checkstyle-suppressions.xml" default="checkstyle-suppressions.xml"/>
-    </module>
     <module name="SuppressWarningsFilter"/>
 
     <module name="TreeWalker">


### PR DESCRIPTION
The `checkstyle-suppressions.xml` file is not needed to be referred from within `checkstyle.xml` as it's defined in the configuration `maven-checkstyle-plugin`, in the parent `pom.xml` and it leads to errors (checkstyle-suppressions.xml file not found) in IntelliJ when running maven goals on any of the modules, as the base directory changes to the corresponding module.
