### PR TITLE
Fix ambigious quote escaping at the end of C-Style string

### DIFF
--- a/docs/appendices/release-notes/5.5.2.rst
+++ b/docs/appendices/release-notes/5.5.2.rst
@@ -98,6 +98,9 @@ Fixes
   :ref:`C-style escaped strings <sql_escape_string_literals>`.
   ``SELECT E'\%'`` used to return ``\%`` instead of ``%``.
 
+- Fixed an issue which led to ``SQLParseException`` when using an escaped quote
+  ``\'`` at the end of :ref:`C-style string <sql_escape_string_literals>`.
+
 - Fixed an issue that caused ``ALTER TABLE DROP COLUMN`` to falsely report
   success on dropping :ref:`system columns <sql_administration_system_columns>`
   despite any follow up queries on the dropped columns work as expected. Now

--- a/libs/sql-parser/src/main/antlr/io/crate/sql/parser/antlr/SqlBaseLexer.g4
+++ b/libs/sql-parser/src/main/antlr/io/crate/sql/parser/antlr/SqlBaseLexer.g4
@@ -367,8 +367,12 @@ STRING
     : '\'' ( ~'\'' | '\'\'' )* '\''
     ;
 
+// Description of rules, in the order of the appearence in |:
+// 1. Restrict single matches of \ or ' inside E'' (to be able to match specific combinations)
+// 2. Allow matching double single quote '' since quote can be escaped by  a quote
+// 3. Allow matching one or many backslashes followed by a non-slash character
 ESCAPED_STRING
-    : 'E' '\'' ( ~'\'' | '\'\'' | '\\\'' )* '\''
+    : 'E' '\'' ( ~('\'' | '\\') | '\'\'' | ('\\'+  ~'\\') )* '\''
     ;
 
 BIT_STRING


### PR DESCRIPTION
Fixes https://github.com/crate/crate/issues/15194

Sequnce `\''` at the end of the string used to be treated as `\` `''` instead of `\'` `'`

This PR restricts matching standalone backslash and instead allows matching one or more slashes followed by any other symbol. 

