### PR TITLE
Fix INSERT INTO .. ON CONFLICT handling with generated primary keys

### DIFF
--- a/docs/appendices/release-notes/5.4.6.rst
+++ b/docs/appendices/release-notes/5.4.6.rst
@@ -46,6 +46,10 @@ See the :ref:`version_5.4.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that caused the value for generated primary key columns to
+  evaluate to ``NULL`` in ``INSERT INTO .. ON CONFLICT`` statements if the
+  column wasn't part of the target column list.
+
 - Creating a table that uses a table-function as part of a default expression or
   generated expression now results in an error on table creation, instead of
   never inserting records due to runtime failures.

--- a/docs/appendices/release-notes/5.5.1.rst
+++ b/docs/appendices/release-notes/5.5.1.rst
@@ -49,6 +49,10 @@ See the :ref:`version_5.5.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that caused the value for generated primary key columns to
+  evaluate to ``NULL`` in ``INSERT INTO .. ON CONFLICT`` statements if the
+  column wasn't part of the target column list.
+
 - Creating a table that uses a table-function as part of a default expression or
   generated expression now results in an error on table creation, instead of
   never inserting records due to runtime failures.

--- a/server/src/main/java/io/crate/execution/dml/upsert/UpdateToInsert.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/UpdateToInsert.java
@@ -31,6 +31,7 @@ import java.util.Map;
 
 import org.jetbrains.annotations.Nullable;
 
+import io.crate.analyze.Id;
 import io.crate.common.collections.Maps;
 import io.crate.data.Input;
 import io.crate.execution.dml.IndexItem;
@@ -48,7 +49,6 @@ import io.crate.metadata.GeneratedReference;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
 import io.crate.metadata.TransactionContext;
