### PR TITLE
Don't expose indices with non-active primary shards in publications

### DIFF
--- a/server/src/test/java/io/crate/replication/logical/MetadataTrackerTest.java
+++ b/server/src/test/java/io/crate/replication/logical/MetadataTrackerTest.java
@@ -98,7 +98,7 @@ public class MetadataTrackerTest extends ESTestCase {
             clusterState = ClusterState.builder(clusterState)
                 .metadata(Metadata.builder(clusterState.metadata())
                               .put(indexMetadata, true))
-                .routingTable(RoutingTable.builder()
+                .routingTable(RoutingTable.builder(clusterState.routingTable())
                     .add(IndexRoutingTable.builder(indexMetadata.getIndex())
                         .addShard(newShardRouting(name, 0, "dummy_node", true, ShardRoutingState.STARTED))
                         .build())
@@ -121,7 +121,7 @@ public class MetadataTrackerTest extends ESTestCase {
             clusterState = ClusterState.builder(clusterState)
                 .metadata(Metadata.builder(clusterState.metadata())
                               .put(indexMetadata, true))
-                .routingTable(RoutingTable.builder()
+                .routingTable(RoutingTable.builder(clusterState.routingTable())
                     .add(IndexRoutingTable.builder(indexMetadata.getIndex())
                         .addShard(newShardRouting(partition, 0, "dummy_node", true, ShardRoutingState.STARTED))
                         .build())
@@ -255,7 +255,7 @@ public class MetadataTrackerTest extends ESTestCase {
         testTable = new RelationName("doc", "test");
         publicationsStateResponse = new Response(Map.of(
             testTable,
-            RelationMetadata.fromMetadata(testTable, PUBLISHER_CLUSTER_STATE.metadata())), List.of());
+            RelationMetadata.fromMetadata(testTable, PUBLISHER_CLUSTER_STATE.metadata(), ignored -> true)), List.of());
 
         SUBSCRIBER_CLUSTER_STATE = new Builder("subscriber")
             .addReplicatingTable("sub1", "test", Map.of("1", "one"), Settings.EMPTY)
@@ -280,9 +280,13 @@ public class MetadataTrackerTest extends ESTestCase {
             .updateTableMapping("test", updatedMapping)
             .build();
 
-        var updatedResponse = new Response(Map.of(
-            testTable,
-            RelationMetadata.fromMetadata(testTable, updatedPublisherClusterState.metadata())), List.of());
+        var updatedResponse = new Response(
+            Map.of(
+                testTable,
+                RelationMetadata.fromMetadata(testTable, updatedPublisherClusterState.metadata(), ignored -> true)
+            ),
+            List.of()
+        );
 
         syncedSubscriberClusterState = MetadataTracker.updateIndexMetadata(
             "sub1",
@@ -305,9 +309,13 @@ public class MetadataTrackerTest extends ESTestCase {
         var updatedPublisherClusterState = new Builder(PUBLISHER_CLUSTER_STATE)
             .updateTableSettings("test", newSettings)
             .build();
-        var updatedResponse = new Response(Map.of(
-            testTable,
-            RelationMetadata.fromMetadata(testTable, updatedPublisherClusterState.metadata())), List.of());
+        var updatedResponse = new Response(
+            Map.of(
+                testTable,
+                RelationMetadata.fromMetadata(testTable, updatedPublisherClusterState.metadata(), ignored -> true)
+            ),
+            List.of()
+        );
         var syncedSubscriberClusterState = MetadataTracker.updateIndexMetadata(
             "sub1",
             SubscriptionsMetadata.get(SUBSCRIBER_CLUSTER_STATE.metadata()).get("sub1"),
@@ -328,9 +336,13 @@ public class MetadataTrackerTest extends ESTestCase {
         var updatedPublisherClusterState = new Builder(PUBLISHER_CLUSTER_STATE)
             .updateTableSettings("test", newSettings)
             .build();
-        var updatedResponse = new Response(Map.of(
-            testTable,
-            RelationMetadata.fromMetadata(testTable, updatedPublisherClusterState.metadata())), List.of());
+        var updatedResponse = new Response(
+            Map.of(
+                testTable,
+                RelationMetadata.fromMetadata(testTable, updatedPublisherClusterState.metadata(), ignored -> true)
+            ),
+            List.of()
+        );
 
         var syncedSubscriberClusterState = MetadataTracker.updateIndexMetadata(
             "sub1",
@@ -349,9 +361,13 @@ public class MetadataTrackerTest extends ESTestCase {
         var updatedPublisherClusterState = new Builder(PUBLISHER_CLUSTER_STATE)
             .updateTableSettings("test", newSettings)
             .build();
-        var updatedResponse = new Response(Map.of(
-            testTable,
-            RelationMetadata.fromMetadata(testTable, updatedPublisherClusterState.metadata())), List.of());
+        var updatedResponse = new Response(
+            Map.of(
+                testTable,
+                RelationMetadata.fromMetadata(testTable, updatedPublisherClusterState.metadata(), ignored -> true)
+            ),
+            List.of()
+        );
 
         var syncedSubscriberClusterState = MetadataTracker.updateIndexMetadata(
             "sub1",
@@ -386,9 +402,13 @@ public class MetadataTrackerTest extends ESTestCase {
             .build();
 
         RelationName table = new RelationName("doc", "t2");
-        var updatedResponse = new Response(Map.of(
-            table,
-            RelationMetadata.fromMetadata(table, publisherState.metadata())), List.of());
+        var updatedResponse = new Response(
+            Map.of(
+                table,
+                RelationMetadata.fromMetadata(table, publisherState.metadata(), ignored -> true)
+            ),
+            List.of()
+        );
 
         RestoreDiff restoreDiff = MetadataTracker.getRestoreDiff(
             SubscriptionsMetadata.get(subscriberClusterState.metadata()).get("sub1"),
@@ -414,7 +434,10 @@ public class MetadataTrackerTest extends ESTestCase {
             .addPartitionedTable(p1, List.of())
             .addPublication("pub1", List.of(p1.indexNameOrAlias()))
             .build();
-        var publisherStateResponse = new Response(Map.of(p1, RelationMetadata.fromMetadata(p1, publisherState.metadata())), List.of());
+        var publisherStateResponse = new Response(
+            Map.of(p1, RelationMetadata.fromMetadata(p1, publisherState.metadata(), ignored -> true)),
+            List.of()
+        );
 
         var restoreDiff = MetadataTracker.getRestoreDiff(
             SubscriptionsMetadata.get(subscriberClusterState.metadata()).get("sub1"),
@@ -440,7 +463,7 @@ public class MetadataTrackerTest extends ESTestCase {
             .addPublication("pub1", List.of(newRelation.indexNameOrAlias()))
             .addPartitionedTable(newRelation, List.of(newPartitionName))
             .build();
-        RelationMetadata relationMetadata = RelationMetadata.fromMetadata(newRelation, publisherState.metadata());
+        RelationMetadata relationMetadata = RelationMetadata.fromMetadata(newRelation, publisherState.metadata(), ignored -> true);
         var publisherStateResponse = new Response(Map.of(newRelation, relationMetadata), List.of());
 
         var restoreDiff = MetadataTracker.getRestoreDiff(
@@ -468,7 +491,7 @@ public class MetadataTrackerTest extends ESTestCase {
             .addPublication("pub1", List.of(relationName.indexNameOrAlias()))
             .addPartitionedTable(relationName, List.of(newPartitionName))
             .build();
-        RelationMetadata relationMetadata = RelationMetadata.fromMetadata(relationName, publisherState.metadata());
+        RelationMetadata relationMetadata = RelationMetadata.fromMetadata(relationName, publisherState.metadata(), ignored -> true);
         var publisherStateResponse = new Response(Map.of(relationName, relationMetadata), List.of());
 
         var restoreDiff = MetadataTracker.getRestoreDiff(

--- a/server/src/test/java/io/crate/replication/logical/action/PublicationsStateActionTest.java
+++ b/server/src/test/java/io/crate/replication/logical/action/PublicationsStateActionTest.java
@@ -21,8 +21,8 @@
 
 package io.crate.replication.logical.action;
 
-import static org.hamcrest.Matchers.contains;
-import static org.junit.Assert.assertThat;
+import static io.crate.testing.Asserts.assertThat;
+import static java.util.Collections.singletonList;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -40,6 +40,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Schemas;
 import io.crate.replication.logical.metadata.Publication;
@@ -84,6 +85,7 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
         SQLExecutor.builder(clusterService)
             .addTable("CREATE TABLE doc.t1 (id int)")
             .addTable("CREATE TABLE doc.t2 (id int) with (\"soft_deletes.enabled\" = false)")
+            .startShards("doc.t1", "doc.t2")
             .build();
         var publication = new Publication("some_user", true, List.of());
 
@@ -97,7 +99,7 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
         ));
 
         Map<RelationName, RelationMetadata> resolvedRelations = publication.resolveCurrentRelations(clusterService.state(), user, user, "dummy");
-        assertThat(resolvedRelations.keySet(), contains(new RelationName("doc", "t1")));
+        assertThat(resolvedRelations.keySet()).contains(new RelationName("doc", "t1"));
         appender.assertAllExpectationsMatched();
     }
 
@@ -123,6 +125,7 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
         SQLExecutor.builder(clusterService)
             .addTable("CREATE TABLE doc.t1 (id int)")
             .addTable("CREATE TABLE doc.t3 (id int)")
+            .startShards("doc.t1", "doc.t3")
             .build();
         var publication = new Publication("publisher", true, List.of());
 
@@ -133,7 +136,7 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
             "dummy"
         );
 
-        assertThat(resolvedRelations.keySet(), contains(new RelationName("doc", "t1")));
+        assertThat(resolvedRelations.keySet()).contains(new RelationName("doc", "t1"));
     }
 
     @Test
@@ -159,11 +162,12 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
         SQLExecutor.builder(clusterService)
             .addTable("CREATE TABLE doc.t1 (id int)")
             .addTable("CREATE TABLE doc.t3 (id int)")
+            .startShards("doc.t1", "doc.t2")
             .build();
         var publication = new Publication("publisher", true, List.of());
 
         var resolvedRelations = publication.resolveCurrentRelations(clusterService.state(), publicationOwner, subscriber, "dummy");
-        assertThat(resolvedRelations.keySet(), contains(new RelationName("doc", "t1")));
+        assertThat(resolvedRelations.keySet()).contains(new RelationName("doc", "t1"));
     }
 
     @Test
@@ -189,6 +193,7 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
         SQLExecutor.builder(clusterService)
             .addTable("CREATE TABLE doc.t1 (id int)")
             .addTable("CREATE TABLE doc.t2 (id int)")
+            .startShards("doc.t1", "doc.t2")
             .build();
         var publication = new Publication("publisher", false,
             List.of(
@@ -203,6 +208,120 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
             subscriber,
             "dummy"
         );
-        assertThat(resolvedRelations.keySet(), contains(new RelationName("doc", "t1")));
+        assertThat(resolvedRelations.keySet()).contains(new RelationName("doc", "t1"));
+    }
+
+    @Test
+    public void test_resolve_relation_names_for_all_tables_ignores_table_with_non_active_primary_shards() throws Exception {
+        var user = new User("dummy", Set.of(), Set.of(), null) {
+            @Override
+            public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, String ident) {
+                return true; // This test case doesn't check privileges.
+            }
+        };
+
+        SQLExecutor.builder(clusterService)
+            .addTable("CREATE TABLE doc.t1 (id int)")
+            .addTable("CREATE TABLE doc.t2 (id int)")
+            .startShards("doc.t1")      // <- only t1 has active primary shards
+            .build();
+        var publication = new Publication("some_user", true, List.of());
+
+        var resolvedRelations = publication.resolveCurrentRelations(
+            clusterService.state(),
+            user,
+            user,
+            "dummy"
+        );
+
+        assertThat(resolvedRelations.keySet()).contains(new RelationName("doc", "t1"));
+    }
+
+    @Test
+    public void test_resolve_relation_names_for_concrete_tables_ignores_table_with_non_active_primary_shards() throws Exception {
+        var user = new User("dummy", Set.of(), Set.of(), null) {
+            @Override
+            public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, String ident) {
+                return true; // This test case doesn't check privileges.
+            }
+        };
+
+        SQLExecutor.builder(clusterService)
+            .addTable("CREATE TABLE doc.t1 (id int)")
+            .addTable("CREATE TABLE doc.t2 (id int)")
+            .startShards("doc.t1")      // <- only t1 has active primary shards
+            .build();
+        var publication = new Publication(
+            "some_user",
+            false,
+            List.of(RelationName.fromIndexName("t1"), RelationName.fromIndexName("doc.t2"))
+        );
+
+        var resolvedRelations = publication.resolveCurrentRelations(
+            clusterService.state(),
+            user,
+            user,
+            "dummy"
+        );
+
+        assertThat(resolvedRelations.keySet()).contains(new RelationName("doc", "t1"));
+    }
+
+    @Test
+    public void test_resolve_relation_names_for_all_tables_ignores_partition_with_non_active_primary_shards() throws Exception {
+        var user = new User("dummy", Set.of(), Set.of(), null) {
+            @Override
+            public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, String ident) {
+                return true; // This test case doesn't check privileges.
+            }
+        };
+
+        SQLExecutor.builder(clusterService)
+            .addPartitionedTable(
+                "CREATE TABLE doc.p1 (id int, p int) partitioned by (p)",
+                new PartitionName(new RelationName("doc", "p1"), singletonList("1")).asIndexName()
+            )
+            .build();
+        var publication = new Publication("some_user", true, List.of());
+
+        var resolvedRelations = publication.resolveCurrentRelations(
+            clusterService.state(),
+            user,
+            user,
+            "dummy"
+        );
+        RelationMetadata relationMetadata = resolvedRelations.get(new RelationName("doc", "p1"));
+        assertThat(relationMetadata.indices()).isEmpty();
+    }
+
+    @Test
+    public void test_resolve_relation_names_for_concrete_tables_ignores_partition_with_non_active_primary_shards() throws Exception {
+        var user = new User("dummy", Set.of(), Set.of(), null) {
+            @Override
+            public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, String ident) {
+                return true; // This test case doesn't check privileges.
+            }
+        };
+
+        SQLExecutor.builder(clusterService)
+            .addPartitionedTable(
+                "CREATE TABLE doc.p1 (id int, p int) partitioned by (p)",
+                new PartitionName(new RelationName("doc", "p1"), singletonList("1")).asIndexName()
+            )
+            .build();
+        var publication = new Publication(
+            "some_user",
+            false,
+            List.of(RelationName.fromIndexName("p1"))
+        );
+
+        var resolvedRelations = publication.resolveCurrentRelations(
+            clusterService.state(),
+            user,
+            user,
+            "dummy"
+        );
+        RelationMetadata relationMetadata = resolvedRelations.get(new RelationName("doc", "p1"));
+        assertThat(relationMetadata.indices()).isEmpty();
     }
 }


### PR DESCRIPTION
Indices where not all shards are active yet must be skipped as the restore may fail if primaries are not (yet) assigned.

This will fix a flaky `MetadataTrackerITest.test_new_table_and_new_partition_is_replicated` test, see https://jenkins.crate.io/blue/organizations/jenkins/CrateDB%2Fcrate_test_hourly_master/detail/crate_test_hourly_master/15879/pipeline.

I'm not sure in which productive scenario this can cause issues, at least disabling the failing `PrimaryShardAllocator.inSyncAllocationIds.isEmpty()` assertions resulted in a successfully restored table/partition.