### PR TITLE
Remove columnName from CheckConstraint

### DIFF
--- a/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -1167,7 +1167,7 @@ class AstBuilder extends SqlBaseParserBaseVisitor<Node> {
         String name = ctx.CONSTRAINT() != null ? getIdentText(ctx.name) : null;
         Expression expression = (Expression) visit(ctx.expression);
         String expressionStr = ExpressionFormatter.formatStandaloneExpression(expression);
-        return new CheckConstraint<>(name, null, expression, expressionStr);
+        return new CheckConstraint<>(name, expression, expressionStr);
     }
 
     @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/CheckConstraint.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/CheckConstraint.java
@@ -30,14 +30,11 @@ public class CheckConstraint<T> extends TableElement<T> {
 
     @Nullable
     private final String name;
-    @Nullable
-    private final String columnName;
     private final T expression;
     private final String expressionStr;
 
-    public CheckConstraint(@Nullable String name, @Nullable String columnName, T expression, String expressionStr) {
+    public CheckConstraint(@Nullable String name, T expression, String expressionStr) {
         this.name = name;
-        this.columnName = columnName;
         this.expression = expression;
         this.expressionStr = expressionStr;
     }
@@ -47,10 +44,6 @@ public class CheckConstraint<T> extends TableElement<T> {
         return name;
     }
 
-    @Nullable
-    public String columnName() {
-        return columnName;
-    }
 
     public T expression() {
         return expression;
@@ -62,7 +55,7 @@ public class CheckConstraint<T> extends TableElement<T> {
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, columnName, expression);
+        return Objects.hash(name, expression);
     }
 
     @Override
@@ -75,8 +68,7 @@ public class CheckConstraint<T> extends TableElement<T> {
         }
         CheckConstraint<?> that = (CheckConstraint<?>) o;
         return Objects.equals(expression, that.expression) &&
-               Objects.equals(name, that.name) &&
-               Objects.equals(columnName, that.columnName);
+               Objects.equals(name, that.name);
     }
 
     @Override
@@ -93,7 +85,6 @@ public class CheckConstraint<T> extends TableElement<T> {
     public String toString() {
         return "CheckConstraint{" +
                "name='" + name + '\'' +
-               ", columnName='" + columnName + '\'' +
                ", expression=" + expression +
                '}';
     }

--- a/server/src/main/java/io/crate/analyze/MetadataToASTNodeResolver.java
+++ b/server/src/main/java/io/crate/analyze/MetadataToASTNodeResolver.java
@@ -110,7 +110,6 @@ public class MetadataToASTNodeResolver {
                 .stream()
                 .map(chk -> new CheckConstraint<>(
                     chk.name(),
-                    chk.columnName(),
                     SqlParser.createExpression(chk.expressionStr()),
                     chk.expressionStr()))
                 .forEach(elements::add);

--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfoFactory.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfoFactory.java
@@ -316,7 +316,7 @@ public class DocTableInfoFactory {
                 SqlParser.createExpression(expressionStr),
                 expressionAnalysisContext
             );
-            var checkConstraint = new CheckConstraint<>(name, null, expression, expressionStr);
+            var checkConstraint = new CheckConstraint<>(name, expression, expressionStr);
             result.add(checkConstraint);
         }
         return result;


### PR DESCRIPTION
It was always `null` and even if it weren't, it wasn't stored in the
metadata/mapping
