### PR TITLE
Remove custom schema IndexParts constructor

### DIFF
--- a/server/src/main/java/io/crate/action/sql/Sessions.java
+++ b/server/src/main/java/io/crate/action/sql/Sessions.java
@@ -211,7 +211,7 @@ public class Sessions {
     public Iterable<Cursor> getCursors(User user) {
         return () -> sessions.values().stream()
             .filter(session ->
-                user.hasPrivilege(Type.AL, Clazz.CLUSTER, null, session.sessionSettings().currentSchema())
+                user.hasPrivilege(Type.AL, Clazz.CLUSTER, null)
                 || session.sessionSettings().sessionUser().equals(user))
             .flatMap(session -> StreamSupport.stream(session.cursors.spliterator(), false))
             .iterator();

--- a/server/src/main/java/io/crate/auth/AccessControlImpl.java
+++ b/server/src/main/java/io/crate/auth/AccessControlImpl.java
@@ -26,13 +26,13 @@ import static io.crate.user.Privilege.Type.READ_WRITE_DEFINE;
 import java.util.Locale;
 
 import io.crate.analyze.AnalyzedAlterBlobTable;
+import io.crate.analyze.AnalyzedAlterRole;
 import io.crate.analyze.AnalyzedAlterTable;
 import io.crate.analyze.AnalyzedAlterTableAddColumn;
 import io.crate.analyze.AnalyzedAlterTableDropCheckConstraint;
 import io.crate.analyze.AnalyzedAlterTableDropColumn;
 import io.crate.analyze.AnalyzedAlterTableOpenClose;
 import io.crate.analyze.AnalyzedAlterTableRename;
-import io.crate.analyze.AnalyzedAlterRole;
 import io.crate.analyze.AnalyzedAnalyze;
 import io.crate.analyze.AnalyzedBegin;
 import io.crate.analyze.AnalyzedClose;
@@ -43,19 +43,19 @@ import io.crate.analyze.AnalyzedCreateAnalyzer;
 import io.crate.analyze.AnalyzedCreateBlobTable;
 import io.crate.analyze.AnalyzedCreateFunction;
 import io.crate.analyze.AnalyzedCreateRepository;
+import io.crate.analyze.AnalyzedCreateRole;
 import io.crate.analyze.AnalyzedCreateSnapshot;
 import io.crate.analyze.AnalyzedCreateTable;
 import io.crate.analyze.AnalyzedCreateTableAs;
-import io.crate.analyze.AnalyzedCreateRole;
 import io.crate.analyze.AnalyzedDeallocate;
 import io.crate.analyze.AnalyzedDeclare;
 import io.crate.analyze.AnalyzedDeleteStatement;
 import io.crate.analyze.AnalyzedDiscard;
 import io.crate.analyze.AnalyzedDropFunction;
 import io.crate.analyze.AnalyzedDropRepository;
+import io.crate.analyze.AnalyzedDropRole;
 import io.crate.analyze.AnalyzedDropSnapshot;
 import io.crate.analyze.AnalyzedDropTable;
-import io.crate.analyze.AnalyzedDropRole;
 import io.crate.analyze.AnalyzedDropView;
 import io.crate.analyze.AnalyzedFetch;
 import io.crate.analyze.AnalyzedGCDanglingArtifacts;
@@ -110,8 +110,8 @@ import io.crate.replication.logical.analyze.AnalyzedDropSubscription;
 import io.crate.sql.tree.SetStatement;
 import io.crate.user.Privilege;
 import io.crate.user.Privileges;
-import io.crate.user.User;
 import io.crate.user.RoleLookup;
+import io.crate.user.User;
 
 public final class AccessControlImpl implements AccessControl {
 
@@ -306,9 +306,9 @@ public final class AccessControlImpl implements AccessControl {
 
         @Override
         public Void visitSwapTable(AnalyzedSwapTable swapTable, User user) {
-            if (!user.hasPrivilege(Privilege.Type.AL, Privilege.Clazz.CLUSTER, null, defaultSchema)) {
-                if (!user.hasPrivilege(Privilege.Type.DDL, Privilege.Clazz.TABLE, swapTable.target().ident().fqn(), defaultSchema)
-                    || !user.hasPrivilege(Privilege.Type.DDL, Privilege.Clazz.TABLE, swapTable.source().ident().fqn(), defaultSchema)
+            if (!user.hasPrivilege(Privilege.Type.AL, Privilege.Clazz.CLUSTER, null)) {
+                if (!user.hasPrivilege(Privilege.Type.DDL, Privilege.Clazz.TABLE, swapTable.target().ident().fqn())
+                    || !user.hasPrivilege(Privilege.Type.DDL, Privilege.Clazz.TABLE, swapTable.source().ident().fqn())
                 ) {
                     throw new MissingPrivilegeException(user.name());
                 }

--- a/server/src/main/java/io/crate/expression/scalar/HasPrivilegeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/HasPrivilegeFunction.java
@@ -39,8 +39,8 @@ import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 import io.crate.user.Privilege;
-import io.crate.user.User;
 import io.crate.user.RoleLookup;
+import io.crate.user.User;
 
 public abstract class HasPrivilegeFunction extends Scalar<Boolean, Object> {
 
@@ -214,8 +214,8 @@ public abstract class HasPrivilegeFunction extends Scalar<Boolean, Object> {
     protected static void validateCallPrivileges(User sessionUser, User user) {
         // Only superusers can call this function for other users
         if (user.name().equals(sessionUser.name()) == false
-            && sessionUser.hasPrivilege(Privilege.Type.DQL, Privilege.Clazz.TABLE, "sys.privileges", null) == false
-            && sessionUser.hasPrivilege(Privilege.Type.AL, Privilege.Clazz.CLUSTER, "crate", null) == false) {
+            && sessionUser.hasPrivilege(Privilege.Type.DQL, Privilege.Clazz.TABLE, "sys.privileges") == false
+            && sessionUser.hasPrivilege(Privilege.Type.AL, Privilege.Clazz.CLUSTER, "crate") == false) {
             throw new MissingPrivilegeException(sessionUser.name());
         }
     }

--- a/server/src/main/java/io/crate/expression/scalar/HasSchemaPrivilegeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/HasSchemaPrivilegeFunction.java
@@ -26,17 +26,16 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.function.BiFunction;
 
-import org.jetbrains.annotations.Nullable;
-
 import org.elasticsearch.common.TriFunction;
+import org.jetbrains.annotations.Nullable;
 
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 import io.crate.metadata.pgcatalog.PgCatalogTableDefinitions;
 import io.crate.types.DataTypes;
 import io.crate.user.Privilege;
-import io.crate.user.User;
 import io.crate.user.RoleLookup;
+import io.crate.user.User;
 
 public class HasSchemaPrivilegeFunction extends HasPrivilegeFunction {
 
@@ -51,7 +50,7 @@ public class HasSchemaPrivilegeFunction extends HasPrivilegeFunction {
                 return true;
             }
             // Last argument is null as it's not used for Privilege.Clazz.SCHEMA
-            result |= user.hasPrivilege(type, Privilege.Clazz.SCHEMA, schemaName, null);
+            result |= user.hasPrivilege(type, Privilege.Clazz.SCHEMA, schemaName);
         }
         return result;
     };

--- a/server/src/main/java/io/crate/metadata/IndexParts.java
+++ b/server/src/main/java/io/crate/metadata/IndexParts.java
@@ -49,10 +49,6 @@ public class IndexParts {
     private final String partitionIdent;
 
     public IndexParts(String indexName) {
-        this(indexName, Schemas.DOC_SCHEMA_NAME);
-    }
-
-    public IndexParts(String indexName, String defaultSchema) {
         if (BlobIndex.isBlobIndex(indexName)) {
             schema = BlobSchemaInfo.NAME;
             table = BlobIndex.stripPrefix(indexName);
@@ -63,7 +59,7 @@ public class IndexParts {
             switch (parts.length) {
                 case 1:
                     // "table_name"
-                    schema = defaultSchema;
+                    schema = Schemas.DOC_SCHEMA_NAME;
                     table = indexName;
                     partitionIdent = null;
                     break;
@@ -76,7 +72,7 @@ public class IndexParts {
                 case 4:
                     // ""."partitioned"."table_name". ["ident"]
                     assertEmpty(parts[0]);
-                    schema = defaultSchema;
+                    schema = Schemas.DOC_SCHEMA_NAME;
                     assertPartitionPrefix(parts[1]);
                     table = parts[2];
                     partitionIdent = parts[3];

--- a/server/src/main/java/io/crate/metadata/sys/SysTableDefinitions.java
+++ b/server/src/main/java/io/crate/metadata/sys/SysTableDefinitions.java
@@ -80,7 +80,7 @@ public class SysTableDefinitions {
                     .filter(x ->
                         user.isSuperUser()
                         || user.name().equals(x.username())
-                        || user.hasPrivilege(Type.AL, Clazz.CLUSTER, null, txnCtx.sessionSettings().currentSchema()))
+                        || user.hasPrivilege(Type.AL, Clazz.CLUSTER, null))
                     .iterator()
             ),
             sysJobsTable.expressions(),
@@ -92,7 +92,7 @@ public class SysTableDefinitions {
                     .filter(x ->
                         user.isSuperUser()
                         || user.name().equals(x.username())
-                        || user.hasPrivilege(Type.AL, Clazz.CLUSTER, null, txnCtx.sessionSettings().currentSchema()))
+                        || user.hasPrivilege(Type.AL, Clazz.CLUSTER, null))
                     .iterator()
             ),
             sysJobsLogTable.expressions(),

--- a/server/src/main/java/io/crate/replication/logical/metadata/Publication.java
+++ b/server/src/main/java/io/crate/replication/logical/metadata/Publication.java
@@ -40,7 +40,6 @@ import org.elasticsearch.index.IndexSettings;
 
 import io.crate.metadata.IndexParts;
 import io.crate.metadata.RelationName;
-import io.crate.metadata.Schemas;
 import io.crate.user.Privilege;
 import io.crate.user.User;
 
@@ -159,7 +158,7 @@ public class Publication implements Writeable {
     }
 
     private static boolean subscriberCanRead(RelationName relationName, User subscriber, String publicationName) {
-        boolean canRead = subscriber.hasPrivilege(Privilege.Type.DQL, Privilege.Clazz.TABLE, relationName.fqn(), Schemas.DOC_SCHEMA_NAME);
+        boolean canRead = subscriber.hasPrivilege(Privilege.Type.DQL, Privilege.Clazz.TABLE, relationName.fqn());
         if (canRead == false) {
             if (LOGGER.isInfoEnabled()) {
                 LOGGER.info("User {} subscribed to the publication {} doesn't have DQL privilege on the table {}, this table will not be replicated.",
@@ -175,7 +174,7 @@ public class Publication implements Writeable {
             // Required privileges correspond to those we check for the pre-defined tables case in AccessControlImpl.visitCreatePublication.
 
             // Schemas.DOC_SCHEMA_NAME is a dummy parameter since we are passing fqn as ident.
-            if (!publicationOwner.hasPrivilege(type, Privilege.Clazz.TABLE, relationName.fqn(), Schemas.DOC_SCHEMA_NAME)) {
+            if (!publicationOwner.hasPrivilege(type, Privilege.Clazz.TABLE, relationName.fqn())) {
                 if (LOGGER.isInfoEnabled()) {
                     LOGGER.info("User {} owning publication {} doesn't have {} privilege on the table {}, this table will not be replicated.",
                         publicationOwner.name(), publicationName, type.name(), relationName.fqn());

--- a/server/src/main/java/io/crate/user/Privileges.java
+++ b/server/src/main/java/io/crate/user/Privileges.java
@@ -21,6 +21,8 @@
 
 package io.crate.user;
 
+import org.jetbrains.annotations.Nullable;
+
 import io.crate.common.annotations.VisibleForTesting;
 import io.crate.exceptions.MissingPrivilegeException;
 import io.crate.exceptions.RelationUnknown;
@@ -29,8 +31,6 @@ import io.crate.metadata.IndexParts;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.information.InformationSchemaInfo;
 import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
-
-import org.jetbrains.annotations.Nullable;
 
 public class Privileges {
 
@@ -50,7 +50,7 @@ public class Privileges {
             return;
         }
         //noinspection PointlessBooleanExpression
-        if (user.hasPrivilege(type, clazz, ident, defaultSchema) == false) {
+        if (user.hasPrivilege(type, clazz, ident) == false) {
             boolean objectIsVisibleToUser = user.hasAnyPrivilege(clazz, ident);
             if (objectIsVisibleToUser) {
                 throw new MissingPrivilegeException(user.name(), type);

--- a/server/src/main/java/io/crate/user/User.java
+++ b/server/src/main/java/io/crate/user/User.java
@@ -88,10 +88,9 @@ public class User {
      * @param type           privilege type
      * @param clazz          privilege class (ie. CLUSTER, TABLE, etc)
      * @param ident          ident of the object
-     * @param defaultSchema  the default schema of the current session
      */
-    public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, @Nullable String ident, String defaultSchema) {
-        return isSuperUser() || privileges.matchPrivilege(type, clazz, ident, defaultSchema);
+    public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, @Nullable String ident) {
+        return isSuperUser() || privileges.matchPrivilege(type, clazz, ident);
     }
 
     /**

--- a/server/src/main/java/io/crate/user/UserPrivileges.java
+++ b/server/src/main/java/io/crate/user/UserPrivileges.java
@@ -21,16 +21,17 @@
 
 package io.crate.user;
 
-import io.crate.metadata.IndexParts;
-
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import io.crate.metadata.IndexParts;
 
 public class UserPrivileges implements Iterable<Privilege> {
 
@@ -116,8 +117,7 @@ public class UserPrivileges implements Iterable<Privilege> {
      */
     public boolean matchPrivilege(@Nullable Privilege.Type type,
                                   Privilege.Clazz clazz,
-                                  @Nullable String ident,
-                                  String defaultSchema) {
+                                  @Nullable String ident) {
         Privilege foundPrivilege = privilegeByIdent.get(new PrivilegeIdent(type, clazz, ident));
         if (foundPrivilege == null) {
             switch (clazz) {
@@ -126,7 +126,7 @@ public class UserPrivileges implements Iterable<Privilege> {
                     break;
                 case TABLE:
                 case VIEW:
-                    String schemaIdent = new IndexParts(ident, defaultSchema).getSchema();
+                    String schemaIdent = new IndexParts(ident).getSchema();
                     foundPrivilege = privilegeByIdent.get(new PrivilegeIdent(type, Privilege.Clazz.SCHEMA, schemaIdent));
                     if (foundPrivilege == null) {
                         foundPrivilege = privilegeByIdent.get(new PrivilegeIdent(type, Privilege.Clazz.CLUSTER, null));

--- a/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
+++ b/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
@@ -34,8 +34,6 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 
-import org.jetbrains.annotations.Nullable;
-
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.RepositoriesMetadata;
@@ -43,6 +41,7 @@ import org.elasticsearch.cluster.metadata.RepositoryMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.test.ClusterServiceUtils;
+import org.jetbrains.annotations.Nullable;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Answers;
@@ -106,14 +105,14 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
                                              "crate")),
                         null) {
             @Override
-            public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, String ident, String defaultSchema) {
+            public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, String ident) {
                 validationCallArguments.add(CollectionUtils.arrayAsArrayList(type, clazz, ident, user.name()));
                 return true;
             }
         };
         superUser = new User("crate", EnumSet.of(User.Role.SUPERUSER), Set.of(), null) {
             @Override
-            public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, @Nullable String ident, String defaultSchema) {
+            public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, @Nullable String ident) {
                 validationCallArguments.add(CollectionUtils.arrayAsArrayList(type, clazz, ident, superUser.name()));
                 return true;
             }
@@ -581,7 +580,7 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
         // custom user has only DML privileges
         var customUser = new User("normal", Set.of(), Set.of(), null) {
             @Override
-            public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, String ident, String defaultSchema) {
+            public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, String ident) {
                 validationCallArguments.add(CollectionUtils.arrayAsArrayList(type, clazz, ident, user.name()));
                 return Privilege.Type.DDL == type;
             }

--- a/server/src/test/java/io/crate/auth/user/UserPrivilegesTest.java
+++ b/server/src/test/java/io/crate/auth/user/UserPrivilegesTest.java
@@ -21,7 +21,7 @@
 
 package io.crate.auth.user;
 
-import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -55,9 +55,9 @@ public class UserPrivilegesTest extends ESTestCase {
     @Test
     public void testMatchPrivilegesEmpty() throws Exception {
         UserPrivileges userPrivileges = new UserPrivileges(Collections.emptyList());
-        assertThat(userPrivileges.matchPrivilege(Privilege.Type.DDL, Privilege.Clazz.CLUSTER, null, "doc")).isFalse();
-        assertThat(userPrivileges.matchPrivilege(Privilege.Type.DDL, Privilege.Clazz.SCHEMA, "doc", "doc")).isFalse();
-        assertThat(userPrivileges.matchPrivilege(Privilege.Type.DDL, Privilege.Clazz.TABLE, "doc.t1", "doc")).isFalse();
+        assertThat(userPrivileges.matchPrivilege(Privilege.Type.DDL, Privilege.Clazz.CLUSTER, null)).isFalse();
+        assertThat(userPrivileges.matchPrivilege(Privilege.Type.DDL, Privilege.Clazz.SCHEMA, "doc")).isFalse();
+        assertThat(userPrivileges.matchPrivilege(Privilege.Type.DDL, Privilege.Clazz.TABLE, "doc.t1")).isFalse();
         assertThat(userPrivileges.matchPrivilegeOfAnyType(Privilege.Clazz.CLUSTER, null)).isFalse();
         assertThat(userPrivileges.matchPrivilegeOfAnyType(Privilege.Clazz.SCHEMA, "doc")).isFalse();
         assertThat(userPrivileges.matchPrivilegeOfAnyType(Privilege.Clazz.TABLE, "doc.t1")).isFalse();
@@ -65,9 +65,9 @@ public class UserPrivilegesTest extends ESTestCase {
 
     @Test
     public void testMatchPrivilegeNoType() throws Exception {
-        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DDL, Privilege.Clazz.CLUSTER, null, "doc")).isFalse();
-        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DDL, Privilege.Clazz.SCHEMA, "doc", "doc")).isFalse();
-        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DDL, Privilege.Clazz.TABLE, "doc.t1", "doc")).isFalse();
+        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DDL, Privilege.Clazz.CLUSTER, null)).isFalse();
+        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DDL, Privilege.Clazz.SCHEMA, "doc")).isFalse();
+        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DDL, Privilege.Clazz.TABLE, "doc.t1")).isFalse();
         assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilegeOfAnyType(Privilege.Clazz.CLUSTER, null)).isTrue();
         assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilegeOfAnyType(Privilege.Clazz.SCHEMA, "doc")).isTrue();
         assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilegeOfAnyType(Privilege.Clazz.TABLE, "doc.t1")).isTrue();
@@ -75,25 +75,25 @@ public class UserPrivilegesTest extends ESTestCase {
 
     @Test
     public void testMatchPrivilegeType() throws Exception {
-        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.CLUSTER, null, "doc")).isTrue();
+        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.CLUSTER, null)).isTrue();
         assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilegeOfAnyType(Privilege.Clazz.CLUSTER, null)).isTrue();
     }
 
     @Test
     public void testMatchPrivilegeSchema() throws Exception {
-        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.SCHEMA, "doc", "doc")).isTrue();
+        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.SCHEMA, "doc")).isTrue();
         assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilegeOfAnyType(Privilege.Clazz.SCHEMA, "doc")).isTrue();
-        assertThat(USER_PRIVILEGES_SCHEMA.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.SCHEMA, "doc", "doc")).isTrue();
+        assertThat(USER_PRIVILEGES_SCHEMA.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.SCHEMA, "doc")).isTrue();
         assertThat(USER_PRIVILEGES_SCHEMA.matchPrivilegeOfAnyType(Privilege.Clazz.SCHEMA, "doc")).isTrue();
     }
 
     @Test
     public void testMatchPrivilegeTable() throws Exception {
-        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.TABLE, "doc.t1", "doc")).isTrue();
+        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.TABLE, "doc.t1")).isTrue();
         assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilegeOfAnyType(Privilege.Clazz.TABLE, "doc.t1")).isTrue();
