### PR TITLE
Fix subscript lookup on object array children

### DIFF
--- a/docs/appendices/release-notes/5.5.3.rst
+++ b/docs/appendices/release-notes/5.5.3.rst
@@ -49,6 +49,14 @@ See the :ref:`version_5.5.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed a regression introduced in 5.5.0 which caused subscript expressions on
+  object arrays to fail in some cases. For example, the following case failed
+  with a ``ClassCastException``::
+
+    CREATE TABLE tbl (obj ARRAY(OBJECT(STRICT) AS (x BIGINT)));
+    INSERT INTO tbl VALUES ([{x = 1}]);
+    SELECT unnest(obj)['x'] FROM tbl;
+
 - Fixed an issue that caused ``UPDATE`` and ``DELETE`` statements to match
   records if the ``WHERE`` clause contained an equality condition on all primary
   keys, and it included an additional clause in an ``AND`` that should have

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/SourceParser.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/SourceParser.java
@@ -236,7 +236,7 @@ public final class SourceParser {
                 if (required instanceof DataType<?> dataType) {
                     type = dataType;
                     required = null;
-                    if (dataType instanceof ObjectType objectType) {
+                    if (ArrayType.unnest(dataType) instanceof ObjectType objectType) {
                         // Use inner types to parse the object sub-columns for type aware parsing
                         required = objectType.innerTypes();
                         // When parsing a complete object, we need to parse also possible ignored sub-columns
@@ -245,8 +245,15 @@ public final class SourceParser {
                     }
                 }
 
-                values.put(fieldName, parseValue(parser, type, (Map) required, droppedColumns,
-                        lookupNameBySourceKey, colPath, currentTreeIncludeUnknown));
+                Object value = parseValue(
+                    parser,
+                    type,
+                    (Map) required,
+                    droppedColumns,
+                    lookupNameBySourceKey,
+                    colPath,
+                    currentTreeIncludeUnknown);
+                values.put(fieldName, value);
 
                 colPath.delete(prevLength, colPath.length());
             }


### PR DESCRIPTION
The change in the following commit removed the `array(object)` handling
from the source parser and caused a regression:

https://github.com/crate/crate/commit/e44102c464ae41651aed05719e90eb9ea3d2e80a

Fixes https://github.com/crate/crate/issues/15283
