### PR TITLE
Change `Roles` to return Map of Roles instead of List

### DIFF
--- a/server/src/main/java/io/crate/metadata/NodeContext.java
+++ b/server/src/main/java/io/crate/metadata/NodeContext.java
@@ -35,7 +35,7 @@ public class NodeContext {
     @Inject
     public NodeContext(Functions functions, Roles roles) {
         this.functions = functions;
-        this.serverStartTimeInMs = SystemClock.currentInstant().toEpochMilli();;
+        this.serverStartTimeInMs = SystemClock.currentInstant().toEpochMilli();
         this.roles = roles;
     }
 

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
@@ -147,7 +147,7 @@ public final class PgCatalogTableDefinitions {
             false
         ));
         tableDefinitions.put(PgRolesTable.IDENT, new StaticTableDefinition<>(
-            () -> completedFuture(roleManagerService.roles()),
+            () -> completedFuture(roleManagerService.roles().values()),
             PgRolesTable.create().expressions(),
             false
         ));

--- a/server/src/main/java/io/crate/role/RoleManagerService.java
+++ b/server/src/main/java/io/crate/role/RoleManagerService.java
@@ -23,6 +23,7 @@ package io.crate.role;
 
 import java.util.Collection;
 import java.util.Locale;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
@@ -84,7 +85,7 @@ public class RoleManagerService implements RoleManager {
         sysTableRegistry.registerSysTable(
             userTable,
             () -> CompletableFuture.completedFuture(
-                roles.roles().stream().filter(Role::isUser).toList()),
+                roles.roles().values().stream().filter(Role::isUser).toList()),
             userTable.expressions(),
             false
         );
@@ -92,7 +93,7 @@ public class RoleManagerService implements RoleManager {
         sysTableRegistry.registerSysTable(
             rolesTable,
             () -> CompletableFuture.completedFuture(
-                roles.roles().stream().filter(r -> r.isUser() == false).toList()),
+                roles.roles().values().stream().filter(r -> r.isUser() == false).toList()),
                 rolesTable.expressions(),
             false
         );
