### PR TITLE
 Rename RoleLookup to Roles

### DIFF
--- a/extensions/lang-js/src/main/java/io/crate/operation/language/JavaScriptUserDefinedFunction.java
+++ b/extensions/lang-js/src/main/java/io/crate/operation/language/JavaScriptUserDefinedFunction.java
@@ -39,7 +39,7 @@ import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataType;
 import io.crate.types.TypeSignature;
-import io.crate.role.RoleLookup;
+import io.crate.role.Roles;
 
 public class JavaScriptUserDefinedFunction extends Scalar<Object, Object> {
 
@@ -51,7 +51,7 @@ public class JavaScriptUserDefinedFunction extends Scalar<Object, Object> {
     }
 
     @Override
-    public Scalar<Object, Object> compile(List<Symbol> arguments, String currentUser, RoleLookup userLookup) {
+    public Scalar<Object, Object> compile(List<Symbol> arguments, String currentUser, Roles roles) {
         try {
             return new CompiledFunction(
                 signature,

--- a/server/src/main/java/io/crate/auth/AlwaysOKAuthentication.java
+++ b/server/src/main/java/io/crate/auth/AlwaysOKAuthentication.java
@@ -21,7 +21,7 @@
 
 package io.crate.auth;
 
-import io.crate.role.RoleLookup;
+import io.crate.role.Roles;
 import io.crate.protocols.postgres.ConnectionProperties;
 import org.elasticsearch.common.inject.Inject;
 
@@ -31,15 +31,15 @@ import org.elasticsearch.common.inject.Inject;
  */
 public class AlwaysOKAuthentication implements Authentication {
 
-    private final RoleLookup userLookup;
+    private final Roles roles;
 
     @Inject
-    public AlwaysOKAuthentication(RoleLookup userLookup) {
-        this.userLookup = userLookup;
+    public AlwaysOKAuthentication(Roles roles) {
+        this.roles = roles;
     }
 
     @Override
     public AuthenticationMethod resolveAuthenticationType(String user, ConnectionProperties connectionProperties) {
-        return new TrustAuthenticationMethod(userLookup);
+        return new TrustAuthenticationMethod(roles);
     }
 }

--- a/server/src/main/java/io/crate/auth/ClientCertAuth.java
+++ b/server/src/main/java/io/crate/auth/ClientCertAuth.java
@@ -30,15 +30,15 @@ import org.jetbrains.annotations.Nullable;
 import io.crate.protocols.SSL;
 import io.crate.protocols.postgres.ConnectionProperties;
 import io.crate.role.Role;
-import io.crate.role.RoleLookup;
+import io.crate.role.Roles;
 
 public class ClientCertAuth implements AuthenticationMethod {
 
     static final String NAME = "cert";
-    private final RoleLookup userLookup;
+    private final Roles roles;
 
-    ClientCertAuth(RoleLookup userLookup) {
-        this.userLookup = userLookup;
+    ClientCertAuth(Roles roles) {
+        this.roles = roles;
     }
 
     @Nullable
@@ -48,7 +48,7 @@ public class ClientCertAuth implements AuthenticationMethod {
         if (clientCert != null) {
             String commonName = SSL.extractCN(clientCert);
             if (Objects.equals(userName, commonName) || connProperties.protocol() == Protocol.TRANSPORT) {
-                Role user = userLookup.findUser(userName);
+                Role user = roles.findUser(userName);
                 if (user != null) {
                     return user;
                 }

--- a/server/src/main/java/io/crate/auth/HostBasedAuthentication.java
+++ b/server/src/main/java/io/crate/auth/HostBasedAuthentication.java
@@ -22,7 +22,7 @@
 package io.crate.auth;
 
 import io.crate.common.annotations.VisibleForTesting;
-import io.crate.role.RoleLookup;
+import io.crate.role.Roles;
 import io.crate.protocols.postgres.ConnectionProperties;
 import org.apache.http.conn.DnsResolver;
 import org.apache.logging.log4j.LogManager;
@@ -93,13 +93,13 @@ public class HostBasedAuthentication implements Authentication {
      }
      */
     private SortedMap<String, Map<String, String>> hbaConf;
-    private final RoleLookup userLookup;
+    private final Roles roles;
     private final DnsResolver dnsResolver;
 
     @Inject
-    public HostBasedAuthentication(Settings settings, RoleLookup userLookup, DnsResolver dnsResolver) {
+    public HostBasedAuthentication(Settings settings, Roles roles, DnsResolver dnsResolver) {
         hbaConf = convertHbaSettingsToHbaConf(settings);
-        this.userLookup = userLookup;
+        this.roles = roles;
         this.dnsResolver = dnsResolver;
     }
 
@@ -122,11 +122,11 @@ public class HostBasedAuthentication implements Authentication {
     private AuthenticationMethod methodForName(String method) {
         switch (method) {
             case (TrustAuthenticationMethod.NAME):
-                return new TrustAuthenticationMethod(userLookup);
+                return new TrustAuthenticationMethod(roles);
             case (ClientCertAuth.NAME):
-                return new ClientCertAuth(userLookup);
+                return new ClientCertAuth(roles);
             case (PasswordAuthenticationMethod.NAME):
-                return new PasswordAuthenticationMethod(userLookup);
+                return new PasswordAuthenticationMethod(roles);
             default:
                 return null;
         }

--- a/server/src/main/java/io/crate/auth/PasswordAuthenticationMethod.java
+++ b/server/src/main/java/io/crate/auth/PasswordAuthenticationMethod.java
@@ -26,22 +26,22 @@ import org.jetbrains.annotations.Nullable;
 
 import io.crate.protocols.postgres.ConnectionProperties;
 import io.crate.role.Role;
-import io.crate.role.RoleLookup;
+import io.crate.role.Roles;
 import io.crate.role.SecureHash;
 
 public class PasswordAuthenticationMethod implements AuthenticationMethod {
 
     public static final String NAME = "password";
-    private final RoleLookup userLookup;
+    private final Roles roles;
 
-    PasswordAuthenticationMethod(RoleLookup userLookup) {
-        this.userLookup = userLookup;
+    PasswordAuthenticationMethod(Roles roles) {
+        this.roles = roles;
     }
 
     @Nullable
     @Override
     public Role authenticate(String userName, SecureString passwd, ConnectionProperties connProperties) {
-        Role user = userLookup.findUser(userName);
+        Role user = roles.findUser(userName);
         if (user != null && passwd != null && passwd.length() > 0) {
             SecureHash secureHash = user.password();
             if (secureHash != null && secureHash.verifyHash(passwd)) {

--- a/server/src/main/java/io/crate/auth/TrustAuthenticationMethod.java
+++ b/server/src/main/java/io/crate/auth/TrustAuthenticationMethod.java
@@ -25,21 +25,21 @@ import org.elasticsearch.common.settings.SecureString;
 
 import io.crate.protocols.postgres.ConnectionProperties;
 import io.crate.role.Role;
-import io.crate.role.RoleLookup;
+import io.crate.role.Roles;
 
 
 public class TrustAuthenticationMethod implements AuthenticationMethod {
 
     static final String NAME = "trust";
-    private final RoleLookup userLookup;
+    private final Roles roles;
 
-    public TrustAuthenticationMethod(RoleLookup userLookup) {
-        this.userLookup = userLookup;
+    public TrustAuthenticationMethod(Roles roles) {
+        this.roles = roles;
     }
 
     @Override
     public Role authenticate(String userName, SecureString passwd, ConnectionProperties connectionProperties) {
-        Role user = userLookup.findUser(userName);
+        Role user = roles.findUser(userName);
         if (user == null) {
             throw new RuntimeException("trust authentication failed for user \"" + userName + "\"");
         }

--- a/server/src/main/java/io/crate/execution/engine/collect/sources/SystemCollectSource.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/sources/SystemCollectSource.java
@@ -59,8 +59,7 @@ import io.crate.metadata.sys.SysNodeChecksTableInfo;
 import io.crate.metadata.sys.SysSchemaInfo;
 import io.crate.metadata.sys.SysTableDefinitions;
 import io.crate.role.Role;
-import io.crate.role.RoleLookup;
-import io.crate.role.RoleManager;
+import io.crate.role.Roles;
 
 /**
  * this collect service can be used to retrieve a collector for system tables (which don't contain shards)
@@ -73,7 +72,7 @@ public class SystemCollectSource implements CollectSource {
     private final ClusterService clusterService;
     private final InputFactory inputFactory;
 
-    private final RoleLookup roleLookup;
+    private final Roles roles;
     private final InformationSchemaTableDefinitions informationSchemaTables;
     private final SysTableDefinitions sysTables;
     private final PgCatalogTableDefinitions pgCatalogTables;
@@ -81,14 +80,14 @@ public class SystemCollectSource implements CollectSource {
     @Inject
     public SystemCollectSource(ClusterService clusterService,
                                NodeContext nodeCtx,
-                               RoleManager roleManager,
+                               Roles roles,
                                InformationSchemaTableDefinitions informationSchemaTables,
                                SysTableDefinitions sysTableDefinitions,
                                SysNodeChecks sysNodeChecks,
                                PgCatalogTableDefinitions pgCatalogTables) {
         this.clusterService = clusterService;
         inputFactory = new InputFactory(nodeCtx);
-        this.roleLookup = roleManager;
+        this.roles = roles;
         this.informationSchemaTables = informationSchemaTables;
         this.sysTables = sysTableDefinitions;
         this.pgCatalogTables = pgCatalogTables;
@@ -134,7 +133,7 @@ public class SystemCollectSource implements CollectSource {
         String table = Iterables.getOnlyElement(locations.get(clusterService.localNode().getId()).keySet());
         RelationName relationName = RelationName.fromIndexName(table);
         StaticTableDefinition<?> tableDefinition = tableDefinition(relationName);
-        Role user = requireNonNull(roleLookup.findUser(txnCtx.sessionSettings().userName()), "User who invoked a statement must exist");
+        Role user = requireNonNull(roles.findUser(txnCtx.sessionSettings().userName()), "User who invoked a statement must exist");
 
         return CompletableFuture.completedFuture(CollectingBatchIterator.newInstance(
             () -> {},

--- a/server/src/main/java/io/crate/expression/BaseImplementationSymbolVisitor.java
+++ b/server/src/main/java/io/crate/expression/BaseImplementationSymbolVisitor.java
@@ -58,7 +58,7 @@ public class BaseImplementationSymbolVisitor<C> extends SymbolVisitor<C, Input<?
 
         if (functionImplementation instanceof Scalar<?, ?>) {
             List<Symbol> arguments = function.arguments();
-            Scalar<?, ?> scalarImpl = ((Scalar) functionImplementation).compile(arguments, txnCtx.sessionSettings().userName(), nodeCtx.userLookup());
+            Scalar<?, ?> scalarImpl = ((Scalar) functionImplementation).compile(arguments, txnCtx.sessionSettings().userName(), nodeCtx.roles());
             Input[] argumentInputs = new Input[arguments.size()];
             int i = 0;
             for (Symbol argument : function.arguments()) {

--- a/server/src/main/java/io/crate/expression/operator/LikeOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/LikeOperator.java
@@ -40,7 +40,7 @@ import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
-import io.crate.role.RoleLookup;
+import io.crate.role.Roles;
 
 public class LikeOperator extends Operator<String> {
 
@@ -92,7 +92,7 @@ public class LikeOperator extends Operator<String> {
     }
 
     @Override
-    public Scalar<Boolean, String> compile(List<Symbol> arguments, String userName, RoleLookup userLookup) {
+    public Scalar<Boolean, String> compile(List<Symbol> arguments, String userName, Roles roles) {
         Symbol pattern = arguments.get(1);
         if (pattern instanceof Input) {
             Object value = ((Input<?>) pattern).value();
@@ -102,7 +102,7 @@ public class LikeOperator extends Operator<String> {
             Character escapeChar = escapeFromSymbols.apply(arguments);
             return new CompiledLike(signature, boundSignature, (String) value, escapeChar, caseSensitivity);
         }
-        return super.compile(arguments, userName, userLookup);
+        return super.compile(arguments, userName, roles);
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/scalar/ArrayDifferenceFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayDifferenceFunction.java
@@ -43,7 +43,7 @@ import io.crate.metadata.functions.Signature;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.TypeSignature;
-import io.crate.role.RoleLookup;
+import io.crate.role.Roles;
 
 class ArrayDifferenceFunction extends Scalar<List<Object>, List<Object>> {
 
@@ -78,7 +78,7 @@ class ArrayDifferenceFunction extends Scalar<List<Object>, List<Object>> {
     }
 
     @Override
-    public Scalar<List<Object>, List<Object>> compile(List<Symbol> arguments, String currentUser, RoleLookup userLookup) {
+    public Scalar<List<Object>, List<Object>> compile(List<Symbol> arguments, String currentUser, Roles roles) {
         Symbol symbol = arguments.get(1);
 
         if (!symbol.symbolType().isValueSymbol()) {

--- a/server/src/main/java/io/crate/expression/scalar/DateBinFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/DateBinFunction.java
@@ -34,7 +34,7 @@ import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
-import io.crate.role.RoleLookup;
+import io.crate.role.Roles;
 
 public class DateBinFunction extends Scalar<Long, Object> {
 
@@ -67,7 +67,7 @@ public class DateBinFunction extends Scalar<Long, Object> {
     }
 
     @Override
-    public Scalar<Long, Object> compile(List<Symbol> arguments, String currentUser, RoleLookup userLookup) {
+    public Scalar<Long, Object> compile(List<Symbol> arguments, String currentUser, Roles roles) {
         assert arguments.size() == 3 : "Invalid number of arguments";
 
         if (arguments.get(0) instanceof Input<?> input) {

--- a/server/src/main/java/io/crate/expression/scalar/DateTruncFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/DateTruncFunction.java
@@ -42,7 +42,7 @@ import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
-import io.crate.role.RoleLookup;
+import io.crate.role.Roles;
 
 public class DateTruncFunction extends Scalar<Long, Object> {
 
@@ -104,7 +104,7 @@ public class DateTruncFunction extends Scalar<Long, Object> {
     }
 
     @Override
-    public Scalar<Long, Object> compile(List<Symbol> arguments, String currentUser, RoleLookup userLookup) {
+    public Scalar<Long, Object> compile(List<Symbol> arguments, String currentUser, Roles roles) {
         assert arguments.size() > 1 && arguments.size() < 4 : "Invalid number of arguments";
 
         if (!arguments.get(0).symbolType().isValueSymbol()) {

--- a/server/src/main/java/io/crate/expression/scalar/HasDatabasePrivilegeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/HasDatabasePrivilegeFunction.java
@@ -35,7 +35,7 @@ import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 import io.crate.role.Privilege;
 import io.crate.role.Role;
-import io.crate.role.RoleLookup;
+import io.crate.role.Roles;
 
 public class HasDatabasePrivilegeFunction extends HasPrivilegeFunction {
 
@@ -193,7 +193,7 @@ public class HasDatabasePrivilegeFunction extends HasPrivilegeFunction {
 
     protected HasDatabasePrivilegeFunction(Signature signature,
                                            BoundSignature boundSignature,
-                                           BiFunction<RoleLookup, Object, Role> getUser,
+                                           BiFunction<Roles, Object, Role> getUser,
                                            TriFunction<Role, Object, Collection<Privilege.Type>, Boolean> checkPrivilege) {
         super(signature, boundSignature, getUser, checkPrivilege);
     }

--- a/server/src/main/java/io/crate/expression/scalar/HasSchemaPrivilegeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/HasSchemaPrivilegeFunction.java
@@ -35,7 +35,7 @@ import io.crate.metadata.pgcatalog.PgCatalogTableDefinitions;
 import io.crate.types.DataTypes;
 import io.crate.role.Privilege;
 import io.crate.role.Role;
-import io.crate.role.RoleLookup;
+import io.crate.role.Roles;
 
 public class HasSchemaPrivilegeFunction extends HasPrivilegeFunction {
 
@@ -164,7 +164,7 @@ public class HasSchemaPrivilegeFunction extends HasPrivilegeFunction {
 
     protected HasSchemaPrivilegeFunction(Signature signature,
                                          BoundSignature boundSignature,
-                                         BiFunction<RoleLookup, Object, Role> getUser,
+                                         BiFunction<Roles, Object, Role> getUser,
                                          TriFunction<Role, Object, Collection<Privilege.Type>, Boolean> checkPrivilege) {
         super(signature, boundSignature, getUser, checkPrivilege);
     }

--- a/server/src/main/java/io/crate/expression/scalar/SubstrFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/SubstrFunction.java
@@ -37,7 +37,7 @@ import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 import io.crate.types.TypeSignature;
-import io.crate.role.RoleLookup;
+import io.crate.role.Roles;
 
 public class SubstrFunction extends Scalar<String, Object> {
 
@@ -146,7 +146,7 @@ public class SubstrFunction extends Scalar<String, Object> {
         }
 
         @Override
-        public Scalar<String, String> compile(List<Symbol> arguments, String currentUser, RoleLookup userLookup) {
+        public Scalar<String, String> compile(List<Symbol> arguments, String currentUser, Roles roles) {
             Symbol patternSymbol = arguments.get(1);
             if (patternSymbol instanceof Input<?> input) {
                 String pattern = (String) input.value();

--- a/server/src/main/java/io/crate/expression/scalar/cast/ImplicitCastFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/cast/ImplicitCastFunction.java
@@ -40,7 +40,7 @@ import io.crate.metadata.functions.Signature;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.TypeSignature;
-import io.crate.role.RoleLookup;
+import io.crate.role.Roles;
 
 public class ImplicitCastFunction extends Scalar<Object, Object> {
 
@@ -71,7 +71,7 @@ public class ImplicitCastFunction extends Scalar<Object, Object> {
     }
 
     @Override
-    public Scalar<Object, Object> compile(List<Symbol> args, String currentUser, RoleLookup userLookup) {
+    public Scalar<Object, Object> compile(List<Symbol> args, String currentUser, Roles roles) {
         assert args.size() == 2 : "number of arguments must be 2";
         Symbol input = args.get(1);
         if (input instanceof Input) {

--- a/server/src/main/java/io/crate/expression/scalar/formatting/ToCharFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/formatting/ToCharFunction.java
@@ -40,7 +40,7 @@ import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
-import io.crate.role.RoleLookup;
+import io.crate.role.Roles;
 
 
 public class ToCharFunction extends Scalar<String, Object> {
@@ -149,7 +149,7 @@ public class ToCharFunction extends Scalar<String, Object> {
     }
 
     @Override
-    public Scalar<String, Object> compile(List<Symbol> arguments, String currentUser, RoleLookup userLookup) {
+    public Scalar<String, Object> compile(List<Symbol> arguments, String currentUser, Roles roles) {
         assert arguments.size() == 2 : "Invalid number of arguments";
 
         if (!arguments.get(1).symbolType().isValueSymbol()) {

--- a/server/src/main/java/io/crate/expression/scalar/regex/RegexpReplaceFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/regex/RegexpReplaceFunction.java
@@ -40,7 +40,7 @@ import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
-import io.crate.role.RoleLookup;
+import io.crate.role.Roles;
 
 public final class RegexpReplaceFunction extends Scalar<String, String> {
 
@@ -88,7 +88,7 @@ public final class RegexpReplaceFunction extends Scalar<String, String> {
     }
 
     @Override
-    public Scalar<String, String> compile(List<Symbol> arguments, String currentUser, RoleLookup userLookup) {
+    public Scalar<String, String> compile(List<Symbol> arguments, String currentUser, Roles roles) {
         assert arguments.size() >= 3 : "number of arguments muts be >= 3";
         Symbol patternSymbol = arguments.get(1);
         if (patternSymbol instanceof Input) {

--- a/server/src/main/java/io/crate/expression/scalar/string/TranslateFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/TranslateFunction.java
@@ -34,7 +34,7 @@ import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
-import io.crate.role.RoleLookup;
+import io.crate.role.Roles;
 
 public class TranslateFunction extends Scalar<String, String> {
 
@@ -64,7 +64,7 @@ public class TranslateFunction extends Scalar<String, String> {
     }
 
     @Override
-    public Scalar<String, String> compile(List<Symbol> args, String currentUser, RoleLookup userLookup) {
+    public Scalar<String, String> compile(List<Symbol> args, String currentUser, Roles roles) {
         assert args.size() == 3 : "translate takes exactly three arguments";
 
         Symbol from = args.get(1);

--- a/server/src/main/java/io/crate/expression/scalar/string/TrimFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/TrimFunctions.java
@@ -36,7 +36,7 @@ import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 import io.crate.sql.tree.TrimMode;
 import io.crate.types.DataTypes;
-import io.crate.role.RoleLookup;
+import io.crate.role.Roles;
 
 
 public final class TrimFunctions {
@@ -174,7 +174,7 @@ public final class TrimFunctions {
         }
 
         @Override
-        public Scalar<String, String> compile(List<Symbol> arguments, String currentUser, RoleLookup userLookup) {
+        public Scalar<String, String> compile(List<Symbol> arguments, String currentUser, Roles roles) {
             assert arguments.size() == 3 : "number of args must be 3";
 
             Symbol modeSymbol = arguments.get(2);

--- a/server/src/main/java/io/crate/expression/tablefunctions/MatchesFunction.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/MatchesFunction.java
@@ -49,7 +49,7 @@ import io.crate.metadata.functions.Signature;
 import io.crate.metadata.tablefunctions.TableFunctionImplementation;
 import io.crate.types.DataTypes;
 import io.crate.types.RowType;
-import io.crate.role.RoleLookup;
+import io.crate.role.Roles;
 
 public final class MatchesFunction extends TableFunctionImplementation<List<Object>> {
 
@@ -121,7 +121,7 @@ public final class MatchesFunction extends TableFunctionImplementation<List<Obje
     }
 
     @Override
-    public Scalar<Iterable<Row>, List<Object>> compile(List<Symbol> arguments, String currentUser, RoleLookup userLookup) {
+    public Scalar<Iterable<Row>, List<Object>> compile(List<Symbol> arguments, String currentUser, Roles roles) {
         assert arguments.size() > 1 : "number of arguments must be > 1";
         String pattern = null;
         if (arguments.get(1).symbolType() == SymbolType.LITERAL) {

--- a/server/src/main/java/io/crate/expression/udf/UserDefinedFunctionService.java
+++ b/server/src/main/java/io/crate/expression/udf/UserDefinedFunctionService.java
@@ -288,7 +288,7 @@ public class UserDefinedFunctionService {
         // The iteration of schemas/tables must happen on the node context WITHOUT the UDF already removed.
         // Otherwise the lazy table factories will already fail while evaluating generated functionsMetadata.
         // To avoid that, a copy of the node context with the removed UDF function is used on concrete expression evaluation.
-        var nodeCtxWithRemovedFunction = new NodeContext(nodeCtx.functions().copyOf(), nodeCtx.userLookup());
+        var nodeCtxWithRemovedFunction = new NodeContext(nodeCtx.functions().copyOf(), nodeCtx.roles());
         updateImplementations(schema, functionsMetadata.functionsMetadata().stream(), nodeCtxWithRemovedFunction);
 
         var metadata = currentState.metadata();

--- a/server/src/main/java/io/crate/metadata/NodeContext.java
+++ b/server/src/main/java/io/crate/metadata/NodeContext.java
@@ -21,7 +21,7 @@
 
 package io.crate.metadata;
 
-import io.crate.role.RoleLookup;
+import io.crate.role.Roles;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
 
@@ -30,13 +30,13 @@ public class NodeContext {
 
     private final Functions functions;
     private final long serverStartTimeInMs;
-    private final RoleLookup userLookup;
+    private final Roles roles;
 
     @Inject
-    public NodeContext(Functions functions, RoleLookup userLookup) {
+    public NodeContext(Functions functions, Roles roles) {
         this.functions = functions;
         this.serverStartTimeInMs = SystemClock.currentInstant().toEpochMilli();;
-        this.userLookup = userLookup;
+        this.roles = roles;
     }
 
     public Functions functions() {
@@ -47,7 +47,7 @@ public class NodeContext {
         return serverStartTimeInMs;
     }
 
-    public RoleLookup userLookup() {
-        return userLookup;
+    public Roles roles() {
+        return roles;
     }
 }

--- a/server/src/main/java/io/crate/metadata/Scalar.java
+++ b/server/src/main/java/io/crate/metadata/Scalar.java
@@ -33,7 +33,7 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.lucene.FunctionToQuery;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
-import io.crate.role.RoleLookup;
+import io.crate.role.Roles;
 
 /**
  * Base class for Scalar functions in crate.
@@ -49,7 +49,7 @@ import io.crate.role.RoleLookup;
  *
  *     Functions also MUST NOT have any internal state that influences the result of future calls.
  *     Functions are used as singletons.
- *     An exception is if {@link #compile(List, String, RoleLookup)} returns a NEW instance.
+ *     An exception is if {@link #compile(List, String, Roles)} returns a NEW instance.
  * </p>
  *
  * To implement scalar functions, you may want to use one of the following abstractions:
@@ -103,7 +103,7 @@ public abstract class Scalar<ReturnType, InputType> implements FunctionImplement
      *                  {@link #evaluate(TransactionContext, NodeContext, Input[])} will have the same
      *                  value as those literals. (Within the scope of a single operation)
      */
-    public Scalar<ReturnType, InputType> compile(List<Symbol> arguments, String currentUser, RoleLookup userLookup) {
+    public Scalar<ReturnType, InputType> compile(List<Symbol> arguments, String currentUser, Roles roles) {
         return this;
     }
 

--- a/server/src/main/java/io/crate/planner/statement/SetSessionAuthorizationPlan.java
+++ b/server/src/main/java/io/crate/planner/statement/SetSessionAuthorizationPlan.java
@@ -32,17 +32,17 @@ import io.crate.planner.Plan;
 import io.crate.planner.PlannerContext;
 import io.crate.planner.operators.SubQueryResults;
 import io.crate.role.Role;
-import io.crate.role.RoleLookup;
+import io.crate.role.Roles;
 
 public class SetSessionAuthorizationPlan implements Plan {
 
     private final AnalyzedSetSessionAuthorizationStatement setSessionAuthorization;
-    private final RoleLookup userLookup;
+    private final Roles roles;
 
     public SetSessionAuthorizationPlan(AnalyzedSetSessionAuthorizationStatement setSessionAuthorization,
-                                       RoleLookup userLookup) {
+                                       Roles roles) {
         this.setSessionAuthorization = setSessionAuthorization;
-        this.userLookup = userLookup;
+        this.roles = roles;
     }
 
     @Override
@@ -60,7 +60,7 @@ public class SetSessionAuthorizationPlan implements Plan {
         String userName = setSessionAuthorization.user();
         Role user;
         if (userName != null) {
-            user = userLookup.findUser(userName);
+            user = roles.findUser(userName);
             if (user == null) {
                 throw new IllegalArgumentException("User '" + userName + "' does not exist.");
             }

--- a/server/src/main/java/io/crate/replication/logical/action/PublicationsStateAction.java
+++ b/server/src/main/java/io/crate/replication/logical/action/PublicationsStateAction.java
@@ -55,7 +55,7 @@ import io.crate.metadata.RelationName;
 import io.crate.replication.logical.metadata.PublicationsMetadata;
 import io.crate.replication.logical.metadata.RelationMetadata;
 import io.crate.role.Role;
-import io.crate.role.RoleLookup;
+import io.crate.role.Roles;
 
 public class PublicationsStateAction extends ActionType<PublicationsStateAction.Response> {
 
@@ -76,13 +76,13 @@ public class PublicationsStateAction extends ActionType<PublicationsStateAction.
     @Singleton
     public static class TransportAction extends TransportMasterNodeReadAction<Request, Response> {
 
-        private final RoleLookup userLookup;
+        private final Roles roles;
 
         @Inject
         public TransportAction(TransportService transportService,
                                ClusterService clusterService,
                                ThreadPool threadPool,
-                               RoleLookup userLookup) {
+                               Roles roles) {
             super(Settings.EMPTY,
                   NAME,
                   false,
@@ -90,7 +90,7 @@ public class PublicationsStateAction extends ActionType<PublicationsStateAction.
                   clusterService,
                   threadPool,
                   Request::new);
-            this.userLookup = userLookup;
+            this.roles = roles;
 
             TransportActionProxy.registerProxyAction(transportService, NAME, Response::new);
         }
@@ -111,7 +111,7 @@ public class PublicationsStateAction extends ActionType<PublicationsStateAction.
                                        ActionListener<Response> listener) throws Exception {
             // Ensure subscribing user was not dropped after remote connection was established on another side.
             // Subscribing users must be checked on a publisher side as they belong to the publishing cluster.
-            Role subscriber = userLookup.findUser(request.subscribingUserName());
+            Role subscriber = roles.findUser(request.subscribingUserName());
             if (subscriber == null) {
                 throw new IllegalStateException(
                     String.format(
@@ -138,7 +138,7 @@ public class PublicationsStateAction extends ActionType<PublicationsStateAction.
 
                 // Publication owner cannot be null as we ensure that users who owns publication cannot be dropped.
                 // Also, before creating publication or subscription we check that owner was not dropped right before creation.
-                Role publicationOwner = userLookup.findUser(publication.owner());
+                Role publicationOwner = roles.findUser(publication.owner());
                 allRelationsInPublications.putAll(publication.resolveCurrentRelations(state, publicationOwner, subscriber, publicationName));
             }
             listener.onResponse(new Response(allRelationsInPublications, unknownPublications));

--- a/server/src/main/java/io/crate/replication/logical/action/TransportCreatePublicationAction.java
+++ b/server/src/main/java/io/crate/replication/logical/action/TransportCreatePublicationAction.java
@@ -28,7 +28,7 @@ import io.crate.metadata.cluster.DDLClusterStateTaskExecutor;
 import io.crate.replication.logical.exceptions.PublicationAlreadyExistsException;
 import io.crate.replication.logical.metadata.Publication;
 import io.crate.replication.logical.metadata.PublicationsMetadata;
-import io.crate.role.RoleLookup;
+import io.crate.role.Roles;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateTaskExecutor;
@@ -47,13 +47,13 @@ import java.util.Locale;
 public class TransportCreatePublicationAction extends AbstractDDLTransportAction<CreatePublicationRequest, AcknowledgedResponse> {
 
     public static final String ACTION_NAME = "internal:crate:replication/logical/publication/create";
-    private final RoleLookup userLookup;
+    private final Roles roles;
 
     @Inject
     public TransportCreatePublicationAction(TransportService transportService,
                                             ClusterService clusterService,
                                             ThreadPool threadPool,
-                                            RoleLookup userLookup) {
+                                            Roles roles) {
         super(ACTION_NAME,
               transportService,
               clusterService,
@@ -62,7 +62,7 @@ public class TransportCreatePublicationAction extends AbstractDDLTransportAction
               AcknowledgedResponse::new,
               AcknowledgedResponse::new,
               "create-publication");
-        this.userLookup = userLookup;
+        this.roles = roles;
     }
 
     @Override
@@ -80,7 +80,7 @@ public class TransportCreatePublicationAction extends AbstractDDLTransportAction
                 }
 
                 // Ensure publication owner exists
-                if (userLookup.findUser(request.owner()) == null) {
+                if (roles.findUser(request.owner()) == null) {
                     throw new IllegalStateException(
                         String.format(
                             Locale.ENGLISH, "Publication '%s' cannot be created as the user '%s' owning the publication has been dropped.",

--- a/server/src/main/java/io/crate/replication/logical/action/TransportCreateSubscriptionAction.java
+++ b/server/src/main/java/io/crate/replication/logical/action/TransportCreateSubscriptionAction.java
@@ -51,7 +51,7 @@ import io.crate.replication.logical.exceptions.SubscriptionAlreadyExistsExceptio
 import io.crate.replication.logical.metadata.RelationMetadata;
 import io.crate.replication.logical.metadata.Subscription;
 import io.crate.replication.logical.metadata.SubscriptionsMetadata;
-import io.crate.role.RoleLookup;
+import io.crate.role.Roles;
 
 public class TransportCreateSubscriptionAction extends TransportMasterNodeAction<CreateSubscriptionRequest, AcknowledgedResponse> {
 
@@ -59,21 +59,21 @@ public class TransportCreateSubscriptionAction extends TransportMasterNodeAction
 
     private final String source;
     private final LogicalReplicationService logicalReplicationService;
-    private final RoleLookup userLookup;
+    private final Roles roles;
 
     @Inject
     public TransportCreateSubscriptionAction(TransportService transportService,
                                              ClusterService clusterService,
                                              LogicalReplicationService logicalReplicationService,
                                              ThreadPool threadPool,
-                                             RoleLookup userLookup) {
+                                             Roles roles) {
         super(ACTION_NAME,
               transportService,
               clusterService,
               threadPool,
               CreateSubscriptionRequest::new);
         this.logicalReplicationService = logicalReplicationService;
-        this.userLookup = userLookup;
+        this.roles = roles;
         this.source = "create-subscription";
     }
 
@@ -93,7 +93,7 @@ public class TransportCreateSubscriptionAction extends TransportMasterNodeAction
                                    ActionListener<AcknowledgedResponse> listener) throws Exception {
 
         // Ensure subscription owner exists
-        if (userLookup.findUser(request.owner()) == null) {
+        if (roles.findUser(request.owner()) == null) {
             throw new IllegalStateException(
                 String.format(
                     Locale.ENGLISH, "Subscription '%s' cannot be created as the user '%s' owning the subscription has been dropped.",

--- a/server/src/main/java/io/crate/rest/action/RestSQLAction.java
+++ b/server/src/main/java/io/crate/rest/action/RestSQLAction.java
@@ -28,7 +28,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 
 import io.crate.action.sql.Sessions;
-import io.crate.role.RoleLookup;
+import io.crate.role.Roles;
 import io.crate.role.RoleManager;
 import io.crate.netty.channel.PipelineRegistry;
 import io.crate.protocols.ssl.SslContextProvider;
@@ -40,7 +40,7 @@ public class RestSQLAction {
     public RestSQLAction(Settings settings,
                          Sessions sqlOperations,
                          PipelineRegistry pipelineRegistry,
-                         RoleLookup userLookup,
+                         Roles roles,
                          Provider<RoleManager> userManagerProvider,
                          CircuitBreakerService breakerService,
                          SslContextProvider sslContextProvider) {
@@ -52,7 +52,7 @@ public class RestSQLAction {
                 settings,
                 sqlOperations,
                 breakerService::getBreaker,
-                userLookup,
+                roles,
                 roleManager::getAccessControl,
                 corsConfig
             )

--- a/server/src/main/java/io/crate/rest/action/SqlHttpHandler.java
+++ b/server/src/main/java/io/crate/rest/action/SqlHttpHandler.java
@@ -64,7 +64,7 @@ import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.settings.CoordinatorSessionSettings;
 import io.crate.protocols.http.Headers;
 import io.crate.role.Role;
-import io.crate.role.RoleLookup;
+import io.crate.role.Roles;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
@@ -85,7 +85,7 @@ public class SqlHttpHandler extends SimpleChannelInboundHandler<FullHttpRequest>
     private final Settings settings;
     private final Sessions sqlOperations;
     private final Function<String, CircuitBreaker> circuitBreakerProvider;
-    private final RoleLookup userLookup;
+    private final Roles roles;
     private final Function<CoordinatorSessionSettings, AccessControl> getAccessControl;
     private final Netty4CorsConfig corsConfig;
 
@@ -94,14 +94,14 @@ public class SqlHttpHandler extends SimpleChannelInboundHandler<FullHttpRequest>
     SqlHttpHandler(Settings settings,
                    Sessions sqlOperations,
                    Function<String, CircuitBreaker> circuitBreakerProvider,
-                   RoleLookup userLookup,
+                   Roles roles,
                    Function<CoordinatorSessionSettings, AccessControl> getAccessControl,
                    Netty4CorsConfig corsConfig) {
         super(false);
         this.settings = settings;
         this.sqlOperations = sqlOperations;
         this.circuitBreakerProvider = circuitBreakerProvider;
-        this.userLookup = userLookup;
+        this.roles = roles;
         this.getAccessControl = getAccessControl;
         this.corsConfig = corsConfig;
     }
@@ -299,7 +299,7 @@ public class SqlHttpHandler extends SimpleChannelInboundHandler<FullHttpRequest>
         if (username == null || username.isEmpty()) {
             username = AuthSettings.AUTH_TRUST_HTTP_DEFAULT_HEADER.get(settings);
         }
-        return userLookup.findUser(username);
+        return roles.findUser(username);
     }
 
     private static boolean bothProvided(@Nullable List<Object> args, @Nullable List<List<Object>> bulkArgs) {

--- a/server/src/main/java/io/crate/role/RoleManager.java
+++ b/server/src/main/java/io/crate/role/RoleManager.java
@@ -32,7 +32,7 @@ import io.crate.metadata.settings.CoordinatorSessionSettings;
 /**
  * responsible for creating and deleting roles (and users)
  */
-public interface RoleManager extends RoleLookup {
+public interface RoleManager extends Roles {
 
     /**
      * Create a role.

--- a/server/src/main/java/io/crate/role/Roles.java
+++ b/server/src/main/java/io/crate/role/Roles.java
@@ -28,7 +28,7 @@ import org.jetbrains.annotations.Nullable;
 import io.crate.metadata.pgcatalog.OidHash;
 
 @FunctionalInterface
-public interface RoleLookup {
+public interface Roles {
 
     /**
      * finds a user by username

--- a/server/src/main/java/io/crate/role/RolesService.java
+++ b/server/src/main/java/io/crate/role/RolesService.java
@@ -39,12 +39,12 @@ import io.crate.role.metadata.RolesMetadata;
 import io.crate.role.metadata.UsersMetadata;
 import io.crate.role.metadata.UsersPrivilegesMetadata;
 
-public class RoleLookupService implements RoleLookup, ClusterStateListener {
+public class RolesService implements Roles, ClusterStateListener {
 
     private volatile Set<Role> roles = Set.of(Role.CRATE_USER);
 
     @Inject
-    public RoleLookupService(ClusterService clusterService) {
+    public RolesService(ClusterService clusterService) {
         clusterService.addListener(this);
     }
 

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -216,8 +216,8 @@ import io.crate.replication.logical.LogicalReplicationService;
 import io.crate.replication.logical.LogicalReplicationSettings;
 import io.crate.replication.logical.ShardReplicationService;
 import io.crate.types.DataTypes;
-import io.crate.role.RoleLookup;
-import io.crate.role.RoleLookupService;
+import io.crate.role.Roles;
+import io.crate.role.RolesService;
 import io.crate.role.RoleManagementModule;
 
 /**
@@ -538,10 +538,10 @@ public class Node implements Closeable {
                 pluginsService.filterPlugins(ActionPlugin.class));
             modules.add(actionModule);
 
-            RoleLookup userLookup = new RoleLookupService(clusterService);
+            Roles roles = new RolesService(clusterService);
             var authentication = AuthSettings.AUTH_HOST_BASED_ENABLED_SETTING.get(settings)
-                ? new HostBasedAuthentication(settings, userLookup, SystemDefaultDnsResolver.INSTANCE)
-                : new AlwaysOKAuthentication(userLookup);
+                ? new HostBasedAuthentication(settings, roles, SystemDefaultDnsResolver.INSTANCE)
+                : new AlwaysOKAuthentication(roles);
 
             final SslContextProvider sslContextProvider = new SslContextProvider(settings);
             final NettyBootstrap nettyBootstrap = new NettyBootstrap(settings);
@@ -775,7 +775,7 @@ public class Node implements Closeable {
                     b.bind(NettyBootstrap.class).toInstance(nettyBootstrap);
                     b.bind(SslContextProvider.class).toInstance(sslContextProvider);
                     b.bind(RerouteService.class).toInstance(rerouteService);
-                    b.bind(RoleLookup.class).toInstance(userLookup);
+                    b.bind(Roles.class).toInstance(roles);
                     b.bind(Authentication.class).toInstance(authentication);
                     b.bind(LogicalReplicationService.class).toInstance(logicalReplicationService);
                     b.bind(LogicalReplicationSettings.class).toInstance(logicalReplicationSettings);

--- a/server/src/test/java/io/crate/action/sql/SessionsTest.java
+++ b/server/src/test/java/io/crate/action/sql/SessionsTest.java
@@ -55,15 +55,15 @@ import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.role.Privilege;
 import io.crate.role.Privilege.State;
 import io.crate.role.Role;
-import io.crate.role.RoleLookup;
+import io.crate.role.Roles;
 
 public class SessionsTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void test_sessions_broadcasts_cancel_if_no_local_match() throws Exception {
         Functions functions = new Functions(Map.of());
-        RoleLookup userLookup = () -> List.of(Role.CRATE_USER);
-        NodeContext nodeCtx = new NodeContext(functions, userLookup);
+        Roles roles = () -> List.of(Role.CRATE_USER);
+        NodeContext nodeCtx = new NodeContext(functions, roles);
         DependencyCarrier dependencies = mock(DependencyCarrier.class);
         ElasticsearchClient client = mock(ElasticsearchClient.class, Answers.RETURNS_MOCKS);
         when(dependencies.client()).thenReturn(client);
@@ -89,8 +89,8 @@ public class SessionsTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void test_super_user_and_al_privileges_can_view_all_cursors() throws Exception {
         Functions functions = new Functions(Map.of());
-        RoleLookup userLookup = () -> List.of(Role.CRATE_USER);
-        NodeContext nodeCtx = new NodeContext(functions, userLookup);
+        Roles roles = () -> List.of(Role.CRATE_USER);
+        NodeContext nodeCtx = new NodeContext(functions, roles);
         Sessions sessions = newSessions(nodeCtx);
         Session session1 = sessions.newSession("doc", Role.userOf("Arthur"));
         session1.cursors.add("c1", newCursor());
@@ -114,8 +114,8 @@ public class SessionsTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void test_user_can_only_view_their_own_cursors() throws Exception {
         Functions functions = new Functions(Map.of());
-        RoleLookup userLookup = () -> List.of(Role.CRATE_USER);
-        NodeContext nodeCtx = new NodeContext(functions, userLookup);
+        Roles roles = () -> List.of(Role.CRATE_USER);
+        NodeContext nodeCtx = new NodeContext(functions, roles);
         Sessions sessions = newSessions(nodeCtx);
 
         Role arthur = Role.userOf("Arthur");
@@ -133,8 +133,8 @@ public class SessionsTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void test_uses_global_statement_timeout_as_default_for() throws Exception {
         Functions functions = new Functions(Map.of());
-        RoleLookup userLookup = () -> List.of(Role.CRATE_USER);
-        NodeContext nodeCtx = new NodeContext(functions, userLookup);
+        Roles roles = () -> List.of(Role.CRATE_USER);
+        NodeContext nodeCtx = new NodeContext(functions, roles);
         Sessions sessions = new Sessions(
             nodeCtx,
             mock(Analyzer.class),

--- a/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
+++ b/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
@@ -69,7 +69,7 @@ import io.crate.types.DataTypes;
 import io.crate.role.Privilege;
 import io.crate.role.Role;
 import io.crate.role.RoleManager;
-import io.crate.role.RoleLookupService;
+import io.crate.role.RolesService;
 import io.crate.role.RoleManagerService;
 
 public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTest {
@@ -118,7 +118,7 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
                 return true;
             }
         };
-        RoleLookupService roleLookupService = new RoleLookupService(clusterService) {
+        RolesService rolesService = new RolesService(clusterService) {
 
             @Nullable
             @Override
@@ -135,7 +135,7 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
             null,
             null,
             mock(SysTableRegistry.class),
-            roleLookupService,
+            rolesService,
             new DDLClusterStateService());
 
         e = SQLExecutor.builder(clusterService)

--- a/server/src/test/java/io/crate/auth/HttpAuthUpstreamHandlerTest.java
+++ b/server/src/test/java/io/crate/auth/HttpAuthUpstreamHandlerTest.java
@@ -61,7 +61,7 @@ public class HttpAuthUpstreamHandlerTest extends ESTestCase {
         .put("auth.host_based.config.0.user", "crate")
         .build();
 
-    // UserLookup always returns null, so there are no users (even no default crate superuser)
+    // Roles always returns null, so there are no users (even no default crate superuser)
     private final Authentication authService = new HostBasedAuthentication(hbaEnabled, List::of, SystemDefaultDnsResolver.INSTANCE);
 
     private static void assertUnauthorized(DefaultFullHttpResponse resp, String expectedBody) {

--- a/server/src/test/java/io/crate/auth/UserAuthenticationMethodTest.java
+++ b/server/src/test/java/io/crate/auth/UserAuthenticationMethodTest.java
@@ -35,12 +35,12 @@ import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
 
 import io.crate.role.Role;
-import io.crate.role.RoleLookup;
+import io.crate.role.Roles;
 import io.crate.role.SecureHash;
 
 public class UserAuthenticationMethodTest extends ESTestCase {
 
-    private static class CrateOrNullUserLookup implements RoleLookup {
+    private static class CrateOrNullRoles implements Roles {
 
         @Override
         public Collection<Role> roles() {
@@ -56,7 +56,7 @@ public class UserAuthenticationMethodTest extends ESTestCase {
 
     @Test
     public void testTrustAuthentication() throws Exception {
-        TrustAuthenticationMethod trustAuth = new TrustAuthenticationMethod(new CrateOrNullUserLookup());
+        TrustAuthenticationMethod trustAuth = new TrustAuthenticationMethod(new CrateOrNullRoles());
         assertThat(trustAuth.name()).isEqualTo("trust");
         assertThat(trustAuth.authenticate("crate", null, null).name()).isEqualTo("crate");
 
@@ -66,7 +66,7 @@ public class UserAuthenticationMethodTest extends ESTestCase {
 
     @Test
     public void testAlwaysOKAuthentication() throws Exception {
-        AlwaysOKAuthentication alwaysOkAuth = new AlwaysOKAuthentication(new CrateOrNullUserLookup());
+        AlwaysOKAuthentication alwaysOkAuth = new AlwaysOKAuthentication(new CrateOrNullRoles());
         AuthenticationMethod alwaysOkAuthMethod = alwaysOkAuth.resolveAuthenticationType("crate", null);
 
         assertThat(alwaysOkAuthMethod.name()).isEqualTo("trust");
@@ -77,7 +77,7 @@ public class UserAuthenticationMethodTest extends ESTestCase {
     }
 
     public void testPasswordAuthentication() throws Exception {
-        PasswordAuthenticationMethod pwAuth = new PasswordAuthenticationMethod(new CrateOrNullUserLookup());
+        PasswordAuthenticationMethod pwAuth = new PasswordAuthenticationMethod(new CrateOrNullRoles());
         assertThat(pwAuth.name()).isEqualTo("password");
 
         assertThat(pwAuth.authenticate("crate", new SecureString("pw".toCharArray()), null).name()).isEqualTo("crate");
@@ -85,7 +85,7 @@ public class UserAuthenticationMethodTest extends ESTestCase {
 
     @Test
     public void testPasswordAuthenticationWrongPassword() throws Exception {
-        PasswordAuthenticationMethod pwAuth = new PasswordAuthenticationMethod(new CrateOrNullUserLookup());
+        PasswordAuthenticationMethod pwAuth = new PasswordAuthenticationMethod(new CrateOrNullRoles());
         assertThat(pwAuth.name()).isEqualTo("password");
 
         assertThatThrownBy(() -> pwAuth.authenticate("crate", new SecureString("wrong".toCharArray()), null))
@@ -95,7 +95,7 @@ public class UserAuthenticationMethodTest extends ESTestCase {
 
     @Test
     public void testPasswordAuthenticationForNonExistingUser() throws Exception {
-        PasswordAuthenticationMethod pwAuth = new PasswordAuthenticationMethod(new CrateOrNullUserLookup());
+        PasswordAuthenticationMethod pwAuth = new PasswordAuthenticationMethod(new CrateOrNullRoles());
         assertThatThrownBy(() -> pwAuth.authenticate("cr8", new SecureString("pw".toCharArray()), null))
             .hasMessage("password authentication failed for user \"cr8\"");
     }

--- a/server/src/test/java/io/crate/execution/engine/collect/files/LineProcessorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/files/LineProcessorTest.java
@@ -45,12 +45,12 @@ import io.crate.metadata.doc.DocSysColumns;
 import io.crate.testing.TestingHelpers;
 import io.crate.types.DataTypes;
 import io.crate.role.Role;
-import io.crate.role.RoleLookup;
+import io.crate.role.Roles;
 
 public class LineProcessorTest {
 
-    RoleLookup userLookup = () -> List.of(Role.CRATE_USER);
-    NodeContext nodeCtx = new NodeContext(new Functions(Map.of()), userLookup);
+    Roles roles = () -> List.of(Role.CRATE_USER);
+    NodeContext nodeCtx = new NodeContext(new Functions(Map.of()), roles);
     InputFactory inputFactory = new InputFactory(nodeCtx);
 
     @Test

--- a/server/src/test/java/io/crate/execution/engine/collect/sources/FileCollectSourceTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/sources/FileCollectSourceTest.java
@@ -51,7 +51,7 @@ import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.TestingHelpers;
 import io.crate.types.DataTypes;
 import io.crate.role.Role;
-import io.crate.role.RoleLookup;
+import io.crate.role.Roles;
 
 public class FileCollectSourceTest extends CrateDummyClusterServiceUnitTest {
 
@@ -87,9 +87,9 @@ public class FileCollectSourceTest extends CrateDummyClusterServiceUnitTest {
             Settings.EMPTY
         );
 
-        RoleLookup userLookup = () -> List.of(Role.CRATE_USER);
+        Roles roles = () -> List.of(Role.CRATE_USER);
         FileCollectSource fileCollectSource = new FileCollectSource(
-            new NodeContext(new Functions(Map.of()), userLookup),
+            new NodeContext(new Functions(Map.of()), roles),
             clusterService,
             Map.of(),
             THREAD_POOL

--- a/server/src/test/java/io/crate/integrationtests/BaseRolesIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/BaseRolesIntegrationTest.java
@@ -31,7 +31,7 @@ import io.crate.action.sql.Session;
 import io.crate.action.sql.Sessions;
 import io.crate.testing.SQLResponse;
 import io.crate.role.Role;
-import io.crate.role.RoleLookup;
+import io.crate.role.Roles;
 
 public abstract class BaseRolesIntegrationTest extends IntegTestCase {
 
@@ -74,8 +74,8 @@ public abstract class BaseRolesIntegrationTest extends IntegTestCase {
 
     public SQLResponse executeAs(String stmt, String userName) {
         Sessions sqlOperations = cluster().getInstance(Sessions.class);
-        RoleLookup userLookup = cluster().getInstance(RoleLookup.class);
-        Role user = Objects.requireNonNull(userLookup.findUser(userName), "User " + userName + " must exist");
+        Roles roles = cluster().getInstance(Roles.class);
+        Role user = Objects.requireNonNull(roles.findUser(userName), "User " + userName + " must exist");
         try (Session session = sqlOperations.newSession(null, user)) {
             return execute(stmt, null, session);
         }

--- a/server/src/test/java/io/crate/integrationtests/LogicalReplicationITest.java
+++ b/server/src/test/java/io/crate/integrationtests/LogicalReplicationITest.java
@@ -49,7 +49,7 @@ import io.crate.replication.logical.metadata.Subscription;
 import io.crate.replication.logical.metadata.SubscriptionsMetadata;
 import io.crate.testing.UseRandomizedSchema;
 import io.crate.role.Role;
-import io.crate.role.RoleLookup;
+import io.crate.role.Roles;
 
 
 @UseRandomizedSchema(random = false)
@@ -63,8 +63,8 @@ public class LogicalReplicationITest extends LogicalReplicationITestCase {
         executeOnPublisher("CREATE USER " + publicationOwner);
         executeOnPublisher("GRANT AL TO " + publicationOwner);
         executeOnPublisher("GRANT DQL, DML, DDL ON TABLE doc.t1 TO " + publicationOwner);
-        RoleLookup userLookup = publisherCluster.getInstance(RoleLookup.class);
-        Role user = Objects.requireNonNull(userLookup.findUser(publicationOwner), "User " + publicationOwner + " must exist");
+        Roles roles = publisherCluster.getInstance(Roles.class);
+        Role user = Objects.requireNonNull(roles.findUser(publicationOwner), "User " + publicationOwner + " must exist");
 
         executeOnPublisher("DROP USER " + publicationOwner);
         assertThatThrownBy(() -> executeOnPublisherAsUser("CREATE PUBLICATION pub1 FOR TABLE doc.t1", user))
@@ -83,8 +83,8 @@ public class LogicalReplicationITest extends LogicalReplicationITestCase {
         executeOnSubscriber("CREATE USER " + subscriptionOwner);
         executeOnSubscriber("GRANT AL TO " + subscriptionOwner);
 
-        RoleLookup userLookup = subscriberCluster.getInstance(RoleLookup.class);
-        Role user = Objects.requireNonNull(userLookup.findUser(subscriptionOwner), "User " + subscriptionOwner + " must exist");
+        Roles roles = subscriberCluster.getInstance(Roles.class);
+        Role user = Objects.requireNonNull(roles.findUser(subscriptionOwner), "User " + subscriptionOwner + " must exist");
 
         executeOnSubscriber("DROP USER " + subscriptionOwner);
         assertThatThrownBy(() -> createSubscriptionAsUser("sub1", "pub1", user))
@@ -102,8 +102,8 @@ public class LogicalReplicationITest extends LogicalReplicationITestCase {
         executeOnPublisher("GRANT AL TO " + publicationOwner);
         executeOnPublisher("GRANT DQL, DML, DDL ON TABLE doc.t1 TO " + publicationOwner);
 
-        RoleLookup userLookup = publisherCluster.getInstance(RoleLookup.class);
-        Role user = Objects.requireNonNull(userLookup.findUser(publicationOwner), "User " + publicationOwner + " must exist");
+        Roles roles = publisherCluster.getInstance(Roles.class);
+        Role user = Objects.requireNonNull(roles.findUser(publicationOwner), "User " + publicationOwner + " must exist");
         executeOnPublisherAsUser("CREATE PUBLICATION pub1 FOR TABLE doc.t1", user);
 
         assertThatThrownBy(() -> executeOnPublisher("DROP USER " + publicationOwner))
@@ -121,8 +121,8 @@ public class LogicalReplicationITest extends LogicalReplicationITestCase {
         executeOnSubscriber("CREATE USER " + subscriptionOwner);
         executeOnSubscriber("GRANT AL TO " + subscriptionOwner);
 
-        RoleLookup userLookup = subscriberCluster.getInstance(RoleLookup.class);
-        Role user = Objects.requireNonNull(userLookup.findUser(subscriptionOwner), "User " + subscriptionOwner + " must exist");
+        Roles roles = subscriberCluster.getInstance(Roles.class);
+        Role user = Objects.requireNonNull(roles.findUser(subscriptionOwner), "User " + subscriptionOwner + " must exist");
         createSubscriptionAsUser("sub1", "pub1", user);
 
         assertThatThrownBy(() -> executeOnSubscriber("DROP USER " + subscriptionOwner))
@@ -140,8 +140,8 @@ public class LogicalReplicationITest extends LogicalReplicationITestCase {
         executeOnSubscriber("CREATE USER " + subscriptionOwner);
         executeOnSubscriber("GRANT AL TO " + subscriptionOwner);
 
-        RoleLookup userLookup = subscriberCluster.getInstance(RoleLookup.class);
-        Role user = Objects.requireNonNull(userLookup.findUser(subscriptionOwner), "User " + subscriptionOwner + " must exist");
+        Roles roles = subscriberCluster.getInstance(Roles.class);
+        Role user = Objects.requireNonNull(roles.findUser(subscriptionOwner), "User " + subscriptionOwner + " must exist");
         var stmt = String.format(Locale.ENGLISH, "CREATE SUBSCRIPTION sub1 CONNECTION 'crate://localhost:12345/mydb?user=%s&mode=pg_tunnel'" +
                                                  " publication pub1", user.name());
         assertThatThrownBy(() -> subscriberSqlExecutor.executeAs(stmt, user))

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -44,7 +44,7 @@ import io.crate.testing.UseJdbc;
 import io.crate.testing.UseNewCluster;
 import io.crate.testing.UseRandomizedOptimizerRules;
 import io.crate.testing.UseRandomizedSchema;
-import io.crate.role.RoleLookup;
+import io.crate.role.Roles;
 
 public class PgCatalogITest extends IntegTestCase {
 
@@ -119,9 +119,9 @@ public class PgCatalogITest extends IntegTestCase {
         execute("create user hoschi");
         execute("grant dql on table doc.t1 to hoschi");
 
-        RoleLookup userLookup = cluster().getInstance(RoleLookup.class);
+        Roles roles = cluster().getInstance(Roles.class);
         Sessions sessions = cluster().getInstance(Sessions.class);
-        try (var session = sessions.newSession("doc", userLookup.findUser("hoschi"))) {
+        try (var session = sessions.newSession("doc", roles.findUser("hoschi"))) {
             execute("select nspname from pg_catalog.pg_namespace order by nspname", session);
             // shows doc due to table permission, but not vip
             assertThat(response).hasRows(
@@ -133,7 +133,7 @@ public class PgCatalogITest extends IntegTestCase {
 
         execute("create view vip.v1 as select 1");
         execute("grant dql on view vip.v1 to hoschi");
-        try (var session = sessions.newSession("doc", userLookup.findUser("hoschi"))) {
+        try (var session = sessions.newSession("doc", roles.findUser("hoschi"))) {
             execute("select nspname from pg_catalog.pg_namespace order by nspname", session);
             assertThat(response).hasRows(
                 "doc",

--- a/server/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
@@ -38,7 +38,7 @@ import io.crate.expression.udf.UserDefinedFunctionService;
 import io.crate.testing.Asserts;
 import io.crate.testing.SQLResponse;
 import io.crate.role.Role;
-import io.crate.role.RoleLookup;
+import io.crate.role.Roles;
 
 public class PrivilegesIntegrationTest extends BaseRolesIntegrationTest {
 
@@ -46,7 +46,7 @@ public class PrivilegesIntegrationTest extends BaseRolesIntegrationTest {
 
     private final UserDefinedFunctionsIntegrationTest.DummyLang dummyLang = new UserDefinedFunctionsIntegrationTest.DummyLang();
     private Sessions sqlOperations;
-    private RoleLookup userLookup;
+    private Roles roles;
 
     private void assertPrivilegeIsGranted(String privilege) {
         SQLResponse response = executeAsSuperuser("select count(*) from sys.privileges where grantee = ? and type = ?",
@@ -65,7 +65,7 @@ public class PrivilegesIntegrationTest extends BaseRolesIntegrationTest {
     }
 
     private Session testUserSession(String defaultSchema) {
-        Role user = userLookup.findUser(TEST_USERNAME);
+        Role user = roles.findUser(TEST_USERNAME);
         assertThat(user).isNotNull();
         return sqlOperations.newSession(defaultSchema, user);
     }
@@ -78,7 +78,7 @@ public class PrivilegesIntegrationTest extends BaseRolesIntegrationTest {
         for (UserDefinedFunctionService udfService : udfServices) {
             udfService.registerLanguage(dummyLang);
         }
-        userLookup = cluster().getInstance(RoleLookup.class);
+        roles = cluster().getInstance(Roles.class);
         sqlOperations = cluster().getInstance(Sessions.class, null);
         executeAsSuperuser("create user " + TEST_USERNAME);
     }

--- a/server/src/test/java/io/crate/replication/logical/action/PublicationsStateActionTest.java
+++ b/server/src/test/java/io/crate/replication/logical/action/PublicationsStateActionTest.java
@@ -50,7 +50,7 @@ import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.role.Privilege;
 import io.crate.role.Role;
-import io.crate.role.RoleLookup;
+import io.crate.role.Roles;
 
 public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTest {
 
@@ -118,9 +118,9 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
             }
         };
 
-        RoleLookup userLookup = mock(RoleLookup.class);
-        when(userLookup.findUser("publisher")).thenReturn(publicationOwner);
-        when(userLookup.findUser("subscriber")).thenReturn(subscriber);
+        Roles roles = mock(Roles.class);
+        when(roles.findUser("publisher")).thenReturn(publicationOwner);
+        when(roles.findUser("subscriber")).thenReturn(subscriber);
 
         SQLExecutor.builder(clusterService)
             .addTable("CREATE TABLE doc.t1 (id int)")
@@ -155,9 +155,9 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
             }
         };
 
-        RoleLookup userLookup = mock(RoleLookup.class);
-        when(userLookup.findUser("publisher")).thenReturn(publicationOwner);
-        when(userLookup.findUser("subscriber")).thenReturn(subscriber);
+        Roles roles = mock(Roles.class);
+        when(roles.findUser("publisher")).thenReturn(publicationOwner);
+        when(roles.findUser("subscriber")).thenReturn(subscriber);
 
         SQLExecutor.builder(clusterService)
             .addTable("CREATE TABLE doc.t1 (id int)")
@@ -186,9 +186,9 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
             }
         };
 
-        RoleLookup userLookup = mock(RoleLookup.class);
-        when(userLookup.findUser("publisher")).thenReturn(publicationOwner);
-        when(userLookup.findUser("subscriber")).thenReturn(subscriber);
+        Roles roles = mock(Roles.class);
+        when(roles.findUser("publisher")).thenReturn(publicationOwner);
+        when(roles.findUser("subscriber")).thenReturn(subscriber);
 
         SQLExecutor.builder(clusterService)
             .addTable("CREATE TABLE doc.t1 (id int)")

--- a/server/src/test/java/io/crate/replication/logical/action/TransportCreateSubscriptionActionTest.java
+++ b/server/src/test/java/io/crate/replication/logical/action/TransportCreateSubscriptionActionTest.java
@@ -56,12 +56,12 @@ import io.crate.replication.logical.metadata.ConnectionInfo;
 import io.crate.replication.logical.metadata.RelationMetadata;
 import io.crate.sql.tree.QualifiedName;
 import io.crate.role.Role;
-import io.crate.role.RoleLookup;
+import io.crate.role.Roles;
 
 public class TransportCreateSubscriptionActionTest {
 
     private final LogicalReplicationService logicalReplicationService = mock(LogicalReplicationService.class);
-    private final RoleLookup userLookup = mock(RoleLookup.class);
+    private final Roles roles = mock(Roles.class);
     private final ClusterService clusterService = mock(ClusterService.class);
     private TransportCreateSubscriptionAction transportCreateSubscriptionAction;
 
@@ -92,10 +92,10 @@ public class TransportCreateSubscriptionActionTest {
             clusterService,
             logicalReplicationService,
             mock(ThreadPool.class),
-            userLookup
+            roles
         );
 
-        when(userLookup.findUser(anyString())).thenReturn(Role.CRATE_USER);
+        when(roles.findUser(anyString())).thenReturn(Role.CRATE_USER);
 
         final DiscoveryNode dataNode = new DiscoveryNode(
             "node",

--- a/server/src/test/java/io/crate/role/RolesServiceTest.java
+++ b/server/src/test/java/io/crate/role/RolesServiceTest.java
@@ -36,21 +36,21 @@ import io.crate.role.metadata.RolesMetadata;
 import io.crate.role.metadata.UsersMetadata;
 import io.crate.role.metadata.UsersPrivilegesMetadata;
 
-public class RoleLookupServiceTest extends CrateDummyClusterServiceUnitTest {
+public class RolesServiceTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testNullAndEmptyMetadata() {
         // the users list will always contain a crate user
-        Set<Role> roles = RoleLookupService.getRoles(null, null, null);
+        Set<Role> roles = RolesService.getRoles(null, null, null);
         assertThat(roles).containsExactly(CRATE_USER);
 
-        roles = RoleLookupService.getRoles(new UsersMetadata(), new RolesMetadata(), new UsersPrivilegesMetadata());
+        roles = RolesService.getRoles(new UsersMetadata(), new RolesMetadata(), new UsersPrivilegesMetadata());
         assertThat(roles).containsExactly(CRATE_USER);
     }
 
     @Test
     public void testUsersAndRoles() {
-        Set<Role> roles = RoleLookupService.getRoles(
+        Set<Role> roles = RolesService.getRoles(
             null,
             new RolesMetadata(RolesDefinitions.DUMMY_USERS_AND_ROLES),
             new UsersPrivilegesMetadata());
@@ -64,7 +64,7 @@ public class RoleLookupServiceTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void test_old_users_metadata_is_preferred_over_roles_metadata() {
-        Set<Role> roles = RoleLookupService.getRoles(
+        Set<Role> roles = RolesService.getRoles(
             new UsersMetadata(Collections.singletonMap("Arthur", null)),
             new RolesMetadata(RolesDefinitions.DUMMY_USERS_AND_ROLES),
             new UsersPrivilegesMetadata());

--- a/server/src/testFixtures/java/io/crate/expression/scalar/ScalarTestCase.java
+++ b/server/src/testFixtures/java/io/crate/expression/scalar/ScalarTestCase.java
@@ -60,7 +60,7 @@ import io.crate.testing.SQLExecutor;
 import io.crate.testing.SqlExpressions;
 import io.crate.types.DataType;
 import io.crate.role.Role;
-import io.crate.role.RoleLookup;
+import io.crate.role.Roles;
 
 public abstract class ScalarTestCase extends CrateDummyClusterServiceUnitTest {
 
@@ -272,7 +272,7 @@ public abstract class ScalarTestCase extends CrateDummyClusterServiceUnitTest {
     @SuppressWarnings({"rawtypes", "unchecked"})
     public void assertCompile(String functionExpression,
                               Role sessionUser,
-                              RoleLookup userLookup,
+                              Roles roles,
                               java.util.function.Function<Scalar, Consumer<Scalar>> matcher) {
         Symbol functionSymbol = sqlExpressions.asSymbol(functionExpression);
         functionSymbol = sqlExpressions.normalize(functionSymbol);
@@ -285,7 +285,7 @@ public abstract class ScalarTestCase extends CrateDummyClusterServiceUnitTest {
             .as("Function implementation not found using full qualified lookup")
             .isNotNull();
 
-        Scalar compiled = scalar.compile(function.arguments(), sessionUser.name(), userLookup);
+        Scalar compiled = scalar.compile(function.arguments(), sessionUser.name(), roles);
         assertThat(compiled).satisfies(matcher.apply(scalar));
     }
 

--- a/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
@@ -220,7 +220,7 @@ import io.crate.testing.UseRandomizedOptimizerRules;
 import io.crate.testing.UseRandomizedSchema;
 import io.crate.types.DataType;
 import io.crate.role.Role;
-import io.crate.role.RoleLookup;
+import io.crate.role.Roles;
 
 /**
  * {@link IntegTestCase} is an abstract base class to run integration
@@ -1682,14 +1682,14 @@ public abstract class IntegTestCase extends ESTestCase {
      */
     public SQLResponse systemExecute(String stmt, @Nullable String schema, String node) {
         Sessions sqlOperations = cluster().getInstance(Sessions.class, node);
-        RoleLookup userLookup;
+        Roles roles;
         try {
-            userLookup = cluster().getInstance(RoleLookup.class, node);
+            roles = cluster().getInstance(Roles.class, node);
         } catch (ConfigurationException ignored) {
-            // If enterprise is not enabled there is no UserLookup instance bound in guice
-            userLookup = () -> List.of(Role.CRATE_USER);
+            // If enterprise is not enabled there is no Roles instance bound in guice
+            roles = () -> List.of(Role.CRATE_USER);
         }
-        try (Session session = sqlOperations.newSession(schema, userLookup.findUser("crate"))) {
+        try (Session session = sqlOperations.newSession(schema, roles.findUser("crate"))) {
             response = sqlExecutor.exec(stmt, session);
         }
         return response;

--- a/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
@@ -108,7 +108,6 @@ import org.elasticsearch.common.CheckedRunnable;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.inject.ConfigurationException;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.settings.Setting;
@@ -206,6 +205,8 @@ import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.rule.MergeFilterAndCollect;
 import io.crate.protocols.postgres.PostgresNetty;
 import io.crate.protocols.postgres.TransactionState;
+import io.crate.role.Role;
+import io.crate.role.Roles;
 import io.crate.sql.Identifiers;
 import io.crate.sql.parser.SqlParser;
 import io.crate.statistics.TableStats;
@@ -219,8 +220,6 @@ import io.crate.testing.UseNewCluster;
 import io.crate.testing.UseRandomizedOptimizerRules;
 import io.crate.testing.UseRandomizedSchema;
 import io.crate.types.DataType;
-import io.crate.role.Role;
-import io.crate.role.Roles;
 
 /**
  * {@link IntegTestCase} is an abstract base class to run integration
@@ -1682,13 +1681,7 @@ public abstract class IntegTestCase extends ESTestCase {
      */
     public SQLResponse systemExecute(String stmt, @Nullable String schema, String node) {
         Sessions sqlOperations = cluster().getInstance(Sessions.class, node);
-        Roles roles;
-        try {
-            roles = cluster().getInstance(Roles.class, node);
-        } catch (ConfigurationException ignored) {
-            // If enterprise is not enabled there is no Roles instance bound in guice
-            roles = () -> List.of(Role.CRATE_USER);
-        }
+        Roles roles = cluster().getInstance(Roles.class, node);
         try (Session session = sqlOperations.newSession(schema, roles.findUser("crate"))) {
             response = sqlExecutor.exec(stmt, session);
         }


### PR DESCRIPTION
- Rename RoleLookup to Roles to prepare for introducing `.hasPrivilege()` methods to the `Roles` interface (moving them from `Role` class). Also rename leftover `userLookup` variables to `roles`.

- Remove try/catch block checking for Enterprise enabled. This was a leftover from when user management was an enterprise feature.


    
Relates: #12109
