### PR TITLE
Move static Role factory methods to a test helper

### DIFF
--- a/server/src/main/java/io/crate/role/Role.java
+++ b/server/src/main/java/io/crate/role/Role.java
@@ -27,7 +27,6 @@ import java.util.Set;
 
 import org.jetbrains.annotations.Nullable;
 
-import io.crate.common.annotations.VisibleForTesting;
 import io.crate.metadata.pgcatalog.OidHash;
 
 public class Role {
@@ -49,12 +48,11 @@ public class Role {
     private final SecureHash password;
     private final Set<UserRole> userRoles;
 
-    @VisibleForTesting
-    protected Role(String name,
-                   boolean isUser,
-                   Set<Privilege> privileges,
-                   @Nullable SecureHash password,
-                   Set<UserRole> userRoles) {
+    public Role(String name,
+                boolean isUser,
+                Set<Privilege> privileges,
+                @Nullable SecureHash password,
+                Set<UserRole> userRoles) {
         if (isUser == false) {
             assert password == null : "Cannot create a Role with password";
             assert userRoles.isEmpty() : "Cannot create a Role with UserRoles";
@@ -65,35 +63,6 @@ public class Role {
         this.privileges = new RolePrivileges(privileges);
         this.password = password;
         this.userRoles = userRoles;
-    }
-
-    public static Role of(String name,
-                 boolean isUser,
-                 Set<Privilege> privileges,
-                 @Nullable SecureHash password) {
-        return new Role(name, isUser, privileges == null ? Set.of() : privileges, password, Set.of());
-    }
-
-    public static Role roleOf(String name) {
-        return new Role(name, false, Set.of(), null, Set.of());
-    }
-
-
-    public static Role userOf(String name) {
-        return new Role(name, true, Set.of(), null, Set.of());
-    }
-
-    public static Role userOf(String name, SecureHash password) {
-        return new Role(name, true, Set.of(), password, Set.of());
-    }
-
-    public static Role userOf(String name, @Nullable Set<Privilege> privileges, SecureHash password) {
-        return new Role(name, true, privileges == null ? Set.of() : privileges, password, Set.of());
-    }
-
-    @VisibleForTesting
-    public static Role userOf(String name, EnumSet<UserRole> userRoles) {
-        return new Role(name, true, Set.of(), null, userRoles);
     }
 
     public String name() {

--- a/server/src/main/java/io/crate/role/RolesService.java
+++ b/server/src/main/java/io/crate/role/RolesService.java
@@ -81,29 +81,31 @@ public class RolesService implements Roles, ClusterStateListener {
             for (Map.Entry<String, SecureHash> user: usersMetadata.users().entrySet()) {
                 String userName = user.getKey();
                 SecureHash password = user.getValue();
-                Set<Privilege> privileges = null;
+                Set<Privilege> privileges = Set.of();
                 if (privilegesMetadata != null) {
                     privileges = privilegesMetadata.getUserPrivileges(userName);
                     if (privileges == null) {
                         // create empty set
-                        privilegesMetadata.createPrivileges(userName, Set.of());
+                        privileges = Set.of();
+                        privilegesMetadata.createPrivileges(userName, privileges);
                     }
                 }
-                roles.put(userName, Role.userOf(userName, privileges, password));
+                roles.put(userName, new Role(userName, true, privileges, password, Set.of()));
             }
         } else if (rolesMetadata != null) {
             for (Map.Entry<String, Role> role: rolesMetadata.roles().entrySet()) {
                 String userName = role.getKey();
                 SecureHash password = role.getValue().password();
-                Set<Privilege> privileges = null;
+                Set<Privilege> privileges = Set.of();
                 if (privilegesMetadata != null) {
                     privileges = privilegesMetadata.getUserPrivileges(userName);
                     if (privileges == null) {
                         // create empty set
-                        privilegesMetadata.createPrivileges(userName, Set.of());
+                        privileges = Set.of();
+                        privilegesMetadata.createPrivileges(userName, privileges);
                     }
                 }
-                roles.put(userName, Role.of(userName, role.getValue().isUser(), privileges, password));
+                roles.put(userName, new Role(userName, role.getValue().isUser(), privileges, password, Set.of()));
             }
         }
         return Collections.unmodifiableSet(new HashSet<>(roles.values()));

--- a/server/src/main/java/io/crate/role/metadata/RolesMetadata.java
+++ b/server/src/main/java/io/crate/role/metadata/RolesMetadata.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.Version;
@@ -75,11 +76,7 @@ public class RolesMetadata extends AbstractNamedDiffable<Metadata.Custom> implem
     }
 
     public void put(String name, boolean isUser, SecureHash password) {
-        if (isUser) {
-            this.roles.put(name, Role.userOf(name, password));
-        } else {
-            this.roles.put(name, Role.roleOf(name));
-        }
+        roles.put(name, new Role(name, isUser, Set.of(), password, Set.of()));
     }
 
     public boolean contains(String name) {
@@ -178,11 +175,7 @@ public class RolesMetadata extends AbstractNamedDiffable<Metadata.Custom> implem
                                         parser.currentToken());
                             }
                         }
-                        if (isUser) {
-                            roles.put(roleName, Role.userOf(roleName, secureHash));
-                        } else {
-                            roles.put(roleName, Role.roleOf(roleName));
-                        }
+                        roles.put(roleName, new Role(roleName, isUser, Set.of(), secureHash, Set.of()));
                     } else {
                         // each custom metadata is packed inside an object.
                         throw new ElasticsearchParseException("failed to parse roles, expected an object token at start");

--- a/server/src/main/java/io/crate/role/metadata/UsersPrivilegesMetadata.java
+++ b/server/src/main/java/io/crate/role/metadata/UsersPrivilegesMetadata.java
@@ -21,21 +21,6 @@
 
 package io.crate.role.metadata;
 
-import io.crate.common.annotations.VisibleForTesting;
-import io.crate.role.Privilege;
-import io.crate.role.Privilege.State;
-import io.crate.metadata.RelationName;
-import io.crate.role.PrivilegeIdent;
-import org.elasticsearch.ElasticsearchParseException;
-import org.elasticsearch.Version;
-import org.elasticsearch.cluster.AbstractNamedDiffable;
-import org.elasticsearch.cluster.metadata.Metadata;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentParser;
-
-import org.jetbrains.annotations.Nullable;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.EnumSet;
@@ -45,6 +30,22 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.AbstractNamedDiffable;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.jetbrains.annotations.Nullable;
+
+import io.crate.common.annotations.VisibleForTesting;
+import io.crate.metadata.RelationName;
+import io.crate.role.Privilege;
+import io.crate.role.Privilege.State;
+import io.crate.role.PrivilegeIdent;
 
 public class UsersPrivilegesMetadata extends AbstractNamedDiffable<Metadata.Custom> implements Metadata.Custom {
 

--- a/server/src/test/java/io/crate/action/sql/SessionsTest.java
+++ b/server/src/test/java/io/crate/action/sql/SessionsTest.java
@@ -49,6 +49,7 @@ import io.crate.metadata.NodeContext;
 import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Planner;
 import io.crate.protocols.postgres.KeyData;
+import io.crate.role.metadata.RolesHelper;
 import io.crate.sql.tree.Declare.Hold;
 import io.crate.statistics.TableStats;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
@@ -92,10 +93,10 @@ public class SessionsTest extends CrateDummyClusterServiceUnitTest {
         Roles roles = () -> List.of(Role.CRATE_USER);
         NodeContext nodeCtx = new NodeContext(functions, roles);
         Sessions sessions = newSessions(nodeCtx);
-        Session session1 = sessions.newSession("doc", Role.userOf("Arthur"));
+        Session session1 = sessions.newSession("doc", RolesHelper.userOf("Arthur"));
         session1.cursors.add("c1", newCursor());
 
-        Session session2 = sessions.newSession("doc", Role.userOf("Trillian"));
+        Session session2 = sessions.newSession("doc", RolesHelper.userOf("Trillian"));
         session2.cursors.add("c2", newCursor());
 
         assertThat(sessions.getCursors(Role.CRATE_USER)).hasSize(2);
@@ -107,7 +108,7 @@ public class SessionsTest extends CrateDummyClusterServiceUnitTest {
             null,
             "crate"
         );
-        Role admin = Role.userOf("admin", Set.of(ALprivilege), null);
+        Role admin = new Role("admin", true, Set.of(ALprivilege), null, Set.of());
         assertThat(sessions.getCursors(admin)).hasSize(2);
     }
 
@@ -118,11 +119,11 @@ public class SessionsTest extends CrateDummyClusterServiceUnitTest {
         NodeContext nodeCtx = new NodeContext(functions, roles);
         Sessions sessions = newSessions(nodeCtx);
 
-        Role arthur = Role.userOf("Arthur");
+        Role arthur = RolesHelper.userOf("Arthur");
         Session session1 = sessions.newSession("doc", arthur);
         session1.cursors.add("c1", newCursor());
 
-        Role trillian = Role.userOf("Trillian");
+        Role trillian = RolesHelper.userOf("Trillian");
         Session session2 = sessions.newSession("doc", trillian);
         session2.cursors.add("c2", newCursor());
 

--- a/server/src/test/java/io/crate/analyze/CreateViewAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateViewAnalyzerTest.java
@@ -36,13 +36,14 @@ import org.junit.Test;
 import io.crate.exceptions.InvalidRelationName;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Schemas;
+import io.crate.role.Role;
+import io.crate.role.metadata.RolesHelper;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
-import io.crate.role.Role;
 
 public class CreateViewAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
-    private static final Role TEST_USER = Role.userOf("test_user");
+    private static final Role TEST_USER = RolesHelper.userOf("test_user");
     private SQLExecutor e;
 
     @Before

--- a/server/src/test/java/io/crate/analyze/PrivilegesDCLAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/PrivilegesDCLAnalyzerTest.java
@@ -44,18 +44,19 @@ import io.crate.exceptions.RelationUnknown;
 import io.crate.exceptions.UnsupportedFeatureException;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.settings.CoordinatorSessionSettings;
-import io.crate.sql.parser.SqlParser;
-import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
-import io.crate.testing.SQLExecutor;
-import io.crate.testing.T3;
 import io.crate.role.Privilege;
 import io.crate.role.Role;
 import io.crate.role.RoleManager;
 import io.crate.role.StubRoleManager;
+import io.crate.role.metadata.RolesHelper;
+import io.crate.sql.parser.SqlParser;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+import io.crate.testing.T3;
 
 public class PrivilegesDCLAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
-    private static final Role GRANTOR_TEST_USER = Role.userOf("test");
+    private static final Role GRANTOR_TEST_USER = RolesHelper.userOf("test");
 
     private static final RoleManager USER_MANAGER = new StubRoleManager();
 

--- a/server/src/test/java/io/crate/auth/ClientCertAuthTest.java
+++ b/server/src/test/java/io/crate/auth/ClientCertAuthTest.java
@@ -41,13 +41,14 @@ import org.junit.Test;
 
 import io.crate.protocols.postgres.ConnectionProperties;
 import io.crate.role.Role;
+import io.crate.role.metadata.RolesHelper;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 
 public class ClientCertAuthTest extends ESTestCase {
 
     private ConnectionProperties sslConnWithCert;
     // "example.com" is the CN used in SelfSignedCertificate
-    private Role exampleUser = Role.userOf("example.com");
+    private Role exampleUser = RolesHelper.userOf("example.com");
     private SSLSession sslSession;
 
     @BeforeClass
@@ -82,7 +83,7 @@ public class ClientCertAuthTest extends ESTestCase {
 
     @Test
     public void testLookupValidUserWithCertWithDifferentCN() throws Exception {
-        ClientCertAuth clientCertAuth = new ClientCertAuth(() -> List.of(Role.userOf("arthur")));
+        ClientCertAuth clientCertAuth = new ClientCertAuth(() -> List.of(RolesHelper.userOf("arthur")));
         assertThatThrownBy(() -> clientCertAuth.authenticate("arthur", null, sslConnWithCert))
             .hasMessage("Common name \"example.com\" in client certificate doesn't match username \"arthur\"");
     }

--- a/server/src/test/java/io/crate/auth/HttpAuthUpstreamHandlerTest.java
+++ b/server/src/test/java/io/crate/auth/HttpAuthUpstreamHandlerTest.java
@@ -31,6 +31,7 @@ import java.security.cert.Certificate;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 
 import javax.net.ssl.SSLSession;
 
@@ -179,7 +180,7 @@ public class HttpAuthUpstreamHandlerTest extends ESTestCase {
 
     @Test
     public void testUserAuthenticationWithDisabledHBA() throws Exception {
-        Role crateUser = Role.userOf("crate", EnumSet.of(Role.UserRole.SUPERUSER));
+        Role crateUser = new Role("crate", true, Set.of(), null, EnumSet.of(Role.UserRole.SUPERUSER));
         Authentication authServiceNoHBA = new AlwaysOKAuthentication(() -> List.of(crateUser));
 
         HttpAuthUpstreamHandler handler = new HttpAuthUpstreamHandler(Settings.EMPTY, authServiceNoHBA);

--- a/server/src/test/java/io/crate/auth/UserAuthenticationMethodTest.java
+++ b/server/src/test/java/io/crate/auth/UserAuthenticationMethodTest.java
@@ -27,7 +27,6 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 
 import org.elasticsearch.common.settings.SecureString;
@@ -37,6 +36,7 @@ import org.junit.Test;
 import io.crate.role.Role;
 import io.crate.role.Roles;
 import io.crate.role.SecureHash;
+import io.crate.role.metadata.RolesHelper;
 
 public class UserAuthenticationMethodTest extends ESTestCase {
 
@@ -50,7 +50,7 @@ public class UserAuthenticationMethodTest extends ESTestCase {
             } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
                 throw new RuntimeException(e);
             }
-            return List.of(Role.userOf("crate", Collections.emptySet(), pwHash));
+            return List.of(RolesHelper.userOf("crate", pwHash));
         }
     }
 

--- a/server/src/test/java/io/crate/execution/engine/collect/stats/JobsLogsTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/stats/JobsLogsTest.java
@@ -64,8 +64,9 @@ import io.crate.expression.reference.sys.operation.OperationContextLog;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.sys.MetricsView;
 import io.crate.planner.operators.StatementClassifier.Classification;
-import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.role.Role;
+import io.crate.role.metadata.RolesHelper;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 
 public class JobsLogsTest extends CrateDummyClusterServiceUnitTest {
 
@@ -365,7 +366,7 @@ public class JobsLogsTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testExecutionStart() {
         JobsLogs jobsLogs = new JobsLogs(() -> true);
-        Role user = Role.userOf("arthur");
+        Role user = RolesHelper.userOf("arthur");
 
         Classification classification =
             new Classification(SELECT, Collections.singleton("Collect"));
@@ -384,7 +385,7 @@ public class JobsLogsTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testExecutionFailure() {
         JobsLogs jobsLogs = new JobsLogs(() -> true);
-        Role user = Role.userOf("arthur");
+        Role user = RolesHelper.userOf("arthur");
         Queue<JobContextLog> q = new BlockingEvictingQueue<>(1);
 
         jobsLogs.updateJobsLog(new QueueSink<>(q, () -> {}));
@@ -402,7 +403,7 @@ public class JobsLogsTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testExecutionFailureIsRecordedInMetrics() {
         JobsLogs jobsLogs = new JobsLogs(() -> true);
-        Role user = Role.userOf("arthur");
+        Role user = RolesHelper.userOf("arthur");
         Queue<JobContextLog> q = new BlockingEvictingQueue<>(1);
 
         jobsLogs.updateJobsLog(new QueueSink<>(q, () -> {}));

--- a/server/src/test/java/io/crate/expression/reference/StaticTableDefinitionTest.java
+++ b/server/src/test/java/io/crate/expression/reference/StaticTableDefinitionTest.java
@@ -38,13 +38,14 @@ import io.crate.metadata.SearchPath;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.settings.SessionSettings;
 import io.crate.role.Role;
+import io.crate.role.metadata.RolesHelper;
 
 public class StaticTableDefinitionTest {
 
     private final TransactionContext dummyTxnCtx = TransactionContext.of(
         new SessionSettings("", SearchPath.createSearchPathFrom("")));
 
-    private final Role dummyUser = Role.userOf("dummy");
+    private final Role dummyUser = RolesHelper.userOf("dummy");
 
     @Test
     public void testTableDefinitionWithPredicate() throws ExecutionException, InterruptedException {

--- a/server/src/test/java/io/crate/expression/scalar/HasDatabasePrivilegeFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/HasDatabasePrivilegeFunctionTest.java
@@ -33,24 +33,25 @@ import org.junit.Test;
 import io.crate.Constants;
 import io.crate.exceptions.MissingPrivilegeException;
 import io.crate.metadata.pgcatalog.OidHash;
-import io.crate.testing.Asserts;
-import io.crate.testing.SqlExpressions;
 import io.crate.role.Privilege;
 import io.crate.role.Role;
+import io.crate.role.metadata.RolesHelper;
+import io.crate.testing.Asserts;
+import io.crate.testing.SqlExpressions;
 
 public class HasDatabasePrivilegeFunctionTest extends ScalarTestCase {
 
-    private static final Role TEST_USER = Role.userOf("test");
+    private static final Role TEST_USER = RolesHelper.userOf("test");
     private static final Role TEST_USER_WITH_CREATE =
-        Role.userOf("testWithCreate",
+        RolesHelper.userOf("testWithCreate",
                 Set.of(new Privilege(Privilege.State.GRANT, Privilege.Type.DDL, Privilege.Clazz.SCHEMA, "doc", Role.CRATE_USER.name())),
                 null);
     private static final Role TEST_USER_WITH_AL_ON_CLUSTER =
-        Role.userOf("testUserWithClusterAL",
+        RolesHelper.userOf("testUserWithClusterAL",
                 Set.of(new Privilege(Privilege.State.GRANT, Privilege.Type.AL, Privilege.Clazz.CLUSTER, "crate", Role.CRATE_USER.name())),
                 null);
     private static final Role TEST_USER_WITH_DQL_ON_SYS =
-        Role.userOf("testUserWithSysDQL",
+        RolesHelper.userOf("testUserWithSysDQL",
                 Set.of(new Privilege(Privilege.State.GRANT, Privilege.Type.DQL, Privilege.Clazz.TABLE, "sys.privileges", Role.CRATE_USER.name())),
                 null);
 

--- a/server/src/test/java/io/crate/expression/scalar/HasSchemaPrivilegeFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/HasSchemaPrivilegeFunctionTest.java
@@ -34,20 +34,21 @@ import io.crate.exceptions.MissingPrivilegeException;
 import io.crate.metadata.information.InformationSchemaInfo;
 import io.crate.metadata.pgcatalog.OidHash;
 import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
-import io.crate.testing.Asserts;
-import io.crate.testing.SqlExpressions;
 import io.crate.role.Privilege;
 import io.crate.role.Role;
+import io.crate.role.metadata.RolesHelper;
+import io.crate.testing.Asserts;
+import io.crate.testing.SqlExpressions;
 
 public class HasSchemaPrivilegeFunctionTest extends ScalarTestCase {
 
-    private static final Role TEST_USER = Role.userOf("test");
+    private static final Role TEST_USER = RolesHelper.userOf("test");
     private static final Role TEST_USER_WITH_AL_ON_CLUSTER =
-        Role.userOf("testUserWithClusterAL",
+        RolesHelper.userOf("testUserWithClusterAL",
                 Set.of(new Privilege(Privilege.State.GRANT, Privilege.Type.AL, Privilege.Clazz.CLUSTER, "crate", Role.CRATE_USER.name())),
                 null);
     private static final Role TEST_USER_WITH_DQL_ON_SYS =
-        Role.userOf("testUserWithSysDQL",
+        RolesHelper.userOf("testUserWithSysDQL",
                 Set.of(new Privilege(Privilege.State.GRANT, Privilege.Type.DQL, Privilege.Clazz.TABLE, "sys.privileges", Role.CRATE_USER.name())),
                 null);
 
@@ -124,7 +125,7 @@ public class HasSchemaPrivilegeFunctionTest extends ScalarTestCase {
     @Test
     public void test_user_with_DQL_permission_has_USAGE_but_not_CREATE_privilege_for_regular_schema() {
         Privilege usage = new Privilege(Privilege.State.GRANT, Privilege.Type.DQL, Privilege.Clazz.SCHEMA, "doc", "crate");
-        var user = Role.userOf("test", Set.of(usage), null);
+        var user = RolesHelper.userOf("test", Set.of(usage), null);
         sqlExpressions = new SqlExpressions(tableSources, null, user);
         assertEvaluate("has_schema_privilege('test', 'doc', 'USAGE')", true);
         assertEvaluate("has_schema_privilege('test', 'doc', 'create, USAGE, CREATE')", true); // true if has at least one privilege
@@ -140,7 +141,7 @@ public class HasSchemaPrivilegeFunctionTest extends ScalarTestCase {
     public void test_user_with_DDL_permission_has_CREATE_but_not_USAGE_privilege_for_regular_schema() {
         // having CREATE doesn't mean having USAGE - checked in PG13 as well.
         Privilege create = new Privilege(Privilege.State.GRANT, Privilege.Type.DDL, Privilege.Clazz.SCHEMA, "doc", "crate");
-        var user = Role.userOf("test", Set.of(create), null);
+        var user = RolesHelper.userOf("test", Set.of(create), null);
         sqlExpressions = new SqlExpressions(tableSources, null, user);
         assertEvaluate("has_schema_privilege('test', 'doc', 'USAGE')", false);
         assertEvaluate("has_schema_privilege('test', 'doc', 'USAGE, CREATE')", true); // true if has at least one privilege

--- a/server/src/test/java/io/crate/integrationtests/BaseRolesIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/BaseRolesIntegrationTest.java
@@ -29,9 +29,10 @@ import org.junit.Before;
 
 import io.crate.action.sql.Session;
 import io.crate.action.sql.Sessions;
-import io.crate.testing.SQLResponse;
 import io.crate.role.Role;
 import io.crate.role.Roles;
+import io.crate.role.metadata.RolesHelper;
+import io.crate.testing.SQLResponse;
 
 public abstract class BaseRolesIntegrationTest extends IntegTestCase {
 
@@ -45,7 +46,7 @@ public abstract class BaseRolesIntegrationTest extends IntegTestCase {
 
     private Session createUserSession() {
         Sessions sqlOperations = cluster().getInstance(Sessions.class);
-        return sqlOperations.newSession(null, Role.userOf("normal"));
+        return sqlOperations.newSession(null, RolesHelper.userOf("normal"));
     }
 
     @Before

--- a/server/src/test/java/io/crate/planner/optimizer/OptimizerRuleSessionSettingProviderTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/OptimizerRuleSessionSettingProviderTest.java
@@ -40,7 +40,7 @@ import io.crate.metadata.NodeContext;
 import io.crate.metadata.SearchPath;
 import io.crate.metadata.settings.CoordinatorSessionSettings;
 import io.crate.planner.optimizer.rule.MergeFilters;
-import io.crate.role.Role;
+import io.crate.role.metadata.RolesHelper;
 
 public class OptimizerRuleSessionSettingProviderTest {
 
@@ -63,8 +63,8 @@ public class OptimizerRuleSessionSettingProviderTest {
 
         SearchPath searchPath = SearchPath.createSearchPathFrom("dummySchema");
         var mergefilterSettings = new CoordinatorSessionSettings(
-            Role.userOf("user"),
-            Role.userOf("user"),
+            RolesHelper.userOf("user"),
+            RolesHelper.userOf("user"),
             searchPath,
             true,
             Set.of(MergeFilters.class),
@@ -74,7 +74,7 @@ public class OptimizerRuleSessionSettingProviderTest {
 
         assertThat(sessionSetting.getValue(mergefilterSettings), is("false"));
 
-        var sessionSettings = new CoordinatorSessionSettings(Role.userOf("user"));
+        var sessionSettings = new CoordinatorSessionSettings(RolesHelper.userOf("user"));
 
         // Disable MergeFilters 'SET SESSION optimizer_merge_filters = false'
         sessionSetting.apply(sessionSettings, List.of(Literal.of(false)), eval);

--- a/server/src/test/java/io/crate/planner/optimizer/OptimizerTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/OptimizerTest.java
@@ -34,15 +34,15 @@ import io.crate.metadata.settings.CoordinatorSessionSettings;
 import io.crate.planner.optimizer.rule.MergeFilters;
 import io.crate.planner.optimizer.rule.MoveFilterBeneathJoin;
 import io.crate.planner.optimizer.rule.RewriteJoinPlan;
-import io.crate.role.Role;
+import io.crate.role.metadata.RolesHelper;
 
 public class OptimizerTest {
 
     @Test
     public void test_rule_filtering() {
         var sessionSettings = new CoordinatorSessionSettings(
-            Role.userOf("User"),
-            Role.userOf("User"),
+            RolesHelper.userOf("User"),
+            RolesHelper.userOf("User"),
             SearchPath.pathWithPGCatalogAndDoc(),
             true,
             Set.of(MergeFilters.class),
@@ -60,8 +60,8 @@ public class OptimizerTest {
     @Test
     public void test_non_removable_rules_are_not_filtered() {
         var sessionSettings = new CoordinatorSessionSettings(
-            Role.userOf("User"),
-            Role.userOf("User"),
+            RolesHelper.userOf("User"),
+            RolesHelper.userOf("User"),
             SearchPath.pathWithPGCatalogAndDoc(),
             true,
             Set.of(RewriteJoinPlan.class), // this rule can not be removed

--- a/server/src/test/java/io/crate/planner/statement/SetSessionAuthorizationPlanTest.java
+++ b/server/src/test/java/io/crate/planner/statement/SetSessionAuthorizationPlanTest.java
@@ -41,6 +41,7 @@ import io.crate.planner.DependencyCarrier;
 import io.crate.planner.NoopPlan;
 import io.crate.planner.Plan;
 import io.crate.planner.operators.SubQueryResults;
+import io.crate.role.metadata.RolesHelper;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.role.Role;
@@ -71,7 +72,7 @@ public class SetSessionAuthorizationPlanTest extends CrateDummyClusterServiceUni
     public void test_set_session_auth_modifies_the_session_user() throws Exception {
         var sessionSettings = e.getSessionSettings();
         sessionSettings.setSessionUser(Role.CRATE_USER);
-        var user = Role.userOf("test");
+        var user = RolesHelper.userOf("test");
         when(roleManager.findUser(eq(user.name()))).thenReturn(user);
 
         execute(e.plan("SET SESSION AUTHORIZATION " + user.name()));
@@ -82,7 +83,7 @@ public class SetSessionAuthorizationPlanTest extends CrateDummyClusterServiceUni
     @Test
     public void test_set_session_auth_to_default_sets_session_user_to_authenticated_user() throws Exception {
         var sessionSettings = e.getSessionSettings();
-        sessionSettings.setSessionUser(Role.userOf("test"));
+        sessionSettings.setSessionUser(RolesHelper.userOf("test"));
         assertThat(
             sessionSettings.sessionUser(),
             is(not(sessionSettings.authenticatedUser()))

--- a/server/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
@@ -70,6 +70,7 @@ import io.crate.execution.jobs.kill.KillJobsNodeRequest;
 import io.crate.metadata.settings.CoordinatorSessionSettings;
 import io.crate.metadata.settings.session.SessionSettingRegistry;
 import io.crate.protocols.postgres.types.PGTypes;
+import io.crate.role.metadata.RolesHelper;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.types.DataTypes;
@@ -537,7 +538,7 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
                 (user, connectionProperties) -> new AuthenticationMethod() {
                     @Override
                     public Role authenticate(String userName, @Nullable SecureString passwd, ConnectionProperties connProperties) {
-                        return Role.userOf("dummy");
+                        return RolesHelper.userOf("dummy");
                     }
 
                     @Override

--- a/server/src/test/java/io/crate/replication/logical/analyze/LogicalReplicationAnalyzerTest.java
+++ b/server/src/test/java/io/crate/replication/logical/analyze/LogicalReplicationAnalyzerTest.java
@@ -42,10 +42,10 @@ import io.crate.replication.logical.exceptions.PublicationAlreadyExistsException
 import io.crate.replication.logical.exceptions.PublicationUnknownException;
 import io.crate.replication.logical.exceptions.SubscriptionAlreadyExistsException;
 import io.crate.replication.logical.exceptions.SubscriptionUnknownException;
+import io.crate.role.metadata.RolesHelper;
 import io.crate.sql.parser.SqlParser;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
-import io.crate.role.Role;
 
 public class LogicalReplicationAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
@@ -129,12 +129,12 @@ public class LogicalReplicationAnalyzerTest extends CrateDummyClusterServiceUnit
     @Test
     public void test_drop_publication_as_non_superuser_and_non_owner_raises_error() {
         var e = SQLExecutor.builder(clusterService)
-            .setUser(Role.userOf("owner"))
+            .setUser(RolesHelper.userOf("owner"))
             .addPublication("pub1", true)
             .build();
         Assertions.assertThatThrownBy(() -> e.analyzer.analyze(
                         SqlParser.createStatement("DROP PUBLICATION pub1"),
-                        new CoordinatorSessionSettings(Role.userOf("other_user")),
+                        new CoordinatorSessionSettings(RolesHelper.userOf("other_user")),
                         ParamTypeHints.EMPTY,
                         e.cursors
             ))
@@ -178,12 +178,12 @@ public class LogicalReplicationAnalyzerTest extends CrateDummyClusterServiceUnit
     @Test
     public void test_alter_publication_as_non_superuser_and_non_owner_raises_error() {
         var e = SQLExecutor.builder(clusterService)
-            .setUser(Role.userOf("owner"))
+            .setUser(RolesHelper.userOf("owner"))
             .addPublication("pub1", false, new RelationName("doc", "t1"))
             .build();
         Assertions.assertThatThrownBy(() -> e.analyzer.analyze(
                         SqlParser.createStatement("ALTER PUBLICATION pub1 ADD TABLE doc.t2"),
-                        new CoordinatorSessionSettings(Role.userOf("other_user")),
+                        new CoordinatorSessionSettings(RolesHelper.userOf("other_user")),
                         ParamTypeHints.EMPTY,
                         e.cursors
             ))
@@ -222,12 +222,12 @@ public class LogicalReplicationAnalyzerTest extends CrateDummyClusterServiceUnit
     @Test
     public void test_drop_subscription_as_non_superuser_and_non_owner_raises_error() {
         var e = SQLExecutor.builder(clusterService)
-            .setUser(Role.userOf("owner"))
+            .setUser(RolesHelper.userOf("owner"))
             .addSubscription("sub1", "pub1")
             .build();
         Assertions.assertThatThrownBy(() -> e.analyzer.analyze(
                         SqlParser.createStatement("DROP SUBSCRIPTION sub1"),
-                        new CoordinatorSessionSettings(Role.userOf("other_user")),
+                        new CoordinatorSessionSettings(RolesHelper.userOf("other_user")),
                         ParamTypeHints.EMPTY,
                         e.cursors
             ))
@@ -238,12 +238,12 @@ public class LogicalReplicationAnalyzerTest extends CrateDummyClusterServiceUnit
     @Test
     public void test_alter_subscription_as_non_superuser_and_non_owner_raises_error() {
         var e = SQLExecutor.builder(clusterService)
-            .setUser(Role.userOf("owner"))
+            .setUser(RolesHelper.userOf("owner"))
             .addSubscription("sub1", "pub1")
             .build();
         Assertions.assertThatThrownBy(() -> e.analyzer.analyze(
                         SqlParser.createStatement("ALTER SUBSCRIPTION sub1 DISABLE"),
-                        new CoordinatorSessionSettings(Role.userOf("other_user")),
+                        new CoordinatorSessionSettings(RolesHelper.userOf("other_user")),
                         ParamTypeHints.EMPTY,
                         e.cursors
             ))

--- a/server/src/test/java/io/crate/rest/action/SqlHttpHandlerTest.java
+++ b/server/src/test/java/io/crate/rest/action/SqlHttpHandlerTest.java
@@ -44,6 +44,7 @@ import io.crate.auth.AccessControl;
 import io.crate.auth.AuthSettings;
 import io.crate.metadata.settings.CoordinatorSessionSettings;
 import io.crate.role.Role;
+import io.crate.role.metadata.RolesHelper;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.FullHttpRequest;
 
@@ -73,7 +74,7 @@ public class SqlHttpHandlerTest {
             settings,
             mock(Sessions.class),
             (s) -> new NoopCircuitBreaker("dummy"),
-            () -> List.of(Role.userOf("trillian")),
+            () -> List.of(RolesHelper.userOf("trillian")),
             sessionSettings -> AccessControl.DISABLED,
             Netty4CorsConfigBuilder.forAnyOrigin().build()
         );
@@ -88,7 +89,7 @@ public class SqlHttpHandlerTest {
             Settings.EMPTY,
             mock(Sessions.class),
             (s) -> new NoopCircuitBreaker("dummy"),
-            () -> List.of(Role.userOf("Aladdin")),
+            () -> List.of(RolesHelper.userOf("Aladdin")),
             sessionSettings -> AccessControl.DISABLED,
             Netty4CorsConfigBuilder.forAnyOrigin().build()
         );
@@ -99,7 +100,7 @@ public class SqlHttpHandlerTest {
 
     @Test
     public void testSessionSettingsArePreservedAcrossRequests() {
-        Role dummyUser = Role.userOf("crate");
+        Role dummyUser = RolesHelper.userOf("crate");
         var sessionSettings = new CoordinatorSessionSettings(dummyUser);
 
         var mockedSession = mock(Session.class);

--- a/server/src/test/java/io/crate/role/PrivilegesTest.java
+++ b/server/src/test/java/io/crate/role/PrivilegesTest.java
@@ -27,10 +27,11 @@ import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
 
 import io.crate.exceptions.MissingPrivilegeException;
+import io.crate.role.metadata.RolesHelper;
 
 public class PrivilegesTest extends ESTestCase {
 
-    private static final Role USER = Role.userOf("ford");
+    private static final Role USER = RolesHelper.userOf("ford");
 
     @Test
     public void testExceptionIsThrownIfUserHasNotRequiredPrivilege() throws Exception {

--- a/server/src/test/java/io/crate/role/RolesServiceTest.java
+++ b/server/src/test/java/io/crate/role/RolesServiceTest.java
@@ -22,7 +22,7 @@
 package io.crate.role;
 
 import static io.crate.role.Role.CRATE_USER;
-import static io.crate.role.metadata.RolesDefinitions.DUMMY_USERS_AND_ROLES;
+import static io.crate.role.metadata.RolesHelper.DUMMY_USERS_AND_ROLES;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
@@ -31,7 +31,7 @@ import java.util.Set;
 import org.junit.Test;
 
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
-import io.crate.role.metadata.RolesDefinitions;
+import io.crate.role.metadata.RolesHelper;
 import io.crate.role.metadata.RolesMetadata;
 import io.crate.role.metadata.UsersMetadata;
 import io.crate.role.metadata.UsersPrivilegesMetadata;
@@ -52,13 +52,13 @@ public class RolesServiceTest extends CrateDummyClusterServiceUnitTest {
     public void testUsersAndRoles() {
         Set<Role> roles = RolesService.getRoles(
             null,
-            new RolesMetadata(RolesDefinitions.DUMMY_USERS_AND_ROLES),
+            new RolesMetadata(RolesHelper.DUMMY_USERS_AND_ROLES),
             new UsersPrivilegesMetadata());
 
         assertThat(roles).containsExactlyInAnyOrder(
             DUMMY_USERS_AND_ROLES.get("Ford"),
             DUMMY_USERS_AND_ROLES.get("John"),
-            Role.roleOf("DummyRole"),
+            RolesHelper.roleOf("DummyRole"),
             CRATE_USER);
     }
 
@@ -66,11 +66,11 @@ public class RolesServiceTest extends CrateDummyClusterServiceUnitTest {
     public void test_old_users_metadata_is_preferred_over_roles_metadata() {
         Set<Role> roles = RolesService.getRoles(
             new UsersMetadata(Collections.singletonMap("Arthur", null)),
-            new RolesMetadata(RolesDefinitions.DUMMY_USERS_AND_ROLES),
+            new RolesMetadata(RolesHelper.DUMMY_USERS_AND_ROLES),
             new UsersPrivilegesMetadata());
 
         assertThat(roles).containsExactlyInAnyOrder(
-            Role.userOf("Arthur"),
+            RolesHelper.userOf("Arthur"),
             CRATE_USER);
     }
 }

--- a/server/src/test/java/io/crate/role/TransportPrivilegesActionTest.java
+++ b/server/src/test/java/io/crate/role/TransportPrivilegesActionTest.java
@@ -36,7 +36,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
 
 import io.crate.role.metadata.RolesMetadata;
-import io.crate.role.metadata.RolesDefinitions;
+import io.crate.role.metadata.RolesHelper;
 import io.crate.role.metadata.UsersPrivilegesMetadata;
 
 public class TransportPrivilegesActionTest extends ESTestCase {
@@ -79,7 +79,7 @@ public class TransportPrivilegesActionTest extends ESTestCase {
     @Test
     public void testValidateUserNamesMissingUser() throws Exception {
         Metadata metadata = Metadata.builder()
-            .putCustom(RolesMetadata.TYPE, new RolesMetadata(RolesDefinitions.SINGLE_USER_ONLY))
+            .putCustom(RolesMetadata.TYPE, new RolesMetadata(RolesHelper.SINGLE_USER_ONLY))
             .build();
         List<String> userNames = List.of("Ford", "Arthur");
         List<String> unknownUserNames = TransportPrivilegesAction.validateUserNames(metadata, userNames);
@@ -89,7 +89,7 @@ public class TransportPrivilegesActionTest extends ESTestCase {
     @Test
     public void testValidateUserNamesAllExists() throws Exception {
         Metadata metadata = Metadata.builder()
-            .putCustom(RolesMetadata.TYPE, new RolesMetadata(RolesDefinitions.DUMMY_USERS))
+            .putCustom(RolesMetadata.TYPE, new RolesMetadata(RolesHelper.DUMMY_USERS))
             .build();
         List<String> unknownUserNames = TransportPrivilegesAction.validateUserNames(metadata, List.of("Ford", "Arthur"));
         assertThat(unknownUserNames).isEmpty();

--- a/server/src/test/java/io/crate/role/TransportRoleActionTest.java
+++ b/server/src/test/java/io/crate/role/TransportRoleActionTest.java
@@ -21,12 +21,12 @@
 
 package io.crate.role;
 
+import static io.crate.role.metadata.RolesHelper.DUMMY_USERS;
+import static io.crate.role.metadata.RolesHelper.DUMMY_USERS_AND_ROLES;
+import static io.crate.role.metadata.RolesHelper.SINGLE_USER_ONLY;
+import static io.crate.role.metadata.RolesHelper.getSecureHash;
+import static io.crate.role.metadata.RolesHelper.usersMetadataOf;
 import static io.crate.testing.Asserts.assertThat;
-import static io.crate.role.metadata.RolesDefinitions.DUMMY_USERS;
-import static io.crate.role.metadata.RolesDefinitions.DUMMY_USERS_AND_ROLES;
-import static io.crate.role.metadata.RolesDefinitions.SINGLE_USER_ONLY;
-import static io.crate.role.metadata.RolesDefinitions.getSecureHash;
-import static io.crate.role.metadata.RolesDefinitions.usersMetadataOf;
 
 import java.util.Map;
 
@@ -34,6 +34,7 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
 
+import io.crate.role.metadata.RolesHelper;
 import io.crate.role.metadata.RolesMetadata;
 import io.crate.role.metadata.UsersMetadata;
 import io.crate.role.metadata.UsersPrivilegesMetadata;
@@ -84,7 +85,7 @@ public class TransportRoleActionTest extends ESTestCase {
         assertThat(roles(mdBuilder)).containsExactlyInAnyOrderEntriesOf(
             Map.of("Arthur", DUMMY_USERS.get("Arthur"),
                 "Ford", DUMMY_USERS.get("Ford"),
-                "RoleFoo", Role.roleOf("RoleFoo")));
+                "RoleFoo", RolesHelper.roleOf("RoleFoo")));
     }
 
     @Test
@@ -98,7 +99,7 @@ public class TransportRoleActionTest extends ESTestCase {
         boolean res = TransportAlterRoleAction.alterRole(mdBuilder, "Arthur", newPasswd);
         assertThat(res).isTrue();
         assertThat(roles(mdBuilder)).containsExactlyInAnyOrderEntriesOf(
-            Map.of("Arthur", Role.userOf("Arthur", newPasswd),
+            Map.of("Arthur", RolesHelper.userOf("Arthur", newPasswd),
                 "Ford", DUMMY_USERS.get("Ford")));
     }
 

--- a/server/src/test/java/io/crate/role/metadata/CustomMetadataTest.java
+++ b/server/src/test/java/io/crate/role/metadata/CustomMetadataTest.java
@@ -46,7 +46,7 @@ public class CustomMetadataTest {
     public void testAllMetadataXContentRoundtrip() throws IOException {
         Metadata metadata = Metadata.builder()
             .putCustom(RolesMetadata.TYPE,
-                new RolesMetadata(RolesDefinitions.DUMMY_USERS))
+                new RolesMetadata(RolesHelper.DUMMY_USERS))
             .putCustom(UserDefinedFunctionsMetadata.TYPE,
                 UserDefinedFunctionsMetadataTest.DUMMY_UDF_METADATA)
             .putCustom(UsersPrivilegesMetadata.TYPE,

--- a/server/src/test/java/io/crate/role/metadata/RolesHelper.java
+++ b/server/src/test/java/io/crate/role/metadata/RolesHelper.java
@@ -27,40 +27,43 @@ import java.security.GeneralSecurityException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import org.elasticsearch.common.settings.SecureString;
+import org.jetbrains.annotations.Nullable;
 
+import io.crate.role.Privilege;
 import io.crate.role.Role;
 import io.crate.role.SecureHash;
 
-public final class RolesDefinitions {
+public final class RolesHelper {
 
-    public static final Map<String, Role> SINGLE_USER_ONLY = Collections.singletonMap("Arthur", Role.userOf("Arthur"));
+    public static final Map<String, Role> SINGLE_USER_ONLY = Collections.singletonMap("Arthur", userOf("Arthur"));
 
     public static final Map<String, Role> DUMMY_USERS = Map.of(
-        "Ford", Role.userOf("Ford", getSecureHash("fords-password")),
-        "Arthur", Role.userOf("Arthur", getSecureHash("arthurs-password"))
+        "Ford", userOf("Ford", getSecureHash("fords-password")),
+        "Arthur", userOf("Arthur", getSecureHash("arthurs-password"))
     );
 
     public static final Map<String, Role> DUMMY_USERS_WITHOUT_PASSWORD = Map.of(
-        "Ford", Role.userOf("Ford"),
-        "Arthur", Role.userOf("Arthur")
+        "Ford", userOf("Ford"),
+        "Arthur", userOf("Arthur")
     );
 
     public static final Map<String, Role> DUMMY_USERS_AND_ROLES = new HashMap<>();
 
     static {
-        DUMMY_USERS_AND_ROLES.put("Ford", Role.userOf("Ford", getSecureHash("fords-pwd")));
-        DUMMY_USERS_AND_ROLES.put("John", Role.userOf("John", getSecureHash("johns-pwd")));
-        DUMMY_USERS_AND_ROLES.put("DummyRole", Role.roleOf("DummyRole"));
+        DUMMY_USERS_AND_ROLES.put("Ford", userOf("Ford", getSecureHash("fords-pwd")));
+        DUMMY_USERS_AND_ROLES.put("John", userOf("John", getSecureHash("johns-pwd")));
+        DUMMY_USERS_AND_ROLES.put("DummyRole", roleOf("DummyRole"));
     }
 
     public static final Map<String, Role> DUMMY_USERS_AND_ROLES_WITHOUT_PASSWORD = new HashMap<>();
 
     static {
-        DUMMY_USERS_AND_ROLES_WITHOUT_PASSWORD.put("Ford", Role.userOf("Ford"));
-        DUMMY_USERS_AND_ROLES_WITHOUT_PASSWORD.put("John", Role.userOf("John"));
-        DUMMY_USERS_AND_ROLES_WITHOUT_PASSWORD.put("DummyRole", Role.roleOf("DummyRole"));
+        DUMMY_USERS_AND_ROLES_WITHOUT_PASSWORD.put("Ford", userOf("Ford"));
+        DUMMY_USERS_AND_ROLES_WITHOUT_PASSWORD.put("John", userOf("John"));
+        DUMMY_USERS_AND_ROLES_WITHOUT_PASSWORD.put("DummyRole", roleOf("DummyRole"));
     }
 
     public static UsersMetadata usersMetadataOf(Map<String, Role> users) {
@@ -81,5 +84,21 @@ public final class RolesDefinitions {
         }
         assertThat(hash).isNotNull();
         return hash;
+    }
+
+    public static Role userOf(String name) {
+        return userOf(name, null);
+    }
+
+    public static Role userOf(String name, @Nullable SecureHash password) {
+        return userOf(name, Set.of(), password);
+    }
+
+    public static Role userOf(String name, Set<Privilege> privileges, @Nullable SecureHash password) {
+        return new Role(name, true, privileges, password, Set.of());
+    }
+
+    public static Role roleOf(String name) {
+        return new Role(name, false, Set.of(), null, Set.of());
     }
 }

--- a/server/src/test/java/io/crate/role/metadata/RolesMetadataTest.java
+++ b/server/src/test/java/io/crate/role/metadata/RolesMetadataTest.java
@@ -22,7 +22,7 @@
 package io.crate.role.metadata;
 
 import static io.crate.testing.Asserts.assertThat;
-import static io.crate.role.metadata.RolesDefinitions.usersMetadataOf;
+import static io.crate.role.metadata.RolesHelper.usersMetadataOf;
 
 import java.io.IOException;
 import java.util.Map;
@@ -43,7 +43,7 @@ public class RolesMetadataTest extends ESTestCase {
 
     @Test
     public void test_roles_metadata_streaming() throws IOException {
-        RolesMetadata roles = new RolesMetadata(RolesDefinitions.DUMMY_USERS_AND_ROLES);
+        RolesMetadata roles = new RolesMetadata(RolesHelper.DUMMY_USERS_AND_ROLES);
         BytesStreamOutput out = new BytesStreamOutput();
         roles.writeTo(out);
 
@@ -59,7 +59,7 @@ public class RolesMetadataTest extends ESTestCase {
         // reflects the logic used to process custom metadata in the cluster state
         builder.startObject();
 
-        RolesMetadata roles = new RolesMetadata(RolesDefinitions.DUMMY_USERS_AND_ROLES);
+        RolesMetadata roles = new RolesMetadata(RolesHelper.DUMMY_USERS_AND_ROLES);
         roles.toXContent(builder, ToXContent.EMPTY_PARAMS);
         builder.endObject();
 
@@ -82,7 +82,7 @@ public class RolesMetadataTest extends ESTestCase {
         // reflects the logic used to process custom metadata in the cluster state
         builder.startObject();
 
-        RolesMetadata roles = new RolesMetadata(RolesDefinitions.DUMMY_USERS_AND_ROLES_WITHOUT_PASSWORD);
+        RolesMetadata roles = new RolesMetadata(RolesHelper.DUMMY_USERS_AND_ROLES_WITHOUT_PASSWORD);
         roles.toXContent(builder, ToXContent.EMPTY_PARAMS);
         builder.endObject();
 
@@ -100,7 +100,7 @@ public class RolesMetadataTest extends ESTestCase {
 
     @Test
     public void test_roles_metadata_with_attributes_streaming() throws Exception {
-        RolesMetadata writeRolesMeta = new RolesMetadata(RolesDefinitions.DUMMY_USERS_AND_ROLES);
+        RolesMetadata writeRolesMeta = new RolesMetadata(RolesHelper.DUMMY_USERS_AND_ROLES);
         BytesStreamOutput out = new BytesStreamOutput();
         writeRolesMeta.writeTo(out);
 
@@ -112,22 +112,22 @@ public class RolesMetadataTest extends ESTestCase {
 
     @Test
     public void test_add_old_users_metadata_to_roles_metadata() {
-        RolesMetadata rolesMetadata = RolesMetadata.ofOldUsersMetadata(usersMetadataOf(RolesDefinitions.DUMMY_USERS));
+        RolesMetadata rolesMetadata = RolesMetadata.ofOldUsersMetadata(usersMetadataOf(RolesHelper.DUMMY_USERS));
         assertThat(rolesMetadata.roles()).containsExactlyInAnyOrderEntriesOf(
-            Map.of("Arthur", RolesDefinitions.DUMMY_USERS.get("Arthur"),
-                "Ford", RolesDefinitions.DUMMY_USERS.get("Ford")));
+            Map.of("Arthur", RolesHelper.DUMMY_USERS.get("Arthur"),
+                "Ford", RolesHelper.DUMMY_USERS.get("Ford")));
     }
 
     @Test
     public void test_roles_metadata_from_cluster_state() {
-        var oldUsersMetadata = usersMetadataOf(RolesDefinitions.DUMMY_USERS);
-        var oldRolesMetadata = new RolesMetadata(RolesDefinitions.DUMMY_USERS_AND_ROLES);
+        var oldUsersMetadata = usersMetadataOf(RolesHelper.DUMMY_USERS);
+        var oldRolesMetadata = new RolesMetadata(RolesHelper.DUMMY_USERS_AND_ROLES);
         Metadata.Builder mdBuilder = new Metadata.Builder()
             .putCustom(UsersMetadata.TYPE, oldUsersMetadata)
             .putCustom(RolesMetadata.TYPE, oldRolesMetadata);
         var newRolesMetadata = RolesMetadata.of(mdBuilder, oldUsersMetadata, oldRolesMetadata);
         assertThat(newRolesMetadata.roles()).containsExactlyInAnyOrderEntriesOf(
-            Map.of("Arthur", RolesDefinitions.DUMMY_USERS.get("Arthur"),
-                "Ford", RolesDefinitions.DUMMY_USERS.get("Ford")));
+            Map.of("Arthur", RolesHelper.DUMMY_USERS.get("Arthur"),
+                "Ford", RolesHelper.DUMMY_USERS.get("Ford")));
     }
 }

--- a/server/src/test/java/io/crate/role/metadata/UsersMetadataTest.java
+++ b/server/src/test/java/io/crate/role/metadata/UsersMetadataTest.java
@@ -47,7 +47,7 @@ public class UsersMetadataTest extends ESTestCase {
 
     @Test
     public void testUsersMetadataStreaming() throws IOException {
-        UsersMetadata users = of(RolesDefinitions.SINGLE_USER_ONLY);
+        UsersMetadata users = of(RolesHelper.SINGLE_USER_ONLY);
         BytesStreamOutput out = new BytesStreamOutput();
         users.writeTo(out);
 
@@ -63,7 +63,7 @@ public class UsersMetadataTest extends ESTestCase {
         // reflects the logic used to process custom metadata in the cluster state
         builder.startObject();
 
-        UsersMetadata users = of(RolesDefinitions.DUMMY_USERS_WITHOUT_PASSWORD);
+        UsersMetadata users = of(RolesHelper.DUMMY_USERS_WITHOUT_PASSWORD);
         users.toXContent(builder, ToXContent.EMPTY_PARAMS);
         builder.endObject();
 
@@ -86,7 +86,7 @@ public class UsersMetadataTest extends ESTestCase {
         // reflects the logic used to process custom metadata in the cluster state
         builder.startObject();
 
-        UsersMetadata users = of(RolesDefinitions.SINGLE_USER_ONLY);
+        UsersMetadata users = of(RolesHelper.SINGLE_USER_ONLY);
         users.toXContent(builder, ToXContent.EMPTY_PARAMS);
         builder.endObject();
 
@@ -104,7 +104,7 @@ public class UsersMetadataTest extends ESTestCase {
 
     @Test
     public void testUserMetadataWithAttributesStreaming() throws Exception {
-        UsersMetadata writeUserMeta = of(RolesDefinitions.DUMMY_USERS);
+        UsersMetadata writeUserMeta = of(RolesHelper.DUMMY_USERS);
         BytesStreamOutput out = new BytesStreamOutput();
         writeUserMeta.writeTo(out);
 

--- a/server/src/test/java/io/crate/role/scalar/UserFunctionTest.java
+++ b/server/src/test/java/io/crate/role/scalar/UserFunctionTest.java
@@ -29,12 +29,13 @@ import org.junit.Test;
 
 import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.expression.symbol.Symbol;
+import io.crate.role.metadata.RolesHelper;
 import io.crate.testing.SqlExpressions;
 import io.crate.role.Role;
 
 public class UserFunctionTest extends ScalarTestCase {
 
-    private static final Role TEST_USER = Role.userOf("testUser");
+    private static final Role TEST_USER = RolesHelper.userOf("testUser");
 
     @Before
     public void prepare() {

--- a/server/src/testFixtures/java/io/crate/expression/scalar/ScalarTestCase.java
+++ b/server/src/testFixtures/java/io/crate/expression/scalar/ScalarTestCase.java
@@ -55,12 +55,13 @@ import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocSchemaInfo;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.settings.SessionSettings;
+import io.crate.role.Role;
+import io.crate.role.Roles;
+import io.crate.role.metadata.RolesHelper;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.testing.SqlExpressions;
 import io.crate.types.DataType;
-import io.crate.role.Role;
-import io.crate.role.Roles;
 
 public abstract class ScalarTestCase extends CrateDummyClusterServiceUnitTest {
 
@@ -260,7 +261,7 @@ public abstract class ScalarTestCase extends CrateDummyClusterServiceUnitTest {
     @SuppressWarnings("rawtypes")
     public void assertCompile(String functionExpression,
                               java.util.function.Function<Scalar, Consumer<Scalar>> matcher) {
-        assertCompile(functionExpression, Role.userOf("dummy"), () -> List.of(Role.userOf("dummy")), matcher);
+        assertCompile(functionExpression, RolesHelper.userOf("dummy"), () -> List.of(RolesHelper.userOf("dummy")), matcher);
     }
 
     @SuppressWarnings("rawtypes")


### PR DESCRIPTION
All these methods were only used in tests.
The only occurence in non-test code was questionable and is replaced by using the real ctor.

Follow up of 0de436ea97821e037a8e8f87d83f2f63fe840aff.
