### PR TITLE
Add unknown type for pgwire

### DIFF
--- a/docs/appendices/release-notes/5.6.0.rst
+++ b/docs/appendices/release-notes/5.6.0.rst
@@ -89,6 +89,10 @@ SQL Statements
 SQL Standard and PostgreSQL Compatibility
 -----------------------------------------
 
+- Added a ``unknown`` type for serialization via the PostgreSQL wire protocol
+  and to the ``pg_catalog.pg_type`` table. This should resolve compatibility
+  issues with ``npgsql`` >= 8.0.
+
 - Added an empty ``pg_catalog.pg_depend`` table.
 
 - Changed ``pg_catalog.pg_roles`` table to be properly populated, as previously

--- a/docs/interfaces/postgres.rst
+++ b/docs/interfaces/postgres.rst
@@ -218,6 +218,7 @@ table available in CrateDB::
     |  600 | point        |     1017 |       0 |     16 | b       | G           |
     |  700 | float4       |     1021 |       0 |      4 | b       | N           |
     |  701 | float8       |     1022 |       0 |      8 | b       | N           |
+    |  705 | unknown      |        0 |       0 |     -2 | p       | X           |
     | 1000 | _bool        |        0 |      16 |     -1 | b       | A           |
     | 1002 | _char        |        0 |      18 |     -1 | b       | A           |
     | 1005 | _int2        |        0 |      21 |     -1 | b       | A           |
@@ -253,7 +254,7 @@ table available in CrateDB::
     | 2277 | anyarray     |        0 |    2276 |     -1 | p       | P           |
     | 2287 | _record      |        0 |    2249 |     -1 | p       | A           |
     +------+--------------+----------+---------+--------+---------+-------------+
-    SELECT 49 rows in set (... sec)
+    SELECT 50 rows in set (... sec)
 
 .. NOTE::
 

--- a/server/src/main/java/io/crate/protocols/postgres/types/PGTypes.java
+++ b/server/src/main/java/io/crate/protocols/postgres/types/PGTypes.java
@@ -62,7 +62,7 @@ public class PGTypes {
         .put(DataTypes.TIMESTAMP, TimestampType.INSTANCE)
         .put(DataTypes.DATE, DateType.INSTANCE)
         .put(DataTypes.IP, VarCharType.INSTANCE) // postgres has no IP type, so map it to varchar - it matches the client representation
-        .put(DataTypes.UNDEFINED, VarCharType.INSTANCE)
+        .put(DataTypes.UNDEFINED, UnknownType.INSTANCE)
         .put(DataTypes.GEO_SHAPE, JsonType.INSTANCE)
         .put(io.crate.types.JsonType.INSTANCE, JsonType.INSTANCE)
         .put(DataTypes.GEO_POINT, PointType.INSTANCE)

--- a/server/src/main/java/io/crate/protocols/postgres/types/UnknownType.java
+++ b/server/src/main/java/io/crate/protocols/postgres/types/UnknownType.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.protocols.postgres.types;
+
+import java.nio.charset.StandardCharsets;
+
+import org.jetbrains.annotations.NotNull;
+
+import io.crate.types.DataTypes;
+import io.crate.types.Regproc;
+import io.netty.buffer.ByteBuf;
+
+public class UnknownType extends PGType<Object> {
+
+    public static final UnknownType INSTANCE = new UnknownType();
+    static final int OID = 705;
+
+    UnknownType() {
+        super(OID, -2, -1, "unknown");
+    }
+
+    @Override
+    public int typArray() {
+        return 0;
+    }
+
+    @Override
+    public String typeCategory() {
+        return TypeCategory.UNKNOWN.code();
+    }
+
+    @Override
+    public String type() {
+        return Type.PSEUDO.code();
+    }
+
+    @Override
+    public Regproc typReceive() {
+        return Regproc.of("unknownrecv");
+    }
+
+    @Override
+    public Regproc typSend() {
+        return Regproc.of("unknownsend");
+    }
+
+    @Override
+    public Regproc typOutput() {
+        return Regproc.of("unknownout");
+    }
+
+    @Override
+    public Regproc typInput() {
+        return Regproc.of("unknownin");
+    }
+
+    @Override
+    public int writeAsBinary(ByteBuf buffer, @NotNull Object value) {
+        String string = DataTypes.STRING.implicitCast(value);
+        int writerIndex = buffer.writerIndex();
+        buffer.writeInt(0);
+        int bytesWritten = buffer.writeCharSequence(string, StandardCharsets.UTF_8);
+        buffer.setInt(writerIndex, bytesWritten);
+        return INT32_BYTE_SIZE + bytesWritten;
+    }
+
+    @Override
+    public String readBinaryValue(ByteBuf buffer, int valueLength) {
+        int readerIndex = buffer.readerIndex();
+        buffer.readerIndex(readerIndex + valueLength);
+        return buffer.toString(readerIndex, valueLength, StandardCharsets.UTF_8);
+    }
+
+    @Override
+    byte[] encodeAsUTF8Text(@NotNull Object value) {
+        return DataTypes.STRING.implicitCast(value).getBytes(StandardCharsets.UTF_8);
+    }
+
+    @Override
+    String decodeUTF8Text(byte[] bytes) {
+        return new String(bytes, StandardCharsets.UTF_8);
+    }
+}


### PR DESCRIPTION
Closes https://github.com/crate/crate/issues/15281
Required for https://github.com/crate/crate-qa/pull/289

Looks like in PostgreSQL it is handled as cstring:
From `varlena.c`:

    /*
     *		unknownin			- converts cstring to internal representation
     */
    Datum
    unknownin(PG_FUNCTION_ARGS)
    {
    	char	   *str = PG_GETARG_CSTRING(0);

    	/* representation is same as cstring */
    	PG_RETURN_CSTRING(pstrdup(str));
    }

    /*
     *		unknownout			- converts internal representation to cstring
     */
    Datum
    unknownout(PG_FUNCTION_ARGS)
    {
    	/* representation is same as cstring */
    	char	   *str = PG_GETARG_CSTRING(0);

    	PG_RETURN_CSTRING(pstrdup(str));
    }

    /*
     *		unknownrecv			- converts external binary format to unknown
     */
    Datum
    unknownrecv(PG_FUNCTION_ARGS)
    {
    	StringInfo	buf = (StringInfo) PG_GETARG_POINTER(0);
    	char	   *str;
    	int			nbytes;

    	str = pq_getmsgtext(buf, buf->len - buf->cursor, &nbytes);
    	/* representation is same as cstring */
    	PG_RETURN_CSTRING(str);
    }

    /*
     *		unknownsend			- converts unknown to binary format
     */
    Datum
    unknownsend(PG_FUNCTION_ARGS)
    {
    	/* representation is same as cstring */
    	char	   *str = PG_GETARG_CSTRING(0);
    	StringInfoData buf;

    	pq_begintypsend(&buf);
    	pq_sendtext(&buf, str, strlen(str));
    	PG_RETURN_BYTEA_P(pq_endtypsend(&buf));
    }
