### PR TITLE
Don't ignore index properties for columns of geo shape array

### DIFF
--- a/docs/appendices/release-notes/5.4.5.rst
+++ b/docs/appendices/release-notes/5.4.5.rst
@@ -81,3 +81,8 @@ Fixes
   :ref:`HTTP error code <http-error-codes>` to be returned, when some internal
   issue occurred during the creation of execution plan for a query, e.g.: shards
   of a table involved in the query become unavailable.
+
+- Fixed an issue that caused the properties of a ``INDEX using`` clause within
+  a type definition for ``ARRAY(GEO_SHAPE)`` in a ``CREATE TABLE`` statement to
+  be ignored.
+

--- a/server/src/main/java/io/crate/analyze/MetadataToASTNodeResolver.java
+++ b/server/src/main/java/io/crate/analyze/MetadataToASTNodeResolver.java
@@ -163,7 +163,7 @@ public class MetadataToASTNodeResolver {
                         ));
                     }
                     constraints.add(new IndexColumnConstraint<>("fulltext", properties));
-                } else if (ref.valueType().equals(DataTypes.GEO_SHAPE)) {
+                } else if (ArrayType.unnest(ref.valueType()).equals(DataTypes.GEO_SHAPE)) {
                     GeoReference geoReference;
                     if (ref instanceof GeneratedReference genRef) {
                         geoReference = (GeoReference) genRef.reference();

--- a/server/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
@@ -275,7 +275,7 @@ public class TableElementsAnalyzer implements FieldProvider<Reference> {
                     sources,
                     analyzer == null ? (indexType == IndexType.PLAIN ? "keyword" : "standard") : analyzer
                 );
-            } else if (type.id() == GeoShapeType.ID) {
+            } else if (ArrayType.unnest(type).id() == GeoShapeType.ID) {
                 Map<String, Object> geoMap = new HashMap<>();
                 GeoSettingsApplier.applySettings(geoMap, indexProperties.map(toValue), indexMethod);
                 Float distError = (Float) geoMap.get("distance_error_pct");

--- a/server/src/test/java/io/crate/analyze/MetadataToASTNodeResolverTest.java
+++ b/server/src/test/java/io/crate/analyze/MetadataToASTNodeResolverTest.java
@@ -21,17 +21,24 @@
 
 package io.crate.analyze;
 
+import static org.elasticsearch.index.mapper.GeoShapeFieldMapper.Names.TREE_QUADTREE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
+import org.assertj.core.api.Assertions;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.GeoReference;
+import io.crate.metadata.Reference;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.sql.SqlFormatter;
 import io.crate.sql.tree.CreateTable;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
+import io.crate.types.ArrayType;
+import io.crate.types.DataTypes;
 
 public class MetadataToASTNodeResolverTest extends CrateDummyClusterServiceUnitTest {
 
@@ -527,4 +534,29 @@ public class MetadataToASTNodeResolverTest extends CrateDummyClusterServiceUnitT
             Matchers.containsString("\"g\" GEO_SHAPE GENERATED ALWAYS AS 'POLYGON (( 5 5, 30 5, 30 30, 5 30, 5 5 ))")
         );
     }
+    @Test
+    public void test_geo_shape_array_index_definition_is_preserved_in_cluster_state() throws Exception {
+        SQLExecutor e = SQLExecutor.builder(clusterService)
+            .addTable("create table t (geo_arr array(geo_shape) INDEX using QUADTREE with (precision='1m', distance_error_pct='0.25'))")
+            .build();
+        DocTableInfo table = e.resolveTableInfo("t");
+        CreateTable<?> node = MetadataToASTNodeResolver.resolveCreateTable(table);
+        assertThat(
+            SqlFormatter.formatSql(node),
+            Matchers.containsString("""
+                "geo_arr" ARRAY(GEO_SHAPE) INDEX USING QUADTREE WITH (
+                      distance_error_pct = 0.25,
+                      precision = '1m'
+                   )
+                """)
+        );
+        Reference reference = table.getReference(new ColumnIdent("geo_arr"));
+        Assertions.assertThat(reference.valueType()).isEqualTo(new ArrayType<>(DataTypes.GEO_SHAPE));
+        GeoReference geoRef = (GeoReference) reference;
+        Assertions.assertThat(geoRef.geoTree()).isEqualTo(TREE_QUADTREE);
+        Assertions.assertThat(geoRef.precision()).isEqualTo("1m");
+        Assertions.assertThat(geoRef.distanceErrorPct()).isEqualTo(0.25);
+
+    }
+
 }


### PR DESCRIPTION
This also exists on 5.4, not a regression (not related to recent refactoring).

Popped up while reviewing https://github.com/crate/crate/pull/14942