### PR TITLE
Add support for `ALTER TABLE RENAME COLUMN`

### DIFF
--- a/docs/appendices/release-notes/5.6.0.rst
+++ b/docs/appendices/release-notes/5.6.0.rst
@@ -75,6 +75,9 @@ SQL Statements
 - Extended the :ref:`EXPLAIN <ref-explain>` statement to support the ``VERBOSE``
   option.
 
+- Added support for
+  :ref:`ALTER TABLE RENAME COLUMN <sql-alter-table-rename-column>` statement.
+
 SQL Standard and PostgreSQL Compatibility
 -----------------------------------------
 

--- a/docs/general/ddl/alter-table.rst
+++ b/docs/general/ddl/alter-table.rst
@@ -164,6 +164,40 @@ And now a nested column named ``name`` is added to the ``obj_column``::
     +--------------------+-----------+
     SELECT 3 rows in set (... sec)
 
+.. _alter-table-rename-column:
+
+Renaming columns
+================
+
+To rename a column of an existing table, use ``ALTER TABLE`` with the
+``RENAME COLUMN`` clause::
+
+    cr> alter table my_table rename new_column_name to renamed_column;
+    ALTER OK, -1 rows affected (... sec)
+
+This also works on object columns::
+
+    cr> alter table my_table rename column obj_column to renamed_obj_column;
+    ALTER OK, -1 rows affected (... sec)
+
+To rename a sub-column of an object column, you can use subscript expressions::
+
+    cr> alter table my_table rename column renamed_obj_column['age'] to
+    ...  renamed_obj_column['renamed_age'];
+    ALTER OK, -1 rows affected (... sec)
+
+
+    cr> select column_name, data_type from information_schema.columns
+    ... where table_name = 'my_table' and column_name like 'renamed_obj_%';
+    +-----------------------------------+-----------+
+    | column_name                       | data_type |
+    +-----------------------------------+-----------+
+    | renamed_obj_column                | object    |
+    | renamed_obj_column['renamed_age'] | integer   |
+    | renamed_obj_column['name']        | text      |
+    +-----------------------------------+-----------+
+    SELECT 3 rows in set (... sec)
+    
 Closing and opening tables
 ==========================
 

--- a/docs/sql/statements/alter-table.rst
+++ b/docs/sql/statements/alter-table.rst
@@ -27,6 +27,7 @@ Synopsis
         | RESET ( parameter [ , ... ] )
         | { ADD [ COLUMN ] column_name data_type [ column_constraint [ ... ] ] } [, ... ]
         | { DROP [ COLUMN ] [ IF EXISTS ] column_name } [, ... ]
+        | { RENAME [ COLUMN ] column_name TO new_name } [, ... ]
         | OPEN
         | CLOSE
         | RENAME TO table_ident
@@ -182,7 +183,7 @@ It's possible to add multiple columns at once.
 
 Can be used to drop a column from a table.
 
-:``column_name``:
+:column_name:
   Name of the column which should be dropped.
   This can be a sub-column of an `OBJECT`.
 
@@ -210,6 +211,24 @@ It's possible to drop multiple columns at once.
 .. NOTE::
 
    Dropping columns of a table created before version 5.5 is not supported.
+
+.. _sql-alter-table-rename-column:
+
+``RENAME COLUMN``
+-----------------
+
+Renames a column of a table
+
+:column_name:
+  Name of the column to rename.
+  Supports subscript expressions to rename sub-columns of ``OBJECT`` columns.
+
+:new_name:
+  The new name of the column.
+
+.. NOTE::
+
+   Renaming columns of a table created before version 5.5 is not supported.
 
 .. _sql-alter-table-open-close:
 

--- a/libs/sql-parser/src/main/antlr/io/crate/sql/parser/antlr/SqlBaseParser.g4
+++ b/libs/sql-parser/src/main/antlr/io/crate/sql/parser/antlr/SqlBaseParser.g4
@@ -126,7 +126,7 @@ alterStmt
         (SET OPEN_ROUND_BRACKET genericProperties CLOSE_ROUND_BRACKET
         | RESET (OPEN_ROUND_BRACKET ident (COMMA ident)* CLOSE_ROUND_BRACKET)?)      #alterBlobTableProperties
     | ALTER (BLOB)? TABLE alterTableDefinition (OPEN | CLOSE)                        #alterTableOpenClose
-    | ALTER (BLOB)? TABLE alterTableDefinition RENAME TO qname                       #alterTableRename
+    | ALTER (BLOB)? TABLE alterTableDefinition RENAME TO qname                       #alterTableRenameTable
     | ALTER (BLOB)? TABLE alterTableDefinition REROUTE rerouteOption                 #alterTableReroute
     | ALTER CLUSTER REROUTE RETRY FAILED                                             #alterClusterRerouteRetryFailed
     | ALTER CLUSTER SWAP TABLE source=qname TO target=qname withProperties?          #alterClusterSwapTable

--- a/libs/sql-parser/src/main/antlr/io/crate/sql/parser/antlr/SqlBaseParser.g4
+++ b/libs/sql-parser/src/main/antlr/io/crate/sql/parser/antlr/SqlBaseParser.g4
@@ -127,6 +127,8 @@ alterStmt
         | RESET (OPEN_ROUND_BRACKET ident (COMMA ident)* CLOSE_ROUND_BRACKET)?)      #alterBlobTableProperties
     | ALTER (BLOB)? TABLE alterTableDefinition (OPEN | CLOSE)                        #alterTableOpenClose
     | ALTER (BLOB)? TABLE alterTableDefinition RENAME TO qname                       #alterTableRenameTable
+    | ALTER (BLOB)? TABLE alterTableDefinition
+        RENAME COLUMN? source=subscriptSafe TO target=subscriptSafe                  #alterTableRenameColumn
     | ALTER (BLOB)? TABLE alterTableDefinition REROUTE rerouteOption                 #alterTableReroute
     | ALTER CLUSTER REROUTE RETRY FAILED                                             #alterClusterRerouteRetryFailed
     | ALTER CLUSTER SWAP TABLE source=qname TO target=qname withProperties?          #alterClusterSwapTable

--- a/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -72,7 +72,7 @@ import io.crate.sql.tree.AlterTable;
 import io.crate.sql.tree.AlterTableAddColumn;
 import io.crate.sql.tree.AlterTableDropColumn;
 import io.crate.sql.tree.AlterTableOpenClose;
-import io.crate.sql.tree.AlterTableRename;
+import io.crate.sql.tree.AlterTableRenameTable;
 import io.crate.sql.tree.AlterTableReroute;
 import io.crate.sql.tree.AnalyzeStatement;
 import io.crate.sql.tree.AnalyzerElement;
@@ -1365,8 +1365,8 @@ class AstBuilder extends SqlBaseParserBaseVisitor<Node> {
     }
 
     @Override
