### PR TITLE
Use `FieldExistsQuery` if at least one arg of `!=` is nullable

### DIFF
--- a/server/src/main/java/io/crate/expression/predicate/NotPredicate.java
+++ b/server/src/main/java/io/crate/expression/predicate/NotPredicate.java
@@ -117,7 +117,7 @@ public class NotPredicate extends Scalar<Boolean, Boolean> {
         }
 
         boolean useFieldExistQuery() {
-            return removeNullValues && !useNotQuery && !enforceThreeValuedLogic;
+            return removeNullValues && !enforceThreeValuedLogic;
         }
     }
 

--- a/server/src/main/java/io/crate/expression/predicate/NotPredicate.java
+++ b/server/src/main/java/io/crate/expression/predicate/NotPredicate.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.lucene.search.Queries;
 
@@ -187,6 +188,9 @@ public class NotPredicate extends Scalar<Boolean, Boolean> {
                 // Ignored objects have no field names in the index, need function filter fallback
                 if (ref.columnPolicy() == ColumnPolicy.IGNORED) {
                     return null;
+                }
+                if (!ref.isNullable()) {
+                    return new MatchAllDocsQuery();
                 }
                 return IsNullPredicate.refExistsQuery(ref, context, true);
             }

--- a/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -726,4 +726,10 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
         query = convert("12.34 != any(d_array_index_off_no_docvalues)");
         assertThat(query).isExactlyInstanceOf(GenericFunctionQuery.class);
     }
+
+    @Test
+    public void test_is_not_null_on_not_null_ref() {
+        Query query = convert("x is not null");
+        assertThat(query).isExactlyInstanceOf(MatchAllDocsQuery.class);
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes https://github.com/crate/crate/issues/15202, a bug from `master`.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