@@ -100,7 +101,7 @@ public class RoleManagerService implements RoleManager {
         var privilegesTable = SysPrivilegesTableInfo.create();
         sysTableRegistry.registerSysTable(
             privilegesTable,
-            () -> CompletableFuture.completedFuture(SysPrivilegesTableInfo.buildPrivilegesRows(roles.roles())),
+            () -> CompletableFuture.completedFuture(SysPrivilegesTableInfo.buildPrivilegesRows(roles.roles().values())),
             privilegesTable.expressions(),
             false
         );
@@ -160,7 +161,8 @@ public class RoleManagerService implements RoleManager {
         return new AccessControlImpl(roles, sessionSettings);
     }
 
-    public Collection<Role> roles() {
+    @Override
+    public Map<String, Role> roles() {
         return roles.roles();
     }
 }

--- a/server/src/main/java/io/crate/role/Roles.java
+++ b/server/src/main/java/io/crate/role/Roles.java
@@ -21,7 +21,7 @@
 
 package io.crate.role;
 
-import java.util.Collection;
+import java.util.Map;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -35,10 +35,9 @@ public interface Roles {
      */
     @Nullable
     default Role findUser(String userName) {
-        for (var role : roles()) {
-            if (role.isUser() && role.name().equals(userName)) {
-                return role;
-            }
+        Role role = roles().get(userName);
+        if (role != null && role.isUser()) {
+            return role;
         }
         return null;
     }
@@ -48,7 +47,7 @@ public interface Roles {
      */
     @Nullable
     default Role findUser(int userOid) {
-        for (var role : roles()) {
+        for (var role : roles().values()) {
             if (role.isUser() && userOid == OidHash.userOid(role.name())) {
                 return role;
             }
@@ -56,5 +55,5 @@ public interface Roles {
         return null;
     }
 
-    Collection<Role> roles();
+    Map<String, Role> roles();
 }

--- a/server/src/main/java/io/crate/role/RolesService.java
+++ b/server/src/main/java/io/crate/role/RolesService.java
@@ -21,10 +21,8 @@
 
 package io.crate.role;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -41,7 +39,7 @@ import io.crate.role.metadata.UsersPrivilegesMetadata;
 
 public class RolesService implements Roles, ClusterStateListener {
 
-    private volatile Set<Role> roles = Set.of(Role.CRATE_USER);
+    private volatile Map<String, Role> roles = Map.of(Role.CRATE_USER.name(), Role.CRATE_USER);
 
     @Inject
     public RolesService(ClusterService clusterService) {
@@ -49,7 +47,7 @@ public class RolesService implements Roles, ClusterStateListener {
     }
 
     @Override
-    public Collection<Role> roles() {
+    public Map<String, Role> roles() {
         return roles;
     }
 
@@ -72,9 +70,9 @@ public class RolesService implements Roles, ClusterStateListener {
     }
 
 
-    static Set<Role> getRoles(@Nullable UsersMetadata usersMetadata,
-                              @Nullable RolesMetadata rolesMetadata,
-                              @Nullable UsersPrivilegesMetadata privilegesMetadata) {
+    static Map<String, Role> getRoles(@Nullable UsersMetadata usersMetadata,
+                                      @Nullable RolesMetadata rolesMetadata,
+                                      @Nullable UsersPrivilegesMetadata privilegesMetadata) {
         Map<String, Role> roles = new HashMap<>();
         roles.put(Role.CRATE_USER.name(), Role.CRATE_USER);
         if (usersMetadata != null) {
@@ -106,6 +104,6 @@ public class RolesService implements Roles, ClusterStateListener {
                 roles.put(userName, Role.of(userName, role.getValue().isUser(), privileges, password));
             }
         }
-        return Collections.unmodifiableSet(new HashSet<>(roles.values()));
+        return Collections.unmodifiableMap(roles);
     }
 }

--- a/server/src/test/java/io/crate/action/sql/SessionsTest.java
+++ b/server/src/test/java/io/crate/action/sql/SessionsTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.action.sql;
 
+import static io.crate.role.RolesDefinitions.DEFAULT_USERS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -49,20 +50,20 @@ import io.crate.metadata.NodeContext;
 import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Planner;
 import io.crate.protocols.postgres.KeyData;
-import io.crate.sql.tree.Declare.Hold;
-import io.crate.statistics.TableStats;
-import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.role.Privilege;
 import io.crate.role.Privilege.State;
 import io.crate.role.Role;
 import io.crate.role.Roles;
+import io.crate.sql.tree.Declare.Hold;
+import io.crate.statistics.TableStats;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 
 public class SessionsTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void test_sessions_broadcasts_cancel_if_no_local_match() throws Exception {
         Functions functions = new Functions(Map.of());
-        Roles roles = () -> List.of(Role.CRATE_USER);
+        Roles roles = () -> DEFAULT_USERS;
         NodeContext nodeCtx = new NodeContext(functions, roles);
         DependencyCarrier dependencies = mock(DependencyCarrier.class);
         ElasticsearchClient client = mock(ElasticsearchClient.class, Answers.RETURNS_MOCKS);
@@ -89,7 +90,7 @@ public class SessionsTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void test_super_user_and_al_privileges_can_view_all_cursors() throws Exception {
         Functions functions = new Functions(Map.of());
-        Roles roles = () -> List.of(Role.CRATE_USER);
+        Roles roles = () -> DEFAULT_USERS;
         NodeContext nodeCtx = new NodeContext(functions, roles);
         Sessions sessions = newSessions(nodeCtx);
         Session session1 = sessions.newSession("doc", Role.userOf("Arthur"));
@@ -114,7 +115,7 @@ public class SessionsTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void test_user_can_only_view_their_own_cursors() throws Exception {
         Functions functions = new Functions(Map.of());
-        Roles roles = () -> List.of(Role.CRATE_USER);
+        Roles roles = () -> DEFAULT_USERS;
         NodeContext nodeCtx = new NodeContext(functions, roles);
         Sessions sessions = newSessions(nodeCtx);
 
@@ -133,7 +134,7 @@ public class SessionsTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void test_uses_global_statement_timeout_as_default_for() throws Exception {
         Functions functions = new Functions(Map.of());
-        Roles roles = () -> List.of(Role.CRATE_USER);
+        Roles roles = () -> DEFAULT_USERS;
         NodeContext nodeCtx = new NodeContext(functions, roles);
         Sessions sessions = new Sessions(
             nodeCtx,

--- a/server/src/test/java/io/crate/auth/AccessControlMaySeeTest.java
+++ b/server/src/test/java/io/crate/auth/AccessControlMaySeeTest.java
@@ -25,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.elasticsearch.common.util.CollectionUtils;
@@ -61,7 +62,7 @@ public class AccessControlMaySeeTest extends ESTestCase {
                 return true;
             }
         };
-        accessControl = new AccessControlImpl(() -> List.of(user), new CoordinatorSessionSettings(user));
+        accessControl = new AccessControlImpl(() -> Map.of(user.name(), user), new CoordinatorSessionSettings(user));
     }
 
     private void assertAskedAnyForCluster() {

--- a/server/src/test/java/io/crate/auth/UserAuthenticationMethodTest.java
+++ b/server/src/test/java/io/crate/auth/UserAuthenticationMethodTest.java
@@ -26,9 +26,8 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
-import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
+import java.util.Map;
 
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.test.ESTestCase;
@@ -43,14 +42,14 @@ public class UserAuthenticationMethodTest extends ESTestCase {
     private static class CrateOrNullRoles implements Roles {
 
         @Override
-        public Collection<Role> roles() {
+        public Map<String, Role> roles() {
             SecureHash pwHash;
             try {
                 pwHash = SecureHash.of(new SecureString("pw".toCharArray()));
             } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
                 throw new RuntimeException(e);
             }
-            return List.of(Role.userOf("crate", Collections.emptySet(), pwHash));
+            return Map.of("crate", Role.userOf("crate", Collections.emptySet(), pwHash));
         }
     }
 

--- a/server/src/test/java/io/crate/execution/engine/collect/files/LineProcessorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/files/LineProcessorTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.execution.engine.collect.files;
 
+import static io.crate.role.RolesDefinitions.DEFAULT_USERS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.URI;
@@ -42,14 +43,13 @@ import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.doc.DocSysColumns;
+import io.crate.role.Roles;
 import io.crate.testing.TestingHelpers;
 import io.crate.types.DataTypes;
-import io.crate.role.Role;
-import io.crate.role.Roles;
 
 public class LineProcessorTest {
 
-    Roles roles = () -> List.of(Role.CRATE_USER);
+    Roles roles = () -> DEFAULT_USERS;
     NodeContext nodeCtx = new NodeContext(new Functions(Map.of()), roles);
     InputFactory inputFactory = new InputFactory(nodeCtx);
 

--- a/server/src/test/java/io/crate/execution/engine/collect/sources/FileCollectSourceTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/sources/FileCollectSourceTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.execution.engine.collect.sources;
 
+import static io.crate.role.RolesDefinitions.DEFAULT_USERS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
@@ -47,11 +48,10 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
+import io.crate.role.Roles;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.TestingHelpers;
 import io.crate.types.DataTypes;
-import io.crate.role.Role;
-import io.crate.role.Roles;
 
 public class FileCollectSourceTest extends CrateDummyClusterServiceUnitTest {
 
@@ -87,7 +87,7 @@ public class FileCollectSourceTest extends CrateDummyClusterServiceUnitTest {
             Settings.EMPTY
         );
 
-        Roles roles = () -> List.of(Role.CRATE_USER);
+        Roles roles = () -> DEFAULT_USERS;
         FileCollectSource fileCollectSource = new FileCollectSource(
             new NodeContext(new Functions(Map.of()), roles),
             clusterService,

--- a/server/src/test/java/io/crate/expression/scalar/HasDatabasePrivilegeFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/HasDatabasePrivilegeFunctionTest.java
@@ -25,6 +25,7 @@ import static io.crate.testing.Asserts.isNotSameInstance;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.junit.Before;
@@ -113,7 +114,10 @@ public class HasDatabasePrivilegeFunctionTest extends ScalarTestCase {
         sqlExpressions = new SqlExpressions(tableSources, null, TEST_USER, List.of(TEST_USER_WITH_AL_ON_CLUSTER));
         assertThatThrownBy(
             () -> assertCompile("has_database_privilege('testUserWithClusterAL', name, 'CREATE')",
-                                TEST_USER, () -> List.of(TEST_USER, TEST_USER_WITH_AL_ON_CLUSTER),
+                                TEST_USER,
+                                () -> Map.of(
+                                    TEST_USER.name(), TEST_USER,
+                                    TEST_USER_WITH_AL_ON_CLUSTER.name(), TEST_USER_WITH_AL_ON_CLUSTER),
                                 s -> s1 -> Asserts.fail("should fail with MissingPrivilegeException")))
             .isExactlyInstanceOf(MissingPrivilegeException.class)
             .hasMessage("Missing privilege for user 'test'");

--- a/server/src/test/java/io/crate/expression/scalar/HasSchemaPrivilegeFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/HasSchemaPrivilegeFunctionTest.java
@@ -25,6 +25,7 @@ import static io.crate.testing.Asserts.isNotSameInstance;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.junit.Before;
@@ -109,7 +110,10 @@ public class HasSchemaPrivilegeFunctionTest extends ScalarTestCase {
         sqlExpressions = new SqlExpressions(tableSources, null, TEST_USER, List.of(TEST_USER_WITH_AL_ON_CLUSTER));
         assertThatThrownBy(
             () -> assertCompile("has_schema_privilege('testUserWithClusterAL', name, 'USAGE')",
-                                TEST_USER, () -> List.of(TEST_USER, TEST_USER_WITH_AL_ON_CLUSTER),
+                                TEST_USER,
+                                () -> Map.of(
+                                    TEST_USER.name(), TEST_USER,
+                                    TEST_USER_WITH_AL_ON_CLUSTER.name(), TEST_USER_WITH_AL_ON_CLUSTER),
                                 s -> s1 -> Asserts.fail("should fail with MissingPrivilegeException")))
             .isExactlyInstanceOf(MissingPrivilegeException.class)
             .hasMessage("Missing privilege for user 'test'");

--- a/server/src/test/java/io/crate/expression/tablefunctions/AbstractTableFunctionsTest.java
+++ b/server/src/test/java/io/crate/expression/tablefunctions/AbstractTableFunctionsTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.expression.tablefunctions;
 
+import static io.crate.role.RolesDefinitions.DEFAULT_USERS;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -30,7 +31,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.List;
 import java.util.Map;
 
 import org.elasticsearch.test.ESTestCase;
@@ -56,7 +56,6 @@ import io.crate.metadata.table.Operation;
 import io.crate.metadata.tablefunctions.TableFunctionImplementation;
 import io.crate.testing.SqlExpressions;
 import io.crate.types.DataTypes;
-import io.crate.role.Role;
 
 public abstract class AbstractTableFunctionsTest extends ESTestCase {
 
@@ -110,7 +109,7 @@ public abstract class AbstractTableFunctionsTest extends ESTestCase {
         Function function = (Function) functionSymbol;
         Scalar scalar = (Scalar) sqlExpressions.nodeCtx.functions().getQualified(function);
         assertThat("Function implementation not found using full qualified lookup", scalar, Matchers.notNullValue());
-        Scalar compiled = scalar.compile(function.arguments(), "dummy", () -> List.of(Role.CRATE_USER));
+        Scalar compiled = scalar.compile(function.arguments(), "dummy", () -> DEFAULT_USERS);
         assertThat(compiled, matcher.apply(scalar));
     }
 

--- a/server/src/test/java/io/crate/planner/optimizer/costs/PlanStatsTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/costs/PlanStatsTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.planner.optimizer.costs;
 
+import static io.crate.role.RolesDefinitions.DEFAULT_USERS;
 import static io.crate.testing.Asserts.assertThat;
 
 import java.util.List;
@@ -54,13 +55,12 @@ import io.crate.statistics.TableStats;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.types.DataTypes;
-import io.crate.role.Role;
 
 
 public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
 
     private CoordinatorTxnCtx txnCtx = CoordinatorTxnCtx.systemTransactionContext();
-    private NodeContext nodeContext = new NodeContext(new Functions(Map.of()), () -> List.of(Role.CRATE_USER));
+    private NodeContext nodeContext = new NodeContext(new Functions(Map.of()), () -> DEFAULT_USERS);
 
     @Test
     public void test_collect() throws Exception {

--- a/server/src/test/java/io/crate/planner/selectivity/SelectivityFunctionsTest.java
+++ b/server/src/test/java/io/crate/planner/selectivity/SelectivityFunctionsTest.java
@@ -22,6 +22,7 @@
 package io.crate.planner.selectivity;
 
 
+import static io.crate.role.RolesDefinitions.DEFAULT_USERS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
@@ -50,7 +51,6 @@ import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SqlExpressions;
 import io.crate.testing.T3;
 import io.crate.types.DataTypes;
-import io.crate.role.Role;
 
 public class SelectivityFunctionsTest extends CrateDummyClusterServiceUnitTest {
 
@@ -58,7 +58,7 @@ public class SelectivityFunctionsTest extends CrateDummyClusterServiceUnitTest {
         new ModulesBuilder()
             .add(new OperatorModule())
             .createInjector().getInstance(Functions.class),
-        () -> List.of(Role.CRATE_USER)
+        () -> DEFAULT_USERS
     );
     TransactionContext txnCtx = CoordinatorTxnCtx.systemTransactionContext();
 

--- a/server/src/test/java/io/crate/planner/statement/SetSessionPlanTest.java
+++ b/server/src/test/java/io/crate/planner/statement/SetSessionPlanTest.java
@@ -65,7 +65,7 @@ public class SetSessionPlanTest extends CrateDummyClusterServiceUnitTest {
         Assignment<Symbol> assignment = new Assignment<Symbol>(Literal.of("statement_timeout"), Literal.of(10));
         SetSessionPlan setSessionPlan = new SetSessionPlan(List.of(assignment), new SessionSettingRegistry(Set.of()));
         TestingRowConsumer consumer = new TestingRowConsumer();
-        NodeContext nodeCtx = new NodeContext(new Functions(Map.of()), () -> List.of());
+        NodeContext nodeCtx = new NodeContext(new Functions(Map.of()), Map::of);
         setSessionPlan.execute(
             mock(DependencyCarrier.class),
             new PlannerContext(

--- a/server/src/test/java/io/crate/protocols/postgres/AuthenticationContextTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/AuthenticationContextTest.java
@@ -21,11 +21,11 @@
 
 package io.crate.protocols.postgres;
 
+import static io.crate.role.RolesDefinitions.DEFAULT_USERS;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
 import java.net.InetAddress;
-import java.util.List;
 
 import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.test.ESTestCase;
@@ -40,7 +40,7 @@ import io.crate.role.Role;
 
 public class AuthenticationContextTest extends ESTestCase {
 
-    private static final Authentication AUTHENTICATION = new AlwaysOKAuthentication(() -> List.of(Role.CRATE_USER));
+    private static final Authentication AUTHENTICATION = new AlwaysOKAuthentication(() -> DEFAULT_USERS);
 
     @Test
     public void testAuthenticationContextCycle() throws Exception {

--- a/server/src/test/java/io/crate/protocols/postgres/PgClientTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/PgClientTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.protocols.postgres;
 
+import static io.crate.role.RolesDefinitions.DEFAULT_USERS;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertThat;
@@ -60,9 +61,9 @@ import io.crate.metadata.settings.session.SessionSettingRegistry;
 import io.crate.netty.NettyBootstrap;
 import io.crate.protocols.ssl.SslContextProvider;
 import io.crate.replication.logical.metadata.ConnectionInfo;
-import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.role.Role;
 import io.crate.role.StubRoleManager;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 
 public class PgClientTest extends CrateDummyClusterServiceUnitTest {
 
@@ -97,7 +98,7 @@ public class PgClientTest extends CrateDummyClusterServiceUnitTest {
         var networkService = new NetworkService(List.of());
         var namedWriteableRegistry = new NamedWriteableRegistry(List.of());
         var circuitBreakerService = new NoneCircuitBreakerService();
-        Authentication authentication = new AlwaysOKAuthentication(() -> List.of(Role.CRATE_USER));
+        Authentication authentication = new AlwaysOKAuthentication(() -> DEFAULT_USERS);
         var sslContextProvider = new SslContextProvider(serverNodeSettings);
         var serverTransport = new Netty4Transport(
             serverNodeSettings,

--- a/server/src/test/java/io/crate/protocols/postgres/PostgresNettyPublishPortTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/PostgresNettyPublishPortTest.java
@@ -22,6 +22,7 @@
 package io.crate.protocols.postgres;
 
 import static io.crate.protocols.postgres.PostgresNetty.resolvePublishPort;
+import static io.crate.role.RolesDefinitions.DEFAULT_USERS;
 import static java.net.InetAddress.getByName;
 import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.equalTo;
@@ -32,7 +33,6 @@ import static org.mockito.Mockito.mock;
 
 import java.net.UnknownHostException;
 import java.util.Collections;
-import java.util.List;
 import java.util.Set;
 
 import org.elasticsearch.common.network.NetworkService;
@@ -52,7 +52,6 @@ import io.crate.auth.AlwaysOKAuthentication;
 import io.crate.metadata.settings.session.SessionSettingRegistry;
 import io.crate.netty.NettyBootstrap;
 import io.crate.protocols.ssl.SslContextProvider;
-import io.crate.role.Role;
 import io.crate.role.StubRoleManager;
 
 public class PostgresNettyPublishPortTest extends ESTestCase {
@@ -192,7 +191,7 @@ public class PostgresNettyPublishPortTest extends ESTestCase {
             userManager,
             networkService,
             null,
-            new AlwaysOKAuthentication(() -> List.of(Role.CRATE_USER)),
+            new AlwaysOKAuthentication(() -> DEFAULT_USERS),
             nettyBootstrap,
             mock(Netty4Transport.class),
             PageCacheRecycler.NON_RECYCLING_INSTANCE,

--- a/server/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.protocols.postgres;
 
+import static io.crate.role.RolesDefinitions.DEFAULT_USERS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -70,10 +71,10 @@ import io.crate.execution.jobs.kill.KillJobsNodeRequest;
 import io.crate.metadata.settings.CoordinatorSessionSettings;
 import io.crate.metadata.settings.session.SessionSettingRegistry;
 import io.crate.protocols.postgres.types.PGTypes;
+import io.crate.role.Role;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.types.DataTypes;
-import io.crate.role.Role;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
@@ -124,7 +125,7 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
                 new SessionSettingRegistry(Set.of()),
                 sessionSettings -> AccessControl.DISABLED,
                 chPipeline -> {},
-                new AlwaysOKAuthentication(() -> List.of()),
+                new AlwaysOKAuthentication(() -> Map.of()),
                 null
             );
         channel = new EmbeddedChannel(ctx.decoder, ctx.handler);
@@ -169,7 +170,7 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
                 new SessionSettingRegistry(Set.of()),
                 sessionSettings -> AccessControl.DISABLED,
                 chPipeline -> {},
-                new AlwaysOKAuthentication(() -> List.of(Role.CRATE_USER)),
+                new AlwaysOKAuthentication(() -> DEFAULT_USERS),
                 null);
         AtomicBoolean flushed = new AtomicBoolean(false);
         channel = new EmbeddedChannel(ctx.decoder, ctx.handler) {
@@ -213,7 +214,7 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
                 new SessionSettingRegistry(Set.of()),
                 sessionSettings -> AccessControl.DISABLED,
                 chPipeline -> {},
-                new AlwaysOKAuthentication(() -> List.of(Role.CRATE_USER)),
+                new AlwaysOKAuthentication(() -> DEFAULT_USERS),
                 null);
         channel = new EmbeddedChannel(ctx.decoder, ctx.handler);
 
@@ -240,7 +241,7 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
                 new SessionSettingRegistry(Set.of()),
                 sessionSettings -> AccessControl.DISABLED,
                 chPipeline -> {},
-                new AlwaysOKAuthentication(() -> List.of(Role.CRATE_USER)),
+                new AlwaysOKAuthentication(() -> DEFAULT_USERS),
                 null);
 
         channel = new EmbeddedChannel(ctx.decoder, ctx.handler);
@@ -300,7 +301,7 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
                 new SessionSettingRegistry(Set.of()),
                 sessionSettings -> AccessControl.DISABLED,
                 chPipeline -> {},
-                new AlwaysOKAuthentication(() -> List.of(Role.CRATE_USER)),
+                new AlwaysOKAuthentication(() -> DEFAULT_USERS),
                 null);
 
         channel = new EmbeddedChannel(ctx.decoder, ctx.handler);
@@ -364,7 +365,7 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
                 new SessionSettingRegistry(Set.of()),
                 sessionSettings -> AccessControl.DISABLED,
                 chPipeline -> {},
-                new AlwaysOKAuthentication(() -> List.of(Role.CRATE_USER)),
+                new AlwaysOKAuthentication(() -> DEFAULT_USERS),
                 null);
 
         channel = new EmbeddedChannel(ctx.decoder, ctx.handler);
@@ -422,7 +423,7 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
                 new SessionSettingRegistry(Set.of()),
                 sessionSettings -> AccessControl.DISABLED,
                 chPipeline -> {},
-                new AlwaysOKAuthentication(() -> List.of()),
+                new AlwaysOKAuthentication(() -> Map.of()),
                 () -> null);
 
         channel = new EmbeddedChannel(ctx.decoder, ctx.handler);
@@ -453,7 +454,7 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
             new SessionSettingRegistry(Set.of()),
             sessionSettings -> AccessControl.DISABLED,
             chPipeline -> {},
-            new AlwaysOKAuthentication(() -> List.of()),
+            new AlwaysOKAuthentication(() -> Map.of()),
             () -> {
                 try {
                     var cert = new SelfSignedCertificate();
@@ -492,7 +493,7 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
             new SessionSettingRegistry(Set.of()),
             sessionSettings -> AccessControl.DISABLED,
             chPipeline -> {},
-            new AlwaysOKAuthentication(() -> List.of(Role.CRATE_USER)),
+            new AlwaysOKAuthentication(() -> DEFAULT_USERS),
             null
         );
         channel = new EmbeddedChannel(ctx.decoder, ctx.handler);
@@ -584,7 +585,7 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
                 new SessionSettingRegistry(Set.of()),
                 sessionSettings -> AccessControl.DISABLED,
                 chPipeline -> {},
-                new AlwaysOKAuthentication(() -> List.of(Role.CRATE_USER)),
+                new AlwaysOKAuthentication(() -> DEFAULT_USERS),
                 null
             );
         channel = new EmbeddedChannel(ctx.decoder, ctx.handler);
@@ -640,7 +641,7 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
                 new SessionSettingRegistry(Set.of()),
                 sessionSettings -> AccessControl.DISABLED,
                 chPipeline -> {},
-                new AlwaysOKAuthentication(() -> List.of(Role.CRATE_USER)),
+                new AlwaysOKAuthentication(() -> DEFAULT_USERS),
                 null
             );
         channel = new EmbeddedChannel(ctx.decoder, ctx.handler);
@@ -661,7 +662,7 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
                 new SessionSettingRegistry(Set.of()),
                 context -> AccessControl.DISABLED,
                 chPipeline -> {},
-                new AlwaysOKAuthentication(() -> List.of(Role.CRATE_USER)),
+                new AlwaysOKAuthentication(() -> DEFAULT_USERS),
                 null
             );
         PostgresWireProtocol pg2 =
@@ -670,7 +671,7 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
                 new SessionSettingRegistry(Set.of()),
                 context -> AccessControl.DISABLED,
                 chPipeline -> {},
-                new AlwaysOKAuthentication(() -> List.of(Role.CRATE_USER)),
+                new AlwaysOKAuthentication(() -> DEFAULT_USERS),
                 null
             );
 
@@ -734,7 +735,7 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
                 new SessionSettingRegistry(Set.of()),
                 sessionCtx -> AccessControl.DISABLED,
                 chPipeline -> {},
-                new AlwaysOKAuthentication(() -> List.of(Role.CRATE_USER)),
+                new AlwaysOKAuthentication(() -> DEFAULT_USERS),
                 null
             );
         channel = new EmbeddedChannel(ctx.decoder, ctx.handler);

--- a/server/src/test/java/io/crate/rest/action/SqlHttpHandlerTest.java
+++ b/server/src/test/java/io/crate/rest/action/SqlHttpHandlerTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.rest.action;
 
+import static io.crate.role.RolesDefinitions.DEFAULT_USERS;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
@@ -31,7 +32,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.List;
+import java.util.Map;
 
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.settings.Settings;
@@ -55,7 +56,7 @@ public class SqlHttpHandlerTest {
             Settings.EMPTY,
             mock(Sessions.class),
             (s) -> new NoopCircuitBreaker("dummy"),
-            () -> List.of(Role.CRATE_USER),
+            () -> DEFAULT_USERS,
             sessionSettings -> AccessControl.DISABLED,
             Netty4CorsConfigBuilder.forAnyOrigin().build()
         );
@@ -73,7 +74,7 @@ public class SqlHttpHandlerTest {
             settings,
             mock(Sessions.class),
             (s) -> new NoopCircuitBreaker("dummy"),
-            () -> List.of(Role.userOf("trillian")),
+            () -> Map.of("trillian", Role.userOf("trillian")),
             sessionSettings -> AccessControl.DISABLED,
             Netty4CorsConfigBuilder.forAnyOrigin().build()
         );
@@ -88,7 +89,7 @@ public class SqlHttpHandlerTest {
             Settings.EMPTY,
             mock(Sessions.class),
             (s) -> new NoopCircuitBreaker("dummy"),
-            () -> List.of(Role.userOf("Aladdin")),
+            () -> Map.of("Aladdin", Role.userOf("Aladdin")),
             sessionSettings -> AccessControl.DISABLED,
             Netty4CorsConfigBuilder.forAnyOrigin().build()
         );
@@ -115,7 +116,7 @@ public class SqlHttpHandlerTest {
             Settings.EMPTY,
             mockedSqlOperations,
             (s) -> new NoopCircuitBreaker("dummy"),
-            () -> List.of(dummyUser),
+            () -> Map.of(dummyUser.name(), dummyUser),
             settings -> AccessControl.DISABLED,
             Netty4CorsConfigBuilder.forAnyOrigin().build()
         );

--- a/server/src/test/java/io/crate/role/RolesServiceTest.java
+++ b/server/src/test/java/io/crate/role/RolesServiceTest.java
@@ -22,7 +22,7 @@
 package io.crate.role;
 
 import static io.crate.role.Role.CRATE_USER;
-import static io.crate.role.metadata.RolesDefinitions.DUMMY_USERS_AND_ROLES;
+import static io.crate.role.RolesDefinitions.DUMMY_USERS_AND_ROLES;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
@@ -30,11 +30,10 @@ import java.util.Set;
 
 import org.junit.Test;
 
-import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
-import io.crate.role.metadata.RolesDefinitions;
 import io.crate.role.metadata.RolesMetadata;
 import io.crate.role.metadata.UsersMetadata;
 import io.crate.role.metadata.UsersPrivilegesMetadata;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 
 public class RolesServiceTest extends CrateDummyClusterServiceUnitTest {
 

--- a/server/src/test/java/io/crate/role/RolesServiceTest.java
+++ b/server/src/test/java/io/crate/role/RolesServiceTest.java
@@ -22,11 +22,12 @@
 package io.crate.role;
 
 import static io.crate.role.Role.CRATE_USER;
+import static io.crate.role.RolesDefinitions.DEFAULT_USERS;
 import static io.crate.role.RolesDefinitions.DUMMY_USERS_AND_ROLES;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
-import java.util.Set;
+import java.util.Map;
 
 import org.junit.Test;
 
@@ -40,36 +41,38 @@ public class RolesServiceTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testNullAndEmptyMetadata() {
         // the users list will always contain a crate user
-        Set<Role> roles = RolesService.getRoles(null, null, null);
-        assertThat(roles).containsExactly(CRATE_USER);
+        Map<String, Role> roles = RolesService.getRoles(null, null, null);
+        assertThat(roles).containsExactlyEntriesOf(DEFAULT_USERS);
 
         roles = RolesService.getRoles(new UsersMetadata(), new RolesMetadata(), new UsersPrivilegesMetadata());
-        assertThat(roles).containsExactly(CRATE_USER);
+        assertThat(roles).containsExactlyEntriesOf(DEFAULT_USERS);
     }
 
     @Test
     public void testUsersAndRoles() {
-        Set<Role> roles = RolesService.getRoles(
+        Map<String, Role> roles = RolesService.getRoles(
             null,
             new RolesMetadata(RolesDefinitions.DUMMY_USERS_AND_ROLES),
             new UsersPrivilegesMetadata());
 
-        assertThat(roles).containsExactlyInAnyOrder(
-            DUMMY_USERS_AND_ROLES.get("Ford"),
-            DUMMY_USERS_AND_ROLES.get("John"),
-            Role.roleOf("DummyRole"),
-            CRATE_USER);
+        assertThat(roles).containsExactlyInAnyOrderEntriesOf(
+            Map.of(
+                "Ford", DUMMY_USERS_AND_ROLES.get("Ford"),
+                "John", DUMMY_USERS_AND_ROLES.get("John"),
+                "DummyRole", Role.roleOf("DummyRole"),
+                CRATE_USER.name(), CRATE_USER));
     }
 
     @Test
     public void test_old_users_metadata_is_preferred_over_roles_metadata() {
-        Set<Role> roles = RolesService.getRoles(
+        Map<String, Role> roles = RolesService.getRoles(
             new UsersMetadata(Collections.singletonMap("Arthur", null)),
             new RolesMetadata(RolesDefinitions.DUMMY_USERS_AND_ROLES),
             new UsersPrivilegesMetadata());
 
-        assertThat(roles).containsExactlyInAnyOrder(
-            Role.userOf("Arthur"),
-            CRATE_USER);
+        assertThat(roles).containsExactlyInAnyOrderEntriesOf(
+            Map.of(
+                "Arthur" ,Role.userOf("Arthur"),
+                CRATE_USER.name(), CRATE_USER));
     }
 }

--- a/server/src/test/java/io/crate/role/TransportPrivilegesActionTest.java
+++ b/server/src/test/java/io/crate/role/TransportPrivilegesActionTest.java
@@ -36,7 +36,6 @@ import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
 
 import io.crate.role.metadata.RolesMetadata;
-import io.crate.role.metadata.RolesDefinitions;
 import io.crate.role.metadata.UsersPrivilegesMetadata;
 
 public class TransportPrivilegesActionTest extends ESTestCase {

--- a/server/src/test/java/io/crate/role/TransportRoleActionTest.java
+++ b/server/src/test/java/io/crate/role/TransportRoleActionTest.java
@@ -21,12 +21,12 @@
 
 package io.crate.role;
 
+import static io.crate.role.RolesDefinitions.DUMMY_USERS;
+import static io.crate.role.RolesDefinitions.DUMMY_USERS_AND_ROLES;
+import static io.crate.role.RolesDefinitions.SINGLE_USER_ONLY;
+import static io.crate.role.RolesDefinitions.getSecureHash;
+import static io.crate.role.RolesDefinitions.usersMetadataOf;
 import static io.crate.testing.Asserts.assertThat;
-import static io.crate.role.metadata.RolesDefinitions.DUMMY_USERS;
-import static io.crate.role.metadata.RolesDefinitions.DUMMY_USERS_AND_ROLES;
-import static io.crate.role.metadata.RolesDefinitions.SINGLE_USER_ONLY;
-import static io.crate.role.metadata.RolesDefinitions.getSecureHash;
-import static io.crate.role.metadata.RolesDefinitions.usersMetadataOf;
 
 import java.util.Map;
 

--- a/server/src/test/java/io/crate/role/metadata/CustomMetadataTest.java
+++ b/server/src/test/java/io/crate/role/metadata/CustomMetadataTest.java
@@ -39,6 +39,7 @@ import io.crate.expression.udf.UserDefinedFunctionsMetadataTest;
 import io.crate.metadata.MetadataModule;
 import io.crate.metadata.view.ViewsMetadata;
 import io.crate.metadata.view.ViewsMetadataTest;
+import io.crate.role.RolesDefinitions;
 
 public class CustomMetadataTest {
 

--- a/server/src/test/java/io/crate/role/metadata/RolesMetadataTest.java
+++ b/server/src/test/java/io/crate/role/metadata/RolesMetadataTest.java
@@ -21,8 +21,8 @@
 
 package io.crate.role.metadata;
 
+import static io.crate.role.RolesDefinitions.usersMetadataOf;
 import static io.crate.testing.Asserts.assertThat;
-import static io.crate.role.metadata.RolesDefinitions.usersMetadataOf;
 
 import java.io.IOException;
 import java.util.Map;
@@ -38,6 +38,8 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
+
+import io.crate.role.RolesDefinitions;
 
 public class RolesMetadataTest extends ESTestCase {
 

--- a/server/src/test/java/io/crate/role/metadata/UsersMetadataTest.java
+++ b/server/src/test/java/io/crate/role/metadata/UsersMetadataTest.java
@@ -28,7 +28,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -41,6 +40,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
 
 import io.crate.role.Role;
+import io.crate.role.RolesDefinitions;
 import io.crate.role.SecureHash;
 
 public class UsersMetadataTest extends ESTestCase {

--- a/server/src/test/java/org/elasticsearch/transport/TransportServiceHandshakeTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportServiceHandshakeTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.transport;
 
+import static io.crate.role.RolesDefinitions.DEFAULT_USERS;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -54,7 +55,6 @@ import org.junit.Test;
 import io.crate.auth.AlwaysOKAuthentication;
 import io.crate.netty.NettyBootstrap;
 import io.crate.protocols.ssl.SslContextProvider;
-import io.crate.role.Role;
 
 public class TransportServiceHandshakeTests extends ESTestCase {
 
@@ -93,7 +93,7 @@ public class TransportServiceHandshakeTests extends ESTestCase {
             new NamedWriteableRegistry(Collections.emptyList()),
             new NoneCircuitBreakerService(),
             nettyBootstrap,
-            new AlwaysOKAuthentication(() -> List.of(Role.CRATE_USER)),
+            new AlwaysOKAuthentication(() -> DEFAULT_USERS),
             new SslContextProvider(settings)
         );
         TransportService transportService = new MockTransportService(

--- a/server/src/testFixtures/java/io/crate/role/RolesDefinitions.java
+++ b/server/src/testFixtures/java/io/crate/role/RolesDefinitions.java
@@ -35,6 +35,8 @@ import io.crate.role.metadata.UsersMetadata;
 
 public final class RolesDefinitions {
 
+    public static final Map<String, Role> DEFAULT_USERS = Map.of(Role.CRATE_USER.name(), Role.CRATE_USER);
+
     public static final Map<String, Role> SINGLE_USER_ONLY = Collections.singletonMap("Arthur", Role.userOf("Arthur"));
 
     public static final Map<String, Role> DUMMY_USERS = Map.of(

--- a/server/src/testFixtures/java/io/crate/role/RolesDefinitions.java
+++ b/server/src/testFixtures/java/io/crate/role/RolesDefinitions.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.  You may
  * obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
@@ -19,7 +19,8 @@
  * software solely pursuant to the terms of the relevant commercial agreement.
  */
 
-package io.crate.role.metadata;
+package io.crate.role;
+
 
 import static io.crate.testing.Asserts.assertThat;
 
@@ -30,8 +31,7 @@ import java.util.Map;
 
 import org.elasticsearch.common.settings.SecureString;
 
-import io.crate.role.Role;
-import io.crate.role.SecureHash;
+import io.crate.role.metadata.UsersMetadata;
 
 public final class RolesDefinitions {
 

--- a/server/src/testFixtures/java/io/crate/role/StubRoleManager.java
+++ b/server/src/testFixtures/java/io/crate/role/StubRoleManager.java
@@ -21,8 +21,10 @@
 
 package io.crate.role;
 
+import static io.crate.role.RolesDefinitions.DEFAULT_USERS;
+
 import java.util.Collection;
-import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import org.jetbrains.annotations.Nullable;
@@ -33,7 +35,7 @@ import io.crate.metadata.settings.CoordinatorSessionSettings;
 
 public class StubRoleManager implements RoleManager {
 
-    private final List<Role> roles = List.of(Role.CRATE_USER);
+    private final Map<String, Role> roles = DEFAULT_USERS;
 
     @Override
     public CompletableFuture<Long> createRole(String roleName, boolean isUser, @Nullable SecureHash hashedPw) {
@@ -66,7 +68,7 @@ public class StubRoleManager implements RoleManager {
     }
 
     @Override
-    public Collection<Role> roles() {
+    public Map<String, Role> roles() {
         return roles;
     }
 

--- a/server/src/testFixtures/java/io/crate/testing/TestingHelpers.java
+++ b/server/src/testFixtures/java/io/crate/testing/TestingHelpers.java
@@ -22,6 +22,7 @@
 package io.crate.testing;
 
 import static io.crate.execution.ddl.tables.MappingUtil.createMapping;
+import static io.crate.role.RolesDefinitions.DEFAULT_USERS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.hasEntry;
@@ -186,10 +187,10 @@ public class TestingHelpers {
     }
 
     public static NodeContext createNodeContext(AbstractModule... additionalModules) {
-        return createNodeContext(List.of(Role.CRATE_USER), additionalModules);
+        return createNodeContext(DEFAULT_USERS, additionalModules);
     }
 
-    public static NodeContext createNodeContext(List<Role> roles, AbstractModule... additionalModules) {
+    public static NodeContext createNodeContext(Map<String, Role> roles, AbstractModule... additionalModules) {
         return new NodeContext(
             prepareModulesBuilder(additionalModules).createInjector().getInstance(Functions.class),
             () -> roles

--- a/server/src/testFixtures/java/org/elasticsearch/test/transport/MockTransportService.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/transport/MockTransportService.java
@@ -19,6 +19,8 @@
 
 package org.elasticsearch.test.transport;
 
+import static io.crate.role.RolesDefinitions.DEFAULT_USERS;
+
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -72,7 +74,6 @@ import io.crate.common.io.IOUtils;
 import io.crate.common.unit.TimeValue;
 import io.crate.netty.NettyBootstrap;
 import io.crate.protocols.ssl.SslContextProvider;
-import io.crate.role.Role;
 
 /**
  * A mock delegate service that allows to simulate different network topology failures.
@@ -121,7 +122,7 @@ public final class MockTransportService extends TransportService {
             namedWriteableRegistry,
             new NoneCircuitBreakerService(),
             nettyBootstrap,
-            new AlwaysOKAuthentication(() -> List.of(Role.CRATE_USER)),
+            new AlwaysOKAuthentication(() -> DEFAULT_USERS),
             new SslContextProvider(allSettings)
         );
         return new MockTransportService(


### PR DESCRIPTION
- Move RolesDefinitions to testFixtures. This is a preparation to add more stuff to have cleaner tests, as `Roles.roles()` will return a `Map<String, Role>` instead of `List<Role>`.

- Change Roles to return Map of Roles instead of List. `List<Roles>` was making tests easier, but a Map is more efficient and it's necessary for upcoming resolution of parent roles.
    
Relates: #12109


