### PR TITLE
Fix docs and failure reproduction info for test method filtering

### DIFF
--- a/devs/docs/tests.rst
+++ b/devs/docs/tests.rst
@@ -70,7 +70,8 @@ value for the remainder of your terminal session.
 
 Filter tests::
 
-    $ ./mvnw '-Dtest=PlannerTest#testSet*' test -pl server
+    $ ./mvnw test -pl server -Dtest=PlannerTest -Dtests.method=testSetTimeZone
+    $ ./mvnw test -pl server -Dtest=PlannerTest '-Dtests.method=testSetTime*'
 
 Extra options::
 

--- a/server/src/testFixtures/java/org/elasticsearch/test/junit/listeners/ReproduceInfoPrinter.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/junit/listeners/ReproduceInfoPrinter.java
@@ -76,14 +76,13 @@ public class ReproduceInfoPrinter extends RunListener {
         final String mvnw = Constants.WINDOWS ? "mvnw" : "./mvnw";
         final StringBuilder b = new StringBuilder("REPRODUCE WITH: " + mvnw);
         b.append(" -pl server test");
-        b.append(" \"-Dtest=");
+        b.append(" -Dtest=");
         b.append(failure.getDescription().getClassName());
         String methodName = failure.getDescription().getMethodName();
         if (methodName != null) {
-            b.append("#");
+            b.append(" -Dtests.method=");
             b.append(methodName);
         }
-        b.append("\"");
         MessageBuilder messageBuilder = new MessageBuilder(b);
         messageBuilder.appendAllOpts(failure.getDescription());
 


### PR DESCRIPTION
`-Dtest=<className>#<classMethod>` doesn't work in combination with `-Dtests.iters=<iterations>`, so use the `-Dtest=<className> -Dtests.method=<methodName>` instead.
