### PR TITLE
Raise an error if using table functions in generated or default expressions

### DIFF
--- a/docs/appendices/release-notes/5.4.6.rst
+++ b/docs/appendices/release-notes/5.4.6.rst
@@ -46,6 +46,10 @@ See the :ref:`version_5.4.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Creating a table that uses a table-function as part of a default expression or
+  generated expression now results in an error on table creation, instead of
+  never inserting records due to runtime failures.
+
 - Improved the error message when using ``COPY FROM`` with
   ``wait_for_completion=false`` and ``RETURN SUMMARY``. It now reports that the
   combination is not supported instead of running into a ``ClassCastException``.

--- a/docs/appendices/release-notes/5.5.1.rst
+++ b/docs/appendices/release-notes/5.5.1.rst
@@ -49,6 +49,10 @@ See the :ref:`version_5.5.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Creating a table that uses a table-function as part of a default expression or
+  generated expression now results in an error on table creation, instead of
+  never inserting records due to runtime failures.
+
 - Improved the error message when using ``COPY FROM`` with
   ``wait_for_completion=false`` and ``RETURN SUMMARY``. It now reports that the
   combination is not supported instead of running into a ``ClassCastException``.

--- a/server/src/main/java/io/crate/expression/symbol/Symbols.java
+++ b/server/src/main/java/io/crate/expression/symbol/Symbols.java
@@ -67,6 +67,10 @@ public class Symbols {
         return s instanceof Function fn && fn.signature().getKind() == FunctionType.AGGREGATE;
     }
 
+    public static boolean isTableFunction(Symbol s) {
+        return s instanceof Function fn && fn.signature().getKind() == FunctionType.TABLE;
+    }
+
     public static List<DataType<?>> typeView(List<? extends Symbol> symbols) {
         return Lists2.mapLazy(symbols, Symbol::valueType);
     }

--- a/server/src/main/java/io/crate/metadata/GeneratedReference.java
+++ b/server/src/main/java/io/crate/metadata/GeneratedReference.java
@@ -68,6 +68,10 @@ public class GeneratedReference implements Reference {
             throw new UnsupportedOperationException(
                 "Aggregation functions are not allowed in generated columns: " + generatedExpression);
         }
+        if (SymbolVisitors.any(Symbols::isTableFunction, generatedExpression)) {
+            throw new UnsupportedOperationException(
+                "Cannot use table function in generated expression of column `" + ref.column().fqn() + "`");
+        }
         this.referencedReferences = new ArrayList<>();
         RefVisitor.visitRefs(generatedExpression, referencedReferences::add);
     }

--- a/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -27,6 +27,7 @@ import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.mapToSortedString;
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_ROUTING_EXCLUDE_GROUP_SETTING;
 import static org.elasticsearch.index.engine.EngineConfig.INDEX_CODEC_SETTING;
@@ -1830,5 +1831,19 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
         assertThatThrownBy(() -> analyze("create table tbl (a int constraint \"\" primary key)"))
             .isExactlyInstanceOf(IllegalArgumentException.class)
             .hasMessage("The name of primary key constraint must not be empty, please either use a name or remove the CONSTRAINT keyword");
+    }
+
+    @Test
+    public void test_cannot_use_table_functions_in_generated_columns() throws Exception {
+        assertThatThrownBy(() -> analyze("create table tbl (x text, y text[] as regexp_matches(x, '(a(.+)z)'))"))
+            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .hasMessage("Cannot use table function in generated expression of column `y`");
+    }
+
+    @Test
+    public void test_cannot_use_table_function_in_default_expression() throws Exception {
+        assertThatThrownBy(() -> analyze("create table tbl (x int default generate_series(1, 10))"))
+            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .hasMessage("Cannot use table function in default expression of column `x`");
     }
 }


### PR DESCRIPTION
Table functions return a set of values, they cannot be stored in a
single row/value.

Relates to https://github.com/crate/crate/issues/15077
