### PR TITLE
Add empty pg_catalog.pg_depend table

### DIFF
--- a/docs/appendices/release-notes/5.6.0.rst
+++ b/docs/appendices/release-notes/5.6.0.rst
@@ -64,7 +64,7 @@ None
 SQL Standard and PostgreSQL Compatibility
 -----------------------------------------
 
-None
+- Added an empty ``pg_catalog.pg_depend`` table.
 
 Data Types
 ----------

--- a/docs/general/information-schema.rst
+++ b/docs/general/information-schema.rst
@@ -88,6 +88,7 @@ number of replicas.
     | pg_catalog         | pg_constraint           | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_cursors              | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_database             | BASE TABLE |             NULL | NULL               |
+    | pg_catalog         | pg_depend               | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_description          | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_enum                 | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_event_trigger        | BASE TABLE |             NULL | NULL               |
@@ -129,7 +130,7 @@ number of replicas.
     | sys                | summits                 | BASE TABLE |             NULL | NULL               |
     | sys                | users                   | BASE TABLE |             NULL | NULL               |
     +--------------------+-------------------------+------------+------------------+--------------------+
-    SELECT 62 rows in set (... sec)
+    SELECT 63 rows in set (... sec)
 
 
 The table also contains additional information such as the specified

--- a/docs/interfaces/postgres.rst
+++ b/docs/interfaces/postgres.rst
@@ -162,8 +162,10 @@ following tables:
  - `pg_constraint <pgsql_pg_constraint_>`__
  - `pg_cursors <pgsql_pg_cursors_>`__
  - `pg_database <pgsql_pg_database_>`__
+ - `pg_depend`_
  - `pg_description`_
  - `pg_enum`_
+ - `pg_event_trigger`_
  - `pg_index <pgsql_pg_index_>`__
  - `pg_indexes <pgsql_pg_indexes_>`__
  - `pg_locks <pgsql_pg_locks_>`__
@@ -182,7 +184,6 @@ following tables:
  - `pg_tablespace`_
  - `pg_type`_
  - `pg_views`_
- - `pg_event_trigger`_
 
 
 .. _postgres-pg_type:
@@ -536,6 +537,7 @@ CrateDB and we love to hear feedback.
 .. _pg_shdescription: https://www.postgresql.org/docs/14/catalog-pg-shdescription.html
 .. _pg_stats: https://www.postgresql.org/docs/14/view-pg-stats.html
 .. _pg_event_trigger: https://www.postgresql.org/docs/current/catalog-pg-event-trigger.html
+.. _pg_depend: https://www.postgresql.org/docs/current/catalog-pg-depend.html
 .. _pgjdbc: https://github.com/pgjdbc/pgjdbc
 .. _pgsql_pg_attrdef: https://www.postgresql.org/docs/14/static/catalog-pg-attrdef.html
 .. _pgsql_pg_attribute: https://www.postgresql.org/docs/14/static/catalog-pg-attribute.html

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
@@ -83,7 +83,8 @@ public final class PgCatalogSchemaInfo implements SchemaInfo {
             Map.entry(PgTablesTable.IDENT.name(), PgTablesTable.create()),
             Map.entry(PgViewsTable.IDENT.name(), PgViewsTable.create()),
             Map.entry(PgCursors.IDENT.name(), PgCursors.create()),
-            Map.entry(PgEventTrigger.NAME.name(), PgEventTrigger.create())
+            Map.entry(PgEventTrigger.NAME.name(), PgEventTrigger.create()),
+            Map.entry(PgDepend.NAME.name(), PgDepend.create())
         );
     }
 

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
@@ -236,6 +236,11 @@ public final class PgCatalogTableDefinitions {
             PgEventTrigger.create().expressions(),
             false
         ));
