### PR TITLE
Make shard creation async/non-blocking on locked shards

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -41,8 +41,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import org.jetbrains.annotations.Nullable;
-
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.search.QueryCache;
 import org.apache.lucene.store.AlreadyClosedException;
@@ -59,7 +57,6 @@ import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.env.ShardLock;
-import org.elasticsearch.env.ShardLockObtainFailedException;
 import org.elasticsearch.gateway.MetadataStateFormat;
 import org.elasticsearch.gateway.WriteStateException;
 import org.elasticsearch.index.analysis.AnalysisRegistry;
@@ -81,6 +78,7 @@ import org.elasticsearch.indices.cluster.IndicesClusterStateService;
 import org.elasticsearch.indices.mapper.MapperRegistry;
 import org.elasticsearch.plugins.IndexStorePlugin;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.jetbrains.annotations.Nullable;
 
 import io.crate.common.io.IOUtils;
 import io.crate.common.unit.TimeValue;
@@ -300,7 +298,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
         IndexShard indexShard = null;
         ShardLock lock = null;
         try {
-            lock = nodeEnv.shardLock(shardId, "starting shard", TimeUnit.SECONDS.toMillis(5));
+            lock = nodeEnv.shardLock(shardId, "starting shard");
             eventListener.beforeIndexShardCreated(shardId, indexSettings);
             ShardPath path;
             try {
@@ -373,8 +371,6 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
             shards = newMapBuilder(shards).put(shardId.id(), indexShard).immutableMap();
             success = true;
             return indexShard;
-        } catch (ShardLockObtainFailedException e) {
-            throw new IOException("failed to obtain in-memory shard lock", e);
         } finally {
             if (success == false) {
                 if (lock != null) {

--- a/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -33,6 +33,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
@@ -619,6 +620,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
             LOGGER.debug("{} creating shard with primary term [{}]", shardRouting.shardId(), primaryTerm);
             RecoveryState recoveryState = new RecoveryState(shardRouting, nodes.getLocalNode(), sourceNode);
             indicesService.createShard(
+                state,
                 shardRouting,
                 recoveryState,
                 recoveryTargetService,
@@ -911,14 +913,15 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
         /**
          * Creates shard for the specified shard routing and starts recovery,
          */
-        T createShard(ShardRouting shardRouting,
-                      RecoveryState recoveryState,
-                      PeerRecoveryTargetService recoveryTargetService,
-                      PeerRecoveryTargetService.RecoveryListener recoveryListener,
-                      RepositoriesService repositoriesService,
-                      Consumer<IndexShard.ShardFailure> onShardFailure,
-                      Consumer<ShardId> globalCheckpointSyncer,
-                      RetentionLeaseSyncer retentionLeaseSyncer) throws IOException;
+        CompletableFuture<T> createShard(ClusterState state,
+                                         ShardRouting shardRouting,
+                                         RecoveryState recoveryState,
+                                         PeerRecoveryTargetService recoveryTargetService,
+                                         PeerRecoveryTargetService.RecoveryListener recoveryListener,
+                                         RepositoriesService repositoriesService,
+                                         Consumer<IndexShard.ShardFailure> onShardFailure,
+                                         Consumer<ShardId> globalCheckpointSyncer,
+                                         RetentionLeaseSyncer retentionLeaseSyncer) throws IOException;
 
         /**
          * Returns shard for the specified id if it exists otherwise returns <code>null</code>.

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -497,6 +497,7 @@ public class Node implements Closeable {
 
             final IndicesService indicesService = new IndicesService(
                 settings,
+                clusterService,
                 pluginsService,
                 nodeEnvironment,
                 xContentRegistry,

--- a/server/src/test/java/io/crate/integrationtests/ShardLockIT.java
+++ b/server/src/test/java/io/crate/integrationtests/ShardLockIT.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.integrationtests;
+
+import static io.crate.testing.Asserts.assertThat;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.env.ShardLock;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.test.IntegTestCase;
+import org.elasticsearch.test.IntegTestCase.ClusterScope;
+import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.junit.annotations.TestLogging;
+import org.junit.Test;
+
+@ClusterScope(numDataNodes = 1)
+public class ShardLockIT extends IntegTestCase {
+
+    @Test
+    @TestLogging("org.elasticsearch.indices.IndicesService:DEBUG")
+    public void test_create_shard_retries_on_shard_lock() throws Exception {
+        String nodeName = cluster().startDataOnlyNode();
+        execute("""
+            create table doc.tbl (x int)
+            clustered into 1 shards
+            with (
+                number_of_replicas = 1,
+                "routing.allocation.exclude._name" = ?
+            )
+            """,
+            new Object[] { nodeName }
+        );
+        Index index = resolveIndex("tbl");
+        ShardId shardId = new ShardId(index, 0);
+        NodeEnvironment nodeEnv = cluster().getInstance(NodeEnvironment.class, nodeName);
+        MockLogAppender appender = new MockLogAppender();
+        var expectation = new MockLogAppender.PatternSeenEventExcpectation(
+            "Logs retries",
+            IndicesService.class.getName(),
+            Level.DEBUG,
+            "Repeated attempts to acquire shardLock for .*\\. Retrying again in .*"
+        );
+        appender.addExpectation(expectation);
+        appender.start();
+        Logger logger = LogManager.getLogger(IndicesService.class);
+        Loggers.addAppender(logger, appender);
+        try (ShardLock shardLock = nodeEnv.shardLock(shardId, "block shard for test")) {
+            execute("alter table doc.tbl reset (\"routing.allocation.exclude._name\")");
+            assertBusy(() -> appender.assertAllExpectationsMatched());
+        } finally {
+            Loggers.removeAppender(logger, appender);
+        }
+
+        ensureGreen();
+        execute("select health from sys.health where table_name = 'tbl'");
+        assertThat(response).hasRows("GREEN");
+    }
+}


### PR DESCRIPTION
This changes the logic to schedule a retry instead of blocking if a
shard lock can't be acquired during shard creation.

During this retry process, the shard remains in the `initializing`
state.

Closes https://github.com/crate/crate/issues/13982
