### PR TITLE
Enable checkstyle for tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
           <suppressionsFileExpression>checkstyle.suppressions.file</suppressionsFileExpression>
           <consoleOutput>true</consoleOutput>
           <failsOnError>true</failsOnError>
+          <includeTestSourceDirectory>true</includeTestSourceDirectory>
           <includeTestResources>false</includeTestResources>
           <linkXRef>false</linkXRef>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,11 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>${versions.plugin.clean}</version>
+      </plugin>
+      <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${versions.plugin.compiler}</version>
         <configuration>
@@ -237,6 +242,7 @@
     <versions.jmh>1.37</versions.jmh>
 
     <!-- Maven Plugins -->
+    <versions.plugin.clean>3.3.2</versions.plugin.clean>
     <versions.plugin.compiler>3.11.0</versions.plugin.compiler>
     <versions.plugin.surefire>3.2.2</versions.plugin.surefire>
     <versions.plugin.checkstyle>3.3.1</versions.plugin.checkstyle>

--- a/server/src/test/java/io/crate/analyze/MetadataToASTNodeResolverTest.java
+++ b/server/src/test/java/io/crate/analyze/MetadataToASTNodeResolverTest.java
@@ -534,6 +534,7 @@ public class MetadataToASTNodeResolverTest extends CrateDummyClusterServiceUnitT
             Matchers.containsString("\"g\" GEO_SHAPE GENERATED ALWAYS AS 'POLYGON (( 5 5, 30 5, 30 30, 5 30, 5 5 ))")
         );
     }
