### PR TITLE
Move check constraint positions extractions into ConstraintInfo

### DIFF
--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/CheckConstraint.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/CheckConstraint.java
@@ -21,7 +21,6 @@
 
 package io.crate.sql.tree;
 
-import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
 
@@ -35,18 +34,12 @@ public class CheckConstraint<T> extends TableElement<T> {
     private final String columnName;
     private final T expression;
     private final String expressionStr;
-    private final List<Short> positions;
 
     public CheckConstraint(@Nullable String name, @Nullable String columnName, T expression, String expressionStr) {
-        this(name, columnName, expression, expressionStr, List.of());
-    }
-
-    public CheckConstraint(@Nullable String name, @Nullable String columnName, T expression, String expressionStr, List<Short> positions) {
         this.name = name;
         this.columnName = columnName;
         this.expression = expression;
         this.expressionStr = expressionStr;
-        this.positions = positions;
     }
 
     @Nullable
@@ -65,10 +58,6 @@ public class CheckConstraint<T> extends TableElement<T> {
 
     public String expressionStr() {
         return expressionStr;
-    }
-
-    public List<Short> positions() {
-        return positions;
     }
 
     @Override

--- a/server/src/main/java/io/crate/metadata/doc/DocIndexMetadata.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocIndexMetadata.java
@@ -57,7 +57,6 @@ import io.crate.common.Booleans;
 import io.crate.common.collections.Lists2;
 import io.crate.common.collections.MapBuilder;
 import io.crate.common.collections.Maps;
-import io.crate.expression.symbol.DefaultTraversalSymbolVisitor;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.CoordinatorTxnCtx;
@@ -739,9 +738,7 @@ public class DocIndexMetadata {
                     String expressionStr = entry.getValue();
                     Expression expr = SqlParser.createExpression(expressionStr);
                     Symbol analyzedExpr = exprAnalyzer.convert(expr, analysisCtx);
-                    ArrayList<Short> positions = new ArrayList<>();
-                    analyzedExpr.accept(RefCollector.REF_COLLECTOR_INSTANCE, positions);
-                    checkConstraintsBuilder.add(new CheckConstraint<>(name, null, analyzedExpr, expressionStr, positions));
+                    checkConstraintsBuilder.add(new CheckConstraint<>(name, null, analyzedExpr, expressionStr));
                 }
             }
         }
@@ -825,17 +822,6 @@ public class DocIndexMetadata {
 
     public Settings tableParameters() {
         return tableParameters;
-    }
-
-    private static class RefCollector extends DefaultTraversalSymbolVisitor<List<Short>, Void> {
-
-        private static final RefCollector REF_COLLECTOR_INSTANCE = new RefCollector();
-
-        @Override
-        public Void visitReference(Reference reference, List<Short> context) {
-            context.add(Short.valueOf((short) reference.position()));
-            return null;
-        }
     }
 
     @SuppressWarnings("unchecked")

--- a/server/src/main/java/io/crate/metadata/table/ConstraintInfo.java
+++ b/server/src/main/java/io/crate/metadata/table/ConstraintInfo.java
@@ -21,11 +21,12 @@
 
 package io.crate.metadata.table;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import io.crate.expression.symbol.RefVisitor;
 import io.crate.metadata.RelationInfo;
 import io.crate.metadata.RelationName;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * This class is used as information store of table constraints when
@@ -77,11 +78,19 @@ public class ConstraintInfo {
     private static List<Short> getConstraintColumnIndices(RelationInfo relationInfo, String constraintName, Type constraintType) {
         if (relationInfo instanceof TableInfo tableInfo) {
             if (constraintType == Type.PRIMARY_KEY) {
-                return relationInfo.primaryKey().stream().map(column -> (short) tableInfo.getReference(column).position()).collect(Collectors.toList());
+                return relationInfo.primaryKey().stream()
+                    .map(column -> (short) tableInfo.getReference(column).position())
+                    .toList();
             } else if (constraintType == Type.CHECK) {
                 return tableInfo.checkConstraints().stream()
                     .filter(checkConstraint -> checkConstraint.name().equals(constraintName))
-                    .map(checkConstraint -> checkConstraint.positions())
+                    .map(checkConstraint -> {
+                        List<Short> positions = new ArrayList<>();
+                        RefVisitor.visitRefs(checkConstraint.expression(), r -> {
+                            positions.add((short) r.position());
+                        });
+                        return positions;
+                    })
                     .findFirst().orElse(List.of());
             }
         }


### PR DESCRIPTION
There were two constructors of `CheckConstraint`, and one allowed to
create inconsistent instances by omitting the positions.

A solution would be to move the positions extraction into the
constructor, but given that the `positions` of `CheckConstraint` aren't
generally useful, this instead removes the `positions` and moves the
logic into `ConstraintInfo`, which is the only place where they're used.
