### PR TITLE
Remove unnecessary Mapper.Builder generic parametrization

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/ArrayMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ArrayMapper.java
@@ -89,18 +89,18 @@ public class ArrayMapper extends FieldMapper implements ArrayValueMapperParser {
         this.innerMapper = innerMapper;
     }
 
-    private static FieldType getFieldType(Mapper.Builder<?> builder) {
-        if (builder instanceof FieldMapper.Builder<?> fieldMapperBuilder) {
+    private static FieldType getFieldType(Mapper.Builder builder) {
+        if (builder instanceof FieldMapper.Builder fieldMapperBuilder) {
             return fieldMapperBuilder.fieldType;
         }
         throw new IllegalArgumentException("expected a FieldMapper.Builder");
     }
 
-    public static class Builder extends FieldMapper.Builder<Builder> {
+    public static class Builder extends FieldMapper.Builder {
 
-        private final Mapper.Builder<?> innerBuilder;
+        private final Mapper.Builder innerBuilder;
 
-        public Builder(String name, Mapper.Builder<?> innerBuilder) {
+        public Builder(String name, Mapper.Builder innerBuilder) {
             super(name, getFieldType(innerBuilder));
             this.innerBuilder = innerBuilder;
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/BitStringFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BitStringFieldMapper.java
@@ -92,13 +92,12 @@ public class BitStringFieldMapper extends FieldMapper {
         }
     }
 
-    public static class Builder extends FieldMapper.Builder<Builder> {
+    public static class Builder extends FieldMapper.Builder {
 
         private Integer length;
 
         public Builder(String name) {
             super(name, Defaults.FIELD_TYPE);
-            this.builder = this;
         }
 
         @Override
@@ -125,7 +124,7 @@ public class BitStringFieldMapper extends FieldMapper {
     public static class TypeParser implements Mapper.TypeParser {
 
         @Override
-        public org.elasticsearch.index.mapper.Mapper.Builder<?> parse(
+        public org.elasticsearch.index.mapper.Mapper.Builder parse(
                 String name,
                 Map<String, Object> node,
                 ParserContext parserContext) throws MapperParsingException {

--- a/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
@@ -62,11 +62,10 @@ public class BooleanFieldMapper extends FieldMapper {
         public static final BytesRef FALSE = new BytesRef("F");
     }
 
-    public static class Builder extends FieldMapper.Builder<Builder> {
+    public static class Builder extends FieldMapper.Builder {
 
         public Builder(String name) {
             super(name, Defaults.FIELD_TYPE);
-            this.builder = this;
         }
 
         @Override
@@ -87,7 +86,7 @@ public class BooleanFieldMapper extends FieldMapper {
 
     public static class TypeParser implements Mapper.TypeParser {
         @Override
-        public Mapper.Builder<Builder> parse(String name,
+        public Mapper.Builder parse(String name,
                                              Map<String, Object> node,
                                              ParserContext parserContext) throws MapperParsingException {
             BooleanFieldMapper.Builder builder = new BooleanFieldMapper.Builder(name);

--- a/server/src/main/java/org/elasticsearch/index/mapper/BuilderFactory.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BuilderFactory.java
@@ -39,7 +39,7 @@ public class BuilderFactory implements DynamicArrayFieldMapperBuilderFactory {
     public Mapper create(String name, ObjectMapper parentMapper, ParseContext context) {
         Mapper.BuilderContext builderContext = new Mapper.BuilderContext(context.indexSettings().getSettings(), context.path());
         try {
-            Mapper.Builder<?> innerBuilder = detectInnerMapper(context, name, context.parser());
+            Mapper.Builder innerBuilder = detectInnerMapper(context, name, context.parser());
             if (innerBuilder == null) {
                 return null;
             }
@@ -65,7 +65,7 @@ public class BuilderFactory implements DynamicArrayFieldMapperBuilderFactory {
     }
 
 
-    private static Mapper.Builder<?> detectInnerMapper(ParseContext parseContext,
+    private static Mapper.Builder detectInnerMapper(ParseContext parseContext,
                                                        String fieldName,
                                                        XContentParser parser) throws IOException {
         XContentParser.Token token = parser.currentToken();

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -66,24 +66,21 @@ public class DateFieldMapper extends FieldMapper {
         }
     }
 
-    public static class Builder extends FieldMapper.Builder<Builder> {
+    public static class Builder extends FieldMapper.Builder {
 
         private Explicit<String> format = new Explicit<>(DEFAULT_FORMAT_PATTERN, false);
         private Boolean ignoreTimezone;
 
         public Builder(String name) {
             super(name, Defaults.FIELD_TYPE);
-            builder = this;
         }
 
-        public Builder ignoreTimezone(boolean ignoreTimezone) {
+        public void ignoreTimezone(boolean ignoreTimezone) {
             this.ignoreTimezone = ignoreTimezone;
-            return builder;
         }
 
-        public Builder format(String format) {
+        public void format(String format) {
             this.format = new Explicit<>(format, true);
-            return this;
         }
 
         protected DateFieldType setupFieldType(BuilderContext context) {
@@ -116,7 +113,7 @@ public class DateFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Mapper.Builder<?> parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+        public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
             Builder builder = new Builder(name);
             TypeParsers.parseField(builder, name, node);
             for (Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator(); iterator.hasNext();) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -88,7 +88,7 @@ public class DocumentMapper implements ToXContentFragment {
             return this;
         }
 
-        public Builder put(MetadataFieldMapper.Builder<?> mapper) {
+        public Builder put(MetadataFieldMapper.Builder mapper) {
             MetadataFieldMapper metadataMapper = mapper.build(builderContext);
             metadataMappers.put(metadataMapper.getClass(), metadataMapper);
             return this;

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -399,7 +399,7 @@ final class DocumentParser {
             if (dynamic == ObjectMapper.Dynamic.STRICT) {
                 throw new StrictDynamicMappingException(mapper.fullPath(), currentFieldName);
             } else if (dynamic == ObjectMapper.Dynamic.TRUE) {
-                Mapper.Builder<?> builder = new ObjectMapper.Builder<>(currentFieldName);
+                Mapper.Builder builder = new ObjectMapper.Builder(currentFieldName);
                 builder.position(getPositionEstimate(context));
                 Mapper.BuilderContext builderContext = new Mapper.BuilderContext(context.indexSettings().getSettings(), context.path());
                 objectMapper = builder.build(builderContext);
@@ -537,15 +537,15 @@ final class DocumentParser {
         }
     }
 
-    private static Mapper.Builder<?> newLongBuilder(String name) {
+    private static Mapper.Builder newLongBuilder(String name) {
         return new NumberFieldMapper.Builder(name, NumberFieldMapper.NumberType.LONG);
     }
 
-    private static Mapper.Builder<?> newFloatBuilder(String name) {
+    private static Mapper.Builder newFloatBuilder(String name) {
         return new NumberFieldMapper.Builder(name, NumberFieldMapper.NumberType.FLOAT);
     }
 
-    static Mapper.Builder<?> createBuilderFromDynamicValue(final ParseContext context, XContentParser.Token token, String currentFieldName) throws IOException {
+    static Mapper.Builder createBuilderFromDynamicValue(final ParseContext context, XContentParser.Token token, String currentFieldName) throws IOException {
         if (token == XContentParser.Token.VALUE_STRING) {
             return new KeywordFieldMapper.Builder(currentFieldName);
         } else if (token == XContentParser.Token.VALUE_NUMBER) {
@@ -576,7 +576,7 @@ final class DocumentParser {
             return;
         }
         final Mapper.BuilderContext builderContext = new Mapper.BuilderContext(context.indexSettings().getSettings(), context.path());
-        final Mapper.Builder<?> builder = createBuilderFromDynamicValue(context, token, currentFieldName);
+        final Mapper.Builder builder = createBuilderFromDynamicValue(context, token, currentFieldName);
         builder.position(getPositionEstimate(context));
         Mapper mapper = builder.build(builderContext);
         context.addDynamicMapper(mapper);
@@ -666,7 +666,7 @@ final class DocumentParser {
                     case STRICT:
                         throw new StrictDynamicMappingException(parent.fullPath(), paths[i]);
                     case TRUE:
-                        Mapper.Builder<?> builder = new ObjectMapper.Builder<>(paths[i]);
+                        Mapper.Builder builder = new ObjectMapper.Builder(paths[i]);
                         builder.position(getPositionEstimate(context));
                         Mapper.BuilderContext builderContext = new Mapper.BuilderContext(context.indexSettings().getSettings(),
                             context.path());

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -40,7 +40,7 @@ import org.jetbrains.annotations.Nullable;
 
 public abstract class FieldMapper extends Mapper implements Cloneable {
 
-    public abstract static class Builder<T extends Builder<T>> extends Mapper.Builder<T> {
+    public abstract static class Builder extends Mapper.Builder {
 
         protected final FieldType fieldType;
         protected boolean indexOptionsSet = false;
@@ -55,33 +55,28 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
             this.fieldType = new FieldType(fieldType);
         }
 
-        public T index(boolean index) {
+        public void index(boolean index) {
             this.indexed = index;
             if (index == false) {
                 this.fieldType.setIndexOptions(IndexOptions.NONE);
             }
-            return builder;
         }
 
-        public T store(boolean store) {
+        public void store(boolean store) {
             this.fieldType.setStored(store);
-            return builder;
         }
 
-        public T docValues(boolean docValues) {
+        public void docValues(boolean docValues) {
             this.hasDocValues = docValues;
-            return builder;
         }
 
-        public T indexOptions(IndexOptions indexOptions) {
+        public void indexOptions(IndexOptions indexOptions) {
             this.fieldType.setIndexOptions(indexOptions);
             this.indexOptionsSet = true;
-            return builder;
         }
 
-        public T copyTo(CopyTo copyTo) {
+        public void copyTo(CopyTo copyTo) {
             this.copyTo = copyTo;
-            return builder;
         }
 
         protected String buildFullName(BuilderContext context) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldNamesFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldNamesFieldMapper.java
@@ -62,7 +62,7 @@ public class FieldNamesFieldMapper extends MetadataFieldMapper {
         }
     }
 
-    static class Builder extends MetadataFieldMapper.Builder<Builder> {
+    static class Builder extends MetadataFieldMapper.Builder {
         private boolean enabled = Defaults.ENABLED;
 
         public Builder(MappedFieldType existing) {
@@ -84,7 +84,7 @@ public class FieldNamesFieldMapper extends MetadataFieldMapper {
 
     public static class TypeParser implements MetadataFieldMapper.TypeParser {
         @Override
-        public MetadataFieldMapper.Builder<?> parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+        public MetadataFieldMapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
             return new Builder(parserContext.mapperService().fieldType(NAME));
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/FloatVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FloatVectorFieldMapper.java
@@ -67,7 +67,7 @@ public class FloatVectorFieldMapper extends FieldMapper implements ArrayValueMap
         }
     }
 
-    public static class Builder extends FieldMapper.Builder<Builder> {
+    public static class Builder extends FieldMapper.Builder {
 
         private int dimensions = 0;
 
@@ -104,7 +104,7 @@ public class FloatVectorFieldMapper extends FieldMapper implements ArrayValueMap
     public static class TypeParser implements Mapper.TypeParser {
 
         @Override
-        public Mapper.Builder<?> parse(String name,
+        public Mapper.Builder parse(String name,
                                        Map<String, Object> node,
                                        ParserContext parserContext) throws MapperParsingException {
             Builder builder = new Builder(name);

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
@@ -56,12 +56,11 @@ public class GeoPointFieldMapper extends FieldMapper implements ArrayValueMapper
         FIELD_TYPE.freeze();
     }
 
-    public static class Builder extends FieldMapper.Builder<Builder> {
+    public static class Builder extends FieldMapper.Builder {
 
         public Builder(String name) {
             super(name, FIELD_TYPE);
             hasDocValues = true;
-            builder = this;
         }
 
 
@@ -84,7 +83,7 @@ public class GeoPointFieldMapper extends FieldMapper implements ArrayValueMapper
 
     public static class TypeParser implements Mapper.TypeParser {
         @Override
-        public Mapper.Builder<?> parse(String name,
+        public Mapper.Builder parse(String name,
                                        Map<String, Object> node,
                                        ParserContext parserContext) throws MapperParsingException {
             Builder builder = new GeoPointFieldMapper.Builder(name);

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeFieldMapper.java
@@ -106,7 +106,7 @@ public class GeoShapeFieldMapper extends FieldMapper {
         public static final double DISTANCE_ERROR_PCT = 0.0;
     }
 
-    public static class Builder extends FieldMapper.Builder<Builder> {
+    public static class Builder extends FieldMapper.Builder {
 
         private String tree = Names.TREE_GEOHASH;
         private int treeLevels;
@@ -174,7 +174,7 @@ public class GeoShapeFieldMapper extends FieldMapper {
     public static class TypeParser implements Mapper.TypeParser {
 
         @Override
-        public Mapper.Builder<?> parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+        public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
             Builder builder = new Builder(name);
             for (Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator(); iterator.hasNext();) {
                 Map.Entry<String, Object> entry = iterator.next();

--- a/server/src/main/java/org/elasticsearch/index/mapper/IdFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IdFieldMapper.java
@@ -58,7 +58,7 @@ public class IdFieldMapper extends MetadataFieldMapper {
 
     public static class TypeParser implements MetadataFieldMapper.TypeParser {
         @Override
-        public MetadataFieldMapper.Builder<?> parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+        public MetadataFieldMapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
             throw new MapperParsingException(NAME + " is not configurable");
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -54,11 +54,10 @@ public class IpFieldMapper extends FieldMapper {
         }
     }
 
-    public static class Builder extends FieldMapper.Builder<Builder> {
+    public static class Builder extends FieldMapper.Builder {
 
         public Builder(String name) {
             super(name, Defaults.FIELD_TYPE);
-            builder = this;
         }
 
         @Override
@@ -83,7 +82,7 @@ public class IpFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Mapper.Builder<?> parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+        public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
             Builder builder = new Builder(name);
             TypeParsers.parseField(builder, name, node);
             return builder;

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -61,7 +61,7 @@ public final class KeywordFieldMapper extends FieldMapper {
         public static final String NULL_VALUE = null;
     }
 
-    public static class Builder extends FieldMapper.Builder<Builder> {
+    public static class Builder extends FieldMapper.Builder {
 
         protected String nullValue = Defaults.NULL_VALUE;
         private Integer lengthLimit;
@@ -69,34 +69,29 @@ public final class KeywordFieldMapper extends FieldMapper {
 
         public Builder(String name) {
             super(name, Defaults.FIELD_TYPE);
-            builder = this;
         }
 
-        public Builder lengthLimit(int lengthLimit) {
+        public void lengthLimit(int lengthLimit) {
             if (lengthLimit < 0) {
                 throw new IllegalArgumentException("[legnth_limit] must be positive, got " + lengthLimit);
             }
             this.lengthLimit = lengthLimit;
-            return this;
         }
 
-        public Builder blankPadding(boolean blankPadding) {
+        public void blankPadding(boolean blankPadding) {
             this.blankPadding = blankPadding;
-            return this;
         }
 
         @Override
-        public Builder indexOptions(IndexOptions indexOptions) {
+        public void indexOptions(IndexOptions indexOptions) {
             if (indexOptions.compareTo(IndexOptions.DOCS_AND_FREQS) > 0) {
                 throw new IllegalArgumentException("The [keyword] field does not support positions, got [index_options]="
                         + indexOptionToString(indexOptions));
             }
-            return super.indexOptions(indexOptions);
         }
 
-        public Builder nullValue(String nullValue) {
+        public void nullValue(String nullValue) {
             this.nullValue = nullValue;
-            return builder;
         }
 
         private KeywordFieldType buildFieldType(BuilderContext context) {
@@ -130,7 +125,7 @@ public final class KeywordFieldMapper extends FieldMapper {
 
     public static class TypeParser implements Mapper.TypeParser {
         @Override
-        public Mapper.Builder<?> parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+        public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
             KeywordFieldMapper.Builder builder = new KeywordFieldMapper.Builder(name);
             parseField(builder, name, node);
             for (Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator(); iterator.hasNext();) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
@@ -67,11 +67,9 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
         }
     }
 
-    public abstract static class Builder<T extends Builder<?>> {
+    public abstract static class Builder {
 
         protected String name;
-
-        protected T builder;
 
         protected Builder(String name) {
             this.name = name;
@@ -130,7 +128,7 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
             }
         }
 
-        Mapper.Builder<?> parse(String name, Map<String, Object> node, ParserContext parserContext)
+        Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext)
             throws MapperParsingException;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/MetadataFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MetadataFieldMapper.java
@@ -36,7 +36,7 @@ public abstract class MetadataFieldMapper extends FieldMapper {
     public interface TypeParser extends Mapper.TypeParser {
 
         @Override
-        MetadataFieldMapper.Builder<?> parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException;
+        MetadataFieldMapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException;
 
         /**
          * Get the default {@link MetadataFieldMapper} to use, if nothing had to be parsed.
@@ -45,17 +45,16 @@ public abstract class MetadataFieldMapper extends FieldMapper {
         MetadataFieldMapper getDefault(ParserContext parserContext);
     }
 
-    public abstract static class Builder<T extends Builder<T>> extends FieldMapper.Builder<T> {
+    public abstract static class Builder extends FieldMapper.Builder {
         public Builder(String name, FieldType fieldType) {
             super(name, fieldType);
         }
 
         @Override
-        public T index(boolean index) {
+        public void index(boolean index) {
             if (index == false) {
                 throw new IllegalArgumentException("Metadata fields must be indexed");
             }
-            return builder;
         }
 
         public abstract MetadataFieldMapper build(BuilderContext context);

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -53,18 +53,17 @@ public class NumberFieldMapper extends FieldMapper {
         FIELD_TYPE.freeze();
     }
 
-    public static class Builder extends FieldMapper.Builder<Builder> {
+    public static class Builder extends FieldMapper.Builder {
 
         private final NumberType type;
 
         public Builder(String name, NumberType type) {
             super(name, FIELD_TYPE);
             this.type = type;
-            builder = this;
         }
 
         @Override
-        public Builder indexOptions(IndexOptions indexOptions) {
+        public void indexOptions(IndexOptions indexOptions) {
             throw new MapperParsingException(
                     "index_options not allowed in field [" + name + "] of type [" + type.typeName() + "]");
         }
@@ -95,7 +94,7 @@ public class NumberFieldMapper extends FieldMapper {
         }
 
         @Override
-        public Mapper.Builder<?> parse(String name,
+        public Mapper.Builder parse(String name,
                                        Map<String, Object> node,
                                        ParserContext parserContext) throws MapperParsingException {
             Builder builder = new Builder(name, type);

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectArrayMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectArrayMapper.java
@@ -40,11 +40,11 @@ import java.util.Map;
  */
 public class ObjectArrayMapper extends ObjectMapper {
 
-    static class Builder extends ObjectMapper.Builder<Builder> {
+    static class Builder extends ObjectMapper.Builder {
 
-        private final ObjectMapper.Builder<?> innerBuilder;
+        private final ObjectMapper.Builder innerBuilder;
 
-        Builder(String name, ObjectMapper.Builder<?> innerBuilder) {
+        Builder(String name, ObjectMapper.Builder innerBuilder) {
             super(name);
             this.innerBuilder = innerBuilder;
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -57,26 +57,22 @@ public class ObjectMapper extends Mapper implements Cloneable {
         STRICT
     }
 
-    public static class Builder<T extends Builder<T>> extends Mapper.Builder<T> {
+    public static class Builder extends Mapper.Builder {
 
         protected Dynamic dynamic = DYNAMIC;
 
-        protected final List<Mapper.Builder<?>> mappersBuilders = new ArrayList<>();
+        protected final List<Mapper.Builder> mappersBuilders = new ArrayList<>();
 
-        @SuppressWarnings("unchecked")
         public Builder(String name) {
             super(name);
-            this.builder = (T) this;
         }
 
-        public T dynamic(Dynamic dynamic) {
+        public void dynamic(Dynamic dynamic) {
             this.dynamic = dynamic;
-            return builder;
         }
 
-        public T add(Mapper.Builder<?> builder) {
+        public void add(Mapper.Builder builder) {
             mappersBuilders.add(builder);
-            return this.builder;
         }
 
         @Override
@@ -85,7 +81,7 @@ public class ObjectMapper extends Mapper implements Cloneable {
             context.path().add(pathName);
 
             Map<String, Mapper> mappers = new HashMap<>();
-            for (Mapper.Builder<?> builder : mappersBuilders) {
+            for (Mapper.Builder builder : mappersBuilders) {
                 Mapper mapper = builder.build(context);
                 var name = mapper.simpleName();
                 if (mapper.columnOID() != COLUMN_OID_UNASSIGNED) {
@@ -222,7 +218,7 @@ public class ObjectMapper extends Mapper implements Cloneable {
                     String realFieldName = fieldNameParts[fieldNameParts.length - 1];
                     Mapper.Builder fieldBuilder = typeParser.parse(realFieldName, propNode, parserContext);
                     for (int i = fieldNameParts.length - 2; i >= 0; --i) {
-                        ObjectMapper.Builder<?> intermediate = new ObjectMapper.Builder<>(fieldNameParts[i]);
+                        ObjectMapper.Builder intermediate = new ObjectMapper.Builder(fieldNameParts[i]);
                         intermediate.add(fieldBuilder);
                         fieldBuilder = intermediate;
                     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
@@ -33,11 +33,10 @@ public class RootObjectMapper extends ObjectMapper {
 
     private ColumnPositionResolver<Mapper> columnPositionResolver = new ColumnPositionResolver<>();
 
-    public static class Builder extends ObjectMapper.Builder<Builder> {
+    public static class Builder extends ObjectMapper.Builder {
 
         public Builder(String name) {
             super(name);
-            this.builder = this;
         }
 
         @Override
@@ -67,7 +66,7 @@ public class RootObjectMapper extends ObjectMapper {
     public static class TypeParser extends ObjectMapper.TypeParser {
 
         @Override
-        public Mapper.Builder<?> parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+        public Mapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
             RootObjectMapper.Builder builder = new Builder(name);
             Iterator<Map.Entry<String, Object>> iterator = node.entrySet().iterator();
             while (iterator.hasNext()) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
@@ -54,7 +54,7 @@ public class SourceFieldMapper extends MetadataFieldMapper {
 
     }
 
-    public static class Builder extends MetadataFieldMapper.Builder<Builder> {
+    public static class Builder extends MetadataFieldMapper.Builder {
 
 
         public Builder() {
@@ -70,7 +70,7 @@ public class SourceFieldMapper extends MetadataFieldMapper {
     public static class TypeParser implements MetadataFieldMapper.TypeParser {
 
         @Override
-        public MetadataFieldMapper.Builder<?> parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+        public MetadataFieldMapper.Builder parse(String name, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
             return new Builder();
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -62,7 +62,7 @@ public class TextFieldMapper extends FieldMapper {
         public static final int POSITION_INCREMENT_GAP = 100;
     }
 
-    public static class Builder extends FieldMapper.Builder<Builder> {
+    public static class Builder extends FieldMapper.Builder {
 
         protected NamedAnalyzer indexAnalyzer;
         protected NamedAnalyzer searchAnalyzer;
@@ -72,72 +72,61 @@ public class TextFieldMapper extends FieldMapper {
 
         public Builder(String name) {
             super(name, Defaults.FIELD_TYPE);
-            builder = this;
         }
 
         @Override
-        public Builder docValues(boolean docValues) {
+        public void docValues(boolean docValues) {
             if (docValues) {
                 throw new IllegalArgumentException("[text] fields do not support doc values");
             }
-            return super.docValues(docValues);
         }
 
-        public Builder indexAnalyzer(NamedAnalyzer indexAnalyzer) {
+        public void indexAnalyzer(NamedAnalyzer indexAnalyzer) {
             this.indexAnalyzer = indexAnalyzer;
-            return builder;
         }
 
-        public Builder searchAnalyzer(NamedAnalyzer searchAnalyzer) {
+        public void searchAnalyzer(NamedAnalyzer searchAnalyzer) {
             this.searchAnalyzer = searchAnalyzer;
-            return builder;
         }
 
-        public Builder searchQuoteAnalyzer(NamedAnalyzer searchQuoteAnalyzer) {
+        public void searchQuoteAnalyzer(NamedAnalyzer searchQuoteAnalyzer) {
             this.searchQuoteAnalyzer = searchQuoteAnalyzer;
-            return builder;
         }
 
-        public Builder omitNorms(boolean omitNorms) {
+        public void omitNorms(boolean omitNorms) {
             this.fieldType.setOmitNorms(omitNorms);
             this.omitNormsSet = true;
-            return builder;
         }
 
-        public Builder storeTermVectors(boolean termVectors) {
+        public void storeTermVectors(boolean termVectors) {
             if (termVectors != this.fieldType.storeTermVectors()) {
                 this.fieldType.setStoreTermVectors(termVectors);
             } // don't set it to false, it is default and might be flipped by a more specific option
-            return builder;
         }
 
-        public Builder storeTermVectorOffsets(boolean termVectorOffsets) {
+        public void storeTermVectorOffsets(boolean termVectorOffsets) {
             if (termVectorOffsets) {
                 this.fieldType.setStoreTermVectors(termVectorOffsets);
             }
             this.fieldType.setStoreTermVectorOffsets(termVectorOffsets);
-            return builder;
         }
 
-        public Builder storeTermVectorPositions(boolean termVectorPositions) {
+        public void storeTermVectorPositions(boolean termVectorPositions) {
             if (termVectorPositions) {
                 this.fieldType.setStoreTermVectors(termVectorPositions);
             }
             this.fieldType.setStoreTermVectorPositions(termVectorPositions);
-            return builder;
         }
 
-        public Builder storeTermVectorPayloads(boolean termVectorPayloads) {
+        public void storeTermVectorPayloads(boolean termVectorPayloads) {
             if (termVectorPayloads) {
                 this.fieldType.setStoreTermVectors(termVectorPayloads);
             }
             this.fieldType.setStoreTermVectorPayloads(termVectorPayloads);
-            return builder;
         }
 
-        public Builder sources(List<String> sources) {
+        public void sources(List<String> sources) {
             this.sources = sources;
-            return this;
         }
 
         private TextFieldType buildFieldType(BuilderContext context) {
@@ -174,7 +163,7 @@ public class TextFieldMapper extends FieldMapper {
 
     public static class TypeParser implements Mapper.TypeParser {
         @Override
-        public Mapper.Builder<?> parse(String fieldName, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
+        public Mapper.Builder parse(String fieldName, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
             TextFieldMapper.Builder builder = new TextFieldMapper.Builder(fieldName);
             builder.indexAnalyzer(parserContext.getIndexAnalyzers().getDefaultIndexAnalyzer());
             builder.searchAnalyzer(parserContext.getIndexAnalyzers().getDefaultSearchAnalyzer());

--- a/server/src/main/java/org/elasticsearch/index/mapper/TypeParsers.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TypeParsers.java
@@ -161,7 +161,7 @@ public class TypeParsers {
     /**
      * Parse common field attributes such as {@code doc_values} or {@code store}.
      */
-    public static void parseField(FieldMapper.Builder<?> builder,
+    public static void parseField(FieldMapper.Builder builder,
                                   String name,
                                   Map<String, Object> fieldNode) {
         for (Iterator<Map.Entry<String, Object>> iterator = fieldNode.entrySet().iterator(); iterator.hasNext();) {
@@ -245,7 +245,7 @@ public class TypeParsers {
         }
     }
 
-    public static void parseCopyFields(Object propNode, FieldMapper.Builder<?> builder) {
+    public static void parseCopyFields(Object propNode, FieldMapper.Builder builder) {
         FieldMapper.CopyTo.Builder copyToBuilder = new FieldMapper.CopyTo.Builder();
         if (propNode instanceof List<?> nodes) {
             for (Object node : nodes) {


### PR DESCRIPTION
We never actually use Mapper.Builder as a fluent builder API, and 
it adds a bunch of cruft to the source, so just remove the generics
and `builder` field.