### PR TITLE
Temporarily disable codeproject.com from linkcheck

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,5 +25,6 @@ extensions.append('crate.sphinx.csv')
 
 linkcheck_ignore = [
     'https://www.iso.org/obp/ui/.*',  # Breaks accessibility via JS ¯\_(ツ)_/¯
+    'https://www.codeproject.com/',   # Went down on 2024-01-10
 ]
 linkcheck_retries = 3


### PR DESCRIPTION
Site has issues, and it stalls our PRs, disabling temporarily until issue is fixed.

