### PR TITLE
Always try to migrate users to roles on CREATE/ALTER/DROP ROLE

### DIFF
--- a/server/src/main/java/io/crate/role/metadata/RolesMetadata.java
+++ b/server/src/main/java/io/crate/role/metadata/RolesMetadata.java
@@ -83,8 +83,8 @@ public class RolesMetadata extends AbstractNamedDiffable<Metadata.Custom> implem
         return roles.containsKey(name);
     }
 
-    public void remove(String name) {
-        roles.remove(name);
+    public Role remove(String name) {
+        return roles.remove(name);
     }
 
     public List<String> roleNames() {


### PR DESCRIPTION
Migration to new RolesMetadata should always kick in, even when:
 - the role to create already exist
 - the role to drop doesn't exist
 - the role to alter doesn't exist