-        assertThat(USER_PRIVILEGES_SCHEMA.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.TABLE, "doc.t1", "doc")).isTrue();
+        assertThat(USER_PRIVILEGES_SCHEMA.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.TABLE, "doc.t1")).isTrue();
         assertThat(USER_PRIVILEGES_SCHEMA.matchPrivilegeOfAnyType(Privilege.Clazz.TABLE, "doc.t1")).isTrue();
-        assertThat(USER_PRIVILEGES_TABLE.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.TABLE, "doc.t1", "doc")).isTrue();
+        assertThat(USER_PRIVILEGES_TABLE.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.TABLE, "doc.t1")).isTrue();
         assertThat(USER_PRIVILEGES_TABLE.matchPrivilegeOfAnyType(Privilege.Clazz.TABLE, "doc.t1")).isTrue();
     }
 
@@ -103,9 +103,9 @@ public class UserPrivilegesTest extends ESTestCase {
             new Privilege(Privilege.State.DENY, Privilege.Type.DQL, Privilege.Clazz.CLUSTER, null, "crate")
         );
         UserPrivileges userPrivileges = new UserPrivileges(privileges);
-        assertThat(userPrivileges.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.CLUSTER, null, "doc")).isFalse();
-        assertThat(userPrivileges.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.SCHEMA, "doc", "doc")).isFalse();
-        assertThat(userPrivileges.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.TABLE, "doc.t1", "doc")).isFalse();
+        assertThat(userPrivileges.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.CLUSTER, null)).isFalse();
+        assertThat(userPrivileges.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.SCHEMA, "doc")).isFalse();
+        assertThat(userPrivileges.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.TABLE, "doc.t1")).isFalse();
         assertThat(userPrivileges.matchPrivilegeOfAnyType(Privilege.Clazz.CLUSTER, null)).isFalse();
         assertThat(userPrivileges.matchPrivilegeOfAnyType(Privilege.Clazz.SCHEMA, "doc")).isFalse();
         assertThat(userPrivileges.matchPrivilegeOfAnyType(Privilege.Clazz.TABLE, "doc.t1")).isFalse();
