### PR TITLE
Disable trust of HTTP ``X-Real-IP`` header by default.

### DIFF
--- a/.github/styles/CrateDB/Terminology.yml
+++ b/.github/styles/CrateDB/Terminology.yml
@@ -19,3 +19,4 @@ swap:
   Github: GitHub
   Hotspot: HotSpot
   hotspot: HotSpot
+  proxied: proxied

--- a/docs/admin/auth/hba.rst
+++ b/docs/admin/auth/hba.rst
@@ -49,8 +49,11 @@ username, IP address,  protocol and connection scheme against these entries
 to determine which authentication method is required. If no entry matches, the
 client authentication request will be denied.
 
-For HTTP connections the ``X-REAL-IP`` request header has priority over the
-actual client IP address in order to allow proxied clients to authenticate.
+To support proxied clients to authenticate, the ``X-REAL-IP`` request header
+can be used. For security reasons, this is disabled by default as it allows
+clients to impersonate other clients. To enable this feature,
+set :ref:`auth.trust.http_support_x_real_ip` to ``true``. If enabled, the
+``X-REAL-IP`` request header has priority over the actual client IP address.
 
 If ``auth.host_based`` is not set, the host based authentication is disabled.
 In this case CrateDB **trusts all connections** and accepts the user provided by

--- a/docs/appendices/release-notes/5.5.2.rst
+++ b/docs/appendices/release-notes/5.5.2.rst
@@ -46,6 +46,17 @@ See the :ref:`version_5.5.0` release notes for a full list of changes in the
 5.5 series.
 
 
+Security Fixes
+==============
+
+- The HTTP transport will not trust any ``X-Real-IP`` header by default anymore.
+  This prevents a client from spoofing its IP address by setting these headers
+  and thus bypassing IP based authentication with is enabled by default for the
+  ``crate`` superuser.
+  To keep allowing the ``X-Real-IP`` header to be trusted, you have to
+  explicitly enable it via the :ref:`auth.trust.http_support_x_real_ip` node
+  setting.
+
 Packaging Changes
 =================
 

--- a/docs/config/node.rst
+++ b/docs/config/node.rst
@@ -517,6 +517,24 @@ Trust authentication
   to CrateDB via HTTP protocol and they do not specify a user via the
   ``Authorization`` request header.
 
+.. _auth.trust.http_support_x_real_ip:
+
+**auth.trust.http_support_x_real_ip**
+  | *Default:* ``false``
+  | *Runtime:* ``no``
+
+  If enabled, the HTTP transport will trust the ``X-Real-IP`` header sent by
+  the client to determine the client's IP address. This is useful when CrateDB
+  is running behind a reverse proxy or load-balancer. For improved security,
+  any ``_local_`` IP address (``127.0.0.1`` and ``::1``) defined in this header
+  will be ignored.
+
+.. warning::
+
+    Enabling this setting can be a security risk, as it allows clients to
+    impersonate other clients by sending a fake ``X-Real-IP`` header.
+
+
 Host-based authentication
 -------------------------
 

--- a/server/src/main/java/io/crate/auth/AuthSettings.java
+++ b/server/src/main/java/io/crate/auth/AuthSettings.java
@@ -21,13 +21,13 @@
 
 package io.crate.auth;
 
