### PR TITLE
Remove unused table size from HashJoinPhase

### DIFF
--- a/server/src/main/java/io/crate/planner/operators/HashJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/HashJoin.java
@@ -177,8 +177,8 @@ public class HashJoin extends AbstractJoinPlan {
             InputColumns.create(lhsHashSymbols, new InputColumns.SourceSymbols(leftOutputs)),
             InputColumns.create(rhsHashSymbols, new InputColumns.SourceSymbols(rightOutputs)),
             Symbols.typeView(leftOutputs),
-            lhStats.estimateSizeForColumns(leftOutputs),
-            lhStats.numDocs());
+            lhStats.estimateSizeForColumns(leftOutputs)
+        );
         return new Join(
             joinPhase,
             leftExecutionPlan,

--- a/server/src/test/java/io/crate/planner/node/dql/JoinPhaseTest.java
+++ b/server/src/test/java/io/crate/planner/node/dql/JoinPhaseTest.java
@@ -149,8 +149,7 @@ public class JoinPhaseTest extends ESTestCase {
             List.of(Literal.of("testLeft"), Literal.of(10)),
             List.of(Literal.of("testRight"), Literal.of(20)),
             List.of(DataTypes.STRING, DataTypes.INTEGER),
-            111,
-            222);
+            111);
 
         BytesStreamOutput output = new BytesStreamOutput();
         node.writeTo(output);
@@ -174,6 +173,5 @@ public class JoinPhaseTest extends ESTestCase {
         assertThat(node.numRightOutputs(), is(node2.numRightOutputs()));
         assertThat(node.leftOutputTypes(), is(node2.leftOutputTypes()));
         assertThat(node.estimatedRowSizeForLeft(), is(node2.estimatedRowSizeForLeft()));
-        assertThat(node.numberOfRowsForLeft(), is(node2.numberOfRowsForLeft()));
     }
 }


### PR DESCRIPTION
Block size calculation no longer rely on the table size starting from https://github.com/crate/crate/commit/df3d28ed7bd2d466a8ce13e8be427fe89acefcb6

`HashJoinPhase.numberOfRowsForLeft` was used only in tests

