### PR TITLE
Implement precedence of DENY for inheritance

### DIFF
--- a/docs/admin/privileges.rst
+++ b/docs/admin/privileges.rst
@@ -489,9 +489,10 @@ on ``sys.users``.
     cr> REVOKE DQL ON TABLE sys.users FROM role_a;
     REVOKE OK, 1 row affected (... sec)
 
-Keep in mind, that ``DENY`` has precedence over ``GRANT``, so even if the user
-has been granted a privilege through role inheritance, if the same privilege is
-denied to the user, then ``DENY`` will prevail, for example::
+Keep in mind that ``DENY`` has precedence over ``GRANT``. If a role has been
+both granted and denied a privilege (directly or through role inheritance), then
+``DENY`` will take effect. For example, ``GRANT`` is inherited from a role
+and ``DENY`` directly set on the user::
 
     cr> GRANT DQL ON TABLE sys.users TO role_a;
     GRANT OK, 1 row affected (... sec)
@@ -516,10 +517,7 @@ User ``john`` cannot query ``sys.users``.
     cr> REVOKE DQL ON TABLE sys.users FROM role_a;
     REVOKE OK, 1 row affected (... sec)
 
-Additionally, ``DENY`` has precedence over ``GRANT`` for the granted roles of a
-user or role. If, for example, a user has been granted two roles, where one has
-a grant privilege and the other has a deny for the same privilege, then ``DENY``
-will prevail::
+Another example with ``DENY`` in effect, inherited from a role::
 
     cr> GRANT DQL ON TABLE sys.users TO role_a;
     GRANT OK, 1 row affected (... sec)

--- a/docs/admin/privileges.rst
+++ b/docs/admin/privileges.rst
@@ -477,6 +477,66 @@ privilege on the table, he is granted ``role_c`` which in turn is granted
 ``role_b`` which is granted ``role_a``, and ``role`` has the ``DQL`` privilege
 on ``sys.users``.
 
+
+.. hide:
+
+    cr> REVOKE role_c FROM john;
+    REVOKE OK, 1 row affected (... sec)
+    cr> REVOKE role_b FROM role_c;
+    REVOKE OK, 1 row affected (... sec)
+    cr> REVOKE role_a FROM role_b;
+    REVOKE OK, 1 row affected (... sec)
+    cr> REVOKE DQL ON TABLE sys.users FROM role_a;
+    REVOKE OK, 1 row affected (... sec)
+
+Keep in mind, that ``DENY`` has precedence over ``GRANT``, so even if the user
+has been granted a privilege through role inheritance, if the same privilege is
+denied to the user, then ``DENY`` will prevail, for example::
+
+    cr> GRANT DQL ON TABLE sys.users TO role_a;
+    GRANT OK, 1 row affected (... sec)
+
+::
+
+    cr> GRANT role_a TO john
+    GRANT OK, 1 row affected (... sec)
+
+::
+
+    cr> DENY DQL ON TABLE sys.users TO john
+    DENY OK, 1 row affected (... sec)
+
+User ``john`` cannot query ``sys.users``.
+
+
+.. hide:
+
+    cr> REVOKE role_a FROM john;
+    REVOKE OK, 1 row affected (... sec)
+    cr> REVOKE DQL ON TABLE sys.users FROM role_a;
+    REVOKE OK, 1 row affected (... sec)
+
+Additionally, ``DENY`` has precedence over ``GRANT`` for the granted roles of a
+user or role. If, for example, a user has been granted two roles, where one has
+a grant privilege and the other has a deny for the same privilege, then ``DENY``
+will prevail::
+
+    cr> GRANT DQL ON TABLE sys.users TO role_a;
+    GRANT OK, 1 row affected (... sec)
+
+::
+
+    cr> DENY DQL ON TABLE sys.users TO role_b;
+    DENY OK, 1 row affected (... sec)
+
+::
+
+    cr> GRANT role_a, role_b TO john;
+    GRANT OK, 2 rows affected (... sec)
+
+User ``john`` cannot query ``sys.users``.
+
+
 .. hide:
 
     cr> DROP USER john;

--- a/docs/sql/statements/grant.rst
+++ b/docs/sql/statements/grant.rst
@@ -35,9 +35,9 @@ be granted on the ``CLUSTER`` level.
 
 With the second one, ``GRANT`` can be used to grant one or more roles to one or
 many others or roles. Thus, the users (or roles) inherit the privileges of the
