### PR TITLE
Support nested arrays in table schemas

### DIFF
--- a/docs/appendices/release-notes/5.7.0.rst
+++ b/docs/appendices/release-notes/5.7.0.rst
@@ -70,7 +70,7 @@ SQL Standard and PostgreSQL Compatibility
 Data Types
 ----------
 
-None
+- Added support for nested arrays in ``CREATE TABLE`` statements
 
 Scalar and Aggregation Functions
 --------------------------------

--- a/docs/general/ddl/data-types.rst
+++ b/docs/general/ddl/data-types.rst
@@ -2885,16 +2885,14 @@ constant array values.
 Nested arrays
 .............
 
-Nested arrays cannot be used directly in column definitions  (i.e.
-``ARRAY(ARRAY(DOUBLE))`` is not accepted), but multiple arrays can be nested
-as long as there are objects in-between:
+You can directly define nested arrays in column definitions:
 
 ::
 
-    CREATE TABLE SensorData (sensorID char(10), readings ARRAY(OBJECT AS (innerarray ARRAY(DOUBLE))));
+    CREATE TABLE SensorData (sensorID char(10), readings ARRAY(ARRAY(DOUBLE)));
 
 
-Nested arrays can still be used directly in input and output to UDFs:
+Nested arrays can also be used directly in input and output to UDFs:
 
 ::
 
@@ -2934,6 +2932,18 @@ requires an intermediate cast:
     |                       2.0 |
     +---------------------------+
 
+.. NOTE::
+
+    Accessing nested arrays will generally require loading
+    sources directly from disk, and will not be very efficient.  If you find
+    yourself using nested arrays frequently, you may want to consider splitting
+    the data up into multiple tables instead.
+
+.. NOTE::
+
+    Nested arrays cannot be created dynamically, either as a
+    :ref:`top level column <column_policy>`
+    or as part of a :ref:`dynamic object <type-object-columns-dynamic>`
 
 .. _type-float_vector:
 

--- a/server/src/main/java/io/crate/analyze/SubscriptContext.java
+++ b/server/src/main/java/io/crate/analyze/SubscriptContext.java
@@ -21,21 +21,24 @@
 
 package io.crate.analyze;
 
