### PR TITLE
 Fix not and != query generation on case expressions

### DIFF
--- a/docs/appendices/release-notes/5.4.6.rst
+++ b/docs/appendices/release-notes/5.4.6.rst
@@ -46,4 +46,6 @@ See the :ref:`version_5.4.0` release notes for a full list of changes in the
 Fixes
 =====
 
-None
+- Fixed an issue that caused queries with a ``NOT`` or ``!=`` on a ``CASE``
+  expression containing a nullable column to exclude ``NULL`` entries.
+

--- a/docs/appendices/release-notes/5.5.1.rst
+++ b/docs/appendices/release-notes/5.5.1.rst
@@ -49,6 +49,9 @@ See the :ref:`version_5.5.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that caused queries with a ``NOT`` or ``!=`` on a ``CASE``
+  expression containing a nullable column to exclude ``NULL`` entries.
+
 - Re-added ``jcmd`` to the bundled JDK distribution.
 
 - Return meaningful error when trying to drop a column which itself or its

--- a/server/src/main/java/io/crate/expression/predicate/NotPredicate.java
+++ b/server/src/main/java/io/crate/expression/predicate/NotPredicate.java
@@ -37,6 +37,7 @@ import io.crate.expression.operator.any.AnyEqOperator;
 import io.crate.expression.operator.any.AnyNeqOperator;
 import io.crate.expression.operator.any.AnyRangeOperator;
 import io.crate.expression.scalar.Ignore3vlFunction;
+import io.crate.expression.scalar.conditional.CaseFunction;
 import io.crate.expression.scalar.conditional.CoalesceFunction;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
@@ -132,7 +133,8 @@ public class NotPredicate extends Scalar<Boolean, Boolean> {
                 AnyRangeOperator.Comparison.LTE.opName(),
                 LikeOperators.ANY_LIKE,
                 LikeOperators.ANY_NOT_LIKE,
-                CoalesceFunction.NAME
+                CoalesceFunction.NAME,
+                CaseFunction.NAME
             );
 
         @Override

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -28,6 +28,7 @@ import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -1609,7 +1610,7 @@ public class TransportSQLActionTest extends IntegTestCase {
         assertThat(response).hasRowCount(1L);
 
         execute("SELECT b, i FROM t WHERE NOT (coalesce(b, false) = true AND i IS NULL)");
-        assertThat(response).hasRowCount(2L);
+        assertThat(response).hasRowCount(3L);
     }
 
     @Test

--- a/server/src/test/java/io/crate/lucene/ThreeValuedLogicQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/ThreeValuedLogicQueryBuilderTest.java
@@ -21,7 +21,7 @@
 
 package io.crate.lucene;
 
-import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.lucene.search.Query;
 import org.junit.Test;
@@ -31,9 +31,9 @@ public class ThreeValuedLogicQueryBuilderTest extends LuceneQueryBuilderTest {
     @Test
     public void testNotAnyEqWith3vl() {
         assertThat(convert("NOT 10 = ANY(y_array)")).hasToString(
-            "+(+*:* -y_array:[10 TO 10]) +(+*:* -((10::bigint = ANY(y_array)) IS NULL))");
+            "+(+*:* -y_array:[10 TO 10]) #(NOT (10::bigint = ANY(y_array)))");
         assertThat(convert("NOT d = ANY([1,2,3])")).hasToString(
-            "+(+*:* -d:{1.0 2.0 3.0}) +(+*:* -((d = ANY([1.0, 2.0, 3.0])) IS NULL))");
+            "+(+*:* -d:{1.0 2.0 3.0}) #(NOT (d = ANY([1.0, 2.0, 3.0])))");
     }
 
     @Test


### PR DESCRIPTION
Similar to `coalesce`, `case` can match if used in a `!=` or `NOT`
operator, despite containing columns where the value is `NULL`.

The query building logic added an implicit `<column> is null` for every
`<column>` contained in the case expression, breaking the query.