### PR TITLE
Fix filter push-down in nested-joins

### DIFF
--- a/docs/appendices/release-notes/5.5.1.rst
+++ b/docs/appendices/release-notes/5.5.1.rst
@@ -85,3 +85,7 @@ Fixes
 
   The hash-symbol generation for the join `t3.c = t2.b AND t1.a = t2.b` was
   broken and would not join the data.
+
+- Fixed a regression introduced in 5.5.0 that caused the loss of filter
+  conditions in nested-joins when the query was optimized by the rule
+  ``optimizer_move_filter_beneath_join``.

--- a/server/src/main/java/io/crate/planner/optimizer/rule/FilterOnJoinsUtil.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/FilterOnJoinsUtil.java
@@ -21,6 +21,8 @@
 
 package io.crate.planner.optimizer.rule;
 
+import static java.util.Objects.requireNonNullElse;
+
 import io.crate.analyze.WhereClause;
 import io.crate.analyze.relations.QuerySplitter;
 import io.crate.common.collections.Sets;
@@ -85,11 +87,11 @@ final class FilterOnJoinsUtil {
 
                 if (matchesRhs.isEmpty() == false && matchesLhs.isEmpty()) {
                     // push filter to rhs
-                    newRhs = getNewSource(symbol, rhs);
+                    newRhs = getNewSource(symbol, requireNonNullElse(newRhs, rhs));
                     it.remove();
                 } else if (matchesRhs.isEmpty() && matchesLhs.isEmpty() == false) {
                     // push filter to lhs
-                    newLhs = getNewSource(symbol, lhs);
+                    newLhs = getNewSource(symbol, requireNonNullElse(newLhs, lhs));
                     it.remove();
                 }
             }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This fixes the filter push-down optimization rule `optimizer_move_filter_beneath_join`. Filter conditions can get lost when multiple constant filters are present in a nested-join query. 

Assume the following plan:

```
Filter[((a > 1) AND (b < 2))
  └ Join[INNER | (a = c)]
     ├ Join[INNER | (a = b)]
     │  ├ Collect[doc.t1 | [a] | true]
     │  └ Collect[doc.t2 | [b] | true]
     └ Collect[doc.t3 | [c] | true]
```

applying `optimizer_move_filter_beneath_join` will wrongly transform the plan to:

```
Join[INNER | (a = c)]
  ├ Filter[(b < 2)]
  │    └ Join[INNER | (a = b)]
  │      ├ Collect[doc.t1 | [a] | true]
  │      └ Collect[doc.t2 | [b] | true]
  └ Collect[doc.t3 | [c] | true]
```

The filter condition `a > 1` is lost because it got overridden while pushing down the filter condition `b < 2`.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
