### PR TITLE
Fix ``NOT AND`` Expression for three-valued logic

### DIFF
--- a/docs/appendices/release-notes/5.4.6.rst
+++ b/docs/appendices/release-notes/5.4.6.rst
@@ -46,6 +46,9 @@ See the :ref:`version_5.4.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that caused queries with a ``NOT (a AND b)`` expression
+  in the where-clause to not evaluate correctly with null values.
+
 - Fixed an issue that caused queries with a ``NOT`` or ``!=`` on a ``CASE``
   expression containing a nullable column to exclude ``NULL`` entries.
 

--- a/docs/appendices/release-notes/5.5.1.rst
+++ b/docs/appendices/release-notes/5.5.1.rst
@@ -49,6 +49,9 @@ See the :ref:`version_5.5.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that caused queries with a ``NOT (a AND b)`` expression
+  in the where-clause to not evaluate correctly with null values.
+
 - Fixed an issue that caused queries with a ``NOT`` or ``!=`` on a ``CASE``
   expression containing a nullable column to exclude ``NULL`` entries.
 

--- a/server/src/main/java/io/crate/expression/predicate/NotPredicate.java
+++ b/server/src/main/java/io/crate/expression/predicate/NotPredicate.java
@@ -31,6 +31,7 @@ import org.apache.lucene.search.Query;
 import org.elasticsearch.common.lucene.search.Queries;
 
 import io.crate.data.Input;
+import io.crate.expression.operator.AndOperator;
 import io.crate.expression.operator.LikeOperators;
 import io.crate.expression.operator.any.AnyEqOperator;
 import io.crate.expression.operator.any.AnyNeqOperator;
@@ -126,6 +127,7 @@ public class NotPredicate extends Scalar<Boolean, Boolean> {
             Set.of(
                 AnyEqOperator.NAME,
                 AnyNeqOperator.NAME,
+                AndOperator.NAME,
                 AnyRangeOperator.Comparison.GT.opName(),
                 AnyRangeOperator.Comparison.GTE.opName(),
                 AnyRangeOperator.Comparison.LT.opName(),

--- a/server/src/test/java/io/crate/lucene/ThreeValuedLogicQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/ThreeValuedLogicQueryBuilderTest.java
@@ -59,4 +59,11 @@ public class ThreeValuedLogicQueryBuilderTest extends LuceneQueryBuilderTest {
             .isEqualTo(q2)
             .hasToString("name:foo");
     }
+
+    @Test
+    public void test_negated_and_three_value_query() {
+        // make sure there is no field-exists-query for the references
+        assertThat(convert("NOT (x AND f)")).hasToString(
+            "+(+*:* -(+x +f)) #(NOT (x AND f))");
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This fixes an issue where a ``NOT (a AND b)`` expression was not correctly evaluated according to the three-valued logic. The expression``NOT (a AND b)`` evaluated with the tuple ``(a:null, b: -1)`` should return `true` but returned `false` instead.

Resolves https://github.com/crate/crate/issues/15050


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
