### PR TITLE
Add optimizer rule to move a limit beneath a union

### DIFF
--- a/docs/appendices/release-notes/5.6.0.rst
+++ b/docs/appendices/release-notes/5.6.0.rst
@@ -102,6 +102,13 @@ None
 Performance and Resilience Improvements
 ---------------------------------------
 
+- Added an optimizer rule ``optimizer_move_limit_beneath_union`` which
+  reduces the number of intermediate rows created when a ``LIMIT`` clause is
+  used in combination with a ``UNION`` operator, by moving the limit beneath
+  the union operator e.g.::
+
+    SELECT a FROM t1 UNION ALL SELECT b FROM t2 LIMIT 10;
+
 - Reduced the amount of disk reads necessary for ``ANALYZE`` operations.
 
 - Improved filter push-down for left/right outer joins when the joins are

--- a/server/src/main/java/io/crate/planner/operators/Limit.java
+++ b/server/src/main/java/io/crate/planner/operators/Limit.java
@@ -55,6 +55,7 @@ public class Limit extends ForwardingLogicalPlan {
 
     final Symbol limit;
     final Symbol offset;
+    final boolean isPushedDown;
 
     static LogicalPlan create(LogicalPlan source, @Nullable Symbol limit, @Nullable Symbol offset) {
         if (limit == null && offset == null) {
@@ -63,14 +64,16 @@ public class Limit extends ForwardingLogicalPlan {
             return new Limit(
                 source,
                 Objects.requireNonNullElse(limit, Literal.of(-1L)),
-                Objects.requireNonNullElse(offset, Literal.of(0)));
+                Objects.requireNonNullElse(offset, Literal.of(0)),
+                false);
         }
     }
 
-    public Limit(LogicalPlan source, Symbol limit, Symbol offset) {
+    public Limit(LogicalPlan source, Symbol limit, Symbol offset, boolean isPushedDown) {
         super(source);
         this.limit = limit;
         this.offset = offset;
+        this.isPushedDown = isPushedDown;
     }
 
     public Symbol limit() {
@@ -79,6 +82,10 @@ public class Limit extends ForwardingLogicalPlan {
 
     public Symbol offset() {
         return offset;
+    }
+
+    public boolean isPushedDown() {
+        return isPushedDown;
     }
 
     @Override
@@ -134,7 +141,7 @@ public class Limit extends ForwardingLogicalPlan {
 
     @Override
     public LogicalPlan replaceSources(List<LogicalPlan> sources) {
-        return new Limit(Lists2.getOnlyElement(sources), limit, offset);
+        return new Limit(Lists2.getOnlyElement(sources), limit, offset, isPushedDown);
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -100,6 +100,7 @@ import io.crate.planner.optimizer.rule.MoveFilterBeneathUnion;
 import io.crate.planner.optimizer.rule.MoveFilterBeneathWindowAgg;
 import io.crate.planner.optimizer.rule.MoveLimitBeneathEval;
 import io.crate.planner.optimizer.rule.MoveLimitBeneathRename;
+import io.crate.planner.optimizer.rule.MoveLimitBeneathUnion;
 import io.crate.planner.optimizer.rule.MoveOrderBeneathFetchOrEval;
 import io.crate.planner.optimizer.rule.MoveOrderBeneathNestedLoop;
 import io.crate.planner.optimizer.rule.MoveOrderBeneathRename;
@@ -145,6 +146,7 @@ public class LogicalPlanner {
         new MoveFilterBeneathWindowAgg(),
         new MoveLimitBeneathRename(),
         new MoveLimitBeneathEval(),
+        new MoveLimitBeneathUnion(),
         new MergeFilterAndCollect(),
         new RewriteFilterOnOuterJoinToInnerJoin(),
         new MoveOrderBeneathUnion(),
@@ -215,7 +217,7 @@ public class LogicalPlanner {
             case SINGLE_COLUMN_EXISTS:
                 // Exists only needs to know if there are any rows
                 fetchSize = 1;
-                maybeApplySoftLimit = plan -> new Limit(plan, Literal.of(1), Literal.of(0));
+                maybeApplySoftLimit = plan -> new Limit(plan, Literal.of(1), Literal.of(0), false);
                 break;
             case SINGLE_COLUMN_SINGLE_VALUE:
                 // SELECT (SELECT foo FROM t)
@@ -223,7 +225,7 @@ public class LogicalPlanner {
                 // The subquery must return at most 1 row, if more than 1 row is returned semantics require us to throw an error.
                 // So we limit the query to 2 if there is no limit to avoid retrieval of many rows while being able to validate max1row
                 fetchSize = 2;
-                maybeApplySoftLimit = plan -> new Limit(plan, Literal.of(2L), Literal.of(0L));
+                maybeApplySoftLimit = plan -> new Limit(plan, Literal.of(2L), Literal.of(0L), false);
                 break;
             case SINGLE_COLUMN_MULTIPLE_VALUES:
             default:

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveLimitBeneathUnion.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveLimitBeneathUnion.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.rule;
+
+import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.matcher.Patterns.source;
+
+import java.util.function.Function;
+
+import io.crate.expression.symbol.Literal;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.operators.Limit;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.Union;
+import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
+import io.crate.planner.optimizer.matcher.Capture;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Pattern;
+import io.crate.types.DataTypes;
+
+public class MoveLimitBeneathUnion implements Rule<Limit> {
+
+    private final Capture<Union> unionCapture;
+    private final Pattern<Limit> pattern;
+
+    public MoveLimitBeneathUnion() {
+        this.unionCapture = new Capture<>();
+        this.pattern = typeOf(Limit.class)
+            .with(l -> l.isPushedDown() == false)
+            .with(source(), typeOf(Union.class).capturedAs(unionCapture));
+    }
+
+    @Override
+    public Pattern<Limit> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public LogicalPlan apply(Limit limit,
+                             Captures captures,
+                             PlanStats planStats,
+                             TransactionContext txnCtx,
+                             NodeContext nodeCtx,
+                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
+        Union union = captures.get(unionCapture);
+        // We cannot push the offset down to the sources, otherwise
+        // we may loose rows, therefore we create a new limit where
+        // the offset is added to the limit.
+        if (limit.limit() instanceof Literal<?> l &&
+            limit.offset() instanceof Literal<?> o) {
+
+            int limitVal = DataTypes.INTEGER.sanitizeValue(l.value());
+            int offSetVal = DataTypes.INTEGER.sanitizeValue(o.value());
+            int newLimit = offSetVal + limitVal;
+
+            return new Limit(
+                new Union(
+                    new Limit(union.lhs(), Literal.of(newLimit), Literal.of(0), false),
+                    new Limit(union.rhs(), Literal.of(newLimit), Literal.of(0), false),
+                    union.outputs()
+                ),
+                limit.limit(),
+                limit.offset(),
+                true
+            );
+        }
+        return null;
+    }
+}

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -244,6 +244,7 @@ public class PgCatalogITest extends IntegTestCase {
             "optimizer_move_filter_beneath_window_agg| true| Indicates if the optimizer rule MoveFilterBeneathWindowAgg is activated.| NULL| NULL",
             "optimizer_move_limit_beneath_eval| true| Indicates if the optimizer rule MoveLimitBeneathEval is activated.| NULL| NULL",
             "optimizer_move_limit_beneath_rename| true| Indicates if the optimizer rule MoveLimitBeneathRename is activated.| NULL| NULL",
+            "optimizer_move_limit_beneath_union| true| Indicates if the optimizer rule MoveLimitBeneathUnion is activated.| NULL| NULL",
             "optimizer_move_order_beneath_fetch_or_eval| true| Indicates if the optimizer rule MoveOrderBeneathFetchOrEval is activated.| NULL| NULL",
             "optimizer_move_order_beneath_nested_loop| true| Indicates if the optimizer rule MoveOrderBeneathNestedLoop is activated.| NULL| NULL",
             "optimizer_move_order_beneath_rename| true| Indicates if the optimizer rule MoveOrderBeneathRename is activated.| NULL| NULL",

--- a/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
@@ -423,6 +423,7 @@ public class ShowIntegrationTest extends IntegTestCase {
             "optimizer_move_filter_beneath_window_agg| true| Indicates if the optimizer rule MoveFilterBeneathWindowAgg is activated.",
             "optimizer_move_limit_beneath_eval| true| Indicates if the optimizer rule MoveLimitBeneathEval is activated.",
             "optimizer_move_limit_beneath_rename| true| Indicates if the optimizer rule MoveLimitBeneathRename is activated.",
+            "optimizer_move_limit_beneath_union| true| Indicates if the optimizer rule MoveLimitBeneathUnion is activated.",
             "optimizer_move_order_beneath_fetch_or_eval| true| Indicates if the optimizer rule MoveOrderBeneathFetchOrEval is activated.",
             "optimizer_move_order_beneath_nested_loop| true| Indicates if the optimizer rule MoveOrderBeneathNestedLoop is activated.",
             "optimizer_move_order_beneath_rename| true| Indicates if the optimizer rule MoveOrderBeneathRename is activated.",

--- a/server/src/test/java/io/crate/planner/PlanPrinterTest.java
+++ b/server/src/test/java/io/crate/planner/PlanPrinterTest.java
@@ -100,29 +100,31 @@ public class PlanPrinterTest extends CrateDummyClusterServiceUnitTest {
                                             "select y from t2 " +
                                             "order by 1 " +
                                             "limit 10");
+
         assertThat(map.toString(),
             is("{UnionExecutionPlan={" +
-               "left={Collect={" +
-                    "collectPhase={COLLECT={distribution={distributedByColumn=0, type=BROADCAST}, " +
-                    "executionNodes=[n1], id=0, orderBy=x ASC, " +
-                    "routing={n1={t1=[0, 1, 2, 3]}}, " +
-                    "toCollect=[x], " +
-                    "type=executionPhase, " +
-                    "where=true}}, " +
-                    "type=executionPlan}}, " +
-               "mergePhase={MERGE={" +
-                    "distribution={distributedByColumn=0, type=BROADCAST}, " +
-                    "executionNodes=[n1], id=2, " +
-                    "projections=[{outputs=INPUT(0), offset=0, limit=10, type=LimitAndOffset}], " +
-                    "type=executionPhase}}, " +
-               "right={Collect={" +
-                    "collectPhase={COLLECT={distribution={distributedByColumn=0, type=BROADCAST}, " +
-                    "executionNodes=[n1], id=1, orderBy=y ASC, " +
-                    "routing={n1={t2=[0, 1, 2, 3]}}, " +
-                    "toCollect=[y], " +
-                    "type=executionPhase, where=true}}, " +
-                    "type=executionPlan}}, " +
-               "type=executionPlan}}"));
+                "left={Collect={" +
+                "collectPhase={COLLECT={distribution={distributedByColumn=0, type=BROADCAST}, " +
+                "executionNodes=[n1], " +
+                "id=0, orderBy=x ASC, " +
+                "projections=[{outputs=INPUT(0), " +
+                "offset=0, " +
+                "limit=10, " +
+                "type=LimitAndOffset}], " +
+                "routing={n1={t1=[0, 1, 2, 3]}}, " +
+                "toCollect=[x], " +
+                "type=executionPhase, " +
+                "where=true}}, " +
+                "type=executionPlan}}, " +
+                "mergePhase={MERGE={distribution={distributedByColumn=0, type=BROADCAST}, " +
+                "executionNodes=[n1], id=2, projections=[{outputs=INPUT(0), offset=0, limit=10, type=LimitAndOffset}], " +
+                "type=executionPhase}}, " +
+                "right={Collect={collectPhase={COLLECT={distribution={distributedByColumn=0, type=BROADCAST}, " +
+                "executionNodes=[n1], id=1, orderBy=y ASC, projections=[{outputs=INPUT(0), " +
+                "offset=0, limit=10, type=LimitAndOffset}], routing={n1={t2=[0, 1, 2, 3]}}, " +
+                "toCollect=[y], type=executionPhase, where=true}}," +
+                " type=executionPlan}}, " +
+                "type=executionPlan}}"));
     }
 
     @Test

--- a/server/src/test/java/io/crate/planner/UnionPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/UnionPlannerTest.java
@@ -93,8 +93,8 @@ public class UnionPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(unionExecutionPlan.mergePhase().orderByPositions()).isExactlyInstanceOf(PositionalOrderBy.class);
         assertThat(unionExecutionPlan.mergePhase().projections())
             .satisfiesExactly(p -> assertThat(p).isExactlyInstanceOf(LimitAndOffsetProjection.class));
-        assertThat(unionExecutionPlan.left()).isExactlyInstanceOf(Collect.class);
-        assertThat(unionExecutionPlan.right()).isExactlyInstanceOf(Collect.class);
+        assertThat(unionExecutionPlan.left()).isExactlyInstanceOf(Merge.class);
+        assertThat(unionExecutionPlan.right()).isExactlyInstanceOf(Merge.class);
     }
 
     @Test
@@ -120,7 +120,7 @@ public class UnionPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(unionExecutionPlan.left()).isExactlyInstanceOf(Merge.class);
         Merge merge = (Merge) unionExecutionPlan.left();
         assertThat(merge.subPlan()).isExactlyInstanceOf(Collect.class);
-        assertThat(unionExecutionPlan.right()).isExactlyInstanceOf(Collect.class);
+        assertThat(unionExecutionPlan.right()).isExactlyInstanceOf(Merge.class);
     }
 
     @Test

--- a/server/src/test/java/io/crate/planner/optimizer/costs/PlanStatsTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/costs/PlanStatsTest.java
@@ -121,7 +121,7 @@ public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
         TableStats tableStats = new TableStats();
         tableStats.updateTableStats(Map.of(a.ident(), new Stats(10L, 1, Map.of())));
 
-        var limit = new Limit(source, Literal.of(5), Literal.of(0));
+        var limit = new Limit(source, Literal.of(5), Literal.of(0), false);
 
         var memo = new Memo(limit);
         PlanStats planStats = new PlanStats(nodeContext, txnCtx, tableStats, memo);

--- a/server/src/test/java/io/crate/planner/optimizer/rule/MoveLimitBeneathUnionTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/MoveLimitBeneathUnionTest.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.rule;
+
+import static io.crate.testing.Asserts.assertThat;
+
+import java.util.Map;
+import java.util.function.Function;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.crate.analyze.relations.AnalyzedRelation;
+import io.crate.common.collections.Lists2;
+import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.RelationName;
+import io.crate.planner.operators.Limit;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.Union;
+import io.crate.planner.optimizer.costs.PlanStats;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Match;
+import io.crate.statistics.TableStats;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+import io.crate.testing.SqlExpressions;
+import io.crate.testing.T3;
+
+public class MoveLimitBeneathUnionTest extends CrateDummyClusterServiceUnitTest {
+
+    private SqlExpressions sqlExpressions;
+    private Map<RelationName, AnalyzedRelation> sources;
+    private PlanStats planStats;
+    private LogicalPlan t1;
+    private LogicalPlan t2;
+
+    @Before
+    public void prepare() throws Exception {
+        sources = T3.sources(clusterService);
+        sqlExpressions = new SqlExpressions(sources);
+        planStats = new PlanStats(sqlExpressions.nodeCtx,
+            CoordinatorTxnCtx.systemTransactionContext(),
+            new TableStats());
+
+        var e = SQLExecutor.builder(clusterService)
+            .addTable("create table t1 (a int)")
+            .addTable("create table t2 (b int)")
+            .build();
+
+        t1 = e.logicalPlan("SELECT a FROM t1");
+        t2 = e.logicalPlan("SELECT b FROM t2");
+    }
+
+    @Test
+    public void test_move_filter_beneath_union() {
+        var union = new Union(t1, t2, Lists2.concat(t1.outputs(), t2.outputs()));
+        var filter = new Limit(union, sqlExpressions.asSymbol("10"), sqlExpressions.asSymbol("0"), false);
+
+        assertThat(filter).hasOperators(
+            "Limit[10;0]",
+            "  └ Union[a, b]",
+            "    ├ Collect[doc.t1 | [a] | true]",
+            "    └ Collect[doc.t2 | [b] | true]"
+        );
+
+        var rule = new MoveLimitBeneathUnion();
+        Match<Limit> match = rule.pattern().accept(filter, Captures.empty());
+
+        Assertions.assertThat(match.isPresent()).isTrue();
+        assertThat(match.value()).isEqualTo(filter);
+
+        var result = rule.apply(match.value(),
+            match.captures(),
+            planStats,
+            CoordinatorTxnCtx.systemTransactionContext(),
+            sqlExpressions.nodeCtx,
+            Function.identity());
+
+        assertThat(result).hasOperators(
+            "Limit[10;0]",
+            "  └ Union[a, b]",
+            "    ├ Limit[10;0]",
+            "    │  └ Collect[doc.t1 | [a] | true]",
+            "    └ Limit[10;0]",
+            "      └ Collect[doc.t2 | [b] | true]"
+        );
+
+        //check that it does not match a second time
+        match = rule.pattern().accept(result, Captures.empty());
+        Assertions.assertThat(match.isPresent()).isFalse();
+    }
+
+    @Test
+    public void test_move_filter_beneath_union_offset_normalization() {
+        var union = new Union(t1, t2, Lists2.concat(t1.outputs(), t2.outputs()));
+        var filter = new Limit(union, sqlExpressions.asSymbol("10"), sqlExpressions.asSymbol("5"), false);
+
+        assertThat(filter).hasOperators(
+            "Limit[10;5]",
+                "  └ Union[a, b]",
+                "    ├ Collect[doc.t1 | [a] | true]",
+                "    └ Collect[doc.t2 | [b] | true]"
+        );
+
+        var rule = new MoveLimitBeneathUnion();
+        Match<Limit> match = rule.pattern().accept(filter, Captures.empty());
+
+        Assertions.assertThat(match.isPresent()).isTrue();
+        assertThat(match.value()).isEqualTo(filter);
+
+        var result = rule.apply(match.value(),
+            match.captures(),
+            planStats,
+            CoordinatorTxnCtx.systemTransactionContext(),
+            sqlExpressions.nodeCtx,
+            Function.identity());
+
+        assertThat(result).hasOperators(
+            "Limit[10;5]",
+            "  └ Union[a, b]",
+            "    ├ Limit[15;0]",
+            "    │  └ Collect[doc.t1 | [a] | true]",
+            "    └ Limit[15;0]",
+            "      └ Collect[doc.t2 | [b] | true]"
+        );
+    }
+
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
This adds the optimizer rule ``optimizer_move_limit_beneath_union`` which reduces the number of intermediate rows created when a ``LIMIT`` clause is used in combination with a ``UNION`` operator, by moving the limit beneath the union operator e.g.:

```
 SELECT a FROM t1 UNION ALL SELECT b FROM t2 LIMIT 10;
```

has the logical plan:

```
Limit[10;0]
  └ Union[a, b]
     ├ Collect[doc.t1 | [a] | true]
     └ Collect[doc.t2 | [b] | true]
```			
becomes after the rule application:

```			
Limit[10;0]
  └ Union[a, b]
    ├ Limit[10;0]
    │  └ Collect[doc.t1 | [a] | true]
    └ Limit[10;0]
       └ Collect[doc.t2 | [b] | true]		
```

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
