### PR TITLE
Add Licence header to new files in Intellij

### DIFF
--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,0 +1,3 @@
+<component name="CopyrightManager">
+  <settings default="CrateASL2" />
+</component>


### PR DESCRIPTION
It was not added anymore since transition from gradle to maven.
