### PR TITLE
Add missing word to our styles config to fix vale

### DIFF
--- a/.github/styles/CrateDB/Terminology.yml
+++ b/.github/styles/CrateDB/Terminology.yml
@@ -19,4 +19,3 @@ swap:
   Github: GitHub
   Hotspot: HotSpot
   hotspot: HotSpot
-  proxied: proxied

--- a/.github/styles/Vocab/CrateDB/accept.txt
+++ b/.github/styles/Vocab/CrateDB/accept.txt
@@ -148,3 +148,4 @@ upserts
 Upserts
 URIs
 vnet
+proxied


### PR DESCRIPTION
I've added the word at the wrong place 🤦 .

Follow up of c27118f25f5a449c0c9c58ce552a1f0980be2581.