### PR TITLE
Fix remote collect DistResultRXTask leak

### DIFF
--- a/docs/appendices/release-notes/5.5.2.rst
+++ b/docs/appendices/release-notes/5.5.2.rst
@@ -49,6 +49,9 @@ See the :ref:`version_5.5.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed a race condition that could lead to a memory leak when relocating a
+  shard from one node to another and concurrently running queries.
+
 - Fixed a performance regression introduced in 5.5.0 for queries with
    ``GROUP BY`` on a single column.
 

--- a/server/src/main/java/io/crate/execution/engine/collect/CollectTask.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/CollectTask.java
@@ -28,14 +28,13 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 
-import io.crate.common.annotations.GuardedBy;
-
-import com.carrotsearch.hppc.IntObjectHashMap;
-
 import org.apache.lucene.search.IndexSearcher;
 import org.elasticsearch.Version;
 import org.elasticsearch.threadpool.ThreadPool;
 
+import com.carrotsearch.hppc.IntObjectHashMap;
+
+import io.crate.common.annotations.GuardedBy;
 import io.crate.common.annotations.VisibleForTesting;
 import io.crate.common.collections.RefCountedItem;
 import io.crate.common.exceptions.Exceptions;

--- a/server/src/main/java/io/crate/execution/engine/collect/collectors/RemoteCollector.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/collectors/RemoteCollector.java
@@ -21,6 +21,15 @@
 
 package io.crate.execution.engine.collect.collectors;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.Executor;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.Nullable;
+
 import io.crate.common.annotations.VisibleForTesting;
 import io.crate.data.Row;
 import io.crate.data.RowConsumer;
@@ -41,14 +50,6 @@ import io.crate.execution.support.ActionExecutor;
 import io.crate.execution.support.NodeRequest;
 import io.crate.metadata.settings.SessionSettings;
 import io.crate.types.DataTypes;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
-import org.jetbrains.annotations.Nullable;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
-import java.util.concurrent.Executor;
 
 public class RemoteCollector {
 
@@ -155,12 +156,12 @@ public class RemoteCollector {
                 .whenComplete(
                     (resp, t) -> {
                         if (t == null) {
-                            LOGGER.trace("RemoteCollector jobAction=onResponse");
+                            LOGGER.trace("RemoteCollector jobId={} jobAction=onResponse collectorKilled={}", jobId, collectorKilled);
                             if (collectorKilled) {
                                 killRemoteContext();
                             }
                         } else {
-                            LOGGER.error("RemoteCollector jobAction=onFailure", t);
+                            LOGGER.error("RemoteCollector jobId={} jobAction=onFailure collectorKilled={} error={}", jobId, collectorKilled, t);
                             context.kill(t.getMessage());
                         }
                     }


### PR DESCRIPTION
The `DistResultRXTask` of a remote collect operation didn't get cleaned
up if the `CollectTask` got killed because the failure propagation was
missing.

`test_decommission` was flaky and failed with a timeout because of this.
