### PR TITLE
Add `parents` column to `sys.users` and `sys.roles`

### DIFF
--- a/docs/admin/system-information.rst
+++ b/docs/admin/system-information.rst
@@ -2154,17 +2154,26 @@ Users
 
 The ``sys.users`` table contains all existing database users in the cluster.
 
-+---------------+----------------------------------------------+-------------+
-| Column Name   | Description                                  | Return Type |
-+===============+==============================================+=============+
-| ``name``      | The name of the database user.               | ``TEXT``    |
-+---------------+----------------------------------------------+-------------+
-| ``superuser`` | Flag to indicate whether the user is a       | ``BOOLEAN`` |
-|               | superuser.                                   |             |
-+---------------+----------------------------------------------+-------------+
-| ``password``  | ``********`` if there is a password set or   | ``TEXT``    |
-|               | ``NULL`` if there is not.                    |             |
-+---------------+----------------------------------------------+-------------+
++-----------------------+-------------------------------------+-------------+
+| Column Name           | Description                         | Return Type |
++=======================+=====================================+=============+
+| ``name``              | The name of the database user.      | ``TEXT``    |
++-----------------------+-------------------------------------+-------------+
+| ``superuser``         | Flag to indicate whether the user   | ``BOOLEAN`` |
+|                       | is a superuser.                     |             |
++-----------------------+-------------------------------------+-------------+
+| ``password``          | ``********`` if there is a password | ``TEXT``    |
+|                       | set or ``NULL`` if there is not.    |             |
++-----------------------+-------------------------------------+-------------+
+| ``parents``           | A list of parent roles granted to   | ``ARRAY``   |
+|                       | the user                            |             |
++-----------------------+-------------------------------------+-------------+
+| ``parents[role]``     | The name of the role granted to     | ``TEXT``    |
+|                       | the user                            |             |
++-----------------------+-------------------------------------+-------------+
+| ``parents[grantor]``  | The name of user who granted the    | ``TEXT``    |
+|                       | role to the user                    |             |
++-----------------------+-------------------------------------+-------------+
 
 .. _sys-roles:
 
@@ -2173,11 +2182,20 @@ Roles
 
 The ``sys.roles`` table contains all existing database roles in the cluster.
 
-+---------------+----------------------------------------------+-------------+
-| Column Name   | Description                                  | Return Type |
-+===============+==============================================+=============+
-| ``name``      | The name of the database user.               | ``TEXT``    |
-+---------------+----------------------------------------------+-------------+
++---------------+---------------------------------------------+-------------+
+| Column Name   | Description                                 | Return Type |
++===============+=============================================+=============+
+| ``name``      | The name of the database user.              | ``TEXT``    |
++---------------+---------------------------------------------+-------------+
+| ``parents``           | A list of parent roles granted to   | ``ARRAY``   |
+|                       | the user                            |             |
++-----------------------+-------------------------------------+-------------+
+| ``parents[role]``     | The name of the role granted to     | ``TEXT``    |
+|                       | the user                            |             |
++-----------------------+-------------------------------------+-------------+
+| ``parents[grantor]``  | The name of user who granted the    | ``TEXT``    |
+|                       | role to the user                    |             |
++-----------------------+-------------------------------------+-------------+
 
 .. _sys-allocations:
 

--- a/docs/admin/user-management.rst
+++ b/docs/admin/user-management.rst
@@ -121,6 +121,15 @@ statement returns an error::
 List users
 ==========
 
+.. hide:
+
+    cr> CREATE ROLE role_a;
+    CREATE OK, 1 row affected (... sec)
+    cr> CREATE ROLE role_b;
+    CREATE OK, 1 row affected (... sec)
+    cr> GRANT role_a, role_b TO user_a;
+    GRANT OK, 2 rows affected (... sec)
+
 CrateDB exposes database users via the read-only :ref:`sys-users` system table.
 The ``sys.users`` table shows all users in the cluster which can be used for
 authentication. The initial superuser ``crate`` which is available for all
@@ -129,18 +138,16 @@ CrateDB clusters is also part of that list.
 To list all existing users query the table::
 
     cr> SELECT * FROM sys.users order by name;
