### PR TITLE
Add empty pg_catalog.pg_event_trigger table

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -2,6 +2,9 @@ StylesPath = .github/styles
 MinAlertLevel = warning
 
 Vocab = CrateDB
+# See https://vale.sh/docs/topics/config/#skippedscopes
+SkippedScopes = script, style, pre, figure, a
+
 
 [*.rst]
 BasedOnStyles = Vale,CrateDB

--- a/docs/appendices/release-notes/5.5.0.rst
+++ b/docs/appendices/release-notes/5.5.0.rst
@@ -101,6 +101,8 @@ SQL Standard and PostgreSQL Compatibility
 
 - Added support for :ref:`INTERVAL <type-interval>` multiplication by integers.
 
+- Added an empty ``pg_catalog.pg_event_trigger`` table.
+
 Data Types
 ----------
 

--- a/docs/general/information-schema.rst
+++ b/docs/general/information-schema.rst
@@ -90,6 +90,7 @@ number of replicas.
     | pg_catalog         | pg_database             | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_description          | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_enum                 | BASE TABLE |             NULL | NULL               |
+    | pg_catalog         | pg_event_trigger        | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_index                | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_indexes              | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_locks                | BASE TABLE |             NULL | NULL               |
@@ -128,7 +129,7 @@ number of replicas.
     | sys                | summits                 | BASE TABLE |             NULL | NULL               |
     | sys                | users                   | BASE TABLE |             NULL | NULL               |
     +--------------------+-------------------------+------------+------------------+--------------------+
-    SELECT 61 rows in set (... sec)
+    SELECT 62 rows in set (... sec)
 
 
 The table also contains additional information such as the specified

--- a/docs/interfaces/postgres.rst
+++ b/docs/interfaces/postgres.rst
@@ -182,6 +182,7 @@ following tables:
  - `pg_tablespace`_
  - `pg_type`_
  - `pg_views`_
+ - `pg_event_trigger`_
 
 
 .. _postgres-pg_type:
@@ -534,6 +535,7 @@ CrateDB and we love to hear feedback.
 .. _pg_views: https://www.postgresql.org/docs/14/view-pg-views.html
 .. _pg_shdescription: https://www.postgresql.org/docs/14/catalog-pg-shdescription.html
 .. _pg_stats: https://www.postgresql.org/docs/14/view-pg-stats.html
+.. _pg_event_trigger: https://www.postgresql.org/docs/current/catalog-pg-event-trigger.html
 .. _pgjdbc: https://github.com/pgjdbc/pgjdbc
 .. _pgsql_pg_attrdef: https://www.postgresql.org/docs/14/static/catalog-pg-attrdef.html
 .. _pgsql_pg_attribute: https://www.postgresql.org/docs/14/static/catalog-pg-attribute.html

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
@@ -25,12 +25,11 @@ package io.crate.metadata.pgcatalog;
 import java.util.Collections;
 import java.util.Map;
 
-import org.jetbrains.annotations.Nullable;
-
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
+import org.jetbrains.annotations.Nullable;
 
 import io.crate.expression.udf.UserDefinedFunctionService;
 import io.crate.expression.udf.UserDefinedFunctionsMetadata;
@@ -83,7 +82,8 @@ public final class PgCatalogSchemaInfo implements SchemaInfo {
             Map.entry(PgSubscriptionRelTable.IDENT.name(), PgSubscriptionRelTable.create()),
             Map.entry(PgTablesTable.IDENT.name(), PgTablesTable.create()),
             Map.entry(PgViewsTable.IDENT.name(), PgViewsTable.create()),
-            Map.entry(PgCursors.IDENT.name(), PgCursors.create())
+            Map.entry(PgCursors.IDENT.name(), PgCursors.create()),
+            Map.entry(PgEventTrigger.NAME.name(), PgEventTrigger.create())
         );
     }
 

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
@@ -231,6 +231,11 @@ public final class PgCatalogTableDefinitions {
             PgCursors.create().expressions(),
             false
         ));
