### PR TITLE
Treat column's generated or default expressions as column constraints

### DIFF
--- a/docs/appendices/release-notes/5.5.2.rst
+++ b/docs/appendices/release-notes/5.5.2.rst
@@ -66,3 +66,8 @@ Fixes
   success on dropping :ref:`system columns <sql_administration_system_columns>`
   despite any follow up queries on the dropped columns work as expected. Now
   an exception is thrown.
+
+- Fixed the SQL parser to be lenient with the position of constraint definitions
+  at the column definition of ``CREATE TABLE`` and ``ALTER TABLE`` statements.
+  E.g. ``CREATE TABLE t (a INT NULL DEFAULT 1)`` is now accepted while before
+  the ``NULL`` constraint had to be placed after the ``DEFAULT`` constraint.

--- a/libs/sql-parser/src/main/antlr/io/crate/sql/parser/antlr/SqlBaseParser.g4
+++ b/libs/sql-parser/src/main/antlr/io/crate/sql/parser/antlr/SqlBaseParser.g4
@@ -644,11 +644,11 @@ tableElement
     ;
 
 columnDefinition
-    : ident dataType? (DEFAULT defaultExpr=expr)? ((GENERATED ALWAYS)? AS generatedExpr=expr)? columnConstraint*
+    : ident dataType? columnConstraint*
     ;
 
 addColumnDefinition
-    : ADD COLUMN? subscriptSafe dataType? ((GENERATED ALWAYS)? AS expr)? columnConstraint*
+    : ADD COLUMN? subscriptSafe dataType? columnConstraint*
     ;
 
 dropColumnDefinition
@@ -696,6 +696,8 @@ columnConstraint
     | INDEX USING method=ident withProperties?                                       #columnIndexConstraint
     | INDEX OFF                                                                      #columnIndexOff
     | STORAGE withProperties                                                         #columnStorageDefinition
+    | (CONSTRAINT name=ident)? DEFAULT defaultExpr=expr                              #columnDefaultConstraint
+    | (CONSTRAINT name=ident)? (GENERATED ALWAYS)? AS generatedExpr=expr             #columnGeneratedConstraint
     | checkConstraint                                                                #columnCheckConstraint
     ;
 

--- a/libs/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
@@ -64,6 +64,7 @@ import io.crate.sql.tree.CreateSubscription;
 import io.crate.sql.tree.CreateTable;
 import io.crate.sql.tree.Declare;
 import io.crate.sql.tree.DecommissionNodeStatement;
+import io.crate.sql.tree.DefaultConstraint;
 import io.crate.sql.tree.DenyPrivilege;
 import io.crate.sql.tree.DropAnalyzer;
 import io.crate.sql.tree.DropBlobTable;
@@ -82,6 +83,7 @@ import io.crate.sql.tree.Fetch;
 import io.crate.sql.tree.Fetch.ScrollMode;
 import io.crate.sql.tree.FunctionArgument;
 import io.crate.sql.tree.GCDanglingArtifacts;
+import io.crate.sql.tree.GeneratedExpressionConstraint;
 import io.crate.sql.tree.GenericProperties;
 import io.crate.sql.tree.GrantPrivilege;
 import io.crate.sql.tree.IndexColumnConstraint;
