### PR TITLE
Rename RemoveRedundantFetchOrEval to RemoveRedundantEval

### DIFF
--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -107,7 +107,7 @@ import io.crate.planner.optimizer.rule.MoveOrderBeneathNestedLoop;
 import io.crate.planner.optimizer.rule.MoveOrderBeneathRename;
 import io.crate.planner.optimizer.rule.MoveOrderBeneathUnion;
 import io.crate.planner.optimizer.rule.OptimizeCollectWhereClauseAccess;
-import io.crate.planner.optimizer.rule.RemoveRedundantFetchOrEval;
+import io.crate.planner.optimizer.rule.RemoveRedundantEval;
 import io.crate.planner.optimizer.rule.ReorderHashJoin;
 import io.crate.planner.optimizer.rule.ReorderNestedLoopJoin;
 import io.crate.planner.optimizer.rule.RewriteFilterOnOuterJoinToInnerJoin;
@@ -132,7 +132,7 @@ public class LogicalPlanner {
 
     // Be careful, the order of the rules matter
     public static final List<Rule<?>> ITERATIVE_OPTIMIZER_RULES = List.of(
-        new RemoveRedundantFetchOrEval(),
+        new RemoveRedundantEval(),
         new MergeAggregateAndCollectToCount(),
         new MergeAggregateRenameAndCollectToCount(),
         new MergeFilters(),
@@ -170,7 +170,7 @@ public class LogicalPlanner {
     );
 
     public static final List<Rule<?>> FETCH_OPTIMIZER_RULES = List.of(
-        new RemoveRedundantFetchOrEval(),
+        new RemoveRedundantEval(),
         new RewriteToQueryThenFetch()
     );
 

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -102,7 +102,7 @@ import io.crate.planner.optimizer.rule.MoveLimitBeneathEval;
 import io.crate.planner.optimizer.rule.MoveLimitBeneathJoin;
 import io.crate.planner.optimizer.rule.MoveLimitBeneathRename;
 import io.crate.planner.optimizer.rule.MoveLimitBeneathUnion;
-import io.crate.planner.optimizer.rule.MoveOrderBeneathFetchOrEval;
+import io.crate.planner.optimizer.rule.MoveOrderBeneathEval;
 import io.crate.planner.optimizer.rule.MoveOrderBeneathNestedLoop;
 import io.crate.planner.optimizer.rule.MoveOrderBeneathRename;
 import io.crate.planner.optimizer.rule.MoveOrderBeneathUnion;
@@ -153,7 +153,7 @@ public class LogicalPlanner {
         new RewriteFilterOnOuterJoinToInnerJoin(),
         new MoveOrderBeneathUnion(),
         new MoveOrderBeneathNestedLoop(),
-        new MoveOrderBeneathFetchOrEval(),
+        new MoveOrderBeneathEval(),
         new MoveOrderBeneathRename(),
         new DeduplicateOrder(),
         new OptimizeCollectWhereClauseAccess(),

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathEval.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathEval.java
@@ -41,15 +41,15 @@ import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 import static io.crate.planner.optimizer.matcher.Patterns.source;
 import static io.crate.planner.optimizer.rule.Util.transpose;
 
-public final class MoveOrderBeneathFetchOrEval implements Rule<Order> {
+public final class MoveOrderBeneathEval implements Rule<Order> {
 
-    private final Capture<Eval> fetchCapture;
+    private final Capture<Eval> evalCapture;
     private final Pattern<Order> pattern;
 
-    public MoveOrderBeneathFetchOrEval() {
-        this.fetchCapture = new Capture<>();
+    public MoveOrderBeneathEval() {
+        this.evalCapture = new Capture<>();
         this.pattern = typeOf(Order.class)
-            .with(source(), typeOf(Eval.class).capturedAs(fetchCapture));
+            .with(source(), typeOf(Eval.class).capturedAs(evalCapture));
     }
 
     @Override
@@ -64,11 +64,11 @@ public final class MoveOrderBeneathFetchOrEval implements Rule<Order> {
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              Function<LogicalPlan, LogicalPlan> resolvePlan) {
-        Eval eval = captures.get(fetchCapture);
-        List<Symbol> outputsOfSourceOfFetch = eval.source().outputs();
+        Eval eval = captures.get(evalCapture);
+        List<Symbol> outputsOfSourceOfEval = eval.source().outputs();
         List<Symbol> orderBySymbols = plan.orderBy().orderBySymbols();
-        if (outputsOfSourceOfFetch.containsAll(orderBySymbols)
-            || outputsOfSourceOfFetch.containsAll(extractColumns(orderBySymbols))) {
+        if (outputsOfSourceOfEval.containsAll(orderBySymbols)
+            || outputsOfSourceOfEval.containsAll(extractColumns(orderBySymbols))) {
             return transpose(plan, eval);
         }
         return null;

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RemoveRedundantEval.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RemoveRedundantEval.java
@@ -37,13 +37,13 @@ import java.util.function.Function;
 /**
  * Eliminates any Eval nodes that have the same output as their source
  */
-public final class RemoveRedundantFetchOrEval implements Rule<Eval> {
+public final class RemoveRedundantEval implements Rule<Eval> {
 
     private final Pattern<Eval> pattern;
 
-    public RemoveRedundantFetchOrEval() {
+    public RemoveRedundantEval() {
         this.pattern = typeOf(Eval.class)
-            .with(fetchOrEval -> fetchOrEval.outputs().equals(fetchOrEval.source().outputs()));
+            .with(eval -> eval.outputs().equals(eval.source().outputs()));
     }
 
     @Override

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -246,7 +246,7 @@ public class PgCatalogITest extends IntegTestCase {
             "optimizer_move_limit_beneath_join| true| Indicates if the optimizer rule MoveLimitBeneathJoin is activated.| NULL| NULL",
             "optimizer_move_limit_beneath_rename| true| Indicates if the optimizer rule MoveLimitBeneathRename is activated.| NULL| NULL",
             "optimizer_move_limit_beneath_union| true| Indicates if the optimizer rule MoveLimitBeneathUnion is activated.| NULL| NULL",
-            "optimizer_move_order_beneath_fetch_or_eval| true| Indicates if the optimizer rule MoveOrderBeneathFetchOrEval is activated.| NULL| NULL",
+            "optimizer_move_order_beneath_eval| true| Indicates if the optimizer rule MoveOrderBeneathEval is activated.| NULL| NULL",
             "optimizer_move_order_beneath_nested_loop| true| Indicates if the optimizer rule MoveOrderBeneathNestedLoop is activated.| NULL| NULL",
             "optimizer_move_order_beneath_rename| true| Indicates if the optimizer rule MoveOrderBeneathRename is activated.| NULL| NULL",
             "optimizer_move_order_beneath_union| true| Indicates if the optimizer rule MoveOrderBeneathUnion is activated.| NULL| NULL",

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -251,7 +251,7 @@ public class PgCatalogITest extends IntegTestCase {
             "optimizer_move_order_beneath_rename| true| Indicates if the optimizer rule MoveOrderBeneathRename is activated.| NULL| NULL",
             "optimizer_move_order_beneath_union| true| Indicates if the optimizer rule MoveOrderBeneathUnion is activated.| NULL| NULL",
             "optimizer_optimize_collect_where_clause_access| true| Indicates if the optimizer rule OptimizeCollectWhereClauseAccess is activated.| NULL| NULL",
-            "optimizer_remove_redundant_fetch_or_eval| true| Indicates if the optimizer rule RemoveRedundantFetchOrEval is activated.| NULL| NULL",
+            "optimizer_remove_redundant_eval| true| Indicates if the optimizer rule RemoveRedundantEval is activated.| NULL| NULL",
             "optimizer_reorder_hash_join| true| Indicates if the optimizer rule ReorderHashJoin is activated.| NULL| NULL",
             "optimizer_reorder_nested_loop_join| true| Indicates if the optimizer rule ReorderNestedLoopJoin is activated.| NULL| NULL",
             "optimizer_rewrite_filter_on_outer_join_to_inner_join| true| Indicates if the optimizer rule RewriteFilterOnOuterJoinToInnerJoin is activated.| NULL| NULL",

--- a/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
@@ -425,7 +425,7 @@ public class ShowIntegrationTest extends IntegTestCase {
             "optimizer_move_limit_beneath_join| true| Indicates if the optimizer rule MoveLimitBeneathJoin is activated.",
             "optimizer_move_limit_beneath_rename| true| Indicates if the optimizer rule MoveLimitBeneathRename is activated.",
             "optimizer_move_limit_beneath_union| true| Indicates if the optimizer rule MoveLimitBeneathUnion is activated.",
-            "optimizer_move_order_beneath_fetch_or_eval| true| Indicates if the optimizer rule MoveOrderBeneathFetchOrEval is activated.",
+            "optimizer_move_order_beneath_eval| true| Indicates if the optimizer rule MoveOrderBeneathEval is activated.",
             "optimizer_move_order_beneath_nested_loop| true| Indicates if the optimizer rule MoveOrderBeneathNestedLoop is activated.",
             "optimizer_move_order_beneath_rename| true| Indicates if the optimizer rule MoveOrderBeneathRename is activated.",
             "optimizer_move_order_beneath_union| true| Indicates if the optimizer rule MoveOrderBeneathUnion is activated.",

--- a/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
@@ -430,7 +430,7 @@ public class ShowIntegrationTest extends IntegTestCase {
             "optimizer_move_order_beneath_rename| true| Indicates if the optimizer rule MoveOrderBeneathRename is activated.",
             "optimizer_move_order_beneath_union| true| Indicates if the optimizer rule MoveOrderBeneathUnion is activated.",
             "optimizer_optimize_collect_where_clause_access| true| Indicates if the optimizer rule OptimizeCollectWhereClauseAccess is activated.",
-            "optimizer_remove_redundant_fetch_or_eval| true| Indicates if the optimizer rule RemoveRedundantFetchOrEval is activated.",
+            "optimizer_remove_redundant_eval| true| Indicates if the optimizer rule RemoveRedundantEval is activated.",
             "optimizer_reorder_hash_join| true| Indicates if the optimizer rule ReorderHashJoin is activated.",
             "optimizer_reorder_nested_loop_join| true| Indicates if the optimizer rule ReorderNestedLoopJoin is activated.",
             "optimizer_rewrite_filter_on_outer_join_to_inner_join| true| Indicates if the optimizer rule RewriteFilterOnOuterJoinToInnerJoin is activated.",

--- a/server/src/test/java/io/crate/testing/SqlTransportExecutorTest.java
+++ b/server/src/test/java/io/crate/testing/SqlTransportExecutorTest.java
@@ -36,7 +36,7 @@ import io.crate.planner.optimizer.rule.MergeFilterAndCollect;
 import io.crate.planner.optimizer.rule.MoveFilterBeneathGroupBy;
 import io.crate.planner.optimizer.rule.MoveFilterBeneathOrder;
 import io.crate.planner.optimizer.rule.MoveLimitBeneathEval;
-import io.crate.planner.optimizer.rule.MoveOrderBeneathFetchOrEval;
+import io.crate.planner.optimizer.rule.MoveOrderBeneathEval;
 import io.crate.planner.optimizer.rule.RewriteFilterOnOuterJoinToInnerJoin;
 import io.crate.planner.optimizer.rule.RewriteNestedLoopJoinToHashJoin;
 import io.crate.planner.optimizer.rule.RewriteToQueryThenFetch;
@@ -54,7 +54,7 @@ public class SqlTransportExecutorTest {
             RewriteToQueryThenFetch.class,
             RewriteNestedLoopJoinToHashJoin.class,
             RewriteFilterOnOuterJoinToInnerJoin.class,
-            MoveOrderBeneathFetchOrEval.class,
+            MoveOrderBeneathEval.class,
             MoveFilterBeneathGroupBy.class
         );
 
@@ -75,7 +75,7 @@ public class SqlTransportExecutorTest {
                 "set optimizer_rewrite_nested_loop_join_to_hash_join=false",
                 "set optimizer_move_filter_beneath_group_by=false",
                 "set optimizer_rewrite_filter_on_outer_join_to_inner_join=false",
-                "set optimizer_move_order_beneath_fetch_or_eval=false",
+                "set optimizer_move_order_beneath_eval=false",
                 "set optimizer_merge_filter_and_collect=false",
                 "set optimizer_rewrite_to_query_then_fetch=false",
                 "set optimizer_deduplicate_order=false",


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
`fetch` is removed from the rule by https://github.com/crate/crate/pull/9669

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
