### PR TITLE
Preserve fulltext indices in DocTableInfo.writeTo

### DIFF
--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
@@ -739,7 +739,13 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
     public Metadata.Builder writeTo(CheckedFunction<IndexMetadata, MapperService, IOException> createMapperService,
                                     Metadata metadata,
                                     Metadata.Builder metadataBuilder) throws IOException {
-        List<Reference> allColumns = Stream.concat(references.values().stream(), droppedColumns.stream())
+        List<Reference> allColumns = Stream.concat(
+                Stream.concat(
+                    droppedColumns.stream(),
+                    indexColumns.values().stream()
+                ),
+                references.values().stream()
+            )
             .filter(ref -> !ref.column().isSystemColumn())
             .sorted(Reference.CMP_BY_POSITION_THEN_NAME)
             .toList();

--- a/server/src/testFixtures/java/io/crate/testing/ReferenceAssert.java
+++ b/server/src/testFixtures/java/io/crate/testing/ReferenceAssert.java
@@ -21,13 +21,15 @@
 
 package io.crate.testing;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.assertj.core.api.AbstractAssert;
+
 import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.IndexReference;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 import io.crate.types.DataType;
-import org.assertj.core.api.AbstractAssert;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class ReferenceAssert extends AbstractAssert<ReferenceAssert, Reference> {
 
@@ -77,5 +79,10 @@ public class ReferenceAssert extends AbstractAssert<ReferenceAssert, Reference> 
         return this;
     }
 
+    public ReferenceAssert hasAnalyzer(String analyzer) {
+        isExactlyInstanceOf(IndexReference.class);
+        assertThat(((IndexReference) actual).analyzer()).isEqualTo(analyzer);
+        return this;
+    }
 
 }

--- a/server/src/testFixtures/java/io/crate/testing/SymbolAssert.java
+++ b/server/src/testFixtures/java/io/crate/testing/SymbolAssert.java
@@ -26,10 +26,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 import java.util.function.Consumer;
 
-import org.jetbrains.annotations.Nullable;
-
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.ObjectAssert;
+import org.jetbrains.annotations.Nullable;
 
 import io.crate.data.Input;
 import io.crate.expression.symbol.Aggregation;
@@ -43,6 +42,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.ScopedSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.VoidReference;
+import io.crate.metadata.IndexReference;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 import io.crate.types.DataType;
@@ -114,6 +114,12 @@ public final class SymbolAssert extends AbstractAssert<SymbolAssert, Symbol> {
     public ReferenceAssert isReference() {
         isNotNull();
         isInstanceOf(Reference.class);
+        return new ReferenceAssert((Reference) actual);
+    }
+
+    public ReferenceAssert isIndexReference() {
+        isNotNull();
+        isExactlyInstanceOf(IndexReference.class);
         return new ReferenceAssert((Reference) actual);
     }
 


### PR DESCRIPTION
Follow up to https://github.com/crate/crate/pull/15055