@@ -760,14 +762,6 @@ public final class SqlFormatter {
             if (type != null) {
                 type.accept(this, indent);
             }
-            if (columnDefinition.defaultExpression() != null) {
-                builder.append(" DEFAULT ")
-                    .append(formatStandaloneExpression(columnDefinition.defaultExpression(), parameters));
-            }
-            if (columnDefinition.generatedExpression() != null) {
-                builder.append(" GENERATED ALWAYS AS ")
-                    .append(formatStandaloneExpression(columnDefinition.generatedExpression(), parameters));
-            }
 
             if (!columnDefinition.constraints().isEmpty()) {
                 for (ColumnConstraint<?> constraint : columnDefinition.constraints()) {
@@ -891,6 +885,22 @@ public final class SqlFormatter {
         @Override
         public Void visitCheckColumnConstraint(CheckColumnConstraint<?> node, Integer indent) {
             visitCheckConstraint(node.name(), node.expressionStr());
+            return null;
+        }
+
+        @Override
+        public Void visitDefaultConstraint(DefaultConstraint<?> node, Integer context) {
+            visitConstraintName(node.name());
+            builder.append("DEFAULT ")
+                .append(formatStandaloneExpression((Expression) node.expression(), parameters));
+            return null;
+        }
+
+        @Override
+        public Void visitGeneratedExpressionConstraint(GeneratedExpressionConstraint<?> node, Integer context) {
+            visitConstraintName(node.name());
+            builder.append("GENERATED ALWAYS AS ")
+                .append(formatStandaloneExpression((Expression) node.expression(), parameters));
             return null;
         }
 

--- a/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -122,6 +122,7 @@ import io.crate.sql.tree.DeallocateStatement;
 import io.crate.sql.tree.Declare;
 import io.crate.sql.tree.Declare.Hold;
 import io.crate.sql.tree.DecommissionNodeStatement;
+import io.crate.sql.tree.DefaultConstraint;
 import io.crate.sql.tree.Delete;
 import io.crate.sql.tree.DenyPrivilege;
 import io.crate.sql.tree.DiscardStatement;
@@ -150,6 +151,7 @@ import io.crate.sql.tree.FrameBound;
 import io.crate.sql.tree.FunctionArgument;
 import io.crate.sql.tree.FunctionCall;
 import io.crate.sql.tree.GCDanglingArtifacts;
+import io.crate.sql.tree.GeneratedExpressionConstraint;
 import io.crate.sql.tree.GenericProperties;
 import io.crate.sql.tree.GenericProperty;
 import io.crate.sql.tree.GrantPrivilege;
@@ -1142,8 +1144,6 @@ class AstBuilder extends SqlBaseParserBaseVisitor<Node> {
     public Node visitColumnDefinition(SqlBaseParser.ColumnDefinitionContext context) {
         return new ColumnDefinition(
             getIdentText(context.ident()),
-            visitOptionalContext(context.defaultExpr, Expression.class),
-            visitOptionalContext(context.generatedExpr, Expression.class),
             visitOptionalContext(context.dataType(), ColumnType.class),
             visitCollection(context.columnConstraint(), ColumnConstraint.class));
     }
@@ -1156,6 +1156,22 @@ class AstBuilder extends SqlBaseParserBaseVisitor<Node> {
     @Override
     public Node visitColumnConstraintNotNull(SqlBaseParser.ColumnConstraintNotNullContext context) {
         return new NotNullColumnConstraint<>();
+    }
+
+    @Override
+    public Node visitColumnGeneratedConstraint(SqlBaseParser.ColumnGeneratedConstraintContext context) {
+        String name = context.CONSTRAINT() != null ? getIdentText(context.name) : null;
+        Expression expression = (Expression) visit(context.expr());
+        String expressionStr = ExpressionFormatter.formatStandaloneExpression(expression);
+        return new GeneratedExpressionConstraint<>(name, expression, expressionStr);
+    }
+
+    @Override
+    public Node visitColumnDefaultConstraint(SqlBaseParser.ColumnDefaultConstraintContext context) {
+        String name = context.CONSTRAINT() != null ? getIdentText(context.name) : null;
+        Expression expression = (Expression) visit(context.expr());
+        String expressionStr = ExpressionFormatter.formatStandaloneExpression(expression);
+        return new DefaultConstraint<>(name, expression, expressionStr);
     }
 
     @Override
@@ -1338,7 +1354,6 @@ class AstBuilder extends SqlBaseParserBaseVisitor<Node> {
     public Node visitAddColumnDefinition(SqlBaseParser.AddColumnDefinitionContext context) {
         return new AddColumnDefinition(
             visit(context.subscriptSafe()),
-            visitOptionalContext(context.expr(), Expression.class),
             visitOptionalContext(context.dataType(), ColumnType.class),
             visitCollection(context.columnConstraint(), ColumnConstraint.class));
     }

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/AddColumnDefinition.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/AddColumnDefinition.java
@@ -31,35 +31,21 @@ public class AddColumnDefinition<T> extends TableElement<T> {
 
     private final T name;
     @Nullable
-    private final T generatedExpression;
-    @Nullable
     private final ColumnType<T> type;
     private final List<ColumnConstraint<T>> constraints;
 
     public AddColumnDefinition(T name,
-                               @Nullable T generatedExpression,
                                @Nullable ColumnType<T> type,
                                List<ColumnConstraint<T>> constraints) {
         this.name = name;
-        this.generatedExpression = generatedExpression;
         this.type = type;
         this.constraints = constraints;
-        if (type == null && generatedExpression == null) {
-            throw new IllegalArgumentException(
-                "Column [" + name + "]: data type needs to be provided " +
-                "or column should be defined as a generated expression");
-        }
+        ColumnDefinition.validateColumnConstraints(name.toString(), type, constraints);
     }
 
     public T name() {
         return name;
     }
-
-    @Nullable
-    public T generatedExpression() {
-        return generatedExpression;
-    }
-
 
     @Nullable
     public ColumnType<T> type() {
@@ -80,21 +66,19 @@ public class AddColumnDefinition<T> extends TableElement<T> {
         }
         AddColumnDefinition<?> that = (AddColumnDefinition<?>) o;
         return Objects.equals(name, that.name) &&
-               Objects.equals(generatedExpression, that.generatedExpression) &&
                Objects.equals(type, that.type) &&
                Objects.equals(constraints, that.constraints);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, generatedExpression, type, constraints);
+        return Objects.hash(name, type, constraints);
     }
 
     @Override
     public String toString() {
         return "AddColumnDefinition{" +
                "name=" + name +
-               ", generatedExpression=" + generatedExpression +
                ", type=" + type +
                ", constraints=" + constraints +
                '}';
@@ -108,7 +92,6 @@ public class AddColumnDefinition<T> extends TableElement<T> {
     @Override
     public void visit(Consumer<? super T> consumer) {
         consumer.accept(name);
-        consumer.accept(generatedExpression);
         for (ColumnConstraint<T> constraint : constraints) {
             constraint.visit(consumer);
         }

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
@@ -388,6 +388,14 @@ public abstract class AstVisitor<R, C> {
         return visitNode(node, context);
     }
 
+    public R visitDefaultConstraint(DefaultConstraint<?> node, C context) {
+        return visitNode(node, context);
+    }
+
+    public R visitGeneratedExpressionConstraint(GeneratedExpressionConstraint<?> node, C context) {
+        return visitNode(node, context);
+    }
+
     public R visitDropCheckConstraint(DropCheckConstraint<?> node, C context) {
         return visitNode(node, context);
     }

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/CheckColumnConstraint.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/CheckColumnConstraint.java
@@ -21,12 +21,13 @@
 
 package io.crate.sql.tree;
 
-import org.jetbrains.annotations.Nullable;
 import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-public class CheckColumnConstraint<T> extends ColumnConstraint<T> {
+import org.jetbrains.annotations.Nullable;
+
+public final class CheckColumnConstraint<T> extends ColumnConstraint<T> {
 
     @Nullable
     private final String name;

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/ColumnConstraint.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/ColumnConstraint.java
@@ -24,7 +24,15 @@ package io.crate.sql.tree;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-public abstract class ColumnConstraint<T> extends Node {
+public abstract sealed class ColumnConstraint<T> extends Node permits
+    PrimaryKeyColumnConstraint,
+    ColumnStorageDefinition,
+    DefaultConstraint,
+    GeneratedExpressionConstraint,
+    IndexColumnConstraint,
+    CheckColumnConstraint,
+    NotNullColumnConstraint,
+    NullColumnConstraint {
 
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/DefaultConstraint.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/DefaultConstraint.java
@@ -25,54 +25,70 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-public final class ColumnStorageDefinition<T> extends ColumnConstraint<T> {
+import org.jetbrains.annotations.Nullable;
 
-    private final GenericProperties<T> properties;
+public final class DefaultConstraint<T> extends ColumnConstraint<T> {
 
-    public ColumnStorageDefinition(GenericProperties<T> properties) {
-        this.properties = properties;
+    @Nullable
+    private final String name;
+
+    private final T expression;
+    private final String expressionStr;
+
+    public DefaultConstraint(@Nullable String name, T expression, String expressionStr) {
+        this.name = name;
+        this.expression = expression;
+        this.expressionStr = expressionStr;
     }
 
-    public GenericProperties<T> properties() {
-        return properties;
+    @Nullable
+    public String name() {
+        return name;
+    }
+
+    public T expression() {
+        return expression;
+    }
+
+    public String expressionStr() {
+        return expressionStr;
     }
 
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
-        return visitor.visitColumnStorageDefinition(this, context);
+        return visitor.visitDefaultConstraint(this, context);
     }
 
     @Override
     public <U> ColumnConstraint<U> map(Function<? super T, ? extends U> mapper) {
-        return new ColumnStorageDefinition<>(properties.map(mapper));
+        return new DefaultConstraint<U>(name, mapper.apply(expression), expressionStr);
     }
 
     @Override
     public void visit(Consumer<? super T> consumer) {
-        properties.properties().values().forEach(consumer);
+        consumer.accept(expression);
     }
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        ColumnStorageDefinition<?> that = (ColumnStorageDefinition<?>) o;
-        return Objects.equals(properties, that.properties);
+        if (this == o) return true;
+        if (!(o instanceof DefaultConstraint<?> that)) return false;
+        return Objects.equals(name, that.name)
+            && Objects.equals(expression, that.expression)
+            && Objects.equals(expressionStr, that.expressionStr);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(properties);
+        return Objects.hash(name, expression, expressionStr);
     }
 
     @Override
     public String toString() {
-        return "ColumnStorageDefinition{" +
-               "properties=" + properties +
-               '}';
+        return "DefaultConstraint{" +
+            "name='" + name + '\'' +
+            ", expression=" + expression +
+            ", expressionStr='" + expressionStr + '\'' +
+            '}';
     }
 }

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/GeneratedExpressionConstraint.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/GeneratedExpressionConstraint.java
@@ -25,54 +25,70 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-public final class ColumnStorageDefinition<T> extends ColumnConstraint<T> {
+import org.jetbrains.annotations.Nullable;
 
-    private final GenericProperties<T> properties;
+public final class GeneratedExpressionConstraint<T> extends ColumnConstraint<T> {
 
-    public ColumnStorageDefinition(GenericProperties<T> properties) {
-        this.properties = properties;
+    @Nullable
+    private final String name;
+
+    private final T expression;
+    private final String expressionStr;
+
+    public GeneratedExpressionConstraint(@Nullable String name, T expression, String expressionStr) {
+        this.name = name;
+        this.expression = expression;
+        this.expressionStr = expressionStr;
     }
 
-    public GenericProperties<T> properties() {
-        return properties;
+    @Nullable
+    public String name() {
+        return name;
+    }
+
+    public T expression() {
+        return expression;
+    }
+
+    public String expressionStr() {
+        return expressionStr;
     }
 
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
-        return visitor.visitColumnStorageDefinition(this, context);
+        return visitor.visitGeneratedExpressionConstraint(this, context);
     }
 
     @Override
     public <U> ColumnConstraint<U> map(Function<? super T, ? extends U> mapper) {
-        return new ColumnStorageDefinition<>(properties.map(mapper));
+        return new GeneratedExpressionConstraint<>(name, mapper.apply(expression), expressionStr);
     }
 
     @Override
     public void visit(Consumer<? super T> consumer) {
-        properties.properties().values().forEach(consumer);
+        consumer.accept(expression);
     }
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        ColumnStorageDefinition<?> that = (ColumnStorageDefinition<?>) o;
-        return Objects.equals(properties, that.properties);
+        if (this == o) return true;
+        if (!(o instanceof GeneratedExpressionConstraint<?> that)) return false;
+        return Objects.equals(name, that.name)
+            && Objects.equals(expression, that.expression)
+            && Objects.equals(expressionStr, that.expressionStr);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(properties);
+        return Objects.hash(name, expression, expressionStr);
     }
 
     @Override
     public String toString() {
-        return "ColumnStorageDefinition{" +
-               "properties=" + properties +
-               '}';
+        return "GeneratedExpressionConstraint{" +
+            "name='" + name + '\'' +
+            ", expression=" + expression +
+            ", expressionStr='" + expressionStr + '\'' +
+            '}';
     }
 }

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/IndexColumnConstraint.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/IndexColumnConstraint.java
@@ -25,7 +25,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-public class IndexColumnConstraint<T> extends ColumnConstraint<T> {
+public final class IndexColumnConstraint<T> extends ColumnConstraint<T> {
 
     private static final IndexColumnConstraint<?> OFF = new IndexColumnConstraint<>("OFF", GenericProperties.empty());
 

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/NotNullColumnConstraint.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/NotNullColumnConstraint.java
@@ -24,7 +24,7 @@ package io.crate.sql.tree;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-public class NotNullColumnConstraint<T> extends ColumnConstraint<T> {
+public final class NotNullColumnConstraint<T> extends ColumnConstraint<T> {
 
     private static final String NAME = "NOT NULL";
 

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/NullColumnConstraint.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/NullColumnConstraint.java
@@ -24,7 +24,7 @@ package io.crate.sql.tree;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-public class NullColumnConstraint<T> extends ColumnConstraint<T> {
+public final class NullColumnConstraint<T> extends ColumnConstraint<T> {
     private static final String NAME = "NULL";
 
     @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/PrimaryKeyColumnConstraint.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/PrimaryKeyColumnConstraint.java
@@ -27,7 +27,7 @@ import java.util.function.Function;
 
 import org.jetbrains.annotations.Nullable;
 
-public class PrimaryKeyColumnConstraint<T> extends ColumnConstraint<T> {
+public final class PrimaryKeyColumnConstraint<T> extends ColumnConstraint<T> {
     private static final String NAME = "PRIMARY_KEY";
     @Nullable
     private final String constraintName;

--- a/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -784,6 +784,7 @@ public class TestStatementBuilder {
     public void testCreateTableDefaultExpression() {
         printStatement("create table test (col1 int default 1)");
         printStatement("create table test (col1 int default random())");
+        printStatement("create table test (col1 int not null default 1)");
     }
 
     @Test
@@ -792,6 +793,54 @@ public class TestStatementBuilder {
             () -> printStatement("create table test (col1 int default random() as 1+1)"))
             .isExactlyInstanceOf(IllegalArgumentException.class)
             .hasMessage("Column [col1]: the default and generated expressions are mutually exclusive");
+    }
+
+    @Test
+    public void test_create_table_column_with_duplicated_constraints_is_not_allowed() {
+        var constraintDefinitions = List.of(
+            "INDEX OFF",
+            "DEFAULT 1",
+            "GENERATED ALWAYS AS 1+1",
+            "PRIMARY KEY",
+            "STORAGE WITH(foobar=1)"
+        );
+        for (var constraintDefinition : constraintDefinitions) {
+            assertThatThrownBy(
+                () -> printStatement("CREATE TABLE test (col1 INT " + constraintDefinition + " " + constraintDefinition + ")"))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessageStartingWith("Column [col1]: multiple")
+                .hasMessageEndingWith("constraints found");
+        }
+    }
+
+    @Test
+    public void test_create_table_column_with_allowed_duplicated_constraints() {
+        printStatement("CREATE TABLE test (col1 INT NULL NULL)");
+        printStatement("CREATE TABLE test (col1 INT NOT NULL NOT NULL)");
+    }
+
+    @Test
+    public void test_alter_table_add_column_with_duplicated_constraints_is_not_allowed() {
+        var constraintDefinitions = List.of(
+            "INDEX OFF",
+            "DEFAULT 1",
+            "GENERATED ALWAYS AS 1+1",
+            "PRIMARY KEY",
+            "STORAGE WITH(foobar=1)"
+        );
+        for (var constraintDefinition : constraintDefinitions) {
+            assertThatThrownBy(
+                () -> printStatement("ALTER TABLE test ADD COLUMN col1 INT " + constraintDefinition + " " + constraintDefinition))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessageStartingWith("Column [\"col1\"]: multiple")
+                .hasMessageEndingWith("constraints found");
+        }
+    }
+
+    @Test
+    public void test_alter_table_add_column_with_ignored_duplicated_constraints() {
+        printStatement("ALTER TABLE test ADD COLUMN col1 INT NULL NULL");
+        printStatement("ALTER TABLE test ADD COLUMN col1 INT NOT NULL NOT NULL");
     }
 
     @Test

--- a/server/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
@@ -80,8 +80,10 @@ import io.crate.sql.tree.ColumnPolicy;
 import io.crate.sql.tree.ColumnStorageDefinition;
 import io.crate.sql.tree.ColumnType;
 import io.crate.sql.tree.CreateTable;
+import io.crate.sql.tree.DefaultConstraint;
 import io.crate.sql.tree.DefaultTraversalVisitor;
 import io.crate.sql.tree.Expression;
+import io.crate.sql.tree.GeneratedExpressionConstraint;
 import io.crate.sql.tree.GenericProperties;
 import io.crate.sql.tree.IndexColumnConstraint;
 import io.crate.sql.tree.IndexDefinition;
@@ -546,24 +548,6 @@ public class TableElementsAnalyzer implements FieldProvider<Reference> {
                 : ColumnIdent.getChildSafe(parent, columnDefinition.ident());
             RefBuilder builder = columns.get(columnName);
 
-            Expression defaultExpression = columnDefinition.defaultExpression();
-            if (defaultExpression != null) {
-                if (builder.type.id() == ObjectType.ID) {
-                    throw new IllegalArgumentException("Default values are not allowed for object columns: " + columnName);
-                }
-                Symbol defaultSymbol = expressionAnalyzer.convert(defaultExpression, expressionContext);
-                builder.defaultExpression = defaultSymbol.cast(builder.type, CastMode.IMPLICIT);
-                // only used to validate; result is not used to preserve functions like `current_timestamp`
-                normalizer.normalize(builder.defaultExpression, txnCtx);
-                RefVisitor.visitRefs(builder.defaultExpression, x -> {
-                    throw new UnsupportedOperationException(
-                        "Cannot reference columns in DEFAULT expression of `" + columnName + "`. " +
-                        "Maybe you wanted to use a string literal with single quotes instead: '" + x.column().name() + "'");
-                });
-                EnsureNoMatchPredicate.ensureNoMatchPredicate(defaultSymbol, "Cannot use MATCH in CREATE TABLE statements");
-            }
-
-            setGeneratedExpression(builder, columnDefinition.generatedExpression());
             for (var constraint : columnDefinition.constraints()) {
                 processConstraint(builder, constraint);
             }
@@ -580,21 +564,6 @@ public class TableElementsAnalyzer implements FieldProvider<Reference> {
             }
 
             return null;
-        }
-
-        private void setGeneratedExpression(RefBuilder builder, @Nullable Expression generatedExpression) {
-            if (generatedExpression == null) {
-                return;
-            }
-            builder.generated = expressionAnalyzer.convert(generatedExpression, expressionContext);
-            EnsureNoMatchPredicate.ensureNoMatchPredicate(builder.generated, "Cannot use MATCH in CREATE TABLE statements");
-            if (builder.type == DataTypes.UNDEFINED) {
-                builder.type = builder.generated.valueType();
-            } else {
-                builder.generated = builder.generated.cast(builder.type, CastMode.IMPLICIT);
-            }
-            // only used to validate; result is not used to preserve functions like `current_timestamp`
-            normalizer.normalize(builder.generated, txnCtx);
         }
 
         private void processConstraint(RefBuilder builder, ColumnConstraint<Expression> constraint) {
@@ -647,6 +616,38 @@ public class TableElementsAnalyzer implements FieldProvider<Reference> {
                     throw new IllegalArgumentException(String.format(Locale.ENGLISH,
                         "Column \"%s\" is declared as NOT NULL, therefore, cannot be declared NULL", columnName));
                 }
+            } else if (constraint instanceof DefaultConstraint<Expression> defaultConstraint) {
+                Expression defaultExpression = defaultConstraint.expression();
+                if (defaultExpression != null) {
+                    if (builder.type.id() == ObjectType.ID) {
+                        throw new IllegalArgumentException("Default values are not allowed for object columns: " + columnName);
+                    }
+                    Symbol defaultSymbol = expressionAnalyzer.convert(defaultExpression, expressionContext);
+                    builder.defaultExpression = defaultSymbol.cast(builder.type, CastMode.IMPLICIT);
+                    // only used to validate; result is not used to preserve functions like `current_timestamp`
+                    normalizer.normalize(builder.defaultExpression, txnCtx);
+                    RefVisitor.visitRefs(builder.defaultExpression, x -> {
+                        throw new UnsupportedOperationException(
+                            "Cannot reference columns in DEFAULT expression of `" + columnName + "`. " +
+                                "Maybe you wanted to use a string literal with single quotes instead: '" + x.column().name() + "'");
+                    });
+                    EnsureNoMatchPredicate.ensureNoMatchPredicate(defaultSymbol, "Cannot use MATCH in CREATE TABLE statements");
+                }
+            } else if (constraint instanceof GeneratedExpressionConstraint<Expression> generatedExpressionConstraint) {
+                Expression generatedExpression = generatedExpressionConstraint.expression();
+                if (generatedExpression != null) {
+                    builder.generated = expressionAnalyzer.convert(generatedExpression, expressionContext);
+                    EnsureNoMatchPredicate.ensureNoMatchPredicate(builder.generated, "Cannot use MATCH in CREATE TABLE statements");
+                    if (builder.type == DataTypes.UNDEFINED) {
+                        builder.type = builder.generated.valueType();
+                    } else {
+                        builder.generated = builder.generated.cast(builder.type, CastMode.IMPLICIT);
+                    }
+                    // only used to validate; result is not used to preserve functions like `current_timestamp`
+                    normalizer.normalize(builder.generated, txnCtx);
+                }
+            } else {
+                throw new UnsupportedOperationException("constraint not supported: " + constraint);
             }
         }
 
@@ -659,7 +660,6 @@ public class TableElementsAnalyzer implements FieldProvider<Reference> {
             ColumnIdent columnName = Symbols.pathFromSymbol(expressionAnalyzer.convert(name, expressionContext));
             RefBuilder builder = columns.get(columnName);
 
-            setGeneratedExpression(builder, columnDefinition.generatedExpression());
             for (var constraint : columnDefinition.constraints()) {
                 processConstraint(builder, constraint);
             }

--- a/server/src/main/java/io/crate/expression/symbol/Symbols.java
+++ b/server/src/main/java/io/crate/expression/symbol/Symbols.java
@@ -268,8 +268,6 @@ public class Symbols {
     public static ColumnDefinition<Expression> toColumnDefinition(Symbol symbol) {
         return new ColumnDefinition<>(
             pathFromSymbol(symbol).sqlFqn(), // allow ObjectTypes to return col name in subscript notation
-            null,
-            null,
             symbol.valueType().toColumnType(
                 symbol instanceof Reference reference ? reference.columnPolicy() : ColumnPolicy.DYNAMIC,
                 null),

--- a/server/src/main/java/io/crate/types/ObjectType.java
+++ b/server/src/main/java/io/crate/types/ObjectType.java
@@ -375,8 +375,6 @@ public class ObjectType extends DataType<Map<String, Object>> implements Streame
                 columnPolicy,
                 Lists2.map(innerTypes.entrySet(), e -> new ColumnDefinition<>(
                     e.getKey(),
-                    null,
-                    null,
                     e.getValue().toColumnType(columnPolicy, convertChildColumn),
                     List.of()
                 ))

--- a/server/src/testFixtures/java/io/crate/testing/NodeAssert.java
+++ b/server/src/testFixtures/java/io/crate/testing/NodeAssert.java
@@ -97,8 +97,6 @@ public final class NodeAssert extends AbstractAssert<NodeAssert, Node> {
 
         assertThat(columnDefinition.ident()).isEqualTo(expectedIdent);
         assertThat(columnDefinition.constraints()).isEmpty();
-        assertThat(columnDefinition.defaultExpression()).isNull();
-        assertThat(columnDefinition.generatedExpression()).isNull();
         assertThat(columnDefinition.type()).as("columnType").satisfies(columnTypeMatcher);
         return this;
     }


### PR DESCRIPTION
Additionally, validate constraints for conflicting definitions.
Fixes #15156