### PR TITLE
Fix flaky test_doc_values_write_and_read_roundtrip_inclusive_doc_mapper_parse

### DIFF
--- a/server/src/testFixtures/java/io/crate/testing/DataTypeTesting.java
+++ b/server/src/testFixtures/java/io/crate/testing/DataTypeTesting.java
@@ -93,10 +93,14 @@ public class DataTypeTesting {
                 return () -> (T) (Boolean) random.nextBoolean();
 
             case StringType.ID:
-                return () -> (T) RandomizedTest.randomAsciiLettersOfLength(random.nextInt(10));
+                Integer maxLength = type.characterMaximumLength();
+                return () -> {
+                    int length = maxLength == null ? random.nextInt(10) : random.nextInt(maxLength + 1);
+                    return (T) RandomizedTest.randomAsciiLettersOfLength(length);
+                };
 
             case CharacterType.ID:
-                return () -> (T) RandomizedTest.randomAsciiLettersOfLength(((CharacterType) type).lengthLimit());
+                return () -> (T) RandomizedTest.randomAsciiLettersOfLength(type.characterMaximumLength());
 
             case IpType.ID:
                 return () -> {


### PR DESCRIPTION
The test failed with seed `8DB195BC45C84F34:485630A4B34D9594`, because
the type randomized to length 1 and the random value generator produced
longer values. For example:

    java.lang.IllegalArgumentException: 'IwCrRpCjeW' is too long for the text type of length: 1
