### PR TITLE
Remove dead code from RefResolver in Indexer

### DIFF
--- a/server/src/main/java/io/crate/execution/dml/Indexer.java
+++ b/server/src/main/java/io/crate/execution/dml/Indexer.java
@@ -203,9 +203,6 @@ public class Indexer {
                 }
             }
             if (column.isRoot()) {
-                if (targetColumns.contains(ref)) {
-                    return NestableCollectExpression.constant(null);
-                }
                 Symbol defaultExpression = ref.defaultExpression();
                 if (defaultExpression == null) {
                     if (ref instanceof GeneratedReference generated) {


### PR DESCRIPTION
The code was never true, a bit above is a:

    int index = targetColumns.indexOf(ref);
    if (index > -1) {
        return ...

If `index <= -1`, then `targetColumns.contains(ref)` must be false.
