### PR TITLE
WIP: Fix replication issue on insert on conflict on a table with non-deterministic generated column

### DIFF
--- a/server/src/main/java/io/crate/execution/dml/Indexer.java
+++ b/server/src/main/java/io/crate/execution/dml/Indexer.java
@@ -928,11 +928,15 @@ public class Indexer {
         }
         List<Reference> newColumns = new ArrayList<>(columns);
         for (var synthetic : undeterministic) {
-            if (synthetic.ref.column().isRoot() && !newColumns.contains(synthetic.ref)) {
-                newColumns.add(synthetic.ref);
-            }
+            maybeAddUndeterministicColumn(synthetic.ref, newColumns);
         }
         return newColumns;
+    }
+
+    public static void maybeAddUndeterministicColumn(Reference reference, List<Reference> newColumns) {
+        if (reference.column().isRoot() && !newColumns.contains(reference)) {
+            newColumns.add(reference);
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
@@ -174,6 +174,9 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
             assert request.insertColumns() == null || insertColumns.subList(0, request.insertColumns().length).equals(Arrays.asList(request.insertColumns()))
                 : "updateToInsert.columns() must be a superset of insertColumns where the start is an exact overlap. It may only add new columns at the end";
         }
+
+        boolean addedUndeterministicColumns = updateToInsert == null ? false : updateToInsert.addedUndeterministicColumns();
+
         Indexer indexer = new Indexer(
             indexName,
             tableInfo,
@@ -183,7 +186,7 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
             insertColumns,
             request.returnValues()
         );
-        if (indexer.hasUndeterministicSynthetics()) {
+        if (indexer.hasUndeterministicSynthetics() && addedUndeterministicColumns == false) {
             // This change also applies for RawIndexer if it's used.
             // RawIndexer adds non-deterministic generated columns in addition to _raw and uses same request.
             request.insertColumns(indexer.insertColumns(insertColumns));

--- a/server/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
+++ b/server/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
@@ -139,7 +139,8 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
                                            IndexShard indexShard,
                                            boolean isRetry,
                                            @Nullable RawIndexer rawIndexer,
-                                           long version) throws Exception {
+                                           long version,
+                                           boolean updateHasUndeterministicSynthetics) throws Exception {
             throw new VersionConflictEngineException(
                 indexShard.shardId(),
                 item.id(),


### PR DESCRIPTION
Fixes https://github.com/crate/crate/issues/15171

TODO:
- [ ] class cast exception is gone, fix primary != replica value next (https://github.com/crate/crate/pull/15270/commits/b39525449c8bdb325468d8e2bb17100efebfffe5)
- [ ] test scenario where non-deterministic generated column is provided (in addition to the not provided one)
- [ ] this covers INSERT ... ON CONFLICT - check regular UPDATE
- [ ] default is not handled at all in UpdateToInsert (extend test by such column/dedicated handling/dedicated change entry)