-roles which they are :ref:`granted<roles_inheritance>`.
+roles which they are :ref:`granted <roles_inheritance>`.
 
-For usage of the ``GRANT`` statement see :ref:`administration-privileges`.
+For usages of the ``GRANT`` statement see :ref:`administration-privileges`.
 
 Parameters
 ==========

--- a/server/src/main/java/io/crate/role/Roles.java
+++ b/server/src/main/java/io/crate/role/Roles.java
@@ -45,14 +45,9 @@ public interface Roles {
                 if (privilege.ident().type() == t) {
                     if (privilege.ident().clazz() == Privilege.Clazz.SCHEMA
                         && OidHash.schemaOid(privilege.ident().ident()) == (Integer) o) {
-
-                        if (privilege.state() == PrivilegeState.DENY || privilege.state() == PrivilegeState.GRANT) {
-                            return privilege.state();
-                        }
+                        return privilege.state();
                     } else if (privilege.ident().clazz() == Privilege.Clazz.CLUSTER) {
-                        if (result == PrivilegeState.REVOKE) {
-                            result = privilege.state();
-                        }
+                        result = privilege.state();
                     }
                 }
             }

--- a/server/src/test/java/io/crate/auth/user/RolePrivilegesTest.java
+++ b/server/src/test/java/io/crate/auth/user/RolePrivilegesTest.java
@@ -21,7 +21,7 @@
 
 package io.crate.auth.user;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static io.crate.testing.Asserts.assertThat;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -56,46 +56,46 @@ public class RolePrivilegesTest extends ESTestCase {
     @Test
     public void testMatchPrivilegesEmpty() throws Exception {
         RolePrivileges rolePrivileges = new RolePrivileges(Collections.emptyList());
-        assertThat(rolePrivileges.matchPrivilege(Privilege.Type.DDL, Privilege.Clazz.CLUSTER, null)).isFalse();
-        assertThat(rolePrivileges.matchPrivilege(Privilege.Type.DDL, Privilege.Clazz.SCHEMA, "doc")).isFalse();
-        assertThat(rolePrivileges.matchPrivilege(Privilege.Type.DDL, Privilege.Clazz.TABLE, "doc.t1")).isFalse();
-        assertThat(rolePrivileges.matchPrivilegeOfAnyType(Privilege.Clazz.CLUSTER, null)).isFalse();
-        assertThat(rolePrivileges.matchPrivilegeOfAnyType(Privilege.Clazz.SCHEMA, "doc")).isFalse();
-        assertThat(rolePrivileges.matchPrivilegeOfAnyType(Privilege.Clazz.TABLE, "doc.t1")).isFalse();
+        assertThat(rolePrivileges.matchPrivilege(Privilege.Type.DDL, Privilege.Clazz.CLUSTER, null)).isMissing();
+        assertThat(rolePrivileges.matchPrivilege(Privilege.Type.DDL, Privilege.Clazz.SCHEMA, "doc")).isMissing();
+        assertThat(rolePrivileges.matchPrivilege(Privilege.Type.DDL, Privilege.Clazz.TABLE, "doc.t1")).isMissing();
+        assertThat(rolePrivileges.matchPrivilegeOfAnyType(Privilege.Clazz.CLUSTER, null)).isMissing();
+        assertThat(rolePrivileges.matchPrivilegeOfAnyType(Privilege.Clazz.SCHEMA, "doc")).isMissing();
+        assertThat(rolePrivileges.matchPrivilegeOfAnyType(Privilege.Clazz.TABLE, "doc.t1")).isMissing();
     }
 
     @Test
     public void testMatchPrivilegeNoType() throws Exception {
-        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DDL, Privilege.Clazz.CLUSTER, null)).isFalse();
-        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DDL, Privilege.Clazz.SCHEMA, "doc")).isFalse();
-        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DDL, Privilege.Clazz.TABLE, "doc.t1")).isFalse();
-        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilegeOfAnyType(Privilege.Clazz.CLUSTER, null)).isTrue();
-        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilegeOfAnyType(Privilege.Clazz.SCHEMA, "doc")).isTrue();
-        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilegeOfAnyType(Privilege.Clazz.TABLE, "doc.t1")).isTrue();
+        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DDL, Privilege.Clazz.CLUSTER, null)).isMissing();
+        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DDL, Privilege.Clazz.SCHEMA, "doc")).isMissing();
+        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DDL, Privilege.Clazz.TABLE, "doc.t1")).isMissing();
+        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilegeOfAnyType(Privilege.Clazz.CLUSTER, null)).isGranted();
+        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilegeOfAnyType(Privilege.Clazz.SCHEMA, "doc")).isGranted();
+        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilegeOfAnyType(Privilege.Clazz.TABLE, "doc.t1")).isGranted();
     }
 
     @Test
     public void testMatchPrivilegeType() throws Exception {
-        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.CLUSTER, null)).isTrue();
-        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilegeOfAnyType(Privilege.Clazz.CLUSTER, null)).isTrue();
+        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.CLUSTER, null)).isGranted();
+        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilegeOfAnyType(Privilege.Clazz.CLUSTER, null)).isGranted();
     }
 
     @Test
     public void testMatchPrivilegeSchema() throws Exception {
-        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.SCHEMA, "doc")).isTrue();
-        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilegeOfAnyType(Privilege.Clazz.SCHEMA, "doc")).isTrue();
-        assertThat(USER_PRIVILEGES_SCHEMA.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.SCHEMA, "doc")).isTrue();
-        assertThat(USER_PRIVILEGES_SCHEMA.matchPrivilegeOfAnyType(Privilege.Clazz.SCHEMA, "doc")).isTrue();
+        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.SCHEMA, "doc")).isGranted();
+        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilegeOfAnyType(Privilege.Clazz.SCHEMA, "doc")).isGranted();
+        assertThat(USER_PRIVILEGES_SCHEMA.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.SCHEMA, "doc")).isGranted();
+        assertThat(USER_PRIVILEGES_SCHEMA.matchPrivilegeOfAnyType(Privilege.Clazz.SCHEMA, "doc")).isGranted();
     }
 
     @Test
     public void testMatchPrivilegeTable() throws Exception {
-        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.TABLE, "doc.t1")).isTrue();
-        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilegeOfAnyType(Privilege.Clazz.TABLE, "doc.t1")).isTrue();
-        assertThat(USER_PRIVILEGES_SCHEMA.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.TABLE, "doc.t1")).isTrue();
-        assertThat(USER_PRIVILEGES_SCHEMA.matchPrivilegeOfAnyType(Privilege.Clazz.TABLE, "doc.t1")).isTrue();
-        assertThat(USER_PRIVILEGES_TABLE.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.TABLE, "doc.t1")).isTrue();
-        assertThat(USER_PRIVILEGES_TABLE.matchPrivilegeOfAnyType(Privilege.Clazz.TABLE, "doc.t1")).isTrue();
+        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.TABLE, "doc.t1")).isGranted();
+        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilegeOfAnyType(Privilege.Clazz.TABLE, "doc.t1")).isGranted();
+        assertThat(USER_PRIVILEGES_SCHEMA.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.TABLE, "doc.t1")).isGranted();
+        assertThat(USER_PRIVILEGES_SCHEMA.matchPrivilegeOfAnyType(Privilege.Clazz.TABLE, "doc.t1")).isGranted();
+        assertThat(USER_PRIVILEGES_TABLE.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.TABLE, "doc.t1")).isGranted();
+        assertThat(USER_PRIVILEGES_TABLE.matchPrivilegeOfAnyType(Privilege.Clazz.TABLE, "doc.t1")).isGranted();
     }
 
     @Test
