### PR TITLE
Test: add test_named_primary_key_constraint_names_are_visible()

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -450,4 +450,11 @@ public class PgCatalogITest extends IntegTestCase {
             """;
         assertThat(TestingHelpers.printedTable(response.rows())).isEqualToIgnoringWhitespace(pgAttributeRows);
     }
+
+    @Test
+    public void test_named_primary_key_constraint_names_are_visible() {
+        execute("create table t (aa int constraint c_aa primary key)");
+        execute("select conname from pg_catalog.pg_constraint where conname = 'c_aa'");
+        assertThat(response).hasRows("c_aa");
+    }
 }


### PR DESCRIPTION
Follows https://github.com/crate/crate/pull/14999.
Enabling PK names to be visible in `information_schema.table_constraints` also enabled `pg_catalog.pg_constraint`. This PR is just to add the missing test.