### PR TITLE
Populate pg_roles table

### DIFF
--- a/docs/appendices/release-notes/5.6.0.rst
+++ b/docs/appendices/release-notes/5.6.0.rst
@@ -72,6 +72,9 @@ SQL Standard and PostgreSQL Compatibility
 
 - Added an empty ``pg_catalog.pg_depend`` table.
 
+- Changed ``pg_catalog.pg_roles`` table to be properly populated, as previously
+  it was always returning ``0`` rows.
+
 Data Types
 ----------
 

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
@@ -46,6 +46,7 @@ import io.crate.replication.logical.metadata.pgcatalog.PgSubscriptionRelTable;
 import io.crate.replication.logical.metadata.pgcatalog.PgSubscriptionTable;
 import io.crate.statistics.TableStats;
 import io.crate.user.Privilege;
+import io.crate.user.UserManagerService;
 
 public final class PgCatalogTableDefinitions {
 
@@ -58,7 +59,8 @@ public final class PgCatalogTableDefinitions {
                                      PgCatalogSchemaInfo pgCatalogSchemaInfo,
                                      SessionSettingRegistry sessionSettingRegistry,
                                      Schemas schemas,
-                                     LogicalReplicationService logicalReplicationService) {
+                                     LogicalReplicationService logicalReplicationService,
+                                     UserManagerService userManagerService) {
         tableDefinitions = new HashMap<>();
         tableDefinitions.put(PgStatsTable.NAME, new StaticTableDefinition<>(
                 tableStats::statsEntries,
@@ -145,7 +147,7 @@ public final class PgCatalogTableDefinitions {
             false
         ));
         tableDefinitions.put(PgRolesTable.IDENT, new StaticTableDefinition<>(
-            () -> completedFuture(emptyList()),
+            () -> completedFuture(userManagerService.roles()),
             PgRolesTable.create().expressions(),
             false
         ));

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgRolesTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgRolesTable.java
@@ -26,9 +26,14 @@ import static io.crate.types.DataTypes.STRING_ARRAY;
 import static io.crate.types.DataTypes.BOOLEAN;
 import static io.crate.types.DataTypes.INTEGER;
 import static io.crate.types.DataTypes.TIMESTAMPZ;
+import static io.crate.user.metadata.SysUsersTableInfo.PASSWORD_PLACEHOLDER;
 
+import io.crate.exceptions.MissingPrivilegeException;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.SystemTable;
+import io.crate.user.Privilege;
+import io.crate.user.Privileges;
+import io.crate.user.Role;
 
 public final class PgRolesTable {
 
@@ -36,21 +41,34 @@ public final class PgRolesTable {
 
     private PgRolesTable() {}
 
-    public static SystemTable<Void> create() {
-        return SystemTable.<Void>builder(IDENT)
-            .add("rolname", STRING, ignored -> null)
-            .add("rolsuper", BOOLEAN, ignored -> null)
-            .add("rolinherit", BOOLEAN, ignored -> null)
-            .add("rolcreaterole", BOOLEAN, ignored -> null)
-            .add("rolcreatedb", BOOLEAN, ignored -> null)
-            .add("rolcanlogin", BOOLEAN, ignored -> null)
-            .add("rolreplication", BOOLEAN, ignored -> null)
-            .add("rolconnlimit", INTEGER, ignored -> null)
-            .add("rolpassword", STRING, ignored -> null)
+    public static SystemTable<Role> create() {
+        return SystemTable.<Role>builder(IDENT)
+            .add("rolname", STRING, Role::name)
+            .add("rolsuper", BOOLEAN, Role::isSuperUser)
+            .add("rolinherit", BOOLEAN, r -> true) // Always inherit
+            .add("rolcreaterole", BOOLEAN, PgRolesTable::canCreateRoleOrSubscription)
+            .add("rolcreatedb", BOOLEAN, ignored -> null) // There is no create database functionality
+            .add("rolcanlogin", BOOLEAN, Role::isUser)
+            .add("rolreplication", BOOLEAN, PgRolesTable::canCreateRoleOrSubscription)
+            .add("rolconnlimit", INTEGER, r -> -1)
+            .add("rolpassword", STRING, r -> r.password() != null ? PASSWORD_PLACEHOLDER : null)
             .add("rolvaliduntil", TIMESTAMPZ, ignored -> null)
             .add("rolbypassrls", BOOLEAN, ignored -> null)
             .add("rolconfig", STRING_ARRAY, ignored -> null)
-            .add("oid", INTEGER, ignored -> null)
+            .add("oid", INTEGER, r -> OidHash.userOid(r.name()))
             .build();
+    }
+
+    private static boolean canCreateRoleOrSubscription(Role role) {
+        try {
+            Privileges.ensureUserHasPrivilege(
+                Privilege.Type.AL,
+                Privilege.Clazz.CLUSTER,
+                null,
+                role);
+            return true;
+        } catch (MissingPrivilegeException e) {
+            return false;
+        }
     }
 }

--- a/server/src/main/java/io/crate/user/metadata/SysUsersTableInfo.java
+++ b/server/src/main/java/io/crate/user/metadata/SysUsersTableInfo.java
@@ -33,7 +33,7 @@ import io.crate.user.Role;
 public class SysUsersTableInfo {
 
     private static final RelationName IDENT = new RelationName(SysSchemaInfo.NAME, "users");
-    private static final String PASSWORD_PLACEHOLDER = "********";
+    public static final String PASSWORD_PLACEHOLDER = "********";
 
     private SysUsersTableInfo() {}
 


### PR DESCRIPTION
Use Users/Roles information to populate `pg_roles` table, which previously was always empty.
