### PR TITLE
Return NULL from subscript lookup instead of error if type contains key

### DIFF
--- a/docs/appendices/release-notes/5.5.3.rst
+++ b/docs/appendices/release-notes/5.5.3.rst
@@ -49,6 +49,19 @@ See the :ref:`version_5.5.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that could cause subscript expressions to raise a
+  ``ColumnUnknownException`` error despite the object having a defined schema.
+  An example case where this happened is::
+
+    CREATE TABLE tbl (obj ARRAY(OBJECT(STRICT) AS (x INT)));
+    INSERT INTO tbl VALUES ([{}]);
+    SELECT unnest(obj)['x'] FROM tbl;
+
+  There were two workarounds for this:
+
+    - Using ``SELECT unnest(obj['x']) FROM tbl``
+    - Disable errors on unknown object keys via ``set error_on_unknown_object_key = false;``
+
 - Fixed a regression introduced in 5.5.0 which caused subscript expressions on
   object arrays to fail in some cases. For example, the following case failed
   with a ``ClassCastException``::

--- a/server/src/main/java/io/crate/expression/scalar/SubscriptObjectFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/SubscriptObjectFunction.java
@@ -122,7 +122,12 @@ public class SubscriptObjectFunction extends Scalar<Object, Map<String, Object>>
             if (mapValue == null) {
                 return null;
             }
-            mapValue = SubscriptFunction.lookupByName(mapValue, args[i].value(), txnCtx.sessionSettings().errorOnUnknownObjectKey());
+            mapValue = SubscriptFunction.lookupByName(
+                boundSignature.argTypes(),
+                mapValue,
+                args[i].value(),
+                txnCtx.sessionSettings().errorOnUnknownObjectKey()
+            );
         }
         return mapValue;
     }

--- a/server/src/test/java/io/crate/expression/scalar/SubscriptFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/SubscriptFunctionTest.java
@@ -115,4 +115,9 @@ public class SubscriptFunctionTest extends ScalarTestCase {
         sqlExpressions.setErrorOnUnknownObjectKey(false);
         assertEvaluateNull("{}['y']");
     }
+
+    @Test
+    public void test_lookup_by_name_with_missing_key_returns_null_if_type_information_are_available() throws Exception {
+        assertEvaluateNull("{}::object(strict) as (y int)['y']");
+    }
 }


### PR DESCRIPTION
Problem: In a case like:

    CREATE TABLE t01 (obj ARRAY(OBJECT(STRICT) AS (txt INT)));
    SELECT unnest(obj)['txt'] FROM t01;

The `subscript` function implementation gets used which raised an error
if the map doesn't contain the `txt` key.

This shouldn't happen because the key is known.

Solution:

Use the type information from the bound signature to figure out if the
key is known.

Fixes https://github.com/crate/crate/issues/15284
