### PR TITLE
Remove unneeded release entry

### DIFF
--- a/docs/appendices/release-notes/5.5.2.rst
+++ b/docs/appendices/release-notes/5.5.2.rst
@@ -70,9 +70,6 @@ Fixes
   despite any follow up queries on the dropped columns work as expected. Now
   an exception is thrown.
 
-- Fixed an issue that caused range queries such as ``<=``, ``>=``, ``<``, or
-  ``>`` on boolean types to return invalid results.
-
 - Fixed the SQL parser to be lenient with the position of constraint definitions
   at the column definition of ``CREATE TABLE`` and ``ALTER TABLE`` statements.
   E.g. ``CREATE TABLE t (a INT NULL DEFAULT 1)`` is now accepted while before


### PR DESCRIPTION
Remove release entry added by https://github.com/crate/crate/pull/15205. It is a bug from `master` not `5.5`.