### PR TITLE
Move privileges resolution to Roles/RolesService

### DIFF
--- a/libs/shared/src/main/java/io/crate/common/FourFunction.java
+++ b/libs/shared/src/main/java/io/crate/common/FourFunction.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.common;
+
+/**
+ * Represents a function that accepts three arguments and produces a result.
+ *
+ * @param <A> the type of the first argument
+ * @param <B> the type of the second argument
+ * @param <C> the type of the third argument
+ * @param <D> the type of the fourth argument
+ * @param <R> the return type
+ */
+@FunctionalInterface
+public interface FourFunction<A, B, C, D, R> {
+    /**
+     * Applies this function to the given arguments.
+     *
+     * @param a the first function argument
+     * @param b the second function argument
+     * @param c the third function argument
+     * @param d the fourth function argument
+     * @return the result
+     */
+    R apply(A a, B b, C c, D d);
+}

--- a/server/src/main/java/io/crate/action/sql/Sessions.java
+++ b/server/src/main/java/io/crate/action/sql/Sessions.java
@@ -49,10 +49,10 @@ import io.crate.metadata.settings.CoordinatorSessionSettings;
 import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Planner;
 import io.crate.protocols.postgres.KeyData;
-import io.crate.statistics.TableStats;
 import io.crate.role.Privilege.Clazz;
 import io.crate.role.Privilege.Type;
 import io.crate.role.Role;
+import io.crate.statistics.TableStats;
 
 
 @Singleton
