### PR TITLE
Restrict itest and blackbox tests to x64

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,7 +63,7 @@ pipeline {
           }
         }
         stage('itest') {
-          agent { label 'medium' }
+          agent { label 'medium && x64' }
           steps {
             sh 'git clean -xdff'
             checkout scm
@@ -72,7 +72,7 @@ pipeline {
           }
         }
         stage('blackbox tests') {
-          agent { label 'medium' }
+          agent { label 'medium && x64' }
           steps {
             sh 'git clean -xdff'
             checkout scm


### PR DESCRIPTION
Some of the test layer components don't work on aarch64
(E.g. the minio server setup doesn't handle it yet)