@@ -119,8 +119,8 @@ public class UserPrivilegesTest extends ESTestCase {
             new Privilege(Privilege.State.GRANT, Privilege.Type.DQL, Privilege.Clazz.TABLE, "doc.t1", "crate")
         );
         UserPrivileges userPrivileges = new UserPrivileges(privileges);
-        assertThat(userPrivileges.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.TABLE, "doc.t1", "doc")).isTrue();
-        assertThat(userPrivileges.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.TABLE, "doc.t2", "doc")).isFalse();
-        assertThat(userPrivileges.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.SCHEMA, "my_schema", "doc")).isTrue();
+        assertThat(userPrivileges.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.TABLE, "doc.t1")).isTrue();
+        assertThat(userPrivileges.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.TABLE, "doc.t2")).isFalse();
+        assertThat(userPrivileges.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.SCHEMA, "my_schema")).isTrue();
     }
 }

--- a/server/src/test/java/io/crate/replication/logical/action/PublicationsStateActionTest.java
+++ b/server/src/test/java/io/crate/replication/logical/action/PublicationsStateActionTest.java
@@ -48,8 +48,8 @@ import io.crate.sql.tree.QualifiedName;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.user.Privilege;
-import io.crate.user.User;
 import io.crate.user.RoleLookup;
+import io.crate.user.User;
 
 public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTest {
 
@@ -73,7 +73,7 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
     public void test_resolve_relation_names_for_all_tables_ignores_table_with_soft_delete_disabled() throws Exception {
         var user = new User("dummy", Set.of(), Set.of(), null) {
             @Override
-            public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, String ident, String defaultSchema) {
+            public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, String ident) {
                 return true; // This test case doesn't check privileges.
             }
         };
@@ -105,13 +105,13 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
     public void test_resolve_relation_names_for_all_tables_ignores_table_when_pub_owner_doesnt_have_read_write_define_permissions() throws Exception {
         var publicationOwner = new User("publisher", Set.of(), Set.of(), null) {
             @Override
-            public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, String ident, String defaultSchema) {
+            public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, String ident) {
                 return ident.equals("doc.t1");
             }
         };
         var subscriber = new User("subscriber", Set.of(), Set.of(), null) {
             @Override
-            public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, String ident, String defaultSchema) {
+            public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, String ident) {
                 return true;
             }
         };
