### PR TITLE
Set null value for missing column in replica upsert request

### DIFF
--- a/docs/appendices/release-notes/5.5.3.rst
+++ b/docs/appendices/release-notes/5.5.3.rst
@@ -93,3 +93,8 @@ Fixes
 
 - Fixed a performance regression introduced in 5.5.0 for aggregations on columns
   with the column store disabled.
+
+- Fixed an issue that caused replication failure leading to an unstable cluster
+  when running ``INSERT... ON CONFLICT... UPDATE SET`` statements on a table
+  with non-deterministic column and one of table's column wasn't part of the
+  ``INSERT`` targets.


### PR DESCRIPTION
Fixes https://github.com/crate/crate/issues/15171

Supersedes https://github.com/crate/crate/pull/15270

Conditions to reproduce:
1.  Table has replicas enabled
2. Table has non-deterministic column(s)
3. `INSERT... ON CONFLICT... DO UPDATE SET` is run on a table and some columns are not used in the statement

Root cause:

1. Even if some columns can be skipped by a user, `UpdateToInsert` adds all table columns as targets
https://github.com/crate/crate/blob/master/server/src/main/java/io/crate/execution/dml/upsert/UpdateToInsert.java#L164-L174 

    This is needed to fetch a row values and copy those of them which are not being updated for the following insert.
https://github.com/crate/crate/blob/master/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java#L476-L487

2. On primary, we end up having request with the following targets/values:
    ```
    targets: col1 col2 unused_col
    values:  val1 val2
    ```
    Indexer goes through values and unused columns are not written to the source.

    When table has replicas enabled and has non-deterministic column(s), we expand targets/values by non-deterministic values.

    Because targets/values have different length, expansion logic can assign generated value to a wrong column. 
    ```
    targets: col1 col2 unused_col          non_deter_col
    values:  val1 val2 non_deter_computed
    ```

In https://github.com/crate/crate/pull/15270 I tried to run "expansion logic" before adding all columns but it was a bit messy as `UpdateToInsert` had to duplicate some Indexer's logic. In general, I think having different length is an error prone approach for the further expansions.

Current approach: align targets/values size before expansion, so that any further columns/values expansion would hit appropriate ends of targets/values. Also, those extra NULL-s wouldn't be stored in the source since `Indexer` [has a protection](https://github.com/crate/crate/blob/master/server/src/main/java/io/crate/execution/dml/Indexer.java#L775-L777) against that.

```
targets: col1 col2 unused_col1  unused_col2 non_deter_col
values:  val1 val2 NULL         NULL        non_deter_computed          
```

Note that if table doesn't have non-deterministic column(s), values expansion logic is not hit and `targets.size` might be greater than `values.size` in replica but it's okay when we don't do expansion.