### PR TITLE
Fix application of optimized iterator for group by queries with a single key

### DIFF
--- a/docs/appendices/release-notes/5.5.2.rst
+++ b/docs/appendices/release-notes/5.5.2.rst
@@ -49,5 +49,8 @@ See the :ref:`version_5.5.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed a performance regression introduced in 5.5.0 for queries with
+   ``GROUP BY`` on a single column.
+
 - Fixed an issue that allowed adding a column under the same name as an existing
   index definition.

--- a/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
@@ -112,7 +112,7 @@ final class DocValuesGroupByOptimizedIterator {
                 return null; // group by on non-reference
             }
             var columnKeyRef = (Reference) DocReferences.inverseSourceLookup(docKeyRef);
-            var keyFieldType = fieldTypeLookup.get(columnKeyRef.column().fqn());
+            var keyFieldType = fieldTypeLookup.get(columnKeyRef.storageIdent());
             if (keyFieldType == null || !keyFieldType.hasDocValues()) {
                 return null;
             } else {

--- a/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
@@ -132,7 +132,7 @@ final class GroupByOptimizedIterator {
             return null; // group by on non-reference
         }
         keyRef = (Reference) DocReferences.inverseSourceLookup(keyRef);
-        MappedFieldType keyFieldType = fieldTypeLookup.get(keyRef.column().fqn());
+        MappedFieldType keyFieldType = fieldTypeLookup.get(keyRef.storageIdent());
         if (keyFieldType == null || !keyFieldType.hasDocValues()) {
             return null;
         }
@@ -181,7 +181,7 @@ final class GroupByOptimizedIterator {
         return getIterator(
             bigArrays,
             searcher.item(),
-            keyRef.column().fqn(),
+            keyRef.storageIdent(),
             aggregations,
             expressions,
             aggExpressions,

--- a/server/src/testFixtures/java/org/elasticsearch/test/ESTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/ESTestCase.java
@@ -945,7 +945,7 @@ public abstract class ESTestCase extends CrateLuceneTestCase {
         return xContent.createParser(xContentRegistry(), LoggingDeprecationHandler.INSTANCE, data.streamInput());
     }
 
-    private static final NamedXContentRegistry DEFAULT_NAMED_X_CONTENT_REGISTRY =
+    protected static final NamedXContentRegistry DEFAULT_NAMED_X_CONTENT_REGISTRY =
             new NamedXContentRegistry(ClusterModule.getNamedXWriteables());
 
     /**


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes #15133

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
