### PR TITLE
Prevent cycle in roles hierarchy

### DIFF
--- a/docs/admin/privileges.rst
+++ b/docs/admin/privileges.rst
@@ -421,9 +421,7 @@ Inheritance
 The inheritance can span multiple levels, so you can have ``role_a`` which is
 granted to ``role_b``, which in turn is granted to ``role_c``, and so on. Each
 role can be granted to multiple other roles and each role or user can be granted
-multiple other roles. Cycles can be created, which **does not** lead to infinite
-loops during privileges resolution, as there is a mechanism that avoids it. For
-example::
+multiple other roles. Cycles cannot be created, for example::
 
     cr> GRANT role_a TO role_b;
     GRANT OK, 1 row affected (... sec)
@@ -436,29 +434,7 @@ example::
 ::
 
     cr> GRANT role_c TO role_a;
-    GRANT OK, 1 row affected (... sec)
-
-In this situation, none of the 3 roles can be dropped::
-
-
-    cr> DROP ROLE role_a;
-    SQLParseException[Cannot drop ROLE: role_a as it is granted on role: role_b]
-
-::
-
-    cr> DROP ROLE role_b;
-    SQLParseException[Cannot drop ROLE: role_b as it is granted on role: role_c]
-
-::
-
-    cr> DROP ROLE role_c;
-    SQLParseException[Cannot drop ROLE: role_c as it is granted on role: role_a]
-
-In order to break the loop you can simple revoke the granted roles which causes
-it::
-
-    cr> REVOKE role_c FROM role_a;
-    REVOKE OK, 1 row affected (... sec)
+    SQLParseException[Cannot grant role role_c to role_a, role_a is a parent role of role_c and a cycle will be created]
 
 
 .. hide:

--- a/server/src/main/java/io/crate/role/Roles.java
+++ b/server/src/main/java/io/crate/role/Roles.java
@@ -53,14 +53,26 @@ public interface Roles {
         };
 
     /**
+     * finds a role by role name
+     */
+    @Nullable
+    default Role findRole(String roleName) {
+        for (var role : roles()) {
+            if (role.name().equals(roleName)) {
+                return role;
+            }
+        }
+        return null;
+    }
+
+    /**
      * finds a user by username
      */
     @Nullable
     default Role findUser(String userName) {
-        for (var role : roles()) {
-            if (role.isUser() && role.name().equals(userName)) {
-                return role;
-            }
+        Role role = findRole(userName);
+        if (role != null && role.isUser()) {
+            return role;
         }
         return null;
     }

--- a/server/src/main/java/io/crate/role/Roles.java
+++ b/server/src/main/java/io/crate/role/Roles.java
@@ -22,6 +22,8 @@
 package io.crate.role;
 
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -126,4 +128,21 @@ public interface Roles {
     }
 
     Collection<Role> roles();
+
+    default Set<String> findAllParents(String roleName) {
+        Set<String> allParents = new HashSet<>();
+        Role role = findRole(roleName);
+        assert role != null : "role must exist";
+        findParents(role, allParents);
+        return allParents;
+    }
+
+    private void findParents(Role role, Set<String> allParents) {
+        allParents.addAll(role.grantedRoleNames());
+        for (var grantedRoleName : role.grantedRoleNames()) {
+            var parentRole = findRole(grantedRoleName);
+            assert parentRole != null : "parent role must exist";
+            findParents(parentRole, allParents);
+        }
+    }
 }

--- a/server/src/main/java/io/crate/role/RolesService.java
+++ b/server/src/main/java/io/crate/role/RolesService.java
@@ -35,7 +35,6 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.jetbrains.annotations.Nullable;
-import org.jetbrains.annotations.VisibleForTesting;
 
 import io.crate.common.FourFunction;
 import io.crate.role.metadata.RolesMetadata;
@@ -66,8 +65,9 @@ public class RolesService implements Roles, ClusterStateListener {
         return null;
     }
 
