### PR TITLE
Handle missing cases while allowing unindexed fields to be queryable

### DIFF
--- a/server/src/main/java/io/crate/expression/operator/CmpOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/CmpOperator.java
@@ -76,8 +76,7 @@ public final class CmpOperator extends Operator<Object> {
         }
         EqQuery eqQuery = storageSupport.eqQuery();
         if (eqQuery == null) {
-            // For types that do not support EqQuery, a `x [>, >=, <, <=] <value>` is always considered a no-match
-            return new MatchNoDocsQuery("column does not exist in this index");
+            return new MatchNoDocsQuery("For types that do not support EqQuery, a `x [>, >=, <, <=] <value>` is always considered a no-match");
         }
         String field = ref.storageIdent();
         return switch (functionName) {

--- a/server/src/main/java/io/crate/expression/operator/EqOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/EqOperator.java
@@ -23,6 +23,7 @@ package io.crate.expression.operator;
 
 import static io.crate.lucene.LuceneQueryBuilder.genericFunctionFilter;
 import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
+import static org.elasticsearch.common.lucene.search.Queries.newUnmappedFieldQuery;
 
 import java.util.Collection;
 import java.util.List;
@@ -198,7 +199,7 @@ public final class EqOperator extends Operator<Object> {
                 return null; // Fallback to generic filter on ARRAY(OBJECT)
             }
             // field doesn't exist, can't match
-            return new MatchNoDocsQuery("column does not exist in this index");
+            return newUnmappedFieldQuery(column);
         }
 
         BooleanQuery.Builder filterClauses = new BooleanQuery.Builder();

--- a/server/src/main/java/io/crate/expression/operator/any/AnyEqOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/any/AnyEqOperator.java
@@ -21,6 +21,8 @@
 
 package io.crate.expression.operator.any;
 
+import static org.elasticsearch.common.lucene.search.Queries.newUnmappedFieldQuery;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -28,7 +30,6 @@ import java.util.function.Consumer;
 
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
-import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.index.mapper.MappedFieldType;
 
@@ -65,7 +66,7 @@ public final class AnyEqOperator extends AnyOperator {
         List<?> values = (List<?>) candidates.value();
         MappedFieldType fieldType = context.getFieldTypeOrNull(columnName);
         if (fieldType == null) {
-            return new MatchNoDocsQuery("column does not exist in this index");
+            return newUnmappedFieldQuery(columnName);
         }
         DataType<?> innerType = ArrayType.unnest(probe.valueType());
         return EqOperator.termsQuery(columnName, innerType, values, probe.hasDocValues(), probe.indexType());
@@ -79,7 +80,7 @@ public final class AnyEqOperator extends AnyOperator {
                 // {x=10} = any(objects)
                 return null;
             }
-            return new MatchNoDocsQuery("column doesn't exist in this index");
+            return newUnmappedFieldQuery(candidates.storageIdent());
         }
         if (DataTypes.isArray(probe.valueType())) {
             // [1, 2] = any(nested_array_ref)

--- a/server/src/main/java/io/crate/expression/operator/any/AnyNeqOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/any/AnyNeqOperator.java
@@ -21,10 +21,11 @@
 
 package io.crate.expression.operator.any;
 
+import static org.elasticsearch.common.lucene.search.Queries.newUnmappedFieldQuery;
+
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
-import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.index.mapper.MappedFieldType;
@@ -61,7 +62,7 @@ public final class AnyNeqOperator extends AnyOperator {
         String columnName = probe.storageIdent();
         MappedFieldType fieldType = context.getFieldTypeOrNull(columnName);
         if (fieldType == null) {
-            return new MatchNoDocsQuery("column does not exist in this index");
+            return newUnmappedFieldQuery(columnName);
         }
 
         BooleanQuery.Builder andBuilder = new BooleanQuery.Builder();
@@ -95,7 +96,7 @@ public final class AnyNeqOperator extends AnyOperator {
 
         MappedFieldType fieldType = context.getFieldTypeOrNull(columnName);
         if (fieldType == null) {
-            return new MatchNoDocsQuery("column does not exist in this index");
+            return newUnmappedFieldQuery(columnName);
         }
         StorageSupport<?> storageSupport = probe.valueType().storageSupport();
         if (storageSupport == null) {

--- a/server/src/main/java/io/crate/expression/scalar/SubscriptFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/SubscriptFunction.java
@@ -23,6 +23,7 @@ package io.crate.expression.scalar;
 
 import static io.crate.expression.scalar.SubscriptObjectFunction.tryToInferReturnTypeFromObjectTypeAndArguments;
 import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
+import static org.elasticsearch.common.lucene.search.Queries.newUnmappedFieldQuery;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -30,7 +31,6 @@ import java.util.Map;
 
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
-import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.jetbrains.annotations.Nullable;
@@ -261,7 +261,7 @@ public class SubscriptFunction extends Scalar<Object, Object> {
                 if (innerType.id() == ObjectType.ID) {
                     return null; // fallback to generic query to enable objects[1] = {x=10}
                 }
-                return new MatchNoDocsQuery("column doesn't exist in this index");
+                return newUnmappedFieldQuery(ref.storageIdent());
             }
             StorageSupport<?> storageSupport = innerType.storageSupport();
             //noinspection unchecked

--- a/server/src/test/java/io/crate/lucene/BooleanEqQueryTest.java
+++ b/server/src/test/java/io/crate/lucene/BooleanEqQueryTest.java
@@ -107,4 +107,19 @@ public class BooleanEqQueryTest extends LuceneQueryBuilderTest {
         assertThat(query.getClass().getName()).endsWith("SortedNumericDocValuesSetQuery");
         assertThat(query).hasToString("arr2: [0, 1]");
     }
+
+    @Test
+    public void test_not_on_boolean_column() {
+        Query query = convert("not(a1)");
+        assertThat(query).isExactlyInstanceOf(BooleanQuery.class);
+        assertThat(query)
+            .as("Uses term query and FieldsExist if index is available")
+            .hasToString("+(+*:* -a1:T) +FieldExistsQuery [field=a1]");
+
+        query = convert("not(a2)");
+        assertThat(query).isExactlyInstanceOf(BooleanQuery.class);
+        assertThat(query)
+            .as("Uses DocValuesRangeQuery and FieldsExist if index is not available")
+            .hasToString("+(+*:* -a2:[1 TO 1]) +FieldExistsQuery [field=a2]");
+    }
 }

--- a/server/src/test/java/io/crate/lucene/CIDRRangeQueryTest.java
+++ b/server/src/test/java/io/crate/lucene/CIDRRangeQueryTest.java
@@ -71,5 +71,17 @@ public class CIDRRangeQueryTest extends CrateDummyClusterServiceUnitTest {
         try (QueryTester tester = builder.build()) {
             assertThat(tester.runQuery("ip_addr", queryStr), Matchers.contains(expectedResults));
         }
+
+        // test ip col with index off
+        builder = new QueryTester.Builder(
+            THREAD_POOL,
+            clusterService,
+            Version.CURRENT,
+            "create table t (ip_addr ip index off)"
+        );
+        builder.indexValues("ip_addr", valuesToIndex);
+        try (QueryTester tester = builder.build()) {
+            assertThat(tester.runQuery("ip_addr", queryStr), Matchers.contains(expectedResults));
+        }
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Unhandled by https://github.com/crate/crate/pull/14856 which was added to `5.6.0` so no backporting required.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