-    public Node visitAlterTableRename(SqlBaseParser.AlterTableRenameContext context) {
-        return new AlterTableRename<>(
+    public Node visitAlterTableRenameTable(SqlBaseParser.AlterTableRenameTableContext context) {
+        return new AlterTableRenameTable<>(
             (Table<?>) visit(context.alterTableDefinition()),
             context.BLOB() != null,
             getQualifiedName(context.qname())

--- a/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -72,6 +72,7 @@ import io.crate.sql.tree.AlterTable;
 import io.crate.sql.tree.AlterTableAddColumn;
 import io.crate.sql.tree.AlterTableDropColumn;
 import io.crate.sql.tree.AlterTableOpenClose;
+import io.crate.sql.tree.AlterTableRenameColumn;
 import io.crate.sql.tree.AlterTableRenameTable;
 import io.crate.sql.tree.AlterTableReroute;
 import io.crate.sql.tree.AnalyzeStatement;
@@ -1371,6 +1372,15 @@ class AstBuilder extends SqlBaseParserBaseVisitor<Node> {
             context.BLOB() != null,
             getQualifiedName(context.qname())
         );
+    }
+
+    @Override
+    public Node visitAlterTableRenameColumn(SqlBaseParser.AlterTableRenameColumnContext ctx) {
+        return new AlterTableRenameColumn<>(
+            (Table<?>) visit(ctx.alterTableDefinition()),
+            (Expression) visit(ctx.source),
+            (Expression) visit(ctx.target));
+
     }
 
     @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/AlterTableRenameColumn.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/AlterTableRenameColumn.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.sql.tree;
+
+import java.util.Objects;
+
+public class AlterTableRenameColumn<T> extends Statement {
+
+    private final Table<T> table;
+    private final Expression column;
+    private final Expression newName;
+
+    public AlterTableRenameColumn(Table<T> table, Expression column, Expression newName) {
+        this.table = table;
+        this.column = column;
+        this.newName = newName;
+    }
+
+    public Table<T> table() {
+        return table;
+    }
+
+    public Expression column() {
+        return column;
+    }
+
+    public Expression newName() {
+        return newName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AlterTableRenameColumn<?> that = (AlterTableRenameColumn<?>) o;
+        return table.equals(that.table) && column.equals(that.column) && newName.equals(that.newName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(table, column, newName);
+    }
+
+    @Override
+    public String toString() {
+        return "AlterTableRenameColumn{" +
+            "table=" + table +
+            ", column=" + column +
+            ", newName=" + newName +
+            '}';
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitAlterTableRenameColumnStatement(this, context);
+    }
+}

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/AlterTableRenameTable.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/AlterTableRenameTable.java
@@ -23,13 +23,13 @@ package io.crate.sql.tree;
 
 import java.util.Objects;
 
-public class AlterTableRename<T> extends Statement {
+public class AlterTableRenameTable<T> extends Statement {
 
     private final Table<T> table;
     private final boolean blob;
     private final QualifiedName newName;
 
-    public AlterTableRename(Table<T> table, boolean blob, QualifiedName newName) {
+    public AlterTableRenameTable(Table<T> table, boolean blob, QualifiedName newName) {
         this.table = table;
         this.blob = blob;
         this.newName = newName;
@@ -37,7 +37,7 @@ public class AlterTableRename<T> extends Statement {
 
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
-        return visitor.visitAlterTableRename(this, context);
+        return visitor.visitAlterTableRenameTable(this, context);
     }
 
     public Table<T> table() {
@@ -60,7 +60,7 @@ public class AlterTableRename<T> extends Statement {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        AlterTableRename<?> that = (AlterTableRename<?>) o;
+        AlterTableRenameTable<?> that = (AlterTableRenameTable<?>) o;
         return blob == that.blob &&
                Objects.equals(table, that.table) &&
                Objects.equals(newName, that.newName);

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
@@ -516,6 +516,10 @@ public abstract class AstVisitor<R, C> {
         return visitStatement(node, context);
     }
 
+    public R visitAlterTableRenameColumnStatement(AlterTableRenameColumn<?> node, C context) {
+        return visitStatement(node, context);
+    }
+
     public R visitRerouteMoveShard(RerouteMoveShard<?> node, C context) {
         return visitNode(node, context);
     }

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
@@ -448,7 +448,7 @@ public abstract class AstVisitor<R, C> {
         return visitStatement(node, context);
     }
 
-    public R visitAlterTableRename(AlterTableRename<?> node, C context) {
+    public R visitAlterTableRenameTable(AlterTableRenameTable<?> node, C context) {
         return visitStatement(node, context);
     }
 

--- a/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -1806,7 +1806,7 @@ public class TestStatementBuilder {
     }
 
     @Test
-    public void testAlterTableRename() {
+    public void testAlterTableRenameTable() {
         printStatement("alter table t rename to t2");
     }
 

--- a/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -664,6 +664,10 @@ public class TestStatementBuilder {
         printStatement("alter table t drop column foo['x']");
         printStatement("alter table t drop if exists foo['x']['y']");
 
+        printStatement("alter table t rename foo to bar");
+        printStatement("alter table t rename foo['x'] to foo['y']");
+        printStatement("alter table t rename column foo to bar");
+
         printStatement("alter table t partition (partitioned_col=1) set (number_of_replicas=4)");
         printStatement("alter table only t set (number_of_replicas=4)");
     }

--- a/server/src/main/java/io/crate/analyze/AlterTableAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/AlterTableAnalyzer.java
@@ -40,7 +40,7 @@ import io.crate.metadata.table.Operation;
 import io.crate.sql.tree.AlterBlobTable;
 import io.crate.sql.tree.AlterTable;
 import io.crate.sql.tree.AlterTableOpenClose;
-import io.crate.sql.tree.AlterTableRename;
+import io.crate.sql.tree.AlterTableRenameTable;
 import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.Table;
 
@@ -90,7 +90,7 @@ class AlterTableAnalyzer {
     }
 
 
-    AnalyzedAlterTableRename analyze(AlterTableRename<Expression> node, SessionSettings sessionSettings) {
+    AnalyzedAlterTableRenameTable analyze(AlterTableRenameTable<Expression> node, SessionSettings sessionSettings) {
         if (!node.table().partitionProperties().isEmpty()) {
             throw new UnsupportedOperationException("Renaming a single partition is not supported");
         }
@@ -118,7 +118,7 @@ class AlterTableAnalyzer {
         } catch (RelationUnknown e) {
             schemas.resolveView(node.table().getName(), sessionSettings.searchPath());
         }
-        return new AnalyzedAlterTableRename(sourceName, targetName, isPartitioned);
+        return new AnalyzedAlterTableRenameTable(sourceName, targetName, isPartitioned);
     }
 
     public AnalyzedAlterTableOpenClose analyze(AlterTableOpenClose<Expression> node,

--- a/server/src/main/java/io/crate/analyze/AlterTableRenameColumnAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/AlterTableRenameColumnAnalyzer.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.analyze;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+import org.elasticsearch.Version;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import io.crate.analyze.expressions.ExpressionAnalysisContext;
+import io.crate.analyze.expressions.ExpressionAnalyzer;
+import io.crate.analyze.relations.FieldProvider;
+import io.crate.expression.symbol.DynamicReference;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.Reference;
+import io.crate.metadata.ReferenceIdent;
+import io.crate.metadata.RowGranularity;
+import io.crate.metadata.Schemas;
+import io.crate.metadata.doc.DocTableInfo;
+import io.crate.metadata.table.Operation;
+import io.crate.sql.tree.AlterTableRenameColumn;
+import io.crate.sql.tree.Expression;
+import io.crate.sql.tree.QualifiedName;
+
+public class AlterTableRenameColumnAnalyzer {
+    private final Schemas schemas;
+    private final NodeContext nodeCtx;
+
+    public AlterTableRenameColumnAnalyzer(Schemas schemas, NodeContext nodeCtx) {
+        this.schemas = schemas;
+        this.nodeCtx = nodeCtx;
+    }
+
+    public AnalyzedAlterTableRenameColumn analyze(AlterTableRenameColumn<Expression> renameColumn,
+                                                  ParamTypeHints paramTypeHints,
+                                                  CoordinatorTxnCtx txnCtx) {
+        if (!renameColumn.table().partitionProperties().isEmpty()) {
+            throw new UnsupportedOperationException("Renaming a column from a single partition is not supported");
+        }
+
+        DocTableInfo tableInfo = (DocTableInfo) schemas.resolveTableInfo(
+            renameColumn.table().getName(),
+            Operation.ALTER,
+            txnCtx.sessionSettings().sessionUser(),
+            txnCtx.sessionSettings().searchPath());
+        if (tableInfo.versionCreated().before(Version.V_5_5_0)) {
+            throw new UnsupportedOperationException(
+                "Renaming columns of a table created before version 5.5 is not supported"
+            );
+        }
+        var expressionAnalyzer = new ExpressionAnalyzer(
+            txnCtx,
+            nodeCtx,
+            paramTypeHints,
+            new FieldProviderResolvesUnknownColumns(tableInfo),
+            null
+        );
+        var expressionContext = new ExpressionAnalysisContext(txnCtx.sessionSettings());
+
+        Reference sourceRef = (Reference) expressionAnalyzer.convert(renameColumn.column(), expressionContext);
+        Reference targetRef = (Reference) expressionAnalyzer.convert(renameColumn.newName(), expressionContext);
+        ColumnIdent sourceCol = sourceRef.column();
+        ColumnIdent targetCol = targetRef.column();
+
+        if (sourceCol.path().size() != targetCol.path().size()) {
+            throw new IllegalArgumentException(
+                String.format(
+                    Locale.ENGLISH,
+                    "Cannot rename a column to a name that has different column level: %s, %s",
+                    sourceCol,
+                    targetCol));
+        }
+        if (!Objects.equals(sourceCol.getParent(), targetCol.getParent())) {
+            throw new IllegalArgumentException(
+                String.format(
+                    Locale.ENGLISH,
+                    "When renaming sub-columns, parent names must be equal: %s, %s",
+                    sourceCol.getParent(),
+                    targetCol.getParent()));
+        }
+
+        tableInfo.renameColumn(sourceRef, targetCol);
+        return new AnalyzedAlterTableRenameColumn(tableInfo.ident(), sourceRef, targetCol);
+    }
+
+    /** Returns DynamicReferences instead of throwing ColumnUnknownExceptions. */
+    public static class FieldProviderResolvesUnknownColumns implements FieldProvider<Reference> {
+
+        private final DocTableInfo table;
+
+        public FieldProviderResolvesUnknownColumns(DocTableInfo table) {
+            this.table = table;
+        }
+
+        @Override
+        @NotNull
+        public Reference resolveField(QualifiedName qualifiedName,
+                                      @Nullable List<String> path,
+                                      Operation operation,
+                                      boolean errorOnUnknownObjectKey) {
+            var columnIdent = ColumnIdent.fromNameSafe(qualifiedName, path);
+            var reference = table.getReference(columnIdent);
+            if (reference == null) {
+                reference = table.indexColumn(columnIdent);
+                if (reference == null) {
+                    return new DynamicReference(new ReferenceIdent(table.ident(), columnIdent), RowGranularity.DOC, -1);
+                }
+            }
+            return reference;
+        }
+    }
+}

--- a/server/src/main/java/io/crate/analyze/AnalyzedAlterTableRenameColumn.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedAlterTableRenameColumn.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.analyze;
+
+import java.util.function.Consumer;
+
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.Reference;
+import io.crate.metadata.RelationName;
+
+public record AnalyzedAlterTableRenameColumn(RelationName table,
+                                             Reference refToRename,
+                                             ColumnIdent newName) implements DDLStatement {
+
+    @Override
+    public <C, R> R accept(AnalyzedStatementVisitor<C, R> visitor, C context) {
+        return visitor.visitAlterTableRenameColumn(this, context);
+    }
+
+    @Override
+    public void visitSymbols(Consumer<? super Symbol> consumer) {
+    }
+}

--- a/server/src/main/java/io/crate/analyze/AnalyzedAlterTableRenameTable.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedAlterTableRenameTable.java
@@ -26,13 +26,13 @@ import java.util.function.Consumer;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.RelationName;
 
-public class AnalyzedAlterTableRename implements DDLStatement {
+public class AnalyzedAlterTableRenameTable implements DDLStatement {
 
     private final RelationName sourceName;
     private final RelationName targetName;
     private final boolean isPartitioned;
 
-    AnalyzedAlterTableRename(RelationName sourceName, RelationName targetName, boolean isPartitioned) {
+    AnalyzedAlterTableRenameTable(RelationName sourceName, RelationName targetName, boolean isPartitioned) {
         this.sourceName = sourceName;
         this.targetName = targetName;
         this.isPartitioned = isPartitioned;
@@ -52,7 +52,7 @@ public class AnalyzedAlterTableRename implements DDLStatement {
 
     @Override
     public <C, R> R accept(AnalyzedStatementVisitor<C, R> analyzedStatementVisitor, C context) {
-        return analyzedStatementVisitor.visitAnalyzedAlterTableRename(this, context);
+        return analyzedStatementVisitor.visitAnalyzedAlterTableRenameTable(this, context);
     }
 
     @Override

--- a/server/src/main/java/io/crate/analyze/AnalyzedStatementVisitor.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedStatementVisitor.java
@@ -99,6 +99,10 @@ public class AnalyzedStatementVisitor<C, R> {
         return visitDDLStatement(analysis, context);
     }
 
+    public R visitAnalyzedAlterTableRenameColumn(AnalyzedAlterTableRenameColumn analysis, C context) {
+        return visitDDLStatement(analysis, context);
+    }
+
     public R visitRerouteRetryFailedStatement(AnalyzedRerouteRetryFailed analysis, C context) {
         return visitDDLStatement(analysis, context);
     }
@@ -238,6 +242,10 @@ public class AnalyzedStatementVisitor<C, R> {
 
     public R visitAlterTableDropColumn(AnalyzedAlterTableDropColumn alterTableDropColumn, C context) {
         return visitDDLStatement(alterTableDropColumn, context);
+    }
+
+    public R visitAlterTableRenameColumn(AnalyzedAlterTableRenameColumn alterTableRenameColumn, C context) {
+        return visitDDLStatement(alterTableRenameColumn, context);
     }
 
     public R visitAlterTableDropCheckConstraint(AnalyzedAlterTableDropCheckConstraint dropCheckConstraint, C context) {

--- a/server/src/main/java/io/crate/analyze/AnalyzedStatementVisitor.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedStatementVisitor.java
@@ -95,7 +95,7 @@ public class AnalyzedStatementVisitor<C, R> {
         return visitDDLStatement(analysis, context);
     }
 
-    public R visitAnalyzedAlterTableRename(AnalyzedAlterTableRename analysis, C context) {
+    public R visitAnalyzedAlterTableRenameTable(AnalyzedAlterTableRenameTable analysis, C context) {
         return visitDDLStatement(analysis, context);
     }
 

--- a/server/src/main/java/io/crate/analyze/Analyzer.java
+++ b/server/src/main/java/io/crate/analyze/Analyzer.java
@@ -47,7 +47,7 @@ import io.crate.sql.tree.AlterTable;
 import io.crate.sql.tree.AlterTableAddColumn;
 import io.crate.sql.tree.AlterTableDropColumn;
 import io.crate.sql.tree.AlterTableOpenClose;
-import io.crate.sql.tree.AlterTableRename;
+import io.crate.sql.tree.AlterTableRenameTable;
 import io.crate.sql.tree.AlterTableReroute;
 import io.crate.sql.tree.AnalyzeStatement;
 import io.crate.sql.tree.AstVisitor;
@@ -303,9 +303,9 @@ public class Analyzer {
         }
 
         @Override
-        public AnalyzedStatement visitAlterTableRename(AlterTableRename<?> node, Analysis context) {
+        public AnalyzedStatement visitAlterTableRenameTable(AlterTableRenameTable<?> node, Analysis context) {
             return alterTableAnalyzer.analyze(
-                (AlterTableRename<Expression>) node,
+                (AlterTableRenameTable<Expression>) node,
                 context.sessionSettings());
         }
 

--- a/server/src/main/java/io/crate/analyze/Analyzer.java
+++ b/server/src/main/java/io/crate/analyze/Analyzer.java
@@ -47,6 +47,7 @@ import io.crate.sql.tree.AlterTable;
 import io.crate.sql.tree.AlterTableAddColumn;
 import io.crate.sql.tree.AlterTableDropColumn;
 import io.crate.sql.tree.AlterTableOpenClose;
+import io.crate.sql.tree.AlterTableRenameColumn;
 import io.crate.sql.tree.AlterTableRenameTable;
 import io.crate.sql.tree.AlterTableReroute;
 import io.crate.sql.tree.AnalyzeStatement;
@@ -132,6 +133,7 @@ public class Analyzer {
     private final AlterTableAnalyzer alterTableAnalyzer;
     private final AlterTableAddColumnAnalyzer alterTableAddColumnAnalyzer;
     private final AlterTableDropColumnAnalyzer alterTableDropColumnAnalyzer;
+    private final AlterTableRenameColumnAnalyzer alterTableRenameColumnAnalyzer;
     private final InsertAnalyzer insertAnalyzer;
     private final CopyAnalyzer copyAnalyzer;
     private final UpdateAnalyzer updateAnalyzer;
@@ -178,6 +180,7 @@ public class Analyzer {
         this.alterTableAnalyzer = new AlterTableAnalyzer(schemas, nodeCtx);
         this.alterTableAddColumnAnalyzer = new AlterTableAddColumnAnalyzer(schemas, nodeCtx);
         this.alterTableDropColumnAnalyzer = new AlterTableDropColumnAnalyzer(schemas, nodeCtx);
+        this.alterTableRenameColumnAnalyzer = new AlterTableRenameColumnAnalyzer(schemas, nodeCtx);
         this.swapTableAnalyzer = new SwapTableAnalyzer(nodeCtx, schemas);
         this.viewAnalyzer = new ViewAnalyzer(relationAnalyzer, schemas);
         this.explainStatementAnalyzer = new ExplainStatementAnalyzer(this);
@@ -290,6 +293,14 @@ public class Analyzer {
         public AnalyzedStatement visitAlterTableDropColumnStatement(AlterTableDropColumn<?> node, Analysis context) {
             return alterTableDropColumnAnalyzer.analyze(
                 (AlterTableDropColumn<Expression>) node,
+                context.paramTypeHints(),
+                context.transactionContext());
+        }
+
+        @Override
+        public AnalyzedStatement visitAlterTableRenameColumnStatement(AlterTableRenameColumn<?> node, Analysis context) {
+            return alterTableRenameColumnAnalyzer.analyze(
+                (AlterTableRenameColumn<Expression>) node,
                 context.paramTypeHints(),
                 context.transactionContext());
         }

--- a/server/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
@@ -53,7 +53,6 @@ import io.crate.expression.symbol.RefReplacer;
 import io.crate.expression.symbol.RefVisitor;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
-import io.crate.expression.symbol.format.Style;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.GeneratedReference;

--- a/server/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
@@ -333,7 +333,7 @@ public class TableElementsAnalyzer implements FieldProvider<Reference> {
                     }
                     return x;
                 });
-                ref = new GeneratedReference(ref, generated.toString(Style.UNQUALIFIED), generated);
+                ref = new GeneratedReference(ref, generated);
             }
 
             builtReference = ref;

--- a/server/src/main/java/io/crate/auth/AccessControlImpl.java
+++ b/server/src/main/java/io/crate/auth/AccessControlImpl.java
@@ -32,6 +32,7 @@ import io.crate.analyze.AnalyzedAlterTableAddColumn;
 import io.crate.analyze.AnalyzedAlterTableDropCheckConstraint;
 import io.crate.analyze.AnalyzedAlterTableDropColumn;
 import io.crate.analyze.AnalyzedAlterTableOpenClose;
+import io.crate.analyze.AnalyzedAlterTableRenameColumn;
 import io.crate.analyze.AnalyzedAlterTableRenameTable;
 import io.crate.analyze.AnalyzedAnalyze;
 import io.crate.analyze.AnalyzedBegin;
@@ -578,6 +579,17 @@ public final class AccessControlImpl implements AccessControl {
                 analysis.table().ident().toString(),
                 user
             );
+            return null;
+        }
+
+        @Override
+        public Void visitAlterTableRenameColumn(AnalyzedAlterTableRenameColumn analysis,
+                                                Role user) {
+            Privileges.ensureUserHasPrivilege(
+                Privilege.Type.DDL,
+                Privilege.Clazz.TABLE,
+                analysis.table().toString(),
+                user);
             return null;
         }
 

--- a/server/src/main/java/io/crate/auth/AccessControlImpl.java
+++ b/server/src/main/java/io/crate/auth/AccessControlImpl.java
@@ -32,7 +32,7 @@ import io.crate.analyze.AnalyzedAlterTableAddColumn;
 import io.crate.analyze.AnalyzedAlterTableDropCheckConstraint;
 import io.crate.analyze.AnalyzedAlterTableDropColumn;
 import io.crate.analyze.AnalyzedAlterTableOpenClose;
-import io.crate.analyze.AnalyzedAlterTableRename;
+import io.crate.analyze.AnalyzedAlterTableRenameTable;
 import io.crate.analyze.AnalyzedAnalyze;
 import io.crate.analyze.AnalyzedBegin;
 import io.crate.analyze.AnalyzedClose;
@@ -510,7 +510,7 @@ public final class AccessControlImpl implements AccessControl {
         }
 
         @Override
-        public Void visitAnalyzedAlterTableRename(AnalyzedAlterTableRename analysis, Role user) {
+        public Void visitAnalyzedAlterTableRenameTable(AnalyzedAlterTableRenameTable analysis, Role user) {
             Privileges.ensureUserHasPrivilege(
                 Privilege.Type.DDL,
                 Privilege.Clazz.TABLE,

--- a/server/src/main/java/io/crate/execution/ddl/tables/AlterTableOperation.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/AlterTableOperation.java
@@ -54,7 +54,7 @@ import org.jetbrains.annotations.Nullable;
 import io.crate.action.FutureActionListener;
 import io.crate.action.sql.CollectingResultReceiver;
 import io.crate.action.sql.Sessions;
-import io.crate.analyze.AnalyzedAlterTableRename;
+import io.crate.analyze.AnalyzedAlterTableRenameTable;
 import io.crate.analyze.BoundAlterTable;
 import io.crate.common.annotations.VisibleForTesting;
 import io.crate.data.Row;
@@ -383,7 +383,7 @@ public class AlterTableOperation {
         });
     }
 
-    public CompletableFuture<Long> executeAlterTableRenameTable(AnalyzedAlterTableRename renameTable) {
+    public CompletableFuture<Long> executeAlterTableRenameTable(AnalyzedAlterTableRenameTable renameTable) {
         var request = new RenameTableRequest(renameTable.sourceName(), renameTable.targetName(), renameTable.isPartitioned());
         return transportRenameTableAction.execute(request, r -> -1L);
     }

--- a/server/src/main/java/io/crate/execution/ddl/tables/RenameColumnAction.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/RenameColumnAction.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.ddl.tables;
+
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+
+public class RenameColumnAction extends ActionType<AcknowledgedResponse> {
+
+    public static final String NAME = "internal:crate:sql/table/rename_column";
+    public static final RenameColumnAction INSTANCE = new RenameColumnAction();
+
+    private RenameColumnAction() {
+        super(NAME);
+    }
+}

--- a/server/src/main/java/io/crate/execution/ddl/tables/RenameColumnRequest.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/RenameColumnRequest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.ddl.tables;
+
+import java.io.IOException;
+
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.jetbrains.annotations.NotNull;
+
+import io.crate.expression.symbol.Symbols;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.Reference;
+import io.crate.metadata.RelationName;
+
+public class RenameColumnRequest extends AcknowledgedRequest<RenameColumnRequest> {
+
+    private final RelationName relationName;
+    private final Reference refToRename;
+    private final ColumnIdent newName;
+
+    public RenameColumnRequest(@NotNull RelationName relationName, @NotNull Reference refToRename, @NotNull ColumnIdent newName) {
+        this.relationName = relationName;
+        this.refToRename = refToRename;
+        this.newName = newName;
+    }
+
+    public RenameColumnRequest(StreamInput in) throws IOException {
+        super(in);
+        this.relationName = new RelationName(in);
+        this.refToRename = (Reference) Symbols.fromStream(in);
+        this.newName = new ColumnIdent(in);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        relationName.writeTo(out);
+        Symbols.toStream(refToRename, out);
+        newName.writeTo(out);
+    }
+
+    public RelationName relationName() {
+        return relationName;
+    }
+
+    public Reference refToRename() {
+        return refToRename;
+    }
+
+    public ColumnIdent newName() {
+        return newName;
+    }
+}

--- a/server/src/main/java/io/crate/execution/ddl/tables/RenameColumnTask.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/RenameColumnTask.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.ddl.tables;
+
+import java.io.IOException;
+
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.index.mapper.MapperService;
+
+import io.crate.common.CheckedFunction;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.cluster.DDLClusterStateTaskExecutor;
+import io.crate.metadata.doc.DocTableInfo;
+import io.crate.metadata.doc.DocTableInfoFactory;
+
+public class RenameColumnTask extends DDLClusterStateTaskExecutor<RenameColumnRequest> {
+
+    private final NodeContext nodeContext;
+    private final CheckedFunction<IndexMetadata, MapperService, IOException> createMapperService;
+
+    public RenameColumnTask(NodeContext nodeContext,
+                            CheckedFunction<IndexMetadata, MapperService, IOException> createMapperService) {
+        this.nodeContext = nodeContext;
+        this.createMapperService = createMapperService;
+    }
+
+    @Override
+    protected ClusterState execute(ClusterState currentState, RenameColumnRequest request) throws Exception {
+        var docTableInfoFactory = new DocTableInfoFactory(nodeContext);
+        Metadata metadata = currentState.metadata();
+        DocTableInfo currentTable = docTableInfoFactory.create(request.relationName(), metadata);
+        DocTableInfo changedTable = currentTable.renameColumn(request.refToRename(), request.newName());
+        if (changedTable == currentTable) {
+            return currentState;
+        }
+        Metadata.Builder metadataBuilder = Metadata.builder(metadata);
+        Metadata newMetadata = changedTable
+            .writeTo(createMapperService, metadata, metadataBuilder)
+            .build();
+        // Ensure table can still be parsed
+        docTableInfoFactory.create(request.relationName(), newMetadata);
+        return ClusterState.builder(currentState)
+            .metadata(newMetadata)
+            .build();
+    }
+}

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportRenameColumnAction.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportRenameColumnAction.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.ddl.tables;
+
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateTaskExecutor;
+import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+import io.crate.execution.ddl.AbstractDDLTransportAction;
+import io.crate.metadata.NodeContext;
+
+@Singleton
+public class TransportRenameColumnAction extends AbstractDDLTransportAction<RenameColumnRequest, AcknowledgedResponse> {
+
+    private final NodeContext nodeContext;
+    private final IndicesService indicesService;
+
+    @Inject
+    public TransportRenameColumnAction(TransportService transportService,
+                                       ClusterService clusterService,
+                                       IndicesService indicesService,
+                                       ThreadPool threadPool,
+                                       NodeContext nodeContext) {
+        super(RenameColumnAction.NAME,
+            transportService,
+            clusterService,
+            threadPool,
+            RenameColumnRequest::new,
+            AcknowledgedResponse::new,
+            AcknowledgedResponse::new,
+            "rename-column");
+        this.nodeContext = nodeContext;
+        this.indicesService = indicesService;
+
+    }
+
+    @Override
+    public ClusterStateTaskExecutor<RenameColumnRequest> clusterStateTaskExecutor(RenameColumnRequest request) {
+        return new RenameColumnTask(nodeContext, indicesService::createIndexMapperService);
+    }
+
+
+    @Override
+    public ClusterBlockException checkBlock(RenameColumnRequest request, ClusterState state) {
+        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+    }
+}

--- a/server/src/main/java/io/crate/metadata/ColumnIdent.java
+++ b/server/src/main/java/io/crate/metadata/ColumnIdent.java
@@ -36,6 +36,7 @@ import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import io.crate.common.StringUtils;
@@ -194,6 +195,21 @@ public class ColumnIdent implements Comparable<ColumnIdent>, Accountable {
             return true;
         }
         return false;
+    }
+
+    /**
+     * Replaces the parent name of this column specified by the 'newName' e.g.::
+     *   'a.b.c'.replacePrefix('a.x') -> 'a.x.c' : parent 'a.b' renamed to 'a.x' such that its child 'a.b.c' is renamed to 'a.x.c'
+     *   'a.b.c'.replacePrefix('x') -> 'x.b.c' : parent 'a' renamed to 'x' such that its child 'a.b.c' is renamed to 'x.b.c'
+     * This method also renames self e.g.::
+     *   'a'.replacePrefix('b') -> 'b'
+     */
+    @NotNull
+    public ColumnIdent replacePrefix(@NotNull ColumnIdent newName) {
+        assert newName.path.isEmpty() || this.isChildOf(newName.getParent());
+        List<String> replaced = new ArrayList<>(newName.path);
+        replaced.addAll(this.path.subList(newName.path.size(), this.path.size()));
+        return new ColumnIdent(newName.name, replaced);
     }
 
     /**

--- a/server/src/main/java/io/crate/metadata/GeneratedReference.java
+++ b/server/src/main/java/io/crate/metadata/GeneratedReference.java
@@ -179,12 +179,12 @@ public class GeneratedReference implements Reference {
 
     @Override
     public String toString() {
-        return toString(Style.UNQUALIFIED);
+        return column().quotedOutputName() + " AS " + formattedGeneratedExpression;
     }
 
     @Override
     public String toString(Style style) {
-        return column().quotedOutputName() + " AS " + formattedGeneratedExpression;
+        return column().quotedOutputName();
     }
 
     @Override

--- a/server/src/main/java/io/crate/metadata/GeneratedReference.java
+++ b/server/src/main/java/io/crate/metadata/GeneratedReference.java
@@ -54,9 +54,13 @@ public class GeneratedReference implements Reference {
     private final Symbol generatedExpression;
     private final List<Reference> referencedReferences;
 
-    public GeneratedReference(Reference ref,
-                              String formattedGeneratedExpression,
-                              Symbol generatedExpression) {
+    public GeneratedReference(Reference ref, Symbol generatedExpression) {
+        this(ref, generatedExpression.toString(Style.UNQUALIFIED),generatedExpression);
+    }
+
+    private GeneratedReference(Reference ref,
+                               String formattedGeneratedExpression,
+                               Symbol generatedExpression) {
         assert generatedExpression != null : "GeneratedExpression is required";
         assert generatedExpression.valueType().equals(ref.valueType())
             : "The type of the generated expression must match the valueType of the `GeneratedReference`";
@@ -163,8 +167,7 @@ public class GeneratedReference implements Reference {
             return false;
         }
         GeneratedReference that = (GeneratedReference) o;
-        return Objects.equals(formattedGeneratedExpression, that.formattedGeneratedExpression) &&
-               Objects.equals(generatedExpression, that.generatedExpression) &&
+        return Objects.equals(generatedExpression, that.generatedExpression) &&
                Objects.equals(referencedReferences, that.referencedReferences) &&
                Objects.equals(ref, that.ref);
     }

--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfoFactory.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfoFactory.java
@@ -232,7 +232,6 @@ public class DocTableInfoFactory {
             assert reference != null : "Column present in generatedColumns must exist";
             GeneratedReference generatedRef = new GeneratedReference(
                 reference,
-                generatedExpressionStr,
                 generatedExpression
             );
             references.put(column, generatedRef);

--- a/server/src/main/java/io/crate/planner/Planner.java
+++ b/server/src/main/java/io/crate/planner/Planner.java
@@ -40,8 +40,8 @@ import io.crate.analyze.AnalyzedAlterTableAddColumn;
 import io.crate.analyze.AnalyzedAlterTableDropCheckConstraint;
 import io.crate.analyze.AnalyzedAlterTableDropColumn;
 import io.crate.analyze.AnalyzedAlterTableOpenClose;
-import io.crate.analyze.AnalyzedAlterTableRename;
 import io.crate.analyze.AnalyzedAlterRole;
+import io.crate.analyze.AnalyzedAlterTableRenameTable;
 import io.crate.analyze.AnalyzedAnalyze;
 import io.crate.analyze.AnalyzedBegin;
 import io.crate.analyze.AnalyzedClose;
@@ -362,8 +362,8 @@ public class Planner extends AnalyzedStatementVisitor<PlannerContext, Plan> {
     }
 
     @Override
-    public Plan visitAnalyzedAlterTableRename(AnalyzedAlterTableRename analysis,
-                                              PlannerContext context) {
+    public Plan visitAnalyzedAlterTableRenameTable(AnalyzedAlterTableRenameTable analysis,
+                                                   PlannerContext context) {
         return new AlterTableRenameTablePlan(analysis);
     }
 

--- a/server/src/main/java/io/crate/planner/Planner.java
+++ b/server/src/main/java/io/crate/planner/Planner.java
@@ -41,6 +41,7 @@ import io.crate.analyze.AnalyzedAlterTableDropCheckConstraint;
 import io.crate.analyze.AnalyzedAlterTableDropColumn;
 import io.crate.analyze.AnalyzedAlterTableOpenClose;
 import io.crate.analyze.AnalyzedAlterRole;
+import io.crate.analyze.AnalyzedAlterTableRenameColumn;
 import io.crate.analyze.AnalyzedAlterTableRenameTable;
 import io.crate.analyze.AnalyzedAnalyze;
 import io.crate.analyze.AnalyzedBegin;
@@ -106,6 +107,7 @@ import io.crate.planner.node.ddl.AlterTableDropCheckConstraintPlan;
 import io.crate.planner.node.ddl.AlterTableDropColumnPlan;
 import io.crate.planner.node.ddl.AlterTableOpenClosePlan;
 import io.crate.planner.node.ddl.AlterTablePlan;
+import io.crate.planner.node.ddl.AlterTableRenameColumnPlan;
 import io.crate.planner.node.ddl.AlterTableRenameTablePlan;
 import io.crate.planner.node.ddl.AlterRolePlan;
 import io.crate.planner.node.ddl.CreateAnalyzerPlan;
@@ -368,6 +370,11 @@ public class Planner extends AnalyzedStatementVisitor<PlannerContext, Plan> {
     }
 
     @Override
+    public Plan visitAnalyzedAlterTableRenameColumn(AnalyzedAlterTableRenameColumn analysis, PlannerContext context) {
+        return new AlterTableRenameColumnPlan(analysis);
+    }
+
+    @Override
     public Plan visitAnalyzedAlterTableOpenClose(AnalyzedAlterTableOpenClose analysis,
                                                  PlannerContext context) {
         return new AlterTableOpenClosePlan(analysis);
@@ -403,6 +410,12 @@ public class Planner extends AnalyzedStatementVisitor<PlannerContext, Plan> {
     public Plan visitAlterTableDropColumn(AnalyzedAlterTableDropColumn alterTableDropColumn,
                                           PlannerContext context) {
         return new AlterTableDropColumnPlan(alterTableDropColumn);
+    }
+
+    @Override
+    public Plan visitAlterTableRenameColumn(AnalyzedAlterTableRenameColumn alterTableRenameColumn,
+                                            PlannerContext context) {
+        return new AlterTableRenameColumnPlan(alterTableRenameColumn);
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/node/ddl/AlterTableRenameColumnPlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/AlterTableRenameColumnPlan.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.node.ddl;
+
+import io.crate.analyze.AnalyzedAlterTableRenameColumn;
+import io.crate.data.Row;
+import io.crate.data.Row1;
+import io.crate.data.RowConsumer;
+import io.crate.execution.ddl.tables.RenameColumnAction;
+import io.crate.execution.ddl.tables.RenameColumnRequest;
+import io.crate.execution.support.OneRowActionListener;
+import io.crate.planner.DependencyCarrier;
+import io.crate.planner.Plan;
+import io.crate.planner.PlannerContext;
+import io.crate.planner.operators.SubQueryResults;
+
+public class AlterTableRenameColumnPlan implements Plan {
+    private final AnalyzedAlterTableRenameColumn renameColumn;
+
+    public AlterTableRenameColumnPlan(AnalyzedAlterTableRenameColumn alterTable) {
+        this.renameColumn = alterTable;
+    }
+
+    @Override
+    public Plan.StatementType type() {
+        return StatementType.DDL;
+    }
+
+    @Override
+    public void executeOrFail(DependencyCarrier dependencies,
+                              PlannerContext plannerContext,
+                              RowConsumer consumer,
+                              Row params,
+                              SubQueryResults subQueryResults) throws Exception {
+        var renameColumnRequest = new RenameColumnRequest(renameColumn.table(), renameColumn.refToRename(), renameColumn.newName());
+        dependencies.client()
+            .execute(RenameColumnAction.INSTANCE, renameColumnRequest)
+            .whenComplete(new OneRowActionListener<>(consumer, r -> r.isAcknowledged() ? new Row1(-1L) : new Row1(0L)));
+    }
+}

--- a/server/src/main/java/io/crate/planner/node/ddl/AlterTableRenameTablePlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/AlterTableRenameTablePlan.java
@@ -21,7 +21,7 @@
 
 package io.crate.planner.node.ddl;
 
-import io.crate.analyze.AnalyzedAlterTableRename;
+import io.crate.analyze.AnalyzedAlterTableRenameTable;
 import io.crate.data.Row;
 import io.crate.data.Row1;
 import io.crate.data.RowConsumer;
@@ -33,10 +33,10 @@ import io.crate.planner.operators.SubQueryResults;
 
 public class AlterTableRenameTablePlan implements Plan {
 
-    private final AnalyzedAlterTableRename analyzedAlterTableRename;
+    private final AnalyzedAlterTableRenameTable analyzedAlterTableRenameTable;
 
-    public AlterTableRenameTablePlan(AnalyzedAlterTableRename analyzedAlterTableRename) {
-        this.analyzedAlterTableRename = analyzedAlterTableRename;
+    public AlterTableRenameTablePlan(AnalyzedAlterTableRenameTable analyzedAlterTableRenameTable) {
+        this.analyzedAlterTableRenameTable = analyzedAlterTableRenameTable;
     }
 
     @Override
@@ -49,7 +49,7 @@ public class AlterTableRenameTablePlan implements Plan {
                               PlannerContext plannerContext,
                               RowConsumer consumer,
                               Row params, SubQueryResults subQueryResults) throws Exception {
-        dependencies.alterTableOperation().executeAlterTableRenameTable(analyzedAlterTableRename)
+        dependencies.alterTableOperation().executeAlterTableRenameTable(analyzedAlterTableRenameTable)
             .whenComplete(new OneRowActionListener<>(consumer, rCount -> new Row1(rCount == null ? -1 : rCount)));
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -108,6 +108,8 @@ import io.crate.blob.TransportPutChunkAction;
 import io.crate.blob.TransportStartBlobAction;
 import io.crate.cluster.decommission.DecommissionNodeAction;
 import io.crate.cluster.decommission.TransportDecommissionNodeAction;
+import io.crate.execution.ddl.tables.RenameColumnAction;
+import io.crate.execution.ddl.tables.TransportRenameColumnAction;
 import io.crate.execution.dml.delete.ShardDeleteAction;
 import io.crate.execution.dml.delete.TransportShardDeleteAction;
 import io.crate.execution.dml.upsert.ShardUpsertAction;
@@ -209,6 +211,7 @@ public class ActionModule extends AbstractModule {
         actions.register(DistributedResultAction.INSTANCE, TransportDistributedResultAction.class);
         actions.register(JobAction.INSTANCE, TransportJobAction.class);
         actions.register(FetchNodeAction.INSTANCE, TransportFetchNodeAction.class);
+        actions.register(RenameColumnAction.INSTANCE, TransportRenameColumnAction.class);
 
         actionPlugins.stream().flatMap(p -> p.getActions().stream()).forEach(actions::register);
 

--- a/server/src/test/java/io/crate/analyze/AlterTableRenameColumnAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/AlterTableRenameColumnAnalyzerTest.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.analyze;
+
+import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.settings.Settings;
+import org.junit.Test;
+
+import io.crate.exceptions.ColumnUnknownException;
+import io.crate.exceptions.InvalidColumnNameException;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.RelationName;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+
+public class AlterTableRenameColumnAnalyzerTest extends CrateDummyClusterServiceUnitTest {
+    private SQLExecutor e;
+
+    @Test
+    public void test_rename_top_level_column() throws IOException {
+        e = SQLExecutor.builder(clusterService)
+            .addTable("create table t (a int)")
+            .build();
+
+        AnalyzedAlterTableRenameColumn analyzed = e.analyze("alter table t rename column a to b");
+        assertThat(analyzed.refToRename()).isReference().hasName("a");
+        assertThat(analyzed.newName()).isEqualTo(new ColumnIdent("b"));
+        assertThat(analyzed.table()).isEqualTo(new RelationName("doc", "t"));
+    }
+
+    @Test
+    public void test_rename_nested_column() throws IOException {
+        e = SQLExecutor.builder(clusterService)
+            .addTable("create table t (o object as (o2 object as (o3 object)))")
+            .build();
+
+        AnalyzedAlterTableRenameColumn analyzed = e.analyze("alter table t rename column o['o2']['o3'] to o['o2']['x']");
+        assertThat(analyzed.refToRename()).isReference().hasColumnIdent(new ColumnIdent("o", List.of("o2", "o3")));
+        assertThat(analyzed.newName()).isEqualTo(new ColumnIdent("o", List.of("o2", "x")));
+        assertThat(analyzed.table()).isEqualTo(new RelationName("doc", "t"));
+    }
+
+    @Test
+    public void test_rename_nested_column_record_subscripts() throws IOException {
+        e = SQLExecutor.builder(clusterService)
+            .addTable("create table t (o object as (o2 object as (o3 object)))")
+            .build();
+
+        AnalyzedAlterTableRenameColumn analyzed = e.analyze("alter table t rename column o['o2']['o3'] to o['o2']['x']");
+        assertThat(analyzed.refToRename()).isReference().hasColumnIdent(new ColumnIdent("o", List.of("o2", "o3")));
+        assertThat(analyzed.newName()).isEqualTo(new ColumnIdent("o", List.of("o2", "x")));
+        assertThat(analyzed.table()).isEqualTo(new RelationName("doc", "t"));
+    }
+
+    @Test
+    public void test_cannot_rename_nested_column_to_target_name_with_different_parent() throws IOException {
+        e = SQLExecutor.builder(clusterService)
+            .addTable("create table t (o object as (o2 object as (o3 object)))")
+            .build();
+
+        assertThatThrownBy(() -> e.analyze("alter table t rename column o['o2']['o3'] to o['x']['x']"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("When renaming sub-columns, parent names must be equal: o['o2'], o['x']");
+    }
+
+    @Test
+    public void test_cannot_rename_nested_column_to_target_name_with_different_depths() throws IOException {
+        e = SQLExecutor.builder(clusterService)
+            .addTable("create table t (o object as (o2 object as (o3 object)))")
+            .build();
+
+        assertThatThrownBy(() -> e.analyze("alter table t rename column o['o2']['o3'] to o['o2']['o3']['y']"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Cannot rename a column to a name that has different column level: o['o2']['o3'], o['o2']['o3']['y']");
+    }
+
+    @Test
+    public void test_cannot_rename_unknown_column() throws IOException {
+        e = SQLExecutor.builder(clusterService)
+            .addTable("create table t (o object)")
+            .build();
+
+        assertThatThrownBy(() -> e.analyze("alter table t rename column o['unknown1'] to o['unknown2']"))
+            .isExactlyInstanceOf(ColumnUnknownException.class)
+            .hasMessage("Column o['unknown1'] unknown");
+    }
+
+    @Test
+    public void test_cannot_rename_to_name_in_use() throws IOException {
+        e = SQLExecutor.builder(clusterService)
+            .addTable("create table t (a int, b int)")
+            .build();
+
+        assertThatThrownBy(() -> e.analyze("alter table t rename column a to b"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Cannot rename column to a name that is in use");
+    }
+
+    @Test
+    public void test_cannot_rename_column_from_single_partition() throws Exception {
+        e = SQLExecutor.builder(clusterService)
+            .addPartitionedTable(
+                TableDefinitions.TEST_PARTITIONED_TABLE_DEFINITION,
+                TableDefinitions.TEST_PARTITIONED_TABLE_PARTITIONS)
+            .build();
+
+        assertThatThrownBy(() -> e.analyze("ALTER TABLE parted partition (date = 1395874800000) rename column name to newName"))
+            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .hasMessage("Renaming a column from a single partition is not supported");
+    }
+
+    @Test
+    public void test_renaming_column_from_old_table_is_not_allowed() throws Exception {
+        e = SQLExecutor.builder(clusterService)
+            .addTable(
+                "create table t (a int)",
+                Settings.builder().put(IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(), Version.V_5_4_0).build()
+            )
+            .build();
+
+        assertThatThrownBy(() -> e.analyze("ALTER TABLE t RENAME COLUMN a to b"))
+            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .hasMessage("Renaming columns of a table created before version 5.5 is not supported");
+    }
+
+    @Test
+    public void test_renaming_index_columns_to_subscript_expressions_is_not_allowed() throws Exception {
+        e = SQLExecutor.builder(clusterService)
+            .addTable("create table t (a text, index b using fulltext (a))")
+            .build();
+
+        assertThatThrownBy(() -> e.analyze("ALTER TABLE t RENAME COLUMN b to o['b']"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Cannot rename a column to a name that has different column level: b, o['b']");
+    }
+
+    @Test
+    public void test_renaming_to_or_from_system_columns_is_not_allowed() throws Exception {
+        e = SQLExecutor.builder(clusterService)
+            .addTable("create table t (a text)")
+            .build();
+        assertThatThrownBy(() -> e.analyze("ALTER TABLE t RENAME COLUMN _doc to x"))
+            .isExactlyInstanceOf(InvalidColumnNameException.class)
+            .hasMessage("\"_doc\" conflicts with system column pattern");
+        assertThatThrownBy(() -> e.analyze("ALTER TABLE t RENAME a to _doc"))
+            .isExactlyInstanceOf(InvalidColumnNameException.class)
+            .hasMessage("\"_doc\" conflicts with system column pattern");
+    }
+}

--- a/server/src/test/java/io/crate/analyze/AlterTableRenameTableAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/AlterTableRenameTableAnalyzerTest.java
@@ -40,7 +40,7 @@ import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.testing.T3;
 
-public class AlterTableRenameAnalyzerTest extends CrateDummyClusterServiceUnitTest {
+public class AlterTableRenameTableAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testRenamePartitionThrowsException() throws Exception {

--- a/server/src/test/java/io/crate/analyze/BlobTableAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/BlobTableAnalyzerTest.java
@@ -265,14 +265,14 @@ public class BlobTableAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
-    public void testAlterBlobTableRename() {
+    public void testAlterBlobTableRenameTable() {
         assertThatThrownBy(() -> e.analyze("alter blob table blobs rename to blobbier"))
             .isExactlyInstanceOf(OperationOnInaccessibleRelationException.class)
             .hasMessage("The relation \"blob.blobs\" doesn't support or allow ALTER RENAME operations.");
     }
 
     @Test
-    public void testAlterBlobTableRenameWithExplicitSchema() {
+    public void testAlterBlobTableRenameTableWithExplicitSchema() {
         assertThatThrownBy(() -> e.analyze("alter blob table schema.blobs rename to blobbier"))
             .isExactlyInstanceOf(IllegalArgumentException.class)
             .hasMessage("The Schema \"schema\" isn't valid in a [CREATE | ALTER] BLOB TABLE clause");

--- a/server/src/test/java/io/crate/analyze/IsWriteOperationTest.java
+++ b/server/src/test/java/io/crate/analyze/IsWriteOperationTest.java
@@ -134,7 +134,7 @@ public class IsWriteOperationTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
-    public void testAlterTableRenameIsAWriteOperation() {
+    public void testAlterTableRenameTableIsAWriteOperation() {
         assertWriteOperation("alter table t1 rename to t2");
     }
 

--- a/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
+++ b/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
@@ -479,6 +479,12 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
     }
 
     @Test
+    public void test_rename_column() {
+        analyze("alter table users rename column floats to flts");
+        assertAskedForTable(Privilege.Type.DDL, "doc.users");
+    }
+
+    @Test
     public void testOpenCloseTable() throws Exception {
         analyze("alter table users close");
         assertAskedForTable(Privilege.Type.DDL, "doc.users");

--- a/server/src/test/java/io/crate/execution/ddl/tables/RenameColumnTaskTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/tables/RenameColumnTaskTest.java
@@ -1,0 +1,338 @@
+package io.crate.execution.ddl.tables;
+
+import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterModule;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.index.MapperTestUtils;
+import org.junit.Test;
+
+import io.crate.exceptions.ColumnUnknownException;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.IndexType;
+import io.crate.metadata.PartitionName;
+import io.crate.metadata.Reference;
+import io.crate.metadata.ReferenceIdent;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.RowGranularity;
+import io.crate.metadata.SimpleReference;
+import io.crate.metadata.doc.DocTableInfo;
+import io.crate.metadata.doc.DocTableInfoFactory;
+import io.crate.sql.tree.ColumnPolicy;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.IndexEnv;
+import io.crate.testing.SQLExecutor;
+import io.crate.types.DataTypes;
+
+public class RenameColumnTaskTest extends CrateDummyClusterServiceUnitTest {
+
+    @Test
+    public void test_rename_simple_columns() throws Exception {
+        // the test is equivalent to : alter table tbl rename column x to y;
+        var e = SQLExecutor.builder(clusterService)
+            .addTable("create table tbl (x int)")
+            .build();
+        DocTableInfo tbl = e.resolveTableInfo("tbl");
+        try (IndexEnv indexEnv = new IndexEnv(
+            THREAD_POOL,
+            tbl,
+            clusterService.state(),
+            Version.CURRENT
+        )) {
+            var renameColumnTask = new RenameColumnTask(e.nodeCtx, imd -> indexEnv.mapperService());
+            Reference refToRename = tbl.getReference(new ColumnIdent("x"));
+            var newName = new ColumnIdent("y");
+            var request = new RenameColumnRequest(tbl.ident(), refToRename, newName);
+            ClusterState newState = renameColumnTask.execute(clusterService.state(), request);
+            DocTableInfo newTable = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
+            assertThat(newTable.getReference(refToRename.column())).isNull();
+            assertThat(newTable.getReference(newName)).isReference().hasName(newName.sqlFqn());
+        }
+    }
+
+    @Test
+    public void test_rename_nested_columns() throws Exception {
+        // equivalent to:
+        // alter table tbl rename column o to p;
+        // alter table tbl rename column p['o2'] to p['p2'];
+        // alter table tbl rename column p['p2']['x'] to p['p2']['y'];
+        var e = SQLExecutor.builder(clusterService)
+            .addTable("create table tbl (o object as (o2 object as (x int)))")
+            .build();
+        DocTableInfo tbl = e.resolveTableInfo("tbl");
+        try (IndexEnv indexEnv = new IndexEnv(
+            THREAD_POOL,
+            tbl,
+            clusterService.state(),
+            Version.CURRENT
+        )) {
+            var renameColumnTask = new RenameColumnTask(e.nodeCtx, imd -> indexEnv.mapperService());
+            Reference refToRename1 = tbl.getReference(new ColumnIdent("o"));
+            var newName1 = new ColumnIdent("p");
+            var request = new RenameColumnRequest(tbl.ident(), refToRename1, newName1);
+            ClusterState newState = renameColumnTask.execute(clusterService.state(), request);
+            tbl = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
+            assertThat(tbl.getReference(refToRename1.column())).isNull();
+            assertThat(tbl.getReference(newName1)).isReference().hasName(newName1.sqlFqn());
+
+            Reference refToRename2 = tbl.getReference(new ColumnIdent("p", List.of("o2")));
+            var newName2 = new ColumnIdent("p", List.of("p2"));
+            request = new RenameColumnRequest(tbl.ident(), refToRename2, newName2);
+            newState = renameColumnTask.execute(newState, request);
+            tbl = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
+            assertThat(tbl.getReference(refToRename2.column())).isNull();
+            assertThat(tbl.getReference(newName2)).isReference().hasName(newName2.sqlFqn());
+
+            Reference refToRename3 = tbl.getReference(new ColumnIdent("p", List.of("p2", "x")));
+            var newName3 = new ColumnIdent("p", List.of("p2", "y"));
+            request = new RenameColumnRequest(tbl.ident(), refToRename3, newName3);
+            newState = renameColumnTask.execute(newState, request);
+            tbl = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
+            assertThat(tbl.getReference(refToRename3.column())).isNull();
+            assertThat(tbl.getReference(newName3)).isReference().hasName(newName3.sqlFqn());
+        }
+    }
+
+    @Test
+    public void test_rename_partitioned_by_columns() throws Exception {
+        // alter table tbl rename column x to y; -- where y is a partitioned by col
+        var e = SQLExecutor.builder(clusterService)
+            .addPartitionedTable("create table doc.tbl (o object as (o2 object as (x int)), x int) partitioned by (o['o2']['x'], x)",
+                new PartitionName(new RelationName("doc", "tbl"), List.of("1", "2")).asIndexName(),
+                new PartitionName(new RelationName("doc", "tbl"), List.of("3", "4")).asIndexName())
+            .build();
+        DocTableInfo tbl = e.resolveTableInfo("doc.tbl");
+        var renameColumnTask = new RenameColumnTask(e.nodeCtx, imd -> MapperTestUtils.newMapperService(
+            new NamedXContentRegistry(ClusterModule.getNamedXWriteables()),
+            createTempDir(),
+            Settings.EMPTY,
+            "doc.tbl"));
+        Reference refToRename = tbl.getReference(new ColumnIdent("x"));
+        var newName = new ColumnIdent("y");
+        var request = new RenameColumnRequest(tbl.ident(), refToRename, newName);
+        ClusterState newState = renameColumnTask.execute(clusterService.state(), request);
+        DocTableInfo newTable = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
+        assertThat(newTable.getReference(refToRename.column())).isNull();
+        assertThat(newTable.partitionedBy()).doesNotContain(refToRename.column());
+        assertThat(newTable.getReference(newName)).isReference().hasName(newName.name());
+        assertThat(newTable.partitionedBy()).doesNotContain(refToRename.column()).contains(newName);
+
+        // alter table tbl rename column o to p;
+        // -- causes partitioned by col to be renamed: o['o2']['x'] -> p['o2']['x']
+        refToRename = tbl.getReference(new ColumnIdent("o"));
+        newName = new ColumnIdent("p");
+        var oldNameOfChild = new ColumnIdent("o", List.of("o2", "x"));
+        var newNameOfChild = new ColumnIdent("p", List.of("o2", "x"));
+        request = new RenameColumnRequest(tbl.ident(), refToRename, newName);
+        newState = renameColumnTask.execute(newState, request);
+        newTable = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
+        assertThat(newTable.getReference(oldNameOfChild)).isNull();
+        assertThat(newTable.getReference(newName)).isReference().hasName(newNameOfChild.name());
+        assertThat(newTable.partitionedBy()).doesNotContain(oldNameOfChild).contains(newNameOfChild);
+    }
+
+    @Test
+    public void test_rename_primary_key_columns() throws Exception {
+        // alter table tbl rename column o['o2'] to o['p2'];
+        // -- causes primary key column to be renamed: o['o2']['o3']['x'] -> o['p2']['o3']['x']
+        var e = SQLExecutor.builder(clusterService)
+            .addTable("create table tbl (o object as (o2 object as (o3 object as (x int primary key))), a int primary key)")
+            .build();
+        DocTableInfo tbl = e.resolveTableInfo("tbl");
+        try (IndexEnv indexEnv = new IndexEnv(
+            THREAD_POOL,
+            tbl,
+            clusterService.state(),
+            Version.CURRENT
+        )) {
+            var renameColumnTask = new RenameColumnTask(e.nodeCtx, imd -> indexEnv.mapperService());
+            Reference refToRename = tbl.getReference(new ColumnIdent("o", List.of("o2")));
+            var newName = new ColumnIdent("o", List.of("p2"));
+            var request = new RenameColumnRequest(tbl.ident(), refToRename, newName);
+            ClusterState newState = renameColumnTask.execute(clusterService.state(), request);
+            DocTableInfo newTable = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
+            var oldPkCol = new ColumnIdent("o", List.of("o2", "o3", "x"));
+            var newPkCol = new ColumnIdent("o", List.of("p2", "o3", "x"));
+            assertThat(newTable.getReference(refToRename.column())).isNull();
+            assertThat(newTable.getReference(newName)).isReference().hasName(newName.sqlFqn());
+            assertThat(newTable.primaryKey()).doesNotContain(oldPkCol).contains(newPkCol);
+        }
+    }
+
+    @Test
+    public void test_rename_check_columns() throws Exception {
+        // alter table tbl rename column o['a'] to o['b'];
+        // alter table tbl rename column o to p;
+        // -- causes check constraint to be renamed: (o['a'] > 1) -> (p['b'] > 1)
+        var e = SQLExecutor.builder(clusterService)
+            .addTable("create table tbl (o object as (a int), constraint c_1 check (o['a'] > 1))")
+            .build();
+        DocTableInfo tbl = e.resolveTableInfo("tbl");
+        try (IndexEnv indexEnv = new IndexEnv(
+            THREAD_POOL,
+            tbl,
+            clusterService.state(),
+            Version.CURRENT
+        )) {
+            var renameColumnTask = new RenameColumnTask(e.nodeCtx, imd -> indexEnv.mapperService());
+            Reference refToRename = tbl.getReference(new ColumnIdent("o", List.of("a")));
+            var newName = new ColumnIdent("o", List.of("b"));
+            var request = new RenameColumnRequest(tbl.ident(), refToRename, newName);
+            ClusterState newState = renameColumnTask.execute(clusterService.state(), request);
+            tbl = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
+
+            refToRename = tbl.getReference(new ColumnIdent("o"));
+            newName = new ColumnIdent("p");
+            request = new RenameColumnRequest(tbl.ident(), refToRename, newName);
+            newState = renameColumnTask.execute(newState, request);
+            tbl = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
+
+            assertThat(tbl.checkConstraints().size()).isEqualTo(1);
+            assertThat(tbl.checkConstraints().get(0).toString())
+                .isEqualTo("CheckConstraint{name='c_1', expression=(p['b'] > 1)}");
+        }
+    }
+
+    @Test
+    public void test_rename_columns_used_in_generated_expressions() throws Exception {
+        // alter table tbl rename column o to o2;
+        // -- causes generated column to be renamed: (o['b'] AS o['a'] + 1) -> (o2['b'] AS o2['a'] + 1)
+        var e = SQLExecutor.builder(clusterService)
+            .addTable("create table tbl (o object as (a int, b int generated always as (o['a']+1)))")
+            .build();
+        DocTableInfo tbl = e.resolveTableInfo("tbl");
+        try (IndexEnv indexEnv = new IndexEnv(
+            THREAD_POOL,
+            tbl,
+            clusterService.state(),
+            Version.CURRENT
+        )) {
+            var renameColumnTask = new RenameColumnTask(e.nodeCtx, imd -> indexEnv.mapperService());
+            Reference refToRename = tbl.getReference(new ColumnIdent("o"));
+            var newName = new ColumnIdent("o2");
+            var request = new RenameColumnRequest(tbl.ident(), refToRename, newName);
+            ClusterState newState = renameColumnTask.execute(clusterService.state(), request);
+            DocTableInfo newTable = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
+            assertThat(newTable.generatedColumns().size()).isEqualTo(1);
+            assertThat(newTable.generatedColumns().get(0).column()).isEqualTo(new ColumnIdent("o2", List.of("b")));
+            assertThat(newTable.generatedColumns().get(0).formattedGeneratedExpression()).isEqualTo("(o2['a'] + 1)");
+        }
+    }
+
+    @Test
+    public void test_cannot_rename_column_to_name_in_use() throws Exception {
+        var e = SQLExecutor.builder(clusterService)
+            .addTable("create table tbl (a int, b int)")
+            .build();
+        DocTableInfo tbl = e.resolveTableInfo("tbl");
+        try (IndexEnv indexEnv = new IndexEnv(
+            THREAD_POOL,
+            tbl,
+            clusterService.state(),
+            Version.CURRENT
+        )) {
+            var renameColumnTask = new RenameColumnTask(e.nodeCtx, imd -> indexEnv.mapperService());
+            Reference refToRename = tbl.getReference(new ColumnIdent("a"));
+            var newName = new ColumnIdent("b");
+            var request = new RenameColumnRequest(tbl.ident(), refToRename, newName);
+            assertThatThrownBy(() -> renameColumnTask.execute(clusterService.state(), request))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Cannot rename column to a name that is in use");
+        }
+    }
+
+    @Test
+    public void test_cannot_rename_column_if_the_column_has_changed() throws Exception {
+        var e = SQLExecutor.builder(clusterService)
+            .addTable("create table tbl (a int)")
+            .build();
+        DocTableInfo tbl = e.resolveTableInfo("tbl");
+        try (IndexEnv indexEnv = new IndexEnv(
+            THREAD_POOL,
+            tbl,
+            clusterService.state(),
+            Version.CURRENT
+        )) {
+            var renameColumnTask = new RenameColumnTask(e.nodeCtx, imd -> indexEnv.mapperService());
+            SimpleReference refToRename = new SimpleReference(
+                new ReferenceIdent(tbl.ident(), "a"),
+                RowGranularity.DOC,
+                // since the analysis, the data type of 'a' has changed from int to double
+                DataTypes.DOUBLE,
+                ColumnPolicy.DYNAMIC,
+                IndexType.PLAIN,
+                true,
+                true,
+                1,
+                1,
+                false,
+                null
+            );
+            var newName = new ColumnIdent("b");
+            var request = new RenameColumnRequest(tbl.ident(), refToRename, newName);
+            assertThatThrownBy(() -> renameColumnTask.execute(clusterService.state(), request))
+                .isExactlyInstanceOf(ColumnUnknownException.class)
+                .hasMessage("Column a unknown");
+        }
+    }
+
+    @Test
+    public void test_rename_clustered_by_columns() throws Exception {
+        var e = SQLExecutor.builder(clusterService)
+            .addTable("create table tbl (x int) clustered by (x)")
+            .build();
+        DocTableInfo tbl = e.resolveTableInfo("tbl");
+        try (IndexEnv indexEnv = new IndexEnv(
+            THREAD_POOL,
+            tbl,
+            clusterService.state(),
+            Version.CURRENT
+        )) {
+            var renameColumnTask = new RenameColumnTask(e.nodeCtx, imd -> indexEnv.mapperService());
+            Reference refToRename = tbl.getReference(new ColumnIdent("x"));
+            var newName = new ColumnIdent("y");
+            var request = new RenameColumnRequest(tbl.ident(), refToRename, newName);
+            ClusterState newState = renameColumnTask.execute(clusterService.state(), request);
+            DocTableInfo newTable = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
+            assertThat(newTable.clusteredBy()).isEqualTo(newName);
+        }
+    }
+
+    @Test
+    public void test_rename_index_column() throws Exception {
+        var e = SQLExecutor.builder(clusterService)
+            .addTable("create table tbl (x text, index i using fulltext (x))")
+            .build();
+        DocTableInfo tbl = e.resolveTableInfo("tbl");
+        try (IndexEnv indexEnv = new IndexEnv(
+            THREAD_POOL,
+            tbl,
+            clusterService.state(),
+            Version.CURRENT
+        )) {
+            var renameColumnTask = new RenameColumnTask(e.nodeCtx, imd -> indexEnv.mapperService());
+            Reference refToRename = tbl.getReference(new ColumnIdent("x"));
+            var newName = new ColumnIdent("x2");
+            var request = new RenameColumnRequest(tbl.ident(), refToRename, newName);
+            ClusterState newState = renameColumnTask.execute(clusterService.state(), request);
+            tbl = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
+
+            refToRename = tbl.indexColumn(new ColumnIdent("i"));
+            newName = new ColumnIdent("i2");
+            request = new RenameColumnRequest(tbl.ident(), refToRename, newName);
+            newState = renameColumnTask.execute(newState, request);
+            tbl = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
+
+            var renamedIndexColumn = tbl.indexColumn(new ColumnIdent("i2"));
+            assertThat(renamedIndexColumn.columns().size()).isEqualTo(1);
+            assertThat(renamedIndexColumn.columns().get(0)).isReference().hasName("x2");
+            assertThat(renamedIndexColumn.column()).isEqualTo(new ColumnIdent("i2"));
+        }
+    }
+}

--- a/server/src/test/java/io/crate/metadata/ColumnIdentTest.java
+++ b/server/src/test/java/io/crate/metadata/ColumnIdentTest.java
@@ -23,6 +23,7 @@ package io.crate.metadata;
 
 import static junit.framework.TestCase.assertTrue;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
@@ -157,5 +158,36 @@ public class ColumnIdentTest {
         }
 
         assertTrue(expecedExceptionIsThrown);
+    }
+
+    @Test
+    public void test_replace_paths() {
+        var a = new ColumnIdent("a");
+        var b = new ColumnIdent("b");
+        var aa = new ColumnIdent("a", List.of("a"));
+        var ba = new ColumnIdent("b", List.of("a"));
+        var ab = new ColumnIdent("a", List.of("b"));
+        var bb = new ColumnIdent("b", List.of("b"));
+        var aaa = new ColumnIdent("a", List.of("a", "a"));
+        var baa = new ColumnIdent("b", List.of("a", "a"));
+        var aba = new ColumnIdent("a", List.of("b", "a"));
+        var aab = new ColumnIdent("a", List.of("a", "b"));
+
+        assertThat(a.replacePrefix(a)).isEqualTo(a);
+        assertThat(a.replacePrefix(b)).isEqualTo(b);
+        assertThatThrownBy(() -> a.replacePrefix(ab)).isExactlyInstanceOf(AssertionError.class);
+
+        assertThat(aa.replacePrefix(a)).isEqualTo(aa);
+        assertThat(aa.replacePrefix(b)).isEqualTo(ba);
+        assertThat(aa.replacePrefix(ab)).isEqualTo(ab);
+        assertThatThrownBy(() -> aa.replacePrefix(ba)).isExactlyInstanceOf(AssertionError.class);
+        assertThatThrownBy(() -> aa.replacePrefix(bb)).isExactlyInstanceOf(AssertionError.class);
+        assertThatThrownBy(() -> aa.replacePrefix(aaa)).isExactlyInstanceOf(AssertionError.class);
+
+        assertThat(aaa.replacePrefix(a)).isEqualTo(aaa);
+        assertThat(aaa.replacePrefix(b)).isEqualTo(baa);
+        assertThat(aaa.replacePrefix(aa)).isEqualTo(aaa);
+        assertThat(aaa.replacePrefix(ab)).isEqualTo(aba);
+        assertThat(aaa.replacePrefix(aab)).isEqualTo(aab);
     }
 }

--- a/server/src/test/java/io/crate/metadata/GeneratedReferenceTest.java
+++ b/server/src/test/java/io/crate/metadata/GeneratedReferenceTest.java
@@ -66,7 +66,7 @@ public class GeneratedReferenceTest extends CrateDummyClusterServiceUnitTest {
         String formattedGeneratedExpression = "concat(a, 'bar')";
         SimpleReference simpleRef = new SimpleReference(referenceIdent, RowGranularity.DOC, StringType.INSTANCE, 1, null);
         Symbol generatedExpression = expressions.normalize(executor.asSymbol(formattedGeneratedExpression));
-        GeneratedReference generatedReferenceInfo = new GeneratedReference(simpleRef, formattedGeneratedExpression, generatedExpression);
+        GeneratedReference generatedReferenceInfo = new GeneratedReference(simpleRef, generatedExpression);
 
         BytesStreamOutput out = new BytesStreamOutput();
         Reference.toStream(out, generatedReferenceInfo);
@@ -91,7 +91,6 @@ public class GeneratedReferenceTest extends CrateDummyClusterServiceUnitTest {
         Symbol dateTrunc = executor.asSymbol("date_trunc('year', a::timestamp)");
         var generatedReference = new GeneratedReference(
             simpleRef,
-            "date_trunc('year', a::timestamp)",
             dateTrunc
         );
         Symbol cast = generatedReference.cast(DataTypes.STRING, CastMode.EXPLICIT);

--- a/server/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -863,7 +863,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
 
         LogicalPlan plan = e.logicalPlan("select 1 from t_pk_part_generated where ts = 0");
         assertThat(plan).isEqualTo(
-            "Get[doc.t_pk_part_generated | 1 | DocKeys{0::bigint, 0::bigint} | ((ts = 0::bigint) AND (p AS date_trunc('day', ts) = 0::bigint))]"
+            "Get[doc.t_pk_part_generated | 1 | DocKeys{0::bigint, 0::bigint} | ((ts = 0::bigint) AND (p = 0::bigint))]"
         );
     }
 

--- a/server/src/test/java/io/crate/planner/WhereClauseOptimizerTest.java
+++ b/server/src/test/java/io/crate/planner/WhereClauseOptimizerTest.java
@@ -181,7 +181,7 @@ public class WhereClauseOptimizerTest extends CrateDummyClusterServiceUnitTest {
         WhereClauseOptimizer.DetailedQuery query = optimize(
             "select * from partdatebin where ts > '2023-05-01'");
         assertThat(query.query()).isSQL(
-            "((doc.partdatebin.ts > 1682899200000::bigint) AND (month AS date_bin('P28D'::interval, ts, 0::bigint) >= 1681344000000::bigint))"
+            "((doc.partdatebin.ts > 1682899200000::bigint) AND (month >= 1681344000000::bigint))"
         );
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Resolves https://github.com/crate/crate/issues/10297

Add support for renaming columns that are top-level or sub-columns of partitioned/non-partitioned tables that are also part of constraints, partitioned by, clustered by, or generated columns.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