-    +-------------+----------+-----------+
-    | name        | password | superuser |
-    +-------------+----------+-----------+
-    | Custom User |     NULL | FALSE     |
-    | crate       |     NULL | TRUE      |
-    | user_a      |     NULL | FALSE     |
-    | user_b      | ******** | FALSE     |
-    +-------------+----------+-----------+
+    +-------------+----------------------------------------------------------------------------------+----------+-----------+
+    | name        | parents                                                                          | password | superuser |
+    +-------------+----------------------------------------------------------------------------------+----------+-----------+
+    | Custom User | []                                                                               | NULL     | FALSE     |
+    | crate       | []                                                                               | NULL     | TRUE      |
+    | user_a      | [{"grantor": "crate", "role": "role_a"}, {"grantor": "crate", "role": "role_b"}] | NULL     | FALSE     |
+    | user_b      | []                                                                               | ******** | FALSE     |
+    +-------------+----------------------------------------------------------------------------------+----------+-----------+
     SELECT 4 rows in set (... sec)
 
-The column ``name`` shows the unique name of the user, the column ``superuser``
-shows whether the user has superuser privileges or not.
 
 .. NOTE::
 
@@ -154,10 +161,11 @@ List roles
 
 .. hide:
 
-    cr> CREATE ROLE role_a;
+    cr> CREATE ROLE role_c;
     CREATE OK, 1 row affected (... sec)
-    cr> CREATE ROLE role_b;
-    CREATE OK, 1 row affected (... sec)
+    cr> GRANT role_c TO role_b;
+    GRANT OK, 1 row affected (... sec)
+
 
 CrateDB exposes database roles via the read-only :ref:`sys-roles` system table.
 The ``sys.roles`` table shows all roles in the cluster which can be used to
@@ -166,15 +174,15 @@ group privileges.
 To list all existing roles query the table::
 
     cr> SELECT * FROM sys.roles order by name;
-    +--------+
-    | name   |
-    +--------+
-    | role_a |
-    | role_b |
-    +--------+
-    SELECT 2 rows in set (... sec)
+    +--------+------------------------------------------+
+    | name   | parents                                  |
+    +--------+------------------------------------------+
+    | role_a | []                                       |
+    | role_b | [{"grantor": "crate", "role": "role_c"}] |
+    | role_c | []                                       |
+    +--------+------------------------------------------+
+    SELECT 3 rows in set (... sec)
 
-The column ``name`` shows the unique name of the role.
 
 .. vale off
 .. Drop Users & Roles
@@ -189,4 +197,6 @@ The column ``name`` shows the unique name of the role.
     cr> DROP ROLE role_a;
     DROP OK, 1 row affected (... sec)
     cr> DROP ROLE role_b;
+    DROP OK, 1 row affected (... sec)
+    cr> DROP ROLE role_c;
     DROP OK, 1 row affected (... sec)

--- a/docs/appendices/release-notes/5.6.0.rst
+++ b/docs/appendices/release-notes/5.6.0.rst
@@ -141,3 +141,6 @@ Administration and Operations
 
 - Added :ref:`sys.roles<sys-roles>` table which contains all database roles
   defined in the cluster.
+
+- Added ``parents`` column to :ref:`sys.users<sys-users>` table which lists the
+  roles granted to a user, together with the user that granted each role.

--- a/server/src/main/java/io/crate/role/GrantedRole.java
+++ b/server/src/main/java/io/crate/role/GrantedRole.java
@@ -31,8 +31,9 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.jetbrains.annotations.NotNull;
 
