### PR TITLE
Fix flaky test: test_copy_from_can_import_json_with_same_columns_in_d…

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
@@ -1190,7 +1190,7 @@ public class CopyIntegrationTest extends SQLHttpIntegrationTest {
 
         execute("copy t from ? with (shared = true)", new Object[]{Paths.get(file.toURI()).toUri().toString()});
         execute("refresh table t");
-        execute("select * from t");
+        execute("select * from t order by id");
         assertThat(response).hasRows(
             "1| 38392| apple safari| 151155",
             "2| 31123| apple safari| 23073"


### PR DESCRIPTION
…ifferent_order

## Summary of the changes / Why this improves CrateDB
Fails with:
```
Actual and expected have the same elements but not in the same order, at index 0 actual element was:
  "2| 31123| apple safari| 23073"
whereas expected element was:
  "1| 38392| apple safari| 151155"
```

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
