### PR TITLE
Change reproduction info for failed server tests

### DIFF
--- a/server/src/testFixtures/java/org/elasticsearch/test/junit/listeners/ReproduceInfoPrinter.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/junit/listeners/ReproduceInfoPrinter.java
@@ -75,7 +75,7 @@ public class ReproduceInfoPrinter extends RunListener {
 
         final String mvnw = Constants.WINDOWS ? "mvnw" : "./mvnw";
         final StringBuilder b = new StringBuilder("REPRODUCE WITH: " + mvnw);
-        b.append(" -pl server test");
+        b.append(" -P server test");
         b.append(" \"-Dtest=");
         b.append(failure.getDescription().getClassName());
         String methodName = failure.getDescription().getMethodName();


### PR DESCRIPTION
Use profile `-P server` to build dependencies as required and avoid the intermediate `install -DskipTests=true` maven goal.

Follows: #14932
