### PR TITLE
Simplify sequence of NOT operators

### DIFF
--- a/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -795,4 +795,9 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
         query = convert("not (y is not null)");
         assertThat(query).hasToString("+*:* -FieldExistsQuery [field=y]");
     }
+
+    @Test
+    public void test_simplify_series_of_is_null() {
+        assertThat(convert("(y is null) is null")).isEqualTo(convert("false"));
+    }
 }

--- a/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -786,4 +786,13 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
         Query query = convert("not (y is not null)");
         assertThat(query).hasToString("+(+*:* -FieldExistsQuery [field=y])");
     }
+
+    @Test
+    public void test_simplify_series_of_not_operators() {
+        Query query = convert("not(y != 1)");
+        assertThat(query).isEqualTo(convert("y = 1"));
+
+        query = convert("not (y is not null)");
+        assertThat(query).hasToString("+*:* -FieldExistsQuery [field=y]");
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
This fixes the very specific bug scenario in https://github.com/crate/crate/issues/15265 but it is not complete.

Queries like `(y is not null) is not null` still fails. I think it is because `NullabilityContext` allows both of its fields `useNotQuery` and `removeNullValues` to be set to `true` which I am thinking need to be mutually exclusive instead.

## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
