### PR TITLE
tests: Remove excess assertj's assertThat imports

### DIFF
--- a/server/src/test/java/io/crate/action/sql/SessionTest.java
+++ b/server/src/test/java/io/crate/action/sql/SessionTest.java
@@ -23,7 +23,6 @@ package io.crate.action.sql;
 
 import static io.crate.testing.Asserts.assertThat;
 import static java.util.concurrent.CompletableFuture.completedFuture;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doReturn;

--- a/server/src/test/java/io/crate/analyze/AlterTableDropCheckConstraintAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/AlterTableDropCheckConstraintAnalyzerTest.java
@@ -21,6 +21,8 @@
 
 package io.crate.analyze;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.IOException;
 
 import org.assertj.core.api.Assertions;
@@ -29,8 +31,6 @@ import org.junit.Test;
 
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class AlterTableDropCheckConstraintAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 

--- a/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -27,7 +27,6 @@ import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.mapToSortedString;
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_ROUTING_EXCLUDE_GROUP_SETTING;
 import static org.elasticsearch.index.engine.EngineConfig.INDEX_CODEC_SETTING;

--- a/server/src/test/java/io/crate/analyze/SetAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SetAnalyzerTest.java
@@ -22,7 +22,6 @@
 package io.crate.analyze;
 
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashMap;
 import java.util.List;

--- a/server/src/test/java/io/crate/auth/AccessControlMaySeeTest.java
+++ b/server/src/test/java/io/crate/auth/AccessControlMaySeeTest.java
@@ -21,10 +21,10 @@
 
 package io.crate.auth;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasItem;
 import static org.junit.Assert.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/CountAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/CountAggregationTest.java
@@ -22,7 +22,6 @@
 package io.crate.execution.engine.aggregation.impl;
 
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/server/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
+++ b/server/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
@@ -22,7 +22,6 @@
 package io.crate.expression.symbol.format;
 
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/server/src/test/java/io/crate/integrationtests/CastIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CastIntegrationTest.java
@@ -23,7 +23,6 @@ package io.crate.integrationtests;
 
 
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 

--- a/server/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
@@ -26,7 +26,6 @@ import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.FileOutputStream;

--- a/server/src/test/java/io/crate/integrationtests/CorrelatedSubqueryITest.java
+++ b/server/src/test/java/io/crate/integrationtests/CorrelatedSubqueryITest.java
@@ -23,7 +23,6 @@ package io.crate.integrationtests;
 
 
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.sql.DriverManager;

--- a/server/src/test/java/io/crate/integrationtests/CreateTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CreateTableIntegrationTest.java
@@ -27,7 +27,6 @@ import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;

--- a/server/src/test/java/io/crate/integrationtests/DeleteIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/DeleteIntegrationTest.java
@@ -23,7 +23,6 @@ package io.crate.integrationtests;
 
 
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import org.elasticsearch.test.IntegTestCase;
 import org.junit.Test;

--- a/server/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
+++ b/server/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
@@ -24,7 +24,6 @@ package io.crate.integrationtests;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.randomAsciiLettersOfLength;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.printedTable;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -24,7 +24,6 @@ package io.crate.integrationtests;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 import java.util.Collections;

--- a/server/src/test/java/io/crate/integrationtests/JoinGroupByIntegrationTests.java
+++ b/server/src/test/java/io/crate/integrationtests/JoinGroupByIntegrationTests.java
@@ -22,7 +22,6 @@
 package io.crate.integrationtests;
 
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.List;

--- a/server/src/test/java/io/crate/integrationtests/LogicalReplicationITestCase.java
+++ b/server/src/test/java/io/crate/integrationtests/LogicalReplicationITestCase.java
@@ -23,7 +23,6 @@ package io.crate.integrationtests;
 
 import static io.crate.replication.logical.LogicalReplicationSettings.REPLICATION_READ_POLL_DURATION;
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.elasticsearch.discovery.DiscoveryModule.DISCOVERY_SEED_PROVIDERS_SETTING;
 import static org.elasticsearch.discovery.SettingsBasedSeedHostsProvider.DISCOVERY_SEED_HOSTS_SETTING;
 
@@ -44,8 +43,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.jetbrains.annotations.Nullable;
-
 import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
 import org.elasticsearch.common.settings.Settings;
@@ -60,6 +57,7 @@ import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.transport.Netty4Plugin;
 import org.elasticsearch.transport.TransportService;
