### PR TITLE
Allow pushdown of filter beneath a view over multiple join

### DIFF
--- a/docs/appendices/release-notes/5.6.0.rst
+++ b/docs/appendices/release-notes/5.6.0.rst
@@ -87,6 +87,19 @@ Performance and Resilience Improvements
 
 - Reduced the amount of disk reads necessary for ``ANALYZE`` operations.
 
+- Improved filter push-down for left/right outer joins when the joins are
+  nested e.g.::
+
+    SELECT * FROM (SELECT * FROM a LEFT JOIN b ON a.a = b.b LEFT JOIN c ON b.b = c.c) t WHERE b > 1;
+  
+  Now, the above query will result in the following logical plan ::
+
+    NestedLoopJoin[LEFT | (b = c)] (rows=unknown)
+      ├ HashJoin[(a = b)] (rows=unknown)
+      │  ├ Collect[doc.a | [a] | true] (rows=unknown)
+      │  └ Collect[doc.b | [b] | (b > 1)] (rows=unknown)
+      └ Collect[doc.c | [c] | true] (rows=unknown)
+
 Administration and Operations
 -----------------------------
 

--- a/server/src/test/java/io/crate/planner/optimizer/rule/MoveFilterBeneathJoinTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/MoveFilterBeneathJoinTest.java
@@ -313,12 +313,261 @@ public class MoveFilterBeneathJoinTest extends CrateDummyClusterServiceUnitTest 
 
         assertThat(result).hasOperators(
             "Join[INNER | (a = c)]",
-            "  ├ Filter[(b < 2)]",
-            "  │  └ Filter[(a > 1)]",
-            "  │    └ Join[INNER | (a = b)]",
-            "  │      ├ Collect[doc.t1 | [a] | true]",
-            "  │      └ Collect[doc.t2 | [b] | true]",
+            "  ├ Filter[((a > 1) AND (b < 2))]",
+            "  │  └ Join[INNER | (a = b)]",
+            "  │    ├ Collect[doc.t1 | [a] | true]",
+            "  │    └ Collect[doc.t2 | [b] | true]",
             "  └ Collect[doc.t3 | [c] | true]"
+        );
+    }
+
+    @Test
+    public void test_push_filter_down_to_preserved_side_of_left_join() {
+        var joinCondition = sqlExpressions.asSymbol("doc.t1.a = doc.t2.b");
+        var join = new JoinPlan(t1, t2, JoinType.LEFT, joinCondition);
+        var filter = new Filter(join, sqlExpressions.asSymbol("doc.t1.a > 1"));
+        assertThat(filter).hasOperators(
+            "Filter[(a > 1)]",
+            "  └ Join[LEFT | (a = b)]",
+            "    ├ Collect[doc.t1 | [a] | true]",
+            "    └ Collect[doc.t2 | [b] | true]"
+        );
+
+        var rule = new MoveFilterBeneathJoin();
+        var match = rule.pattern().accept(filter, Captures.empty());
+
+        assertThat(match.isPresent()).isTrue();
+        assertThat(match.value()).isEqualTo(filter);
+
+        var result = rule.apply(match.value(),
+            match.captures(),
+            planStats,
+            CoordinatorTxnCtx.systemTransactionContext(),
+            sqlExpressions.nodeCtx,
+            Function.identity());
+
+        assertThat(result).hasOperators(
+            "Join[LEFT | (a = b)]",
+            "  ├ Filter[(a > 1)]",
+            "  │  └ Collect[doc.t1 | [a] | true]",
+            "  └ Collect[doc.t2 | [b] | true]"
+        );
+    }
+
+    @Test
+    public void test_cannot_push_filter_down_to_non_preserved_side_of_left_join() {
+        var joinCondition = sqlExpressions.asSymbol("doc.t1.a = doc.t2.b");
+        var join = new JoinPlan(t1, t2, JoinType.LEFT, joinCondition);
+        var filter = new Filter(join, sqlExpressions.asSymbol("doc.t2.b > 1"));
+        assertThat(filter).hasOperators(
+            "Filter[(b > 1)]",
+            "  └ Join[LEFT | (a = b)]",
+            "    ├ Collect[doc.t1 | [a] | true]",
+            "    └ Collect[doc.t2 | [b] | true]"
+        );
+
+        var rule = new MoveFilterBeneathJoin();
+        var match = rule.pattern().accept(filter, Captures.empty());
+
+        assertThat(match.isPresent()).isTrue();
+        assertThat(match.value()).isEqualTo(filter);
+
+        var result = rule.apply(match.value(),
+            match.captures(),
+            planStats,
+            CoordinatorTxnCtx.systemTransactionContext(),
+            sqlExpressions.nodeCtx,
+            Function.identity());
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    public void test_push_filter_down_to_preserved_of_right_join() {
+        var joinCondition = sqlExpressions.asSymbol("doc.t1.a = doc.t2.b");
+        var join = new JoinPlan(t1, t2, JoinType.RIGHT, joinCondition);
+        var filter = new Filter(join, sqlExpressions.asSymbol("doc.t2.b > 1"));
+        assertThat(filter).hasOperators(
+            "Filter[(b > 1)]",
+            "  └ Join[RIGHT | (a = b)]",
+            "    ├ Collect[doc.t1 | [a] | true]",
+            "    └ Collect[doc.t2 | [b] | true]"
+        );
+
+        var rule = new MoveFilterBeneathJoin();
+        var match = rule.pattern().accept(filter, Captures.empty());
+
+        assertThat(match.isPresent()).isTrue();
+        assertThat(match.value()).isEqualTo(filter);
+
+        var result = rule.apply(match.value(),
+            match.captures(),
+            planStats,
+            CoordinatorTxnCtx.systemTransactionContext(),
+            sqlExpressions.nodeCtx,
+            Function.identity());
+
+        assertThat(result).hasOperators(
+            "Join[RIGHT | (a = b)]",
+            "  ├ Collect[doc.t1 | [a] | true]",
+            "  └ Filter[(b > 1)]",
+            "    └ Collect[doc.t2 | [b] | true]"
+        );
+    }
+
+    @Test
+    public void test_cannot_push_filter_down_to_non_preserved_side_of_right_join() {
+        var joinCondition = sqlExpressions.asSymbol("doc.t1.a = doc.t2.b");
+        var join = new JoinPlan(t1, t2, JoinType.RIGHT, joinCondition);
+        var filter = new Filter(join, sqlExpressions.asSymbol("doc.t1.a > 1"));
+        assertThat(filter).hasOperators(
+            "Filter[(a > 1)]",
+            "  └ Join[RIGHT | (a = b)]",
+            "    ├ Collect[doc.t1 | [a] | true]",
+            "    └ Collect[doc.t2 | [b] | true]"
+        );
+
+        var rule = new MoveFilterBeneathJoin();
+        var match = rule.pattern().accept(filter, Captures.empty());
+
+        assertThat(match.isPresent()).isTrue();
+        assertThat(match.value()).isEqualTo(filter);
+
+        var result = rule.apply(match.value(),
+            match.captures(),
+            planStats,
+            CoordinatorTxnCtx.systemTransactionContext(),
+            sqlExpressions.nodeCtx,
+            Function.identity());
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    public void test_cannot_push_filter_down_to_full_join() {
+        var joinCondition = sqlExpressions.asSymbol("doc.t1.a = doc.t2.b");
+        var join = new JoinPlan(t1, t2, JoinType.FULL, joinCondition);
+        var filter = new Filter(join, sqlExpressions.asSymbol("doc.t1.a > 1 and doc.t2.b > 1"));
+        assertThat(filter).hasOperators(
+            "Filter[((a > 1) AND (b > 1))]",
+            "  └ Join[FULL | (a = b)]",
+            "    ├ Collect[doc.t1 | [a] | true]",
+            "    └ Collect[doc.t2 | [b] | true]"
+        );
+
+        var rule = new MoveFilterBeneathJoin();
+        var match = rule.pattern().accept(filter, Captures.empty());
+
+        assertThat(match.isPresent()).isFalse();
+    }
+
+    @Test
+    public void test_push_filter_down_to_cross_join() {
+        var join = new JoinPlan(t1, t2, JoinType.CROSS, null);
+        var filter = new Filter(join, sqlExpressions.asSymbol("doc.t2.b > 1"));
+        assertThat(filter).hasOperators(
+            "Filter[(b > 1)]",
+            "  └ Join[CROSS]",
+            "    ├ Collect[doc.t1 | [a] | true]",
+            "    └ Collect[doc.t2 | [b] | true]"
+        );
+
+        var rule = new MoveFilterBeneathJoin();
+        var match = rule.pattern().accept(filter, Captures.empty());
+
+        assertThat(match.isPresent()).isTrue();
+        assertThat(match.value()).isEqualTo(filter);
+
+        var result = rule.apply(match.value(),
+            match.captures(),
+            planStats,
+            CoordinatorTxnCtx.systemTransactionContext(),
+            sqlExpressions.nodeCtx,
+            Function.identity());
+
+        assertThat(result).hasOperators(
+            "Join[CROSS]",
+            "  ├ Collect[doc.t1 | [a] | true]",
+            "  └ Filter[(b > 1)]",
+            "    └ Collect[doc.t2 | [b] | true]"
+        );
+    }
+
+    @Test
+    public void test_push_filter_down_to_preserved_side_of_left_nested_join() {
+        var joinCondition1 = sqlExpressions.asSymbol("doc.t1.a = doc.t2.b");
+        var join1 = new JoinPlan(t1, t2, JoinType.LEFT, joinCondition1);
+        var joinCondition2 = sqlExpressions.asSymbol("doc.t1.a = doc.t3.c");
+        var join2 = new JoinPlan(join1, t3, JoinType.LEFT, joinCondition2);
+        var filter = new Filter(join2, sqlExpressions.asSymbol("doc.t1.a > 1"));
+        assertThat(filter).hasOperators(
+            "Filter[(a > 1)]",
+            "  └ Join[LEFT | (a = c)]",
+            "    ├ Join[LEFT | (a = b)]",
+            "    │  ├ Collect[doc.t1 | [a] | true]",
+            "    │  └ Collect[doc.t2 | [b] | true]",
+            "    └ Collect[doc.t3 | [c] | true]"
+        );
+
+        var rule = new MoveFilterBeneathJoin();
+        var match = rule.pattern().accept(filter, Captures.empty());
+
+        assertThat(match.isPresent()).isTrue();
+        assertThat(match.value()).isEqualTo(filter);
+
+        var result = rule.apply(match.value(),
+            match.captures(),
+            planStats,
+            CoordinatorTxnCtx.systemTransactionContext(),
+            sqlExpressions.nodeCtx,
+            Function.identity());
+
+        assertThat(result).hasOperators(
+            "Join[LEFT | (a = c)]",
+            "  ├ Filter[(a > 1)]",
+            "  │  └ Join[LEFT | (a = b)]",
+            "  │    ├ Collect[doc.t1 | [a] | true]",
+            "  │    └ Collect[doc.t2 | [b] | true]",
+            "  └ Collect[doc.t3 | [c] | true]"
+        );
+    }
+
+    @Test
+    public void test_push_filter_down_to_preserved_side_of_right_nested_join() {
+        var joinCondition1 = sqlExpressions.asSymbol("doc.t1.a = doc.t2.b");
+        var join1 = new JoinPlan(t1, t2, JoinType.RIGHT, joinCondition1);
+        var joinCondition2 = sqlExpressions.asSymbol("doc.t2.b = doc.t3.c");
+        var join2 = new JoinPlan(t3, join1, JoinType.RIGHT, joinCondition2);
+        var filter = new Filter(join2, sqlExpressions.asSymbol("doc.t2.b > 1"));
+        assertThat(filter).hasOperators(
+            "Filter[(b > 1)]",
+            "  └ Join[RIGHT | (b = c)]",
+            "    ├ Collect[doc.t3 | [c] | true]",
+            "    └ Join[RIGHT | (a = b)]",
+            "      ├ Collect[doc.t1 | [a] | true]",
+            "      └ Collect[doc.t2 | [b] | true]"
+        );
+
+        var rule = new MoveFilterBeneathJoin();
+        var match = rule.pattern().accept(filter, Captures.empty());
+
+        assertThat(match.isPresent()).isTrue();
+        assertThat(match.value()).isEqualTo(filter);
+
+        var result = rule.apply(match.value(),
+            match.captures(),
+            planStats,
+            CoordinatorTxnCtx.systemTransactionContext(),
+            sqlExpressions.nodeCtx,
+            Function.identity());
+
+        assertThat(result).hasOperators(
+            "Join[RIGHT | (b = c)]",
+            "  ├ Collect[doc.t3 | [c] | true]",
+            "  └ Filter[(b > 1)]",
+            "    └ Join[RIGHT | (a = b)]",
+            "      ├ Collect[doc.t1 | [a] | true]",
+            "      └ Collect[doc.t2 | [b] | true]"
         );
     }
 }

--- a/server/src/test/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoinTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoinTest.java
@@ -1,0 +1,263 @@
+package io.crate.planner.optimizer.rule;
+
+import static io.crate.testing.Asserts.assertThat;
+
+import java.util.Map;
+import java.util.function.Function;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.crate.analyze.relations.AnalyzedRelation;
+import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.RelationName;
+import io.crate.planner.operators.Filter;
+import io.crate.planner.operators.JoinPlan;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.optimizer.costs.PlanStats;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.sql.tree.JoinType;
+import io.crate.statistics.TableStats;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+import io.crate.testing.SqlExpressions;
+import io.crate.testing.T3;
+
+public class RewriteFilterOnOuterJoinToInnerJoinTest extends CrateDummyClusterServiceUnitTest {
+
+    private SqlExpressions sqlExpressions;
+    private Map<RelationName, AnalyzedRelation> sources;
+    private PlanStats planStats;
+    private LogicalPlan t1;
+    private LogicalPlan t2;
+
+    @Before
+    public void prepare() throws Exception {
+        sources = T3.sources(clusterService);
+        sqlExpressions = new SqlExpressions(sources);
+        planStats = new PlanStats(sqlExpressions.nodeCtx,
+            CoordinatorTxnCtx.systemTransactionContext(),
+            new TableStats());
+
+        var e = SQLExecutor.builder(clusterService)
+            .addTable("create table t1 (a int)")
+            .addTable("create table t2 (b int)")
+            .build();
+
+        t1 = e.logicalPlan("SELECT a FROM t1");
+        t2 = e.logicalPlan("SELECT b FROM t2");
+    }
+
+    @Test
+    public void test_push_filter_down_to_non_preserved_side_of_left_join_and_rewrites_to_inner_join() {
+        var joinCondition = sqlExpressions.asSymbol("doc.t1.a = doc.t2.b");
+        var join = new JoinPlan(t1, t2, JoinType.LEFT, joinCondition);
+        var filter = new Filter(join, sqlExpressions.asSymbol("doc.t2.b > 1"));
+        assertThat(filter).hasOperators(
+            "Filter[(b > 1)]",
+            "  └ Join[LEFT | (a = b)]",
+            "    ├ Collect[doc.t1 | [a] | true]",
+            "    └ Collect[doc.t2 | [b] | true]"
+        );
+
+        var rule = new RewriteFilterOnOuterJoinToInnerJoin();
+        var match = rule.pattern().accept(filter, Captures.empty());
+
+        assertThat(match.isPresent()).isTrue();
+        assertThat(match.value()).isEqualTo(filter);
+
+        var result = rule.apply(match.value(),
+            match.captures(),
+            planStats,
+            CoordinatorTxnCtx.systemTransactionContext(),
+            sqlExpressions.nodeCtx,
+            Function.identity());
+
+        assertThat(result).hasOperators(
+            "Join[INNER | (a = b)]",
+            "  ├ Collect[doc.t1 | [a] | true]",
+            "  └ Filter[(b > 1)]",
+            "    └ Collect[doc.t2 | [b] | true]"
+        );
+    }
+
+    @Test
+    public void test_cannot_push_filter_down_to_preserved_side_of_left_join_and_cannot_rewrite_to_inner_join() {
+        var joinCondition = sqlExpressions.asSymbol("doc.t1.a = doc.t2.b");
+        var join = new JoinPlan(t1, t2, JoinType.LEFT, joinCondition);
+        var filter = new Filter(join, sqlExpressions.asSymbol("doc.t1.a > 1"));
+        assertThat(filter).hasOperators(
+            "Filter[(a > 1)]",
+            "  └ Join[LEFT | (a = b)]",
+            "    ├ Collect[doc.t1 | [a] | true]",
+            "    └ Collect[doc.t2 | [b] | true]"
+        );
+
+        var rule = new RewriteFilterOnOuterJoinToInnerJoin();
+        var match = rule.pattern().accept(filter, Captures.empty());
+
+        assertThat(match.isPresent()).isTrue();
+        assertThat(match.value()).isEqualTo(filter);
+
+        var result = rule.apply(match.value(),
+            match.captures(),
+            planStats,
+            CoordinatorTxnCtx.systemTransactionContext(),
+            sqlExpressions.nodeCtx,
+            Function.identity());
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    public void test_cannot_push_filter_down_to_non_preserved_side_of_left_join_and_cannot_rewrite_to_inner_join_if_the_filter_matches_nulls() {
+        var joinCondition = sqlExpressions.asSymbol("doc.t1.a = doc.t2.b");
+        var join = new JoinPlan(t1, t2, JoinType.LEFT, joinCondition);
+        var filter = new Filter(join, sqlExpressions.asSymbol("doc.t2.b is null"));
+        assertThat(filter).hasOperators(
+            "Filter[(b IS NULL)]",
+            "  └ Join[LEFT | (a = b)]",
+            "    ├ Collect[doc.t1 | [a] | true]",
+            "    └ Collect[doc.t2 | [b] | true]"
+        );
+
+        var rule = new RewriteFilterOnOuterJoinToInnerJoin();
+        var match = rule.pattern().accept(filter, Captures.empty());
+
+        assertThat(match.isPresent()).isTrue();
+        assertThat(match.value()).isEqualTo(filter);
+
+        var result = rule.apply(match.value(),
+            match.captures(),
+            planStats,
+            CoordinatorTxnCtx.systemTransactionContext(),
+            sqlExpressions.nodeCtx,
+            Function.identity());
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    public void test_push_filter_down_to_non_preserved_side_of_right_join_and_rewrites_to_inner_join() {
+        var joinCondition = sqlExpressions.asSymbol("doc.t1.a = doc.t2.b");
+        var join = new JoinPlan(t1, t2, JoinType.RIGHT, joinCondition);
+        var filter = new Filter(join, sqlExpressions.asSymbol("doc.t1.a > 1"));
+        assertThat(filter).hasOperators(
+            "Filter[(a > 1)]",
+            "  └ Join[RIGHT | (a = b)]",
+            "    ├ Collect[doc.t1 | [a] | true]",
+            "    └ Collect[doc.t2 | [b] | true]"
+        );
+
+        var rule = new RewriteFilterOnOuterJoinToInnerJoin();
+        var match = rule.pattern().accept(filter, Captures.empty());
+
+        assertThat(match.isPresent()).isTrue();
+        assertThat(match.value()).isEqualTo(filter);
+
+        var result = rule.apply(match.value(),
+            match.captures(),
+            planStats,
+            CoordinatorTxnCtx.systemTransactionContext(),
+            sqlExpressions.nodeCtx,
+            Function.identity());
+
+        assertThat(result).hasOperators(
+            "Join[INNER | (a = b)]",
+            "  ├ Filter[(a > 1)]",
+            "  │  └ Collect[doc.t1 | [a] | true]",
+            "  └ Collect[doc.t2 | [b] | true]"
+        );
+    }
+
+    @Test
+    public void test_cannot_push_filter_down_to_preserved_side_of_right_join_and_cannot_rewrite_to_inner_join() {
+        var joinCondition = sqlExpressions.asSymbol("doc.t1.a = doc.t2.b");
+        var join = new JoinPlan(t1, t2, JoinType.RIGHT, joinCondition);
+        var filter = new Filter(join, sqlExpressions.asSymbol("doc.t2.b > 1"));
+        assertThat(filter).hasOperators(
+            "Filter[(b > 1)]",
+            "  └ Join[RIGHT | (a = b)]",
+            "    ├ Collect[doc.t1 | [a] | true]",
+            "    └ Collect[doc.t2 | [b] | true]"
+        );
+
+        var rule = new RewriteFilterOnOuterJoinToInnerJoin();
+        var match = rule.pattern().accept(filter, Captures.empty());
+
+        assertThat(match.isPresent()).isTrue();
+        assertThat(match.value()).isEqualTo(filter);
+
+        var result = rule.apply(match.value(),
+            match.captures(),
+            planStats,
+            CoordinatorTxnCtx.systemTransactionContext(),
+            sqlExpressions.nodeCtx,
+            Function.identity());
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    public void test_cannot_push_filter_down_to_non_preserved_side_of_right_join_and_cannot_rewrite_to_inner_join_if_the_filter_matches_nulls() {
+        var joinCondition = sqlExpressions.asSymbol("doc.t1.a = doc.t2.b");
+        var join = new JoinPlan(t1, t2, JoinType.RIGHT, joinCondition);
+        var filter = new Filter(join, sqlExpressions.asSymbol("doc.t1.a is null"));
+        assertThat(filter).hasOperators(
+            "Filter[(a IS NULL)]",
+            "  └ Join[RIGHT | (a = b)]",
+            "    ├ Collect[doc.t1 | [a] | true]",
+            "    └ Collect[doc.t2 | [b] | true]"
+        );
+
+        var rule = new RewriteFilterOnOuterJoinToInnerJoin();
+        var match = rule.pattern().accept(filter, Captures.empty());
+
+        assertThat(match.isPresent()).isTrue();
+        assertThat(match.value()).isEqualTo(filter);
+
+        var result = rule.apply(match.value(),
+            match.captures(),
+            planStats,
+            CoordinatorTxnCtx.systemTransactionContext(),
+            sqlExpressions.nodeCtx,
+            Function.identity());
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    public void test_push_filter_down_to_preserved_sides_of_full_join_and_rewrites_to_inner_join() {
+        var joinCondition = sqlExpressions.asSymbol("doc.t1.a = doc.t2.b");
+        var join = new JoinPlan(t1, t2, JoinType.FULL, joinCondition);
+        var filter = new Filter(join, sqlExpressions.asSymbol("doc.t1.a > 1 and doc.t2.b > 1"));
+        assertThat(filter).hasOperators(
+            "Filter[((a > 1) AND (b > 1))]",
+            "  └ Join[FULL | (a = b)]",
+            "    ├ Collect[doc.t1 | [a] | true]",
+            "    └ Collect[doc.t2 | [b] | true]"
+        );
+
+        var rule = new RewriteFilterOnOuterJoinToInnerJoin();
+        var match = rule.pattern().accept(filter, Captures.empty());
+
+        assertThat(match.isPresent()).isTrue();
+        assertThat(match.value()).isEqualTo(filter);
+
+        var result = rule.apply(match.value(),
+            match.captures(),
+            planStats,
+            CoordinatorTxnCtx.systemTransactionContext(),
+            sqlExpressions.nodeCtx,
+            Function.identity());
+
+        assertThat(result).hasOperators(
+            "Filter[((a > 1) AND (b > 1))]",
+            "  └ Join[INNER | (a = b)]",
+            "    ├ Filter[(a > 1)]",
+            "    │  └ Collect[doc.t1 | [a] | true]",
+            "    └ Filter[(b > 1)]",
+            "      └ Collect[doc.t2 | [b] | true]"
+        );
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Resolves https://github.com/crate/crate/issues/14899.

explain output of the failing scenario:
```
cr> explain verbose select * from customersviewleftjoin where customer_id=1; 
                                                                                                                                            
+--------------------------------------+----------------------------------------------------------------------------------------------------+
| STEP                                 | QUERY PLAN                                                                                         |
+--------------------------------------+----------------------------------------------------------------------------------------------------+
| Initial logical plan                 | Filter[(customer_id = 1)] (rows=0)                                                                 |
|                                      |   └ Rename[customer_id, customer_name, city, typedesc] AS doc.customersviewleftjoin (rows=unknown) |
|                                      |     └ Eval[customer_id, customer_name, city, typedesc] (rows=unknown)                              |
|                                      |       └ Join[LEFT | (customer_id = customer_id)] (rows=unknown)                                    |
|                                      |         ├ Join[LEFT | (customer_id = customer_id)] (rows=unknown)                                  |
|                                      |         │  ├ Collect[doc.customers | [customer_id, customer_name] | true] (rows=unknown)           |
|                                      |         │  └ Collect[doc.customer_city | [city, customer_id] | true] (rows=unknown)                |
|                                      |         └ Collect[doc.customer_type | [typedesc, customer_id] | true] (rows=unknown)               |
| optimizer_move_filter_beneath_rename | Rename[customer_id, customer_name, city, typedesc] AS doc.customersviewleftjoin (rows=0)           |
|                                      |   └ Filter[(customer_id = 1)] (rows=0)                                                             |
|                                      |     └ Eval[customer_id, customer_name, city, typedesc] (rows=unknown)                              |
|                                      |       └ Join[LEFT | (customer_id = customer_id)] (rows=unknown)                                    |
|                                      |         ├ Join[LEFT | (customer_id = customer_id)] (rows=unknown)                                  |
|                                      |         │  ├ Collect[doc.customers | [customer_id, customer_name] | true] (rows=unknown)           |
|                                      |         │  └ Collect[doc.customer_city | [city, customer_id] | true] (rows=unknown)                |
|                                      |         └ Collect[doc.customer_type | [typedesc, customer_id] | true] (rows=unknown)               |
| optimizer_move_filter_beneath_eval   | Rename[customer_id, customer_name, city, typedesc] AS doc.customersviewleftjoin (rows=0)           |
|                                      |   └ Eval[customer_id, customer_name, city, typedesc] (rows=0)                                      |
|                                      |     └ Filter[(customer_id = 1)] (rows=0)                                                           |
|                                      |       └ Join[LEFT | (customer_id = customer_id)] (rows=unknown)                                    |
|                                      |         ├ Join[LEFT | (customer_id = customer_id)] (rows=unknown)                                  |
|                                      |         │  ├ Collect[doc.customers | [customer_id, customer_name] | true] (rows=unknown)           |
|                                      |         │  └ Collect[doc.customer_city | [city, customer_id] | true] (rows=unknown)                |
|                                      |         └ Collect[doc.customer_type | [typedesc, customer_id] | true] (rows=unknown)               |
| optimizer_rewrite_join_plan          | Rename[customer_id, customer_name, city, typedesc] AS doc.customersviewleftjoin (rows=0)           |
|                                      |   └ Eval[customer_id, customer_name, city, typedesc] (rows=0)                                      |
|                                      |     └ Filter[(customer_id = 1)] (rows=0)                                                           |
|                                      |       └ NestedLoopJoin[LEFT | (customer_id = customer_id)] (rows=unknown)                          |
|                                      |         ├ Join[LEFT | (customer_id = customer_id)] (rows=unknown)                                  |
|                                      |         │  ├ Collect[doc.customers | [customer_id, customer_name] | true] (rows=unknown)           |
|                                      |         │  └ Collect[doc.customer_city | [city, customer_id] | true] (rows=unknown)                |
|                                      |         └ Collect[doc.customer_type | [typedesc, customer_id] | true] (rows=unknown)               |
| optimizer_rewrite_join_plan          | Rename[customer_id, customer_name, city, typedesc] AS doc.customersviewleftjoin (rows=0)           |
|                                      |   └ Eval[customer_id, customer_name, city, typedesc] (rows=0)                                      |
|                                      |     └ Filter[(customer_id = 1)] (rows=0)                                                           |
|                                      |       └ NestedLoopJoin[LEFT | (customer_id = customer_id)] (rows=unknown)                          |
|                                      |         ├ NestedLoopJoin[LEFT | (customer_id = customer_id)] (rows=unknown)                        |
|                                      |         │  ├ Collect[doc.customers | [customer_id, customer_name] | true] (rows=unknown)           |
|                                      |         │  └ Collect[doc.customer_city | [city, customer_id] | true] (rows=unknown)                |
|                                      |         └ Collect[doc.customer_type | [typedesc, customer_id] | true] (rows=unknown)               |
| Final logical plan                   | Rename[customer_id, customer_name, city, typedesc] AS doc.customersviewleftjoin (rows=0)           |
|                                      |   └ Eval[customer_id, customer_name, city, typedesc] (rows=0)                                      |
|                                      |     └ Filter[(customer_id = 1)] (rows=0)                                                           |  <-- not pushed down
|                                      |       └ NestedLoopJoin[LEFT | (customer_id = customer_id)] (rows=unknown)                          |
|                                      |         ├ NestedLoopJoin[LEFT | (customer_id = customer_id)] (rows=unknown)                        |
|                                      |         │  ├ Collect[doc.customers | [customer_id, customer_name] | true] (rows=unknown)           |
|                                      |         │  └ Collect[doc.customer_city | [city, customer_id] | true] (rows=unknown)                |
|                                      |         └ Collect[doc.customer_type | [typedesc, customer_id] | true] (rows=unknown)               |
+--------------------------------------+----------------------------------------------------------------------------------------------------+
EXPLAIN 6 rows in set (0.008 sec)
```

With this PR, the filter is pushed down to the collect operator:
```
cr> explain verbose select * from customersviewleftjoin where customer_id=1; 
                                                                                                                                            
+--------------------------------------+-----------------------------------------------------------------------------------------------------+
| STEP                                 | QUERY PLAN                                                                                          |
+--------------------------------------+-----------------------------------------------------------------------------------------------------+
| Initial logical plan                 | Filter[(customer_id = 1)] (rows=0)                                                                  |
|                                      |   └ Rename[customer_id, customer_name, city, typedesc] AS doc.customersviewleftjoin (rows=unknown)  |
|                                      |     └ Eval[customer_id, customer_name, city, typedesc] (rows=unknown)                               |
|                                      |       └ Join[LEFT | (customer_id = customer_id)] (rows=unknown)                                     |
|                                      |         ├ Join[LEFT | (customer_id = customer_id)] (rows=unknown)                                   |
|                                      |         │  ├ Collect[doc.customers | [customer_id, customer_name] | true] (rows=unknown)            |
|                                      |         │  └ Collect[doc.customer_city | [city, customer_id] | true] (rows=unknown)                 |
|                                      |         └ Collect[doc.customer_type | [typedesc, customer_id] | true] (rows=unknown)                |
| optimizer_move_filter_beneath_rename | Rename[customer_id, customer_name, city, typedesc] AS doc.customersviewleftjoin (rows=0)            |
|                                      |   └ Filter[(customer_id = 1)] (rows=0)                                                              |
|                                      |     └ Eval[customer_id, customer_name, city, typedesc] (rows=unknown)                               |
|                                      |       └ Join[LEFT | (customer_id = customer_id)] (rows=unknown)                                     |
|                                      |         ├ Join[LEFT | (customer_id = customer_id)] (rows=unknown)                                   |
|                                      |         │  ├ Collect[doc.customers | [customer_id, customer_name] | true] (rows=unknown)            |
|                                      |         │  └ Collect[doc.customer_city | [city, customer_id] | true] (rows=unknown)                 |
|                                      |         └ Collect[doc.customer_type | [typedesc, customer_id] | true] (rows=unknown)                |
| optimizer_move_filter_beneath_eval   | Rename[customer_id, customer_name, city, typedesc] AS doc.customersviewleftjoin (rows=0)            |
|                                      |   └ Eval[customer_id, customer_name, city, typedesc] (rows=0)                                       |
|                                      |     └ Filter[(customer_id = 1)] (rows=0)                                                            |
|                                      |       └ Join[LEFT | (customer_id = customer_id)] (rows=unknown)                                     |
|                                      |         ├ Join[LEFT | (customer_id = customer_id)] (rows=unknown)                                   |
|                                      |         │  ├ Collect[doc.customers | [customer_id, customer_name] | true] (rows=unknown)            |
|                                      |         │  └ Collect[doc.customer_city | [city, customer_id] | true] (rows=unknown)                 |
|                                      |         └ Collect[doc.customer_type | [typedesc, customer_id] | true] (rows=unknown)                |
| optimizer_move_filter_beneath_join   | Rename[customer_id, customer_name, city, typedesc] AS doc.customersviewleftjoin (rows=unknown)      |
|                                      |   └ Eval[customer_id, customer_name, city, typedesc] (rows=unknown)                                 |
|                                      |     └ Join[LEFT | (customer_id = customer_id)] (rows=unknown)                                       |
|                                      |       ├ Filter[(customer_id = 1)] (rows=0)                                                          |
|                                      |       │  └ Join[LEFT | (customer_id = customer_id)] (rows=unknown)                                  |
|                                      |       │    ├ Collect[doc.customers | [customer_id, customer_name] | true] (rows=unknown)            |
|                                      |       │    └ Collect[doc.customer_city | [city, customer_id] | true] (rows=unknown)                 |
|                                      |       └ Collect[doc.customer_type | [typedesc, customer_id] | true] (rows=unknown)                  |
| optimizer_rewrite_join_plan          | Rename[customer_id, customer_name, city, typedesc] AS doc.customersviewleftjoin (rows=unknown)      |
|                                      |   └ Eval[customer_id, customer_name, city, typedesc] (rows=unknown)                                 |
|                                      |     └ NestedLoopJoin[LEFT | (customer_id = customer_id)] (rows=unknown)                             |
|                                      |       ├ Filter[(customer_id = 1)] (rows=0)                                                          |
|                                      |       │  └ Join[LEFT | (customer_id = customer_id)] (rows=unknown)                                  |
|                                      |       │    ├ Collect[doc.customers | [customer_id, customer_name] | true] (rows=unknown)            |
|                                      |       │    └ Collect[doc.customer_city | [city, customer_id] | true] (rows=unknown)                 |
|                                      |       └ Collect[doc.customer_type | [typedesc, customer_id] | true] (rows=unknown)                  |
| optimizer_move_filter_beneath_join   | Rename[customer_id, customer_name, city, typedesc] AS doc.customersviewleftjoin (rows=unknown)      |
|                                      |   └ Eval[customer_id, customer_name, city, typedesc] (rows=unknown)                                 |
|                                      |     └ NestedLoopJoin[LEFT | (customer_id = customer_id)] (rows=unknown)                             |
|                                      |       ├ Join[LEFT | (customer_id = customer_id)] (rows=unknown)                                     |
|                                      |       │  ├ Filter[(customer_id = 1)] (rows=0)                                                       |
|                                      |       │  │  └ Collect[doc.customers | [customer_id, customer_name] | true] (rows=unknown)           |
|                                      |       │  └ Collect[doc.customer_city | [city, customer_id] | true] (rows=unknown)                   |
|                                      |       └ Collect[doc.customer_type | [typedesc, customer_id] | true] (rows=unknown)                  |
| optimizer_rewrite_join_plan          | Rename[customer_id, customer_name, city, typedesc] AS doc.customersviewleftjoin (rows=unknown)      |
|                                      |   └ Eval[customer_id, customer_name, city, typedesc] (rows=unknown)                                 |
|                                      |     └ NestedLoopJoin[LEFT | (customer_id = customer_id)] (rows=unknown)                             |
|                                      |       ├ NestedLoopJoin[LEFT | (customer_id = customer_id)] (rows=unknown)                           |
|                                      |       │  ├ Filter[(customer_id = 1)] (rows=0)                                                       |
|                                      |       │  │  └ Collect[doc.customers | [customer_id, customer_name] | true] (rows=unknown)           |
|                                      |       │  └ Collect[doc.customer_city | [city, customer_id] | true] (rows=unknown)                   |
|                                      |       └ Collect[doc.customer_type | [typedesc, customer_id] | true] (rows=unknown)                  |
| optimizer_merge_filter_and_collect   | Rename[customer_id, customer_name, city, typedesc] AS doc.customersviewleftjoin (rows=unknown)      |
|                                      |   └ Eval[customer_id, customer_name, city, typedesc] (rows=unknown)                                 |
|                                      |     └ NestedLoopJoin[LEFT | (customer_id = customer_id)] (rows=unknown)                             |
|                                      |       ├ NestedLoopJoin[LEFT | (customer_id = customer_id)] (rows=unknown)                           |
|                                      |       │  ├ Collect[doc.customers | [customer_id, customer_name] | (customer_id = 1)] (rows=unknown) |
|                                      |       │  └ Collect[doc.customer_city | [city, customer_id] | true] (rows=unknown)                   |
|                                      |       └ Collect[doc.customer_type | [typedesc, customer_id] | true] (rows=unknown)                  |
| Final logical plan                   | Rename[customer_id, customer_name, city, typedesc] AS doc.customersviewleftjoin (rows=unknown)      |
|                                      |   └ Eval[customer_id, customer_name, city, typedesc] (rows=unknown)                                 |
|                                      |     └ NestedLoopJoin[LEFT | (customer_id = customer_id)] (rows=unknown)                             |
|                                      |       ├ NestedLoopJoin[LEFT | (customer_id = customer_id)] (rows=unknown)                           |
|                                      |       │  ├ Collect[doc.customers | [customer_id, customer_name] | (customer_id = 1)] (rows=unknown) |  <-- pushed down
|                                      |       │  └ Collect[doc.customer_city | [city, customer_id] | true] (rows=unknown)                   |
|                                      |       └ Collect[doc.customer_type | [typedesc, customer_id] | true] (rows=unknown)                  |
+--------------------------------------+-----------------------------------------------------------------------------------------------------+
EXPLAIN 9 rows in set (0.007 sec)
```

Originally `RewriteFilterOnOuterJoinToInnerJoin` was responsible for 1) filter push-downs of outer joins and 2) rewriting outer joins to inner joins and `MoveFilterBeneathJoin` was responsible for filter push-downs of inner joins. Since we wanted to have this missing filter push-down logic into `MoveFilterBeneathJoin`(the missing filter push down as well as [these use-cases](https://github.com/crate/crate/pull/15085#pullrequestreview-1746171920)), we needed to refactor the two rules first as a prerequisite. Now `RewriteFilterOnOuterJoinToInnerJoin` is responsible for 1) filter push-downs to non-preserved sides of joins and 2) rewriting outer joins to inner joins and `MoveFilterBeneathJoin` is responsible for filter push-downs to preserved sides of joins. Then the missing filter push down is taken cared of as part of the refactoring.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
