### PR TITLE
Fix null value handling of NOT Predicate

### DIFF
--- a/docs/appendices/release-notes/5.4.6.rst
+++ b/docs/appendices/release-notes/5.4.6.rst
@@ -46,6 +46,9 @@ See the :ref:`version_5.4.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that caused queries with a ``NOT`` expression in the where
+  clause to fail on evaluation ``NULL`` correctly.
+
 - Creating a table that uses a table-function as part of a default expression or
   generated expression now results in an error on table creation, instead of
   never inserting records due to runtime failures.

--- a/docs/appendices/release-notes/5.5.1.rst
+++ b/docs/appendices/release-notes/5.5.1.rst
@@ -49,6 +49,9 @@ See the :ref:`version_5.5.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that caused queries with a ``NOT`` expression in the where
+  clause to fail on evaluation ``NULL`` correctly.
+
 - Creating a table that uses a table-function as part of a default expression or
   generated expression now results in an error on table creation, instead of
   never inserting records due to runtime failures.


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This simplifies the Three-Valued-Logic Optimization (3vl) for the `NotPredicate`. 
Instead of explicitly including the functions where 3vl is needed, this makes 3vl the default behaviour and handles the cases where the 3vl can be ignored: 

- No function is involved `NOT x`
- A comparison operator from a reference to a value `NOT x = 1`
- ignore3vl function `ignore3vl( ... )`

Resolves https://github.com/crate/crate/issues/15083


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
