### PR TITLE
Fix a couple of doc issues

### DIFF
--- a/docs/appendices/release-notes/4.8.0.rst
+++ b/docs/appendices/release-notes/4.8.0.rst
@@ -49,8 +49,7 @@ SQL Statements and Compatibility
 - Implemented cancelling requests section of PostgreSQL wire protocol.
 
 - Added a ``WITH`` clause parameter, ``validation`` to ``COPY FROM`` which
-  can enable or disable the newly added type validation feature. Please see
-  :ref:`validation <sql-copy-from-validation>` for more details.
+  can enable or disable the newly added type validation feature.
 
 - Added type validation logic to ``COPY FROM``. Now raw data will be parsed and
   validated against the target table schema and casted if possible utilizing

--- a/docs/config/session.rst
+++ b/docs/config/session.rst
@@ -226,7 +226,7 @@ releases.
 
 .. vale on
 
-.... _experimental-warning:
+.. _experimental-warning:
 
 .. WARNING::
 


### PR DESCRIPTION
- Fix experimental_warning reference
- Remove ref to `sql-copy-from-validation in 4.8.0 release notes as this setting (and ref) has been removed with: #14654
