### PR TITLE
Replace USERS & PRIVILEGES with USERMANAGEMENT for snapshot restore

### DIFF
--- a/docs/admin/snapshots.rst
+++ b/docs/admin/snapshots.rst
@@ -212,8 +212,8 @@ partitions). For example:
   On the other hand, you can use ``METADATA`` to restore *everything but*
   tables.
 
-- You can use ``USERS`` to restore database users only.  Or, you can
-  use ``USERS, PRIVILIGES`` to restore both database users and privileges.
+- You can use ``USERMANAGEMENT`` to restore database users, roles and their
+  privileges.
 
 See the :ref:`sql-restore-snapshot` documentation for all possible options.
 

--- a/docs/admin/user-management.rst
+++ b/docs/admin/user-management.rst
@@ -18,9 +18,10 @@ superusers that already exist in the CrateDB cluster. The `CREATE USER`_ and
 When CrateDB is started, the cluster contains one predefined superuser. This
 user is called ``crate``. It is not possible to create any other superusers
 
-The definition of all users, including hashes of their passwords, is backed up
-together with the cluster's metadata when a snapshot is created, and it is 
-restored when using the ``ALL``, ``METADATA``, or ``USERS`` keywords with the 
+The definition of all users and roles, including hashes of their passwords,
+together with their privileges is backed up together with the cluster's metadata
+when a snapshot is created, and it is restored when using the ``ALL``,
+``METADATA``, or ``USERMANAGEMENT`` keywords with the
 :ref:`sql-restore-snapshot` command.
 
 .. rubric:: Table of contents

--- a/docs/appendices/release-notes/5.6.0.rst
+++ b/docs/appendices/release-notes/5.6.0.rst
@@ -41,17 +41,25 @@ Version 5.6.0 - Unreleased
 .. contents::
    :local:
 
+.. _5.6.0_breaking_changes:
 
 Breaking Changes
 ================
 
-None
+- When :ref:`restoring a snapshot <sql-restore-snapshot>`, ``USERS`` and
+  ``PRIVILEGES`` keywords, used to restore user management metadata has been
+  replaced by ``USERMANAGEMENT``, which dictates that all users and roles of the
+  database together with their privileges are restored. Restoring ``USERS`` or
+  ``PRIVILEGES`` separately is not possible anymore.
 
 Deprecations
 ============
 
-None
-
+- ``USERS`` and ``PRIVILEGES`` keywords, used when
+  :ref:`restoring a snapshot <sql-restore-snapshot>`, in order to restore users
+  and privileges metadata respectively, have been deprecated. They have been
+  replaced by ``USERMANAGEMENT`` and their behavior has been modified, please
+  see :ref:`Breaking Changes <5.6.0_breaking_changes>` for details.
 
 Changes
 =======

--- a/docs/sql/statements/restore-snapshot.rst
+++ b/docs/sql/statements/restore-snapshot.rst
@@ -32,8 +32,9 @@ where ``data_section``::
 
    {  TABLES |
       VIEWS |
-      USERS |
-      PRIVILEGES |
+      USERS |      -- Deprecated, use USERMANAGEMENT instead
+      PRIVILEGES | -- Deprecated, use USERMANAGEMENT instead
+      USERMANAGEMENT |
       ANALYZERS |
       UDFS }
 
@@ -55,9 +56,9 @@ with a ``table_ident`` and a optional partition reference given the
 It is possible to restore all tables using the ``TABLES`` keyword. This will
 restore all tables but will not restore metadata.
 
-To restore only the metadata (including views, users, privileges, analyzers,
-user-defined-functions, and all cluster settings), instead use the ``METADATA``
-keyword.
+To restore only the metadata (including views, users, roles, privileges,
+analyzers, user-defined-functions, and all cluster settings), instead use the
+``METADATA`` keyword.
 
 A single metadata group can be restored by using the related ``data_section``
 keyword.

--- a/server/src/test/java/io/crate/analyze/RestoreSnapshotAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/RestoreSnapshotAnalyzerTest.java
@@ -64,7 +64,7 @@ import io.crate.planner.operators.SubQueryResults;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 
-public class SnapshotRestoreAnalyzerTest extends CrateDummyClusterServiceUnitTest {
+public class RestoreSnapshotAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     private SQLExecutor e;
     private PlannerContext plannerContext;


### PR DESCRIPTION
Previously, users could use ``USERS`` and ``PRIVILEGES`` separately when restoring metadata from a snapshot, therefore it was possible to restore only users, or only privileges which doesn't make much sense and can lead to issues and confusion. ``USERMANAGEMENT`` has been introduced to replace ``USERS`` and ``PRIVILEGES`` keywords, which dictates that all users, roles together their privileges are restored. ``USERS`` and ``PRIVILEGES`` are accepted for backwards compatibility, but they are synonyms to ``USER_MANAGEMENT``, so even if only ``USERS``, or only ``PRIVILEGES`` are defined, everything (also roles) is restored.

Relates to: #12109