-import io.crate.sql.tree.Expression;
-import io.crate.sql.tree.QualifiedName;
-
-import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.crate.sql.tree.Expression;
+import io.crate.sql.tree.QualifiedName;
+
+/**
+ * Holds information about a parsed subscript expression
+ */
 public class SubscriptContext {
 
     private QualifiedName qName;
 
-    private Expression expression;
+    private boolean hasExpression;
 
     private final List<String> parts = new ArrayList<>();
-    private Expression index;
+
+    private final List<Expression> index = new ArrayList<>();
 
     public SubscriptContext() {
     }
@@ -46,32 +49,32 @@ public class SubscriptContext {
 
     public void qualifiedName(QualifiedName qName) {
         this.qName = qName;
+        assert this.hasExpression == false;
     }
 
     public List<String> parts() {
         return parts;
     }
 
-    public void add(String part) {
+    public void addKey(String part) {
         parts.add(0, part);
     }
 
-    public void index(Expression index) {
-        this.index = index;
+    public void addIndex(Expression index) {
+        this.index.add(0, index);
     }
 
-    @Nullable
-    public Expression index() {
+    public List<Expression> index() {
         return index;
     }
 
-    @Nullable
-    public Expression expression() {
-        return expression;
+    public void expression(Expression expression) {
+        assert this.qName == null;
+        this.hasExpression = true;
     }
 
-    public void expression(Expression expression) {
-        this.expression = expression;
+    public boolean hasExpression() {
+        return this.hasExpression;
     }
 
 }

--- a/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -46,7 +46,7 @@ import io.crate.analyze.NegateLiterals;
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.ParamTypeHints;
 import io.crate.analyze.SubscriptContext;
-import io.crate.analyze.SubscriptValidator;
+import io.crate.analyze.SubscriptVisitor;
 import io.crate.analyze.WindowDefinition;
 import io.crate.analyze.WindowFrameDefinition;
 import io.crate.analyze.relations.AnalyzedRelation;
@@ -671,63 +671,77 @@ public class ExpressionAnalyzer {
 
         @Override
         protected Symbol visitSubscriptExpression(SubscriptExpression node, ExpressionAnalysisContext context) {
-            SubscriptContext subscriptContext = new SubscriptContext();
-            SubscriptValidator.validate(node, subscriptContext);
-            QualifiedName qualifiedName = subscriptContext.qualifiedName();
-            List<String> parts = subscriptContext.parts();
+            SubscriptContext subscriptContext = SubscriptVisitor.visit(node);
 
-            if (qualifiedName == null) {
+            if (subscriptContext.hasExpression()) {
+                // The left hand side of the expression isn't a column, it's something like a
+                // static array or a cast, so we recurse into it.
                 Symbol base = node.base().accept(this, context);
                 Symbol index = node.index().accept(this, context);
                 return allocateFunction(SubscriptFunction.NAME, List.of(base, index), context);
-            } else {
-                // Detect and process partial quoted subscript expression
-                var columnName = qualifiedName.getSuffix();
-                var maybeQuotedSubscript = detectAndGenerateSubscriptExpressions(columnName);
-                if (maybeQuotedSubscript != null) {
-                    return visitSubscriptExpression(new SubscriptExpression(maybeQuotedSubscript, node.index()), context);
-                }
+            }
 
-                // Ideally the above base+index + subscriptFunction case would be enough
-                // But:
-                // - We want to avoid subscript functions if possible (we've nested object values in a column store)
-                // - In DDL statement we can't turn a `PRIMARY KEY o['x']` into a subscript either
-                // - In DML statements we can have assignments: obj['x'] = 30
-                // We should come up with a design that addresses those and remove the duct-tape logic below.
+            // Detect and process partial quoted subscript expression
+            QualifiedName qualifiedName = subscriptContext.qualifiedName();
+            var columnName = qualifiedName.getSuffix();
+            var maybeQuotedSubscript = detectAndGenerateSubscriptExpressions(columnName);
+            if (maybeQuotedSubscript != null) {
+                return visitSubscriptExpression(new SubscriptExpression(maybeQuotedSubscript, node.index()), context);
+            }
 
-                Symbol name;
-                try {
-                    name = fieldProvider.resolveField(qualifiedName, parts, operation, context.errorOnUnknownObjectKey());
-                } catch (ColumnUnknownException e) {
-                    if (operation != Operation.READ) {
-                        throw e;
-                    }
-                    try {
-                        Symbol base = fieldProvider.resolveField(qualifiedName,
-                                                                 List.of(),
-                                                                 operation,
-                                                                 context.errorOnUnknownObjectKey());
-                        if (base instanceof Reference) {
-                            throw e;
-                        }
-                        return allocateFunction(
-                            SubscriptFunction.NAME,
-                            List.of(
-                                node.base().accept(this, context),
-                                node.index().accept(this, context)
-                            ),
-                            context
-                        );
-                    } catch (ColumnUnknownException e2) {
-                        throw e;
-                    }
+            // Ideally the above base+index + subscriptFunction case would be enough
+            // But:
+            // - We want to avoid subscript functions if possible (we've nested object values in a column store)
+            // - In DDL statement we can't turn a `PRIMARY KEY o['x']` into a subscript either
+            // - In DML statements we can have assignments: obj['x'] = 30
+            // We should come up with a design that addresses those and remove the duct-tape logic below.
+
+            Symbol ref;
+            try {
+                List<String> parts = subscriptContext.parts();
+                ref = fieldProvider.resolveField(qualifiedName, parts, operation, context.errorOnUnknownObjectKey());
+            } catch (ColumnUnknownException e) {
+                return resolveUnindexedSubscriptExpression(node, context, qualifiedName, e);
+            }
+
+            // If there are any array subscripts, recursively wrap the resolved expression in an
+            // array subscript function for each nested array dereference.
+            for (Expression idx : subscriptContext.index()) {
+                Symbol index = idx.accept(this, context);
+                ref = allocateFunction(SubscriptFunction.NAME, List.of(ref, index), context);
+            }
+            return ref;
+        }
+
+        // If a subscript expression doesn't resolve to an indexed field, try instead
+        // to resolve the base field and use a subscript function to extract the values
+        private Symbol resolveUnindexedSubscriptExpression(
+            SubscriptExpression node,
+            ExpressionAnalysisContext context,
+            QualifiedName qualifiedName,
+            ColumnUnknownException e
+        ) {
+            if (operation != Operation.READ) {
+                throw e;
+            }
+            try {
+                Symbol base = fieldProvider.resolveField(qualifiedName,
+                    List.of(),
+                    operation,
+                    context.errorOnUnknownObjectKey());
+                if (base instanceof Reference) {
+                    throw e;
                 }
-                Expression idxExpression = subscriptContext.index();
-                if (idxExpression != null) {
-                    Symbol index = idxExpression.accept(this, context);
-                    return allocateFunction(SubscriptFunction.NAME, List.of(name, index), context);
-                }
-                return name;
+                return allocateFunction(
+                    SubscriptFunction.NAME,
+                    List.of(
+                        node.base().accept(this, context),
+                        node.index().accept(this, context)
+                    ),
+                    context
+                );
+            } catch (ColumnUnknownException e2) {
+                throw e;
             }
         }
 

--- a/server/src/main/java/io/crate/execution/dml/ObjectIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/ObjectIndexer.java
@@ -237,6 +237,7 @@ public class ObjectIndexer implements ValueIndexer<Map<String, Object>> {
                 continue;
             }
             var type = DynamicIndexer.guessType(innerValue);
+            DynamicIndexer.throwOnNestedArray(type);
             innerValue = type.sanitizeValue(innerValue);
             StorageSupport<?> storageSupport = type.storageSupport();
             if (storageSupport == null) {

--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfoFactory.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfoFactory.java
@@ -556,8 +556,13 @@ public class DocTableInfoFactory {
      * Array types have the mapping for their inner type within `inner`
      **/
     private static Map<String, Object> innerProperties(Map<String, Object> columnProperties) {
-        Map<String, Object> inner = Maps.get(columnProperties, "inner");
-        return inner == null ? columnProperties : inner;
+        var inner = columnProperties;
+        var next = inner;
+        while (next != null) {
+            inner = next;
+            next = Maps.get(inner, "inner");
+        }
+        return inner;
     }
 
     private static List<ColumnIdent> getPrimaryKeys(Map<String, Object> metaMap) {

--- a/server/src/main/java/io/crate/types/ArrayType.java
+++ b/server/src/main/java/io/crate/types/ArrayType.java
@@ -179,7 +179,7 @@ public class ArrayType<T> extends DataType<List<T>> {
         return convert(value, innerType, innerType::sanitizeValue, CoordinatorTxnCtx.systemTransactionContext().sessionSettings());
     }
 
-    public List<String> fromAnyArray(Object[] values) throws IllegalArgumentException {
+    public static List<String> fromAnyArray(Object[] values) throws IllegalArgumentException {
         if (values == null) {
             return null;
         } else {
@@ -191,7 +191,7 @@ public class ArrayType<T> extends DataType<List<T>> {
         }
     }
 
-    public List<String> fromAnyArray(List<?> values) throws IllegalArgumentException {
+    public static List<String> fromAnyArray(List<?> values) throws IllegalArgumentException {
         if (values == null) {
             return null;
         } else {
@@ -204,7 +204,7 @@ public class ArrayType<T> extends DataType<List<T>> {
     }
 
     @SuppressWarnings("unchecked")
-    private String anyValueToString(Object value) {
+    private static String anyValueToString(Object value) {
         if (value == null) {
             return null;
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/ArrayMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ArrayMapper.java
@@ -91,6 +91,10 @@ public class ArrayMapper extends FieldMapper implements ArrayValueMapperParser {
         this.innerMapper = innerMapper;
     }
 
+    public Mapper getInnerMapper() {
+        return innerMapper;
+    }
+
     private static FieldType getFieldType(Mapper.Builder builder) {
         if (builder instanceof FieldMapper.Builder fieldMapperBuilder) {
             return fieldMapperBuilder.fieldType;

--- a/server/src/main/java/org/elasticsearch/index/mapper/ArrayTypeParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ArrayTypeParser.java
@@ -42,8 +42,6 @@ public class ArrayTypeParser implements Mapper.TypeParser {
         String typeName = (String) innerNode.get("type");
         if (typeName == null && innerNode.containsKey("properties")) {
             typeName = ObjectMapper.CONTENT_TYPE;
-        } else if (ArrayMapper.CONTENT_TYPE.equalsIgnoreCase(typeName)) {
-            throw new MapperParsingException("nested arrays are not supported");
         }
 
         Mapper.TypeParser innerTypeParser = parserContext.typeParser(typeName);

--- a/server/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
@@ -639,14 +639,14 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
             .build();
 
         assertThatThrownBy(() -> e.analyze("update t set a['b'][1][1] = 10;"))
-            .isExactlyInstanceOf(UnsupportedOperationException.class)
-            .hasMessage("Nested array access is not supported");
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("cannot use expression \"a\"['b'][1][1] as a left side of an assignment");
         assertThatThrownBy(() -> e.analyze("update t set a[1][1]['b'] = 10;"))
-            .isExactlyInstanceOf(UnsupportedOperationException.class)
-            .hasMessage("Nested array access is not supported");
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("cannot use expression \"a\"[1][1]['b'] as a left side of an assignment");
         assertThatThrownBy(() -> e.analyze("update t set a[1]['b'][1] = 10;"))
-            .isExactlyInstanceOf(UnsupportedOperationException.class)
-            .hasMessage("Nested array access is not supported");
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("cannot use expression \"a\"[1]['b'][1] as a left side of an assignment");
 
         assertThatThrownBy(() -> e.analyze("update t set a['b'][1]::array(integer)[1] = 10;"))
             .isExactlyInstanceOf(IllegalArgumentException.class)

--- a/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -23,6 +23,7 @@ package io.crate.analyze.expressions;
 
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.exactlyInstanceOf;
+import static io.crate.testing.Asserts.isFunction;
 import static io.crate.testing.Asserts.isLiteral;
 import static io.crate.testing.Asserts.isReference;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -118,9 +119,16 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
             isLiteral(1)
         );
 
-        assertThatThrownBy(() -> executor.asSymbol("o_arr['o_arr_nested']['y'][1][1]"))
-            .isExactlyInstanceOf(UnsupportedOperationException.class)
-            .hasMessage("Nested array access is not supported");
+        symbol = executor.asSymbol("o_arr['o_arr_nested']['y'][2][1]");
+        assertThat(symbol).isFunction(
+            "subscript",
+            isFunction(
+                "subscript",
+                isReference("o_arr['o_arr_nested']['y']"),
+                isLiteral(2)
+            ),
+            isLiteral(1)
+        );
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/dml/IndexerTest.java
+++ b/server/src/test/java/io/crate/execution/dml/IndexerTest.java
@@ -23,7 +23,6 @@ package io.crate.execution.dml;
 
 import static io.crate.metadata.doc.mappers.array.ArrayMapperTest.mapper;
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
 import static org.elasticsearch.index.mapper.GeoShapeFieldMapper.Names.TREE_BKD;
@@ -1200,6 +1199,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
+    @Ignore(value = "We don't support dynamic creation of nested arrays due to translog restrictions")
     public void test_index_nested_array() throws Exception {
         SQLExecutor executor = SQLExecutor.builder(clusterService)
             .addTable("create table tbl (x int) with (column_policy = 'dynamic')")

--- a/server/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
@@ -542,12 +542,13 @@ public class CopyIntegrationTest extends SQLHttpIntegrationTest {
 
     @Test
     public void testCopyFromNestedArrayRow() throws Exception {
-        // assert that rows with nested arrays aren't imported
+        // assert that rows with nested arrays are not imported, because they would
+        // dynamically create a new nested array column which is not supported
         execute("create table users (id int, " +
             "name string) with (number_of_replicas=0, column_policy = 'dynamic')");
         execute("copy users from ? with (shared=true)", new Object[]{
             nestedArrayCopyFilePath + "nested_array_copy_from.json"});
-        assertThat(response).hasRowCount(1L); // only 1 document got inserted
+        assertThat(response).hasRowCount(1L);
         refresh();
 
         execute("select * from users");

--- a/server/src/test/java/io/crate/metadata/doc/mappers/array/ArrayMapperTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/mappers/array/ArrayMapperTest.java
@@ -22,6 +22,7 @@
 package io.crate.metadata.doc.mappers.array;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -51,9 +52,11 @@ import org.elasticsearch.index.mapper.ArrayMapper;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.DocumentMapperParser;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
+import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.Mapping;
+import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.mapper.ObjectArrayMapper;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.mapper.SourceToParse;
@@ -339,10 +342,18 @@ public class ArrayMapperTest extends CrateDummyClusterServiceUnitTest {
             .endObject()
             .endObject()
             .endObject().endObject().endObject());
-
-        expectedException.expect(MapperParsingException.class);
-        expectedException.expectMessage("nested arrays are not supported");
-        mapper(INDEX, mapping);
+        DocumentMapper mapper = mapper(INDEX, mapping);
+        Mapper m = mapper.mappers().getMapper("array_field");
+        assertThat(m.name(), equalTo("array_field"));
+        assertThat(m, instanceOf(ArrayMapper.class));
+        ArrayMapper am = (ArrayMapper) m;
+        m = am.getInnerMapper();
+        assertThat(m.name(), equalTo("array_field"));
+        assertThat(m, instanceOf(ArrayMapper.class));
+        am = (ArrayMapper) m;
+        m = am.getInnerMapper();
+        assertThat(m.name(), equalTo("array_field"));
+        assertThat(m, instanceOf(NumberFieldMapper.class));
     }
 
     @Test

--- a/server/src/test/java/io/crate/types/ArrayTypeTest.java
+++ b/server/src/test/java/io/crate/types/ArrayTypeTest.java
@@ -48,10 +48,8 @@ public class ArrayTypeTest extends DataTypeTestCase<List<Object>> {
     }
 
     @Override
-    public void test_doc_values_write_and_read_roundtrip_inclusive_doc_mapper_parse() throws Exception {
-        // skip base class case. It doesn't deal with arrays:
-        // - doesn't initialize sources correctly
-        // - doesn't expect multi values per field
+    protected boolean supportsDocValues() {
+        return false;
     }
 
     @Test

--- a/server/src/test/java/io/crate/types/NestedArrayTypeTest.java
+++ b/server/src/test/java/io/crate/types/NestedArrayTypeTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.types;
+
+import static io.crate.execution.dml.IndexerTest.getIndexer;
+import static io.crate.testing.Asserts.assertThat;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.IntField;
+import org.elasticsearch.index.mapper.ParsedDocument;
+import org.junit.Test;
+
+import io.crate.execution.dml.IndexItem;
+import io.crate.execution.dml.Indexer;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.doc.DocTableInfo;
+import io.crate.testing.DataTypeTesting;
+import io.crate.testing.SQLExecutor;
+
+public class NestedArrayTypeTest extends DataTypeTestCase<List<List<Object>>> {
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public DataType<List<List<Object>>> getType() {
+        DataType<Object> randomType = (DataType<Object>) DataTypeTesting.randomType();
+        return new ArrayType<>(new ArrayType<>(randomType));
+    }
+
+    @Override
+    protected boolean supportsDocValues() {
+        return false;
+    }
+
+    @Test
+    public void test_index_structure() throws IOException {
+        // create a table with a nested array
+        var sqlExecutor = SQLExecutor.builder(clusterService)
+            .addTable("create table tbl (id int, x int[][])")
+            .build();
+        DocTableInfo table = sqlExecutor.resolveTableInfo("tbl");
+
+        // Parse a document using the table schema
+        Indexer indexer = getIndexer(sqlExecutor, table.ident().name(), f -> null, "x");
+        Object[] insertValues = new Object[] { (List.of(List.of(1, 2), List.of(3, 4))) };
+        ParsedDocument doc
+            = indexer.index(new IndexItem.StaticItem("id", List.of(), insertValues, 0, 0));
+
+        // Leaf values are stored as individual int points + docvalues
+        Document expected = new Document();
+        String resolvedField = table.getReference(ColumnIdent.fromPath("x")).storageIdent();
+        expected.add(new IntField(resolvedField, 1, Field.Store.NO));
+        expected.add(new IntField(resolvedField, 2, Field.Store.NO));
+        expected.add(new IntField(resolvedField, 3, Field.Store.NO));
+        expected.add(new IntField(resolvedField, 4, Field.Store.NO));
+        assertThat(doc).hasSameResolvedFields(expected, resolvedField);
+
+        // Source stores the original nested array structure
+        assertThat(doc.source().utf8ToString()).isEqualTo("{\"" + resolvedField + "\":[[1,2],[3,4]]}");
+    }
+}

--- a/server/src/testFixtures/java/io/crate/testing/ParsedDocumentAssert.java
+++ b/server/src/testFixtures/java/io/crate/testing/ParsedDocumentAssert.java
@@ -23,6 +23,7 @@ package io.crate.testing;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.apache.lucene.document.Document;
 import org.apache.lucene.index.IndexableField;
 import org.assertj.core.api.AbstractAssert;
 import org.elasticsearch.index.mapper.ParsedDocument;
@@ -34,9 +35,12 @@ public class ParsedDocumentAssert extends AbstractAssert<ParsedDocumentAssert, P
     }
 
     public void hasSameFieldsWithNameAs(ParsedDocument expected, String fieldName) {
-        IndexableField[] expectedFields = expected.doc().getFields(fieldName);
-        IndexableField[] actualFields = actual.doc().getFields(fieldName);
+        hasSameResolvedFields(expected.doc(), fieldName);
+    }
 
+    public void hasSameResolvedFields(Document expected, String fieldName) {
+        IndexableField[] expectedFields = expected.getFields(fieldName);
+        IndexableField[] actualFields = actual.doc().getFields(fieldName);
         assertThat(expectedFields).hasSize(actualFields.length);
         for (int i = 0; i < expectedFields.length; i++) {
             var field1 = expectedFields[i];


### PR DESCRIPTION
You can now create tables with column definitions like `(int[][] XS)`.  This
only applies to columns explicitly defined in a table schema, and nested
arrays cannot be dynamically created, either as a top level column or as part
of a dynamic object.

Relates to https://github.com/crate/crate/issues/14328