+import org.jetbrains.annotations.Nullable;
 import org.junit.After;
 import org.junit.Before;
 

--- a/server/src/test/java/io/crate/integrationtests/LuceneQueryBuilderIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/LuceneQueryBuilderIntegrationTest.java
@@ -26,7 +26,6 @@ import static com.carrotsearch.randomizedtesting.RandomizedTest.$$;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.DataTypeTesting.randomType;
 import static io.crate.testing.TestingHelpers.printedTable;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.function.Supplier;

--- a/server/src/test/java/io/crate/integrationtests/MetadataTrackerITest.java
+++ b/server/src/test/java/io/crate/integrationtests/MetadataTrackerITest.java
@@ -22,7 +22,6 @@
 package io.crate.integrationtests;
 
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;

--- a/server/src/test/java/io/crate/integrationtests/NodeStatsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/NodeStatsTest.java
@@ -22,7 +22,6 @@
 package io.crate.integrationtests;
 
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.HashMap;

--- a/server/src/test/java/io/crate/integrationtests/OpenCloseTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/OpenCloseTableIntegrationTest.java
@@ -26,7 +26,6 @@ import static io.crate.protocols.postgres.PGErrorStatus.UNDEFINED_TABLE;
 import static io.crate.testing.Asserts.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static io.netty.handler.codec.rtsp.RtspResponseStatuses.BAD_REQUEST;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import java.util.List;

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -22,7 +22,6 @@
 package io.crate.integrationtests;
 
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/server/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
@@ -27,7 +27,6 @@ import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static io.netty.handler.codec.http.HttpResponseStatus.UNAUTHORIZED;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.After;
 import org.junit.Before;

--- a/server/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
@@ -26,7 +26,6 @@ import static com.carrotsearch.randomizedtesting.RandomizedTest.$$;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionSingleNodeTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionSingleNodeTest.java
@@ -23,7 +23,6 @@ package io.crate.integrationtests;
 
 
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -28,7 +28,6 @@ import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;

--- a/server/src/test/java/io/crate/integrationtests/UserDefinedFunctionsIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/UserDefinedFunctionsIntegrationTest.java
@@ -24,7 +24,6 @@ package io.crate.integrationtests;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.Locale;

--- a/server/src/test/java/io/crate/integrationtests/VersionHandlingIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/VersionHandlingIntegrationTest.java
@@ -24,7 +24,6 @@ package io.crate.integrationtests;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 

--- a/server/src/test/java/io/crate/integrationtests/ViewsITest.java
+++ b/server/src/test/java/io/crate/integrationtests/ViewsITest.java
@@ -26,7 +26,6 @@ import static io.crate.protocols.postgres.PGErrorStatus.DUPLICATE_TABLE;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.CONFLICT;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.stream.Collectors;

--- a/server/src/test/java/io/crate/integrationtests/WherePKIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/WherePKIntegrationTest.java
@@ -22,7 +22,6 @@
 package io.crate.integrationtests;
 
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.List;

--- a/server/src/test/java/io/crate/integrationtests/disruption/routing/PrimaryAllocationIT.java
+++ b/server/src/test/java/io/crate/integrationtests/disruption/routing/PrimaryAllocationIT.java
@@ -22,9 +22,7 @@
 package io.crate.integrationtests.disruption.routing;
 
 
-
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collection;
 import java.util.Collections;

--- a/server/src/test/java/io/crate/planner/WhereClauseOptimizerTest.java
+++ b/server/src/test/java/io/crate/planner/WhereClauseOptimizerTest.java
@@ -24,7 +24,6 @@ package io.crate.planner;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.isLiteral;
 import static java.util.Collections.singletonList;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 

--- a/server/src/test/java/io/crate/planner/operators/FetchRewriteTest.java
+++ b/server/src/test/java/io/crate/planner/operators/FetchRewriteTest.java
@@ -29,7 +29,6 @@ import static io.crate.testing.Asserts.isField;
 import static io.crate.testing.Asserts.isFunction;
 import static io.crate.testing.Asserts.isReference;
 import static io.crate.testing.Asserts.toCondition;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 

--- a/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -23,7 +23,6 @@ package io.crate.planner.operators;
 
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.MemoryLimits.assertMaxBytesAllocated;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.List;

