### PR TITLE
Add use_path_style_access setting for S3 snapshot repository.

### DIFF
--- a/docs/appendices/release-notes/5.7.0.rst
+++ b/docs/appendices/release-notes/5.7.0.rst
@@ -83,7 +83,9 @@ None
 Administration and Operations
 -----------------------------
 
-None
+- Added the ability to set a
+  :ref:`use_path_style_access <sql-create-repo-s3-use_path_style_access>` for
+  S3 repositories.
 
 User Interface
 --------------

--- a/docs/sql/statements/create-repository.rst
+++ b/docs/sql/statements/create-repository.rst
@@ -388,6 +388,15 @@ Parameters
   The S3 storage class used for objects stored in the repository. This only 
   affects the S3 storage class used for newly created objects in the repository.
 
+.. _sql-create-repo-s3-use_path_style_access:
+
+**use_path_style_access**
+  | *Type:*    ``boolean``
+  | *Default:* ``false``
+
+  Whether CrateDB should use path style access.
+  Useful for some S3-compatible providers.
+
 .. _sql-create-repo-azure:
 
 ``azure``

--- a/plugins/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3ClientSettings.java
+++ b/plugins/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3ClientSettings.java
@@ -31,6 +31,7 @@ import static org.elasticsearch.repositories.s3.S3RepositorySettings.READ_TIMEOU
 import static org.elasticsearch.repositories.s3.S3RepositorySettings.SECRET_KEY_SETTING;
 import static org.elasticsearch.repositories.s3.S3RepositorySettings.SESSION_TOKEN_SETTING;
 import static org.elasticsearch.repositories.s3.S3RepositorySettings.USE_THROTTLE_RETRIES_SETTING;
+import static org.elasticsearch.repositories.s3.S3RepositorySettings.USE_PATH_STYLE_ACCESS;
 
 import java.util.Objects;
 
@@ -83,6 +84,9 @@ final class S3ClientSettings {
     /** Whether the s3 client should use an exponential backoff retry policy. */
     final boolean throttleRetries;
 
+    /** Whether the s3 client should use path style access. */
+    final boolean pathStyleAccess;
+
     private S3ClientSettings(@Nullable AWSCredentials credentials,
                              String endpoint,
                              Protocol protocol,
@@ -92,7 +96,8 @@ final class S3ClientSettings {
                              String proxyPassword,
                              int readTimeoutMillis,
                              int maxRetries,
-                             boolean throttleRetries) {
+                             boolean throttleRetries,
+                             boolean pathStyleAccess) {
         this.credentials = credentials;
         this.endpoint = endpoint;
         this.protocol = protocol;
@@ -103,6 +108,7 @@ final class S3ClientSettings {
         this.readTimeoutMillis = readTimeoutMillis;
         this.maxRetries = maxRetries;
         this.throttleRetries = throttleRetries;
+        this.pathStyleAccess = pathStyleAccess;
     }
 
     private static AWSCredentials loadCredentials(Settings settings) {
@@ -151,7 +157,8 @@ final class S3ClientSettings {
                     proxyPassword.toString(),
                     Math.toIntExact(getConfigValue(settings, READ_TIMEOUT_SETTING).millis()),
                     getConfigValue(settings, MAX_RETRIES_SETTING),
-                    getConfigValue(settings, USE_THROTTLE_RETRIES_SETTING)
+                    getConfigValue(settings, USE_THROTTLE_RETRIES_SETTING),
+                    getConfigValue(settings, USE_PATH_STYLE_ACCESS)
             );
         }
     }
@@ -178,7 +185,8 @@ final class S3ClientSettings {
                protocol == that.protocol &&
                Objects.equals(proxyHost, that.proxyHost) &&
                Objects.equals(proxyUsername, that.proxyUsername) &&
-               Objects.equals(proxyPassword, that.proxyPassword);
+               Objects.equals(proxyPassword, that.proxyPassword) &&
+               pathStyleAccess == that.pathStyleAccess;
     }
 
     @Override
@@ -199,7 +207,8 @@ final class S3ClientSettings {
                             proxyPassword,
                             readTimeoutMillis,
                             maxRetries,
-                            throttleRetries);
+                            throttleRetries,
+                            pathStyleAccess);
     }
 
     private boolean compareCredentials(@Nullable AWSCredentials first, @Nullable AWSCredentials second) {

--- a/plugins/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
+++ b/plugins/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Repository.java
@@ -48,6 +48,7 @@ import static org.elasticsearch.repositories.s3.S3RepositorySettings.READONLY_SE
 import static org.elasticsearch.repositories.s3.S3RepositorySettings.SECRET_KEY_SETTING;
 import static org.elasticsearch.repositories.s3.S3RepositorySettings.SERVER_SIDE_ENCRYPTION_SETTING;
 import static org.elasticsearch.repositories.s3.S3RepositorySettings.STORAGE_CLASS_SETTING;
+import static org.elasticsearch.repositories.s3.S3RepositorySettings.USE_PATH_STYLE_ACCESS;
 import static org.elasticsearch.repositories.s3.S3RepositorySettings.USE_THROTTLE_RETRIES_SETTING;
 
 /**
@@ -85,7 +86,8 @@ public class S3Repository extends BlobStoreRepository {
                        MAX_RETRIES_SETTING,
                        USE_THROTTLE_RETRIES_SETTING,
                        READONLY_SETTING,
-                       STORAGE_CLASS_SETTING);
+                       STORAGE_CLASS_SETTING,
+                       USE_PATH_STYLE_ACCESS);
     }
 
     private final S3Service service;

--- a/plugins/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RepositorySettings.java
+++ b/plugins/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RepositorySettings.java
@@ -203,4 +203,12 @@ class S3RepositorySettings {
         "use_throttle_retries",
         ClientConfiguration.DEFAULT_THROTTLE_RETRIES,
         Setting.Property.NodeScope);
+
+
+    /**
+     * Whether to use Path Style Access.
+     */
+    static final Setting<Boolean> USE_PATH_STYLE_ACCESS = Setting.boolSetting(
+        "use_path_style_access",
+        false);
 }

--- a/plugins/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Service.java
+++ b/plugins/es-repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Service.java
@@ -94,6 +94,9 @@ class S3Service implements Closeable {
         // We do this because directly constructing the client is deprecated (was already deprecated in 1.1.223 too)
         // so this change removes that usage of a deprecated API.
         builder.withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(endpoint, null));
+        if (clientSettings.pathStyleAccess) {
+            builder.enablePathStyleAccess();
+        }
 
         return builder.build();
     }

--- a/plugins/es-repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3ClientSettingsTests.java
+++ b/plugins/es-repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3ClientSettingsTests.java
@@ -129,4 +129,12 @@ public class S3ClientSettingsTests extends ESTestCase {
         cache.add(settings);
         assertThat(cache.contains(settings)).isTrue();
     }
+    @Test
+    public void testPathStyleAccessCanBeSet() {
+        final S3ClientSettings settings = S3ClientSettings.getClientSettings(
+            Settings.builder()
+                .put("use_path_style_access", true)
+                .build());
+        assertThat(settings.pathStyleAccess).isEqualTo(true);
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Added 'use_path_style_access' boolean option to CREATE REPOSITORY of type S3 to support other compatible providers, for example Oracle Cloud Infrastructure.
The param is optional and default behavior is disabled to maintain current compatibility. If set tu true a call to  builder.enablePathStyleAccess(); is made.

Checked to work on OCI.

## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [*] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