-public record GrantedRole(String roleName, String grantor) implements ToXContent, Writeable {
+public record GrantedRole(String roleName, String grantor) implements ToXContent, Writeable, Comparable<GrantedRole> {
 
     public GrantedRole(StreamInput in) throws IOException {
         this(in.readString(), in.readString());
@@ -108,5 +109,14 @@ public record GrantedRole(String roleName, String grantor) implements ToXContent
     @Override
     public String toString() {
         return "GrantedRole{" + roleName + ", grantor: " + grantor + '}';
+    }
+
+    @Override
+    public int compareTo(@NotNull GrantedRole o) {
+        int cmp = this.roleName.compareTo(o.roleName);
+        if (cmp != 0) {
+            return cmp;
+        }
+        return this.grantor.compareTo(o.grantor);
     }
 }

--- a/server/src/main/java/io/crate/role/metadata/SysRolesTableInfo.java
+++ b/server/src/main/java/io/crate/role/metadata/SysRolesTableInfo.java
@@ -27,6 +27,7 @@ import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.SystemTable;
 import io.crate.metadata.sys.SysSchemaInfo;
+import io.crate.role.GrantedRole;
 import io.crate.role.Role;
 
 public class SysRolesTableInfo {
@@ -38,6 +39,10 @@ public class SysRolesTableInfo {
     public static SystemTable<Role> create() {
         return SystemTable.<Role>builder(IDENT)
             .add("name", STRING, Role::name)
+            .startObjectArray("parents", r -> r.grantedRoles().stream().sorted().toList())
+                .add("role", STRING, GrantedRole::roleName)
+                .add("grantor", STRING, GrantedRole::grantor)
+            .endObjectArray()
             .setPrimaryKeys(new ColumnIdent("name"))
             .build();
     }

--- a/server/src/main/java/io/crate/role/metadata/SysUsersTableInfo.java
+++ b/server/src/main/java/io/crate/role/metadata/SysUsersTableInfo.java
@@ -28,6 +28,7 @@ import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.SystemTable;
 import io.crate.metadata.sys.SysSchemaInfo;
+import io.crate.role.GrantedRole;
 import io.crate.role.Role;
 
 public class SysUsersTableInfo {
@@ -42,6 +43,10 @@ public class SysUsersTableInfo {
             .add("name", STRING, Role::name)
             .add("superuser", BOOLEAN, Role::isSuperUser)
             .add("password", STRING, x -> x.password() == null ? null : PASSWORD_PLACEHOLDER)
+            .startObjectArray("parents", r -> r.grantedRoles().stream().sorted().toList())
+                .add("role", STRING, GrantedRole::roleName)
+                .add("grantor", STRING, GrantedRole::grantor)
+            .endObjectArray()
             .setPrimaryKeys(new ColumnIdent("name"))
             .build();
     }

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -565,7 +565,7 @@ public class InformationSchemaTest extends IntegTestCase {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertThat(response.rowCount()).isEqualTo(975);
+        assertThat(response.rowCount()).isEqualTo(981);
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/RoleManagementIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/RoleManagementIntegrationTest.java
@@ -29,14 +29,46 @@ import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static io.netty.handler.codec.http.HttpResponseStatus.UNAUTHORIZED;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.Set;
+
 import org.elasticsearch.test.IntegTestCase;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
+import io.crate.action.sql.Session;
+import io.crate.action.sql.Sessions;
 import io.crate.exceptions.UnsupportedFeatureException;
+import io.crate.role.Privilege;
+import io.crate.role.PrivilegeState;
+import io.crate.role.metadata.RolesHelper;
 import io.crate.testing.Asserts;
 
 @IntegTestCase.ClusterScope(minNumDataNodes = 2)
 public class RoleManagementIntegrationTest extends BaseRolesIntegrationTest {
+
+    private Session grantorUserSession;
+
+    private Session createGrantorUserSession() {
+        Sessions sqlOperations = cluster().getInstance(Sessions.class);
+        var alPriv = new Privilege(
+            PrivilegeState.GRANT,
+            Privilege.Type.AL,
+            Privilege.Clazz.CLUSTER,
+            null,
+            "crate");
+        return sqlOperations.newSession(null, RolesHelper.userOf("the_grantor", Set.of(alPriv), null));
+    }
+
+    @Before
+    public void setUpAdditionalSessions() {
+        grantorUserSession = createGrantorUserSession();
+    }
+
+    @After
+    public void closeAdditionalSessions() {
+        grantorUserSession.close();
+    }
 
     @Test
     public void testCreateUser() {
@@ -64,16 +96,19 @@ public class RoleManagementIntegrationTest extends BaseRolesIntegrationTest {
         // The sys.users table contains 3 columns, name, password and superuser flag
         executeAsSuperuser("select column_name, data_type from information_schema.columns where table_name='users' and table_schema='sys'");
         assertThat(response).hasRows(
-                "name| text",
-                "password| text",
-                "superuser| boolean");
+            "name| text",
+            "parents| object_array",
+            "parents['grantor']| text_array",
+            "parents['role']| text_array",
+            "password| text",
+            "superuser| boolean");
     }
 
     @Test
     public void testSysUsersTableDefaultUser() {
         // The sys.users table always contains the superuser crate
-        executeAsSuperuser("select name, password, superuser from sys.users where name = 'crate'");
-        assertThat(response).hasRows("crate| NULL| true");
+        executeAsSuperuser("select * from sys.users where name = 'crate'");
+        assertThat(response).hasRows("crate| []| NULL| true");
     }
 
     @Test
@@ -82,18 +117,24 @@ public class RoleManagementIntegrationTest extends BaseRolesIntegrationTest {
         assertUserIsCreated("arthur");
         executeAsSuperuser("CREATE USER ford WITH (password = 'foo')");
         assertUserIsCreated("ford");
-        executeAsSuperuser("SELECT name, password, superuser FROM sys.users WHERE superuser = FALSE ORDER BY name");
+        executeAsSuperuser("CREATE ROLE a_role");
+        assertRoleIsCreated("a_role");
+        execute("GRANT a_role to arthur", null, grantorUserSession);
+        executeAsSuperuser("SELECT * FROM sys.users WHERE superuser = FALSE ORDER BY name");
         // Every created user is not a superuser
         assertThat(response).hasRows(
-                "arthur| NULL| false",
-                "ford| ********| false");
+            "arthur| [{role=a_role, grantor=the_grantor}]| NULL| false",
+            "ford| []| ********| false");
     }
 
     @Test
     public void testSysRolesTableColumns() {
-        // The sys.roles table contains one column
         executeAsSuperuser("select column_name, data_type from information_schema.columns where table_name='roles' and table_schema='sys'");
-        assertThat(response).hasRows("name| text");
+        assertThat(response).hasRows(
+            "name| text",
+            "parents| object_array",
+            "parents['grantor']| text_array",
+            "parents['role']| text_array");
     }
 
     @Test
@@ -102,10 +143,15 @@ public class RoleManagementIntegrationTest extends BaseRolesIntegrationTest {
         assertRoleIsCreated("role1");
         executeAsSuperuser("CREATE ROLE role2");
         assertRoleIsCreated("role2");
+        executeAsSuperuser("CREATE ROLE role3");
+        assertRoleIsCreated("role3");
+        execute("GRANT role3, role2 TO role1", null, grantorUserSession);
         executeAsSuperuser("SELECT * FROM sys.roles ORDER BY name");
         assertThat(response).hasRows(
-            "role1",
-            "role2");
+            "role1| [{role=role2, grantor=the_grantor}, {role=role3, grantor=the_grantor}]",
+            "role2| []",
+            "role3| []"
+        );
     }
 
     @Test
@@ -124,8 +170,8 @@ public class RoleManagementIntegrationTest extends BaseRolesIntegrationTest {
         executeAsSuperuser("ALTER USER ford SET (password = ?)", new Object[]{"pass"});
         executeAsSuperuser("SELECT name, password, superuser FROM sys.users WHERE superuser = FALSE ORDER BY name");
         assertThat(response).hasRows(
-                "arthur| ********| false",
-                "ford| ********| false");
+            "arthur| ********| false",
+            "ford| ********| false");
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
@@ -1000,12 +1000,12 @@ public class SnapshotRestoreIntegrationTest extends IntegTestCase {
         execute("CREATE ROLE \"DummyRole\"");
         execute("SELECT * FROM sys.users ORDER BY name");
         assertThat(response).hasRows(
-            "Arthur| NULL| false",
-            "John| ********| false",
-            "crate| NULL| true");
+            "Arthur| []| NULL| false",
+            "John| []| ********| false",
+            "crate| []| NULL| true");
 
         execute("SELECT * FROM sys.roles ORDER BY name");
-        assertThat(response).hasRows("DummyRole");
+        assertThat(response).hasRows("DummyRole| []");
 
         execute("GRANT AL TO \"DummyRole\"");
         execute("GRANT DML ON SCHEMA \"doc\" TO \"Arthur\"");
@@ -1024,10 +1024,10 @@ public class SnapshotRestoreIntegrationTest extends IntegTestCase {
 
         execute("SELECT * FROM sys.users ORDER BY name");
         assertThat(response).hasRows(
-            "Arthur| ********| false",
-            "Ford| ********| false",
-            "John| NULL| false",
-            "crate| NULL| true");
+            "Arthur| []| ********| false",
+            "Ford| []| ********| false",
+            "John| []| NULL| false",
+            "crate| []| NULL| true");
         execute("SELECT count(*) FROM sys.roles");
         assertThat(response).hasRows("0");
 
@@ -1061,10 +1061,10 @@ public class SnapshotRestoreIntegrationTest extends IntegTestCase {
         execute("ALTER USER \"John\" SET (password='johns-new-password')");
         execute("SELECT * FROM sys.users ORDER BY name");
         assertThat(response).hasRows(
-            "Arthur| ********| false",
-            "Ford| ********| false",
-            "John| ********| false",
-            "crate| NULL| true");
+            "Arthur| []| ********| false",
+            "Ford| []| ********| false",
+            "John| []| ********| false",
+            "crate| []| NULL| true");
         execute("SELECT count(*) FROM sys.roles");
         assertThat(response).hasRows("0");
 


### PR DESCRIPTION
The column is an object array which contains tuples of granted role together with the grantor (user who granted the role).

Relates: #12109
