### PR TITLE
Generate IndexReference for columns with analyzer in DocTableInfoFactory

### DIFF
--- a/server/src/main/java/io/crate/analyze/AlterTableDropColumnAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/AlterTableDropColumnAnalyzer.java
@@ -33,9 +33,9 @@ import io.crate.analyze.expressions.ExpressionAnalyzer;
 import io.crate.analyze.relations.DocTableRelation;
 import io.crate.analyze.relations.NameFieldProvider;
 import io.crate.exceptions.ColumnUnknownException;
-import io.crate.expression.symbol.SymbolType;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.IndexReference;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
 import io.crate.metadata.Schemas;
@@ -111,7 +111,7 @@ public class AlterTableDropColumnAnalyzer {
             }
             uniqueSet.add(colToDrop);
 
-            if (refToDrop.symbolType() == SymbolType.INDEX_REFERENCE) {
+            if (refToDrop instanceof IndexReference indexRef && !indexRef.columns().isEmpty()) {
                 throw new UnsupportedOperationException("Dropping INDEX column '" + colToDrop.fqn() + "' is not supported");
             }
 

--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfoFactory.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfoFactory.java
@@ -447,19 +447,38 @@ public class DocTableInfoFactory {
                             .sources(sources);
                     }
                 } else {
-                    Reference ref = new SimpleReference(
-                        refIdent,
-                        granularity,
-                        type,
-                        ColumnPolicy.DYNAMIC,
-                        indexType,
-                        nullable,
-                        hasDocValues,
-                        position,
-                        oid,
-                        isDropped,
-                        defaultExpression
-                    );
+                    Reference ref;
+                    if (analyzer == null) {
+                        ref = new SimpleReference(
+                            refIdent,
+                            granularity,
+                            type,
+                            ColumnPolicy.DYNAMIC,
+                            indexType,
+                            nullable,
+                            hasDocValues,
+                            position,
+                            oid,
+                            isDropped,
+                            defaultExpression
+                        );
+                    } else {
+                        ref = new IndexReference(
+                            refIdent,
+                            granularity,
+                            type,
+                            ColumnPolicy.DYNAMIC,
+                            indexType,
+                            nullable,
+                            hasDocValues,
+                            position,
+                            oid,
+                            isDropped,
+                            defaultExpression,
+                            List.of(),
+                            analyzer
+                        );
+                    }
                     references.put(column, ref);
                 }
             }

--- a/server/src/test/java/io/crate/metadata/doc/DocIndexMetadataTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocIndexMetadataTest.java
@@ -444,8 +444,10 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
         assertThat(stringNotAnalyzed.defaultExpression()).isLiteral("default");
 
         Reference stringAnalyzed = table.getReference(new ColumnIdent("stringAnalyzed"));
+        assertThat(stringAnalyzed).isExactlyInstanceOf(IndexReference.class);
         assertThat(stringAnalyzed.indexType()).isEqualTo(IndexType.FULLTEXT);
         assertThat(stringAnalyzed.defaultExpression()).isLiteral("default");
+        assertThat(((IndexReference) stringAnalyzed).analyzer()).isEqualTo("standard");
 
         Reference integerWithCast = table.getReference(new ColumnIdent("integerWithCast"));
         assertThat(integerWithCast.indexType()).isEqualTo(IndexType.PLAIN);


### PR DESCRIPTION
Ran into this while working on https://github.com/crate/crate/pull/15107
Adding a new column lost the fulltext/analyzer information of an
existing column because `SimpleReference.toMapping` was used instead of
`IndexReference.toMapping`

It's currently not resulting in a test failure on master due to how the
existing add-column task is applying a delta on the mapping.

Might have been introduced with https://github.com/crate/crate/pull/15028
