### PR TITLE
Docs: references to overload protection for copy and insert from query

### DIFF
--- a/docs/sql/statements/copy-from.rst
+++ b/docs/sql/statements/copy-from.rst
@@ -51,6 +51,10 @@ Here's an example:
     cr> COPY quotes FROM 'file:///tmp/import_data/quotes.json';
     COPY OK, 3 rows affected (... sec)
 
+.. NOTE::
+
+    The ``COPY`` statements use :ref:`Overload Protection <overload_protection>` to ensure other
+    queries can still perform. Please change these settings during large inserts if needed.
 
 .. _sql-copy-from-formats:
 

--- a/docs/sql/statements/copy-to.rst
+++ b/docs/sql/statements/copy-to.rst
@@ -61,6 +61,8 @@ Here's an example:
    Currently only user tables can be exported. System tables like ``sys.nodes``
    and blob tables don't work with the ``COPY TO`` statement.
 
+   The ``COPY`` statements use :ref:`Overload Protection <overload_protection>` to ensure other
+   queries can still perform. Please change these settings during large inserts if needed.
 
 .. _sql-copy-to-params:
 

--- a/docs/sql/statements/insert.rst
+++ b/docs/sql/statements/insert.rst
@@ -93,6 +93,10 @@ will attempt automatic :ref:`type conversion <data-types-casting>`.
     the number of rows for which the ``INSERT`` succeeded.
     Please refer to :ref:`dml` for more details.
 
+    Inserting data from a query uses :ref:`Overload Protection <overload_protection>` 
+    to ensure other queries can still perform. Please change these settings during 
+    large inserts if needed.
+
 The optional ``RETURNING`` clause causes the ``INSERT`` statement to compute
 and return values from each row inserted (or updated, in the case of ``ON
 CONFLICT DO UPDATE``). You can take advantage of this behavior to obtain values


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

- Documentation improvement: Added references to overload protection for insert and copy statements to increase understanding why these statements might be slow if the cluster is under load.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes
