### PR TITLE
Fix three-valued-logic for NOT-Predicate

### DIFF
--- a/docs/appendices/release-notes/5.4.6.rst
+++ b/docs/appendices/release-notes/5.4.6.rst
@@ -46,6 +46,9 @@ See the :ref:`version_5.4.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that caused queries with a ``NOT`` expression in the where
+  clause to fail on evaluation ``NULL`` correctly.
+
 - Fixed an issue that caused the value for generated primary key columns to
   evaluate to ``NULL`` in ``INSERT INTO .. ON CONFLICT`` statements if the
   column wasn't part of the target column list.

--- a/docs/appendices/release-notes/5.5.1.rst
+++ b/docs/appendices/release-notes/5.5.1.rst
@@ -49,6 +49,9 @@ See the :ref:`version_5.5.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that caused queries with a ``NOT`` expression in the where
+  clause to fail on evaluation ``NULL`` correctly.
+
 - Fixed an issue that caused the value for generated primary key columns to
   evaluate to ``NULL`` in ``INSERT INTO .. ON CONFLICT`` statements if the
   column wasn't part of the target column list.

--- a/server/src/main/java/io/crate/expression/predicate/NotPredicate.java
+++ b/server/src/main/java/io/crate/expression/predicate/NotPredicate.java
@@ -36,9 +36,20 @@ import io.crate.expression.operator.LikeOperators;
 import io.crate.expression.operator.any.AnyEqOperator;
 import io.crate.expression.operator.any.AnyNeqOperator;
 import io.crate.expression.operator.any.AnyRangeOperator;
+import io.crate.expression.scalar.ArrayAppendFunction;
+import io.crate.expression.scalar.ArrayCatFunction;
+import io.crate.expression.scalar.ArrayUniqueFunction;
+import io.crate.expression.scalar.ConcatFunction;
+import io.crate.expression.scalar.ConcatWsFunction;
+import io.crate.expression.scalar.FormatFunction;
 import io.crate.expression.scalar.Ignore3vlFunction;
+import io.crate.expression.scalar.SubscriptObjectFunction;
+import io.crate.expression.scalar.arithmetic.ArrayFunction;
+import io.crate.expression.scalar.arithmetic.MapFunction;
+import io.crate.expression.scalar.cast.TryCastFunction;
 import io.crate.expression.scalar.conditional.CaseFunction;
 import io.crate.expression.scalar.conditional.CoalesceFunction;
+import io.crate.expression.scalar.conditional.IfFunction;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
@@ -135,7 +146,19 @@ public class NotPredicate extends Scalar<Boolean, Boolean> {
                 LikeOperators.ANY_LIKE,
                 LikeOperators.ANY_NOT_LIKE,
                 CoalesceFunction.NAME,
-                CaseFunction.NAME
+                CaseFunction.NAME,
+                ConcatFunction.NAME,
+                ConcatWsFunction.NAME,
+                ArrayCatFunction.NAME,
+                ArrayAppendFunction.NAME,
+                ArrayFunction.NAME,
+                ArrayUniqueFunction.NAME,
+                FormatFunction.NAME,
+                IfFunction.NAME,
+                IsNullPredicate.NAME,
+                MapFunction.NAME,
+                TryCastFunction.NAME,
+                SubscriptObjectFunction.NAME
             );
 
         @Override

--- a/server/src/main/java/io/crate/expression/scalar/ArrayAppendFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayAppendFunction.java
@@ -36,7 +36,7 @@ import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.TypeSignature;
 
-class ArrayAppendFunction extends Scalar<List<Object>, Object> {
+public class ArrayAppendFunction extends Scalar<List<Object>, Object> {
 
     public static final String NAME = "array_append";
 

--- a/server/src/main/java/io/crate/expression/scalar/ArrayCatFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayCatFunction.java
@@ -37,7 +37,7 @@ import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.TypeSignature;
 
-class ArrayCatFunction extends Scalar<List<Object>, List<Object>> {
+public class ArrayCatFunction extends Scalar<List<Object>, List<Object>> {
 
     public static final String NAME = "array_cat";
 

--- a/server/src/main/java/io/crate/expression/scalar/ArrayUniqueFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayUniqueFunction.java
@@ -40,7 +40,7 @@ import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.TypeSignature;
 
-class ArrayUniqueFunction extends Scalar<List<Object>, List<Object>> {
+public class ArrayUniqueFunction extends Scalar<List<Object>, List<Object>> {
 
     public static final String NAME = "array_unique";
 

--- a/server/src/test/java/io/crate/lucene/ThreeValuedLogicQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/ThreeValuedLogicQueryBuilderTest.java
@@ -66,4 +66,10 @@ public class ThreeValuedLogicQueryBuilderTest extends LuceneQueryBuilderTest {
         assertThat(convert("NOT (x AND f)")).hasToString(
             "+(+*:* -(+x +f)) #(NOT (x AND f))");
     }
+
+    @Test
+    public void test_negated_concat_with_three_valued_logic() {
+        assertThat(convert("NOT (x || 1) < -1")).hasToString(
+            "+(+*:* -(concat(x, '1') < -1)) #(NOT (concat(x, '1') < -1))");
+    }
 }


### PR DESCRIPTION
This fixes the three-valued-logici (3vl) for the ``NOT`` Predicate by adding all functions to handle as 3vl strict where the property nullable `null -> null` is not fulfilled.

Resolves https://github.com/crate/crate/issues/15083

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