-import io.crate.metadata.doc.DocSysColumns;
 import io.crate.metadata.doc.DocTableInfo;
 
 /**
@@ -160,13 +160,12 @@ public final class UpdateToInsert {
         if (insertColumns != null) {
             this.columns.addAll(insertColumns);
         }
+        List<String> updateColumnList = Arrays.asList(updateColumns);
         for (var ref : table.columns()) {
             // The Indexer later on injects the generated column values
             // We only include them here if they are provided in the `updateColumns` to validate
             // that users provided the right value (otherwise they'd get ignored and we'd generate them later)
-            if (ref instanceof GeneratedReference
-                    && !Arrays.asList(updateColumns).contains(ref.column().fqn())
-                    && !table.primaryKey().contains(ref.column())) {
+            if (ref instanceof GeneratedReference && !updateColumnList.contains(ref.column().fqn())) {
                 continue;
             }
             if (!this.columns.contains(ref)) {
@@ -204,12 +203,6 @@ public final class UpdateToInsert {
     public IndexItem convert(Doc doc, Symbol[] updateAssignments, Object[] excludedValues) {
         Values values = new Values(doc, excludedValues);
         Object[] insertValues = new Object[columns.size()];
-        int pkSize = table.primaryKey().equals(List.of(DocSysColumns.ID))
-            ? 0
-            : table.primaryKey().size();
-        String[] primaryKeys = new String[pkSize];
-
-
         Iterator<Reference> it = columns.iterator();
         for (int i = 0; it.hasNext(); i++) {
             Reference ref = it.next();
@@ -244,26 +237,9 @@ public final class UpdateToInsert {
             }
             Maps.mergeInto(source, targetPath.name(), targetPath.path(), value);
         }
-
-        for (int pkIndex = 0; pkIndex < pkSize; pkIndex++) {
-            ColumnIdent pk = table.primaryKey().get(pkIndex);
-            Object value;
-            if (pk.isRoot()) {
-                int valuesIdx = Reference.indexOf(columns, pk);
-                assert valuesIdx > -1 : "Primary key column must exist in columns";
-                value = insertValues[valuesIdx];
-            } else {
-                int valuesIdx = Reference.indexOf(columns, pk.getRoot());
-                Object object = insertValues[valuesIdx];
-                value = Maps.getByPath((Map<String, Object>) object, pk.path());
-            }
-            if (value != null) {
-                primaryKeys[pkIndex] = value.toString();
-            }
-        }
         return new IndexItem.StaticItem(
             doc.getId(),
-            Arrays.asList(primaryKeys),
+            Id.decode(table.primaryKey(), doc.getId()),
             insertValues,
             doc.getSeqNo(),
             doc.getPrimaryTerm()

--- a/server/src/test/java/io/crate/execution/dml/upsert/UpdateToInsertTest.java
+++ b/server/src/test/java/io/crate/execution/dml/upsert/UpdateToInsertTest.java
@@ -23,17 +23,21 @@ package io.crate.execution.dml.upsert;
 
 
 import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.junit.Test;
 
+import io.crate.analyze.Id;
 import io.crate.execution.dml.IndexItem;
 import io.crate.expression.reference.Doc;
 import io.crate.expression.symbol.InputColumn;
@@ -48,7 +52,7 @@ import io.crate.testing.SQLExecutor;
 
 public class UpdateToInsertTest extends CrateDummyClusterServiceUnitTest {
 
-    private static Doc doc(String index, Map<String, Object> source) {
+    private static Doc doc(String id, String index, Map<String, Object> source) {
         Supplier<String> rawSource = () -> {
             try {
                 return Strings.toString(JsonXContent.builder().map(source));
@@ -56,7 +60,7 @@ public class UpdateToInsertTest extends CrateDummyClusterServiceUnitTest {
                 throw new RuntimeException(e1);
             }
         };
-        return new Doc(1, index, "id-1", 1, 1, 1, source, rawSource);
+        return new Doc(1, index, id, 1, 1, 1, source, rawSource);
     }
 
     @Test
@@ -73,7 +77,7 @@ public class UpdateToInsertTest extends CrateDummyClusterServiceUnitTest {
             null
         );
         Map<String, Object> source = Map.of("x", 10, "y", 5);
-        Doc doc = doc(table.concreteIndices()[0], source);
+        Doc doc = doc(UUIDs.randomBase64UUID(), table.concreteIndices()[0], source);
 
         IndexItem item = updateToInsert.convert(
             doc,
@@ -98,7 +102,7 @@ public class UpdateToInsertTest extends CrateDummyClusterServiceUnitTest {
             null
         );
         Map<String, Object> source = Map.of("x", 10, "y", 5);
-        Doc doc = doc(table.concreteIndices()[0], source);
+        Doc doc = doc(UUIDs.randomBase64UUID(), table.concreteIndices()[0], source);
 
         IndexItem item = updateToInsert.convert(
             doc,
@@ -123,7 +127,7 @@ public class UpdateToInsertTest extends CrateDummyClusterServiceUnitTest {
             null
         );
         Map<String, Object> source = Map.of("x", 1, "o", Map.of("y", 2));
-        Doc doc = doc(table.concreteIndices()[0], source);
+        Doc doc = doc(UUIDs.randomBase64UUID(), table.concreteIndices()[0], source);
         IndexItem item = updateToInsert.convert(
             doc,
             new Symbol[] { Literal.of(3) },
@@ -147,7 +151,7 @@ public class UpdateToInsertTest extends CrateDummyClusterServiceUnitTest {
             null
         );
         Map<String, Object> source = Map.of("x", 1, "y", 5);
-        Doc doc = doc(table.concreteIndices()[0], source);
+        Doc doc = doc(UUIDs.randomBase64UUID(), table.concreteIndices()[0], source);
         IndexItem item = updateToInsert.convert(
             doc,
             new Symbol[] { Literal.of(8) },
@@ -174,7 +178,7 @@ public class UpdateToInsertTest extends CrateDummyClusterServiceUnitTest {
             null
         );
         Map<String, Object> source = Map.of("x", 12);
-        Doc doc = doc(table.concreteIndices()[0], source);
+        Doc doc = doc(UUIDs.randomBase64UUID(), table.concreteIndices()[0], source);
 
         Symbol[] assignments = new Symbol[] { Literal.of(8) };
         IndexItem item = updateToInsert.convert(doc, assignments, new Object[0]);
@@ -196,7 +200,7 @@ public class UpdateToInsertTest extends CrateDummyClusterServiceUnitTest {
             null
         );
         Map<String, Object> source = Map.of("x", 12);
-        Doc doc = doc(table.concreteIndices()[0], source);
+        Doc doc = doc(UUIDs.randomBase64UUID(), table.concreteIndices()[0], source);
         IndexItem item = updateToInsert.convert(
             doc,
             new Symbol[] { Literal.of(1), Literal.of(2) },
@@ -224,7 +228,7 @@ public class UpdateToInsertTest extends CrateDummyClusterServiceUnitTest {
             null
         );
         Map<String, Object> source = Map.of("y", 1, "o", Map.of("x", 3));
-        Doc doc = doc(table.concreteIndices()[0], source);
+        Doc doc = doc("3", table.concreteIndices()[0], source);
         IndexItem item = updateToInsert.convert(
             doc,
             new Symbol[] { Literal.of(1) },
@@ -275,7 +279,7 @@ public class UpdateToInsertTest extends CrateDummyClusterServiceUnitTest {
             );
 
         Map<String, Object> source = Map.of("x", 1, "y", 2, "z", 3);
-        Doc doc = doc(table.concreteIndices()[0], source);
+        Doc doc = doc(UUIDs.randomBase64UUID(), table.concreteIndices()[0], source);
         IndexItem item = updateToInsert.convert(
             doc,
             new Symbol[] { Literal.of(20) },
@@ -315,7 +319,8 @@ public class UpdateToInsertTest extends CrateDummyClusterServiceUnitTest {
                 );
 
         Map<String, Object> source = Map.of("x", 1, "y", Map.of("a", 2), "z", 3);
-        Doc doc = doc(table.concreteIndices()[0], source);
+        String id = UUIDs.randomBase64UUID();
+        Doc doc = doc(id, table.concreteIndices()[0], source);
         IndexItem item = updateToInsert.convert(
                 doc,
                 new Symbol[] { Literal.of(20) },
@@ -353,7 +358,8 @@ public class UpdateToInsertTest extends CrateDummyClusterServiceUnitTest {
             Arrays.asList(insertColumns)
         );
         Map<String, Object> source = Map.of("x", 1, "y", 2, "z", 3);
-        Doc doc = doc(table.concreteIndices()[0], source);
+        String id = Id.encode(List.of("1", "2"), -1);
+        Doc doc = doc(id, table.concreteIndices()[0], source);
         IndexItem item = updateToInsert.convert(
             doc,
             new Symbol[] { new InputColumn(1) },
@@ -361,11 +367,10 @@ public class UpdateToInsertTest extends CrateDummyClusterServiceUnitTest {
         );
         assertThat(updateToInsert.columns()).satisfiesExactly(
             x -> assertThat(x).isReference().hasName("x"),
-            x -> assertThat(x).isReference().hasName("z"),
-            x -> assertThat(x).isReference().hasName("y")
+            x -> assertThat(x).isReference().hasName("z")
         );
         assertThat(item.pkValues()).containsExactly("1", "2");
-        assertThat(item.insertValues()).containsExactly(1, 20, 2);
+        assertThat(item.insertValues()).containsExactly(1, 20);
     }
 
     @Test
@@ -401,7 +406,8 @@ public class UpdateToInsertTest extends CrateDummyClusterServiceUnitTest {
             "o", Map.of("y", 2),
             "z", 3
         );
-        Doc doc = doc(table.concreteIndices()[0], source);
+        String id = Id.encode(List.of("1", "2"), -1);
+        Doc doc = doc(id, table.concreteIndices()[0], source);
         IndexItem item = updateToInsert.convert(
             doc,
             new Symbol[] { new InputColumn(1) },
@@ -442,7 +448,8 @@ public class UpdateToInsertTest extends CrateDummyClusterServiceUnitTest {
             "y", 10,
             "z", 3
         );
-        Doc doc = doc(table.concreteIndices()[0], source);
+        String id = Id.encode(List.of("1", "10"), -1);
+        Doc doc = doc(id, table.concreteIndices()[0], source);
         IndexItem item = updateToInsert.convert(
             doc,
             new Symbol[] { new InputColumn(1) },


### PR DESCRIPTION
In a statement like:

    INSERT INTO tbl (id, date, value) VALUES (...)
    ON CONFLICT (id, date, year)
    DO UPDATE SET value = excluded.value

Where `year` is generated, part of the primary key, and derived from
`date`, the `year` value was set to `NULL`.

This happened because `UpdateToInsert` added `year` to the
`insertColumns`. That didn't work because in the non-conflict code path
the value is not provided, and because of that it remained a `NULL`.

Closes https://github.com/crate/crate/issues/15089