--- a/server/src/test/java/io/crate/planner/optimizer/costs/PlanStatsTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/costs/PlanStatsTest.java
@@ -21,8 +21,8 @@
 
 package io.crate.planner.optimizer.costs;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.Map;

--- a/server/src/test/java/io/crate/planner/optimizer/rule/EliminateCrossJoinTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/EliminateCrossJoinTest.java
@@ -22,8 +22,8 @@
 package io.crate.planner.optimizer.rule;
 
 import static io.crate.common.collections.Iterables.getOnlyElement;
-import static org.assertj.core.api.Assertions.assertThat;
 import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;

--- a/server/src/test/java/io/crate/planner/optimizer/rule/MergeFiltersTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/MergeFiltersTest.java
@@ -22,7 +22,6 @@
 package io.crate.planner.optimizer.rule;
 
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
 import java.util.Map;

--- a/server/src/test/java/io/crate/planner/optimizer/rule/MoveFilterBeneathJoinTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/MoveFilterBeneathJoinTest.java
@@ -21,6 +21,8 @@
 
 package io.crate.planner.optimizer.rule;
 
+import static io.crate.testing.Asserts.assertThat;
+
 import java.util.Map;
 import java.util.function.Function;
 
@@ -42,8 +44,6 @@ import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.testing.SqlExpressions;
 import io.crate.testing.T3;
