### PR TITLE
Remove waitForMappingUpdateOnAll

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/ColumnPolicyIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ColumnPolicyIntegrationTest.java
@@ -27,7 +27,6 @@ import static io.crate.protocols.postgres.PGErrorStatus.UNDEFINED_COLUMN;
 import static io.crate.testing.Asserts.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -141,7 +140,6 @@ public class ColumnPolicyIntegrationTest extends IntegTestCase {
         execute("insert into dynamic_table (id, name, boo) values (2, 'Trillian', true)");
         execute("refresh table dynamic_table");
 
-        waitForMappingUpdateOnAll("dynamic_table", "boo");
         execute("select * from dynamic_table order by id");
         assertThat(response).hasColumns("id", "name", "boo");
         assertThat(response).hasRows(
@@ -158,7 +156,6 @@ public class ColumnPolicyIntegrationTest extends IntegTestCase {
         ensureYellow();
         execute("insert into dynamic_table (new, meta) values(['a', 'b', 'c'], 'hello')");
         execute("insert into dynamic_table (new) values(['d', 'e', 'f'])");
-        waitForMappingUpdateOnAll("dynamic_table", "new", "meta");
         Map<String, Object> sourceMap = getSourceMap("dynamic_table");
         assertThat(getByPath(sourceMap, "properties.new.type")).isEqualTo("array");
         assertThat(getByPath(sourceMap, "properties.new.inner.type")).isEqualTo("keyword");
@@ -172,7 +169,6 @@ public class ColumnPolicyIntegrationTest extends IntegTestCase {
         execute("insert into dynamic_table (person) values " +
                 "({name='Ford', addresses=[{city='West Country', country='GB'}]})");
         refresh();
-        waitForMappingUpdateOnAll("dynamic_table", "person.name");
 
         Map<String, Object> sourceMap = getSourceMap("dynamic_table");
         assertThat(getByPath(sourceMap, "properties.person.properties.addresses.type")).isEqualTo("array");
@@ -200,7 +196,6 @@ public class ColumnPolicyIntegrationTest extends IntegTestCase {
         execute("refresh table dynamic_table");
         execute("insert into dynamic_table (new) values({nest={}, new={}})");
 
-        waitForMappingUpdateOnAll("dynamic_table", "new");
         Map<String, Object> sourceMap = getSourceMap("dynamic_table");
         assertThat(getByPath(sourceMap, "properties.new.properties.a.type")).isEqualTo("array");
         assertThat(getByPath(sourceMap, "properties.new.properties.a.inner.type")).isEqualTo("keyword");
@@ -220,7 +215,6 @@ public class ColumnPolicyIntegrationTest extends IntegTestCase {
         execute("insert into c.dynamic_table (meta) values({meta={a=['a','b']}})");
         execute("refresh table c.dynamic_table");
         execute("insert into c.dynamic_table (meta) values({meta={a=['c','d']}})");
-        waitForMappingUpdateOnAll(new RelationName("c", "dynamic_table"), "meta.meta.a");
         Map<String, Object> sourceMap = getSourceMap("c", "dynamic_table");
         assertThat(getByPath(sourceMap, "properties.meta.properties.meta.properties.a.type")).isEqualTo("array");
         assertThat(getByPath(sourceMap, "properties.meta.properties.meta.properties.a.inner.type")).isEqualTo("keyword");
@@ -236,7 +230,6 @@ public class ColumnPolicyIntegrationTest extends IntegTestCase {
         execute("insert into dynamic_table (my_object) values ({a=['a','b']}),({b=['a']})");
         execute("refresh table dynamic_table");
 
-        waitForMappingUpdateOnAll("dynamic_table", "my_object.a", "my_object.b");
         Map<String, Object> sourceMap = getSourceMap("dynamic_table");
         assertThat(getByPath(sourceMap, "properties.my_object.properties.a.type")).isEqualTo("array");
         assertThat(getByPath(sourceMap, "properties.my_object.properties.a.inner.type")).isEqualTo("keyword");
@@ -290,7 +283,6 @@ public class ColumnPolicyIntegrationTest extends IntegTestCase {
         execute("update dynamic_table set name='Trillian', boo=true where name='Ford'");
         execute("refresh table dynamic_table");
 
-        waitForMappingUpdateOnAll("dynamic_table", "boo");
         execute("select * from dynamic_table");
         assertThat(response)
             .hasColumns("id", "name", "boo")
@@ -315,7 +307,6 @@ public class ColumnPolicyIntegrationTest extends IntegTestCase {
         execute("insert into dynamic_table (id, score, good) values (2, -0.01, false)");
         execute("refresh table dynamic_table");
 
-        waitForMappingUpdateOnAll("dynamic_table", "good");
         execute("select * from dynamic_table order by id");
         assertThat(response).hasColumns("id", "score", "good");
         assertThat(response).hasRows(
@@ -342,7 +333,6 @@ public class ColumnPolicyIntegrationTest extends IntegTestCase {
         execute("update dynamic_table set name='Trillian', good=true where score > 0.0");
         execute("refresh table dynamic_table");
 
-        waitForMappingUpdateOnAll("dynamic_table", "name");
         execute("select * from dynamic_table");
         assertThat(response)
             .hasColumns("id", "score", "name", "good")
@@ -459,7 +449,6 @@ public class ColumnPolicyIntegrationTest extends IntegTestCase {
         ensureYellow();
         execute("refresh table numbers");
 
-        waitForMappingUpdateOnAll("numbers", "perfect");
         execute("select * from numbers order by num");
         assertThat(response).hasColumns("num", "odd", "prime", "perfect");
         assertThat(response).hasRows(
@@ -470,7 +459,6 @@ public class ColumnPolicyIntegrationTest extends IntegTestCase {
         execute("update numbers set prime=true, changed='2014-10-23T10:20', author='troll' where num=28");
         assertThat(response).hasRowCount(1);
 
-        waitForMappingUpdateOnAll("numbers", "changed");
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -914,7 +914,6 @@ public class InformationSchemaTest extends IntegTestCase {
                 "last_name", "Adams")});
         execute("refresh table t4");
 
-        waitForMappingUpdateOnAll("t4", "stuff.first_name", "stuff.middle_name", "stuff.last_name");
         execute("select column_name, ordinal_position from information_schema.columns where table_name='t4'");
         assertThat(response.rowCount()).isEqualTo(5);
     }
@@ -1155,7 +1154,6 @@ public class InformationSchemaTest extends IntegTestCase {
         };
         execute(stmtInsert, argsInsert);
         assertThat(response.rowCount()).isEqualTo(1L);
-        waitForMappingUpdateOnAll("data_points", "data.somestringroute");
         refresh();
 
         String stmtIsColumns = "select table_name, column_name, data_type " +

--- a/server/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
@@ -1365,7 +1365,6 @@ public class InsertIntoIntegrationTest extends IntegTestCase {
         ensureYellow();
         execute("insert into dyn_ts (id, ts) values (0, '2015-01-01')");
         refresh();
-        waitForMappingUpdateOnAll("dyn_ts", "ts");
         execute("insert into dyn_ts (id, ts) values (1, '2015-02-01')");
         // string is not converted to timestamp
         execute("select data_type from information_schema.columns where table_name='dyn_ts' and column_name='ts'");

--- a/server/src/test/java/io/crate/integrationtests/ObjectColumnTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ObjectColumnTest.java
@@ -82,7 +82,6 @@ public class ObjectColumnTest extends IntegTestCase {
                 authorMap
             });
         refresh();
-        waitForMappingUpdateOnAll("ot", "author.dead");
         execute("select title, author, author['dead'] from ot order by title");
         assertThat(response.rowCount()).isEqualTo(2);
         assertThat(response.rows()[0][0]).isEqualTo("Life, the Universe and Everything");
@@ -163,7 +162,6 @@ public class ObjectColumnTest extends IntegTestCase {
         execute("update ot set author['job']='Writer' " +
                 "where author['name']['first_name']='Douglas' and author['name']['last_name']='Adams'");
         refresh();
-        waitForMappingUpdateOnAll("ot", "author.job");
         execute("select author, author['job'] from ot " +
                 "where author['name']['first_name']='Douglas' and author['name']['last_name']='Adams'");
         assertThat(response.rowCount()).isEqualTo(1);
@@ -221,7 +219,6 @@ public class ObjectColumnTest extends IntegTestCase {
                 authorMap
             });
         refresh();
-        waitForMappingUpdateOnAll("ot", "author.dead");
         execute("select author from ot where author['dead']=true");
         assertThat(response.rowCount()).isEqualTo(1);
         assertThat(response.rows()[0][0]).isEqualTo(authorMap);
@@ -276,7 +273,6 @@ public class ObjectColumnTest extends IntegTestCase {
             }
         );
         refresh();
-        waitForMappingUpdateOnAll("ot", "author.dead");
         execute("select title, author['dead'] from ot order by author['dead'] desc");
         assertThat(response.rowCount()).isEqualTo(3);
         assertThat(response.rows()[0][0]).isEqualTo("The Hitchhiker's Guide to the Galaxy");
@@ -296,7 +292,6 @@ public class ObjectColumnTest extends IntegTestCase {
                 "('I''m addicted to kite', {name='Youri', addresses=[{city='Dirksland', country='NL'}]})");
         execute("refresh table test");
 
-        waitForMappingUpdateOnAll("test", "person.name");
         execute("select message, person['name'], person['addresses']['city'] from test " +
                 "where person['name'] = 'Youri'");
 

--- a/server/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
@@ -1139,7 +1139,6 @@ public class PartitionedTableIntegrationTest extends IntegTestCase {
             });
         ensureYellow();
         refresh();
-        waitForMappingUpdateOnAll("quotes", "author.surname");
 
         execute("select * from information_schema.columns where table_name = 'quotes'");
         assertEquals(6L, response.rowCount());
@@ -1888,7 +1887,6 @@ public class PartitionedTableIntegrationTest extends IntegTestCase {
         execute("insert into event (day, data) values ('2015-01-03', {sessionid = null})");
         execute("insert into event (day, data) values ('2015-01-01', {sessionid = 'hello'})");
         execute("refresh table event");
-        waitForMappingUpdateOnAll("event", "data.sessionid");
         execute("select data['sessionid'] from event group by data['sessionid'] " +
                 "order by format('%s', data['sessionid'])");
         assertThat(response.rows().length, Is.is(2));
@@ -1909,7 +1907,6 @@ public class PartitionedTableIntegrationTest extends IntegTestCase {
         execute("insert into event (day, data) values ('2015-01-01', {sessionid = 'hello'})");
         execute("insert into event (day, data) values ('2015-02-08', {sessionid = 'ciao'})");
         execute("refresh table event");
-        waitForMappingUpdateOnAll("event", "data.sessionid");
         execute("select data['sessionid'] from event where " +
                 "format('%s', data['sessionid']) = 'ciao' order by data['sessionid']");
         assertThat(response.rows().length, Is.is(1));
@@ -1930,7 +1927,6 @@ public class PartitionedTableIntegrationTest extends IntegTestCase {
         execute("insert into event (day, data, number) values ('2015-01-01', {sessionid = 'hello'}, 42)");
         execute("insert into event (day, data, number) values ('2015-02-08', {sessionid = 'ciao'}, 42)");
         execute("refresh table event");
-        waitForMappingUpdateOnAll("event", "data.sessionid");
         execute("select data['sessionid'] from event order by data['sessionid'] ASC nulls first");
         assertThat(printedTable(response.rows()), is(
             "NULL\n" +
@@ -1971,7 +1967,6 @@ public class PartitionedTableIntegrationTest extends IntegTestCase {
         execute("insert into event (day, data, number) values ('2015-02-08', {sessionid = 'ciao'}, 42)");
         execute("insert into event (day, number) values ('2015-03-08', 84)");
         execute("refresh table event");
-        waitForMappingUpdateOnAll("event", "data.sessionid");
 
         execute("select data " +
                 "from event " +
@@ -2005,7 +2000,6 @@ public class PartitionedTableIntegrationTest extends IntegTestCase {
         execute("insert into event (day, sessionid) values ('2015-01-01', 'hello')");
         execute("refresh table event");
 
-        waitForMappingUpdateOnAll("event", "sessionid");
         execute("select sessionid from event group by sessionid order by sessionid");
         assertThat(response.rows().length, Is.is(2));
         assertThat((String) response.rows()[0][0], Is.is("hello"));

--- a/server/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
@@ -25,7 +25,6 @@ import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.Locale;
@@ -281,7 +280,6 @@ public class SQLTypeMappingTest extends IntegTestCase {
     public void testInsertObjectIntoString() throws Exception {
         execute("create table t1 (o object)");
         execute("insert into t1 values ({a='abc'})");
-        waitForMappingUpdateOnAll("t1", "o.a");
 
         Asserts.assertSQLError(() -> execute("insert into t1 values ({a=['123', '456']})"))
             .hasPGError(INTERNAL_ERROR)
@@ -307,7 +305,6 @@ public class SQLTypeMappingTest extends IntegTestCase {
                     });
         refresh();
 
-        waitForMappingUpdateOnAll("t1", "new_col");
         SQLResponse response = execute("select id, new_col from t1 where id=0");
         @SuppressWarnings("unchecked")
         Map<String, Object> mapped = (Map<String, Object>) response.rows()[0][1];

--- a/server/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
@@ -27,7 +27,6 @@ import static io.crate.testing.Asserts.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.CONFLICT;
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -310,7 +309,6 @@ public class SnapshotRestoreIntegrationTest extends IntegTestCase {
         execute("CREATE SNAPSHOT " + snapshotName() + " TABLE my_other with (wait_for_completion=true)");
 
         execute("alter table my_other add column x double");
-        waitForMappingUpdateOnAll("my_other", "x");
         execute("delete from my_other");
 
         execute("CREATE TABLE survivor (bla string, blubb float) partitioned by (blubb) with (number_of_replicas=0)");

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionSingleNodeTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionSingleNodeTest.java
@@ -170,7 +170,6 @@ public class TransportSQLActionSingleNodeTest extends IntegTestCase {
         assertThat(rowCounts[0]).isEqualTo(1L);
         assertThat(rowCounts[1]).isEqualTo(1L);
 
-        waitForMappingUpdateOnAll("foo", "bar");
         execute("select data_type from information_schema.columns where table_name = 'foo' and column_name = 'bar'");
         // integer values for unknown columns will be result in a long type for range safety
         assertThat(response.rows()[0][0]).isEqualTo("bigint_array");

--- a/server/src/test/java/io/crate/integrationtests/UpdateIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/UpdateIntegrationTest.java
@@ -274,7 +274,6 @@ public class UpdateIntegrationTest extends IntegTestCase {
         assertThat(response).hasRowCount(1);
         refresh();
 
-        waitForMappingUpdateOnAll("test", "coolness.x");
         execute("select coolness['x'], coolness['y'] from test");
         assertThat(response).hasRowCount(1);
         assertThat(response.rows()[0][0]).isEqualTo("3");
@@ -516,7 +515,6 @@ public class UpdateIntegrationTest extends IntegTestCase {
         assertThat(response).hasRowCount(1);
         refresh();
 
-        waitForMappingUpdateOnAll("test", "coolness.x");
         execute("select coolness['y'], coolness['x'] from test");
         assertThat(response).hasRowCount(1);
         assertThat(response.rows()[0][0]).isEqualTo(new_map);

--- a/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
@@ -1915,20 +1915,6 @@ public abstract class IntegTestCase extends ESTestCase {
         return Strings.toString(builder);
     }
 
-    public void waitForMappingUpdateOnAll(final RelationName relationName, final String... fieldNames) throws Exception {
-        assertBusy(() -> {
-            Iterable<Schemas> referenceInfosIterable = cluster().getInstances(Schemas.class);
-            for (Schemas schemas : referenceInfosIterable) {
-                TableInfo tableInfo = schemas.getTableInfo(relationName);
-                assertThat(tableInfo).isNotNull();
-                for (String fieldName : fieldNames) {
-                    ColumnIdent columnIdent = ColumnIdent.fromPath(fieldName);
-                    assertThat(tableInfo.getReference(columnIdent)).isNotNull();
-                }
-            }
-        }, 20L, TimeUnit.SECONDS);
-    }
-
     public void assertFunctionIsCreatedOnAll(String schema, String name, List<DataType<?>> argTypes) throws Exception {
         SearchPath searchPath = SearchPath.pathWithPGCatalogAndDoc();
         assertBusy(() -> {
@@ -1965,10 +1951,6 @@ public abstract class IntegTestCase extends ESTestCase {
 
             }
         }, 20L, TimeUnit.SECONDS);
-    }
-
-    public void waitForMappingUpdateOnAll(final String tableOrPartition, final String... fieldNames) throws Exception {
-        waitForMappingUpdateOnAll(new RelationName(sqlExecutor.getCurrentSchema(), tableOrPartition), fieldNames);
     }
 
     /**


### PR DESCRIPTION
All dynamic mapping updates are done in a dedicated atomic action and is a blocking operation, we don't need this method.

For waiting for pending tasks we have `waitNoPendingTasksOnAll()`

See also https://github.com/crate/crate/pull/14936