@@ -104,12 +104,12 @@ public class RolePrivilegesTest extends ESTestCase {
             new Privilege(PrivilegeState.DENY, Privilege.Type.DQL, Privilege.Clazz.CLUSTER, null, "crate")
         );
         RolePrivileges rolePrivileges = new RolePrivileges(privileges);
-        assertThat(rolePrivileges.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.CLUSTER, null)).isFalse();
-        assertThat(rolePrivileges.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.SCHEMA, "doc")).isFalse();
-        assertThat(rolePrivileges.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.TABLE, "doc.t1")).isFalse();
-        assertThat(rolePrivileges.matchPrivilegeOfAnyType(Privilege.Clazz.CLUSTER, null)).isFalse();
-        assertThat(rolePrivileges.matchPrivilegeOfAnyType(Privilege.Clazz.SCHEMA, "doc")).isFalse();
-        assertThat(rolePrivileges.matchPrivilegeOfAnyType(Privilege.Clazz.TABLE, "doc.t1")).isFalse();
+        assertThat(rolePrivileges.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.CLUSTER, null)).isDenied();
+        assertThat(rolePrivileges.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.SCHEMA, "doc")).isDenied();
+        assertThat(rolePrivileges.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.TABLE, "doc.t1")).isDenied();
+        assertThat(rolePrivileges.matchPrivilegeOfAnyType(Privilege.Clazz.CLUSTER, null)).isDenied();
+        assertThat(rolePrivileges.matchPrivilegeOfAnyType(Privilege.Clazz.SCHEMA, "doc")).isDenied();
+        assertThat(rolePrivileges.matchPrivilegeOfAnyType(Privilege.Clazz.TABLE, "doc.t1")).isDenied();
     }
 
     @Test
