### PR TITLE
tests: Migrate to assertj

### DIFF
--- a/server/src/test/java/io/crate/cluster/gracefulstop/DecommissioningServiceTest.java
+++ b/server/src/test/java/io/crate/cluster/gracefulstop/DecommissioningServiceTest.java
@@ -21,8 +21,7 @@
 
 package io.crate.cluster.gracefulstop;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static io.crate.testing.Asserts.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -32,12 +31,11 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.jetbrains.annotations.Nullable;
-
 import org.elasticsearch.action.admin.cluster.health.TransportClusterHealthAction;
 import org.elasticsearch.action.admin.cluster.settings.TransportClusterUpdateSettingsAction;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
+import org.jetbrains.annotations.Nullable;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Answers;
@@ -76,16 +74,16 @@ public class DecommissioningServiceTest extends CrateDummyClusterServiceUnitTest
     @Test
     public void testExitIfNoActiveRequests() throws Exception {
         decommissioningService.exitIfNoActiveRequests(0);
-        assertThat(exited.get(), is(true));
-        assertThat(decommissioningService.forceStopOrAbortCalled, is(false));
+        assertThat(exited.get()).isTrue();
+        assertThat(decommissioningService.forceStopOrAbortCalled).isFalse();
     }
 
     @Test
     public void testNoExitIfRequestAreActive() throws Exception {
         jobsLogs.logExecutionEnd(UUID.randomUUID(), null);
         decommissioningService.exitIfNoActiveRequests(System.nanoTime());
-        assertThat(exited.get(), is(false));
-        assertThat(decommissioningService.forceStopOrAbortCalled, is(false));
+        assertThat(exited.get()).isFalse();
+        assertThat(decommissioningService.forceStopOrAbortCalled).isFalse();
         verify(executorService, times(1)).schedule(
             Mockito.any(Runnable.class), Mockito.anyLong(), Mockito.any(TimeUnit.class));
     }
@@ -94,7 +92,7 @@ public class DecommissioningServiceTest extends CrateDummyClusterServiceUnitTest
     public void testAbortOrForceStopIsCalledOnTimeout() throws Exception {
         jobsLogs.logExecutionEnd(UUID.randomUUID(), null);
         decommissioningService.exitIfNoActiveRequests(System.nanoTime() - TimeValue.timeValueHours(3).nanos());
-        assertThat(decommissioningService.forceStopOrAbortCalled, is(true));
+        assertThat(decommissioningService.forceStopOrAbortCalled).isTrue();
         verify(sqlOperations, times(1)).enable();
     }
 

--- a/server/src/test/java/io/crate/execution/engine/JobLauncherWaitForCompletionTest.java
+++ b/server/src/test/java/io/crate/execution/engine/JobLauncherWaitForCompletionTest.java
@@ -21,9 +21,8 @@
 
 package io.crate.execution.engine;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertThrows;
