### PR TITLE
Avoid cycling searchers & leafs in ReservoirSampler; prefer source lookups

### DIFF
--- a/docs/appendices/release-notes/5.6.0.rst
+++ b/docs/appendices/release-notes/5.6.0.rst
@@ -82,7 +82,9 @@ None
 Performance and Resilience Improvements
 ---------------------------------------
 
-None
+- Tuned the behavior of the ``ANALYZE`` statement and the periodic stats update.
+  The operations should now require fewer reads from disk and the rate limiting
+  via the ``stats.service.max_bytes_per_sec`` setting should work better.
 
 Administration and Operations
 -----------------------------


### PR DESCRIPTION
So far the sampling was done in two steps:

1. Sample docIds
2. Load values for docIds

The sampled docIds could hit many different readers and they weren't
processed in order, which could multiply the number of times a reader
needed to be loaded, and was taxing the fs cache.

Further, this switches to use source lookups, since on large tables only
a small subset of values is actually read. It avoids loading doc-values,
and should interact better with the rate-limiting setting.
