### PR TITLE
Code improvements for RolesMetadata and its Test

### DIFF
--- a/server/src/main/java/io/crate/role/TransportPrivilegesAction.java
+++ b/server/src/main/java/io/crate/role/TransportPrivilegesAction.java
@@ -149,7 +149,7 @@ public class TransportPrivilegesAction extends TransportMasterNodeAction<Privile
             if (request.privileges().isEmpty() == false) {
                 affectedRows = PrivilegesModifier.applyPrivileges(newMetadata, request.roleNames(), request.privileges());
             } else {
-                affectedRows = newMetadata.applyPrivileges(request.roleNames(), request.rolePrivilege());
+                affectedRows = newMetadata.applyRolePrivileges(request.roleNames(), request.rolePrivilege());
                 mdBuilder.putCustom(RolesMetadata.TYPE, newMetadata);
             }
         }

--- a/server/src/main/java/io/crate/role/metadata/RolesMetadata.java
+++ b/server/src/main/java/io/crate/role/metadata/RolesMetadata.java
@@ -193,7 +193,7 @@ public class RolesMetadata extends AbstractNamedDiffable<Metadata.Custom> implem
      * @return the number of affected role privileges
      *         (doesn't count no-ops e.g.: granting a role to a user which already has)
      */
-    public long applyPrivileges(Collection<String> userNames, RolePrivilegeToApply newRolePrivilegeToApply) {
+    public long applyRolePrivileges(Collection<String> userNames, RolePrivilegeToApply newRolePrivilegeToApply) {
         long affectedPrivileges = 0L;
         for (String userName : userNames) {
             affectedPrivileges += applyRolePrivilegesToUser(userName, newRolePrivilegeToApply);
@@ -214,17 +214,16 @@ public class RolesMetadata extends AbstractNamedDiffable<Metadata.Custom> implem
             }
             if (newRolePrivilegeToApply.state() == PrivilegeState.GRANT) {
                 if (grantedRoles.add(new GrantedRole(roleNameToApply, newRolePrivilegeToApply.grantor()))) {
-                    roles.put(role.name(), new Role(
-                        role.name(), role.isUser(), Set.of(), grantedRoles, role.password()));
                     affectedCount++;
                 }
             } else if (newRolePrivilegeToApply.state() == PrivilegeState.REVOKE) {
                 if (grantedRoles.remove(new GrantedRole(roleNameToApply, newRolePrivilegeToApply.grantor()))) {
-                    roles.put(role.name(), new Role(
-                        role.name(), role.isUser(), Set.of(), grantedRoles, role.password()));
                     affectedCount++;
                 }
             }
+        }
+        if (affectedCount > 0) {
+            roles.put(role.name(), new Role(role.name(), role.isUser(), Set.of(), grantedRoles, role.password()));
         }
         return affectedCount;
     }


### PR DESCRIPTION
- Rename `applyPrivileges` to `applyRolePrivileges` to clarify the method.
- User RoleHelper static imports
- Small improvement of applyRolePrivilegesToUser: put the modified user back to the `roles` map, only once.

Follows: 4940b7f293fc12e16419786233318e091c513aae
Relates: #12019
