### PR TITLE
Fix 2 regressions

### DIFF
--- a/docs/appendices/release-notes/5.5.3.rst
+++ b/docs/appendices/release-notes/5.5.3.rst
@@ -49,4 +49,7 @@ See the :ref:`version_5.5.0` release notes for a full list of changes in the
 Fixes
 =====
 
-None
+- Fixed a regression introduced in 5.3.0 that caused storing an object as
+  ``NULL`` if object had generated sub-columns and the object column wasn't
+  part of the ``INSERT`` targets. An object with generated sub-columns is
+  stored now.

--- a/docs/appendices/release-notes/5.5.3.rst
+++ b/docs/appendices/release-notes/5.5.3.rst
@@ -53,3 +53,9 @@ Fixes
   ``NULL`` if object had generated sub-columns and the object column wasn't
   part of the ``INSERT`` targets. An object with generated sub-columns is
   stored now.
+
+- Fixed a regression introduced in 5.3.0 that caused failure for ``INSERT``
+  statements if a target table had 1 or more replicas, an object column with
+  non-deterministic generated or default sub-column and the object column
+  wasn't part of the ``INSERT`` targets.
+

--- a/server/src/main/java/io/crate/execution/dml/Indexer.java
+++ b/server/src/main/java/io/crate/execution/dml/Indexer.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -127,6 +128,7 @@ public class Indexer {
     private final List<Synthetic> undeterministic = new ArrayList<>();
     private final BytesStreamOutput stream;
     private final boolean writeOids;
+    private final Function<ColumnIdent, Reference> getRef;
 
     /**
      * Function to resolve a field type based on the columns {@link Reference#storageIdent()}.
@@ -421,6 +423,7 @@ public class Indexer {
         this.synthetics = new HashMap<>();
         this.stream = new BytesStreamOutput();
         this.writeOids = table.versionCreated().onOrAfter(Version.V_5_5_0);
+        this.getRef = columnIdent -> table.getReference(columnIdent);
         this.getFieldType = getFieldType;
         Function<ColumnIdent, Reference> getRef = table::getReference;
         PartitionName partitionName = table.isPartitioned()
@@ -941,8 +944,21 @@ public class Indexer {
         }
         List<Reference> newColumns = new ArrayList<>(columns);
         for (var synthetic : undeterministic) {
-            if (synthetic.ref.column().isRoot() && !newColumns.contains(synthetic.ref)) {
-                newColumns.add(synthetic.ref);
+            if (synthetic.ref.column().isRoot()) {
+                if (newColumns.contains(synthetic.ref) == false) {
+                    newColumns.add(synthetic.ref);
+                }
+            } else {
+                var rootIdent = synthetic.ref.column().getRoot();
+                int rootIndex = Reference.indexOf(newColumns, rootIdent);
+                if (rootIndex == -1) {
+                    // Synthetic is a generated/default sub-column with root not listed in the insert/upsert targets.
+                    // We need to add the root to replica targets
+                    // since we will generate object value in addGeneratedValues().
+                    Reference rootRef = getRef.apply(rootIdent);
+                    assert rootRef != null : "Root must exist in the table";
+                    newColumns.add(rootRef);
+                }
             }
         }
         return newColumns;
@@ -951,33 +967,35 @@ public class Indexer {
     @SuppressWarnings("unchecked")
     public Object[] addGeneratedValues(IndexItem item) {
         Object[] insertValues = item.insertValues();
-        int numExtra = (int) undeterministic.stream()
-            .filter(x -> x.ref().column().isRoot())
-            .count();
-        Object[] result = new Object[insertValues.length + numExtra];
-        System.arraycopy(insertValues, 0, result, 0, insertValues.length);
+        //  We don't know in advance how many values we will add: we can have multiple generated sub-columns.
+        //  Some of them can have their root listed in the insert/upsert targets (and thus not causing array expansion) and some not.
+        List<Object> extendedValues = new ArrayList<>(insertValues.length);
+        Collections.addAll(extendedValues, insertValues);
 
-        int i = 0;
         for (var synthetic : undeterministic) {
             ColumnIdent column = synthetic.ref.column();
             if (column.isRoot()) {
-                result[insertValues.length + i] = synthetic.value();
-                i++;
+                extendedValues.add(synthetic.value());
             } else {
                 int valueIdx = Reference.indexOf(columns, column.getRoot());
-                assert valueIdx > -1 : "synthetic column must exist in columns";
-
+                Map<String, Object> root;
+                if (valueIdx == -1) {
+                    // Object column is unused in the insert statement and doesn't exist in targets.
+                    root = new HashMap<>();
+                    extendedValues.add(root);
+                } else {
+                    root = (Map<String, Object>) insertValues[valueIdx];
+                }
                 ColumnIdent child = column.shiftRight();
                 Object value = synthetic.value();
-                Object object = insertValues[valueIdx];
                 Maps.mergeInto(
-                    (Map<String, Object>) object,
+                    root,
                     child.name(),
                     child.path(),
                     value
                 );
             }
         }
-        return result;
+        return extendedValues.toArray();
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/ObjectColumnTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ObjectColumnTest.java
@@ -348,21 +348,49 @@ public class ObjectColumnTest extends IntegTestCase {
             create table tbl (
                 id int,
                 o object as (
-                    key text default 'd'
+                    key text default 'synth'
                 ),
                 os array(object as (
-                    x text default 'd',
+                    x text default 'synth',
                     y text
                 )),
                 complex object as (
                     os array(object as (
-                        key text default 'd'
+                        key text default 'synth'
                     )),
-                    x text default 'd'
+                    x text default 'synth'
                 )
             )
             """
         );
+        execute_inserts_into_table_with_synthetic_sub_cols_skip_roots_in_targets();
+    }
+
+    @Test
+    public void test_generated_columns_in_object_result_in_object_creation_if_missing_from_insert() throws Exception {
+        execute("""
+            create table tbl (
+                id int,
+                o object as (
+                    key text as 'synth'
+                ),
+                os array(object as (
+                    x text as 'synth',
+                    y text
+                )),
+                complex object as (
+                    os array(object as (
+                        key text as 'synth'
+                    )),
+                    x text as 'synth'
+                )
+            )
+            """
+        );
+        execute_inserts_into_table_with_synthetic_sub_cols_skip_roots_in_targets();
+    }
+
+    private void execute_inserts_into_table_with_synthetic_sub_cols_skip_roots_in_targets() {
         execute("insert into tbl (id) values (1)");
         assertThat(response).hasRowCount(1);
 
@@ -374,9 +402,9 @@ public class ObjectColumnTest extends IntegTestCase {
 
         execute("refresh table tbl");
         assertThat(execute("select id, o, os, complex from tbl order by 1 asc")).hasRows(
-            "1| {key=d}| NULL| {x=d}",
-            "2| {key=d}| [{x=d}, null, {x=d, y=10}, {x=1, y=2}]| {x=d}",
-            "3| {key=d}| NULL| {os=[{key=d}, null], x=d}"
+            "1| {key=synth}| NULL| {x=synth}",
+            "2| {key=synth}| [{x=synth}, null, {x=synth, y=10}, {x=1, y=2}]| {x=synth}",
+            "3| {key=synth}| NULL| {os=[{key=synth}, null], x=synth}"
         );
     }
 


### PR DESCRIPTION
2 regressions 

1. Similar to https://github.com/crate/crate/commit/54111db697530378afa33549ef1f98510a0cc4f2 but on generated expression (reused code and test)

2. 
table with non-deterministic sub-column with replicas enabled (default config)
```
create table tbl (
                    a int,
                    o object as (
                        c int as round((random() + 1) * 100)
                    )
                );
cr> insert into tbl(a) values (2);
ArrayIndexOutOfBoundsException[Index -1 out of bounds for length 1]
```

