### PR TITLE
Add jcmd to bundled JDK

### DIFF
--- a/docs/appendices/release-notes/5.5.1.rst
+++ b/docs/appendices/release-notes/5.5.1.rst
@@ -49,6 +49,8 @@ See the :ref:`version_5.5.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Re-added ``jcmd`` to the bundled JDK distribution.
+
 - Return meaningful error when trying to drop a column which itself or its
   sub-columns participates in a
   :ref:`table level constraint with other columns <check_constraint_multiple_cols>`.

--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,8 @@
 
             <!-- To support -XX:StartFlightRecording=[...] -->
             <addModule>jdk.jfr</addModule>
+
+            <addModule>jdk.jcmd</addModule>
           </addModules>
         </configuration>
       </plugin>


### PR DESCRIPTION
With the switch to jlink to bundle the JDK we missed to include jcmd.
On regular machines it could be installed separately, but for docker it's
nice if we bundle it.

Some of the CrateDB cloud alerts mention using jcmd to take heap dumps
or trigger JFR recordings
