### PR TITLE
Make `ANY` operator nullable to improve query performance

### DIFF
--- a/server/src/main/java/io/crate/expression/operator/any/AnyOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/any/AnyOperator.java
@@ -95,11 +95,12 @@ public abstract sealed class AnyOperator extends Operator<Object>
     private static void reg(OperatorModule module, String name, FunctionFactory operatorFactory) {
         module.register(
             Signature.scalar(
-                name,
-                TypeSignature.parse("E"),
-                TypeSignature.parse("array(E)"),
-                Operator.RETURN_TYPE.getTypeSignature()
-            ).withTypeVariableConstraints(TypeVariableConstraint.typeVariable("E")),
+                    name,
+                    TypeSignature.parse("E"),
+                    TypeSignature.parse("array(E)"),
+                    Operator.RETURN_TYPE.getTypeSignature()
+                ).withFeature(Feature.NULLABLE)
+                .withTypeVariableConstraints(TypeVariableConstraint.typeVariable("E")),
             operatorFactory
         );
     }

--- a/server/src/main/java/io/crate/expression/predicate/NotPredicate.java
+++ b/server/src/main/java/io/crate/expression/predicate/NotPredicate.java
@@ -21,6 +21,8 @@
 
 package io.crate.expression.predicate;
 
+import static io.crate.expression.predicate.IsNullPredicate.isNullFuncToQuery;
+
 import java.util.HashSet;
 import java.util.Set;
 
@@ -204,10 +206,9 @@ public class NotPredicate extends Scalar<Boolean, Boolean> {
         if (ctx.enforceThreeValuedLogic()) {
             // we require strict 3vl logic, therefore we need to add the function as generic function filter
             // which is less efficient
-            return new BooleanQuery.Builder()
-                .add(notX, Occur.MUST)
-                .add(LuceneQueryBuilder.genericFunctionFilter(input, context), Occur.FILTER)
-                .build();
+            return new BooleanQuery.Builder().add(notX, BooleanClause.Occur.MUST).add(
+                Queries.not(isNullFuncToQuery(arg, context)),
+                BooleanClause.Occur.MUST).build();
         } else {
             BooleanQuery.Builder builder = new BooleanQuery.Builder();
             builder.add(notX, BooleanClause.Occur.MUST);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This fixes regression https://github.com/orgs/crate/projects/21/views/1?pane=issue&itemId=43425855
introduced by https://github.com/crate/crate/pull/15142

```
Q: select count(*) from t where not 50 = any(a)
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |       18.168 ±  122.179 |      0.588 |      1.100 |      1.524 |   1634.643 |
|   V2    |        1.511 ±    4.616 |      0.566 |      1.055 |      1.371 |     98.771 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               - 169.28%                           -   4.18%
There is a 99.76% probability that the observed difference is not random, and the best estimate of that difference is 169.28%
The test has statistical significance
```


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
