### PR TITLE
Ignore backslash in C-Style escaped string unless it's escaped by another backslash

### DIFF
--- a/docs/appendices/release-notes/5.5.2.rst
+++ b/docs/appendices/release-notes/5.5.2.rst
@@ -54,3 +54,7 @@ Fixes
 
 - Fixed an issue that allowed adding a column under the same name as an existing
   index definition.
+
+- Fixed an issue with wrong escaping of backslash in
+  :ref:`C-style escaped strings <sql_escape_string_literals>`.
+  ``SELECT E'\%'`` used to return ``\%`` instead of ``%``.

--- a/libs/sql-parser/src/main/java/io/crate/sql/Literals.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/Literals.java
@@ -124,8 +124,7 @@ public class Literals {
                         i = endIdx - 1; // skip already consumed chars
                         break;
                     default:
-                        // non-valid escaped char sequence
-                        builder.append(currentChar);
+                        // Ignore backslash in C-Style escaped string unless it's escaped by another backslash.
                 }
             } else if (currentChar == '\'' && i > 1 && i + 1 < length) {
                 // handle normal escaped quote: ''

--- a/libs/sql-parser/src/test/java/io/crate/sql/LiteralsTest.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/LiteralsTest.java
@@ -102,6 +102,11 @@ public class LiteralsTest {
         assertThat(Literals.replaceEscapedChars("\\t\\n\\f")).isEqualTo("\t\n\f");
     }
 
+    @Test
+    public void test_next_symbol_after_backslash_is_taken_literally() {
+        assertThat(Literals.replaceEscapedChars("ab\\%cde")).isEqualTo("ab%cde");
+    }
+
     // Invalid escaped literals
 
     @Test
@@ -120,18 +125,13 @@ public class LiteralsTest {
     }
 
     @Test
-    public void testThatInvalidEscapeSequenceIsNotReplaced() {
-        assertThat(Literals.replaceEscapedChars("\\s")).isEqualTo("\\s");
+    public void test_next_symbol_after_backslash_at_the_beginning_is_taken_literally() {
+        assertThat(Literals.replaceEscapedChars("\\shello")).isEqualTo("shello");
     }
 
     @Test
-    public void testThatInvalidEscapeSequenceAtBeginningOfLiteralIsNotReplaced() {
-        assertThat(Literals.replaceEscapedChars("\\shello")).isEqualTo("\\shello");
-    }
-
-    @Test
-    public void testThatInvalidEscapeSequenceAtEndOfLiteralIsNotReplaced() {
-        assertThat(Literals.replaceEscapedChars("hello\\s")).isEqualTo("hello\\s");
+    public void test_next_symbol_after_backslash_at_the_endis_taken_literally() {
+        assertThat(Literals.replaceEscapedChars("hello\\s")).isEqualTo("hellos");
     }
 
     // Octal Byte Values

--- a/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -2045,6 +2045,18 @@ public class TestStatementBuilder {
             .hasMessage("line 1:30: mismatched input 'add' expecting 'DROP'");
     }
 
+    @Test
+    public void test_like_with_pattern_as_a_c_style_string() {
+        printStatement("select 'TextToMatch' LIKE E'Te\\%tch'");
+        printStatement("select 'TextToMatch' NOT LIKE E'Te\\%tch'");
+        printStatement("select 'TextToMatch' ILIKE E'te\\%tch'");
+        printStatement("select 'TextToMatch' NOT ILIKE E'te\\%tch'");
+        printStatement("select 'TextToMatch' LIKE ANY (array[E'Te\\%tch'])");
+        printStatement("select 'TextToMatch' NOT LIKE ANY (array[E'Te\\%tch'])");
+        printStatement("select 'TextToMatch' ILIKE ANY (array[E'te\\%tch'])");
+        printStatement("select 'TextToMatch' NOT ILIKE ANY (array[E'te\\%tch'])");
+    }
+
     private static void printStatement(String sql) {
         println(sql.trim());
         println("");

--- a/server/src/test/java/io/crate/expression/operator/LikeOperatorTest.java
+++ b/server/src/test/java/io/crate/expression/operator/LikeOperatorTest.java
@@ -185,4 +185,12 @@ public class LikeOperatorTest extends ScalarTestCase {
         var re = patternToRegex(expression, DEFAULT_ESCAPE, true);
         assertEquals("^\\{\\}$", re);
     }
+
+    @Test
+    public void test_wildcard_escaped_in_c_style_string() {
+        assertEvaluate("'TextToMatch' LIKE E'Te\\%tch'", true);
+        assertEvaluate("'TextToMatch' NOT LIKE E'Te\\%tch'", false);
+        assertEvaluate("'TextToMatch' ILIKE E'te\\%tch'", true);
+        assertEvaluate("'TextToMatch' NOT ILIKE E'te\\%tch'", false);
+    }
 }

--- a/server/src/test/java/io/crate/expression/operator/any/AnyLikeOperatorTest.java
+++ b/server/src/test/java/io/crate/expression/operator/any/AnyLikeOperatorTest.java
@@ -141,4 +141,10 @@ public class AnyLikeOperatorTest extends ScalarTestCase {
         assertNormalize("1 ilike any ([1, null, 2])", isLiteral(true));
         assertNormalize("1 not ilike any ([1])", isLiteral(false));
     }
+
+    @Test
+    public void test_wildcard_escaped_in_c_style_string() {
+        assertEvaluate("'TextToMatch' LIKE ANY ([E'Te\\%tch'])", true);
+        assertEvaluate("'TextToMatch' ILIKE ANY ([E'te\\%tch'])", true);
+    }
 }

--- a/server/src/test/java/io/crate/expression/operator/any/AnyNotLikeOperatorTest.java
+++ b/server/src/test/java/io/crate/expression/operator/any/AnyNotLikeOperatorTest.java
@@ -141,4 +141,10 @@ public class AnyNotLikeOperatorTest extends ScalarTestCase {
         assertNormalize("'BaR' not ilike any (['z_ar'])", isLiteral(true));
         assertNormalize("'foobar' not ilike any (['%O_a%'])", isLiteral(false));
     }
+
+    @Test
+    public void test_wildcard_escaped_in_c_style_string() {
+        assertEvaluate("'TextToMatch' NOT LIKE ANY ([E'Te\\%tch'])", false);
+        assertEvaluate("'TextToMatch' NOT ILIKE ANY ([E'te\\%tch'])", false);
+    }
 }


### PR DESCRIPTION
Addresses https://github.com/crate/crate/issues/14790#issuecomment-1780700963

Current behaviour contradicts to docs
https://cratedb.com/docs/crate/reference/en/5.4/sql/general/lexical-structure.html#string-literals-with-c-style-escapes

We currently also include backslash to the final string. When E'' with % inside is used in LIKE pattern, then % doesn't work because of the extra slash.
