### PR TITLE
Rename `parents` to `granted_roles` for `sys.roles/users`

### DIFF
--- a/docs/admin/system-information.rst
+++ b/docs/admin/system-information.rst
@@ -2154,26 +2154,27 @@ Users
 
 The ``sys.users`` table contains all existing database users in the cluster.
 
-+-----------------------+-------------------------------------+-------------+
-| Column Name           | Description                         | Return Type |
-+=======================+=====================================+=============+
-| ``name``              | The name of the database user.      | ``TEXT``    |
-+-----------------------+-------------------------------------+-------------+
-| ``superuser``         | Flag to indicate whether the user   | ``BOOLEAN`` |
-|                       | is a superuser.                     |             |
-+-----------------------+-------------------------------------+-------------+
-| ``password``          | ``********`` if there is a password | ``TEXT``    |
-|                       | set or ``NULL`` if there is not.    |             |
-+-----------------------+-------------------------------------+-------------+
-| ``parents``           | A list of parent roles granted to   | ``ARRAY``   |
-|                       | the user                            |             |
-+-----------------------+-------------------------------------+-------------+
-| ``parents[role]``     | The name of the role granted to     | ``TEXT``    |
-|                       | the user                            |             |
-+-----------------------+-------------------------------------+-------------+
-| ``parents[grantor]``  | The name of user who granted the    | ``TEXT``    |
-|                       | role to the user                    |             |
-+-----------------------+-------------------------------------+-------------+
++----------------------------+----------------------------------+-------------+
+| Column Name                | Description                      | Return Type |
++============================+==================================+=============+
+| ``name``                   | The name of the database user.   | ``TEXT``    |
++----------------------------+----------------------------------+-------------+
+| ``superuser``              | Flag to indicate whether the     | ``BOOLEAN`` |
+|                            | user is a superuser.             |             |
++----------------------------+----------------------------------+-------------+
+| ``password``               | ``********`` if there is a       | ``TEXT``    |
+|                            | password set or ``NULL`` if      |             |
+|                            | there is not.                    |             |
++----------------------------+----------------------------------+-------------+
+| ``granted_roles``          | A list of parent roles granted   | ``ARRAY``   |
+|                            | to the user                      |             |
++----------------------------+----------------------------------+-------------+
+| ``granted_roles[role]``    | The name of the role granted to  | ``TEXT``    |
+|                            | the user                         |             |
++----------------------------+----------------------------------+-------------+
+| ``granted_roles[grantor]`` | The name of user who granted the | ``TEXT``    |
+|                            | role to the user                 |             |
++----------------------------+----------------------------------+-------------+
 
 .. _sys-roles:
 
@@ -2182,20 +2183,20 @@ Roles
 
 The ``sys.roles`` table contains all existing database roles in the cluster.
 
-+---------------+---------------------------------------------+-------------+
-| Column Name   | Description                                 | Return Type |
-+===============+=============================================+=============+
-| ``name``      | The name of the database user.              | ``TEXT``    |
-+---------------+---------------------------------------------+-------------+
-| ``parents``           | A list of parent roles granted to   | ``ARRAY``   |
-|                       | the user                            |             |
-+-----------------------+-------------------------------------+-------------+
-| ``parents[role]``     | The name of the role granted to     | ``TEXT``    |
-|                       | the user                            |             |
-+-----------------------+-------------------------------------+-------------+
-| ``parents[grantor]``  | The name of user who granted the    | ``TEXT``    |
-|                       | role to the user                    |             |
-+-----------------------+-------------------------------------+-------------+
++----------------------------+----------------------------------+-------------+
+| Column Name                | Description                      | Return Type |
++============================+==================================+=============+
+| ``name``                   | The name of the database user.   | ``TEXT``    |
++----------------------------+----------------------------------+-------------+
+| ``granted_roles``          | A list of parent roles granted   | ``ARRAY``   |
+|                            | to the user                      |             |
++----------------------------+----------------------------------+-------------+
+| ``granted_roles[role]``    | The name of the role granted to  | ``TEXT``    |
+|                            | the user                         |             |
++----------------------------+----------------------------------+-------------+
+| ``granted_roles[grantor]`` | The name of user who granted the | ``TEXT``    |
+|                            | role to the user                 |             |
++----------------------------+----------------------------------+-------------+
 
 .. _sys-allocations:
 

--- a/docs/admin/user-management.rst
+++ b/docs/admin/user-management.rst
@@ -149,9 +149,9 @@ group privileges.
 
 To list all existing roles query the table::
 
-    cr> SELECT * FROM sys.roles order by name;
+    cr> SELECT name, granted_roles FROM sys.roles order by name;
     +--------+------------------------------------------+
-    | name   | parents                                  |
+    | name   | granted_roles                            |
     +--------+------------------------------------------+
     | role_a | []                                       |
     | role_b | [{"grantor": "crate", "role": "role_c"}] |
