### PR TITLE
Avoid unnecessary extraction of the logical plan from the memo

### DIFF
--- a/server/src/main/java/io/crate/planner/node/management/VerboseOptimizerTracer.java
+++ b/server/src/main/java/io/crate/planner/node/management/VerboseOptimizerTracer.java
@@ -43,6 +43,11 @@ public class VerboseOptimizerTracer implements OptimizerTracer {
     }
 
     @Override
+    public boolean isActive() {
+        return true;
+    }
+
+    @Override
     public void optimizationStarted(LogicalPlan initialPlan, PlanStats planStats) {
         // A plan can go through multiple optimizers. Here, we capture the initial plan only once.
         if (steps.isEmpty()) {

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/IterativeOptimizer.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/IterativeOptimizer.java
@@ -135,7 +135,10 @@ public class IterativeOptimizer {
                     node = transformed;
                     done = false;
                     progress = true;
-                    context.tracer.ruleApplied(rule, context.memo.extract(), context.planStats);
+                    var tracer = context.tracer;
+                    if (tracer.isActive()) {
+                        tracer.ruleApplied(rule, context.memo.extract(), context.planStats);
+                    }
                 }
             }
         }

--- a/server/src/main/java/io/crate/planner/optimizer/tracer/LoggingOptimizerTracer.java
+++ b/server/src/main/java/io/crate/planner/optimizer/tracer/LoggingOptimizerTracer.java
@@ -46,6 +46,11 @@ public class LoggingOptimizerTracer implements OptimizerTracer {
     }
 
     @Override
+    public boolean isActive() {
+        return LOGGER.isTraceEnabled();
+    }
+
+    @Override
     public void optimizationStarted(LogicalPlan initialPlan, PlanStats planStatsWithMemo) {
         PrintContext printContext = new PrintContext(planStatsWithMemo);
         initialPlan.print(printContext);

--- a/server/src/main/java/io/crate/planner/optimizer/tracer/OptimizerTracer.java
+++ b/server/src/main/java/io/crate/planner/optimizer/tracer/OptimizerTracer.java
@@ -28,6 +28,7 @@ import io.crate.planner.optimizer.costs.PlanStats;
 public interface OptimizerTracer {
 
     OptimizerTracer NOOP = new OptimizerTracer() {
+
         @Override
         public void optimizationStarted(LogicalPlan initialPlan, PlanStats planStats) {
         }
@@ -39,7 +40,14 @@ public interface OptimizerTracer {
         @Override
         public void ruleApplied(Rule<?> rule, LogicalPlan plan, PlanStats planStats) {
         }
+
+        @Override
+        public boolean isActive() {
+            return false;
+        }
     };
+
+    boolean isActive();
 
     void optimizationStarted(LogicalPlan initialPlan, PlanStats planStats);
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

We should only extract the logical plan when we want to capture the progress of the optimizer or when we are finished with optimizing the plan. 

Follow-up https://github.com/crate/crate/pull/15064

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
