### PR TITLE
Fix performance regression for (group/hash) aggregates without doc-values

### DIFF
--- a/docs/appendices/release-notes/5.5.3.rst
+++ b/docs/appendices/release-notes/5.5.3.rst
@@ -59,3 +59,5 @@ Fixes
   non-deterministic generated or default sub-column and the object column
   wasn't part of the ``INSERT`` targets.
 
+- Fixed a performance regression introduced in 5.5.0 for aggregations on columns
+  with the column store disabled.

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/SourceParser.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/SourceParser.java
@@ -129,12 +129,12 @@ public final class SourceParser {
     }
 
     public Map<String, Object> parse(BytesReference bytes, boolean includeUnknownCols) {
-        try (InputStream inputStream = XContentHelper.getUncompressedInputStream(bytes)) {
-            XContentParser parser = XContentType.JSON.xContent().createParser(
-                NamedXContentRegistry.EMPTY,
-                DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
-                inputStream
-            );
+        try (InputStream inputStream = XContentHelper.getUncompressedInputStream(bytes);
+             XContentParser parser = XContentType.JSON.xContent().createParser(
+                 NamedXContentRegistry.EMPTY,
+                 DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                 inputStream
+             )) {
             Token token = parser.currentToken();
             if (token == null) {
                 parser.nextToken();


### PR DESCRIPTION
Fixes https://github.com/crate/crate/issues/15224.

The reasoning behind this change has been described in https://github.com/crate/crate/issues/15224#issuecomment-1873465335.

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
