### PR TITLE
Don't set version on template in DocTableInfo.writeTo

### DIFF
--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
@@ -800,10 +800,8 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
             if (indexTemplateMetadata == null) {
                 throw new UnsupportedOperationException("Cannot create template via DocTableInfo.writeTo");
             }
-            Integer version = indexTemplateMetadata.getVersion();
             var template = new IndexTemplateMetadata.Builder(indexTemplateMetadata)
                 .putMapping(Strings.toString(JsonXContent.builder().map(mapping)))
-                .version(version == null ? 1 : version + 1)
                 .build();
             metadataBuilder.put(template);
         }


### PR DESCRIPTION
*Edit*: This is probably the wrong fix, don't merge

Follow up to:

- https://github.com/crate/crate/pull/15055
- https://github.com/crate/crate/pull/15107

We didn't set the version before, and setting it leads to exceptions in
the log, e.g. running `test_alter_partitioned_table_drop_column_can_add_again`:

    Caused by: org.elasticsearch.indices.InvalidIndexTemplateException: index_template [yfijfv..partitioned.t.] invalid, cause [Validation Failed: 1: private index setting [index.version.created] can not be set explicitly;]
            at org.elasticsearch.cluster.metadata.MetadataIndexTemplateService.validate(MetadataIndexTemplateService.java:322) ~[classes/:?]
            at org.elasticsearch.cluster.metadata.MetadataIndexTemplateService.putTemplate(MetadataIndexTemplateService.java:156) ~[classes/:?]
            at org.elasticsearch.action.admin.indices.template.put.TransportPutIndexTemplateAction.masterOperation(TransportPutIndexTemplateAction.java:83) ~[classes/:?]
            at org.elasticsearch.action.admin.indices.template.put.TransportPutIndexTemplateAction.masterOperation(TransportPutIndexTemplateAction.java:1) ~[classes/:?]
            at org.elasticsearch.action.support.master.TransportMasterNodeAction$AsyncSingleAction.lambda$3(TransportMasterNodeAction.java:177) ~[classes/:?]

Triggered by the `TemplateUpgradeService`:

        at org.elasticsearch.cluster.metadata.TemplateUpgradeService.upgradeTemplates(TemplateUpgradeService.java:147) ~[classes/:?]
        at org.elasticsearch.cluster.metadata.TemplateUpgradeService.lambda$1(TemplateUpgradeService.java:136) ~[classes/:?]
