### PR TITLE
docs: Update syntax for CREATE USER

### DIFF
--- a/docs/sql/statements/create-user.rst
+++ b/docs/sql/statements/create-user.rst
@@ -17,7 +17,8 @@ Synopsis
 .. code-block:: psql
 
   CREATE USER username
-  [ WITH ( user_parameter = value [, ...]) ]
+  [ WITH ( user_parameter = value [, ...]) ] |
+  [ [ WITH ] user_parameter [value] [ ... ] ]
 
 Description
 ===========
@@ -51,4 +52,18 @@ Clauses
 The following ``user_parameter`` are supported to define a new user account:
 
 :password:
-  The password as cleartext entered as string literal.
+  The password as cleartext entered as string literal. e.g.::
+
+     CREATE USER john WITH (password='foo')
+
+  ::
+
+     CREATE USER john WITH password='foo'
+
+  ::
+
+     CREATE USER john WITH password 'foo'
+
+  ::
+
+     CREATE USER john password 'foo'


### PR DESCRIPTION
Update syntax for `CREATE USER` statement as with #15041 we also allow the PostgreSQL syntax.