@@ -120,8 +120,8 @@ public class RolePrivilegesTest extends ESTestCase {
             new Privilege(PrivilegeState.GRANT, Privilege.Type.DQL, Privilege.Clazz.TABLE, "doc.t1", "crate")
         );
         RolePrivileges rolePrivileges = new RolePrivileges(privileges);
-        assertThat(rolePrivileges.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.TABLE, "doc.t1")).isTrue();
-        assertThat(rolePrivileges.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.TABLE, "doc.t2")).isFalse();
-        assertThat(rolePrivileges.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.SCHEMA, "my_schema")).isTrue();
+        assertThat(rolePrivileges.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.TABLE, "doc.t1")).isGranted();
+        assertThat(rolePrivileges.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.TABLE, "doc.t2")).isDenied();
+        assertThat(rolePrivileges.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.SCHEMA, "my_schema")).isGranted();
     }
 }

--- a/server/src/testFixtures/java/io/crate/testing/Asserts.java
+++ b/server/src/testFixtures/java/io/crate/testing/Asserts.java
@@ -44,6 +44,7 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Scalar;
 import io.crate.planner.operators.LogicalPlan;
+import io.crate.role.PrivilegeState;
 import io.crate.sql.tree.ColumnPolicy;
 import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.Node;
@@ -109,6 +110,10 @@ public class Asserts extends Assertions {
 
     public static ParsedDocumentAssert assertThat(ParsedDocument actual) {
         return new ParsedDocumentAssert(actual);
+    }
+
+    public static PrivilegeResolutionAssert assertThat(PrivilegeState actual) {
+        return new PrivilegeResolutionAssert(actual);
     }
 
     // generic helper methods

--- a/server/src/testFixtures/java/io/crate/testing/PrivilegeResolutionAssert.java
+++ b/server/src/testFixtures/java/io/crate/testing/PrivilegeResolutionAssert.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.testing;
+
+import org.assertj.core.api.AbstractAssert;
+
+import io.crate.role.PrivilegeState;
+
+public final class PrivilegeResolutionAssert extends AbstractAssert<PrivilegeResolutionAssert, PrivilegeState> {
+
+    public PrivilegeResolutionAssert(PrivilegeState actual) {
+        super(actual, PrivilegeResolutionAssert.class);
+    }
+
+    public PrivilegeResolutionAssert isGranted() {
+        isNotNull();
+        if (actual != PrivilegeState.GRANT) {
+            failWithMessage("Expected PrivilegeState to be GRANTED");
+        }
+        return this;
+    }
+
+    public PrivilegeResolutionAssert isDenied() {
+        isNotNull();
+        if (actual != PrivilegeState.DENY) {
+            failWithMessage("Expected PrivilegeState to be DENIED");
+        }
+        return this;
+    }
+
+    public PrivilegeResolutionAssert isMissing() {
+        isNotNull();
+        if (actual != PrivilegeState.REVOKE) {
+            failWithMessage("Expected PrivilegeState to be missing");
+        }
+        return this;
+    }
+}


### PR DESCRIPTION
- Change matchPrivilege methods to return a 3vl result
   In order to properly resolve DENY with precedence from parent roles, it's necessary to change the boolean return value modeling grant and missing-or-deny, to a 3vl result which will return a `PrivilegeState` (to avoid introducing another enum) where `REVOKE` means that the privilege is copmletely missing.

- Implement inheritance of DENY
  `DENY` has precedence, so on the same level of parents hierarchy, if out of let's say 3 parent roles, if one of them DENies the privilege, then the privilege is denied. The privilege result is resolved in a depth-first fashion.

Follows: https://github.com/crate/crate/pull/15249
Follows: https://github.com/crate/crate/pull/15271
Relates: https://github.com/crate/crate/issues/12109
