### PR TITLE
Improve three-valued-logic processing for scalar function evalution

### DIFF
--- a/libs/shared/src/main/java/io/crate/common/collections/Sets.java
+++ b/libs/shared/src/main/java/io/crate/common/collections/Sets.java
@@ -25,6 +25,7 @@ import java.util.AbstractSet;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -46,6 +47,15 @@ public class Sets {
         Objects.requireNonNull(left);
         Objects.requireNonNull(right);
         return left.stream().noneMatch(right::contains);
+    }
+
+    @SafeVarargs
+    public static <T> Set<T> concat(Set<T> left, T ... right) {
+        Objects.requireNonNull(left);
+        Objects.requireNonNull(right);
+        var result = new HashSet<T>(left);
+        result.addAll(List.of(right));
+        return Collections.unmodifiableSet(result);
     }
 
     public static <T> Set<T> union(Set<T> left, Set<T> right) {

--- a/server/src/main/java/io/crate/expression/operator/AllOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/AllOperator.java
@@ -60,11 +60,12 @@ public final class AllOperator extends Operator<Object> {
         for (var type : Type.values()) {
             module.register(
                 Signature.scalar(
-                    type.fullQualifiedName,
-                    TypeSignature.parse("E"),
-                    TypeSignature.parse("array(E)"),
-                    Operator.RETURN_TYPE.getTypeSignature()
-                ).withTypeVariableConstraints(typeVariable("E")),
+                        type.fullQualifiedName,
+                        TypeSignature.parse("E"),
+                        TypeSignature.parse("array(E)"),
+                        Operator.RETURN_TYPE.getTypeSignature()
+                    ).withTypeVariableConstraints(typeVariable("E"))
+                    .withFeature(Feature.NULLABLE),
                 (signature, boundSignature) ->
                     new AllOperator(
                         signature,

--- a/server/src/main/java/io/crate/expression/operator/CIDROperator.java
+++ b/server/src/main/java/io/crate/expression/operator/CIDROperator.java
@@ -58,7 +58,7 @@ public final class CIDROperator {
                 DataTypes.IP.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature(),
                 Operator.RETURN_TYPE.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.NULLABLE),
             ContainedWithinOperator::new
         );
     }

--- a/server/src/main/java/io/crate/expression/operator/EqOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/EqOperator.java
@@ -71,11 +71,12 @@ public final class EqOperator extends Operator<Object> {
     public static final String NAME = "op_=";
 
     public static final Signature SIGNATURE = Signature.scalar(
-        NAME,
-        TypeSignature.parse("E"),
-        TypeSignature.parse("E"),
-        Operator.RETURN_TYPE.getTypeSignature()
-    ).withTypeVariableConstraints(typeVariable("E"));
+            NAME,
+            TypeSignature.parse("E"),
+            TypeSignature.parse("E"),
+            Operator.RETURN_TYPE.getTypeSignature()
+        ).withFeature(Feature.NULLABLE)
+        .withTypeVariableConstraints(typeVariable("E"));
 
     public static void register(OperatorModule module) {
         module.register(

--- a/server/src/main/java/io/crate/expression/operator/ExistsOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/ExistsOperator.java
@@ -37,10 +37,11 @@ public class ExistsOperator extends Operator<List<Object>> {
 
     public static void register(OperatorModule module) {
         Signature signature = Signature.scalar(
-            NAME,
-            TypeSignature.parse("array(E)"),
-            Operator.RETURN_TYPE.getTypeSignature()
-        ).withTypeVariableConstraints(TypeVariableConstraint.typeVariable("E"));
+                NAME,
+                TypeSignature.parse("array(E)"),
+                Operator.RETURN_TYPE.getTypeSignature()
+            ).withTypeVariableConstraints(TypeVariableConstraint.typeVariable("E"))
+            .withFeature(Feature.NULLABLE);
         module.register(signature, ExistsOperator::new);
     }
 

--- a/server/src/main/java/io/crate/expression/operator/GtOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/GtOperator.java
@@ -21,6 +21,7 @@
 
 package io.crate.expression.operator;
 
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
@@ -36,7 +37,7 @@ public final class GtOperator {
                     supportedType.getTypeSignature(),
                     supportedType.getTypeSignature(),
                     Operator.RETURN_TYPE.getTypeSignature()
-                ),
+                ).withFeature(Scalar.Feature.NULLABLE),
                 (signature, boundSignature) -> new CmpOperator(
                     signature,
                     boundSignature,

--- a/server/src/main/java/io/crate/expression/operator/GteOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/GteOperator.java
@@ -21,6 +21,7 @@
 
 package io.crate.expression.operator;
 
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
@@ -36,7 +37,7 @@ public final class GteOperator {
                     supportedType.getTypeSignature(),
                     supportedType.getTypeSignature(),
                     Operator.RETURN_TYPE.getTypeSignature()
-                ),
+                ).withFeature(Scalar.Feature.NULLABLE),
                 (signature, boundSignature) -> new CmpOperator(
                     signature,
                     boundSignature,

--- a/server/src/main/java/io/crate/expression/operator/LikeOperators.java
+++ b/server/src/main/java/io/crate/expression/operator/LikeOperators.java
@@ -32,6 +32,7 @@ import io.crate.expression.operator.any.AnyLikeOperator;
 import io.crate.expression.operator.any.AnyNotLikeOperator;
 import io.crate.expression.operator.any.AnyOperator;
 import io.crate.lucene.match.CrateRegexQuery;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
@@ -110,7 +111,7 @@ public class LikeOperators {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature(),
                 Operator.RETURN_TYPE.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new LikeOperator(signature, boundSignature, LikeOperators::matches, CaseSensitivity.SENSITIVE)
         );
@@ -120,7 +121,7 @@ public class LikeOperators {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature(),
                 Operator.RETURN_TYPE.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new LikeOperator(signature, boundSignature, LikeOperators::matches, CaseSensitivity.INSENSITIVE)
         );
@@ -153,7 +154,7 @@ public class LikeOperators {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING_ARRAY.getTypeSignature(),
                 Operator.RETURN_TYPE.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new AnyLikeOperator(
                     signature,
@@ -167,7 +168,7 @@ public class LikeOperators {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING_ARRAY.getTypeSignature(),
                 Operator.RETURN_TYPE.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new AnyNotLikeOperator(
                     signature,
@@ -181,7 +182,7 @@ public class LikeOperators {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING_ARRAY.getTypeSignature(),
                 Operator.RETURN_TYPE.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new AnyLikeOperator(
                     signature,
@@ -195,7 +196,7 @@ public class LikeOperators {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING_ARRAY.getTypeSignature(),
                 Operator.RETURN_TYPE.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new AnyNotLikeOperator(
                     signature,

--- a/server/src/main/java/io/crate/expression/operator/LtOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/LtOperator.java
@@ -21,6 +21,7 @@
 
 package io.crate.expression.operator;
 
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
@@ -36,7 +37,7 @@ public final class LtOperator {
                     supportedType.getTypeSignature(),
                     supportedType.getTypeSignature(),
                     Operator.RETURN_TYPE.getTypeSignature()
-                ),
+                ).withFeature(Scalar.Feature.NULLABLE),
                 (signature, boundSignature) ->
                     new CmpOperator(signature, boundSignature, cmpResult -> cmpResult < 0)
             );

--- a/server/src/main/java/io/crate/expression/operator/LteOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/LteOperator.java
@@ -21,6 +21,7 @@
 
 package io.crate.expression.operator;
 
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
@@ -36,7 +37,7 @@ public final class LteOperator {
                     supportedType.getTypeSignature(),
                     supportedType.getTypeSignature(),
                     Operator.RETURN_TYPE.getTypeSignature()
-                ),
+                ).withFeature(Scalar.Feature.NULLABLE),
                 (signature, boundSignature) -> new CmpOperator(
                     signature,
                     boundSignature,

--- a/server/src/main/java/io/crate/expression/predicate/IsNullPredicate.java
+++ b/server/src/main/java/io/crate/expression/predicate/IsNullPredicate.java
@@ -65,10 +65,11 @@ public class IsNullPredicate<T> extends Scalar<Boolean, T> {
 
     public static final String NAME = "op_isnull";
     public static final Signature SIGNATURE = Signature.scalar(
-        NAME,
-        TypeSignature.parse("E"),
-        DataTypes.BOOLEAN.getTypeSignature()
-    ).withTypeVariableConstraints(typeVariable("E"));
+            NAME,
+            TypeSignature.parse("E"),
+            DataTypes.BOOLEAN.getTypeSignature()
+        ).withFeature(Feature.NON_NULLABLE)
+        .withTypeVariableConstraints(typeVariable("E"));
 
     public static void register(PredicateModule module) {
         module.register(

--- a/server/src/main/java/io/crate/expression/predicate/MatchPredicate.java
+++ b/server/src/main/java/io/crate/expression/predicate/MatchPredicate.java
@@ -59,6 +59,7 @@ import io.crate.lucene.LuceneQueryBuilder;
 import io.crate.lucene.LuceneQueryBuilder.Context;
 import io.crate.lucene.match.MatchQueries;
 import io.crate.metadata.FunctionImplementation;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 import io.crate.server.xcontent.LoggingDeprecationHandler;
@@ -90,7 +91,7 @@ public class MatchPredicate implements FunctionImplementation, FunctionToQuery {
         DataTypes.STRING.getTypeSignature(),
         DataTypes.UNTYPED_OBJECT.getTypeSignature(),
         DataTypes.BOOLEAN.getTypeSignature()
-    );
+    ).withFeature(Scalar.Feature.NON_NULLABLE);
 
     public static final Signature GEO_MATCH = Signature.scalar(
         NAME,
@@ -99,7 +100,7 @@ public class MatchPredicate implements FunctionImplementation, FunctionToQuery {
         DataTypes.STRING.getTypeSignature(),
         DataTypes.UNTYPED_OBJECT.getTypeSignature(),
         DataTypes.BOOLEAN.getTypeSignature()
-    );
+    ).withFeature(Scalar.Feature.NON_NULLABLE);
 
 
     public static void register(PredicateModule module) {

--- a/server/src/main/java/io/crate/expression/scalar/AgeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/AgeFunction.java
@@ -24,6 +24,8 @@ package io.crate.expression.scalar;
 
 import static io.crate.metadata.functions.Signature.scalar;
 
+import java.util.EnumSet;
+
 import org.joda.time.DateTimeZone;
 import org.joda.time.Interval;
 import org.joda.time.Period;
@@ -49,7 +51,7 @@ public class AgeFunction extends Scalar<Period, Object> {
                 NAME,
                 DataTypes.TIMESTAMP.getTypeSignature(),
                 DataTypes.INTERVAL.getTypeSignature()
-            ).withFeatures(NO_FEATURES),
+            ).withFeatures(EnumSet.of(Feature.NULLABLE)),
             AgeFunction::new
         );
 
@@ -59,7 +61,7 @@ public class AgeFunction extends Scalar<Period, Object> {
                 DataTypes.TIMESTAMP.getTypeSignature(),
                 DataTypes.TIMESTAMP.getTypeSignature(),
                 DataTypes.INTERVAL.getTypeSignature()
-            ).withFeatures(NO_FEATURES),
+            ).withFeatures(EnumSet.of(Feature.NULLABLE)),
             AgeFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/ArrayAppendFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayAppendFunction.java
@@ -43,11 +43,12 @@ public class ArrayAppendFunction extends Scalar<List<Object>, Object> {
     public static void register(ScalarFunctionModule module) {
         module.register(
             Signature.scalar(
-                NAME,
-                TypeSignature.parse("array(E)"),
-                TypeSignature.parse("E"),
-                TypeSignature.parse("array(E)")
-            ).withTypeVariableConstraints(typeVariable("E")),
+                    NAME,
+                    TypeSignature.parse("array(E)"),
+                    TypeSignature.parse("E"),
+                    TypeSignature.parse("array(E)")
+                ).withTypeVariableConstraints(typeVariable("E"))
+                .withFeature(Feature.NON_NULLABLE),
             ArrayAppendFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/ArrayCatFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayCatFunction.java
@@ -48,7 +48,7 @@ public class ArrayCatFunction extends Scalar<List<Object>, List<Object>> {
                 TypeSignature.parse("array(E)"),
                 TypeSignature.parse("array(E)"),
                 TypeSignature.parse("array(E)")
-            )
+            ).withFeature(Feature.NON_NULLABLE)
                 .withTypeVariableConstraints(typeVariable("E")),
             ArrayCatFunction::new
         );

--- a/server/src/main/java/io/crate/expression/scalar/ArrayDifferenceFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayDifferenceFunction.java
@@ -52,11 +52,12 @@ class ArrayDifferenceFunction extends Scalar<List<Object>, List<Object>> {
     public static void register(ScalarFunctionModule module) {
         module.register(
             Signature.scalar(
-                NAME,
-                TypeSignature.parse("array(E)"),
-                TypeSignature.parse("array(E)"),
-                TypeSignature.parse("array(E)")
-            ).withTypeVariableConstraints(typeVariable("E")),
+                    NAME,
+                    TypeSignature.parse("array(E)"),
+                    TypeSignature.parse("array(E)"),
+                    TypeSignature.parse("array(E)")
+                ).withTypeVariableConstraints(typeVariable("E"))
+                .withFeature(Feature.NULLABLE),
             (signature, boundSignature) ->
                 new ArrayDifferenceFunction(
                     signature,

--- a/server/src/main/java/io/crate/expression/scalar/ArrayLowerFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayLowerFunction.java
@@ -44,11 +44,12 @@ class ArrayLowerFunction extends Scalar<Integer, Object> {
     public static void register(ScalarFunctionModule module) {
         module.register(
             Signature.scalar(
-                NAME,
-                TypeSignature.parse("array(E)"),
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.INTEGER.getTypeSignature()
-            ).withTypeVariableConstraints(typeVariable("E")),
+                    NAME,
+                    TypeSignature.parse("array(E)"),
+                    DataTypes.INTEGER.getTypeSignature(),
+                    DataTypes.INTEGER.getTypeSignature()
+                ).withTypeVariableConstraints(typeVariable("E"))
+                .withFeature(Feature.NULLABLE),
             ArrayLowerFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/ArrayMaxFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayMaxFunction.java
@@ -46,10 +46,11 @@ public class ArrayMaxFunction<T> extends Scalar<T, List<T>> {
 
         module.register(
             Signature.scalar(
-                NAME,
-                new ArrayType(DataTypes.NUMERIC).getTypeSignature(),
-                DataTypes.NUMERIC.getTypeSignature()
-            ),
+                    NAME,
+                    new ArrayType(DataTypes.NUMERIC).getTypeSignature(),
+                    DataTypes.NUMERIC.getTypeSignature()
+                )
+                .withFeature(Feature.NULLABLE),
             ArrayMaxFunction::new
         );
 
@@ -59,7 +60,8 @@ public class ArrayMaxFunction<T> extends Scalar<T, List<T>> {
                     NAME,
                     new ArrayType(supportedType).getTypeSignature(),
                     supportedType.getTypeSignature()
-                ),
+                )
+                .withFeature(Feature.NULLABLE),
                 ArrayMaxFunction::new
             );
         }

--- a/server/src/main/java/io/crate/expression/scalar/ArrayMinFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayMinFunction.java
@@ -46,20 +46,22 @@ public class ArrayMinFunction<T> extends Scalar<T, List<T>> {
 
         module.register(
             Signature.scalar(
-                NAME,
-                new ArrayType(DataTypes.NUMERIC).getTypeSignature(),
-                DataTypes.NUMERIC.getTypeSignature()
-            ),
+                    NAME,
+                    new ArrayType(DataTypes.NUMERIC).getTypeSignature(),
+                    DataTypes.NUMERIC.getTypeSignature()
+                )
+                .withFeature(Feature.NULLABLE),
             ArrayMinFunction::new
         );
 
         for (var supportedType : DataTypes.PRIMITIVE_TYPES) {
             module.register(
                 Signature.scalar(
-                    NAME,
-                    new ArrayType(supportedType).getTypeSignature(),
-                    supportedType.getTypeSignature()
-                ),
+                        NAME,
+                        new ArrayType(supportedType).getTypeSignature(),
+                        supportedType.getTypeSignature()
+                    )
+                    .withFeature(Feature.NULLABLE),
                 ArrayMinFunction::new
             );
         }

--- a/server/src/main/java/io/crate/expression/scalar/ArrayPositionFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayPositionFunction.java
@@ -48,19 +48,21 @@ public class ArrayPositionFunction extends Scalar<Integer, List<Object>> {
     public static void register(ScalarFunctionModule scalarFunctionModule) {
         scalarFunctionModule.register(
             Signature.scalar(NAME,
-                TypeSignature.parse("array(T)"),
-                TypeSignature.parse("T"),
-                DataTypes.INTEGER.getTypeSignature()
-            ).withTypeVariableConstraints(typeVariable("T")),
+                    TypeSignature.parse("array(T)"),
+                    TypeSignature.parse("T"),
+                    DataTypes.INTEGER.getTypeSignature()
+                ).withTypeVariableConstraints(typeVariable("T"))
+                .withFeature(Feature.NULLABLE),
             ArrayPositionFunction::new);
 
         scalarFunctionModule.register(
             Signature.scalar(NAME,
-                TypeSignature.parse("array(T)"),
-                TypeSignature.parse("T"),
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.INTEGER.getTypeSignature()
-            ).withTypeVariableConstraints(typeVariable("T")),
+                    TypeSignature.parse("array(T)"),
+                    TypeSignature.parse("T"),
+                    DataTypes.INTEGER.getTypeSignature(),
+                    DataTypes.INTEGER.getTypeSignature()
+                ).withTypeVariableConstraints(typeVariable("T"))
+                .withFeature(Feature.NULLABLE),
             ArrayPositionFunction::new);
     }
 

--- a/server/src/main/java/io/crate/expression/scalar/ArraySetFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArraySetFunction.java
@@ -44,22 +44,24 @@ public class ArraySetFunction extends Scalar<List<Object>, Object> {
         TypeSignature arrayESignature = TypeSignature.parse("array(E)");
         module.register(
             Signature.scalar(
-                NAME,
-                arrayESignature,
-                new ArrayType<>(DataTypes.INTEGER).getTypeSignature(),
-                arrayESignature,
-                arrayESignature
-            ).withTypeVariableConstraints(typeVariable("E")),
+                    NAME,
+                    arrayESignature,
+                    new ArrayType<>(DataTypes.INTEGER).getTypeSignature(),
+                    arrayESignature,
+                    arrayESignature
+                ).withTypeVariableConstraints(typeVariable("E"))
+                .withFeature(Feature.NULLABLE),
             ArraySetFunction::new
         );
         module.register(
             Signature.scalar(
-                NAME,
-                arrayESignature,
-                DataTypes.INTEGER.getTypeSignature(),
-                TypeSignature.parse("E"),
-                arrayESignature
-            ).withTypeVariableConstraints(typeVariable("E")),
+                    NAME,
+                    arrayESignature,
+                    DataTypes.INTEGER.getTypeSignature(),
+                    TypeSignature.parse("E"),
+                    arrayESignature
+                ).withTypeVariableConstraints(typeVariable("E"))
+                .withFeature(Feature.NULLABLE),
             SingleArraySetFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/ArraySliceFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArraySliceFunction.java
@@ -43,12 +43,13 @@ public class ArraySliceFunction extends Scalar<List<Object>, Object> {
     public static void register(ScalarFunctionModule module) {
         module.register(
             Signature.scalar(
-                NAME,
-                TypeSignature.parse("array(E)"),
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.INTEGER.getTypeSignature(),
-                TypeSignature.parse("array(E)")
-            ).withTypeVariableConstraints(typeVariable("E")),
+                    NAME,
+                    TypeSignature.parse("array(E)"),
+                    DataTypes.INTEGER.getTypeSignature(),
+                    DataTypes.INTEGER.getTypeSignature(),
+                    TypeSignature.parse("array(E)")
+                ).withTypeVariableConstraints(typeVariable("E"))
+                .withFeature(Feature.NON_NULLABLE),
             ArraySliceFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/ArraySumFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArraySumFunction.java
@@ -49,10 +49,10 @@ public class ArraySumFunction<T extends Number, R extends Number> extends Scalar
 
         module.register(
             Signature.scalar(
-                NAME,
-                new ArrayType(DataTypes.NUMERIC).getTypeSignature(),
-                DataTypes.NUMERIC.getTypeSignature()
-            ),
+                    NAME,
+                    new ArrayType(DataTypes.NUMERIC).getTypeSignature(),
+                    DataTypes.NUMERIC.getTypeSignature()
+                ).withFeature(Feature.NULLABLE),
             ArraySumFunction::new
         );
 
@@ -64,10 +64,10 @@ public class ArraySumFunction<T extends Number, R extends Number> extends Scalar
 
             module.register(
                 Signature.scalar(
-                    NAME,
-                    new ArrayType(supportedType).getTypeSignature(),
-                    inputDependantOutputType.getTypeSignature()
-                ),
+                        NAME,
+                        new ArrayType(supportedType).getTypeSignature(),
+                        inputDependantOutputType.getTypeSignature()
+                    ).withFeature(Feature.NULLABLE),
                 ArraySumFunction::new
             );
         }

--- a/server/src/main/java/io/crate/expression/scalar/ArrayToStringFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayToStringFunction.java
@@ -45,21 +45,23 @@ class ArrayToStringFunction extends Scalar<String, Object> {
     public static void register(ScalarFunctionModule module) {
         module.register(
             Signature.scalar(
-                FQN,
-                TypeSignature.parse("array(E)"),
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withTypeVariableConstraints(typeVariable("E")),
+                    FQN,
+                    TypeSignature.parse("array(E)"),
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature()
+                ).withTypeVariableConstraints(typeVariable("E"))
+                .withFeature(Feature.NULLABLE),
             ArrayToStringFunction::new
         );
         module.register(
             Signature.scalar(
-                FQN,
-                TypeSignature.parse("array(E)"),
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withTypeVariableConstraints(typeVariable("E")),
+                    FQN,
+                    TypeSignature.parse("array(E)"),
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature()
+                ).withTypeVariableConstraints(typeVariable("E"))
+                .withFeature(Feature.NULLABLE),
             ArrayToStringFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/ArrayUniqueFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayUniqueFunction.java
@@ -47,19 +47,21 @@ public class ArrayUniqueFunction extends Scalar<List<Object>, List<Object>> {
     public static void register(ScalarFunctionModule module) {
         module.register(
             Signature.scalar(
-                NAME,
-                TypeSignature.parse("array(E)"),
-                TypeSignature.parse("array(E)")
-            ).withTypeVariableConstraints(typeVariable("E")),
+                    NAME,
+                    TypeSignature.parse("array(E)"),
+                    TypeSignature.parse("array(E)")
+                ).withTypeVariableConstraints(typeVariable("E"))
+                .withFeature(Feature.NON_NULLABLE),
             ArrayUniqueFunction::new
         );
         module.register(
             Signature.scalar(
-                NAME,
-                TypeSignature.parse("array(E)"),
-                TypeSignature.parse("array(E)"),
-                TypeSignature.parse("array(E)")
-            ).withTypeVariableConstraints(typeVariable("E")),
+                    NAME,
+                    TypeSignature.parse("array(E)"),
+                    TypeSignature.parse("array(E)"),
+                    TypeSignature.parse("array(E)")
+                ).withTypeVariableConstraints(typeVariable("E"))
+                .withFeature(Feature.NON_NULLABLE),
             ArrayUniqueFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/ArrayUnnestFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayUnnestFunction.java
@@ -47,10 +47,11 @@ public class ArrayUnnestFunction extends Scalar<List<Object>, List<List<Object>>
 
     public static final String NAME = "array_unnest";
     public static final Signature SIGNATURE = Signature.scalar(
-        NAME,
-        TypeSignature.parse("array(array(E))"),
-        TypeSignature.parse("array(E)")
-    ).withTypeVariableConstraints(typeVariable("E"));
+            NAME,
+            TypeSignature.parse("array(array(E))"),
+            TypeSignature.parse("array(E)")
+        ).withTypeVariableConstraints(typeVariable("E"))
+        .withFeature(Feature.NULLABLE);
 
     public static void register(ScalarFunctionModule module) {
         module.register(SIGNATURE, ArrayUnnestFunction::new);

--- a/server/src/main/java/io/crate/expression/scalar/ArrayUpperFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayUpperFunction.java
@@ -67,11 +67,12 @@ public class ArrayUpperFunction extends Scalar<Integer, Object> {
         for (var name : List.of(ARRAY_UPPER, ARRAY_LENGTH)) {
             module.register(
                 Signature.scalar(
-                    name,
-                    TypeSignature.parse("array(E)"),
-                    DataTypes.INTEGER.getTypeSignature(),
-                    DataTypes.INTEGER.getTypeSignature()
-                ).withTypeVariableConstraints(typeVariable("E")),
+                        name,
+                        TypeSignature.parse("array(E)"),
+                        DataTypes.INTEGER.getTypeSignature(),
+                        DataTypes.INTEGER.getTypeSignature()
+                    ).withTypeVariableConstraints(typeVariable("E"))
+                    .withFeature(Feature.NULLABLE),
                 ArrayUpperFunction::new
             );
         }

--- a/server/src/main/java/io/crate/expression/scalar/CollectionAverageFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/CollectionAverageFunction.java
@@ -41,10 +41,11 @@ public class CollectionAverageFunction extends Scalar<Double, List<Object>> {
     public static void register(ScalarFunctionModule module) {
         module.register(
             Signature.scalar(
-                NAME,
-                TypeSignature.parse("array(E)"),
-                DataTypes.DOUBLE.getTypeSignature()
-            ).withTypeVariableConstraints(typeVariable("E")),
+                    NAME,
+                    TypeSignature.parse("array(E)"),
+                    DataTypes.DOUBLE.getTypeSignature()
+                ).withTypeVariableConstraints(typeVariable("E"))
+                .withFeature(Feature.NULLABLE),
             CollectionAverageFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/CollectionCountFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/CollectionCountFunction.java
@@ -41,10 +41,11 @@ public class CollectionCountFunction extends Scalar<Long, List<Object>> {
     public static void register(ScalarFunctionModule module) {
         module.register(
             Signature.scalar(
-                NAME,
-                TypeSignature.parse("array(E)"),
-                DataTypes.LONG.getTypeSignature()
-            ).withTypeVariableConstraints(typeVariable("E")),
+                    NAME,
+                    TypeSignature.parse("array(E)"),
+                    DataTypes.LONG.getTypeSignature()
+                ).withTypeVariableConstraints(typeVariable("E"))
+                .withFeature(Feature.NULLABLE),
             CollectionCountFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/ConcatFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ConcatFunction.java
@@ -47,7 +47,8 @@ public abstract class ConcatFunction extends Scalar<String, String> {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            )
+            .withFeature(Feature.NON_NULLABLE),
             StringConcatFunction::new
         );
 
@@ -57,7 +58,8 @@ public abstract class ConcatFunction extends Scalar<String, String> {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
             )
-                .withVariableArity(),
+            .withFeature(Feature.NON_NULLABLE)
+            .withVariableArity(),
             GenericConcatFunction::new
         );
 
@@ -69,7 +71,8 @@ public abstract class ConcatFunction extends Scalar<String, String> {
                 TypeSignature.parse("array(E)"),
                 TypeSignature.parse("array(E)")
             )
-                .withTypeVariableConstraints(typeVariable("E")),
+            .withFeature(Feature.NON_NULLABLE)
+            .withTypeVariableConstraints(typeVariable("E")),
             ArrayCatFunction::new
         );
 
@@ -79,7 +82,8 @@ public abstract class ConcatFunction extends Scalar<String, String> {
                 DataTypes.UNTYPED_OBJECT.getTypeSignature(),
                 DataTypes.UNTYPED_OBJECT.getTypeSignature(),
                 DataTypes.UNTYPED_OBJECT.getTypeSignature()
-            ),
+            )
+            .withFeature(Feature.NON_NULLABLE),
             ObjectMergeFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/ConcatWsFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ConcatWsFunction.java
@@ -30,7 +30,6 @@ import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
 public class ConcatWsFunction extends Scalar<String, String> {
-
     public static final String NAME = "concat_ws";
 
     public static void register(ScalarFunctionModule module) {
@@ -39,7 +38,9 @@ public class ConcatWsFunction extends Scalar<String, String> {
                 NAME,
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ).withVariableArity(),
+            )
+            .withFeature(Feature.NULLABLE)
+            .withVariableArity(),
             ConcatWsFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/CurrentDatabaseFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/CurrentDatabaseFunction.java
@@ -41,7 +41,7 @@ final class CurrentDatabaseFunction extends Scalar<String, Void> {
             Signature.scalar(
                 FQN,
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Feature.NON_NULLABLE),
             CurrentDatabaseFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/CurrentDateFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/CurrentDateFunction.java
@@ -21,6 +21,8 @@
 
 package io.crate.expression.scalar;
 
+import java.util.EnumSet;
+
 import io.crate.data.Input;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -38,7 +40,7 @@ public final class CurrentDateFunction extends Scalar<Long, String> {
             Signature.scalar(
                 NAME,
                 DataTypes.DATE.getTypeSignature()
-            ).withFeatures(NO_FEATURES),
+            ).withFeatures(EnumSet.of(Feature.NON_NULLABLE)),
             CurrentDateFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/DateBinFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/DateBinFunction.java
@@ -21,6 +21,7 @@
 
 package io.crate.expression.scalar;
 
+import java.util.EnumSet;
 import java.util.List;
 
 import org.joda.time.Period;
@@ -47,7 +48,7 @@ public class DateBinFunction extends Scalar<Long, Object> {
                 DataTypes.TIMESTAMPZ.getTypeSignature(), // source
                 DataTypes.TIMESTAMPZ.getTypeSignature(), // origin
                 DataTypes.TIMESTAMPZ.getTypeSignature()
-            ).withFeatures(Scalar.DETERMINISTIC_AND_COMPARISON_REPLACEMENT),
+            ).withFeatures(EnumSet.of(Feature.DETERMINISTIC, Feature.COMPARISON_REPLACEMENT, Feature.NULLABLE)),
             DateBinFunction::new);
 
         module.register(
@@ -57,7 +58,7 @@ public class DateBinFunction extends Scalar<Long, Object> {
                 DataTypes.TIMESTAMP.getTypeSignature(), // source
                 DataTypes.TIMESTAMP.getTypeSignature(), // origin
                 DataTypes.TIMESTAMP.getTypeSignature()
-            ).withFeatures(Scalar.DETERMINISTIC_AND_COMPARISON_REPLACEMENT),
+            ).withFeatures(EnumSet.of(Feature.DETERMINISTIC, Feature.COMPARISON_REPLACEMENT, Feature.NULLABLE)),
             DateBinFunction::new);
     }
 

--- a/server/src/main/java/io/crate/expression/scalar/FormatFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/FormatFunction.java
@@ -45,6 +45,7 @@ public class FormatFunction extends Scalar<String, Object> {
             TypeSignature.parse("E"),
             DataTypes.STRING.getTypeSignature()
         )
+            .withFeature(Feature.NON_NULLABLE)
             .withTypeVariableConstraints(typeVariableOfAnyType("E"))
             .withVariableArity();
 

--- a/server/src/main/java/io/crate/expression/scalar/GenRandomTextUUIDFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/GenRandomTextUUIDFunction.java
@@ -21,6 +21,8 @@
 
 package io.crate.expression.scalar;
 
+import java.util.EnumSet;
+
 import org.elasticsearch.common.UUIDs;
 
 import io.crate.data.Input;
@@ -40,7 +42,7 @@ public final class GenRandomTextUUIDFunction extends Scalar<String, Void> {
             Signature.scalar(
                 NAME,
                 DataTypes.STRING.getTypeSignature()
-            ).withFeatures(NO_FEATURES),
+            ).withFeatures(EnumSet.of(Feature.NON_NULLABLE)),
             GenRandomTextUUIDFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/Ignore3vlFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/Ignore3vlFunction.java
@@ -54,7 +54,7 @@ public class Ignore3vlFunction extends Scalar<Boolean, Boolean> {
         NAME,
         DataTypes.BOOLEAN.getTypeSignature(),
         DataTypes.BOOLEAN.getTypeSignature()
-    );
+    ).withFeature(Feature.NON_NULLABLE);
 
     public static void register(ScalarFunctionModule module) {
         module.register(

--- a/server/src/main/java/io/crate/expression/scalar/NullOrEmptyFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/NullOrEmptyFunction.java
@@ -55,16 +55,17 @@ public final class NullOrEmptyFunction extends Scalar<Boolean, Object> {
             Signature.scalar(
                 "null_or_empty",
                 DataTypes.UNTYPED_OBJECT.getTypeSignature(),
-                DataTypes.BOOLEAN.getTypeSignature()
-            ),
+                DataTypes.BOOLEAN.getTypeSignature())
+                .withFeature(Feature.NON_NULLABLE),
             NullOrEmptyFunction::new
         );
         module.register(
             Signature.scalar(
-                "null_or_empty",
-                TypeSignature.parse("array(E)"),
-                DataTypes.BOOLEAN.getTypeSignature()
-            ).withTypeVariableConstraints(TypeVariableConstraint.typeVariableOfAnyType("E")),
+                    "null_or_empty",
+                    TypeSignature.parse("array(E)"),
+                    DataTypes.BOOLEAN.getTypeSignature()
+                ).withTypeVariableConstraints(TypeVariableConstraint.typeVariableOfAnyType("E"))
+                .withFeature(Feature.NON_NULLABLE),
             NullOrEmptyFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/PiFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/PiFunction.java
@@ -38,7 +38,8 @@ public final class PiFunction extends Scalar<Double, Object> {
             Signature.scalar(
                 NAME,
                 DataTypes.DOUBLE.getTypeSignature()
-            ),
+            )
+            .withFeature(Feature.NON_NULLABLE),
             PiFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/ArrayFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/ArrayFunction.java
@@ -46,6 +46,7 @@ public class ArrayFunction extends Scalar<Object, Object> {
             .argumentTypes(TypeSignature.parse("E"))
             .returnType(TypeSignature.parse("array(E)"))
             .setVariableArity(true)
+            .feature(Feature.NON_NULLABLE)
             .build();
 
 

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/IntervalArithmeticFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/IntervalArithmeticFunctions.java
@@ -45,7 +45,7 @@ public class IntervalArithmeticFunctions {
                 DataTypes.INTERVAL.getTypeSignature(),
                 DataTypes.INTERVAL.getTypeSignature(),
                 DataTypes.INTERVAL.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new IntervalIntervalArithmeticScalar(Period::plus, signature, boundSignature)
         );
@@ -55,7 +55,7 @@ public class IntervalArithmeticFunctions {
                 DataTypes.INTERVAL.getTypeSignature(),
                 DataTypes.INTERVAL.getTypeSignature(),
                 DataTypes.INTERVAL.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new IntervalIntervalArithmeticScalar(Period::minus, signature, boundSignature)
         );
@@ -65,7 +65,7 @@ public class IntervalArithmeticFunctions {
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.INTERVAL.getTypeSignature(),
                 DataTypes.INTERVAL.getTypeSignature()
-            ),
+                ).withFeature(Scalar.Feature.NULLABLE),
             MultiplyIntervalByIntegerScalar::new
         );
         module.register(
@@ -74,7 +74,7 @@ public class IntervalArithmeticFunctions {
                 DataTypes.INTERVAL.getTypeSignature(),
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.INTERVAL.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.NULLABLE),
             MultiplyIntervalByIntegerScalar::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/LogFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/LogFunction.java
@@ -71,7 +71,8 @@ public abstract class LogFunction extends Scalar<Number, Number> {
                     NAME,
                     DataTypes.DOUBLE.getTypeSignature(),
                     DataTypes.DOUBLE.getTypeSignature(),
-                    TypeSignature.parse("double precision")),
+                    TypeSignature.parse("double precision"))
+                    .withFeature(Feature.NULLABLE),
                 LogBaseFunction::new
             );
         }
@@ -108,8 +109,8 @@ public abstract class LogFunction extends Scalar<Number, Number> {
                 scalar(
                     NAME,
                     DataTypes.DOUBLE.getTypeSignature(),
-                    DataTypes.DOUBLE.getTypeSignature()
-                ),
+                    DataTypes.DOUBLE.getTypeSignature())
+                    .withFeature(Feature.NULLABLE),
                 Log10Function::new
             );
         }
@@ -142,8 +143,8 @@ public abstract class LogFunction extends Scalar<Number, Number> {
                 scalar(
                     LnFunction.NAME,
                     DataTypes.DOUBLE.getTypeSignature(),
-                    DataTypes.DOUBLE.getTypeSignature()
-                ),
+                    DataTypes.DOUBLE.getTypeSignature())
+                    .withFeature(Feature.NULLABLE),
                 LnFunction::new
             );
         }

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/RandomFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/RandomFunction.java
@@ -24,6 +24,7 @@ package io.crate.expression.scalar.arithmetic;
 
 import static io.crate.metadata.functions.Signature.scalar;
 
+import java.util.EnumSet;
 import java.util.Random;
 
 import io.crate.data.Input;
@@ -46,7 +47,7 @@ public class RandomFunction extends Scalar<Double, Void> {
             scalar(
                 NAME,
                 DataTypes.DOUBLE.getTypeSignature()
-            ).withFeatures(NO_FEATURES),
+            ).withFeatures(EnumSet.of(Feature.NON_NULLABLE)),
             RandomFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/SquareRootFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/SquareRootFunction.java
@@ -23,6 +23,7 @@ package io.crate.expression.scalar.arithmetic;
 
 import io.crate.expression.scalar.DoubleScalar;
 import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.metadata.Scalar;
 import io.crate.types.DataTypes;
 
 import static io.crate.metadata.functions.Signature.scalar;
@@ -35,7 +36,8 @@ public final class SquareRootFunction {
         for (var type : DataTypes.NUMERIC_PRIMITIVE_TYPES) {
             var typeSignature = type.getTypeSignature();
             module.register(
-                scalar(NAME, typeSignature, DataTypes.DOUBLE.getTypeSignature()),
+                scalar(NAME, typeSignature, DataTypes.DOUBLE.getTypeSignature())
+                    .withFeature(Scalar.Feature.NULLABLE),
                 (signature, boundSignature) ->
                     new DoubleScalar(signature, boundSignature, SquareRootFunction::sqrt)
             );

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/TrigonometricFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/TrigonometricFunctions.java
@@ -65,7 +65,7 @@ public final class TrigonometricFunctions {
                 name,
                 DataTypes.DOUBLE.getTypeSignature(),
                 DataTypes.DOUBLE.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new DoubleScalar(signature, boundSignature, func)
         );

--- a/server/src/main/java/io/crate/expression/scalar/conditional/CoalesceFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/conditional/CoalesceFunction.java
@@ -42,7 +42,8 @@ public class CoalesceFunction extends Scalar<Object, Object> {
                     TypeSignature.parse("E"),
                     TypeSignature.parse("E"))
                 .withVariableArity()
-                .withTypeVariableConstraints(typeVariable("E")),
+                .withTypeVariableConstraints(typeVariable("E"))
+                .withFeature(Feature.NULLABLE),
             CoalesceFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/conditional/NullIfFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/conditional/NullIfFunction.java
@@ -37,11 +37,12 @@ public class NullIfFunction extends Scalar<Object, Object> {
     public static void register(ScalarFunctionModule module) {
         module.register(
             Signature.scalar(
-                NAME,
-                TypeSignature.parse("E"),
-                TypeSignature.parse("E"),
-                TypeSignature.parse("E")
-            ).withTypeVariableConstraints(typeVariable("E")),
+                    NAME,
+                    TypeSignature.parse("E"),
+                    TypeSignature.parse("E"),
+                    TypeSignature.parse("E")
+                ).withTypeVariableConstraints(typeVariable("E"))
+                .withFeature(Feature.NON_NULLABLE),
             NullIfFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/geo/DistanceFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/geo/DistanceFunction.java
@@ -66,7 +66,7 @@ public class DistanceFunction extends Scalar<Double, Point> {
                 DataTypes.GEO_POINT.getTypeSignature(),
                 DataTypes.GEO_POINT.getTypeSignature(),
                 DataTypes.DOUBLE.getTypeSignature()
-            ),
+            ).withFeature(Feature.NULLABLE),
             DistanceFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/geo/IntersectsFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/geo/IntersectsFunction.java
@@ -49,7 +49,7 @@ public class IntersectsFunction extends Scalar<Boolean, Object> {
                 DataTypes.GEO_SHAPE.getTypeSignature(),
                 DataTypes.GEO_SHAPE.getTypeSignature(),
                 DataTypes.BOOLEAN.getTypeSignature()
-            ),
+            ).withFeature(Feature.NULLABLE),
             IntersectsFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/postgres/CurrentSettingFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/postgres/CurrentSettingFunction.java
@@ -49,7 +49,7 @@ public class CurrentSettingFunction extends Scalar<String, Object> {
                 FQN,
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Feature.NULLABLE),
             (signature, boundSignature) ->
                 new CurrentSettingFunction(
                     signature,
@@ -64,7 +64,7 @@ public class CurrentSettingFunction extends Scalar<String, Object> {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.BOOLEAN.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Feature.NULLABLE),
             (signature, boundSignature) ->
                 new CurrentSettingFunction(
                     signature,

--- a/server/src/main/java/io/crate/expression/scalar/postgres/PgBackendPidFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/postgres/PgBackendPidFunction.java
@@ -23,6 +23,8 @@ package io.crate.expression.scalar.postgres;
 
 import static io.crate.metadata.functions.Signature.scalar;
 
+import java.util.EnumSet;
+
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.symbol.Function;
@@ -47,7 +49,7 @@ public class PgBackendPidFunction extends Scalar<Integer, Void> {
             scalar(
                 FQN,
                 DataTypes.INTEGER.getTypeSignature()
-            ).withFeatures(NO_FEATURES),
+            ).withFeatures(EnumSet.of(Feature.NON_NULLABLE)),
             PgBackendPidFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/postgres/PgEncodingToCharFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/postgres/PgEncodingToCharFunction.java
@@ -44,7 +44,7 @@ public class PgEncodingToCharFunction extends Scalar<String, Integer> {
                 FQN,
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Feature.NON_NULLABLE),
             PgEncodingToCharFunction:: new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/postgres/PgPostmasterStartTime.java
+++ b/server/src/main/java/io/crate/expression/scalar/postgres/PgPostmasterStartTime.java
@@ -22,6 +22,8 @@
 
 package io.crate.expression.scalar.postgres;
 
+import java.util.EnumSet;
+
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.FunctionName;
@@ -43,7 +45,7 @@ public final class PgPostmasterStartTime extends Scalar<Long, Void> {
             Signature.scalar(
                 FQN,
                 DataTypes.TIMESTAMPZ.getTypeSignature()
-            ).withFeatures(NO_FEATURES),
+            ).withFeatures(EnumSet.of(Feature.NON_NULLABLE)),
             PgPostmasterStartTime::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/string/ChrFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/ChrFunction.java
@@ -38,7 +38,7 @@ public final class ChrFunction extends Scalar<String, Object> {
                 "chr",
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Feature.NULLABLE),
             ChrFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/string/ParseURIFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/ParseURIFunction.java
@@ -46,7 +46,7 @@ public final class ParseURIFunction extends Scalar<Object, String> {
                 NAME,
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.UNTYPED_OBJECT.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.NULLABLE),
             ParseURIFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/string/ParseURLFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/ParseURLFunction.java
@@ -54,7 +54,7 @@ public final class ParseURLFunction extends Scalar<Object, String> {
                 NAME,
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.UNTYPED_OBJECT.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.NULLABLE),
             ParseURLFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/string/TrimFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/TrimFunctions.java
@@ -55,7 +55,7 @@ public final class TrimFunctions {
                 TRIM_NAME,
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new OneCharTrimFunction(
                     signature,
@@ -71,7 +71,7 @@ public final class TrimFunctions {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.NULLABLE),
             TrimFunction::new
         );
 
@@ -81,7 +81,7 @@ public final class TrimFunctions {
                 LTRIM_NAME,
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new SideTrimFunction(
                     signature,
@@ -96,7 +96,7 @@ public final class TrimFunctions {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new SideTrimFunction(
                     signature,
@@ -111,7 +111,7 @@ public final class TrimFunctions {
                 RTRIM_NAME,
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new SideTrimFunction(
                     signature,
@@ -126,7 +126,7 @@ public final class TrimFunctions {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new SideTrimFunction(
                     signature,
@@ -142,7 +142,7 @@ public final class TrimFunctions {
                 BTRIM_NAME,
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new SideTrimFunction(
                     signature,
@@ -157,7 +157,7 @@ public final class TrimFunctions {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new SideTrimFunction(
                     signature,

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/CurrentSchemaFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/CurrentSchemaFunction.java
@@ -21,6 +21,8 @@
 
 package io.crate.expression.scalar.systeminformation;
 
+import java.util.EnumSet;
+
 import org.jetbrains.annotations.Nullable;
 
 import io.crate.data.Input;
@@ -49,7 +51,7 @@ public class CurrentSchemaFunction extends Scalar<String, Object> {
             Signature.scalar(
                 FQN,
                 DataTypes.STRING.getTypeSignature()
-            ).withFeatures(NO_FEATURES),
+            ).withFeatures(EnumSet.of(Feature.NON_NULLABLE)),
             CurrentSchemaFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/CurrentSchemasFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/CurrentSchemasFunction.java
@@ -22,6 +22,7 @@
 package io.crate.expression.scalar.systeminformation;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 
 import io.crate.data.Input;
@@ -46,7 +47,7 @@ public class CurrentSchemasFunction extends Scalar<List<String>, Boolean> {
                 FQN,
                 DataTypes.BOOLEAN.getTypeSignature(),
                 DataTypes.STRING_ARRAY.getTypeSignature()
-            ).withFeatures(NO_FEATURES),
+            ).withFeatures(EnumSet.of(Feature.NON_NULLABLE)),
             CurrentSchemasFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/FormatTypeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/FormatTypeFunction.java
@@ -46,7 +46,7 @@ public final class FormatTypeFunction extends Scalar<String, Object> {
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Feature.NULLABLE),
             FormatTypeFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/PgFunctionIsVisibleFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/PgFunctionIsVisibleFunction.java
@@ -40,7 +40,7 @@ public final class PgFunctionIsVisibleFunction extends Scalar<Boolean, Integer> 
                 NAME,
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.BOOLEAN.getTypeSignature()
-            ),
+            ).withFeature(Feature.NULLABLE),
             PgFunctionIsVisibleFunction::new);
     }
 

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetFunctionResultFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetFunctionResultFunction.java
@@ -40,7 +40,7 @@ public final class PgGetFunctionResultFunction extends Scalar<String, Integer> {
                 NAME,
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Feature.NULLABLE),
             PgGetFunctionResultFunction::new);
     }
 

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/PgTypeofFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/PgTypeofFunction.java
@@ -42,11 +42,12 @@ public final class PgTypeofFunction extends Scalar<String, Object> {
     public static void register(ScalarFunctionModule module) {
         module.register(
             Signature.scalar(
-                FQNAME,
-                TypeSignature.parse("E"),
-                DataTypes.STRING.getTypeSignature()
-            )
-                .withTypeVariableConstraints(typeVariable("E")),
+                    FQNAME,
+                    TypeSignature.parse("E"),
+                    DataTypes.STRING.getTypeSignature()
+                )
+                .withTypeVariableConstraints(typeVariable("E"))
+                .withFeature(Feature.NON_NULLABLE),
             PgTypeofFunction::new
         );
 

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/VersionFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/VersionFunction.java
@@ -21,6 +21,7 @@
 
 package io.crate.expression.scalar.systeminformation;
 
+import java.util.EnumSet;
 import java.util.Locale;
 
 import org.elasticsearch.Build;
@@ -48,7 +49,7 @@ public class VersionFunction extends Scalar<String, Void> {
             Signature.scalar(
                 FQN,
                 DataTypes.STRING.getTypeSignature()
-            ).withFeatures(Scalar.NO_FEATURES),
+            ).withFeatures(EnumSet.of(Feature.NON_NULLABLE)),
             VersionFunction::new
         );
 

--- a/server/src/main/java/io/crate/expression/scalar/timestamp/CurrentTimeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/timestamp/CurrentTimeFunction.java
@@ -46,14 +46,14 @@ public class CurrentTimeFunction extends Scalar<TimeTZ, Integer> {
                 NAME,
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.TIMETZ.getTypeSignature()
-            ),
+            ).withFeature(Feature.NON_NULLABLE),
             CurrentTimeFunction::new
         );
         module.register(
             Signature.scalar(
                 NAME,
                 DataTypes.TIMETZ.getTypeSignature()
-            ),
+            ).withFeature(Feature.NON_NULLABLE),
             CurrentTimeFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/timestamp/CurrentTimestampFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/timestamp/CurrentTimestampFunction.java
@@ -23,6 +23,7 @@ package io.crate.expression.scalar.timestamp;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.EnumSet;
 import java.util.Locale;
 
 import io.crate.data.Input;
@@ -44,7 +45,7 @@ public class CurrentTimestampFunction extends Scalar<Long, Integer> {
             Signature.scalar(
                 NAME,
                 DataTypes.TIMESTAMPZ.getTypeSignature()
-            ).withFeatures(NO_FEATURES),
+            ).withFeatures(EnumSet.of(Feature.NON_NULLABLE)),
             CurrentTimestampFunction::new
         );
         module.register(
@@ -52,7 +53,7 @@ public class CurrentTimestampFunction extends Scalar<Long, Integer> {
                 NAME,
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.TIMESTAMPZ.getTypeSignature()
-            ).withFeatures(NO_FEATURES),
+            ).withFeatures(EnumSet.of(Feature.NON_NULLABLE)),
             CurrentTimestampFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/timestamp/NowFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/timestamp/NowFunction.java
@@ -23,6 +23,7 @@ package io.crate.expression.scalar.timestamp;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.EnumSet;
 
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
@@ -42,7 +43,7 @@ public final class NowFunction extends Scalar<Long, Object> {
             Signature.scalar(
                 NAME,
                 DataTypes.TIMESTAMPZ.getTypeSignature()
-            ).withFeatures(Scalar.NO_FEATURES),
+            ).withFeatures(EnumSet.of(Feature.NON_NULLABLE)),
             NowFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/tablefunctions/EmptyRowTableFunction.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/EmptyRowTableFunction.java
@@ -26,6 +26,7 @@ import java.util.List;
 import io.crate.data.Input;
 import io.crate.data.Row;
 import io.crate.metadata.NodeContext;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
@@ -41,7 +42,7 @@ public class EmptyRowTableFunction {
 
     public static void register(TableFunctionModule module) {
         module.register(
-            Signature.table(NAME, RowType.EMPTY.getTypeSignature()),
+            Signature.table(NAME, RowType.EMPTY.getTypeSignature()).withFeature(Scalar.Feature.NON_NULLABLE),
             EmptyRowTableFunctionImplementation::new
         );
     }

--- a/server/src/main/java/io/crate/expression/tablefunctions/GenerateSeries.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/GenerateSeries.java
@@ -71,7 +71,7 @@ public final class GenerateSeries<T extends Number> extends TableFunctionImpleme
                 DataTypes.LONG.getTypeSignature(),
                 DataTypes.LONG.getTypeSignature(),
                 DataTypes.LONG.getTypeSignature()
-            ),
+            ).withFeature(Feature.NON_NULLABLE),
             (signature, boundSignature) -> new GenerateSeries<>(
                 signature,
                 boundSignature,
@@ -88,7 +88,7 @@ public final class GenerateSeries<T extends Number> extends TableFunctionImpleme
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.INTEGER.getTypeSignature()
-            ),
+            ).withFeature(Feature.NON_NULLABLE),
             (signature, boundSignature) -> new GenerateSeries<>(
                 signature,
                 boundSignature,
@@ -108,7 +108,7 @@ public final class GenerateSeries<T extends Number> extends TableFunctionImpleme
                 DataTypes.LONG.getTypeSignature(),
                 DataTypes.LONG.getTypeSignature(),
                 DataTypes.LONG.getTypeSignature()
-            ),
+            ).withFeature(Feature.NON_NULLABLE),
             (signature, boundSignature) -> new GenerateSeries<>(
                 signature,
                 boundSignature,
@@ -126,7 +126,7 @@ public final class GenerateSeries<T extends Number> extends TableFunctionImpleme
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.INTEGER.getTypeSignature()
-            ),
+            ).withFeature(Feature.NON_NULLABLE),
             (signature, boundSignature) -> new GenerateSeries<>(
                 signature,
                 boundSignature,
@@ -147,7 +147,7 @@ public final class GenerateSeries<T extends Number> extends TableFunctionImpleme
                     supportedType.getTypeSignature(),
                     DataTypes.INTERVAL.getTypeSignature(),
                     supportedType.getTypeSignature()
-                ),
+                ).withFeature(Feature.NON_NULLABLE),
                 (signature, boundSignature) -> new GenerateSeriesIntervals(
                     signature,
                     boundSignature,

--- a/server/src/main/java/io/crate/expression/tablefunctions/GenerateSubscripts.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/GenerateSubscripts.java
@@ -49,21 +49,23 @@ public final class GenerateSubscripts<T> extends TableFunctionImplementation<T> 
     public static void register(TableFunctionModule module) {
         module.register(
             Signature.table(
-                NAME,
-                TypeSignature.parse("array(E)"),
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.INTEGER.getTypeSignature()
-            ).withTypeVariableConstraints(typeVariable("E")),
+                    NAME,
+                    TypeSignature.parse("array(E)"),
+                    DataTypes.INTEGER.getTypeSignature(),
+                    DataTypes.INTEGER.getTypeSignature()
+                ).withTypeVariableConstraints(typeVariable("E"))
+                .withFeature(Feature.NON_NULLABLE),
             GenerateSubscripts::new
         );
         module.register(
             Signature.table(
-                NAME,
-                TypeSignature.parse("array(E)"),
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.BOOLEAN.getTypeSignature(),
-                DataTypes.INTEGER.getTypeSignature()
-            ).withTypeVariableConstraints(typeVariable("E")),
+                    NAME,
+                    TypeSignature.parse("array(E)"),
+                    DataTypes.INTEGER.getTypeSignature(),
+                    DataTypes.BOOLEAN.getTypeSignature(),
+                    DataTypes.INTEGER.getTypeSignature()
+                ).withTypeVariableConstraints(typeVariable("E"))
+                .withFeature(Feature.NON_NULLABLE),
             GenerateSubscripts::new
         );
     }

--- a/server/src/main/java/io/crate/expression/tablefunctions/MatchesFunction.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/MatchesFunction.java
@@ -68,7 +68,7 @@ public final class MatchesFunction extends TableFunctionImplementation<List<Obje
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING_ARRAY.getTypeSignature()
-            ),
+            ).withFeature(Feature.NON_NULLABLE),
             (signature, boundSignature) -> new MatchesFunction(
                 signature,
                 boundSignature,
@@ -82,7 +82,7 @@ public final class MatchesFunction extends TableFunctionImplementation<List<Obje
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING_ARRAY.getTypeSignature()
-            ),
+            ).withFeature(Feature.NON_NULLABLE),
             (signature, boundSignature) -> new MatchesFunction(
                 signature,
                 boundSignature,

--- a/server/src/main/java/io/crate/expression/tablefunctions/PgExpandArray.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/PgExpandArray.java
@@ -49,10 +49,11 @@ public final class PgExpandArray extends TableFunctionImplementation<List<Object
     public static void register(TableFunctionModule module) {
         module.register(
             Signature.table(
-                FUNCTION_NAME,
-                TypeSignature.parse("array(E)"),
-                TypeSignature.parse("record(x E, n integer)")
-            ).withTypeVariableConstraints(typeVariable("E")),
+                    FUNCTION_NAME,
+                    TypeSignature.parse("array(E)"),
+                    TypeSignature.parse("record(x E, n integer)")
+                ).withTypeVariableConstraints(typeVariable("E"))
+                .withFeature(Feature.NON_NULLABLE),
             PgExpandArray::new
         );
     }

--- a/server/src/main/java/io/crate/expression/tablefunctions/PgGetKeywordsFunction.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/PgGetKeywordsFunction.java
@@ -53,9 +53,9 @@ public final class PgGetKeywordsFunction extends TableFunctionImplementation<Lis
 
         module.register(
             Signature.table(
-                FUNCTION_NAME,
-                RETURN_TYPE.getTypeSignature()
-            ),
+                    FUNCTION_NAME,
+                    RETURN_TYPE.getTypeSignature()
+                ).withFeature(Feature.NON_NULLABLE),
             PgGetKeywordsFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/tablefunctions/UnnestFunction.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/UnnestFunction.java
@@ -35,6 +35,7 @@ import io.crate.data.Input;
 import io.crate.data.Row;
 import io.crate.legacy.LegacySettings;
 import io.crate.metadata.NodeContext;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
@@ -57,7 +58,8 @@ public class UnnestFunction {
                     TypeSignature.parse("array(E)"),
                     TypeSignature.parse("E")
                 )
-                .withTypeVariableConstraints(typeVariable("E")),
+                .withTypeVariableConstraints(typeVariable("E"))
+                .withFeature(Scalar.Feature.NON_NULLABLE),
             (signature, boundSignature) -> new UnnestTableFunctionImplementation(
                 signature,
                 boundSignature,
@@ -74,7 +76,8 @@ public class UnnestFunction {
                     RowType.EMPTY.getTypeSignature()
                 )
                 .withTypeVariableConstraints(typeVariable("E"), typeVariableOfAnyType("N"))
-                .withVariableArity(),
+                .withFeature(Scalar.Feature.NON_NULLABLE)
+            .withVariableArity(),
             (signature, boundSignature) -> {
                 var argTypes = boundSignature.argTypes();
                 ArrayList<DataType<?>> fieldTypes = new ArrayList<>(argTypes.size());
@@ -99,7 +102,7 @@ public class UnnestFunction {
             Signature.table(
                 NAME,
                 DataTypes.UNTYPED_OBJECT.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.NON_NULLABLE),
             (signature, boundSignature) -> new UnnestTableFunctionImplementation(
                 signature,
                 boundSignature,

--- a/server/src/main/java/io/crate/metadata/Scalar.java
+++ b/server/src/main/java/io/crate/metadata/Scalar.java
@@ -220,6 +220,14 @@ public abstract class Scalar<ReturnType, InputType> implements FunctionImplement
          * So for f comparisons cannot be replaced.
          */
         COMPARISON_REPLACEMENT,
-        LAZY_ATTRIBUTES
+        LAZY_ATTRIBUTES,
+        /**
+         * If this feature is set, the function will return for null argument(s) as result null.
+         */
+        NULLABLE,
+        /**
+         * If this feature is set, the function will never return null.
+         */
+        NON_NULLABLE
     }
 }

--- a/server/src/main/java/io/crate/metadata/functions/Signature.java
+++ b/server/src/main/java/io/crate/metadata/functions/Signature.java
@@ -39,6 +39,7 @@ import org.elasticsearch.common.io.stream.Writeable;
 
 import io.crate.common.collections.EnumSets;
 import io.crate.common.collections.Lists2;
+import io.crate.common.collections.Sets;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.FunctionType;
 import io.crate.metadata.Scalar;
@@ -202,6 +203,11 @@ public final class Signature implements Writeable, Accountable {
             return this;
         }
 
+        public Builder feature(Scalar.Feature feature) {
+            this.features = Sets.concat(this.features, feature);
+            return this;
+        }
+
         public Builder features(Set<Scalar.Feature> features) {
             this.features = features;
             return this;
@@ -351,6 +357,12 @@ public final class Signature implements Writeable, Accountable {
     public Signature withForbiddenCoercion() {
         return Signature.builder(this)
             .forbidCoercion()
+            .build();
+    }
+
+    public Signature withFeature(Scalar.Feature feature) {
+        return Signature.builder(this)
+            .feature(feature)
             .build();
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/ScalarNullabilityTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ScalarNullabilityTest.java
@@ -1,0 +1,115 @@
+package io.crate.expression.scalar;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import io.crate.data.Input;
+import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.FunctionName;
+import io.crate.metadata.FunctionProvider;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.BoundSignature;
+import io.crate.metadata.functions.Signature;
+import io.crate.testing.TestingHelpers;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+import io.crate.types.TypeSignature;
+
+/**
+ * This test check if the scalar functions fulfill their nullability requirements
+ */
+public class ScalarNullabilityTest {
+
+    final TransactionContext txnCtx = CoordinatorTxnCtx.systemTransactionContext();
+    final NodeContext nodeContext = TestingHelpers.createNodeContext();
+
+    @Test
+    public void test_nullability_scalars_return_null_on_null_input() {
+        var numberOfFunctionsToTested = 0;
+        for (var functionProvider : getFunctionProviders()) {
+            var signature = functionProvider.getSignature();
+            if (signature.hasFeature(Scalar.Feature.NULLABLE)) {
+                var bound = getBoundSignature(signature);
+                var function = functionProvider.getFactory().apply(signature, bound);
+                var arguments = getArguments(bound);
+                if (function instanceof Scalar<?, ?> scalar) {
+                    var result = scalar.evaluate(txnCtx, nodeContext, arguments);
+                    var name = function.signature().getName();
+                    assertThat(result).as("Return value must be null for null arguments: " + name).isNull();
+                    numberOfFunctionsToTested++;
+                }
+            }
+        }
+        assertThat(numberOfFunctionsToTested).isGreaterThan(0);
+    }
+
+    @Test
+    public void test_non_nullability_scalars_return_not_null_on_null_input() {
+        var numberOfFunctionsToTested = 0;
+        for (var functionProvider : getFunctionProviders()) {
+            var signature = functionProvider.getSignature();
+            if (signature.hasFeature(Scalar.Feature.NON_NULLABLE)) {
+                var bound = getBoundSignature(signature);
+                var function = functionProvider.getFactory().apply(signature, bound);
+                var arguments = getArguments(bound);
+                if (function instanceof Scalar<?, ?> scalar) {
+                    try {
+                        var evaluate = scalar.evaluate(txnCtx, nodeContext, arguments);
+                        FunctionName name = function.signature().getName();
+                        assertThat(evaluate).as("Return value must not be null for null arguments: " + name).isNotNull();
+                    } catch (IllegalArgumentException | AssertionError e) {
+                        assertThat(true).isTrue();
+                    }
+                    numberOfFunctionsToTested++;
+                }
+            }
+        }
+        assertThat(numberOfFunctionsToTested).isGreaterThan(0);
+    }
+
+    List<FunctionProvider> getFunctionProviders() {
+        var functions = nodeContext.functions();
+        var functionResolvers = functions.functionResolvers();
+        var result = new ArrayList<FunctionProvider>();
+        for (var value : functionResolvers.values()) {
+            result.addAll(value);
+        }
+        return result;
+    }
+
+    BoundSignature getBoundSignature(Signature signature) {
+        var boundTypes = new ArrayList<DataType<?>>();
+        for (TypeSignature typeSignature : signature.getArgumentTypes()) {
+            boundTypes.add(getDataType(typeSignature));
+        }
+        var returnType = getDataType(signature.getReturnType());
+        return new BoundSignature(boundTypes, returnType);
+    }
+
+    Input[] getArguments(BoundSignature boundSignature) {
+        var inputArguments = new Input[boundSignature.argTypes().size()];
+        for (int i = 0; i < boundSignature.argTypes().size(); i++) {
+            inputArguments[i] = (Input<Object>) () -> null;
+        }
+        return inputArguments;
+    }
+
+    DataType<?> getDataType(TypeSignature typeSignature) {
+        var baseTypeName = typeSignature.getBaseTypeName();
+        if (baseTypeName.length() == 1) {
+            // resolve generic types to string
+            return DataTypes.STRING;
+        }
+        return switch (baseTypeName) {
+            case "array" -> DataTypes.STRING_ARRAY;
+            default -> DataTypes.ofName(typeSignature.getBaseTypeName());
+        };
+    }
+
+}

--- a/server/src/test/java/io/crate/lucene/ThreeValuedLogicQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/ThreeValuedLogicQueryBuilderTest.java
@@ -70,13 +70,13 @@ public class ThreeValuedLogicQueryBuilderTest extends LuceneQueryBuilderTest {
     @Test
     public void test_negated_concat_with_three_valued_logic() {
         assertThat(convert("NOT (x || 1) < -1")).hasToString(
-            "+(+*:* -(concat(x, '1') < -1)) #(NOT (concat(x, '1') < -1))");
+            "+(+*:* -(concat(x, '1') < -1))");
     }
 
     @Test
     public void test_nullif() {
         assertThat(convert("NULLIF(2, x) != 1")).hasToString(
-            "+(+*:* -(nullif(2, x) = 1)) #(NOT (nullif(2, x) = 1))");
+            "+(+*:* -(nullif(2, x) = 1))");
     }
 
     @Test
@@ -84,5 +84,4 @@ public class ThreeValuedLogicQueryBuilderTest extends LuceneQueryBuilderTest {
         assertThat(convert("NOT (x OR y) > true")).hasToString(
             "+(+*:* -((x OR y) > true)) #(NOT ((x OR y) > true))");
     }
-
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This pr optimizes the Lucene Query generation for the `NotPredicate`. It improves the three-valued-logic (3vl) processing by grouping all scalar functions into the following categories:

- Nullable, when the function returns a null value for a null argument. 
- Non-nullable, when the function returns never null values for any arguments. 
- Conditional, when the scalar functions follows its own logic, maybe null maybe not. By default each scalar function is conditional. 

Based on these three groups the generation of the Lucene queries for the NotPredicate can be optimized in the following way:

- If all involved scalar functions are nullable, no 3vl is required and the query will be negated and null values can be excluded by using a field exist query.
- If all involved scalar functions are non-nullable or nullable, no 3vl is required and the query can be simply negated.
- If any of the scalar functions are conditional then 3vl is required. The query will be negated and the scalar functions will be converted to generic function filters.




Resolves https://github.com/crate/crate/issues/15122


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