@@ -211,7 +211,7 @@ public class Sessions {
     public Iterable<Cursor> getCursors(Role user) {
         return () -> sessions.values().stream()
             .filter(session ->
-                user.hasPrivilege(Type.AL, Clazz.CLUSTER, null)
+                nodeCtx.roles().hasPrivilege(user, Type.AL, Clazz.CLUSTER, null)
                 || session.sessionSettings().sessionUser().equals(user))
             .flatMap(session -> StreamSupport.stream(session.cursors.spliterator(), false))
             .iterator();

--- a/server/src/main/java/io/crate/execution/engine/collect/sources/ShardCollectSource.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/sources/ShardCollectSource.java
@@ -170,7 +170,7 @@ public class ShardCollectSource implements CollectSource, IndexEventListener {
                               ShardCollectorProviderFactory shardCollectorProviderFactory) {
         this.unassignedShardReferenceResolver = new StaticTableReferenceResolver<>(
             SysShardsTableInfo.unassignedShardsExpressions());
-        this.shardReferenceResolver = new StaticTableReferenceResolver<>(SysShardsTableInfo.create().expressions());
+        this.shardReferenceResolver = new StaticTableReferenceResolver<>(SysShardsTableInfo.create(nodeCtx.roles()).expressions());
         this.indicesService = indicesService;
         this.clusterService = clusterService;
         this.remoteCollectorFactory = remoteCollectorFactory;

--- a/server/src/main/java/io/crate/expression/scalar/HasDatabasePrivilegeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/HasDatabasePrivilegeFunction.java
@@ -26,23 +26,23 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.function.BiFunction;
 
-import org.elasticsearch.common.TriFunction;
 import org.jetbrains.annotations.Nullable;
 
 import io.crate.Constants;
+import io.crate.common.FourFunction;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
-import io.crate.types.DataTypes;
 import io.crate.role.Privilege;
 import io.crate.role.Role;
 import io.crate.role.Roles;
+import io.crate.types.DataTypes;
 
 public class HasDatabasePrivilegeFunction extends HasPrivilegeFunction {
 
     public static final String NAME = "has_database_privilege";
 
-    private static final TriFunction<Role, Object, Collection<Privilege.Type>, Boolean> CHECK_BY_DB_NAME =
-        (user, db, privileges) -> {
+    private static final FourFunction<Roles, Role, Object, Collection<Privilege.Type>, Boolean> CHECK_BY_DB_NAME =
+        (roles, user, db, privileges) -> {
             if (Constants.DB_NAME.equals(db) == false) {
                 throw new IllegalArgumentException(String.format(Locale.ENGLISH,
                                                                  "database \"%s\" does not exist",
@@ -51,8 +51,8 @@ public class HasDatabasePrivilegeFunction extends HasPrivilegeFunction {
             return checkPrivileges(user, privileges);
         };
 
-    private static final TriFunction<Role, Object, Collection<Privilege.Type>, Boolean> CHECK_BY_DB_OID =
-        (user, db, privileges) -> {
+    private static final FourFunction<Roles, Role, Object, Collection<Privilege.Type>, Boolean> CHECK_BY_DB_OID =
+        (roles, user, db, privileges) -> {
             if (Constants.DB_OID != (Integer) db) {
                 throw new IllegalArgumentException(String.format(Locale.ENGLISH,
                                                                  "database with OID \"%d\" does not exist",
@@ -194,7 +194,7 @@ public class HasDatabasePrivilegeFunction extends HasPrivilegeFunction {
     protected HasDatabasePrivilegeFunction(Signature signature,
                                            BoundSignature boundSignature,
                                            BiFunction<Roles, Object, Role> getUser,
-                                           TriFunction<Role, Object, Collection<Privilege.Type>, Boolean> checkPrivilege) {
+                                           FourFunction<Roles, Role, Object, Collection<Privilege.Type>, Boolean> checkPrivilege) {
         super(signature, boundSignature, getUser, checkPrivilege);
     }
 }

--- a/server/src/main/java/io/crate/metadata/SystemTable.java
+++ b/server/src/main/java/io/crate/metadata/SystemTable.java
@@ -21,6 +21,8 @@
 
 package io.crate.metadata;
 
+import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -53,8 +55,6 @@ import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.ObjectType;
-
-import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
 
 public final class SystemTable<T> implements TableInfo {
 

--- a/server/src/main/java/io/crate/metadata/blob/BlobTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/blob/BlobTableInfo.java
@@ -30,11 +30,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.jetbrains.annotations.Nullable;
-
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.common.settings.Settings;
+import org.jetbrains.annotations.Nullable;
 
 import io.crate.analyze.TableParameters;
 import io.crate.analyze.WhereClause;

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
@@ -41,6 +41,7 @@ import io.crate.replication.logical.metadata.pgcatalog.PgPublicationTable;
 import io.crate.replication.logical.metadata.pgcatalog.PgPublicationTablesTable;
 import io.crate.replication.logical.metadata.pgcatalog.PgSubscriptionRelTable;
 import io.crate.replication.logical.metadata.pgcatalog.PgSubscriptionTable;
+import io.crate.role.Roles;
 import io.crate.statistics.TableStats;
 
 @Singleton
@@ -52,7 +53,7 @@ public final class PgCatalogSchemaInfo implements SchemaInfo {
     private final SystemTable<PgClassTable.Entry> pgClassTable;
 
     @Inject
-    public PgCatalogSchemaInfo(UserDefinedFunctionService udfService, TableStats tableStats) {
+    public PgCatalogSchemaInfo(UserDefinedFunctionService udfService, TableStats tableStats, Roles roles) {
         this.udfService = udfService;
         this.pgClassTable = PgClassTable.create(tableStats);
         tableInfoMap = Map.<String, TableInfo>ofEntries(
@@ -70,7 +71,7 @@ public final class PgCatalogSchemaInfo implements SchemaInfo {
             Map.entry(PgProcTable.IDENT.name(), PgProcTable.create()),
             Map.entry(PgRangeTable.IDENT.name(), PgRangeTable.create()),
             Map.entry(PgEnumTable.IDENT.name(), PgEnumTable.create()),
-            Map.entry(PgRolesTable.IDENT.name(), PgRolesTable.create()),
+            Map.entry(PgRolesTable.IDENT.name(), PgRolesTable.create(roles)),
             Map.entry(PgAmTable.IDENT.name(), PgAmTable.create()),
             Map.entry(PgTablespaceTable.IDENT.name(), PgTablespaceTable.create()),
             Map.entry(PgIndexesTable.IDENT.name(), PgIndexesTable.create()),

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
@@ -44,9 +44,9 @@ import io.crate.replication.logical.metadata.pgcatalog.PgPublicationTable;
 import io.crate.replication.logical.metadata.pgcatalog.PgPublicationTablesTable;
 import io.crate.replication.logical.metadata.pgcatalog.PgSubscriptionRelTable;
 import io.crate.replication.logical.metadata.pgcatalog.PgSubscriptionTable;
-import io.crate.statistics.TableStats;
 import io.crate.role.Privilege;
-import io.crate.role.RoleManagerService;
+import io.crate.role.Roles;
+import io.crate.statistics.TableStats;
 
 public final class PgCatalogTableDefinitions {
 
@@ -60,11 +60,11 @@ public final class PgCatalogTableDefinitions {
                                      SessionSettingRegistry sessionSettingRegistry,
                                      Schemas schemas,
                                      LogicalReplicationService logicalReplicationService,
-                                     RoleManagerService roleManagerService) {
+                                     Roles roles) {
         tableDefinitions = new HashMap<>();
         tableDefinitions.put(PgStatsTable.NAME, new StaticTableDefinition<>(
                 tableStats::statsEntries,
-                (user, t) -> user.hasAnyPrivilege(Privilege.Clazz.TABLE, t.relation().fqn()),
+                (user, t) -> roles.hasAnyPrivilege(user, Privilege.Clazz.TABLE, t.relation().fqn()),
                 PgStatsTable.create().expressions()
             )
         );
@@ -74,15 +74,15 @@ public final class PgCatalogTableDefinitions {
             false));
         tableDefinitions.put(PgClassTable.IDENT, new StaticTableDefinition<>(
             informationSchemaIterables::pgClasses,
-            (user, t) -> user.hasAnyPrivilege(Privilege.Clazz.TABLE, t.ident.fqn())
+            (user, t) -> roles.hasAnyPrivilege(user, Privilege.Clazz.TABLE, t.ident.fqn())
                          // we also need to check for views which have privileges set
-                         || user.hasAnyPrivilege(Privilege.Clazz.VIEW, t.ident.fqn())
+                         || roles.hasAnyPrivilege(user, Privilege.Clazz.VIEW, t.ident.fqn())
                          || isPgCatalogOrInformationSchema(t.ident.schema()),
             pgCatalogSchemaInfo.pgClassTable().expressions()
         ));
         tableDefinitions.put(PgProcTable.IDENT, new StaticTableDefinition<>(
             informationSchemaIterables::pgProc,
-            (user, f) -> user.hasAnyPrivilege(Privilege.Clazz.SCHEMA, f.functionName.schema())
+            (user, f) -> roles.hasAnyPrivilege(user, Privilege.Clazz.SCHEMA, f.functionName.schema())
                          || f.functionName.isBuiltin(),
             PgProcTable.create().expressions())
         );
@@ -93,16 +93,16 @@ public final class PgCatalogTableDefinitions {
         tableDefinitions.put(PgNamespaceTable.IDENT, new StaticTableDefinition<>(
             informationSchemaIterables::schemas,
             (user, s) -> {
-                if (user.hasAnyPrivilege(Privilege.Clazz.SCHEMA, s.name()) || isPgCatalogOrInformationSchema(s.name())) {
+                if (roles.hasAnyPrivilege(user, Privilege.Clazz.SCHEMA, s.name()) || isPgCatalogOrInformationSchema(s.name())) {
                     return true;
                 }
                 for (var table : s.getTables()) {
-                    if (user.hasAnyPrivilege(Privilege.Clazz.TABLE, table.ident().fqn())) {
+                    if (roles.hasAnyPrivilege(user, Privilege.Clazz.TABLE, table.ident().fqn())) {
                         return true;
                     }
                 }
                 for (var view : s.getViews()) {
-                    if (user.hasAnyPrivilege(Privilege.Clazz.VIEW, view.ident().fqn())) {
+                    if (roles.hasAnyPrivilege(user, Privilege.Clazz.VIEW, view.ident().fqn())) {
                         return true;
                     }
                 }
@@ -116,8 +116,8 @@ public final class PgCatalogTableDefinitions {
             false));
         tableDefinitions.put(PgAttributeTable.IDENT, new StaticTableDefinition<>(
             informationSchemaIterables::columns,
-            (user, c) -> user.hasAnyPrivilege(Privilege.Clazz.TABLE, c.relation().ident().fqn())
-                         || user.hasAnyPrivilege(Privilege.Clazz.VIEW, c.relation().ident().fqn())
+            (user, c) -> roles.hasAnyPrivilege(user, Privilege.Clazz.TABLE, c.relation().ident().fqn())
+                         || roles.hasAnyPrivilege(user, Privilege.Clazz.VIEW, c.relation().ident().fqn())
                          || isPgCatalogOrInformationSchema(c.relation().ident().schema()),
             PgAttributeTable.create().expressions()
         ));
@@ -127,7 +127,7 @@ public final class PgCatalogTableDefinitions {
             false));
         tableDefinitions.put(PgConstraintTable.IDENT, new StaticTableDefinition<>(
             informationSchemaIterables::pgConstraints,
-            (user, t) -> user.hasAnyPrivilege(Privilege.Clazz.TABLE, t.relationName().fqn())
+            (user, t) -> roles.hasAnyPrivilege(user, Privilege.Clazz.TABLE, t.relationName().fqn())
                          || isPgCatalogOrInformationSchema(t.relationName().schema()),
             PgConstraintTable.create().expressions()
         ));
@@ -147,8 +147,8 @@ public final class PgCatalogTableDefinitions {
             false
         ));
         tableDefinitions.put(PgRolesTable.IDENT, new StaticTableDefinition<>(
-            () -> completedFuture(roleManagerService.roles()),
-            PgRolesTable.create().expressions(),
+            () -> completedFuture(roles.roles()),
+            PgRolesTable.create(roles).expressions(),
             false
         ));
         tableDefinitions.put(PgAmTable.IDENT, new StaticTableDefinition<>(
@@ -212,13 +212,13 @@ public final class PgCatalogTableDefinitions {
 
         tableDefinitions.put(PgTablesTable.IDENT, new StaticTableDefinition<>(
             informationSchemaIterables::tables,
-            (user, t) -> user.hasAnyPrivilege(Privilege.Clazz.TABLE, t.ident().fqn()),
+            (user, t) -> roles.hasAnyPrivilege(user, Privilege.Clazz.TABLE, t.ident().fqn()),
             PgTablesTable.create().expressions()
         ));
 
         tableDefinitions.put(PgViewsTable.IDENT, new StaticTableDefinition<>(
             informationSchemaIterables::views,
-            (user, t) -> user.hasAnyPrivilege(Privilege.Clazz.VIEW, t.ident().fqn()),
+            (user, t) -> roles.hasAnyPrivilege(user, Privilege.Clazz.VIEW, t.ident().fqn()),
             PgViewsTable.create().expressions()
         ));
 

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgRolesTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgRolesTable.java
@@ -21,12 +21,12 @@
 
 package io.crate.metadata.pgcatalog;
 
-import static io.crate.types.DataTypes.STRING;
-import static io.crate.types.DataTypes.STRING_ARRAY;
+import static io.crate.role.metadata.SysUsersTableInfo.PASSWORD_PLACEHOLDER;
 import static io.crate.types.DataTypes.BOOLEAN;
 import static io.crate.types.DataTypes.INTEGER;
+import static io.crate.types.DataTypes.STRING;
+import static io.crate.types.DataTypes.STRING_ARRAY;
 import static io.crate.types.DataTypes.TIMESTAMPZ;
-import static io.crate.role.metadata.SysUsersTableInfo.PASSWORD_PLACEHOLDER;
 
 import io.crate.exceptions.MissingPrivilegeException;
 import io.crate.metadata.RelationName;
@@ -34,6 +34,7 @@ import io.crate.metadata.SystemTable;
 import io.crate.role.Privilege;
 import io.crate.role.Privileges;
 import io.crate.role.Role;
+import io.crate.role.Roles;
 
 public final class PgRolesTable {
 
@@ -41,15 +42,15 @@ public final class PgRolesTable {
 
     private PgRolesTable() {}
 
-    public static SystemTable<Role> create() {
+    public static SystemTable<Role> create(Roles roles) {
         return SystemTable.<Role>builder(IDENT)
             .add("rolname", STRING, Role::name)
             .add("rolsuper", BOOLEAN, Role::isSuperUser)
             .add("rolinherit", BOOLEAN, r -> true) // Always inherit
-            .add("rolcreaterole", BOOLEAN, PgRolesTable::canCreateRoleOrSubscription)
+            .add("rolcreaterole", BOOLEAN, r -> canCreateRoleOrSubscription(roles, r))
             .add("rolcreatedb", BOOLEAN, ignored -> null) // There is no create database functionality
             .add("rolcanlogin", BOOLEAN, Role::isUser)
-            .add("rolreplication", BOOLEAN, PgRolesTable::canCreateRoleOrSubscription)
+            .add("rolreplication", BOOLEAN, r -> canCreateRoleOrSubscription(roles, r))
             .add("rolconnlimit", INTEGER, r -> -1)
             .add("rolpassword", STRING, r -> r.password() != null ? PASSWORD_PLACEHOLDER : null)
             .add("rolvaliduntil", TIMESTAMPZ, ignored -> null)
@@ -59,13 +60,14 @@ public final class PgRolesTable {
             .build();
     }
 
-    private static boolean canCreateRoleOrSubscription(Role role) {
+    private static boolean canCreateRoleOrSubscription(Roles roles, Role role) {
         try {
             Privileges.ensureUserHasPrivilege(
+                roles,
+                role,
                 Privilege.Type.AL,
                 Privilege.Clazz.CLUSTER,
-                null,
-                role);
+                null);
             return true;
         } catch (MissingPrivilegeException e) {
             return false;

--- a/server/src/main/java/io/crate/metadata/shard/ShardReferenceResolver.java
+++ b/server/src/main/java/io/crate/metadata/shard/ShardReferenceResolver.java
@@ -52,8 +52,10 @@ import io.crate.metadata.sys.SysShardsTableInfo;
 public class ShardReferenceResolver implements ReferenceResolver<NestableInput<?>> {
 
     private static final Logger LOGGER = LogManager.getLogger(ShardReferenceResolver.class);
+    // Use a dummy Roles (List::of) here, as we resolve privileges at a table level, not a shard level,
+    // and the shards need to only be protected (resolve privileges) in SysShardsTableInfo (sys.shards)
     private static final StaticTableReferenceResolver<ShardRowContext> SHARD_REFERENCE_RESOLVER_DELEGATE =
-        new StaticTableReferenceResolver<>(SysShardsTableInfo.create().expressions());
+        new StaticTableReferenceResolver<>(SysShardsTableInfo.create(List::of).expressions());
     private static final ReferenceResolver<NestableInput<?>> EMPTY_RESOLVER =
         new MapBackedRefResolver(Collections.emptyMap());
 

--- a/server/src/main/java/io/crate/metadata/sys/SysSchemaInfo.java
+++ b/server/src/main/java/io/crate/metadata/sys/SysSchemaInfo.java
@@ -35,6 +35,7 @@ import org.elasticsearch.common.inject.Singleton;
 import io.crate.metadata.table.SchemaInfo;
 import io.crate.metadata.table.TableInfo;
 import io.crate.metadata.view.ViewInfo;
+import io.crate.role.Roles;
 
 @Singleton
 public class SysSchemaInfo implements SchemaInfo {
@@ -43,11 +44,11 @@ public class SysSchemaInfo implements SchemaInfo {
     private final Map<String, TableInfo> tableInfos;
 
     @Inject
-    public SysSchemaInfo(ClusterService clusterService) {
+    public SysSchemaInfo(ClusterService clusterService, Roles roles) {
         tableInfos = new HashMap<>();
         tableInfos.put(SysClusterTableInfo.IDENT.name(), SysClusterTableInfo.of(clusterService));
         tableInfos.put(SysNodesTableInfo.IDENT.name(), SysNodesTableInfo.create());
-        tableInfos.put(SysShardsTableInfo.IDENT.name(), SysShardsTableInfo.create());
+        tableInfos.put(SysShardsTableInfo.IDENT.name(), SysShardsTableInfo.create(roles));
         Supplier<DiscoveryNode> localNode = clusterService::localNode;
         tableInfos.put(SysJobsTableInfo.IDENT.name(), SysJobsTableInfo.create(localNode));
         tableInfos.put(SysJobsLogTableInfo.IDENT.name(), SysJobsLogTableInfo.create(localNode));

--- a/server/src/main/java/io/crate/metadata/sys/SysSnapshotRestoreTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/sys/SysSnapshotRestoreTableInfo.java
@@ -27,9 +27,8 @@ import static io.crate.types.DataTypes.STRING;
 import java.util.Collections;
 import java.util.stream.StreamSupport;
 
-import org.jetbrains.annotations.Nullable;
-
 import org.elasticsearch.cluster.RestoreInProgress;
+import org.jetbrains.annotations.Nullable;
 
 import io.crate.expression.reference.sys.snapshot.SysSnapshotRestoreInProgress;
 import io.crate.metadata.ColumnIdent;

--- a/server/src/main/java/io/crate/replication/logical/action/PublicationsStateAction.java
+++ b/server/src/main/java/io/crate/replication/logical/action/PublicationsStateAction.java
@@ -139,7 +139,8 @@ public class PublicationsStateAction extends ActionType<PublicationsStateAction.
                 // Publication owner cannot be null as we ensure that users who owns publication cannot be dropped.
                 // Also, before creating publication or subscription we check that owner was not dropped right before creation.
                 Role publicationOwner = roles.findUser(publication.owner());
-                allRelationsInPublications.putAll(publication.resolveCurrentRelations(state, publicationOwner, subscriber, publicationName));
+                allRelationsInPublications.putAll(
+                    publication.resolveCurrentRelations(state, roles, publicationOwner, subscriber, publicationName));
             }
             listener.onResponse(new Response(allRelationsInPublications, unknownPublications));
         }

--- a/server/src/main/java/io/crate/role/Role.java
+++ b/server/src/main/java/io/crate/role/Role.java
@@ -32,8 +32,6 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.jetbrains.annotations.Nullable;
 
-import io.crate.metadata.pgcatalog.OidHash;
-
 public class Role implements ToXContent {
 
     public static final Role CRATE_USER = new Role("crate",
@@ -87,55 +85,8 @@ public class Role implements ToXContent {
         return userRoles.contains(UserRole.SUPERUSER);
     }
 
-    public Iterable<Privilege> privileges() {
+    public RolePrivileges privileges() {
         return privileges;
-    }
-
-    /**
-     * Checks if the user has a privilege that matches the given class, type, ident and
-     * default schema. Currently only the type is checked since Class is always
-     * CLUSTER and ident null.
-     * @param type           privilege type
-     * @param clazz          privilege class (ie. CLUSTER, TABLE, etc)
-     * @param ident          ident of the object
-     */
-    public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, @Nullable String ident) {
-        return isSuperUser() || privileges.matchPrivilege(type, clazz, ident);
-    }
-
-    /**
-     * Checks if the user has a schema privilege that matches the given type and ident OID.
-     * @param type           privilege type
-     * @param schemaOid      OID of the schema
-     */
-    public boolean hasSchemaPrivilege(Privilege.Type type, Integer schemaOid) {
-        if (isSuperUser()) {
-            return true;
-        }
-        for (Privilege privilege : privileges) {
-            if (privilege.state() == PrivilegeState.GRANT && privilege.ident().type() == type) {
-                if (privilege.ident().clazz() == Privilege.Clazz.CLUSTER) {
-                    return true;
-                }
-                if (privilege.ident().clazz() == Privilege.Clazz.SCHEMA &&
-                    OidHash.schemaOid(privilege.ident().ident()) == schemaOid) {
-                    return true;
-                }
-            }
-        }
-        return false;
-
-    }
-
-    /**
-     * Checks if the user has any privilege that matches the given class, type and ident
-     * currently we check for any privilege, since Class is always CLUSTER and ident null.
-     *
-     * @param clazz privilege class (ie. CLUSTER, TABLE, etc)
-     * @param ident ident of the object
-     */
-    public boolean hasAnyPrivilege(Privilege.Clazz clazz, @Nullable String ident) {
-        return isSuperUser() || privileges.matchPrivilegeOfAnyType(clazz, ident);
     }
 
     @Override

--- a/server/src/main/java/io/crate/role/Roles.java
+++ b/server/src/main/java/io/crate/role/Roles.java
@@ -27,7 +27,6 @@ import org.jetbrains.annotations.Nullable;
 
 import io.crate.metadata.pgcatalog.OidHash;
 
-@FunctionalInterface
 public interface Roles {
 
     /**

--- a/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
+++ b/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
@@ -24,13 +24,13 @@ package io.crate.auth;
 import static io.crate.expression.udf.UdfUnitTest.DUMMY_LANG;
 import static io.crate.role.Privilege.Type.READ_WRITE_DEFINE;
 import static io.crate.role.Role.CRATE_USER;
+import static io.crate.role.metadata.RolesHelper.userOf;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
 import java.util.ArrayList;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 
@@ -76,10 +76,11 @@ import io.crate.types.DataTypes;
 public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTest {
 
     private List<List<Object>> validationCallArguments;
-    private Role user;
+    private Role normalUser;
+    private Role ddlOnlyUser;
     private SQLExecutor e;
     private RoleManager roleManager;
-    private Role superUser;
+    private Role superUser = Role.CRATE_USER;
 
     @Before
     public void setUpSQLExecutor() throws Exception {
@@ -97,28 +98,16 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
             .build();
         ClusterServiceUtils.setState(clusterService, clusterState);
 
-        user = new Role("normal",
-                        true,
-                        Set.of(new Privilege(PrivilegeState.GRANT,
-                                             Privilege.Type.DQL,
-                                             Privilege.Clazz.SCHEMA,
-                                             "custom_schema",
-                                             "crate")),
-                        null,
-            Set.of()) {
-            @Override
-            public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, String ident) {
-                validationCallArguments.add(CollectionUtils.arrayAsArrayList(type, clazz, ident, user.name()));
-                return true;
-            }
-        };
-        superUser = new Role("crate", true, Set.of(), null, EnumSet.of(Role.UserRole.SUPERUSER)) {
-            @Override
-            public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, @Nullable String ident) {
-                validationCallArguments.add(CollectionUtils.arrayAsArrayList(type, clazz, ident, superUser.name()));
-                return true;
-            }
-        };
+        normalUser = userOf(
+                       "normal",
+                       Set.of(new Privilege(PrivilegeState.GRANT,
+                                            Privilege.Type.DQL,
+                                            Privilege.Clazz.SCHEMA,
+                                            "custom_schema",
+                                            "crate")),
+                       null);
+        ddlOnlyUser = userOf("ddlOnly");
+
         RolesService rolesService = new RolesService(clusterService) {
 
             @Nullable
@@ -128,6 +117,15 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
                     return superUser;
                 }
                 return super.findUser(userName);
+            }
+
+            @Override
+            public boolean hasPrivilege(Role user, Privilege.Type type, Privilege.Clazz clazz, @Nullable String ident) {
+                validationCallArguments.add(CollectionUtils.arrayAsArrayList(type, clazz, ident, user.name()));
+                if ("ddlOnly".equals(user.name())) {
+                    return Privilege.Type.DDL == type;
+                }
+                return true;
             }
         };
         roleManager = new RoleManagerService(
@@ -174,7 +172,7 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
     }
 
     private void analyze(String stmt) {
-        analyze(stmt, user);
+        analyze(stmt, normalUser);
     }
 
     private void analyzeAsSuperUser(String stmt) {
@@ -187,17 +185,21 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
     }
 
     private void assertAskedForCluster(Privilege.Type type) {
+        assertAskedForCluster(type, normalUser);
+    }
+
+    private void assertAskedForCluster(Privilege.Type type, Role user) {
         assertThat(validationCallArguments).anySatisfy(
             s -> assertThat(s).containsExactly(type, Privilege.Clazz.CLUSTER, null, user.name()));
     }
 
     private void assertAskedForSchema(Privilege.Type type, String ident) {
         assertThat(validationCallArguments).anySatisfy(
-            s -> assertThat(s).containsExactly(type, Privilege.Clazz.SCHEMA, ident, user.name()));
+            s -> assertThat(s).containsExactly(type, Privilege.Clazz.SCHEMA, ident, normalUser.name()));
     }
 
     private void assertAskedForTable(Privilege.Type type, String ident) {
-        assertAskedForTable(type, ident, user);
+        assertAskedForTable(type, ident, normalUser);
     }
 
     private void assertAskedForTable(Privilege.Type type, String ident, Role user) {
@@ -207,7 +209,7 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
 
     private void assertAskedForView(Privilege.Type type, String ident) {
         assertThat(validationCallArguments).anySatisfy(
-            s -> assertThat(s).containsExactly(type, Privilege.Clazz.VIEW, ident, user.name()));
+            s -> assertThat(s).containsExactly(type, Privilege.Clazz.VIEW, ident, normalUser.name()));
     }
 
     @Test
@@ -565,37 +567,29 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
 
     @Test
     public void test_alter_cluster_reroute_retry_works_for_normal_user_with_AL_privileges() {
-        analyze("alter cluster reroute retry failed", user);
+        analyze("alter cluster reroute retry failed", normalUser);
         assertAskedForCluster(Privilege.Type.AL);
     }
 
     @Test
     public void test_alter_cluster_gc_dangling_artifacts_works_for_normal_user_with_AL_privileges() {
-        analyze("alter cluster gc dangling artifacts", user);
+        analyze("alter cluster gc dangling artifacts", normalUser);
         assertAskedForCluster(Privilege.Type.AL);
     }
 
     @Test
     public void test_alter_cluster_swap_table_works_for_normal_user_with_AL_privileges() {
         // pre-configured user has all privileges
-        analyze("alter cluster swap table doc.t1 to doc.t2 with (drop_source = true)", user);
+        analyze("alter cluster swap table doc.t1 to doc.t2 with (drop_source = true)", normalUser);
         assertAskedForCluster(Privilege.Type.AL);
     }
 
     @Test
     public void test_alter_cluster_swap_table_works_for_normal_user_with_no_AI_with_DDL_on_both_tables() {
-        // custom user has only DML privileges
-        var customUser = new Role("normal", true, Set.of(), null, Set.of()) {
-            @Override
-            public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, String ident) {
-                validationCallArguments.add(CollectionUtils.arrayAsArrayList(type, clazz, ident, user.name()));
-                return Privilege.Type.DDL == type;
-            }
-        };
-        analyze("alter cluster swap table doc.t1 to doc.t2 with (drop_source = true)", customUser);
-        assertAskedForCluster(Privilege.Type.AL); // first checks AL and if user doesn't have it, checks both DDL-s
-        assertAskedForTable(Privilege.Type.DDL, "doc.t2", customUser);
-        assertAskedForTable(Privilege.Type.DDL, "doc.t1", customUser);
+        analyze("alter cluster swap table doc.t1 to doc.t2 with (drop_source = true)", ddlOnlyUser);
+        assertAskedForCluster(Privilege.Type.AL, ddlOnlyUser); // first checks AL and if user doesn't have it, checks both DDL-s
+        assertAskedForTable(Privilege.Type.DDL, "doc.t2", ddlOnlyUser);
+        assertAskedForTable(Privilege.Type.DDL, "doc.t1", ddlOnlyUser);
     }
 
     @Test
@@ -637,13 +631,13 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
 
     @Test
     public void test_set_session_user_from_superuser_to_normal_user_succeeds() {
-        analyze("SET SESSION AUTHORIZATION " + user.name(), superUser);
+        analyze("SET SESSION AUTHORIZATION " + normalUser.name(), superUser);
         assertThat(validationCallArguments).isEmpty();
     }
 
     @Test
     public void test_set_session_user_from_normal_user_fails() {
-        assertThatThrownBy(() -> analyze("SET SESSION AUTHORIZATION 'someuser'", user))
+        assertThatThrownBy(() -> analyze("SET SESSION AUTHORIZATION 'someuser'", normalUser))
             .isExactlyInstanceOf(UnauthorizedException.class)
             .hasMessage("User \"normal\" is not authorized to execute the statement. " +
                         "Superuser permissions are required or you can set the session " +
@@ -653,7 +647,7 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void test_set_session_user_from_normal_user_to_superuser_fails() {
         String stmt = "SET SESSION AUTHORIZATION " + superUser.name();
-        assertThatThrownBy(() -> analyze(stmt, user))
+        assertThatThrownBy(() -> analyze(stmt, normalUser))
             .isExactlyInstanceOf(UnauthorizedException.class)
             .hasMessage("User \"normal\" is not authorized to execute the statement. " +
                         "Superuser permissions are required or you can set the session " +
@@ -664,7 +658,7 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
     public void test_set_session_user_from_normal_to_originally_authenticated_user_succeeds() {
         e.analyzer.analyze(
             SqlParser.createStatement("SET SESSION AUTHORIZATION " + superUser.name()),
-            new CoordinatorSessionSettings(superUser, user),
+            new CoordinatorSessionSettings(superUser, normalUser),
             ParamTypeHints.EMPTY,
             e.cursors
         );
@@ -675,7 +669,7 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
     public void test_set_session_user_from_normal_user_to_default_succeeds() {
         e.analyzer.analyze(
             SqlParser.createStatement("SET SESSION AUTHORIZATION DEFAULT"),
-            new CoordinatorSessionSettings(superUser, user),
+            new CoordinatorSessionSettings(superUser, normalUser),
             ParamTypeHints.EMPTY,
             e.cursors);
         assertThat(validationCallArguments).isEmpty();
@@ -685,7 +679,7 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
     public void test_reset_session_authorization_from_normal_user_succeeds() {
         e.analyzer.analyze(
             SqlParser.createStatement("RESET SESSION AUTHORIZATION"),
-            new CoordinatorSessionSettings(superUser, user),
+            new CoordinatorSessionSettings(superUser, normalUser),
             ParamTypeHints.EMPTY,
             e.cursors
         );
@@ -713,7 +707,7 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
 
     @Test
     public void test_create_publication_asks_cluster_AL_and_all_for_each_table() {
-        analyze("create publication pub1 FOR TABLE t1, t2", user);
+        analyze("create publication pub1 FOR TABLE t1, t2", normalUser);
         assertAskedForCluster(Privilege.Type.AL);
         for (Privilege.Type type: READ_WRITE_DEFINE) {
             assertAskedForTable(type, "doc.t1");
@@ -724,22 +718,22 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void test_drop_publication_asks_cluster_AL() {
         e = SQLExecutor.builder(clusterService)
-            .setUser(user)
+            .setUser(normalUser)
             .addPublication("pub1", true)
             .setUserManager(roleManager)
             .build();
-        analyze("DROP PUBLICATION pub1", user);
+        analyze("DROP PUBLICATION pub1", normalUser);
         assertAskedForCluster(Privilege.Type.AL);
     }
 
     @Test
     public void test_alter_publication_asks_cluster_AL() throws Exception {
         e = SQLExecutor.builder(clusterService)
-            .setUser(user)
+            .setUser(normalUser)
             .addPublication("pub1", false, new RelationName("doc", "t1"))
             .setUserManager(roleManager)
             .build();
-        analyze("ALTER PUBLICATION pub1 ADD TABLE t2", user);
+        analyze("ALTER PUBLICATION pub1 ADD TABLE t2", normalUser);
         assertAskedForCluster(Privilege.Type.AL);
         for (Privilege.Type type: READ_WRITE_DEFINE) {
             assertAskedForTable(type, "doc.t2");
@@ -748,41 +742,41 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
 
     @Test
     public void test_create_subscription_asks_cluster_AL() {
-        analyze("create subscription sub1 CONNECTION 'postgresql://user@localhost/crate:5432' PUBLICATION pub1", user);
+        analyze("create subscription sub1 CONNECTION 'postgresql://user@localhost/crate:5432' PUBLICATION pub1", normalUser);
         assertAskedForCluster(Privilege.Type.AL);
     }
 
     @Test
     public void test_drop_subscription_asks_cluster_AL() {
         e = SQLExecutor.builder(clusterService)
-            .setUser(user)
+            .setUser(normalUser)
             .addSubscription("sub1", "pub1")
             .setUserManager(roleManager)
             .build();
-        analyze("DROP SUBSCRIPTION sub1", user);
+        analyze("DROP SUBSCRIPTION sub1", normalUser);
         assertAskedForCluster(Privilege.Type.AL);
     }
 
     @Test
     public void test_alter_subscription_asks_cluster_AL() {
         e = SQLExecutor.builder(clusterService)
-            .setUser(user)
+            .setUser(normalUser)
             .addSubscription("sub1", "pub1")
             .setUserManager(roleManager)
             .build();
-        analyze("ALTER SUBSCRIPTION sub1 DISABLE", user);
+        analyze("ALTER SUBSCRIPTION sub1 DISABLE", normalUser);
         assertAskedForCluster(Privilege.Type.AL);
     }
 
     @Test
     public void test_anaylze_works_for_normal_user_with_AL_privileges() {
-        analyze("ANALYZE", user);
+        analyze("ANALYZE", normalUser);
         assertAskedForCluster(Privilege.Type.AL);
     }
 
     @Test
     public void test_declare_cursor_for_non_super_users() {
-        analyze("DECLARE this_cursor NO SCROLL CURSOR FOR SELECT * FROM sys.summits;", user);
+        analyze("DECLARE this_cursor NO SCROLL CURSOR FOR SELECT * FROM sys.summits;", normalUser);
         assertAskedForTable(Privilege.Type.DQL, "sys.summits");
     }
 

--- a/server/src/test/java/io/crate/execution/engine/collect/BlobShardCollectorProviderTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/BlobShardCollectorProviderTest.java
@@ -112,7 +112,7 @@ public class BlobShardCollectorProviderTest extends SQLHttpIntegrationTest {
                 String indexUUID = metadata.index(".blob_b1").getIndexUUID();
                 BlobIndicesService blobIndicesService = cluster().getDataNodeInstance(BlobIndicesService.class);
                 BlobShard blobShard = blobIndicesService.blobShard(new ShardId(".blob_b1", indexUUID, 0));
-                Schemas schemas = new Schemas(Collections.emptyMap(), clusterService, null);
+                Schemas schemas = new Schemas(Collections.emptyMap(), clusterService, null, List::of);
                 assertNotNull(blobShard);
                 collectorProvider = new BlobShardCollectorProvider(
                     blobShard,

--- a/server/src/test/java/io/crate/expression/reference/sys/SysShardsExpressionsTest.java
+++ b/server/src/test/java/io/crate/expression/reference/sys/SysShardsExpressionsTest.java
@@ -35,6 +35,7 @@ import static org.mockito.Mockito.when;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.lucene.store.AlreadyClosedException;
@@ -99,14 +100,15 @@ public class SysShardsExpressionsTest extends CrateDummyClusterServiceUnitTest {
             nodeCtx
         );
         schemas = new Schemas(
-            Map.of("sys", new SysSchemaInfo(this.clusterService)),
+            Map.of("sys", new SysSchemaInfo(this.clusterService, List::of)),
             clusterService,
             new DocSchemaInfoFactory(
                 new DocTableInfoFactory(nodeCtx),
                 new ViewInfoFactory(() -> new RelationAnalyzer(nodeCtx, schemas)),
                 nodeCtx,
                 udfService
-            )
+            ),
+            List::of
         );
         resolver = new ShardReferenceResolver(schemas, new ShardRowContext(indexShard, clusterService));
         sysShards = schemas.getTableInfo(SysShardsTableInfo.IDENT);

--- a/server/src/test/java/io/crate/metadata/SchemasTest.java
+++ b/server/src/test/java/io/crate/metadata/SchemasTest.java
@@ -140,7 +140,7 @@ public class SchemasTest extends CrateDummyClusterServiceUnitTest {
     private Schemas getReferenceInfos(SchemaInfo schemaInfo) {
         Map<String, SchemaInfo> builtInSchema = new HashMap<>();
         builtInSchema.put(schemaInfo.name(), schemaInfo);
-        return new Schemas(builtInSchema, clusterService, mock(DocSchemaInfoFactory.class));
+        return new Schemas(builtInSchema, clusterService, mock(DocSchemaInfoFactory.class), List::of);
     }
 
     @Test

--- a/server/src/test/java/io/crate/metadata/sys/SystemTableInfoTest.java
+++ b/server/src/test/java/io/crate/metadata/sys/SystemTableInfoTest.java
@@ -23,6 +23,7 @@ package io.crate.metadata.sys;
 
 import static org.junit.Assert.assertThat;
 
+import java.util.List;
 import java.util.Locale;
 
 import org.junit.Before;
@@ -39,7 +40,7 @@ public class SystemTableInfoTest extends CrateDummyClusterServiceUnitTest {
 
     @Before
     public void prepare() {
-        sysSchemaInfo = new SysSchemaInfo(this.clusterService);
+        sysSchemaInfo = new SysSchemaInfo(this.clusterService, List::of);
     }
 
     @Test

--- a/server/src/test/java/io/crate/replication/logical/MetadataTrackerTest.java
+++ b/server/src/test/java/io/crate/replication/logical/MetadataTrackerTest.java
@@ -22,6 +22,7 @@
 package io.crate.replication.logical;
 
 import static io.crate.replication.logical.LogicalReplicationSettings.REPLICATION_SUBSCRIPTION_NAME;
+import static io.crate.role.Role.CRATE_USER;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_INDEX_UUID;
 import static org.elasticsearch.cluster.routing.TestShardRouting.newShardRouting;
@@ -67,7 +68,6 @@ import io.crate.replication.logical.metadata.PublicationsMetadata;
 import io.crate.replication.logical.metadata.RelationMetadata;
 import io.crate.replication.logical.metadata.Subscription;
 import io.crate.replication.logical.metadata.SubscriptionsMetadata;
-import io.crate.role.Role;
 
 public class MetadataTrackerTest extends ESTestCase {
 
@@ -525,7 +525,8 @@ public class MetadataTrackerTest extends ESTestCase {
         PublicationsMetadata publicationsMetadata = publisherState.metadata().custom(PublicationsMetadata.TYPE);
         Publication publication = publicationsMetadata.publications().get("pub1");
         var publisherStateResponse = new Response(
-                publication.resolveCurrentRelations(publisherState, Role.CRATE_USER, Role.CRATE_USER, "dummy"), List.of());
+                publication.resolveCurrentRelations(
+                    publisherState, () -> List.of(CRATE_USER), CRATE_USER, CRATE_USER, "dummy"), List.of());
 
         var restoreDiff = MetadataTracker.getRestoreDiff(
             SubscriptionsMetadata.get(subscriberClusterState.metadata()).get("sub1"),
@@ -555,7 +556,8 @@ public class MetadataTrackerTest extends ESTestCase {
         PublicationsMetadata publicationsMetadata = publisherClusterState.metadata().custom(PublicationsMetadata.TYPE);
         Publication publication = publicationsMetadata.publications().get("pub1");
         var publisherStateResponse = new Response(
-                publication.resolveCurrentRelations(publisherClusterState, Role.CRATE_USER, Role.CRATE_USER, "dummy"), List.of());
+                publication.resolveCurrentRelations(
+                    publisherClusterState, () -> List.of(CRATE_USER), CRATE_USER, CRATE_USER, "dummy"), List.of());
 
         var restoreDiff = MetadataTracker.getRestoreDiff(
             SubscriptionsMetadata.get(subscriberClusterState.metadata()).get("sub1"),

--- a/server/src/test/java/io/crate/replication/logical/action/PublicationsStateActionTest.java
+++ b/server/src/test/java/io/crate/replication/logical/action/PublicationsStateActionTest.java
@@ -21,14 +21,13 @@
 
 package io.crate.replication.logical.action;
 
+import static io.crate.role.metadata.RolesHelper.userOf;
 import static io.crate.testing.Asserts.assertThat;
 import static java.util.Collections.singletonList;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import org.apache.logging.log4j.Level;
 import org.elasticsearch.Version;
@@ -36,6 +35,7 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.test.MockLogAppender;
+import org.jetbrains.annotations.Nullable;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -45,12 +45,12 @@ import io.crate.metadata.RelationName;
 import io.crate.metadata.Schemas;
 import io.crate.replication.logical.metadata.Publication;
 import io.crate.replication.logical.metadata.RelationMetadata;
-import io.crate.sql.tree.QualifiedName;
-import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
-import io.crate.testing.SQLExecutor;
 import io.crate.role.Privilege;
 import io.crate.role.Role;
 import io.crate.role.Roles;
+import io.crate.sql.tree.QualifiedName;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
 
 public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTest {
 
@@ -72,12 +72,19 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
 
     @Test
     public void test_resolve_relation_names_for_all_tables_ignores_table_with_soft_delete_disabled() throws Exception {
-        var user = new Role("dummy", true, Set.of(), null, Set.of()) {
+        var user = userOf("dummy");
+        var roles = new Roles() {
             @Override
-            public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, String ident) {
+            public Collection<Role> roles() {
+                return List.of(user);
+            }
+
+            @Override
+            public boolean hasPrivilege(Role user, Privilege.Type type, Privilege.Clazz clazz, @Nullable String ident) {
                 return true; // This test case doesn't check privileges.
             }
         };
+
         // Soft-deletes are mandatory from 5.0, so let's use 4.8 to create a table with soft-deletes disabled
         clusterService = createClusterService(additionalClusterSettings().stream().filter(Setting::hasNodeScope).toList(),
                                                   Metadata.EMPTY_METADATA,
@@ -98,29 +105,31 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
             expectedLogMessage
         ));
 
-        Map<RelationName, RelationMetadata> resolvedRelations = publication.resolveCurrentRelations(clusterService.state(), user, user, "dummy");
+        Map<RelationName, RelationMetadata> resolvedRelations = publication.resolveCurrentRelations(clusterService.state(), roles, user, user, "dummy");
         assertThat(resolvedRelations.keySet()).contains(new RelationName("doc", "t1"));
         appender.assertAllExpectationsMatched();
     }
 
     @Test
     public void test_resolve_relation_names_for_all_tables_ignores_table_when_pub_owner_doesnt_have_read_write_define_permissions() throws Exception {
-        var publicationOwner = new Role("publisher", true, Set.of(), null, Set.of()) {
-            @Override
-            public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, String ident) {
-                return ident.equals("doc.t1");
-            }
-        };
-        var subscriber = new Role("subscriber", true, Set.of(), null, Set.of()) {
-            @Override
-            public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, String ident) {
-                return true;
-            }
-        };
+        var publicationOwner = userOf("publisher");
+        var subscriber = userOf("subscriber");
 
-        Roles roles = mock(Roles.class);
-        when(roles.findUser("publisher")).thenReturn(publicationOwner);
-        when(roles.findUser("subscriber")).thenReturn(subscriber);
+        Roles roles = new Roles() {
+            @Override
+            public Collection<Role> roles() {
+                return List.of(publicationOwner, subscriber);
+            }
+
+            @Override
+            public boolean hasPrivilege(Role user, Privilege.Type type, Privilege.Clazz clazz, @Nullable String ident) {
+                if (user.name().equals("publisher")) {
+                    return "doc.t1".equals(ident);
+                } else {
+                    return true;
+                }
+            }
+        };
 
         SQLExecutor.builder(clusterService)
             .addTable("CREATE TABLE doc.t1 (id int)")
@@ -131,6 +140,7 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
 
         var resolvedRelations = publication.resolveCurrentRelations(
             clusterService.state(),
+            roles,
             publicationOwner,
             subscriber,
             "dummy"
@@ -141,23 +151,25 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
 
     @Test
     public void test_resolve_relation_names_for_all_tables_ignores_table_when_subscriber_doesnt_have_read_permissions() throws Exception {
-        var publicationOwner = new Role("publisher", true, Set.of(), null, Set.of()) {
-            @Override
-            public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, String ident) {
-                return true;
-            }
-        };
+        var publicationOwner = userOf("publisher");
+        var subscriber = userOf("subscriber");
 
-        var subscriber = new Role("subscriber", true, Set.of(), null, Set.of()) {
+        Roles roles = new Roles() {
             @Override
-            public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, String ident) {
-                return ident.equals("doc.t1");
+            public Collection<Role> roles() {
+                return List.of(publicationOwner, subscriber);
             }
-        };
 
-        Roles roles = mock(Roles.class);
-        when(roles.findUser("publisher")).thenReturn(publicationOwner);
-        when(roles.findUser("subscriber")).thenReturn(subscriber);
+            @Override
+            public boolean hasPrivilege(Role user, Privilege.Type type, Privilege.Clazz clazz, @Nullable String ident) {
+                if (user.name().equals("subscriber")) {
+                    return "doc.t1".equals(ident);
+                } else {
+                    return true;
+                }
+            }
+
+        };
 
         SQLExecutor.builder(clusterService)
             .addTable("CREATE TABLE doc.t1 (id int)")
@@ -166,29 +178,30 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
             .build();
         var publication = new Publication("publisher", true, List.of());
 
-        var resolvedRelations = publication.resolveCurrentRelations(clusterService.state(), publicationOwner, subscriber, "dummy");
+        var resolvedRelations = publication.resolveCurrentRelations(clusterService.state(), roles, publicationOwner, subscriber, "dummy");
         assertThat(resolvedRelations.keySet()).contains(new RelationName("doc", "t1"));
     }
 
     @Test
     public void test_resolve_relation_names_for_fixed_tables_ignores_table_when_subscriber_doesnt_have_read_permissions() throws Exception {
-        var publicationOwner = new Role("publisher", true, Set.of(), null, Set.of()) {
+        var publicationOwner = userOf("publisher");
+        var subscriber = userOf("subscriber");
+
+        Roles roles = new Roles() {
             @Override
-            public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, String ident) {
-                return true;
+            public Collection<Role> roles() {
+                return List.of(publicationOwner, subscriber);
+            }
+
+            @Override
+            public boolean hasPrivilege(Role user, Privilege.Type type, Privilege.Clazz clazz, @Nullable String ident) {
+                if (user.name().equals("subscriber")) {
+                    return "doc.t1".equals(ident);
+                } else {
+                    return true;
+                }
             }
         };
-
-        var subscriber = new Role("subscriber", true, Set.of(), null, Set.of()) {
-            @Override
-            public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, String ident) {
-                return ident.equals("doc.t1");
-            }
-        };
-
-        Roles roles = mock(Roles.class);
-        when(roles.findUser("publisher")).thenReturn(publicationOwner);
-        when(roles.findUser("subscriber")).thenReturn(subscriber);
 
         SQLExecutor.builder(clusterService)
             .addTable("CREATE TABLE doc.t1 (id int)")
@@ -204,6 +217,7 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
 
         var resolvedRelations = publication.resolveCurrentRelations(
             clusterService.state(),
+            roles,
             publicationOwner,
             subscriber,
             "dummy"
@@ -213,9 +227,15 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
 
     @Test
     public void test_resolve_relation_names_for_all_tables_ignores_table_with_non_active_primary_shards() throws Exception {
-        var user = new Role("dummy", true, Set.of(), null, Set.of()) {
+        var user = userOf("dummy");
+        Roles roles = new Roles() {
             @Override
-            public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, String ident) {
+            public Collection<Role> roles() {
+                return List.of(user);
+            }
+
+            @Override
+            public boolean hasPrivilege(Role user, Privilege.Type type, Privilege.Clazz clazz, @Nullable String ident) {
                 return true; // This test case doesn't check privileges.
             }
         };
@@ -229,6 +249,7 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
 
         var resolvedRelations = publication.resolveCurrentRelations(
             clusterService.state(),
+            roles,
             user,
             user,
             "dummy"
@@ -239,9 +260,15 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
 
     @Test
     public void test_resolve_relation_names_for_concrete_tables_ignores_table_with_non_active_primary_shards() throws Exception {
-        var user = new Role("dummy", true, Set.of(), null, Set.of()) {
+        var user = userOf("dummy");
+        Roles roles = new Roles() {
             @Override
-            public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, String ident) {
+            public Collection<Role> roles() {
+                return List.of(user);
+            }
+
+            @Override
+            public boolean hasPrivilege(Role user, Privilege.Type type, Privilege.Clazz clazz, @Nullable String ident) {
                 return true; // This test case doesn't check privileges.
             }
         };
@@ -259,6 +286,7 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
 
         var resolvedRelations = publication.resolveCurrentRelations(
             clusterService.state(),
+            roles,
             user,
             user,
             "dummy"
@@ -269,9 +297,15 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
 
     @Test
     public void test_resolve_relation_names_for_all_tables_ignores_partition_with_non_active_primary_shards() throws Exception {
-        var user = new Role("dummy", true, Set.of(), null, Set.of()) {
+        var user = userOf("dummy");
+        Roles roles = new Roles() {
             @Override
-            public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, String ident) {
+            public Collection<Role> roles() {
+                return List.of(user);
+            }
+
+            @Override
+            public boolean hasPrivilege(Role user, Privilege.Type type, Privilege.Clazz clazz, @Nullable String ident) {
                 return true; // This test case doesn't check privileges.
             }
         };
@@ -286,6 +320,7 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
 
         var resolvedRelations = publication.resolveCurrentRelations(
             clusterService.state(),
+            roles,
             user,
             user,
             "dummy"
@@ -296,9 +331,15 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
 
     @Test
     public void test_resolve_relation_names_for_concrete_tables_ignores_partition_with_non_active_primary_shards() throws Exception {
-        var user = new Role("dummy", true, Set.of(), null, Set.of()) {
+        var user = userOf("dummy");
+        Roles roles = new Roles() {
             @Override
-            public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, String ident) {
+            public Collection<Role> roles() {
+                return List.of(user);
+            }
+
+            @Override
+            public boolean hasPrivilege(Role user, Privilege.Type type, Privilege.Clazz clazz, @Nullable String ident) {
                 return true; // This test case doesn't check privileges.
             }
         };
@@ -317,6 +358,7 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
 
         var resolvedRelations = publication.resolveCurrentRelations(
             clusterService.state(),
+            roles,
             user,
             user,
             "dummy"

--- a/server/src/test/java/io/crate/role/PrivilegesTest.java
+++ b/server/src/test/java/io/crate/role/PrivilegesTest.java
@@ -23,6 +23,8 @@ package io.crate.role;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.List;
+
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
 
@@ -32,11 +34,11 @@ import io.crate.role.metadata.RolesHelper;
 public class PrivilegesTest extends ESTestCase {
 
     private static final Role USER = RolesHelper.userOf("ford");
+    private static final Roles ROLES = () -> List.of(USER);
 
     @Test
     public void testExceptionIsThrownIfUserHasNotRequiredPrivilege() throws Exception {
-        assertThatThrownBy(() ->
-            Privileges.ensureUserHasPrivilege(Privilege.Type.DQL, Privilege.Clazz.CLUSTER, null, USER))
+        assertThatThrownBy(() -> ensureUserHasPrivilege(Privilege.Type.DQL, Privilege.Clazz.CLUSTER, null))
             .isExactlyInstanceOf(MissingPrivilegeException.class)
             .hasMessage("Missing 'DQL' privilege for user 'ford'");
     }
@@ -44,13 +46,12 @@ public class PrivilegesTest extends ESTestCase {
     @Test
     public void testNoExceptionIsThrownIfUserHasNotRequiredPrivilegeOnInformationSchema() throws Exception {
         //ensureUserHasPrivilege will not throw an exception if the schema is `information_schema`
-        Privileges.ensureUserHasPrivilege(Privilege.Type.DQL, Privilege.Clazz.SCHEMA, "information_schema",
-                                          USER);
+        ensureUserHasPrivilege(Privilege.Type.DQL, Privilege.Clazz.SCHEMA, "information_schema");
     }
 
     @Test
     public void testExceptionIsThrownIfUserHasNotAnyPrivilege() throws Exception {
-        assertThatThrownBy(() -> Privileges.ensureUserHasPrivilege(Privilege.Clazz.CLUSTER, null, USER))
+        assertThatThrownBy(() -> ensureUserHasPrivilege(Privilege.Clazz.CLUSTER, null))
             .isExactlyInstanceOf(MissingPrivilegeException.class)
             .hasMessage("Missing privilege for user 'ford'");
     }
@@ -58,16 +59,24 @@ public class PrivilegesTest extends ESTestCase {
     @Test
     public void testUserWithNoPrivilegeCanAccessInformationSchema() throws Exception {
         //ensureUserHasPrivilege will not throw an exception if the schema is `information_schema`
-        Privileges.ensureUserHasPrivilege(Privilege.Clazz.SCHEMA, "information_schema", USER);
-        Privileges.ensureUserHasPrivilege(Privilege.Clazz.TABLE, "information_schema.table", USER);
-        Privileges.ensureUserHasPrivilege(Privilege.Clazz.TABLE, "information_schema.views", USER);
+        ensureUserHasPrivilege(Privilege.Clazz.SCHEMA, "information_schema");
+        ensureUserHasPrivilege(Privilege.Clazz.TABLE, "information_schema.table");
+        ensureUserHasPrivilege(Privilege.Clazz.TABLE, "information_schema.views");
     }
 
     @Test
     public void testUserWithNoPrivilegesCanAccessPgCatalogSchema() throws Exception {
         //ensureUserHasPrivilege will not throw an exception if the schema is `pg_catalog`
-        Privileges.ensureUserHasPrivilege(Privilege.Clazz.SCHEMA, "pg_catalog", USER);
-        Privileges.ensureUserHasPrivilege(Privilege.Clazz.TABLE, "pg_catalog.pg_am", USER);
-        Privileges.ensureUserHasPrivilege(Privilege.Clazz.TABLE, "pg_catalog.pg_database", USER);
+        ensureUserHasPrivilege(Privilege.Clazz.SCHEMA, "pg_catalog");
+        ensureUserHasPrivilege(Privilege.Clazz.TABLE, "pg_catalog.pg_am");
+        ensureUserHasPrivilege(Privilege.Clazz.TABLE, "pg_catalog.pg_database");
+    }
+
+    private static void ensureUserHasPrivilege(Privilege.Clazz clazz, String ident) {
+        Privileges.ensureUserHasPrivilege(ROLES, USER, clazz, ident);
+    }
+
+    private static void ensureUserHasPrivilege(Privilege.Type type, Privilege.Clazz clazz, String ident) {
+        Privileges.ensureUserHasPrivilege(ROLES, USER, type, clazz, ident);
     }
 }

--- a/server/src/test/java/io/crate/role/RolesServiceTest.java
+++ b/server/src/test/java/io/crate/role/RolesServiceTest.java
@@ -1,3 +1,24 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
 package io.crate.role;
 
 import static io.crate.role.Role.CRATE_USER;

--- a/server/src/test/java/io/crate/role/RolesServiceTest.java
+++ b/server/src/test/java/io/crate/role/RolesServiceTest.java
@@ -1,76 +1,60 @@
-/*
- * Licensed to Crate.io GmbH ("Crate") under one or more contributor
- * license agreements.  See the NOTICE file distributed with this work for
- * additional information regarding copyright ownership.  Crate licenses
- * this file to you under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.  You may
- * obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
- *
- * However, if you have executed another commercial license agreement
- * with Crate these terms will supersede the license and you may use the
- * software solely pursuant to the terms of the relevant commercial agreement.
- */
-
 package io.crate.role;
 
 import static io.crate.role.Role.CRATE_USER;
 import static io.crate.role.metadata.RolesHelper.DUMMY_USERS_AND_ROLES;
+import static io.crate.role.metadata.RolesHelper.roleOf;
+import static io.crate.role.metadata.RolesHelper.userOf;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
-import java.util.Set;
+import java.util.Map;
 
 import org.junit.Test;
 
-import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
-import io.crate.role.metadata.RolesHelper;
 import io.crate.role.metadata.RolesMetadata;
 import io.crate.role.metadata.UsersMetadata;
 import io.crate.role.metadata.UsersPrivilegesMetadata;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 
 public class RolesServiceTest extends CrateDummyClusterServiceUnitTest {
+
+    private static final Map<String, Role> DEFAULT_USERS = Map.of(CRATE_USER.name(), CRATE_USER);
 
     @Test
     public void testNullAndEmptyMetadata() {
         // the users list will always contain a crate user
-        Set<Role> roles = RolesService.getRoles(null, null, null);
-        assertThat(roles).containsExactly(CRATE_USER);
+        Map<String, Role> roles = RolesService.getRoles(null, null, null);
+        assertThat(roles).containsExactlyEntriesOf(DEFAULT_USERS);
 
         roles = RolesService.getRoles(new UsersMetadata(), new RolesMetadata(), new UsersPrivilegesMetadata());
-        assertThat(roles).containsExactly(CRATE_USER);
+        assertThat(roles).containsExactlyEntriesOf(DEFAULT_USERS);
     }
 
     @Test
     public void testUsersAndRoles() {
-        Set<Role> roles = RolesService.getRoles(
+        Map<String, Role> roles = RolesService.getRoles(
             null,
-            new RolesMetadata(RolesHelper.DUMMY_USERS_AND_ROLES),
+            new RolesMetadata(DUMMY_USERS_AND_ROLES),
             new UsersPrivilegesMetadata());
 
-        assertThat(roles).containsExactlyInAnyOrder(
-            DUMMY_USERS_AND_ROLES.get("Ford"),
-            DUMMY_USERS_AND_ROLES.get("John"),
-            RolesHelper.roleOf("DummyRole"),
-            CRATE_USER);
+        assertThat(roles).containsExactlyInAnyOrderEntriesOf(
+            Map.of(
+                "Ford", DUMMY_USERS_AND_ROLES.get("Ford"),
+                "John", DUMMY_USERS_AND_ROLES.get("John"),
+                "DummyRole", roleOf("DummyRole"),
+                CRATE_USER.name(), CRATE_USER));
     }
 
     @Test
     public void test_old_users_metadata_is_preferred_over_roles_metadata() {
-        Set<Role> roles = RolesService.getRoles(
+        Map<String, Role> roles = RolesService.getRoles(
             new UsersMetadata(Collections.singletonMap("Arthur", null)),
-            new RolesMetadata(RolesHelper.DUMMY_USERS_AND_ROLES),
+            new RolesMetadata(DUMMY_USERS_AND_ROLES),
             new UsersPrivilegesMetadata());
 
-        assertThat(roles).containsExactlyInAnyOrder(
-            RolesHelper.userOf("Arthur"),
-            CRATE_USER);
+        assertThat(roles).containsExactlyInAnyOrderEntriesOf(
+            Map.of(
+                "Arthur" , userOf("Arthur"),
+                CRATE_USER.name(), CRATE_USER));
     }
 }


### PR DESCRIPTION
- Use a `Map<String, Role>` instead of a list in `RolesService`. Keep the `List<Role>` in the `Roles` interface for easier testing but implement use a `Map<String, Role>` in `RolesService` internally and override the `findUser()` to do a fast map lookup instead of iterating over the list.
- Move privileges resolution to Roles/RolesService, this is a preparation step to make recursive resolution based also on granted roles (hierarchy) easier.

Relates: #12109
