### PR TITLE
Provide nice error message when `crate` superuser is granted roles

### DIFF
--- a/docs/admin/privileges.rst
+++ b/docs/admin/privileges.rst
@@ -415,6 +415,11 @@ of each role before or after granting roles to other roles or users.
     Roles can be granted to other roles or users, but users (roles which can
     also login to the database) cannot be granted to other roles or users.
 
+.. NOTE::
+
+    Superuser ``crate`` cannot be granted to other users or roles, and roles
+    cannot be granted to it.
+
 Inheritance
 ...........
 

--- a/server/src/test/java/io/crate/analyze/PrivilegesAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/PrivilegesAnalyzerTest.java
@@ -362,6 +362,20 @@ public class PrivilegesAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
+    public void test_cannot_grant_superuser() {
+        assertThatThrownBy(() -> analyzePrivilegesStatement("GRANT role1, crate TO role2"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Cannot grant crate superuser, to other users or roles");
+    }
+
+    @Test
+    public void test_cannot_grant_roles_to_superuser() {
+        assertThatThrownBy(() -> analyzePrivilegesStatement("GRANT role1 TO role2, crate"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Cannot grant roles to crate superuser");
+    }
+
+    @Test
     public void test_grant_role_to_user() {
         AnalyzedPrivileges analysis = analyzePrivilegesStatement("GRANT role1, role2, role1 TO user1, user2");
         assertThat(analysis.userNames()).containsExactly("user1", "user2");


### PR DESCRIPTION
Previously, when trying to grant roles to `crate`, or grant `crate` to other roles/users, an error that user/role doesn't exist was thrown. This is because the check takes place on `RolesMetadata` which doesn't contain the superuser `crate` (this is added everytime "manually" to `Roles.roles()` list.

Instead throw a nice error message when `crate` user is involved in `GRANT` statements.

Relates: #12109
