### PR TITLE
Forbid renaming a table/view if the target exists

### DIFF
--- a/docs/appendices/release-notes/5.5.3.rst
+++ b/docs/appendices/release-notes/5.5.3.rst
@@ -49,6 +49,10 @@ See the :ref:`version_5.5.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Forbid :ref:`renaming <sql-alter-table-rename-to>` of views and tables if the
+  target table or view already exists, and return an error message. Previously,
+  such a rename was allowed which caused the existing view or table to be lost.
+
 - Fixed a regression introduced in 4.2.0 that caused queries with ``UNNEST``
   with a single nested array as parameter to fail with a
   ``ClassCastException``. For example::

--- a/server/src/main/java/io/crate/metadata/cluster/RenameTableClusterStateExecutor.java
+++ b/server/src/main/java/io/crate/metadata/cluster/RenameTableClusterStateExecutor.java
@@ -21,6 +21,8 @@
 
 package io.crate.metadata.cluster;
 
+import java.util.Locale;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -67,7 +69,19 @@ public class RenameTableClusterStateExecutor {
         Metadata currentMetadata = currentState.metadata();
         Metadata.Builder newMetadata = Metadata.builder(currentMetadata);
         ViewsMetadata views = currentMetadata.custom(ViewsMetadata.TYPE);
-        if (views != null && views.contains(source)) {
+        boolean isView = views != null && views.contains(source);
+
+        boolean viewExists = views != null && views.contains(target);
+        boolean tableExists = currentMetadata.hasIndex(target.indexNameOrAlias()) || // simple table
+            DDLClusterStateHelpers.templateMetadata(currentMetadata, target) != null; // partitioned table
+        if (viewExists || tableExists) {
+            throw new IllegalArgumentException(String.format(
+                Locale.ENGLISH,
+                "Cannot rename %s %s to %s, %s %s already exists",
+                isView ? "view" : "table", source, target, viewExists ? "view" : "table", target));
+        }
+
+        if (isView) {
             ViewsMetadata updatedViewsMetadata = views.rename(source, target);
             newMetadata.putCustom(ViewsMetadata.TYPE, updatedViewsMetadata);
             return ClusterState.builder(currentState)

--- a/server/src/test/java/io/crate/integrationtests/RenameTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/RenameTableIntegrationTest.java
@@ -21,14 +21,10 @@
 
 package io.crate.integrationtests;
 
-import static org.hamcrest.Matchers.anyOf;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static io.crate.testing.Asserts.assertThat;
 
 import org.elasticsearch.test.IntegTestCase;
 import org.junit.Test;
-
-import io.crate.testing.TestingHelpers;
 
 public class RenameTableIntegrationTest extends IntegTestCase {
 
@@ -39,17 +35,20 @@ public class RenameTableIntegrationTest extends IntegTestCase {
         refresh();
 
         execute("alter table t1 rename to t2");
-        assertThat(response.rowCount(), anyOf(is(-1L), is(0L)));
+        assertThat(response.rowCount()).satisfiesAnyOf(
+            rc -> assertThat(rc).isEqualTo(-1),
+            rc -> assertThat(rc).isEqualTo(0));
 
         execute("select * from t2 order by id");
-        assertThat(TestingHelpers.printedTable(response.rows()), is("1\n" +
-                                                                    "2\n"));
+        assertThat(response).hasRows(
+            "1",
+            "2");
 
         execute("select * from information_schema.tables where table_name = 't2'");
-        assertThat(response.rowCount(), is(1L));
+        assertThat(response).hasRowCount(1);
 
         execute("select * from information_schema.tables where table_name = 't1'");
-        assertThat(response.rowCount(), is(0L));
+        assertThat(response).hasRowCount(0);
     }
 
     @Test
@@ -75,10 +74,12 @@ public class RenameTableIntegrationTest extends IntegTestCase {
         execute("alter table t1 close");
 
         execute("alter table t1 rename to t2");
-        assertThat(response.rowCount(), anyOf(is(0L), is(-1L)));
+        assertThat(response.rowCount()).satisfiesAnyOf(
+            rc -> assertThat(rc).isEqualTo(-1),
+            rc -> assertThat(rc).isEqualTo(0));
 
         execute("select closed from information_schema.tables where table_name = 't2'");
-        assertThat(response.rows()[0][0], is(true));
+        assertThat((boolean) response.rows()[0][0]).isTrue();
     }
 
     @Test
@@ -88,17 +89,20 @@ public class RenameTableIntegrationTest extends IntegTestCase {
         refresh();
 
         execute("alter table tp1 rename to tp2");
-        assertThat(response.rowCount(), anyOf(is(-1L), is(0L)));
+        assertThat(response.rowCount()).satisfiesAnyOf(
+            rc -> assertThat(rc).isEqualTo(-1),
+            rc -> assertThat(rc).isEqualTo(0));
 
         execute("select id from tp2 order by id2");
-        assertThat(TestingHelpers.printedTable(response.rows()), is("1\n" +
-                                                                    "2\n"));
+        assertThat(response).hasRows(
+            "1",
+            "2");
 
         execute("select * from information_schema.tables where table_name = 'tp2'");
-        assertThat(response.rowCount(), is(1L));
+        assertThat(response.rowCount()).isEqualTo(1);
 
         execute("select * from information_schema.tables where table_name = 'tp1'");
-        assertThat(response.rowCount(), is(0L));
+        assertThat(response.rowCount()).isEqualTo(0);
     }
 
     @Test
@@ -107,10 +111,12 @@ public class RenameTableIntegrationTest extends IntegTestCase {
         refresh();
 
         execute("alter table tp1 rename to tp2");
-        assertThat(response.rowCount(), anyOf(is(0L), is(-1L)));
+        assertThat(response.rowCount()).satisfiesAnyOf(
+            rc -> assertThat(rc).isEqualTo(-1),
+            rc -> assertThat(rc).isEqualTo(0));
 
         execute("select * from tp2");
-        assertThat(response.rowCount(), is(0L));
+        assertThat(response.rowCount()).isEqualTo(0);
     }
 
     @Test
@@ -127,11 +133,11 @@ public class RenameTableIntegrationTest extends IntegTestCase {
 
         refresh();
         execute("select * from tp1");
-        assertThat(response.rowCount(), is(2L));
+        assertThat(response.rowCount()).isEqualTo(2);
         execute("drop table tp1");
 
         execute("select * from tp2");
-        assertThat(response.rowCount(), is(2L));
+        assertThat(response.rowCount()).isEqualTo(2);
     }
 
     @Test
@@ -145,6 +151,6 @@ public class RenameTableIntegrationTest extends IntegTestCase {
         execute("alter table tp1 rename to tp2");
 
         execute("select closed from information_schema.table_partitions where partition_ident = '04132'");
-        assertThat(response.rows()[0][0], is(true));
+        assertThat((boolean) response.rows()[0][0]).isTrue();
     }
 }

--- a/server/src/test/java/io/crate/role/metadata/RolesMetadataTest.java
+++ b/server/src/test/java/io/crate/role/metadata/RolesMetadataTest.java
@@ -51,9 +51,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import io.crate.role.GrantedRole;
+import io.crate.role.GrantedRolesChange;
 import io.crate.role.PrivilegeState;
 import io.crate.role.Role;
-import io.crate.role.GrantedRolesChange;
 
 public class RolesMetadataTest extends ESTestCase {
 


### PR DESCRIPTION
- Migrate RenameTableIntegrationTest.java to asser
    
- Forbid renaming a table or view if the target (either table or view already exists).
  Fixes: #15316