@@ -280,9 +280,9 @@ CrateDB clusters is also part of that list.
 
 To list all existing users query the table::
 
-    cr> SELECT * FROM sys.users order by name;
+    cr> SELECT name, granted_roles, password, superuser FROM sys.users order by name;
     +--------+----------------------------------------------------------------------------------+----------+-----------+
-    | name   | parents                                                                          | password | superuser |
+    | name   | granted_roles                                                                    | password | superuser |
     +--------+----------------------------------------------------------------------------------+----------+-----------+
     | crate  | []                                                                               | NULL     | TRUE      |
     | user_a | [{"grantor": "crate", "role": "role_a"}, {"grantor": "crate", "role": "role_b"}] | NULL     | FALSE     |

--- a/docs/appendices/release-notes/5.6.0.rst
+++ b/docs/appendices/release-notes/5.6.0.rst
@@ -159,5 +159,6 @@ Administration and Operations
 - Added :ref:`sys.roles<sys-roles>` table which contains all database roles
   defined in the cluster.
 
-- Added ``parents`` column to :ref:`sys.users<sys-users>` table which lists the
-  roles granted to a user, together with the user that granted each role.
+- Added ``granted_roles`` column to :ref:`sys.users<sys-users>` table which
+  lists the roles granted to a user, together with the user that granted each
+  role.

--- a/server/src/main/java/io/crate/role/metadata/SysRolesTableInfo.java
+++ b/server/src/main/java/io/crate/role/metadata/SysRolesTableInfo.java
@@ -39,7 +39,7 @@ public class SysRolesTableInfo {
     public static SystemTable<Role> create() {
         return SystemTable.<Role>builder(IDENT)
             .add("name", STRING, Role::name)
-            .startObjectArray("parents", r -> r.grantedRoles().stream().sorted().toList())
+            .startObjectArray("granted_roles", r -> r.grantedRoles().stream().sorted().toList())
                 .add("role", STRING, GrantedRole::roleName)
                 .add("grantor", STRING, GrantedRole::grantor)
             .endObjectArray()

--- a/server/src/main/java/io/crate/role/metadata/SysUsersTableInfo.java
+++ b/server/src/main/java/io/crate/role/metadata/SysUsersTableInfo.java
@@ -43,7 +43,7 @@ public class SysUsersTableInfo {
             .add("name", STRING, Role::name)
             .add("superuser", BOOLEAN, Role::isSuperUser)
             .add("password", STRING, x -> x.password() == null ? null : PASSWORD_PLACEHOLDER)
-            .startObjectArray("parents", r -> r.grantedRoles().stream().sorted().toList())
+            .startObjectArray("granted_roles", r -> r.grantedRoles().stream().sorted().toList())
                 .add("role", STRING, GrantedRole::roleName)
                 .add("grantor", STRING, GrantedRole::grantor)
             .endObjectArray()

--- a/server/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
@@ -998,13 +998,13 @@ public class SnapshotRestoreIntegrationTest extends IntegTestCase {
         execute("CREATE USER \"John\" WITH (password='johns-password')");
         execute("CREATE USER \"Arthur\"");
         execute("CREATE ROLE \"DummyRole\"");
-        execute("SELECT * FROM sys.users ORDER BY name");
+        execute("SELECT name, granted_roles, password, superuser FROM sys.users ORDER BY name");
         assertThat(response).hasRows(
             "Arthur| []| NULL| false",
             "John| []| ********| false",
             "crate| []| NULL| true");
 
-        execute("SELECT * FROM sys.roles ORDER BY name");
+        execute("SELECT name, granted_roles FROM sys.roles ORDER BY name");
         assertThat(response).hasRows("DummyRole| []");
 
         execute("GRANT AL TO \"DummyRole\"");
@@ -1022,7 +1022,7 @@ public class SnapshotRestoreIntegrationTest extends IntegTestCase {
         // GRANT AL TO "Ford";
         execute("RESTORE SNAPSHOT users_repo.usersnap USERS with (wait_for_completion=true)");
 
-        execute("SELECT * FROM sys.users ORDER BY name");
+        execute("SELECT name, granted_roles, password, superuser FROM sys.users ORDER BY name");
         assertThat(response).hasRows(
             "Arthur| []| ********| false",
             "Ford| []| ********| false",
@@ -1059,7 +1059,7 @@ public class SnapshotRestoreIntegrationTest extends IntegTestCase {
         );
 
         execute("ALTER USER \"John\" SET (password='johns-new-password')");
-        execute("SELECT * FROM sys.users ORDER BY name");
+        execute("SELECT name, granted_roles, password, superuser FROM sys.users ORDER BY name");
         assertThat(response).hasRows(
             "Arthur| []| ********| false",
             "Ford| []| ********| false",


### PR DESCRIPTION
Use a more appropriate name `granted_roles` instead of `parents` for `sys.roles` and `sys.users` tables.

Follows: #15263
Follows: #15271
Relates: #12109
