### PR TITLE
Fix handling of new query while same portal is suspended

### DIFF
--- a/docs/appendices/release-notes/5.4.5.rst
+++ b/docs/appendices/release-notes/5.4.5.rst
@@ -46,6 +46,10 @@ See the :ref:`version_5.4.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that led to ``Received resultset tuples, but no field structure
+  for them`` errors in clients using the PostgreSQL wire protocol, if a query
+  was triggered after another query was suspended and left unconsumed.
+
 - Fixed an issue that led to ``Couldn't create execution plan from logical plan
   ..`` errors when trying to use a correlated join in the ``WHERE`` clause of a
   query with a join. For example::

--- a/server/src/main/java/io/crate/action/sql/RowConsumerToResultReceiver.java
+++ b/server/src/main/java/io/crate/action/sql/RowConsumerToResultReceiver.java
@@ -125,7 +125,9 @@ public class RowConsumerToResultReceiver implements RowConsumer {
         if (activeIt != null) {
             activeIt.close();
             completionFuture.complete(null);
-            resultReceiver.allFinished();
+            // resultReceiver is left untouched:
+            // - A previous .batchCompleted() call already flushed out pending messages
+            // - Calling failure/allFinished would lead to extra messages, including  sentCommandComplete, to the client, which can lead to issues on the client.
         }
     }
 


### PR DESCRIPTION
A client using the PostgreSQL wire protocol level fetch functionality
can have a query in suspended mode and then execute a new query.

The new query causes the old portal to close, and by closing it a
`CommandComplete` message was sent to the client as a side effect. This
led to a message flow like this:

    msg=P msgLength=21 readableBytes=21
    stmtName= query=select * from tbl paramTypes=[]
    msg=B msgLength=8 readableBytes=8
    portalName= statementName= params=[]
    msg=D msgLength=2 readableBytes=2
    type=P portalOrStatement=
    msg=E msgLength=5 readableBytes=5
    portalName= maxRows=200
    msg=S msgLength=0 readableBytes=0
    sentParseComplete
    sentBindComplete
    sentRowDescription
    sentPortalSuspended
    sentReadyForQuery

    msg=P msgLength=41 readableBytes=41
    method=parse stmtName= query=SELECT current_schema(), session_user paramTypes=[]
    msg=B msgLength=8 readableBytes=8
    method=bind portalName= statementName= params=[]
    sentParseComplete
    💀 sentCommandComplete ❗
    msg=D msgLength=2 readableBytes=2
    method=describe type=P portalOrStatement=
    msg=E msgLength=5 readableBytes=5
    method=execute portalName= maxRows=0
    msg=S msgLength=0 readableBytes=0
    sentBindComplete
    sentRowDescription
    sentCommandComplete
    sentReadyForQuery
    msg=X msgLength=0 readableBytes=0

Fixes https://github.com/crate/crate/issues/14778