-import io.crate.types.DataTypes;
-import io.netty.handler.ssl.ClientAuth;
+import java.util.function.Function;
 
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 
-import java.util.function.Function;
+import io.crate.types.DataTypes;
+import io.netty.handler.ssl.ClientAuth;
 
 public final class AuthSettings {
 
@@ -54,6 +54,11 @@ public final class AuthSettings {
     );
 
     public static final String HTTP_HEADER_REAL_IP = "X-Real-Ip";
+    public static final Setting<Boolean> AUTH_TRUST_HTTP_SUPPORT_X_REAL_IP = Setting.boolSetting(
+        "auth.trust.http_support_x_real_ip",
+        false,
+        Setting.Property.NodeScope
+    );
 
     public static ClientAuth resolveClientAuth(Settings settings, Protocol protocol) {
         Settings hbaSettings = AUTH_HOST_BASED_CONFIG_SETTING.get(settings);

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -435,6 +435,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
         AuthSettings.AUTH_HOST_BASED_ENABLED_SETTING,
         AuthSettings.AUTH_HOST_BASED_CONFIG_SETTING,
         AuthSettings.AUTH_TRUST_HTTP_DEFAULT_HEADER,
+        AuthSettings.AUTH_TRUST_HTTP_SUPPORT_X_REAL_IP,
         SslSettings.SSL_TRANSPORT_MODE,
         SslSettings.SSL_HTTP_ENABLED,
         SslSettings.SSL_PSQL_ENABLED,

--- a/server/src/test/java/io/crate/auth/HttpAuthUpstreamHandlerTest.java
+++ b/server/src/test/java/io/crate/auth/HttpAuthUpstreamHandlerTest.java
@@ -141,7 +141,51 @@ public class HttpAuthUpstreamHandlerTest extends ESTestCase {
 
         DefaultHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/_sql");
         request.headers().add(HttpHeaderNames.AUTHORIZATION.toString(), "Basic QWxhZGRpbjpPcGVuU2VzYW1l");
-        request.headers().add("X-Real-Ip", "10.1.0.100");
+
+        ch.writeInbound(request);
+        ch.releaseInbound();
+        assertThat(handler.authorized()).isFalse();
+
+        assertUnauthorized(
+            ch.readOutbound(),
+            "No valid auth.host_based.config entry found for host \"127.0.0.1\", user \"Aladdin\", protocol \"http\". Did you enable TLS in your client?\n");
+    }
+
+    /**
+     * Ensure that the {@code X-Real-IP} header is ignored by default as this allows to by-pass HBA rules.
+     * See https://github.com/crate/crate/issues/15231.
+     */
+    @Test
+    public void test_real_ip_header_is_ignored_by_default() {
+        HttpAuthUpstreamHandler handler = new HttpAuthUpstreamHandler(Settings.EMPTY, authService);
+        EmbeddedChannel ch = new EmbeddedChannel(handler);
+
+        DefaultHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/_sql");
+        request.headers().add(HttpHeaderNames.AUTHORIZATION.toString(), "Basic QWxhZGRpbjpPcGVuU2VzYW1l");
+
+        request.headers().add("X-Real-IP", "10.1.0.100");
+
+        ch.writeInbound(request);
+        ch.releaseInbound();
+        assertThat(handler.authorized()).isFalse();
+
+        assertUnauthorized(
+            ch.readOutbound(),
+            "No valid auth.host_based.config entry found for host \"127.0.0.1\", user \"Aladdin\", protocol \"http\". Did you enable TLS in your client?\n");
+    }
+
+    @Test
+    public void test_real_ip_header_is_used_if_enabled() {
+        var settings = Settings.builder()
+            .put(AuthSettings.AUTH_TRUST_HTTP_SUPPORT_X_REAL_IP.getKey(), true)
+            .build();
+        HttpAuthUpstreamHandler handler = new HttpAuthUpstreamHandler(settings, authService);
+        EmbeddedChannel ch = new EmbeddedChannel(handler);
+
+        DefaultHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/_sql");
+        request.headers().add(HttpHeaderNames.AUTHORIZATION.toString(), "Basic QWxhZGRpbjpPcGVuU2VzYW1l");
+
+        request.headers().add("X-Real-IP", "10.1.0.100");
 
         ch.writeInbound(request);
         ch.releaseInbound();
@@ -150,6 +194,28 @@ public class HttpAuthUpstreamHandlerTest extends ESTestCase {
         assertUnauthorized(
             ch.readOutbound(),
             "No valid auth.host_based.config entry found for host \"10.1.0.100\", user \"Aladdin\", protocol \"http\". Did you enable TLS in your client?\n");
+    }
+
+    @Test
+    public void test_real_ip_header_blacklist() {
+        var settings = Settings.builder()
+            .put(AuthSettings.AUTH_TRUST_HTTP_SUPPORT_X_REAL_IP.getKey(), true)
+            .build();
+        HttpAuthUpstreamHandler handler = new HttpAuthUpstreamHandler(settings, authService);
+        EmbeddedChannel ch = new EmbeddedChannel(handler);
+
+        DefaultHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/_sql");
+        request.headers().add(HttpHeaderNames.AUTHORIZATION.toString(), "Basic QWxhZGRpbjpPcGVuU2VzYW1l");
+
+        request.headers().add("X-Real-IP", "::1");
+
+        ch.writeInbound(request);
+        ch.releaseInbound();
+        assertThat(handler.authorized()).isFalse();
+
+        assertUnauthorized(
+            ch.readOutbound(),
+            "No valid auth.host_based.config entry found for host \"127.0.0.1\", user \"Aladdin\", protocol \"http\". Did you enable TLS in your client?\n");
     }
 
     @Test


### PR DESCRIPTION
It can be enabled by a newly introduced node setting. If enabled, it will be ignored if matching any _local_ address.

Relates to #15231.