+
     @Test
     public void test_geo_shape_array_index_definition_is_preserved_in_cluster_state() throws Exception {
         SQLExecutor e = SQLExecutor.builder(clusterService)

--- a/server/src/test/java/io/crate/breaker/CrateCircuitBreakerServiceTest.java
+++ b/server/src/test/java/io/crate/breaker/CrateCircuitBreakerServiceTest.java
@@ -113,7 +113,7 @@ public class CrateCircuitBreakerServiceTest extends CrateDummyClusterServiceUnit
 
     @Test
     public void testStats() throws Exception {
-        try(CircuitBreakerService breakerService = new HierarchyCircuitBreakerService(
+        try (CircuitBreakerService breakerService = new HierarchyCircuitBreakerService(
             Settings.EMPTY, clusterService.getClusterSettings()
         )) {
             CircuitBreakerStats queryBreakerStats = breakerService.stats(HierarchyCircuitBreakerService.QUERY);

--- a/server/src/test/java/io/crate/execution/dml/upsert/UpdateToInsertTest.java
+++ b/server/src/test/java/io/crate/execution/dml/upsert/UpdateToInsertTest.java
@@ -311,12 +311,12 @@ public class UpdateToInsertTest extends CrateDummyClusterServiceUnitTest {
                 Arrays.asList(insertColumns)
         );
         assertThat(updateToInsert.columns())
-                .as("Start References of columns() must match insertColumns")
-                .satisfiesExactly(
-                        x -> assertThat(x).isReference().hasName("z"),
-                        x -> assertThat(x).isReference().hasName("x"),
-                        x -> assertThat(x).isReference().hasName("y")
-                );
+            .as("Start References of columns() must match insertColumns")
+            .satisfiesExactly(
+                    x -> assertThat(x).isReference().hasName("z"),
+                    x -> assertThat(x).isReference().hasName("x"),
+                    x -> assertThat(x).isReference().hasName("y")
+            );
 
         Map<String, Object> source = Map.of("x", 1, "y", Map.of("a", 2), "z", 3);
         String id = UUIDs.randomBase64UUID();
@@ -327,7 +327,6 @@ public class UpdateToInsertTest extends CrateDummyClusterServiceUnitTest {
                 new Object[] { Literal.of(3) }
         );
         assertThat(item.insertValues()).containsExactly(3, 1, Map.of("a", 20));
-
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/AverageAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/AverageAggregationTest.java
@@ -123,7 +123,7 @@ public class AverageAggregationTest extends AggregationTestCase {
         }
 
         //AverageAggregation returns double
-       assertThat((double) executeAvgAgg(DataTypes.FLOAT, data))
+        assertThat((double) executeAvgAgg(DataTypes.FLOAT, data))
             .isEqualTo(10000.1d, Offset.offset(0.1d));
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/ScalarNullabilityTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ScalarNullabilityTest.java
@@ -1,3 +1,24 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
 package io.crate.expression.scalar;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/server/src/test/java/io/crate/integrationtests/BkdTreeGeoMatchIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/BkdTreeGeoMatchIntegrationTest.java
@@ -1,3 +1,24 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
 package io.crate.integrationtests;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/server/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
@@ -1976,7 +1976,7 @@ public class InsertIntoIntegrationTest extends IntegTestCase {
             INSERT INTO tbl (real_id, \"date\", value) VALUES (6, '2030-11-15 12:13:13', 99999)
             ON CONFLICT (real_id, \"date\", year)
             DO UPDATE SET value = excluded.value
-        """);
+            """);
         execute("refresh table tbl");
         execute("select year, value from tbl");
         assertThat(response).hasRows(
@@ -1986,7 +1986,7 @@ public class InsertIntoIntegrationTest extends IntegTestCase {
             INSERT INTO tbl (real_id, \"date\", value) VALUES (6, '2030-11-15 12:13:13', 99998)
             ON CONFLICT (real_id, \"date\", year)
             DO UPDATE SET value = excluded.value
-        """);
+            """);
         execute("refresh table tbl");
         execute("select year, value from tbl");
         assertThat(response).hasRows(

--- a/server/src/test/java/io/crate/integrationtests/PrefixTreeGeoMatchIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PrefixTreeGeoMatchIntegrationTest.java
@@ -1,3 +1,24 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
 package io.crate.integrationtests;
 
 import org.elasticsearch.index.mapper.GeoShapeFieldMapper;

--- a/server/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
@@ -946,7 +946,7 @@ public class SnapshotRestoreIntegrationTest extends IntegTestCase {
         execute("select partition_ident from information_schema.table_partitions " +
             "where table_name = 'my_table_1_single_partition'");
         assertThat(response).hasRowCount(1);
-        assertThat(response).hasRows( "04130");
+        assertThat(response).hasRows("04130");
     }
 
 

--- a/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -711,6 +711,7 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
             assertThat(tester.runQuery("a", "a != any(['s'])")).containsExactly("t");
         }
     }
+
     @Test
     public void test_eq_object_with_undefined_key() {
         Query query = convert("obj = {x=1, y=2, z=3}"); // z undefined

--- a/server/src/test/java/io/crate/planner/operators/HashJoinTest.java
+++ b/server/src/test/java/io/crate/planner/operators/HashJoinTest.java
@@ -1,3 +1,24 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
 package io.crate.planner.operators;
 
 import static io.crate.testing.Asserts.assertThat;

--- a/server/src/test/java/io/crate/planner/optimizer/rule/EliminateCrossJoinTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/EliminateCrossJoinTest.java
@@ -23,7 +23,6 @@ package io.crate.planner.optimizer.rule;
 
 import static io.crate.common.collections.Iterables.getOnlyElement;
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
@@ -524,10 +523,10 @@ public class EliminateCrossJoinTest extends CrateDummyClusterServiceUnitTest {
 
         var reordered = EliminateCrossJoin.reorder(joinGraph, List.of(b, a));
         assertThat(reordered).hasOperators(
-          "Filter[(x > 1)]",
-              "  └ Join[INNER | (x = y)]",
-              "    ├ Collect[doc.b | [y] | true]",
-              "    └ Collect[doc.a | [x] | true]"
+            "Filter[(x > 1)]",
+            "  └ Join[INNER | (x = y)]",
+            "    ├ Collect[doc.b | [y] | true]",
+            "    └ Collect[doc.a | [x] | true]"
         );
     }
 }

--- a/server/src/test/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoinTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoinTest.java
@@ -1,3 +1,24 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
 package io.crate.planner.optimizer.rule;
 
 import static io.crate.testing.Asserts.assertThat;

--- a/server/src/test/java/io/crate/role/UserActionsTest.java
+++ b/server/src/test/java/io/crate/role/UserActionsTest.java
@@ -89,7 +89,7 @@ public class UserActionsTest extends ESTestCase {
     @Test
     public void testInvalidPasswordProperty() throws Exception {
         GenericProperties<Symbol> properties = new GenericProperties<>(Map.of("invalid", Literal.of("password")));
-        assertThatThrownBy( () -> UserActions.generateSecureHash(properties, Row.EMPTY, txnCtx, NODE_CTX))
+        assertThatThrownBy(() -> UserActions.generateSecureHash(properties, Row.EMPTY, txnCtx, NODE_CTX))
             .isExactlyInstanceOf(IllegalArgumentException.class)
             .hasMessage("\"invalid\" is not a valid user property");
     }


### PR DESCRIPTION
- Add version for maven-clean-plugin
  This avoids warning that `maven-clean-plugin` version is not locked.

- Enable checkstyle checks for test java files
  Since migrataion from gradle, checkstyle was not ran on tests.
  Fix some checkstyle issues in tests since checkstyle is now enabled
  for them as well.

