### PR TITLE
Change drop column to operate on DocTable, then serialize to mapping

### DIFF
--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/CheckConstraint.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/CheckConstraint.java
@@ -23,6 +23,7 @@ package io.crate.sql.tree;
 
 import java.util.Objects;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -47,6 +48,10 @@ public class CheckConstraint<T> extends TableElement<T> {
 
     public T expression() {
         return expression;
+    }
+
+    public <U> CheckConstraint<U> map(Function<? super T, ? extends U> mapper) {
+        return new CheckConstraint<U>(name, mapper.apply(expression), expressionStr);
     }
 
     public String expressionStr() {

--- a/server/src/main/java/io/crate/analyze/BoundCreateTable.java
+++ b/server/src/main/java/io/crate/analyze/BoundCreateTable.java
@@ -73,7 +73,7 @@ public record BoundCreateTable(
         return Lists2.map(partitionedByColumns, BoundCreateTable::toPartitionMapping);
     }
 
-    private static List<String> toPartitionMapping(Symbol symbol) {
+    public static List<String> toPartitionMapping(Symbol symbol) {
         String fqn = Symbols.pathFromSymbol(symbol).fqn();
         String typeMappingName = DataTypes.esMappingNameFrom(symbol.valueType().id());
         return List.of(fqn, typeMappingName);

--- a/server/src/main/java/io/crate/execution/ddl/tables/DropColumnTask.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/DropColumnTask.java
@@ -21,45 +21,15 @@
 
 package io.crate.execution.ddl.tables;
 
-import static io.crate.execution.ddl.tables.MappingUtil.removeConstraints;
-import static io.crate.execution.ddl.tables.MappingUtil.toProperties;
-import static io.crate.metadata.Reference.buildTree;
-import static io.crate.metadata.cluster.AlterTableClusterStateExecutor.resolveIndices;
-
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
-import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
-import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
-import org.elasticsearch.common.settings.IndexScopedSettings;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.index.Index;
-import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.MapperService;
 
-import io.crate.analyze.AlterTableDropColumnAnalyzer;
-import io.crate.analyze.DropColumn;
 import io.crate.common.CheckedFunction;
-import io.crate.common.collections.Lists2;
-import io.crate.common.collections.Maps;
-import io.crate.exceptions.ColumnUnknownException;
-import io.crate.execution.ddl.tables.MappingUtil.AllocPosition;
-import io.crate.expression.symbol.RefVisitor;
-import io.crate.expression.symbol.Symbols;
-import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.PartitionName;
-import io.crate.metadata.Reference;
-import io.crate.metadata.cluster.DDLClusterStateHelpers;
 import io.crate.metadata.cluster.DDLClusterStateTaskExecutor;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.doc.DocTableInfoFactory;
@@ -76,159 +46,20 @@ public final class DropColumnTask extends DDLClusterStateTaskExecutor<DropColumn
     @Override
     public ClusterState execute(ClusterState currentState, DropColumnRequest request) throws Exception {
         DocTableInfoFactory docTableInfoFactory = new DocTableInfoFactory(nodeContext);
-        DocTableInfo currentTable = docTableInfoFactory.create(request.relationName(), currentState.metadata());
-
-        List<DropColumn> normalizedColumns = AlterTableDropColumnAnalyzer.validateDynamic(
-            currentTable, normalizeColumns(request, currentTable));
-
-        if (normalizedColumns.isEmpty()) {
+        Metadata metadata = currentState.metadata();
+        DocTableInfo currentTable = docTableInfoFactory.create(request.relationName(), metadata);
+        DocTableInfo changedTable = currentTable.dropColumns(request.colsToDrop());
+        if (changedTable == currentTable) {
             return currentState;
         }
-
-        var refsToDrop = Lists2.map(normalizedColumns, dc -> dc.ref().withDropped(true));
-
-        // Prepare columns tree, it will be used twice:
-        // 1. For creating mapping for dropped columns.
-        // 2. For creating "path-only, no properties" mapping to remove.
-        List<Reference> references = new ArrayList<>(refsToDrop);
-        for (var colToDrop : refsToDrop) {
-            ColumnIdent parent = colToDrop.column();
-            while ((parent = parent.getParent()) != null) {
-                if (!Symbols.containsColumn(refsToDrop, parent)
-                    && !Symbols.containsColumn(references, parent)) {
-                    references.add(currentTable.getReference(parent));
-                }
-            }
-        }
-        // Add relevant constraints to be removed
-        Set<String> constraintsToRemove = new HashSet<>();
-        for (var constraint : currentTable.checkConstraints()) {
-            Set<ColumnIdent> columnsInConstraint = new HashSet<>();
-            RefVisitor.visitRefs(constraint.expression(), r -> columnsInConstraint.add(r.column()));
-
-            if (columnsInConstraint.stream().allMatch(
-                columnInConstraint -> {
-                    for (var refToDrop : refsToDrop) {
-                        if (columnInConstraint.equals(refToDrop.column()) || columnInConstraint.isChildOf(refToDrop.column())) {
-                            return true;
-                        }
-                    }
-                    return false;
-                })) {
-                constraintsToRemove.add(constraint.name());
-            }
-        }
-
-        HashMap<ColumnIdent, List<Reference>> tree = buildTree(references);
-        Map<String, Map<String, Object>> properties = toProperties(AllocPosition.forTable(currentTable), tree);
-        Map<String, String> constraintsToRemoveAsMap = constraintsToRemove
-            .stream().collect(Collectors.toMap(c -> c, c -> ""));
-        Map<String, Object> mapping =
-            Map.of("_meta", Map.of("check_constraints", constraintsToRemoveAsMap),
-                "properties", properties);
-        Map<String, Object> mappingToRemove =
-            Map.of("_meta", Map.of("check_constraints", constraintsToRemoveAsMap),
-                "properties", MappingUtil.toNamesOnlyProperties(tree));
-
-        Metadata.Builder metadataBuilder = Metadata.builder(currentState.metadata());
-        String templateName = PartitionName.templateName(request.relationName().schema(), request.relationName().name());
-        IndexTemplateMetadata indexTemplateMetadata = currentState.metadata().templates().get(templateName);
-        if (indexTemplateMetadata != null) {
-            // Partitioned table
-            IndexTemplateMetadata newIndexTemplateMetadata = DDLClusterStateHelpers.updateTemplate(
-                indexTemplateMetadata,
-                mapping,
-                mappingToRemove,
-                Settings.EMPTY,
-                IndexScopedSettings.DEFAULT_SCOPED_SETTINGS // Not used if new settings are empty
-            );
-            metadataBuilder.put(newIndexTemplateMetadata);
-        }
-
-        currentState = updateMapping(
-            currentState,
-            metadataBuilder,
-            request.relationName().indexNameOrAlias(),
-            properties,
-            mappingToRemove,
-            constraintsToRemove
-        );
-        // ensure the table can still be parsed into a DocTableInfo to avoid breaking the table.
-        docTableInfoFactory.create(request.relationName(), currentState.metadata());
-        return currentState;
-    }
-
-
-    /**
-     * Replace existing references by taking them from the cluster state (so that we get an actual version with assigned OID).
-     */
-    static List<DropColumn> normalizeColumns(DropColumnRequest request, DocTableInfo currentTable) {
-        List<DropColumn> dropColumns = new ArrayList<>();
-
-        // Get existing references
-        for (var colToDrop : request.colsToDrop()) {
-            var col = colToDrop.ref().column();
-            Reference ref = currentTable.getReference(col);
-            if (ref == null || ref.isDropped()) {
-                if (colToDrop.ifExists() == false) {
-                    throw new ColumnUnknownException(col, currentTable.ident());
-                }
-            } else {
-                dropColumns.add(new DropColumn(ref, colToDrop.ifExists())); // Actually a column to drop, Get updated reference from the cluster state.
-            }
-        }
-        return dropColumns;
-    }
-
-    private ClusterState updateMapping(ClusterState currentState,
-                                       Metadata.Builder metadataBuilder,
-                                       String indexName,
-                                       Map<String, Map<String, Object>> propertiesMap,
-                                       Map<String, Object> mappingToRemove,
-                                       Set<String> constraintsToRemove) throws IOException {
-        Index[] concreteIndices = resolveIndices(currentState, indexName);
-
-        for (Index index : concreteIndices) {
-            final IndexMetadata indexMetadata = currentState.metadata().getIndexSafe(index);
-
-            Map<String, Object> indexMapping = indexMetadata.mapping().sourceAsMap();
-            removeConstraints(indexMapping, constraintsToRemove);
-
-            mergeDeltaIntoExistingMapping(indexMapping, propertiesMap);
-            indexMapping = DDLClusterStateHelpers.removeFromMapping(indexMapping, mappingToRemove);
-
-            MapperService mapperService = createMapperService.apply(indexMetadata);
-
-            DocumentMapper mapper = mapperService.merge(indexMapping, MapperService.MergeReason.MAPPING_UPDATE);
-
-            IndexMetadata.Builder imBuilder = IndexMetadata.builder(indexMetadata);
-            imBuilder.putMapping(new MappingMetadata(mapper.mappingSource())).mappingVersion(1 + imBuilder.mappingVersion());
-
-            metadataBuilder.put(imBuilder); // implicitly increments metadata version.
-        }
-
-        return ClusterState.builder(currentState).metadata(metadataBuilder).build();
-    }
-
-    @SuppressWarnings("unchecked")
-    private static void mergeDeltaIntoExistingMapping(Map<String, Object> existingMapping,
-                                                      Map<String, Map<String, Object>> propertiesMap) {
-
-        Map<String, Object> meta = (Map<String, Object>) existingMapping.get("_meta");
-        if (meta == null) {
-            // existingMapping passed as an empty map in case of partitioned tables as template gets all changes unfiltered.
-            // Create _meta so that we have a base to merge constraints.
-            meta = new HashMap<>();
-            existingMapping.put("_meta", meta);
-        }
-
-        existingMapping.merge(
-            "properties",
-            propertiesMap,
-            (oldMap, newMap) -> {
-                Maps.extendRecursive((Map<String, Object>) oldMap, (Map<String, Object>) newMap);
-                return oldMap;
-            }
-        );
+        Metadata.Builder metadataBuilder = Metadata.builder(metadata);
+        Metadata newMetadata = changedTable
+            .writeTo(createMapperService, metadata, metadataBuilder)
+            .build();
+        // Ensure table can still be parsed
+        docTableInfoFactory.create(request.relationName(), newMetadata);
+        return ClusterState.builder(currentState)
+            .metadata(newMetadata)
+            .build();
     }
 }

--- a/server/src/main/java/io/crate/metadata/GeneratedReference.java
+++ b/server/src/main/java/io/crate/metadata/GeneratedReference.java
@@ -302,6 +302,15 @@ public class GeneratedReference implements Reference {
     }
 
     @Override
+    public Reference withValueType(DataType<?> type) {
+        return new GeneratedReference(
+            ref.withValueType(type),
+            formattedGeneratedExpression,
+            generatedExpression
+        );
+    }
+
+    @Override
     public long ramBytesUsed() {
         return SHALLOW_SIZE
             + ref.ramBytesUsed()

--- a/server/src/main/java/io/crate/metadata/GeoReference.java
+++ b/server/src/main/java/io/crate/metadata/GeoReference.java
@@ -202,6 +202,25 @@ public class GeoReference extends SimpleReference {
     }
 
     @Override
+    public GeoReference withValueType(DataType<?> newType) {
+        return new GeoReference(
+            ident,
+            newType,
+            columnPolicy,
+            indexType,
+            nullable,
+            position,
+            oid,
+            isDropped,
+            defaultExpression,
+            geoTree,
+            precision,
+            treeLevels,
+            distanceErrorPct
+        );
+    }
+
+    @Override
     public Map<String, Object> toMapping(int position) {
         Map<String, Object> mapping = super.toMapping(position);
         Maps.putNonNull(mapping, "tree", geoTree);

--- a/server/src/main/java/io/crate/metadata/IndexReference.java
+++ b/server/src/main/java/io/crate/metadata/IndexReference.java
@@ -284,6 +284,25 @@ public class IndexReference extends SimpleReference {
     }
 
     @Override
+    public IndexReference withValueType(DataType<?> newType) {
+        return new IndexReference(
+            ident,
+            granularity,
+            newType,
+            columnPolicy,
+            indexType,
+            nullable,
+            hasDocValues,
+            position,
+            oid,
+            isDropped,
+            defaultExpression,
+            columns,
+            analyzer
+        );
+    }
+
+    @Override
     public Map<String, Object> toMapping(int position) {
         Map<String, Object> mapping = super.toMapping(position);
         if (analyzer != null) {

--- a/server/src/main/java/io/crate/metadata/Reference.java
+++ b/server/src/main/java/io/crate/metadata/Reference.java
@@ -40,6 +40,7 @@ import org.jetbrains.annotations.Nullable;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolType;
 import io.crate.sql.tree.ColumnPolicy;
+import io.crate.types.DataType;
 
 public interface Reference extends Symbol {
 
@@ -91,6 +92,8 @@ public interface Reference extends Symbol {
     Reference withColumnOid(LongSupplier oidSupplier);
 
     Reference withDropped(boolean dropped);
+
+    Reference withValueType(DataType<?> type);
 
     /**
      * Return the identifier of this column used inside the storage engine

--- a/server/src/main/java/io/crate/metadata/SimpleReference.java
+++ b/server/src/main/java/io/crate/metadata/SimpleReference.java
@@ -207,6 +207,23 @@ public class SimpleReference implements Reference {
     }
 
     @Override
+    public Reference withValueType(DataType<?> newType) {
+        return new SimpleReference(
+            ident,
+            granularity,
+            newType,
+            columnPolicy,
+            indexType,
+            nullable,
+            hasDocValues,
+            position,
+            oid,
+            isDropped,
+            defaultExpression
+        );
+    }
+
+    @Override
     public SymbolType symbolType() {
         return SymbolType.REFERENCE;
     }

--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
@@ -22,13 +22,16 @@
 package io.crate.metadata.doc;
 
 import static io.crate.expression.reference.doc.lucene.SourceParser.UNKNOWN_COLUMN_PREFIX;
-import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
 
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -40,16 +43,33 @@ import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
+import org.elasticsearch.cluster.metadata.MappingMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.index.mapper.MapperService;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import com.carrotsearch.hppc.IntArrayList;
+
+import io.crate.analyze.BoundCreateTable;
+import io.crate.analyze.DropColumn;
 import io.crate.analyze.NumberOfReplicas;
 import io.crate.analyze.WhereClause;
+import io.crate.common.CheckedFunction;
 import io.crate.common.collections.Lists2;
 import io.crate.exceptions.ColumnUnknownException;
+import io.crate.execution.ddl.tables.MappingUtil;
+import io.crate.execution.ddl.tables.MappingUtil.AllocPosition;
 import io.crate.expression.symbol.DynamicReference;
+import io.crate.expression.symbol.RefReplacer;
+import io.crate.expression.symbol.RefVisitor;
 import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.Symbols;
 import io.crate.expression.symbol.VoidReference;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.GeneratedReference;
@@ -69,6 +89,9 @@ import io.crate.metadata.table.StoredTable;
 import io.crate.metadata.table.TableInfo;
 import io.crate.sql.tree.CheckConstraint;
 import io.crate.sql.tree.ColumnPolicy;
+import io.crate.types.ArrayType;
+import io.crate.types.DataType;
+import io.crate.types.ObjectType;
 
 
 /**
@@ -211,7 +234,7 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
         this.indexColumns = indexColumns;
         leafNamesByOid = new HashMap<>();
         Stream.concat(Stream.concat(this.references.values().stream(), indexColumns.values().stream()), droppedColumns.stream())
-            .filter(r -> r.oid() != COLUMN_OID_UNASSIGNED)
+            .filter(r -> r.oid() != Metadata.COLUMN_OID_UNASSIGNED)
             .forEach(r -> leafNamesByOid.put(Long.toString(r.oid()), r.column().leafName()));
         this.analyzers = analyzers;
         this.ident = ident;
@@ -580,5 +603,195 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
         } else {
             return Function.identity();
         }
+    }
+
+
+    private void validateDropColumns(List<DropColumn> dropColumns) {
+        var leftOverCols = columns().stream().map(Reference::column).collect(Collectors.toSet());
+        for (int i = 0 ; i < dropColumns.size(); i++) {
+            var refToDrop = dropColumns.get(i).ref();
+            var colToDrop = refToDrop.column();
+            for (var indexRef : indexColumns()) {
+                if (indexRef.columns().contains(refToDrop)) {
+                    throw new UnsupportedOperationException("Dropping column: " + colToDrop.sqlFqn() + " which " +
+                                                            "is part of INDEX: " + indexRef + " is not allowed");
+                }
+            }
+            for (var genRef : generatedColumns()) {
+                if (genRef.referencedReferences().contains(refToDrop)) {
+                    throw new UnsupportedOperationException(String.format(
+                        Locale.ENGLISH,
+                        "Cannot drop column `%s`. It's used in generated column `%s`: %s",
+                        colToDrop.sqlFqn(),
+                        genRef.column().sqlFqn(),
+                        genRef.formattedGeneratedExpression()
+                    ));
+                }
+            }
+            for (var checkConstraint : checkConstraints()) {
+                Set<ColumnIdent> columnsInConstraint = new HashSet<>();
+                RefVisitor.visitRefs(checkConstraint.expression(), r -> columnsInConstraint.add(r.column()));
+                if (columnsInConstraint.size() > 1 && columnsInConstraint.contains(colToDrop)) {
+                    throw new UnsupportedOperationException("Dropping column: " + colToDrop.sqlFqn() + " which " +
+                        "is used in CHECK CONSTRAINT: " + checkConstraint.name() + " is not allowed");
+                }
+                boolean constraintColIsSubColOfColToDrop = false;
+                for (var columnInConstraint : columnsInConstraint) {
+                    if (columnInConstraint.isChildOf(colToDrop)) {
+                        constraintColIsSubColOfColToDrop = true; // subcol of the dropped col referred in constraint
+                    }
+                }
+                if (constraintColIsSubColOfColToDrop) {
+                    for (var columnInConstraint : columnsInConstraint) {
+                        // Check if sibling, parent, or cols of another object are contained in the same constraint
+                        if (columnInConstraint.isChildOf(colToDrop) == false
+                            && columnInConstraint.path().equals(colToDrop.path()) == false) {
+                            throw new UnsupportedOperationException("Dropping column: " + colToDrop.sqlFqn() +
+                                " which is used in CHECK CONSTRAINT: " + checkConstraint.name() +
+                                " is not allowed");
+                        }
+                    }
+                }
+            }
+            leftOverCols.remove(colToDrop);
+        }
+        if (leftOverCols.isEmpty()) {
+            throw new UnsupportedOperationException("Dropping all columns of a table is not allowed");
+        }
+    }
+
+    public DocTableInfo dropColumns(List<DropColumn> columns) {
+        validateDropColumns(columns);
+        HashSet<Reference> toDrop = HashSet.newHashSet(columns.size());
+        HashMap<ColumnIdent, Reference> newReferences = new HashMap<>(references);
+        droppedColumns.forEach(ref -> newReferences.put(ref.column(), ref));
+        HashMap<Reference, Reference> changedReferences = new HashMap<>();
+        for (var column : columns) {
+            ColumnIdent columnIdent = column.ref().column();
+            Reference reference = references.get(columnIdent);
+            if (reference == null || reference.isDropped()) {
+                if (!column.ifExists()) {
+                    throw new ColumnUnknownException(columnIdent, ident);
+                }
+                continue;
+            }
+            ColumnIdent parent = columnIdent.getParent();
+            if (parent != null) {
+                Reference parentRef = references.get(parent);
+                DataType<?> parentType = parentRef.valueType();
+                int dimensions = ArrayType.dimensions(parentType);
+                DataType<?> parentTypeElement = ArrayType.unnest(parentType);
+                ObjectType newObjectType = ((ObjectType) parentTypeElement)
+                    .withoutChild(columnIdent.leafName());
+                DataType<?> newParentType = ArrayType.makeArray(newObjectType, dimensions);
+                Reference updatedParent = parentRef.withValueType(newParentType);
+                newReferences.replace(parent, updatedParent);
+                changedReferences.put(parentRef, updatedParent);
+            }
+            toDrop.add(reference.withDropped(true));
+            newReferences.replace(columnIdent, reference.withDropped(true));
+            for (var ref : references.values()) {
+                if (ref.column().isChildOf(columnIdent)) {
+                    toDrop.add(ref);
+                    newReferences.remove(ref.column());
+                }
+            }
+        }
+        if (toDrop.isEmpty()) {
+            return this;
+        }
+        Function<Symbol, Symbol> updateRef = symbol -> RefReplacer.replaceRefs(symbol, ref -> changedReferences.getOrDefault(ref, ref));
+        ArrayList<CheckConstraint<Symbol>> newCheckConstraints = new ArrayList<>(checkConstraints.size());
+        for (var constraint : checkConstraints) {
+            boolean drop = false;
+            for (var ref : toDrop) {
+                drop = Symbols.containsColumn(constraint.expression(), ref.column());
+                if (drop) {
+                    break;
+                }
+            }
+            if (!drop) {
+                newCheckConstraints.add(constraint.map(updateRef));
+            }
+        }
+        return new DocTableInfo(
+            ident,
+            newReferences,
+            indexColumns,
+            analyzers,
+            pkConstraintName,
+            primaryKeys,
+            newCheckConstraints,
+            clusteredBy,
+            concreteIndices,
+            concreteOpenIndices,
+            tableParameters,
+            partitionedBy,
+            partitions,
+            columnPolicy,
+            versionCreated,
+            versionUpgraded,
+            closed,
+            supportedOperations
+        );
+    }
+
+    public Metadata.Builder writeTo(CheckedFunction<IndexMetadata, MapperService, IOException> createMapperService,
+                                    Metadata metadata,
+                                    Metadata.Builder metadataBuilder) throws IOException {
+        List<Reference> allColumns = Stream.concat(references.values().stream(), droppedColumns.stream())
+            .filter(ref -> !ref.column().isSystemColumn())
+            .sorted(Reference.CMP_BY_POSITION_THEN_NAME)
+            .toList();
+        IntArrayList pKeyIndices = new IntArrayList(primaryKeys.size());
+        for (ColumnIdent pk : primaryKeys) {
+            int idx = Reference.indexOf(allColumns, pk);
+            if (idx >= 0) {
+                pKeyIndices.add(idx);
+            }
+        }
+        Map<String, String> checkConstraintMap = HashMap.newHashMap(checkConstraints.size());
+        for (var check : checkConstraints) {
+            checkConstraintMap.put(check.name(), check.expressionStr());
+        }
+        AllocPosition allocPosition = AllocPosition.forTable(this);
+        Map<String, Object> mapping = Map.of("default", MappingUtil.createMapping(
+            allocPosition,
+            pkConstraintName,
+            allColumns,
+            pKeyIndices,
+            checkConstraintMap,
+            Lists2.map(partitionedByColumns, BoundCreateTable::toPartitionMapping),
+            columnPolicy,
+            clusteredBy == DocSysColumns.ID ? null : clusteredBy.fqn()
+        ));
+        for (String indexName : concreteIndices) {
+            IndexMetadata indexMetadata = metadata.index(indexName);
+            if (indexMetadata == null) {
+                throw new UnsupportedOperationException("Cannot create index via DocTableInfo.writeTo");
+            }
+            MapperService mapperService = createMapperService.apply(indexMetadata);
+            DocumentMapper mapper = mapperService.merge(mapping, MapperService.MergeReason.MAPPING_UPDATE);
+            metadataBuilder.put(
+                IndexMetadata.builder(indexMetadata)
+                    .putMapping(new MappingMetadata(mapper.mappingSource()))
+                    .numberOfShards(numberOfShards)
+                    .mappingVersion(indexMetadata.getMappingVersion() + 1)
+            );
+        }
+        if (isPartitioned) {
+            String templateName = PartitionName.templateName(ident.schema(), ident.name());
+            IndexTemplateMetadata indexTemplateMetadata = metadata.templates().get(templateName);
+            if (indexTemplateMetadata == null) {
+                throw new UnsupportedOperationException("Cannot create template via DocTableInfo.writeTo");
+            }
+            Integer version = indexTemplateMetadata.getVersion();
+            var template = new IndexTemplateMetadata.Builder(indexTemplateMetadata)
+                .putMapping(Strings.toString(JsonXContent.builder().map(mapping)))
+                .version(version == null ? 1 : version + 1)
+                .build();
+            metadataBuilder.put(template);
+        }
+        return metadataBuilder;
     }
 }

--- a/server/src/main/java/io/crate/types/ObjectType.java
+++ b/server/src/main/java/io/crate/types/ObjectType.java
@@ -276,6 +276,12 @@ public class ObjectType extends DataType<Map<String, Object>> implements Streame
         return mergedObjectBuilder.build();
     }
 
+    public ObjectType withoutChild(String childColumn) {
+        LinkedHashMap<String, DataType<?>> newInnerTypes = new LinkedHashMap<>(innerTypes);
+        newInnerTypes.remove(childColumn);
+        return new ObjectType(Collections.unmodifiableMap(newInnerTypes));
+    }
+
     @Override
     public boolean equals(Object o) {
         if (!super.equals(o)) {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -38,8 +38,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 
-import org.jetbrains.annotations.Nullable;
-
 import org.elasticsearch.Assertions;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.support.ActiveShardCount;
@@ -68,6 +66,7 @@ import org.elasticsearch.gateway.MetadataStateFormat;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.rest.RestStatus;
+import org.jetbrains.annotations.Nullable;
 
 import com.carrotsearch.hppc.LongArrayList;
 import com.carrotsearch.hppc.cursors.IntObjectCursor;
@@ -798,7 +797,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
 
     public static class Builder {
 
-        private String index;
+        private String indexName;
         private State state = State.OPEN;
         private long version = 1;
         private long mappingVersion = 1;
@@ -811,15 +810,15 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         private final ImmutableOpenIntMap.Builder<Set<String>> inSyncAllocationIds;
         private Integer routingNumShards;
 
-        public Builder(String index) {
-            this.index = index;
+        public Builder(String indexName) {
+            this.indexName = indexName;
             this.aliases = ImmutableOpenMap.builder();
             this.customMetadata = ImmutableOpenMap.builder();
             this.inSyncAllocationIds = ImmutableOpenIntMap.builder();
         }
 
         public Builder(IndexMetadata indexMetadata) {
-            this.index = indexMetadata.getIndex().getName();
+            this.indexName = indexMetadata.getIndex().getName();
             this.state = indexMetadata.state;
             this.version = indexMetadata.version;
             this.mappingVersion = indexMetadata.mappingVersion;
@@ -834,11 +833,11 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         }
 
         public String index() {
-            return index;
+            return indexName;
         }
 
         public Builder index(String index) {
-            this.index = index;
+            this.indexName = index;
             return this;
         }
 
@@ -1046,26 +1045,26 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
 
             Integer maybeNumberOfShards = settings.getAsInt(SETTING_NUMBER_OF_SHARDS, null);
             if (maybeNumberOfShards == null) {
-                throw new IllegalArgumentException("must specify numberOfShards for index [" + index + "]");
+                throw new IllegalArgumentException("must specify numberOfShards for index [" + indexName + "]");
             }
             int numberOfShards = maybeNumberOfShards;
             if (numberOfShards <= 0) {
-                throw new IllegalArgumentException("must specify positive number of shards for index [" + index + "]");
+                throw new IllegalArgumentException("must specify positive number of shards for index [" + indexName + "]");
             }
 
             Integer maybeNumberOfReplicas = settings.getAsInt(SETTING_NUMBER_OF_REPLICAS, null);
             if (maybeNumberOfReplicas == null) {
-                throw new IllegalArgumentException("must specify numberOfReplicas for index [" + index + "]");
+                throw new IllegalArgumentException("must specify numberOfReplicas for index [" + indexName + "]");
             }
             int numberOfReplicas = maybeNumberOfReplicas;
             if (numberOfReplicas < 0) {
-                throw new IllegalArgumentException("must specify non-negative number of shards for index [" + index + "]");
+                throw new IllegalArgumentException("must specify non-negative number of shards for index [" + indexName + "]");
             }
 
             int routingPartitionSize = INDEX_ROUTING_PARTITION_SIZE_SETTING.get(settings);
             if (routingPartitionSize != 1 && routingPartitionSize >= getRoutingNumShards()) {
                 throw new IllegalArgumentException("routing partition size [" + routingPartitionSize + "] should be a positive number"
-                        + " less than the number of shards [" + getRoutingNumShards() + "] for [" + index + "]");
+                        + " less than the number of shards [" + getRoutingNumShards() + "] for [" + indexName + "]");
             }
             // fill missing slots in inSyncAllocationIds with empty set if needed and make all entries immutable
             ImmutableOpenIntMap.Builder<Set<String>> filledInSyncAllocationIds = ImmutableOpenIntMap.builder();
@@ -1124,7 +1123,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             final String uuid = settings.get(SETTING_INDEX_UUID, INDEX_UUID_NA_VALUE);
 
             return new IndexMetadata(
-                new Index(index, uuid),
+                new Index(indexName, uuid),
                 version,
                 mappingVersion,
                 settingsVersion,


### PR DESCRIPTION
We have several places where we directly modify the mapping of
`IndexMetadata` and `IndexTemplateMetadata`

One example is the `DropColumnTask`.
Manipulating the mapping directly is a bit tedious because of the
weak typing of `Map<String, Object>`.

This changes the approach:

- Use rich structures in `DocTableInfo` to alter the state
- Then write out the _full_ table to the cluster state/meta data

The same approach could then also be used for alter-table add column and rename column.