@@ -140,14 +140,14 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
     public void test_resolve_relation_names_for_all_tables_ignores_table_when_subscriber_doesnt_have_read_permissions() throws Exception {
         var publicationOwner = new User("publisher", Set.of(), Set.of(), null) {
             @Override
-            public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, String ident, String defaultSchema) {
+            public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, String ident) {
                 return true;
             }
         };
 
         var subscriber = new User("subscriber", Set.of(), Set.of(), null) {
             @Override
-            public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, String ident, String defaultSchema) {
+            public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, String ident) {
                 return ident.equals("doc.t1");
             }
         };
@@ -170,14 +170,14 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
     public void test_resolve_relation_names_for_fixed_tables_ignores_table_when_subscriber_doesnt_have_read_permissions() throws Exception {
         var publicationOwner = new User("publisher", Set.of(), Set.of(), null) {
             @Override
-            public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, String ident, String defaultSchema) {
+            public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, String ident) {
                 return true;
             }
         };
 
         var subscriber = new User("subscriber", Set.of(), Set.of(), null) {
             @Override
-            public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, String ident, String defaultSchema) {
+            public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, String ident) {
                 return ident.equals("doc.t1");
             }
         };


### PR DESCRIPTION
The index-name encoding is independant of the current session default
schema and the schema is _always_ `doc` if not part of the index name.