+        tableDefinitions.put(PgDepend.NAME, new StaticTableDefinition<>(
+            () -> completedFuture(emptyList()),
+            PgDepend.create().expressions(),
+            false
+        ));
     }
 
     public StaticTableDefinition<?> get(RelationName relationName) {

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgDepend.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgDepend.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.metadata.pgcatalog;
+
+import io.crate.metadata.RelationName;
+import io.crate.metadata.SystemTable;
+import io.crate.types.DataTypes;
+
+public class PgDepend {
+
+    public static final RelationName NAME = new RelationName(PgCatalogSchemaInfo.NAME, "pg_depend");
+
+    private PgDepend() {}
+
+    public static SystemTable<Void> create() {
+        // https://www.postgresql.org/docs/current/catalog-pg-depend.html
+        return SystemTable.<Void>builder(NAME)
+            .add("classid", DataTypes.INTEGER, c -> null)
+            .add("objid", DataTypes.INTEGER, c -> null)
+            .add("objsubid", DataTypes.INTEGER, c -> null)
+            .add("refclassid", DataTypes.INTEGER, c -> null)
+            .add("refobjid", DataTypes.INTEGER, c -> null)
+            .add("refobjsubid", DataTypes.INTEGER, c -> null)
+            .add("deptype", DataTypes.CHARACTER, c -> null)
+            .build();
+    }
+}

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -59,7 +59,7 @@ public class InformationSchemaTest extends IntegTestCase {
     @Test
     public void testDefaultTables() {
         execute("select * from information_schema.tables order by table_schema, table_name");
-        assertThat(response.rowCount()).isEqualTo(58L);
+        assertThat(response.rowCount()).isEqualTo(59L);
 
         assertThat(response).hasRows(
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| crate| character_sets| information_schema| BASE TABLE| NULL",
@@ -80,6 +80,7 @@ public class InformationSchemaTest extends IntegTestCase {
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| crate| pg_constraint| pg_catalog| BASE TABLE| NULL",
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| crate| pg_cursors| pg_catalog| BASE TABLE| NULL",
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| crate| pg_database| pg_catalog| BASE TABLE| NULL",
+            "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| crate| pg_depend| pg_catalog| BASE TABLE| NULL",
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| crate| pg_description| pg_catalog| BASE TABLE| NULL",
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| crate| pg_enum| pg_catalog| BASE TABLE| NULL",
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| crate| pg_event_trigger| pg_catalog| BASE TABLE| NULL",
@@ -201,13 +202,13 @@ public class InformationSchemaTest extends IntegTestCase {
     @Test
     public void testSearchInformationSchemaTablesRefresh() {
         execute("select * from information_schema.tables");
-        assertThat(response.rowCount()).isEqualTo(58L);
+        assertThat(response.rowCount()).isEqualTo(59L);
 
         execute("create table t4 (col1 integer, col2 string) with(number_of_replicas=0)");
         ensureYellow(getFqn("t4"));
 
         execute("select * from information_schema.tables");
-        assertThat(response.rowCount()).isEqualTo(59L);
+        assertThat(response.rowCount()).isEqualTo(60L);
     }
 
     @Test
@@ -562,7 +563,7 @@ public class InformationSchemaTest extends IntegTestCase {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertThat(response.rowCount()).isEqualTo(967);
+        assertThat(response.rowCount()).isEqualTo(974);
     }
 
     @Test
@@ -883,7 +884,7 @@ public class InformationSchemaTest extends IntegTestCase {
         execute("create table t3 (id integer, col1 string) clustered into 3 shards with(number_of_replicas=0)");
         execute("select count(*) from information_schema.tables");
         assertThat(response.rowCount()).isEqualTo(1);
-        assertThat(response.rows()[0][0]).isEqualTo(61L);
+        assertThat(response.rows()[0][0]).isEqualTo(62L);
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
@@ -510,6 +510,7 @@ public class PrivilegesIntegrationTest extends BaseUsersIntegrationTest {
             "pg_constraint",
             "pg_cursors",
             "pg_database",
+            "pg_depend",
             "pg_description",
             "pg_enum",
             "pg_event_trigger",
@@ -641,7 +642,7 @@ public class PrivilegesIntegrationTest extends BaseUsersIntegrationTest {
         //make sure a new user has default accesses to pg tables with information and pg catalog schema related entries
         try (Session testUserSession = testUserSession()) {
             execute("select * from pg_catalog.pg_attribute order by attname", null, testUserSession);
-            assertThat(response).hasRowCount(528L);
+            assertThat(response).hasRowCount(535L);
 
             //create a table with an attribute that a new user is not privileged to access
             executeAsSuperuser("create table test_schema.my_table (my_col int)");

--- a/server/src/test/java/io/crate/integrationtests/TableSettingsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TableSettingsTest.java
@@ -102,7 +102,7 @@ public class TableSettingsTest extends IntegTestCase {
     public void testFilterOnNull() throws Exception {
         execute("select * from information_schema.tables " +
                 "where settings IS NULL");
-        assertEquals(58L, response.rowCount());
+        assertEquals(59L, response.rowCount());
         execute("select * from information_schema.tables " +
                 "where table_name = 'settings_table' and settings['warmer']['enabled'] IS NULL");
         assertEquals(0, response.rowCount());


### PR DESCRIPTION
Motivated by trying to debug https://github.com/crate/crate/issues/14778
Very likely unrelated, but helps to get rid of the noise

    2023-10-24 10:43:07.054 - Initiate connection to PostgreSQL database [postgres@localhost] for SQLEditor <Script.sql>
    2023-10-24 10:43:10.359 - Error reading table columns
    org.jkiss.dbeaver.model.sql.DBSQLException: SQL Error [42P01]: ERROR: Relation 'pg_depend' unknown
      Where: io.crate.exceptions.RelationUnknown.of(RelationUnknown.java:44)
    io.crate.metadata.Schemas.resolveTableInfo(Schemas.java:134)
    [...]
    io.crate.analyze.relations.RelationAnalyzer.analyze(RelationAnalyzer.java:139)
    io.crate.analyze.Analyzer$AnalyzerDispatcher.visitQuery(Analyzer.java:541)
    	at org.jkiss.dbeaver.model.impl.jdbc.exec.JDBCPreparedStatementImpl.executeStatement(JDBCPreparedStatementImpl.java:208)