+        tableDefinitions.put(PgEventTrigger.NAME, new StaticTableDefinition<>(
+            () -> completedFuture(emptyList()),
+            PgEventTrigger.create().expressions(),
+            false
+        ));
     }
 
     public StaticTableDefinition<?> get(RelationName relationName) {

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgEventTrigger.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgEventTrigger.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.metadata.pgcatalog;
+
+import io.crate.metadata.RelationName;
+import io.crate.metadata.SystemTable;
+import io.crate.types.DataTypes;
+
+public class PgEventTrigger {
+
+    public static final RelationName NAME = new RelationName(PgCatalogSchemaInfo.NAME, "pg_event_trigger");
+
+    private PgEventTrigger() {}
+
+    public static SystemTable<Void> create() {
+        // See https://www.postgresql.org/docs/current/catalog-pg-event-trigger.html
+        return SystemTable.<Void>builder(NAME)
+            .add("oid", DataTypes.INTEGER, c -> null)
+            .add("evtname", DataTypes.STRING, c -> null)
+            .add("evtevent", DataTypes.STRING, c -> null)
+            .add("evtowner", DataTypes.INTEGER, c -> null)
+            .add("evtfoid", DataTypes.INTEGER, c -> null)
+            .add("evtenabled", DataTypes.CHARACTER, c -> null)
+            .add("evttags", DataTypes.STRING_ARRAY, c -> null)
+            .build();
+    }
+}

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -24,6 +24,7 @@ package io.crate.integrationtests;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 import java.util.Collections;
@@ -59,7 +60,7 @@ public class InformationSchemaTest extends IntegTestCase {
     @Test
     public void testDefaultTables() {
         execute("select * from information_schema.tables order by table_schema, table_name");
-        assertThat(response.rowCount()).isEqualTo(57L);
+        assertThat(response.rowCount()).isEqualTo(58L);
 
         assertThat(response).hasRows(
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| crate| character_sets| information_schema| BASE TABLE| NULL",
@@ -82,6 +83,7 @@ public class InformationSchemaTest extends IntegTestCase {
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| crate| pg_database| pg_catalog| BASE TABLE| NULL",
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| crate| pg_description| pg_catalog| BASE TABLE| NULL",
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| crate| pg_enum| pg_catalog| BASE TABLE| NULL",
+            "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| crate| pg_event_trigger| pg_catalog| BASE TABLE| NULL",
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| crate| pg_index| pg_catalog| BASE TABLE| NULL",
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| crate| pg_indexes| pg_catalog| BASE TABLE| NULL",
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| crate| pg_locks| pg_catalog| BASE TABLE| NULL",
@@ -200,13 +202,13 @@ public class InformationSchemaTest extends IntegTestCase {
     @Test
     public void testSearchInformationSchemaTablesRefresh() {
         execute("select * from information_schema.tables");
-        assertThat(response.rowCount()).isEqualTo(57L);
+        assertThat(response.rowCount()).isEqualTo(58L);
 
         execute("create table t4 (col1 integer, col2 string) with(number_of_replicas=0)");
         ensureYellow(getFqn("t4"));
 
         execute("select * from information_schema.tables");
-        assertThat(response.rowCount()).isEqualTo(58L);
+        assertThat(response.rowCount()).isEqualTo(59L);
     }
 
     @Test
@@ -561,7 +563,7 @@ public class InformationSchemaTest extends IntegTestCase {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertThat(response.rowCount()).isEqualTo(960);
+        assertThat(response.rowCount()).isEqualTo(967);
     }
 
     @Test
@@ -882,7 +884,7 @@ public class InformationSchemaTest extends IntegTestCase {
         execute("create table t3 (id integer, col1 string) clustered into 3 shards with(number_of_replicas=0)");
         execute("select count(*) from information_schema.tables");
         assertThat(response.rowCount()).isEqualTo(1);
-        assertThat(response.rows()[0][0]).isEqualTo(60L);
+        assertThat(response.rows()[0][0]).isEqualTo(61L);
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
@@ -513,6 +513,7 @@ public class PrivilegesIntegrationTest extends BaseUsersIntegrationTest {
             "pg_database",
             "pg_description",
             "pg_enum",
+            "pg_event_trigger",
             "pg_index",
             "pg_indexes",
             "pg_locks",
@@ -641,7 +642,7 @@ public class PrivilegesIntegrationTest extends BaseUsersIntegrationTest {
         //make sure a new user has default accesses to pg tables with information and pg catalog schema related entries
         try (Session testUserSession = testUserSession()) {
             execute("select * from pg_catalog.pg_attribute order by attname", null, testUserSession);
-            assertThat(response).hasRowCount(521L);
+            assertThat(response).hasRowCount(528L);
 
             //create a table with an attribute that a new user is not privileged to access
             executeAsSuperuser("create table test_schema.my_table (my_col int)");

--- a/server/src/test/java/io/crate/integrationtests/TableSettingsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TableSettingsTest.java
@@ -102,7 +102,7 @@ public class TableSettingsTest extends IntegTestCase {
     public void testFilterOnNull() throws Exception {
         execute("select * from information_schema.tables " +
                 "where settings IS NULL");
-        assertEquals(57L, response.rowCount());
+        assertEquals(58L, response.rowCount());
         execute("select * from information_schema.tables " +
                 "where table_name = 'settings_table' and settings['warmer']['enabled'] IS NULL");
         assertEquals(0, response.rowCount());


### PR DESCRIPTION
Queried by DBeaver. I noticed this while looking at
https://github.com/crate/crate/issues/14778

It seems unrelated but just to rule it out.