-    @VisibleForTesting
-    protected Role findRole(String roleName) {
+    @Override
+    @Nullable
+    public Role findRole(String roleName) {
         return roles.get(roleName);
     }
 

--- a/server/src/main/java/io/crate/role/RolesService.java
+++ b/server/src/main/java/io/crate/role/RolesService.java
@@ -24,7 +24,6 @@ package io.crate.role;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
@@ -138,8 +137,6 @@ public class RolesService implements Roles, ClusterStateListener {
             return true;
         }
 
-        Set<String> rolesVisited = new HashSet<>();
-        rolesVisited.add(role.name());
         Set<String> rolesToVisit = new LinkedHashSet<>(role.grantedRoleNames());
 
         var iter = rolesToVisit.iterator();
@@ -149,9 +146,8 @@ public class RolesService implements Roles, ClusterStateListener {
             if (result == null) {
                 return true;
             }
-            rolesVisited.add(roleName);
-            result.removeAll(rolesVisited);
-            rolesToVisit = result;
+            iter.remove();
+            rolesToVisit.addAll(result);
             iter = rolesToVisit.iterator();
         }
         return false;

--- a/server/src/main/java/io/crate/role/metadata/RolesMetadata.java
+++ b/server/src/main/java/io/crate/role/metadata/RolesMetadata.java
@@ -209,9 +209,7 @@ public class RolesMetadata extends AbstractNamedDiffable<Metadata.Custom> implem
         Set<GrantedRole> grantedRoles = new HashSet<>(role.grantedRoles());
         long affectedCount = 0L;
         for (var roleNameToApply : newRolePrivilegeToApply.roleNames()) {
-            if (roles.get(roleNameToApply).isUser()) {
-                throw new IllegalArgumentException("Cannot " + newRolePrivilegeToApply.state().name() + " a USER to a ROLE");
-            }
+
             if (newRolePrivilegeToApply.state() == PrivilegeState.GRANT) {
                 if (grantedRoles.add(new GrantedRole(roleNameToApply, newRolePrivilegeToApply.grantor()))) {
                     affectedCount++;

--- a/server/src/test/java/io/crate/analyze/PrivilegesAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/PrivilegesAnalyzerTest.java
@@ -355,6 +355,13 @@ public class PrivilegesAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
+    public void test_cannot_grant_role_to_same_role() {
+        assertThatThrownBy(() -> analyzePrivilegesStatement("GRANT role3, role2 TO role1, role2"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Cannot grant role role2 to itself as a cycle will be created");
+    }
+
+    @Test
     public void test_grant_role_to_user() {
         AnalyzedPrivileges analysis = analyzePrivilegesStatement("GRANT role1, role2, role1 TO user1, user2");
         assertThat(analysis.userNames()).containsExactly("user1", "user2");

--- a/server/src/test/java/io/crate/role/metadata/RolesMetadataTest.java
+++ b/server/src/test/java/io/crate/role/metadata/RolesMetadataTest.java
@@ -29,7 +29,6 @@ import static io.crate.role.metadata.RolesHelper.roleOf;
 import static io.crate.role.metadata.RolesHelper.userOf;
 import static io.crate.role.metadata.RolesHelper.usersMetadataOf;
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -173,17 +172,6 @@ public class RolesMetadataTest extends ESTestCase {
         assertThat(newRolesMetadata.roles()).containsExactlyInAnyOrderEntriesOf(
             Map.of("Arthur", DUMMY_USERS.get("Arthur").with(OLD_DUMMY_USERS_PRIVILEGES.get("Arthur")),
                 "Ford", DUMMY_USERS.get("Ford").with(OLD_DUMMY_USERS_PRIVILEGES.get("Ford"))));
-    }
-
-    @Test
-    public void test_grant_revoke_user_to_another_user_is_not_allowed() {
-        var rolesMetadata = new RolesMetadata(DummyUsersAndRolesWithParentRoles);
-        for (PrivilegeState state : List.of(PrivilegeState.GRANT, PrivilegeState.REVOKE)) {
-            assertThatThrownBy(() -> rolesMetadata.applyRolePrivileges(
-                List.of("Ford"), new RolePrivilegeToApply(state, Set.of("John"), null)))
-                .isExactlyInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Cannot " + state + " a USER to a ROLE");
-        }
     }
 
     @Test


### PR DESCRIPTION
- Move validations from RolesMetadata to TransportPrivilegesAction
  This is a preparation step to check for cycles in roles hierarchy, which needs `Roles` service to be available, which is not for `RolesMetadata`. So, in order to keep the validations in one place, move also the check to not grant a user to another user or role.

- Prevent cycles when granting roles
  Previously, we allowed them, and we infitine loops were avoided during calls of `hasPrivilege` method. Since we want to properly handle [`DENY` in parent roles hierarchy](https://github.com/crate/crate/pull/15271#discussion_r1438241462), it will complicate the code of `hasPrivilege` a lot, so instead, prevent from creating cycles in the first place, when granting roles to other roles or users. This way we are also in sync with PostgreSQL which also detects and prevents cycle for `GRANT` statements.

Follows: #15249
Follows: #15271 
Relates: #12109 