### PR TITLE
Add sys.roles table

### DIFF
--- a/docs/admin/system-information.rst
+++ b/docs/admin/system-information.rst
@@ -2166,6 +2166,19 @@ The ``sys.users`` table contains all existing database users in the cluster.
 |               | ``NULL`` if there is not.                    |             |
 +---------------+----------------------------------------------+-------------+
 
+.. _sys-roles:
+
+Roles
+=====
+
+The ``sys.roles`` table contains all existing database roles in the cluster.
+
++---------------+----------------------------------------------+-------------+
+| Column Name   | Description                                  | Return Type |
++===============+==============================================+=============+
+| ``name``      | The name of the database user.               | ``TEXT``    |
++---------------+----------------------------------------------+-------------+
+
 .. _sys-allocations:
 
 Allocations

--- a/docs/admin/user-management.rst
+++ b/docs/admin/user-management.rst
@@ -125,7 +125,7 @@ The ``sys.users`` table shows all users in the cluster which can be used for
 authentication. The initial superuser ``crate`` which is available for all
 CrateDB clusters is also part of that list.
 
-To list all existing users query that table::
+To list all existing users query the table::
 
     cr> SELECT * FROM sys.users order by name;
     +-------------+----------+-----------+
@@ -148,8 +148,35 @@ shows whether the user has superuser privileges or not.
     <scalar-current_user>`, :ref:`USER <scalar-user>` and :ref:`SESSION_USER
     <scalar-session_user>`.
 
+List roles
+==========
+
+.. hide:
+
+    cr> CREATE ROLE role_a;
+    CREATE OK, 1 row affected (... sec)
+    cr> CREATE ROLE role_b;
+    CREATE OK, 1 row affected (... sec)
+
+CrateDB exposes database roles via the read-only :ref:`sys-roles` system table.
+The ``sys.roles`` table shows all roles in the cluster which can be used to
+group privileges.
+
+To list all existing roles query the table::
+
+    cr> SELECT * FROM sys.roles order by name;
+    +--------+
+    | name   |
+    +--------+
+    | role_a |
+    | role_b |
+    +--------+
+    SELECT 2 rows in set (... sec)
+
+The column ``name`` shows the unique name of the role.
+
 .. vale off
-.. Drop Users
+.. Drop Users & Roles
 .. hide:
 
     cr> DROP USER "Custom User";
@@ -157,4 +184,8 @@ shows whether the user has superuser privileges or not.
     cr> DROP USER user_a;
     DROP OK, 1 row affected (... sec)
     cr> DROP USER user_b;
+    DROP OK, 1 row affected (... sec)
+    cr> DROP ROLE role_a;
+    DROP OK, 1 row affected (... sec)
+    cr> DROP ROLE role_b;
     DROP OK, 1 row affected (... sec)

--- a/docs/appendices/release-notes/5.6.0.rst
+++ b/docs/appendices/release-notes/5.6.0.rst
@@ -110,3 +110,5 @@ Administration and Operations
   ``table_rename_replacement`` to :ref:`RESTORE SNAPSHOT<sql-restore-snapshot>`
   to allow renaming tables during restore.
 
+- Added :ref:`sys.roles<sys-roles>` table which contains all database roles
+  defined in the cluster.

--- a/docs/general/information-schema.rst
+++ b/docs/general/information-schema.rst
@@ -123,6 +123,7 @@ number of replicas.
     | sys                | operations_log          | BASE TABLE |             NULL | NULL               |
     | sys                | privileges              | BASE TABLE |             NULL | NULL               |
     | sys                | repositories            | BASE TABLE |             NULL | NULL               |
+    | sys                | roles                   | BASE TABLE |             NULL | NULL               |
     | sys                | segments                | BASE TABLE |             NULL | NULL               |
     | sys                | shards                  | BASE TABLE |             NULL | NULL               |
     | sys                | snapshot_restore        | BASE TABLE |             NULL | NULL               |
@@ -130,7 +131,7 @@ number of replicas.
     | sys                | summits                 | BASE TABLE |             NULL | NULL               |
     | sys                | users                   | BASE TABLE |             NULL | NULL               |
     +--------------------+-------------------------+------------+------------------+--------------------+
-    SELECT 63 rows in set (... sec)
+    SELECT 64 rows in set (... sec)
 
 
 The table also contains additional information such as the specified

--- a/server/src/main/java/io/crate/user/UserManagerService.java
+++ b/server/src/main/java/io/crate/user/UserManagerService.java
@@ -38,6 +38,7 @@ import io.crate.execution.engine.collect.sources.SysTableRegistry;
 import io.crate.metadata.cluster.DDLClusterStateService;
 import io.crate.metadata.settings.CoordinatorSessionSettings;
 import io.crate.user.metadata.SysPrivilegesTableInfo;
+import io.crate.user.metadata.SysRolesTableInfo;
 import io.crate.user.metadata.SysUsersTableInfo;
 
 @Singleton
@@ -85,6 +86,14 @@ public class UserManagerService implements UserManager {
             () -> CompletableFuture.completedFuture(
                 userLookup.roles().stream().filter(Role::isUser).toList()),
             userTable.expressions(),
+            false
+        );
+        var rolesTable = SysRolesTableInfo.create();
+        sysTableRegistry.registerSysTable(
+            rolesTable,
+            () -> CompletableFuture.completedFuture(
+                userLookup.roles().stream().filter(r -> r.isUser() == false).toList()),
+                rolesTable.expressions(),
             false
         );
 

--- a/server/src/main/java/io/crate/user/metadata/SysRolesTableInfo.java
+++ b/server/src/main/java/io/crate/user/metadata/SysRolesTableInfo.java
@@ -21,7 +21,6 @@
 
 package io.crate.user.metadata;
 
-import static io.crate.types.DataTypes.BOOLEAN;
 import static io.crate.types.DataTypes.STRING;
 
 import io.crate.metadata.ColumnIdent;
@@ -30,18 +29,15 @@ import io.crate.metadata.SystemTable;
 import io.crate.metadata.sys.SysSchemaInfo;
 import io.crate.user.Role;
 
-public class SysUsersTableInfo {
+public class SysRolesTableInfo {
 
-    private static final RelationName IDENT = new RelationName(SysSchemaInfo.NAME, "users");
-    private static final String PASSWORD_PLACEHOLDER = "********";
+    private SysRolesTableInfo() {}
 
-    private SysUsersTableInfo() {}
+    private static final RelationName IDENT = new RelationName(SysSchemaInfo.NAME, "roles");
 
     public static SystemTable<Role> create() {
         return SystemTable.<Role>builder(IDENT)
             .add("name", STRING, Role::name)
-            .add("superuser", BOOLEAN, Role::isSuperUser)
-            .add("password", STRING, x -> x.password() == null ? null : PASSWORD_PLACEHOLDER)
             .setPrimaryKeys(new ColumnIdent("name"))
             .build();
     }

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -59,7 +59,7 @@ public class InformationSchemaTest extends IntegTestCase {
     @Test
     public void testDefaultTables() {
         execute("select * from information_schema.tables order by table_schema, table_name");
-        assertThat(response.rowCount()).isEqualTo(59L);
+        assertThat(response.rowCount()).isEqualTo(60L);
 
         assertThat(response).hasRows(
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| crate| character_sets| information_schema| BASE TABLE| NULL",
@@ -115,6 +115,7 @@ public class InformationSchemaTest extends IntegTestCase {
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| crate| operations_log| sys| BASE TABLE| NULL",
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| crate| privileges| sys| BASE TABLE| NULL",
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| crate| repositories| sys| BASE TABLE| NULL",
+            "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| crate| roles| sys| BASE TABLE| NULL",
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| crate| segments| sys| BASE TABLE| NULL",
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| crate| shards| sys| BASE TABLE| NULL",
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| crate| snapshot_restore| sys| BASE TABLE| NULL",
@@ -202,13 +203,13 @@ public class InformationSchemaTest extends IntegTestCase {
     @Test
     public void testSearchInformationSchemaTablesRefresh() {
         execute("select * from information_schema.tables");
-        assertThat(response.rowCount()).isEqualTo(59L);
+        assertThat(response.rowCount()).isEqualTo(60L);
 
         execute("create table t4 (col1 integer, col2 string) with(number_of_replicas=0)");
         ensureYellow(getFqn("t4"));
 
         execute("select * from information_schema.tables");
-        assertThat(response.rowCount()).isEqualTo(60L);
+        assertThat(response.rowCount()).isEqualTo(61L);
     }
 
     @Test
@@ -420,6 +421,7 @@ public class InformationSchemaTest extends IntegTestCase {
             "nodes_pk| PRIMARY KEY| nodes| sys",
             "privileges_pk| PRIMARY KEY| privileges| sys",
             "repositories_pk| PRIMARY KEY| repositories| sys",
+            "roles_pk| PRIMARY KEY| roles| sys",
             "shards_pk| PRIMARY KEY| shards| sys",
             "snapshot_restore_pk| PRIMARY KEY| snapshot_restore| sys",
             "snapshots_pk| PRIMARY KEY| snapshots| sys",
@@ -563,7 +565,7 @@ public class InformationSchemaTest extends IntegTestCase {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertThat(response.rowCount()).isEqualTo(974);
+        assertThat(response.rowCount()).isEqualTo(975);
     }
 
     @Test
@@ -884,7 +886,7 @@ public class InformationSchemaTest extends IntegTestCase {
         execute("create table t3 (id integer, col1 string) clustered into 3 shards with(number_of_replicas=0)");
         execute("select count(*) from information_schema.tables");
         assertThat(response.rowCount()).isEqualTo(1);
-        assertThat(response.rows()[0][0]).isEqualTo(62L);
+        assertThat(response.rows()[0][0]).isEqualTo(63L);
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -145,7 +145,7 @@ public class PgCatalogITest extends IntegTestCase {
     @Test
     public void testPgIndexTable() {
         execute("select count(*) from pg_catalog.pg_index");
-        assertThat(response).hasRows("23");
+        assertThat(response).hasRows("24");
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/TableSettingsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TableSettingsTest.java
@@ -102,7 +102,7 @@ public class TableSettingsTest extends IntegTestCase {
     public void testFilterOnNull() throws Exception {
         execute("select * from information_schema.tables " +
                 "where settings IS NULL");
-        assertEquals(59L, response.rowCount());
+        assertEquals(60L, response.rowCount());
         execute("select * from information_schema.tables " +
                 "where table_name = 'settings_table' and settings['warmer']['enabled'] IS NULL");
         assertEquals(0, response.rowCount());


### PR DESCRIPTION
Currently we distinguish Users and Roles and since Role has no password (cannot login) the only column for `sys.roles` table is `name`.

Part of: https://github.com/crate/crate/issues/12109