-
-import static io.crate.testing.Asserts.assertThat;
 
 public class MoveFilterBeneathJoinTest extends CrateDummyClusterServiceUnitTest {
 

--- a/server/src/test/java/io/crate/planner/statement/CopyFromPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/statement/CopyFromPlannerTest.java
@@ -23,7 +23,6 @@ package io.crate.planner.statement;
 
 import static io.crate.analyze.TableDefinitions.USER_TABLE_DEFINITION;
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitionsActionTest.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitionsActionTest.java
@@ -21,16 +21,13 @@
 
 package org.elasticsearch.action.admin.indices.create;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import com.carrotsearch.hppc.cursors.ObjectCursor;
-import io.crate.metadata.PartitionName;
-import io.crate.testing.UseRandomizedSchema;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.Metadata;
@@ -40,7 +37,11 @@ import org.elasticsearch.test.IntegTestCase;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.carrotsearch.hppc.cursors.ObjectCursor;
+
 import io.crate.exceptions.SQLExceptions;
+import io.crate.metadata.PartitionName;
+import io.crate.testing.UseRandomizedSchema;
 
 @UseRandomizedSchema(random = false)
 public class TransportCreatePartitionsActionTest extends IntegTestCase {

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/UnsafeBootstrapAndDetachCommandIT.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/UnsafeBootstrapAndDetachCommandIT.java
@@ -23,7 +23,6 @@
 package org.elasticsearch.cluster.coordination;
 
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.elasticsearch.gateway.DanglingIndicesState.AUTO_IMPORT_DANGLING_INDICES_SETTING;
 import static org.elasticsearch.indices.recovery.RecoverySettings.INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING;

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DiffableStringMapTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DiffableStringMapTests.java
@@ -19,15 +19,15 @@
 
 package org.elasticsearch.cluster.metadata;
 
-import org.elasticsearch.cluster.Diff;
-import org.elasticsearch.common.io.stream.BytesStreamOutput;
-import org.elasticsearch.test.ESTestCase;
+import static io.crate.testing.Asserts.assertThat;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import static io.crate.testing.Asserts.assertThat;
+import org.elasticsearch.cluster.Diff;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.test.ESTestCase;
 
 public class DiffableStringMapTests extends ESTestCase {
 

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/DecisionsImpactOnClusterHealthTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/DecisionsImpactOnClusterHealthTests.java
@@ -19,6 +19,12 @@
 
 package org.elasticsearch.cluster.routing.allocation;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Set;
+
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
@@ -41,12 +47,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.snapshots.EmptySnapshotsInfoService;
 import org.elasticsearch.test.gateway.TestGatewayAllocator;
-
-import java.io.IOException;
-import java.util.Collections;
-import java.util.Set;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * This class of tests exercise various scenarios of

--- a/server/src/test/java/org/elasticsearch/common/compress/DeflateCompressTests.java
+++ b/server/src/test/java/org/elasticsearch/common/compress/DeflateCompressTests.java
@@ -19,8 +19,7 @@
 
 package org.elasticsearch.common.compress;
 
-import org.apache.lucene.tests.util.LineFileDocs;
-import org.elasticsearch.test.ESTestCase;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -31,7 +30,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.apache.lucene.tests.util.LineFileDocs;
+import org.elasticsearch.test.ESTestCase;
 
 /**
  * Test streaming compression (e.g. used for recovery)

--- a/server/src/test/java/org/elasticsearch/common/compress/DeflateCompressedXContentTests.java
+++ b/server/src/test/java/org/elasticsearch/common/compress/DeflateCompressedXContentTests.java
@@ -19,16 +19,17 @@
 
 package org.elasticsearch.common.compress;
 
-import com.carrotsearch.randomizedtesting.generators.RandomStrings;
-import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.io.stream.BytesStreamOutput;
-import org.elasticsearch.test.ESTestCase;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Random;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.test.ESTestCase;
+
+import com.carrotsearch.randomizedtesting.generators.RandomStrings;
 
 
 public class DeflateCompressedXContentTests extends ESTestCase {

--- a/server/src/test/java/org/elasticsearch/index/IndexSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexSettingsTests.java
@@ -23,7 +23,6 @@ package org.elasticsearch.index;
 
 
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;

--- a/server/src/test/java/org/elasticsearch/index/engine/MaxDocsLimitIT.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/MaxDocsLimitIT.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.index.engine;
 
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;

--- a/server/src/test/java/org/elasticsearch/index/snapshots/blobstore/SlicedInputStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/index/snapshots/blobstore/SlicedInputStreamTests.java
@@ -18,8 +18,7 @@
  */
 package org.elasticsearch.index.snapshots.blobstore;
 
-import com.carrotsearch.randomizedtesting.generators.RandomNumbers;
-import org.elasticsearch.test.ESTestCase;
+import static io.crate.testing.Asserts.assertThat;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -28,7 +27,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Random;
 
-import static io.crate.testing.Asserts.assertThat;
+import org.elasticsearch.test.ESTestCase;
+
+import com.carrotsearch.randomizedtesting.generators.RandomNumbers;
 
 public class SlicedInputStreamTests extends ESTestCase {
     public void testReadRandom() throws IOException {

--- a/server/src/test/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
@@ -24,7 +24,6 @@ package org.elasticsearch.indices.recovery;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.biasedDoubleBetween;
 import static io.crate.testing.Asserts.assertThat;
 import static java.util.Collections.singletonMap;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.elasticsearch.node.RecoverySettingsChunkSizePlugin.CHUNK_SIZE_SETTING;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;

--- a/server/src/test/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
@@ -22,7 +22,6 @@
 package org.elasticsearch.snapshots;
 
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.InstanceOfAssertFactories.THROWABLE;
 import static org.elasticsearch.snapshots.SnapshotsService.MAX_CONCURRENT_SNAPSHOT_OPERATIONS_SETTING;

--- a/server/src/test/java/org/elasticsearch/transport/CompressibleBytesOutputStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/CompressibleBytesOutputStreamTests.java
@@ -19,6 +19,11 @@
 
 package org.elasticsearch.transport;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.EOFException;
+import java.io.IOException;
+
 import org.assertj.core.api.Assertions;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressorFactory;
@@ -27,11 +32,6 @@ import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.InputStreamStreamInput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.test.ESTestCase;
-
-import java.io.EOFException;
-import java.io.IOException;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class CompressibleBytesOutputStreamTests extends ESTestCase {
 

--- a/server/src/test/java/org/elasticsearch/transport/TransportServiceDeserializationFailureTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportServiceDeserializationFailureTests.java
@@ -19,6 +19,12 @@
 
 package org.elasticsearch.transport;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.elasticsearch.node.Node.NODE_NAME_SETTING;
+import static org.junit.Assert.fail;
+
+import java.util.List;
+
 import org.elasticsearch.Version;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.ClusterName;
@@ -29,12 +35,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.transport.MockTransport;
 import org.elasticsearch.threadpool.ThreadPool;
-
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.elasticsearch.node.Node.NODE_NAME_SETTING;
-import static org.junit.Assert.fail;
 
 public class TransportServiceDeserializationFailureTests extends ESTestCase {
 


### PR DESCRIPTION
In several tests we already import our CrateDB's `Asserts.assertThat(`) so the assertj's one is not needed, also apply some re-ordering.