+import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.util.List;
@@ -75,12 +74,13 @@ public class JobLauncherWaitForCompletionTest extends CrateDummyClusterServiceUn
     public void testCopyPlanNoWaitForCompletion() throws Exception {
         TestingRowConsumer consumer = new TestingRowConsumer();
         jobLauncher.execute(consumer, plannerContext.transactionContext(), false);
-        assertThat((Long)consumer.getResult(50).get(0)[0], is(-1L));
+        assertThat((Long) consumer.getResult(50).get(0)[0]).isEqualTo(-1);
     }
 
     public void testCopyPlanWaitForCompletion() throws Exception {
         TestingRowConsumer consumer = new TestingRowConsumer();
         jobLauncher.execute(consumer, plannerContext.transactionContext(), true);
-        assertThrows(TimeoutException.class, () -> consumer.getResult(100));
+        assertThatThrownBy(() -> consumer.getResult(100))
+            .isExactlyInstanceOf(TimeoutException.class);
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/collect/CollectTaskTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/CollectTaskTest.java
@@ -100,6 +100,7 @@ public class CollectTaskTest extends ESTestCase {
         );
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     public void testAddingSameContextTwice() throws Exception {
         RefCountedItem<IndexSearcher> mock1 = mock(RefCountedItem.class);
@@ -157,6 +158,7 @@ public class CollectTaskTest extends ESTestCase {
     }
 
 
+    @SuppressWarnings("unchecked")
     @Test
     public void test_kill_before_start_triggers_consumer() throws Exception {
         RefCountedItem<IndexSearcher> searcher = mock(RefCountedItem.class);

--- a/server/src/test/java/io/crate/execution/engine/collect/CollectTaskTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/CollectTaskTest.java
@@ -21,10 +21,9 @@
 
 package io.crate.execution.engine.collect;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertThrows;
+import static io.crate.testing.Asserts.assertThat;
+import static io.crate.testing.Asserts.assertThatThrownBy;
+import static io.crate.testing.Asserts.fail;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -109,7 +108,7 @@ public class CollectTaskTest extends ESTestCase {
             collectTask.addSearcher(1, mock1);
             collectTask.addSearcher(1, mock2);
 
-            assertFalse(true); // second addContext call should have raised an exception
+            fail("2nd addContext call should have raised an exception");
         } catch (IllegalArgumentException e) {
             verify(mock1, times(1)).close();
             verify(mock2, times(0)).close(); // would be closed via `kill` on the context
@@ -119,7 +118,7 @@ public class CollectTaskTest extends ESTestCase {
     @Test
     public void testThreadPoolNameForDocTables() throws Exception {
         String threadPoolExecutorName = CollectTask.threadPoolName(collectPhase, true);
-        assertThat(threadPoolExecutorName, is(ThreadPool.Names.SEARCH));
+        assertThat(threadPoolExecutorName).isEqualTo(ThreadPool.Names.SEARCH);
     }
 
     @Test
@@ -132,29 +131,29 @@ public class CollectTaskTest extends ESTestCase {
         // sys.cluster (single row collector)
         when(collectPhase.maxRowGranularity()).thenReturn(RowGranularity.CLUSTER);
         String threadPoolExecutorName = CollectTask.threadPoolName(collectPhase, true);
-        assertThat(threadPoolExecutorName, is(ThreadPool.Names.SEARCH));
+        assertThat(threadPoolExecutorName).isEqualTo(ThreadPool.Names.SEARCH);
 
         // partition values only of a partitioned doc table (single row collector)
         when(collectPhase.maxRowGranularity()).thenReturn(RowGranularity.PARTITION);
         threadPoolExecutorName = CollectTask.threadPoolName(collectPhase, true);
-        assertThat(threadPoolExecutorName, is(ThreadPool.Names.SEARCH));
+        assertThat(threadPoolExecutorName).isEqualTo(ThreadPool.Names.SEARCH);
 
         // sys.nodes (single row collector)
         when(collectPhase.maxRowGranularity()).thenReturn(RowGranularity.NODE);
         threadPoolExecutorName = CollectTask.threadPoolName(collectPhase, true);
-        assertThat(threadPoolExecutorName, is(ThreadPool.Names.GET));
+        assertThat(threadPoolExecutorName).isEqualTo(ThreadPool.Names.GET);
 
         // sys.shards
         when(routing.containsShards(localNodeId)).thenReturn(true);
         when(collectPhase.maxRowGranularity()).thenReturn(RowGranularity.SHARD);
         threadPoolExecutorName = CollectTask.threadPoolName(collectPhase, true);
-        assertThat(threadPoolExecutorName, is(ThreadPool.Names.GET));
+        assertThat(threadPoolExecutorName).isEqualTo(ThreadPool.Names.GET);
         when(routing.containsShards(localNodeId)).thenReturn(false);
 
         // information_schema.*
         when(collectPhase.maxRowGranularity()).thenReturn(RowGranularity.DOC);
         threadPoolExecutorName = CollectTask.threadPoolName(collectPhase, false);
-        assertThat(threadPoolExecutorName, is(ThreadPool.Names.SAME));
+        assertThat(threadPoolExecutorName).isEqualTo(ThreadPool.Names.SAME);
     }
 
 
@@ -164,10 +163,8 @@ public class CollectTaskTest extends ESTestCase {
         RefCountedItem<IndexSearcher> searcher = mock(RefCountedItem.class);
         collectTask.addSearcher(1, searcher);
         collectTask.kill(JobKilledException.of(null));
-        assertThrows(
-            JobKilledException.class,
-            consumer::getBucket
-        );
+        assertThatThrownBy(consumer::getBucket)
+            .isExactlyInstanceOf(JobKilledException.class);
         verify(searcher, times(1)).close();
     }
 
@@ -180,10 +177,8 @@ public class CollectTaskTest extends ESTestCase {
         collectTask.start();
         collectTask.kill(JobKilledException.of(null));
         futureBatchIterator.complete(batchIterator);
-        assertThrows(
-            JobKilledException.class,
-            consumer::getBucket
-        );
+        assertThatThrownBy(consumer::getBucket)
+            .isExactlyInstanceOf(JobKilledException.class);
     }
 
     @Test
@@ -235,7 +230,8 @@ public class CollectTaskTest extends ESTestCase {
     public void test_add_searcher_after_kill_completed_does_close_searcher() throws Exception {
         RefCountedItem<IndexSearcher> searcher = mock(RefCountedItem.class);
         collectTask.kill(JobKilledException.of(null));
-        assertThrows(JobKilledException.class, () -> collectTask.addSearcher(0, searcher));
+        assertThatThrownBy(() -> collectTask.addSearcher(0, searcher))
+            .isExactlyInstanceOf(JobKilledException.class);
         verify(searcher, times(1)).close();
     }
 
@@ -244,6 +240,7 @@ public class CollectTaskTest extends ESTestCase {
         when(collectOperation.createIterator(Mockito.any(), Mockito.any(), anyBoolean(), Mockito.any()))
             .thenThrow(new RuntimeException("create iterator failed"));
         collectTask.start();
-        assertThrows(RuntimeException.class, consumer::getBucket);
+        assertThatThrownBy(consumer::getBucket)
+            .isExactlyInstanceOf(RuntimeException.class);
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/collect/collectors/NodeStatsTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/collectors/NodeStatsTest.java
@@ -23,8 +23,7 @@ package io.crate.execution.engine.collect.collectors;
 
 import static io.crate.testing.DiscoveryNodes.newNode;
 import static io.crate.testing.TestingHelpers.createNodeContext;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -180,9 +179,9 @@ public class NodeStatsTest extends ESTestCase {
         assertThat(req.getAllValues().stream()
                        .map(NodeStatsRequest::nodeId)
                        .sorted()
-                       .collect(Collectors.toList()), is(List.of("nodeOne", "nodeTwo")));
-        assertThat(capturedReq1.timeout(), is(TimeValue.timeValueMillis(3000L)));
-        assertThat(capturedReq2.timeout(), is(TimeValue.timeValueMillis(3000L)));
+                       .collect(Collectors.toList())).containsExactly("nodeOne", "nodeTwo");
+        assertThat(capturedReq1.timeout()).isEqualTo(TimeValue.timeValueMillis(3000L));
+        assertThat(capturedReq2.timeout()).isEqualTo(TimeValue.timeValueMillis(3000L));
 
         verifyNoMoreInteractions(nodeStatsAction);
     }

--- a/server/src/test/java/io/crate/execution/engine/collect/collectors/NodeStatsTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/collectors/NodeStatsTest.java
@@ -84,9 +84,7 @@ public class NodeStatsTest extends ESTestCase {
     @Before
     public void prepare() {
         nodeStatsAction = mock(TransportNodeStatsAction.class);
-        nodeStatesExecutor = req -> {
-            return nodeStatsAction.execute(req);
-        };
+        nodeStatesExecutor = req -> nodeStatsAction.execute(req);
 
         idRef = new SimpleReference(
             new ReferenceIdent(SysNodesTableInfo.IDENT, SysNodesTableInfo.Columns.ID),
@@ -174,6 +172,7 @@ public class NodeStatsTest extends ESTestCase {
 
         ArgumentCaptor<NodeStatsRequest> req = ArgumentCaptor.forClass(NodeStatsRequest.class);
         // Hostnames needs to be collected so requests need to be performed
+        //noinspection unchecked
         verify(nodeStatsAction, times(2)).doExecute(req.capture(), any(ActionListener.class));
         var capturedReq1 = req.getAllValues().get(0);
         var capturedReq2 = req.getAllValues().get(1);

--- a/server/src/test/java/io/crate/execution/engine/collect/collectors/RemoteCollectorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/collectors/RemoteCollectorTest.java
@@ -22,8 +22,8 @@
 package io.crate.execution.engine.collect.collectors;
 
 import static io.crate.testing.TestingHelpers.createReference;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -133,10 +133,11 @@ public class RemoteCollectorTest extends CrateDummyClusterServiceUnitTest {
         remoteCollector.kill(new InterruptedException("KILLED"));
         remoteCollector.doCollect();
 
+        //noinspection unchecked
         verify(transportJobAction, times(0)).doExecute(any(NodeRequest.class), any(ActionListener.class));
 
-        expectedException.expect(InterruptedException.class);
-        consumer.getResult();
+        assertThatThrownBy(() -> consumer.getResult())
+            .isExactlyInstanceOf(InterruptedException.class);
     }
 
 
@@ -146,9 +147,10 @@ public class RemoteCollectorTest extends CrateDummyClusterServiceUnitTest {
         remoteCollector.kill(new InterruptedException());
         remoteCollector.createRemoteContext();
 
+        //noinspection unchecked
         verify(transportJobAction, times(0)).doExecute(any(NodeRequest.class), any(ActionListener.class));
-        expectedException.expect(JobKilledException.class);
-        consumer.getResult();
+        assertThatThrownBy(() -> consumer.getResult())
+            .isExactlyInstanceOf(JobKilledException.class);
     }
 
     @Test
@@ -156,13 +158,13 @@ public class RemoteCollectorTest extends CrateDummyClusterServiceUnitTest {
         remoteCollector.doCollect();
         ArgumentCaptor<NodeRequest<JobRequest>> argumentCaptor = ArgumentCaptor.forClass(NodeRequest.class);
         verify(transportJobAction, times(1)).doExecute(argumentCaptor.capture(), listenerCaptor.capture());
-        assertThat(argumentCaptor.getValue().nodeId(), is("remoteNode"));
+        assertThat(argumentCaptor.getValue().nodeId()).isEqualTo("remoteNode");
 
         remoteCollector.kill(new InterruptedException());
 
         ActionListener<JobResponse> listener = listenerCaptor.getValue();
         listener.onResponse(new JobResponse(List.of()));
 
-        assertThat(numBroadcastCalls.get(), is(1));
+        assertThat(numBroadcastCalls).hasValue(1);
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/collect/count/InternalCountOperationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/count/InternalCountOperationTest.java
@@ -22,8 +22,6 @@
 package io.crate.execution.engine.collect.count;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -80,7 +78,7 @@ public class InternalCountOperationTest extends IntegTestCase {
 
         {
             CompletableFuture<Long> count = countOperation.count(txnCtx, indexShards, Literal.BOOLEAN_TRUE);
-            assertThat(count.get(5, TimeUnit.SECONDS), is(3L));
+            assertThat(count.get(5, TimeUnit.SECONDS)).isEqualTo(3L);
         }
 
         Schemas schemas = cluster().getInstance(Schemas.class);
@@ -92,7 +90,7 @@ public class InternalCountOperationTest extends IntegTestCase {
         Symbol filter = sqlExpressions.normalize(sqlExpressions.asSymbol("name = 'Marvin'"));
         {
             CompletableFuture<Long> count = countOperation.count(txnCtx, indexShards, filter);
-            assertThat(count.get(5, TimeUnit.SECONDS), is(1L));
+            assertThat(count.get(5, TimeUnit.SECONDS)).isEqualTo(1L);
         }
     }
 

--- a/server/src/test/java/io/crate/execution/engine/distribution/DistributingConsumerTest.java
+++ b/server/src/test/java/io/crate/execution/engine/distribution/DistributingConsumerTest.java
@@ -173,9 +173,7 @@ public class DistributingConsumerTest extends ESTestCase {
             (byte) 0,
             0,
             Collections.singletonList("n1"),
-            req -> {
-                return distributedResultAction.execute(req);
-            },
+            distributedResultAction::execute,
             2 // pageSize
         );
     }
@@ -199,6 +197,7 @@ public class DistributingConsumerTest extends ESTestCase {
         );
     }
 
+    @SuppressWarnings("unchecked")
     private TransportDistributedResultAction createFakeTransport(Streamer<?>[] streamers, DistResultRXTask distResultRXTask) {
         TransportDistributedResultAction distributedResultAction = mock(TransportDistributedResultAction.class);
         doAnswer((InvocationOnMock invocationOnMock) -> {

--- a/server/src/test/java/io/crate/execution/engine/distribution/DistributingConsumerTest.java
+++ b/server/src/test/java/io/crate/execution/engine/distribution/DistributingConsumerTest.java
@@ -21,8 +21,8 @@
 
 package io.crate.execution.engine.distribution;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -41,7 +41,6 @@ import java.util.concurrent.TimeUnit;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.test.ESTestCase;
-import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -95,12 +94,12 @@ public class DistributingConsumerTest extends ESTestCase {
             distributingConsumer.accept(batchSimulatingIterator, null);
 
             List<Object[]> result = collectingConsumer.getResult();
-            assertThat(TestingHelpers.printedTable(new CollectionBucket(result)),
-                is("0\n" +
+            assertThat(TestingHelpers.printedTable(new CollectionBucket(result))).isEqualTo(
+                "0\n" +
                    "1\n" +
                    "2\n" +
                    "3\n" +
-                   "4\n"));
+                   "4\n");
 
             // pageSize=2 and 5 rows causes 3x pushResult
             verify(distributedResultAction, times(3)).doExecute(any(), any());
@@ -120,9 +119,9 @@ public class DistributingConsumerTest extends ESTestCase {
 
         distributingConsumer.accept(null, new CompletionException(new IllegalArgumentException("foobar")));
 
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("foobar");
-        collectingConsumer.getResult();
+        assertThatThrownBy(() -> collectingConsumer.getResult())
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("foobar");
     }
 
     @Test
@@ -135,8 +134,8 @@ public class DistributingConsumerTest extends ESTestCase {
 
         distributingConsumer.accept(FailingBatchIterator.failOnAllLoaded(), null);
 
-        expectedException.expect(InterruptedException.class);
-        collectingConsumer.getResult();
+        assertThatThrownBy(() -> collectingConsumer.getResult())
+            .isExactlyInstanceOf(InterruptedException.class);
     }
 
     @Test
@@ -160,8 +159,8 @@ public class DistributingConsumerTest extends ESTestCase {
             };
         distributingConsumer.accept(batchSimulatingIterator, null);
 
-        expectedException.expect(CircuitBreakingException.class);
-        collectingConsumer.getResult();
+        assertThatThrownBy(() -> collectingConsumer.getResult())
+            .isExactlyInstanceOf(CircuitBreakingException.class);
     }
 
     private DistributingConsumer createDistributingConsumer(Streamer<?>[] streamers, TransportDistributedResultAction distributedResultAction) {
@@ -206,7 +205,7 @@ public class DistributingConsumerTest extends ESTestCase {
             ActionListener<DistributedResultResponse> listener = (ActionListener<DistributedResultResponse>) args[1];
             Throwable throwable = resultRequest.throwable();
             PageBucketReceiver bucketReceiver = distResultRXTask.getBucketReceiver(resultRequest.executionPhaseInputId());
-            assertThat(bucketReceiver, Matchers.notNullValue());
+            assertThat(bucketReceiver).isNotNull();
             if (throwable == null) {
                 bucketReceiver.setBucket(
                     resultRequest.bucketIdx(),

--- a/server/src/test/java/io/crate/execution/jobs/RootTaskTest.java
+++ b/server/src/test/java/io/crate/execution/jobs/RootTaskTest.java
@@ -21,10 +21,7 @@
 
 package io.crate.execution.jobs;
 
-import static org.hamcrest.Matchers.hasKey;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
@@ -42,7 +39,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.Version;
 import org.elasticsearch.test.ESTestCase;
-import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -80,11 +76,11 @@ public class RootTaskTest extends ESTestCase {
         builder.addTask(ctx2);
         RootTask rootTask = builder.build();
 
-        assertThat(rootTask.kill(null), Matchers.greaterThanOrEqualTo(1L));
-        assertThat(rootTask.kill(null), is(0L)); // Everything is killed already
+        assertThat(rootTask.kill(null)).isGreaterThanOrEqualTo(1);
+        assertThat(rootTask.kill(null)).isZero(); // Everything is killed already
 
-        assertThat(ctx1.numKill.get(), is(1));
-        assertThat(ctx2.numKill.get(), is(1));
+        assertThat(ctx1.numKill.get()).isEqualTo(1);
+        assertThat(ctx2.numKill.get()).isEqualTo(1);
     }
 
     @Test
@@ -163,8 +159,8 @@ public class RootTaskTest extends ESTestCase {
         // other contexts must be killed with same failure
         verify(distResultRXTask, times(1)).kill(failure);
 
-        assertThat(rootTask.getTask(1).completionFuture().isDone(), is(true));
-        assertThat(rootTask.getTask(2).completionFuture().isDone(), is(true));
+        assertThat(rootTask.getTask(1).completionFuture().isDone()).isTrue();
+        assertThat(rootTask.getTask(2).completionFuture().isDone()).isTrue();
     }
 
     @Test
@@ -185,14 +181,9 @@ public class RootTaskTest extends ESTestCase {
         Thread.sleep(5L);
         // kill because the testing subcontexts would run infinitely
         rootTask.kill(null);
-        assertThat(rootTask.executionTimes(), hasKey("1-TestingTask"));
-        assertThat(
-            ((double) rootTask.executionTimes().get("1-TestingTask")),
-            Matchers.greaterThan(0d));
-        assertTrue(rootTask.executionTimes().containsKey("2-TestingTask"));
-        assertThat(
-            ((double) rootTask.executionTimes().get("2-TestingTask")),
-            Matchers.greaterThan(0d));
-        assertThat(rootTask.completionFuture().isCompletedExceptionally(), is(true));
+        assertThat(rootTask.executionTimes()).containsKeys("1-TestingTask", "2-TestingTask");
+        assertThat(((double) rootTask.executionTimes().get("1-TestingTask"))).isGreaterThan(0);
+        assertThat(((double) rootTask.executionTimes().get("2-TestingTask"))).isGreaterThan(0);
+        assertThat(rootTask.completionFuture()).isCompletedExceptionally();
     }
 }

--- a/server/src/test/java/io/crate/expression/reference/sys/check/node/SysNodeChecksTest.java
+++ b/server/src/test/java/io/crate/expression/reference/sys/check/node/SysNodeChecksTest.java
@@ -21,8 +21,7 @@
 
 package io.crate.expression.reference.sys.check.node;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static io.crate.testing.Asserts.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -78,9 +77,9 @@ public class SysNodeChecksTest extends CrateDummyClusterServiceUnitTest {
             new RecoveryExpectedNodesSysCheck(clusterService, Settings.EMPTY);
 
 
-        assertThat(recoveryExpectedNodesCheck.id(), is(1));
-        assertThat(recoveryExpectedNodesCheck.severity(), is(SysCheck.Severity.MEDIUM));
-        assertThat(recoveryExpectedNodesCheck.isValid(), is(true));
+        assertThat(recoveryExpectedNodesCheck.id()).isEqualTo(1);
+        assertThat(recoveryExpectedNodesCheck.severity()).isEqualTo(SysCheck.Severity.MEDIUM);
+        assertThat(recoveryExpectedNodesCheck.isValid()).isTrue();
     }
 
     @Test
@@ -99,9 +98,9 @@ public class SysNodeChecksTest extends CrateDummyClusterServiceUnitTest {
         RecoveryExpectedNodesSysCheck recoveryExpectedNodesCheck =
             new RecoveryExpectedNodesSysCheck(clusterService, settings);
 
-        assertThat(recoveryExpectedNodesCheck.id(), is(1));
-        assertThat(recoveryExpectedNodesCheck.severity(), is(SysCheck.Severity.MEDIUM));
-        assertThat(recoveryExpectedNodesCheck.isValid(), is(false));
+        assertThat(recoveryExpectedNodesCheck.id()).isEqualTo(1);
+        assertThat(recoveryExpectedNodesCheck.severity()).isEqualTo(SysCheck.Severity.MEDIUM);
+        assertThat(recoveryExpectedNodesCheck.isValid()).isFalse();
     }
 
     @Test
@@ -118,9 +117,9 @@ public class SysNodeChecksTest extends CrateDummyClusterServiceUnitTest {
         RecoveryExpectedNodesSysCheck recoveryExpectedNodesCheck =
             new RecoveryExpectedNodesSysCheck(clusterService, settings);
 
-        assertThat(recoveryExpectedNodesCheck.id(), is(1));
-        assertThat(recoveryExpectedNodesCheck.severity(), is(SysCheck.Severity.MEDIUM));
-        assertThat(recoveryExpectedNodesCheck.isValid(), is(false));
+        assertThat(recoveryExpectedNodesCheck.id()).isEqualTo(1);
+        assertThat(recoveryExpectedNodesCheck.severity()).isEqualTo(SysCheck.Severity.MEDIUM);
+        assertThat(recoveryExpectedNodesCheck.isValid()).isFalse();
     }
 
     @Test
@@ -140,9 +139,9 @@ public class SysNodeChecksTest extends CrateDummyClusterServiceUnitTest {
         RecoveryExpectedNodesSysCheck recoveryExpectedNodesCheck =
             new RecoveryExpectedNodesSysCheck(clusterService, settings);
 
-        assertThat(recoveryExpectedNodesCheck.id(), is(1));
-        assertThat(recoveryExpectedNodesCheck.severity(), is(SysCheck.Severity.MEDIUM));
-        assertThat(recoveryExpectedNodesCheck.isValid(), is(true));
+        assertThat(recoveryExpectedNodesCheck.id()).isEqualTo(1);
+        assertThat(recoveryExpectedNodesCheck.severity()).isEqualTo(SysCheck.Severity.MEDIUM);
+        assertThat(recoveryExpectedNodesCheck.isValid()).isTrue();
     }
 
     @Test
@@ -162,9 +161,9 @@ public class SysNodeChecksTest extends CrateDummyClusterServiceUnitTest {
         RecoveryExpectedNodesSysCheck recoveryExpectedNodesCheck =
             new RecoveryExpectedNodesSysCheck(clusterService, settings);
 
-        assertThat(recoveryExpectedNodesCheck.id(), is(1));
-        assertThat(recoveryExpectedNodesCheck.severity(), is(SysCheck.Severity.MEDIUM));
-        assertThat(recoveryExpectedNodesCheck.isValid(), is(false));
+        assertThat(recoveryExpectedNodesCheck.id()).isEqualTo(1);
+        assertThat(recoveryExpectedNodesCheck.severity()).isEqualTo(SysCheck.Severity.MEDIUM);
+        assertThat(recoveryExpectedNodesCheck.isValid()).isFalse();
     }
 
     @Test
@@ -172,9 +171,9 @@ public class SysNodeChecksTest extends CrateDummyClusterServiceUnitTest {
         RecoveryAfterNodesSysCheck recoveryAfterNodesCheck =
             new RecoveryAfterNodesSysCheck(clusterService, Settings.EMPTY);
 
-        assertThat(recoveryAfterNodesCheck.id(), is(2));
-        assertThat(recoveryAfterNodesCheck.severity(), is(SysCheck.Severity.MEDIUM));
-        assertThat(recoveryAfterNodesCheck.isValid(), is(true));
+        assertThat(recoveryAfterNodesCheck.id()).isEqualTo(2);
+        assertThat(recoveryAfterNodesCheck.severity()).isEqualTo(SysCheck.Severity.MEDIUM);
+        assertThat(recoveryAfterNodesCheck.isValid()).isTrue();
     }
 
     @Test
@@ -194,9 +193,9 @@ public class SysNodeChecksTest extends CrateDummyClusterServiceUnitTest {
         RecoveryAfterNodesSysCheck recoveryAfterNodesCheck =
             new RecoveryAfterNodesSysCheck(clusterService, settings);
 
-        assertThat(recoveryAfterNodesCheck.id(), is(2));
-        assertThat(recoveryAfterNodesCheck.severity(), is(SysCheck.Severity.MEDIUM));
-        assertThat(recoveryAfterNodesCheck.isValid(), is(false));
+        assertThat(recoveryAfterNodesCheck.id()).isEqualTo(2);
+        assertThat(recoveryAfterNodesCheck.severity()).isEqualTo(SysCheck.Severity.MEDIUM);
+        assertThat(recoveryAfterNodesCheck.isValid()).isFalse();
     }
 
     @Test
@@ -214,9 +213,9 @@ public class SysNodeChecksTest extends CrateDummyClusterServiceUnitTest {
         RecoveryAfterNodesSysCheck recoveryAfterNodesCheck =
             new RecoveryAfterNodesSysCheck(clusterService, settings);
 
-        assertThat(recoveryAfterNodesCheck.id(), is(2));
-        assertThat(recoveryAfterNodesCheck.severity(), is(SysCheck.Severity.MEDIUM));
-        assertThat(recoveryAfterNodesCheck.isValid(), is(false));
+        assertThat(recoveryAfterNodesCheck.id()).isEqualTo(2);
+        assertThat(recoveryAfterNodesCheck.severity()).isEqualTo(SysCheck.Severity.MEDIUM);
+        assertThat(recoveryAfterNodesCheck.isValid()).isFalse();
     }
 
     @Test
@@ -236,9 +235,9 @@ public class SysNodeChecksTest extends CrateDummyClusterServiceUnitTest {
         RecoveryAfterNodesSysCheck recoveryAfterNodesCheck =
             new RecoveryAfterNodesSysCheck(clusterService, settings);
 
-        assertThat(recoveryAfterNodesCheck.id(), is(2));
-        assertThat(recoveryAfterNodesCheck.severity(), is(SysCheck.Severity.MEDIUM));
-        assertThat(recoveryAfterNodesCheck.isValid(), is(true));
+        assertThat(recoveryAfterNodesCheck.id()).isEqualTo(2);
+        assertThat(recoveryAfterNodesCheck.severity()).isEqualTo(SysCheck.Severity.MEDIUM);
+        assertThat(recoveryAfterNodesCheck.isValid()).isTrue();
     }
 
     @Test
@@ -250,7 +249,7 @@ public class SysNodeChecksTest extends CrateDummyClusterServiceUnitTest {
             .build();
 
         RecoveryAfterTimeSysCheck recoveryAfterNodesCheck = new RecoveryAfterTimeSysCheck(settings);
-        assertThat(recoveryAfterNodesCheck.isValid(), is(true));
+        assertThat(recoveryAfterNodesCheck.isValid()).isTrue();
     }
 
     @Test
@@ -262,16 +261,16 @@ public class SysNodeChecksTest extends CrateDummyClusterServiceUnitTest {
             .build();
 
         RecoveryAfterTimeSysCheck recoveryAfterNodesCheck = new RecoveryAfterTimeSysCheck(settings);
-        assertThat(recoveryAfterNodesCheck.isValid(), is(true));
+        assertThat(recoveryAfterNodesCheck.isValid()).isTrue();
     }
 
     @Test
     public void testRecoveryAfterTimeCheckWithDefaultSetting() {
         RecoveryAfterTimeSysCheck recoveryAfterNodesCheck = new RecoveryAfterTimeSysCheck(Settings.EMPTY);
 
-        assertThat(recoveryAfterNodesCheck.id(), is(3));
-        assertThat(recoveryAfterNodesCheck.severity(), is(SysCheck.Severity.MEDIUM));
-        assertThat(recoveryAfterNodesCheck.isValid(), is(true));
+        assertThat(recoveryAfterNodesCheck.id()).isEqualTo(3);
+        assertThat(recoveryAfterNodesCheck.severity()).isEqualTo(SysCheck.Severity.MEDIUM);
+        assertThat(recoveryAfterNodesCheck.isValid()).isTrue();
     }
 
     @Test
@@ -284,7 +283,7 @@ public class SysNodeChecksTest extends CrateDummyClusterServiceUnitTest {
 
         RecoveryAfterTimeSysCheck recoveryAfterNodesCheck = new RecoveryAfterTimeSysCheck(settings);
 
-        assertThat(recoveryAfterNodesCheck.isValid(), is(false));
+        assertThat(recoveryAfterNodesCheck.isValid()).isFalse();
     }
 
     @Test
@@ -295,12 +294,12 @@ public class SysNodeChecksTest extends CrateDummyClusterServiceUnitTest {
             mock(NodeService.class, Answers.RETURNS_MOCKS)
         );
 
-        assertThat(low.id(), is(6));
-        assertThat(low.severity(), is(SysCheck.Severity.HIGH));
+        assertThat(low.id()).isEqualTo(6);
+        assertThat(low.severity()).isEqualTo(SysCheck.Severity.HIGH);
 
         // default threshold is: 85% used
-        assertThat(low.isValid(15, 100), is(true));
-        assertThat(low.isValid(14, 100), is(false));
+        assertThat(low.isValid(15, 100)).isTrue();
+        assertThat(low.isValid(14, 100)).isFalse();
     }
 
     @Test
@@ -310,7 +309,7 @@ public class SysNodeChecksTest extends CrateDummyClusterServiceUnitTest {
             Settings.builder().put("cluster.routing.allocation.disk.threshold_enabled", false).build(),
             mock(NodeService.class, Answers.RETURNS_MOCKS)
         );
-        assertThat(check.isValid(), is(true));
+        assertThat(check.isValid()).isTrue();
     }
 
     @Test
@@ -321,12 +320,12 @@ public class SysNodeChecksTest extends CrateDummyClusterServiceUnitTest {
             mock(NodeService.class, Answers.RETURNS_MOCKS)
         );
 
-        assertThat(high.id(), is(5));
-        assertThat(high.severity(), is(SysCheck.Severity.HIGH));
+        assertThat(high.id()).isEqualTo(5);
+        assertThat(high.severity()).isEqualTo(SysCheck.Severity.HIGH);
 
         // default threshold is: 90% used
-        assertThat(high.isValid(10, 100), is(true));
-        assertThat(high.isValid(9, 100), is(false));
+        assertThat(high.isValid(10, 100)).isTrue();
+        assertThat(high.isValid(9, 100)).isFalse();
     }
 
     @Test
@@ -337,12 +336,12 @@ public class SysNodeChecksTest extends CrateDummyClusterServiceUnitTest {
             mock(NodeService.class, Answers.RETURNS_MOCKS)
         );
 
-        assertThat(floodStage.id(), is(7));
-        assertThat(floodStage.severity(), is(SysCheck.Severity.HIGH));
+        assertThat(floodStage.id()).isEqualTo(7);
+        assertThat(floodStage.severity()).isEqualTo(SysCheck.Severity.HIGH);
 
         // default threshold is: 95% used
-        assertThat(floodStage.isValid(5, 100), is(true));
-        assertThat(floodStage.isValid(4, 100), is(false));
+        assertThat(floodStage.isValid(5, 100)).isTrue();
+        assertThat(floodStage.isValid(4, 100)).isFalse();
     }
 
     @Test
@@ -394,9 +393,9 @@ public class SysNodeChecksTest extends CrateDummyClusterServiceUnitTest {
 
         var maxShardsPerNodeSysCheck = new MaxShardsPerNodeSysCheck(clusterService);
 
-        assertThat(maxShardsPerNodeSysCheck.id(), is(8));
-        assertThat(maxShardsPerNodeSysCheck.severity(), is(SysCheck.Severity.MEDIUM));
-        assertThat(maxShardsPerNodeSysCheck.isValid(), is(true));
+        assertThat(maxShardsPerNodeSysCheck.id()).isEqualTo(8);
+        assertThat(maxShardsPerNodeSysCheck.severity()).isEqualTo(SysCheck.Severity.MEDIUM);
+        assertThat(maxShardsPerNodeSysCheck.isValid()).isTrue();
 
         // Validate that with `cluster.max_shards_per_node = 90` and 85 shards the check fails
         setting = Settings.builder().put(ShardLimitValidator.SETTING_CLUSTER_MAX_SHARDS_PER_NODE.getKey(), 90).build();
@@ -405,6 +404,6 @@ public class SysNodeChecksTest extends CrateDummyClusterServiceUnitTest {
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
 
         maxShardsPerNodeSysCheck = new MaxShardsPerNodeSysCheck(clusterService);
-        assertThat(maxShardsPerNodeSysCheck.isValid(), is(false));
+        assertThat(maxShardsPerNodeSysCheck.isValid()).isFalse();
     }
 }

--- a/server/src/test/java/io/crate/replication/logical/action/ReplayChangesActionTest.java
+++ b/server/src/test/java/io/crate/replication/logical/action/ReplayChangesActionTest.java
@@ -21,10 +21,7 @@
 
 package io.crate.replication.logical.action;
 
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static io.crate.testing.Asserts.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -114,7 +111,7 @@ public class ReplayChangesActionTest extends CrateDummyClusterServiceUnitTest {
         var exception = new AtomicReference<Throwable>();
         transportAction.shardOperationOnPrimary(req, indexShard, ActionListener.wrap(r -> {}, exception::set));
 
-        assertThat(exception.get(), instanceOf(InvalidShardEngineException.class));
+        assertThat(exception.get()).isExactlyInstanceOf(InvalidShardEngineException.class);
     }
 
     @Test
@@ -152,11 +149,11 @@ public class ReplayChangesActionTest extends CrateDummyClusterServiceUnitTest {
         var exception = new AtomicReference<Throwable>();
         transportAction.shardOperationOnPrimary(req, indexShard, ActionListener.wrap(result::set, exception::set));
 
-        assertThat(exception.get(), nullValue());
+        assertThat(exception.get()).isNull();
         var replicaReq = (ReplayChangesAction.Request) result.get().replicaRequest();
 
         // Failure happened on 2nd item, so only 1 item must be replicated
-        assertThat(replicaReq.changes().size(), is(1));
+        assertThat(replicaReq.changes()).hasSize(1);
     }
 
     @Test
@@ -185,7 +182,7 @@ public class ReplayChangesActionTest extends CrateDummyClusterServiceUnitTest {
         ArrayList<Engine.Result> engineResults = new ArrayList<>();
         transportAction.performOnPrimary(indexShard, req, new ArrayList<>(),0, engineResults::addAll, e -> {});
 
-        assertThat(engineResults.get(0).getFailure(), nullValue());
-        assertThat(engineResults.get(1).getFailure(), instanceOf(InvalidShardEngineException.class));
+        assertThat(engineResults.get(0).getFailure()).isNull();
+        assertThat(engineResults.get(1).getFailure()).isExactlyInstanceOf(InvalidShardEngineException.class);
     }
 }

--- a/server/src/test/java/io/crate/statistics/TableStatsServiceTest.java
+++ b/server/src/test/java/io/crate/statistics/TableStatsServiceTest.java
@@ -21,12 +21,11 @@
 
 package io.crate.statistics;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
-import org.hamcrest.Matchers;
-import org.hamcrest.core.IsNull;
-import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Answers;
 import org.mockito.ArgumentMatchers;
@@ -48,9 +47,8 @@ public class TableStatsServiceTest extends CrateDummyClusterServiceUnitTest {
             clusterService,
             Mockito.mock(Sessions.class, Answers.RETURNS_MOCKS));
 
-        Assert.assertThat(statsService.refreshInterval,
-                          Matchers.is(TimeValue.timeValueMinutes(0)));
-        Assert.assertThat(statsService.scheduledRefresh, Matchers.is(Matchers.nullValue()));
+        assertThat(statsService.refreshInterval).isEqualTo(TimeValue.timeValueMinutes(0));
+        assertThat(statsService.scheduledRefresh).isNull();
 
         // Default setting
         statsService = new TableStatsService(
@@ -59,9 +57,9 @@ public class TableStatsServiceTest extends CrateDummyClusterServiceUnitTest {
             clusterService,
             Mockito.mock(Sessions.class, Answers.RETURNS_MOCKS));
 
-        Assert.assertThat(statsService.refreshInterval,
-                          Matchers.is(TableStatsService.STATS_SERVICE_REFRESH_INTERVAL_SETTING.getDefault(Settings.EMPTY)));
-        Assert.assertThat(statsService.scheduledRefresh, Matchers.is(IsNull.notNullValue()));
+        assertThat(statsService.refreshInterval)
+            .isEqualTo(TableStatsService.STATS_SERVICE_REFRESH_INTERVAL_SETTING.getDefault(Settings.EMPTY));
+        assertThat(statsService.scheduledRefresh).isNotNull();
 
         ClusterSettings clusterSettings = clusterService.getClusterSettings();
 
@@ -69,24 +67,22 @@ public class TableStatsServiceTest extends CrateDummyClusterServiceUnitTest {
         clusterSettings.applySettings(Settings.builder()
             .put(TableStatsService.STATS_SERVICE_REFRESH_INTERVAL_SETTING.getKey(), "10m").build());
 
-        Assert.assertThat(statsService.refreshInterval, Matchers.is(TimeValue.timeValueMinutes(10)));
-        Assert.assertThat(statsService.scheduledRefresh,
-                          Matchers.is(IsNull.notNullValue()));
+        assertThat(statsService.refreshInterval).isEqualTo(TimeValue.timeValueMinutes(10));
+        assertThat(statsService.scheduledRefresh).isNotNull();
 
         // Disable
         clusterSettings.applySettings(Settings.builder()
             .put(TableStatsService.STATS_SERVICE_REFRESH_INTERVAL_SETTING.getKey(), 0).build());
 
-        Assert.assertThat(statsService.refreshInterval, Matchers.is(TimeValue.timeValueMillis(0)));
-        Assert.assertThat(statsService.scheduledRefresh,
-                          Matchers.is(Matchers.nullValue()));
+        assertThat(statsService.refreshInterval).isEqualTo(TimeValue.timeValueMillis(0));
+        assertThat(statsService.scheduledRefresh).isNull();
 
         // Reset setting
         clusterSettings.applySettings(Settings.builder().build());
 
-        Assert.assertThat(statsService.refreshInterval,
-                          Matchers.is(TableStatsService.STATS_SERVICE_REFRESH_INTERVAL_SETTING.getDefault(Settings.EMPTY)));
-        Assert.assertThat(statsService.scheduledRefresh, Matchers.is(IsNull.notNullValue()));
+        assertThat(statsService.refreshInterval)
+            .isEqualTo(TableStatsService.STATS_SERVICE_REFRESH_INTERVAL_SETTING.getDefault(Settings.EMPTY));
+        assertThat(statsService.scheduledRefresh).isNotNull();
     }
 
     @Test


### PR DESCRIPTION
- Migrate to assertj the following tests:
    - DecommissioningServiceTest
    - JobLauncherWaitForCompletionTest
    - CollectTaskTest
    - NodeStatsTest
    - RemoteCollectorTest
    - InternalCountOperationTest
    - DistributingConsumerTest
    - RootTaskTest
    - SysNodeChecksTest
    - ReplayChangesActionTest
    - TableStatsServiceTest


- Minor code improvements & fix warnings
