### PR TITLE
Infer not-null columns from references in DocTableInfo

### DIFF
--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfoFactory.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfoFactory.java
@@ -262,7 +262,6 @@ public class DocTableInfoFactory {
         return new DocTableInfo(
             relation,
             references,
-            notNullColumns,
             indexColumns.entrySet().stream()
                 .collect(Collectors.toMap(Entry::getKey, e -> e.getValue().build(references))),
             analyzers,

--- a/server/src/test/java/io/crate/metadata/doc/DocSchemaInfoTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocSchemaInfoTest.java
@@ -247,7 +247,6 @@ public class DocSchemaInfoTest extends CrateDummyClusterServiceUnitTest {
         return new DocTableInfo(
             new RelationName(Schemas.DOC_SCHEMA_NAME, name),
             Map.of(),
-            List.of(),
             Map.of(),
             Map.of(),
             null,

--- a/server/src/test/java/io/crate/metadata/doc/DocTableInfoTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocTableInfoTest.java
@@ -72,7 +72,6 @@ public class DocTableInfoTest extends CrateDummyClusterServiceUnitTest {
                     null
                 )
             ),
-            List.of(),
             Map.of(),
             Map.of(),
             null,
@@ -142,7 +141,6 @@ public class DocTableInfoTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo info = new DocTableInfo(
             dummy,
             references,
-            List.of(),
             Map.of(),
             Map.of(),
             null,
@@ -283,7 +281,6 @@ public class DocTableInfoTest extends CrateDummyClusterServiceUnitTest {
                             null
                     )
                 ),
-                List.of(),
                 Map.of(),
                 Map.of(),
                 null,

--- a/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
+++ b/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
@@ -384,7 +384,6 @@ public abstract class AggregationTestCase extends ESTestCase {
         DocTableInfo table = new DocTableInfo(
             new RelationName("doc", shard.shardId().getIndexName()),
             targetColumns.stream().collect(Collectors.toMap(Reference::column, r -> r)),
-            List.of(),
             Map.of(),
             Map.of(),
             null,


### PR DESCRIPTION
Removes another parameter from DocTableInfo that is redundant and
could've led to inconsistent instances.
