### PR TITLE
Exclude checkerframework from caffeine dependency

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -263,6 +263,12 @@
       <groupId>com.github.ben-manes.caffeine</groupId>
       <artifactId>caffeine</artifactId>
       <version>${versions.caffeine}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.checkerframework</groupId>
+          <artifactId>checker-qual</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
We're already using jetbrains annotations, no need for two annotation
libraries.
