### PR TITLE
docs: Add sys.privileges table in reference section

### DIFF
--- a/docs/admin/privileges.rst
+++ b/docs/admin/privileges.rst
@@ -31,7 +31,12 @@ The privileges that can be granted, denied or revoked are:
 
 Skip to :ref:`privilege_types` for details.
 
-These privileges can be granted on different levels:
+.. _privileges-classes:
+
+Privilege Classes
+=================
+
+The privileges can be granted on different classes:
 
 - ``CLUSTER``
 - ``SCHEMA``
@@ -336,7 +341,8 @@ like this::
 List privileges
 ===============
 
-CrateDB exposes privileges ``sys.privileges`` system table.
+CrateDB exposes the privileges of users and roles of the database through the
+:ref:`sys.privileges <sys-privileges>` system table.
 
 By querying the ``sys.privileges`` table you can get all
 information regarding the existing privileges. E.g.::
@@ -351,13 +357,6 @@ information regarding the existing privileges. E.g.::
     | CLUSTER | wolfgang | crate   | NULL           | GRANT | DML  |
     +---------+----------+---------+----------------+-------+------+
     SELECT 4 rows in set (... sec)
-
-The column ``grantor`` shows the user who granted or denied the privilege,
-the column ``grantee`` shows the user or role for which the privilege was
-granted or denied. The column ``class`` identifies on which type of context the
-privilege applies. ``ident`` stands for the ident of the object that the
-privilege is set on and finally ``type`` stands for the type of privileges that
-was granted or denied.
 
 .. hide:
 

--- a/docs/admin/system-information.rst
+++ b/docs/admin/system-information.rst
@@ -2198,6 +2198,37 @@ The ``sys.roles`` table contains all existing database roles in the cluster.
 |                            | role to the user                 |             |
 +----------------------------+----------------------------------+-------------+
 
+.. _sys-privileges:
+
+Privileges
+==========
+
+The ``sys.privileges`` table contains all privileges for each user and role of
+the database.
+
++--------------+-------------------------------------------------+-------------+
+| Column Name  | Description                                     | Return Type |
++==============+=================================================+=============+
+| ``class``    | The :ref:`class <privileges-classes>` on which  | ``TEXT``    |
+|              | the privilege applies                           |             |
++--------------+-------------------------------------------------+-------------+
+| ``grantee``  | The name of the database user or role for which | ``TEXT``    |
+|              | the privilege is granted or denied              |             |
++--------------+-------------------------------------------------+-------------+
+| ``grantor``  | The name of the database user who granted or    | ``TEXT``    |
+|              | denied the privilege                            |             |
++--------------+-------------------------------------------------+-------------+
+| ``ident``    | The name of the database object on which the    | ``TEXT``    |
+|              | privilege applies                               |             |
++--------------+-------------------------------------------------+-------------+
+| ``state``    | Either ``GRANT`` or ``DENY``, which indicates   | ``ARRAY``   |
+|              | if the user or role has been granted or denied  |             |
+|              | access to the specific database object          |             |
++--------------+-------------------------------------------------+-------------+
+| ``type``     | The :ref:`type of access <privilege_types>`     | ``TEXT``    |
+|              | for the specific database object                |             |
++--------------+-------------------------------------------------+-------------+
+
 .. _sys-allocations:
 
 Allocations


### PR DESCRIPTION
`sys.privileges` table was missing from the `system-information` page, and was only referred to in `privileges`. Add the missing description for the table in `system-information` page and refer to it in privileges page.
