### PR TITLE
Rename Privilege.Clazz to Securable

### DIFF
--- a/libs/sql-parser/src/main/antlr/io/crate/sql/parser/antlr/SqlBaseParser.g4
+++ b/libs/sql-parser/src/main/antlr/io/crate/sql/parser/antlr/SqlBaseParser.g4
@@ -82,11 +82,11 @@ statement
         TO DIRECTORY? path=expr withProperties?                                      #copyTo
     | dropStmt                                                                       #drop
     | GRANT (priviliges=idents | ALL PRIVILEGES?)
-        (ON clazz qnames)? TO users=idents                                           #grantPrivilege
+        (ON securable qnames)? TO users=idents                                           #grantPrivilege
     | DENY (priviliges=idents | ALL PRIVILEGES?)
-        (ON clazz qnames)? TO users=idents                                           #denyPrivilege
+        (ON securable qnames)? TO users=idents                                           #denyPrivilege
     | REVOKE (privileges=idents | ALL PRIVILEGES?)
-        (ON clazz qnames)? FROM users=idents                                         #revokePrivilege
+        (ON securable qnames)? FROM users=idents                                         #revokePrivilege
     | createStmt                                                                     #create
     | DEALLOCATE (PREPARE)? (ALL | prepStmt=stringLiteralOrIdentifierOrQname)        #deallocate
     | ANALYZE                                                                        #analyze
@@ -786,7 +786,7 @@ on
     : ON
     ;
 
-clazz
+securable
     : SCHEMA
     | TABLE
     | VIEW

--- a/libs/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
@@ -71,10 +71,10 @@ import io.crate.sql.tree.DropBlobTable;
 import io.crate.sql.tree.DropFunction;
 import io.crate.sql.tree.DropPublication;
 import io.crate.sql.tree.DropRepository;
+import io.crate.sql.tree.DropRole;
 import io.crate.sql.tree.DropSnapshot;
 import io.crate.sql.tree.DropSubscription;
 import io.crate.sql.tree.DropTable;
-import io.crate.sql.tree.DropRole;
 import io.crate.sql.tree.DropView;
 import io.crate.sql.tree.EscapedCharStringLiteral;
 import io.crate.sql.tree.Explain;
@@ -1388,8 +1388,8 @@ public final class SqlFormatter {
                 appendPrivilegesList(node.privileges());
             }
 
-            if (!node.clazz().equals("CLUSTER")) {
-                builder.append(" ON ").append(node.clazz()).append(" ");
+            if (!node.securable().equals("CLUSTER")) {
+                builder.append(" ON ").append(node.securable()).append(" ");
                 appendTableOrSchemaNames(node.privilegeIdents());
             }
 

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/DenyPrivilege.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/DenyPrivilege.java
@@ -25,12 +25,15 @@ import java.util.List;
 
 public final class DenyPrivilege extends PrivilegeStatement {
 
-    public DenyPrivilege(List<String> userNames, String clazz, List<QualifiedName> tableOrSchemaNames) {
-        super(userNames, clazz, tableOrSchemaNames);
+    public DenyPrivilege(List<String> userNames, String securable, List<QualifiedName> tableOrSchemaNames) {
+        super(userNames, securable, tableOrSchemaNames);
     }
 
-    public DenyPrivilege(List<String> userNames, List<String> privilegeTypes, String clazz, List<QualifiedName> tableOrSchemaNames) {
-        super(userNames, privilegeTypes, clazz, tableOrSchemaNames);
+    public DenyPrivilege(List<String> userNames,
+                         List<String> privilegeTypes,
+                         String securable,
+                         List<QualifiedName> tableOrSchemaNames) {
+        super(userNames, privilegeTypes, securable, tableOrSchemaNames);
     }
 
 

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/GrantPrivilege.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/GrantPrivilege.java
@@ -26,12 +26,15 @@ import java.util.List;
 
 public final class GrantPrivilege extends PrivilegeStatement {
 
-    public GrantPrivilege(List<String> userNames, String clazz, List<QualifiedName> tableOrSchemaNames) {
-        super(userNames, clazz, tableOrSchemaNames);
+    public GrantPrivilege(List<String> userNames, String securable, List<QualifiedName> tableOrSchemaNames) {
+        super(userNames, securable, tableOrSchemaNames);
     }
 
-    public GrantPrivilege(List<String> userNames, List<String> privilegeTypes, String clazz, List<QualifiedName> tableOrSchemaNames) {
-        super(userNames, privilegeTypes, clazz, tableOrSchemaNames);
+    public GrantPrivilege(List<String> userNames,
+                          List<String> privilegeTypes,
+                          String securable,
+                          List<QualifiedName> tableOrSchemaNames) {
+        super(userNames, privilegeTypes, securable, tableOrSchemaNames);
     }
 
 

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/PrivilegeStatement.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/PrivilegeStatement.java
@@ -31,22 +31,22 @@ public abstract sealed class PrivilegeStatement extends Statement
     protected final List<String> userNames;
     protected final List<String> privilegeTypes;
     private final List<QualifiedName> tableOrSchemaNames;
-    private final String clazz;
+    private final String securable;
     protected final boolean all;
 
-    protected PrivilegeStatement(List<String> userNames, String clazz, List<QualifiedName> tableOrSchemaNames) {
+    protected PrivilegeStatement(List<String> userNames, String securable, List<QualifiedName> tableOrSchemaNames) {
         this.userNames = userNames;
         privilegeTypes = Collections.emptyList();
         all = true;
-        this.clazz = clazz;
+        this.securable = securable;
         this.tableOrSchemaNames = tableOrSchemaNames;
     }
 
-    protected PrivilegeStatement(List<String> userNames, List<String> privilegeTypes, String clazz, List<QualifiedName> tableOrSchemaNames) {
+    protected PrivilegeStatement(List<String> userNames, List<String> privilegeTypes, String securable, List<QualifiedName> tableOrSchemaNames) {
         this.userNames = userNames;
         this.privilegeTypes = privilegeTypes;
         this.all = false;
-        this.clazz = clazz;
+        this.securable = securable;
         this.tableOrSchemaNames = tableOrSchemaNames;
     }
 
@@ -66,8 +66,8 @@ public abstract sealed class PrivilegeStatement extends Statement
         return tableOrSchemaNames;
     }
 
-    public String clazz() {
-        return clazz;
+    public String securable() {
+        return securable;
     }
 
     @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/RevokePrivilege.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/RevokePrivilege.java
@@ -26,12 +26,15 @@ import java.util.List;
 
 public final class RevokePrivilege extends PrivilegeStatement {
 
-    public RevokePrivilege(List<String> userNames, String clazz, List<QualifiedName> tableOrSchemaNames) {
-        super(userNames, clazz, tableOrSchemaNames);
+    public RevokePrivilege(List<String> userNames, String securable, List<QualifiedName> tableOrSchemaNames) {
+        super(userNames, securable, tableOrSchemaNames);
     }
 
-    public RevokePrivilege(List<String> userNames, List<String> privilegeTypes, String clazz, List<QualifiedName> tableOrSchemaNames) {
-        super(userNames, privilegeTypes, clazz, tableOrSchemaNames);
+    public RevokePrivilege(List<String> userNames,
+                           List<String> privilegeTypes,
+                           String securable,
+                           List<QualifiedName> tableOrSchemaNames) {
+        super(userNames, privilegeTypes, securable, tableOrSchemaNames);
     }
 
     @Override

--- a/server/src/main/java/io/crate/action/sql/Sessions.java
+++ b/server/src/main/java/io/crate/action/sql/Sessions.java
@@ -49,9 +49,9 @@ import io.crate.metadata.settings.CoordinatorSessionSettings;
 import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Planner;
 import io.crate.protocols.postgres.KeyData;
-import io.crate.role.Privilege.Clazz;
 import io.crate.role.Privilege.Type;
 import io.crate.role.Role;
+import io.crate.role.Securable;
 import io.crate.statistics.TableStats;
 
 
@@ -211,7 +211,7 @@ public class Sessions {
     public Iterable<Cursor> getCursors(Role user) {
         return () -> sessions.values().stream()
             .filter(session ->
-                nodeCtx.roles().hasPrivilege(user, Type.AL, Clazz.CLUSTER, null)
+                nodeCtx.roles().hasPrivilege(user, Type.AL, Securable.CLUSTER, null)
                 || session.sessionSettings().sessionUser().equals(user))
             .flatMap(session -> StreamSupport.stream(session.cursors.spliterator(), false))
             .iterator();

--- a/server/src/main/java/io/crate/auth/AccessControlImpl.java
+++ b/server/src/main/java/io/crate/auth/AccessControlImpl.java
@@ -113,6 +113,7 @@ import io.crate.role.PrivilegeState;
 import io.crate.role.Privileges;
 import io.crate.role.Role;
 import io.crate.role.Roles;
+import io.crate.role.Securable;
 import io.crate.sql.tree.SetStatement;
 
 public final class AccessControlImpl implements AccessControl {
@@ -198,7 +199,7 @@ public final class AccessControlImpl implements AccessControl {
                 roles,
                 context.user,
                 context.type,
-                Privilege.Clazz.TABLE,
+                Securable.TABLE,
                 tableRelation.tableInfo().ident().fqn()
             );
             return null;
@@ -210,7 +211,7 @@ public final class AccessControlImpl implements AccessControl {
                 roles,
                 context.user,
                 context.type,
-                Privilege.Clazz.TABLE,
+                Securable.TABLE,
                 relation.tableInfo().ident().fqn()
             );
             return null;
@@ -223,7 +224,7 @@ public final class AccessControlImpl implements AccessControl {
             // ex) select * from custom_schema.udf(); -- the user must have privilege for custom_schema
             if (schema != null) {
                 Privileges.ensureUserHasPrivilege(
-                    roles, context.user, Privilege.Type.DQL, Privilege.Clazz.SCHEMA, schema);
+                    roles, context.user, Privilege.Type.DQL, Securable.SCHEMA, schema);
             }
             // On the other hand, all users should be able to access built-in functions without any privileges.
             // ex) select * from abs(1);
@@ -249,7 +250,7 @@ public final class AccessControlImpl implements AccessControl {
                 roles,
                 context.user,
                 context.type,
-                Privilege.Clazz.VIEW,
+                Securable.VIEW,
                 analyzedView.name().toString()
             );
             Role owner = analyzedView.owner() == null ? null : roles.findUser(analyzedView.owner());
@@ -307,9 +308,9 @@ public final class AccessControlImpl implements AccessControl {
         @Override
         public Void visitSwapTable(AnalyzedSwapTable swapTable, Role user) {
             Roles roles = relationVisitor.roles;
-            if (!roles.hasPrivilege(user, Privilege.Type.AL, Privilege.Clazz.CLUSTER, null)) {
-                if (!roles.hasPrivilege(user, Privilege.Type.DDL, Privilege.Clazz.TABLE, swapTable.target().ident().fqn())
-                    || !roles.hasPrivilege(user, Privilege.Type.DDL, Privilege.Clazz.TABLE, swapTable.source().ident().fqn())
+            if (!roles.hasPrivilege(user, Privilege.Type.AL, Securable.CLUSTER, null)) {
+                if (!roles.hasPrivilege(user, Privilege.Type.DDL, Securable.TABLE, swapTable.target().ident().fqn())
+                    || !roles.hasPrivilege(user, Privilege.Type.DDL, Securable.TABLE, swapTable.source().ident().fqn())
                 ) {
                     throw new MissingPrivilegeException(user.name());
                 }
@@ -323,7 +324,7 @@ public final class AccessControlImpl implements AccessControl {
                 relationVisitor.roles,
                 user,
                 Privilege.Type.AL,
-                Privilege.Clazz.CLUSTER,
+                Securable.CLUSTER,
                 null
             );
             return null;
@@ -335,7 +336,7 @@ public final class AccessControlImpl implements AccessControl {
                 relationVisitor.roles,
                 user,
                 Privilege.Type.AL,
-                Privilege.Clazz.CLUSTER,
+                Securable.CLUSTER,
                 null
             );
             return null;
@@ -357,7 +358,7 @@ public final class AccessControlImpl implements AccessControl {
                 relationVisitor.roles,
                 user,
                 Privilege.Type.DDL,
-                Privilege.Clazz.TABLE,
+                Securable.TABLE,
                 alterTable.tableInfo().ident().toString()
             );
             return null;
@@ -369,7 +370,7 @@ public final class AccessControlImpl implements AccessControl {
                 relationVisitor.roles,
                 user,
                 Privilege.Type.DML,
-                Privilege.Clazz.TABLE,
+                Securable.TABLE,
                 analysis.tableInfo().ident().toString()
             );
             return null;
@@ -381,7 +382,7 @@ public final class AccessControlImpl implements AccessControl {
                 relationVisitor.roles,
                 user,
                 Privilege.Type.DQL,
-                Privilege.Clazz.TABLE,
+                Securable.TABLE,
                 analysis.tableInfo().ident().fqn()
             );
             return null;
@@ -393,7 +394,7 @@ public final class AccessControlImpl implements AccessControl {
                 relationVisitor.roles,
                 user,
                 Privilege.Type.DDL,
-                Privilege.Clazz.SCHEMA,
+                Securable.SCHEMA,
                 createTable.relationName().schema()
             );
             return null;
@@ -405,7 +406,7 @@ public final class AccessControlImpl implements AccessControl {
                 relationVisitor.roles,
                 user,
                 Privilege.Type.DDL,
-                Privilege.Clazz.SCHEMA,
+                Securable.SCHEMA,
                 createTableAs.analyzedCreateTable().relationName().schema()
             );
             visitRelation(createTableAs.sourceRelation(), user, Privilege.Type.DQL);
@@ -418,7 +419,7 @@ public final class AccessControlImpl implements AccessControl {
                 relationVisitor.roles,
                 user,
                 Privilege.Type.DDL,
-                Privilege.Clazz.CLUSTER,
+                Securable.CLUSTER,
                 null
             );
             return null;
@@ -436,7 +437,7 @@ public final class AccessControlImpl implements AccessControl {
                 relationVisitor.roles,
                 user,
                 Privilege.Type.DML,
-                Privilege.Clazz.TABLE,
+                Securable.TABLE,
                 analysis.tableInfo().ident().toString()
             );
             visitRelation(analysis.subQueryRelation(), user, Privilege.Type.DQL);
@@ -461,7 +462,7 @@ public final class AccessControlImpl implements AccessControl {
                 relationVisitor.roles,
                 user,
                 Privilege.Type.DDL,
-                Privilege.Clazz.SCHEMA,
+                Securable.SCHEMA,
                 analysis.schema()
             );
             return null;
@@ -473,7 +474,7 @@ public final class AccessControlImpl implements AccessControl {
                 relationVisitor.roles,
                 user,
                 Privilege.Type.DDL,
-                Privilege.Clazz.SCHEMA,
+                Securable.SCHEMA,
                 analysis.schema()
             );
             return null;
@@ -487,7 +488,7 @@ public final class AccessControlImpl implements AccessControl {
                     relationVisitor.roles,
                     user,
                     Privilege.Type.DDL,
-                    Privilege.Clazz.TABLE,
+                    Securable.TABLE,
                     table.ident().toString()
                 );
             }
@@ -500,7 +501,7 @@ public final class AccessControlImpl implements AccessControl {
                 relationVisitor.roles,
                 user,
                 Privilege.Type.DDL,
-                Privilege.Clazz.CLUSTER,
+                Securable.CLUSTER,
                 null
             );
             return null;
@@ -512,7 +513,7 @@ public final class AccessControlImpl implements AccessControl {
                 relationVisitor.roles,
                 user,
                 Privilege.Type.DDL,
-                Privilege.Clazz.SCHEMA,
+                Securable.SCHEMA,
                 analysis.relationName().schema()
             );
             return null;
@@ -525,7 +526,7 @@ public final class AccessControlImpl implements AccessControl {
                     relationVisitor.roles,
                     user,
                     Privilege.Type.DQL,
-                    Privilege.Clazz.TABLE,
+                    Securable.TABLE,
                     tableInfo.ident().fqn()
                 );
             }
@@ -538,7 +539,7 @@ public final class AccessControlImpl implements AccessControl {
                 relationVisitor.roles,
                 user,
                 Privilege.Type.DDL,
-                Privilege.Clazz.TABLE,
+                Securable.TABLE,
                 analysis.sourceName().fqn()
             );
             return null;
@@ -550,7 +551,7 @@ public final class AccessControlImpl implements AccessControl {
                 relationVisitor.roles,
                 user,
                 Privilege.Type.DDL,
-                Privilege.Clazz.TABLE,
+                Securable.TABLE,
                 analysis.tableInfo().ident().toString()
             );
             return null;
@@ -563,7 +564,7 @@ public final class AccessControlImpl implements AccessControl {
                     relationVisitor.roles,
                     user,
                     Privilege.Type.AL,
-                    Privilege.Clazz.CLUSTER,
+                    Securable.CLUSTER,
                     null
                 );
             }
@@ -589,7 +590,7 @@ public final class AccessControlImpl implements AccessControl {
                 relationVisitor.roles,
                 user,
                 Privilege.Type.DDL,
-                Privilege.Clazz.TABLE,
+                Securable.TABLE,
                 analysis.table().ident().toString()
             );
             return null;
@@ -601,7 +602,7 @@ public final class AccessControlImpl implements AccessControl {
                 relationVisitor.roles,
                 user,
                 Privilege.Type.DDL,
-                Privilege.Clazz.TABLE,
+                Securable.TABLE,
                 analysis.table().ident().toString()
             );
             return null;
@@ -613,7 +614,7 @@ public final class AccessControlImpl implements AccessControl {
                 relationVisitor.roles,
                 user,
                 Privilege.Type.DDL,
-                Privilege.Clazz.TABLE,
+                Securable.TABLE,
                 analysis.table().toString()
             );
             return null;
@@ -626,7 +627,7 @@ public final class AccessControlImpl implements AccessControl {
                 relationVisitor.roles,
                 user,
                 Privilege.Type.DDL,
-                Privilege.Clazz.TABLE,
+                Securable.TABLE,
                 dropCheckConstraint.tableInfo().ident().toString()
             );
             return null;
@@ -638,7 +639,7 @@ public final class AccessControlImpl implements AccessControl {
                 relationVisitor.roles,
                 user,
                 Privilege.Type.DDL,
-                Privilege.Clazz.TABLE,
+                Securable.TABLE,
                 analysis.tableInfo().ident().toString()
             );
             return null;
@@ -662,7 +663,7 @@ public final class AccessControlImpl implements AccessControl {
                 relationVisitor.roles,
                 user,
                 Privilege.Type.DQL,
-                Privilege.Clazz.TABLE,
+                Securable.TABLE,
                 analysis.tableInfo().ident().toString()
             );
             return null;
@@ -674,7 +675,7 @@ public final class AccessControlImpl implements AccessControl {
                 relationVisitor.roles,
                 user,
                 Privilege.Type.DDL,
-                Privilege.Clazz.CLUSTER,
+                Securable.CLUSTER,
                 null
             );
             return null;
@@ -686,7 +687,7 @@ public final class AccessControlImpl implements AccessControl {
                 relationVisitor.roles,
                 user,
                 Privilege.Type.DDL,
-                Privilege.Clazz.CLUSTER,
+                Securable.CLUSTER,
                 null
             );
             return null;
@@ -698,7 +699,7 @@ public final class AccessControlImpl implements AccessControl {
                 relationVisitor.roles,
                 user,
                 Privilege.Type.DDL,
-                Privilege.Clazz.CLUSTER,
+                Securable.CLUSTER,
                 null
             );
             return null;
@@ -710,7 +711,7 @@ public final class AccessControlImpl implements AccessControl {
                 relationVisitor.roles,
                 user,
                 Privilege.Type.DDL,
-                Privilege.Clazz.CLUSTER,
+                Securable.CLUSTER,
                 null
             );
             return null;
@@ -722,7 +723,7 @@ public final class AccessControlImpl implements AccessControl {
                 relationVisitor.roles,
                 user,
                 Privilege.Type.AL,
-                Privilege.Clazz.CLUSTER,
+                Securable.CLUSTER,
                 null
             );
             return null;
@@ -749,7 +750,7 @@ public final class AccessControlImpl implements AccessControl {
                 relationVisitor.roles,
                 user,
                 Privilege.Type.DDL,
-                Privilege.Clazz.SCHEMA,
+                Securable.SCHEMA,
                 createViewStmt.name().schema()
             );
             visitRelation(createViewStmt.analyzedQuery(), user, Privilege.Type.DQL);
@@ -762,7 +763,7 @@ public final class AccessControlImpl implements AccessControl {
                 relationVisitor.roles,
                 user,
                 Privilege.Type.AL,
-                Privilege.Clazz.CLUSTER,
+                Securable.CLUSTER,
                 null
             );
             return null;
@@ -774,7 +775,7 @@ public final class AccessControlImpl implements AccessControl {
                 relationVisitor.roles,
                 user,
                 Privilege.Type.AL,
-                Privilege.Clazz.CLUSTER,
+                Securable.CLUSTER,
                 null
             );
             return null;
@@ -786,7 +787,7 @@ public final class AccessControlImpl implements AccessControl {
                 relationVisitor.roles,
                 user,
                 Privilege.Type.AL,
-                Privilege.Clazz.CLUSTER,
+                Securable.CLUSTER,
                 null
             );
             for (Privilege privilege : changePrivileges.privileges()) {
@@ -795,7 +796,7 @@ public final class AccessControlImpl implements AccessControl {
                         relationVisitor.roles,
                         user,
                         privilege.ident().type(),
-                        privilege.ident().clazz(),
+                        privilege.ident().securable(),
                         privilege.ident().ident()
                     );
                 }
@@ -810,7 +811,7 @@ public final class AccessControlImpl implements AccessControl {
                     relationVisitor.roles,
                     user,
                     Privilege.Type.DDL,
-                    Privilege.Clazz.VIEW,
+                    Securable.VIEW,
                     name.toString()
                 );
             }
@@ -834,7 +835,7 @@ public final class AccessControlImpl implements AccessControl {
                     relationVisitor.roles,
                     user,
                     Privilege.Type.DDL,
-                    Privilege.Clazz.TABLE,
+                    Securable.TABLE,
                     table.ident().toString()
                 );
             }
@@ -847,7 +848,7 @@ public final class AccessControlImpl implements AccessControl {
                 relationVisitor.roles,
                 user,
                 Privilege.Type.AL,
-                Privilege.Clazz.CLUSTER,
+                Securable.CLUSTER,
                 null
             );
             // All tables cannot be checked on publication creation - they are checked before actual replication starts
@@ -858,7 +859,7 @@ public final class AccessControlImpl implements AccessControl {
                         relationVisitor.roles,
                         user,
                         type,
-                        Privilege.Clazz.TABLE,
+                        Securable.TABLE,
                         relationName.fqn()
                     );
                 }
@@ -872,7 +873,7 @@ public final class AccessControlImpl implements AccessControl {
                 relationVisitor.roles,
                 user,
                 Privilege.Type.AL,
-                Privilege.Clazz.CLUSTER,
+                Securable.CLUSTER,
                 null
             );
             return null;
@@ -884,7 +885,7 @@ public final class AccessControlImpl implements AccessControl {
                 relationVisitor.roles,
                 user,
                 Privilege.Type.AL,
-                Privilege.Clazz.CLUSTER,
+                Securable.CLUSTER,
                 null
             );
             for (RelationName relationName: alterPublication.tables()) {
@@ -893,7 +894,7 @@ public final class AccessControlImpl implements AccessControl {
                         relationVisitor.roles,
                         user,
                         type,
-                        Privilege.Clazz.TABLE,
+                        Securable.TABLE,
                         relationName.fqn()
                     );
                 }
@@ -907,7 +908,7 @@ public final class AccessControlImpl implements AccessControl {
                 relationVisitor.roles,
                 user,
                 Privilege.Type.AL,
-                Privilege.Clazz.CLUSTER,
+                Securable.CLUSTER,
                 null
             );
             return null;
@@ -919,7 +920,7 @@ public final class AccessControlImpl implements AccessControl {
                 relationVisitor.roles,
                 user,
                 Privilege.Type.AL,
-                Privilege.Clazz.CLUSTER,
+                Securable.CLUSTER,
                 null
             );
             return null;
@@ -931,7 +932,7 @@ public final class AccessControlImpl implements AccessControl {
                 relationVisitor.roles,
                 user,
                 Privilege.Type.AL,
-                Privilege.Clazz.CLUSTER,
+                Securable.CLUSTER,
                 null
             );
             return null;
@@ -943,7 +944,7 @@ public final class AccessControlImpl implements AccessControl {
                 relationVisitor.roles,
                 user,
                 Privilege.Type.AL,
-                Privilege.Clazz.CLUSTER,
+                Securable.CLUSTER,
                 null
             );
             return null;
@@ -967,7 +968,7 @@ public final class AccessControlImpl implements AccessControl {
         @Override
         protected Void visitTableScopeException(TableScopeException e, Role user) {
             for (RelationName relationName : e.getTableIdents()) {
-                Privileges.ensureUserHasPrivilege(roles, user, Privilege.Clazz.TABLE, relationName.toString());
+                Privileges.ensureUserHasPrivilege(roles, user, Securable.TABLE, relationName.toString());
             }
             return null;
         }
@@ -992,7 +993,7 @@ public final class AccessControlImpl implements AccessControl {
 
         @Override
         protected Void visitSchemaScopeException(SchemaScopeException e, Role user) {
-            Privileges.ensureUserHasPrivilege(roles, user, Privilege.Clazz.SCHEMA, e.getSchemaName());
+            Privileges.ensureUserHasPrivilege(roles, user, Securable.SCHEMA, e.getSchemaName());
             return null;
         }
 
@@ -1006,7 +1007,7 @@ public final class AccessControlImpl implements AccessControl {
 
         @Override
         protected Void visitClusterScopeException(ClusterScopeException e, Role user) {
-            Privileges.ensureUserHasPrivilege(roles, user, Privilege.Clazz.CLUSTER, null);
+            Privileges.ensureUserHasPrivilege(roles, user, Securable.CLUSTER, null);
             return null;
         }
 

--- a/server/src/main/java/io/crate/expression/scalar/HasDatabasePrivilegeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/HasDatabasePrivilegeFunction.java
@@ -35,6 +35,7 @@ import io.crate.metadata.functions.Signature;
 import io.crate.role.Privilege;
 import io.crate.role.Role;
 import io.crate.role.Roles;
+import io.crate.role.Securable;
 import io.crate.types.DataTypes;
 
 public class HasDatabasePrivilegeFunction extends HasPrivilegeFunction {
@@ -82,7 +83,7 @@ public class HasDatabasePrivilegeFunction extends HasPrivilegeFunction {
         }
         for (Privilege p : user.privileges()) {
             if (p.ident().type() == Privilege.Type.DDL &&
-                (p.ident().clazz() == Privilege.Clazz.SCHEMA || p.ident().clazz() == Privilege.Clazz.CLUSTER)) {
+                (p.ident().securable() == Securable.SCHEMA || p.ident().securable() == Securable.CLUSTER)) {
                 return true;
             }
         }

--- a/server/src/main/java/io/crate/expression/scalar/HasPrivilegeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/HasPrivilegeFunction.java
@@ -41,6 +41,7 @@ import io.crate.metadata.functions.Signature;
 import io.crate.role.Privilege;
 import io.crate.role.Role;
 import io.crate.role.Roles;
+import io.crate.role.Securable;
 
 public abstract class HasPrivilegeFunction extends Scalar<Boolean, Object> {
 
@@ -218,8 +219,8 @@ public abstract class HasPrivilegeFunction extends Scalar<Boolean, Object> {
     protected static void validateCallPrivileges(Roles roles, Role sessionUser, Role user) {
         // Only superusers can call this function for other users
         if (user.name().equals(sessionUser.name()) == false
-            && roles.hasPrivilege(sessionUser, Privilege.Type.DQL, Privilege.Clazz.TABLE, "sys.privileges") == false
-            && roles.hasPrivilege(sessionUser, Privilege.Type.AL, Privilege.Clazz.CLUSTER, "crate") == false) {
+            && roles.hasPrivilege(sessionUser, Privilege.Type.DQL, Securable.TABLE, "sys.privileges") == false
+            && roles.hasPrivilege(sessionUser, Privilege.Type.AL, Securable.CLUSTER, "crate") == false) {
             throw new MissingPrivilegeException(sessionUser.name());
         }
     }

--- a/server/src/main/java/io/crate/expression/scalar/HasSchemaPrivilegeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/HasSchemaPrivilegeFunction.java
@@ -35,6 +35,7 @@ import io.crate.metadata.pgcatalog.PgCatalogTableDefinitions;
 import io.crate.role.Privilege;
 import io.crate.role.Role;
 import io.crate.role.Roles;
+import io.crate.role.Securable;
 import io.crate.types.DataTypes;
 
 public class HasSchemaPrivilegeFunction extends HasPrivilegeFunction {
@@ -50,8 +51,8 @@ public class HasSchemaPrivilegeFunction extends HasPrivilegeFunction {
                 if (type == Privilege.Type.DQL && PgCatalogTableDefinitions.isPgCatalogOrInformationSchema(schemaName)) {
                     return true;
                 }
-                // Last argument is null as it's not used for Privilege.Clazz.SCHEMA
-                result |= roles.hasPrivilege(user, type, Privilege.Clazz.SCHEMA, schemaName);
+                // Last argument is null as it's not used for Privilege.Securable.SCHEMA
+                result |= roles.hasPrivilege(user, type, Securable.SCHEMA, schemaName);
             }
             return result;
         };

--- a/server/src/main/java/io/crate/metadata/Schemas.java
+++ b/server/src/main/java/io/crate/metadata/Schemas.java
@@ -67,9 +67,9 @@ import io.crate.metadata.table.TableInfo;
 import io.crate.metadata.view.View;
 import io.crate.metadata.view.ViewMetadata;
 import io.crate.metadata.view.ViewsMetadata;
-import io.crate.role.Privilege;
 import io.crate.role.Role;
 import io.crate.role.Roles;
+import io.crate.role.Securable;
 import io.crate.sql.tree.QualifiedName;
 
 
@@ -158,7 +158,7 @@ public class Schemas extends AbstractLifecycleComponent implements Iterable<Sche
         LevenshteinDistance levenshteinDistance = new LevenshteinDistance();
         ArrayList<Candidate> candidates = new ArrayList<>();
         for (TableInfo table : tables) {
-            if (roles.hasAnyPrivilege(user, Privilege.Clazz.TABLE, table.ident().fqn())) {
+            if (roles.hasAnyPrivilege(user, Securable.TABLE, table.ident().fqn())) {
                 String candidate = table.ident().name();
                 float score = levenshteinDistance.getDistance(tableName.toLowerCase(Locale.ENGLISH), candidate.toLowerCase(Locale.ENGLISH));
                 if (score > 0.7f) {
@@ -177,7 +177,7 @@ public class Schemas extends AbstractLifecycleComponent implements Iterable<Sche
         LevenshteinDistance levenshteinDistance = new LevenshteinDistance();
         ArrayList<Candidate> candidates = new ArrayList<>();
         for (String availableSchema : schemas.keySet()) {
-            if (roles.hasAnyPrivilege(user, Privilege.Clazz.SCHEMA, availableSchema)) {
+            if (roles.hasAnyPrivilege(user, Securable.SCHEMA, availableSchema)) {
                 float score = levenshteinDistance.getDistance(schema.toLowerCase(Locale.ENGLISH), availableSchema.toLowerCase(Locale.ENGLISH));
                 if (score > 0.7f) {
                     candidates.add(new Candidate(score, availableSchema));

--- a/server/src/main/java/io/crate/metadata/information/InformationSchemaTableDefinitions.java
+++ b/server/src/main/java/io/crate/metadata/information/InformationSchemaTableDefinitions.java
@@ -33,8 +33,8 @@ import org.elasticsearch.common.inject.Singleton;
 import io.crate.execution.engine.collect.sources.InformationSchemaIterables;
 import io.crate.expression.reference.StaticTableDefinition;
 import io.crate.metadata.RelationName;
-import io.crate.role.Privilege;
 import io.crate.role.Roles;
+import io.crate.role.Securable;
 
 @Singleton
 public class InformationSchemaTableDefinitions {
@@ -46,42 +46,42 @@ public class InformationSchemaTableDefinitions {
         tableDefinitions = HashMap.newHashMap(11);
         tableDefinitions.put(InformationSchemataTableInfo.IDENT, new StaticTableDefinition<>(
             informationSchemaIterables::schemas,
-            (user, s) -> roles.hasAnyPrivilege(user, Privilege.Clazz.SCHEMA, s.name()),
+            (user, s) -> roles.hasAnyPrivilege(user, Securable.SCHEMA, s.name()),
             InformationSchemataTableInfo.create().expressions()
         ));
         tableDefinitions.put(InformationTablesTableInfo.IDENT, new StaticTableDefinition<>(
             informationSchemaIterables::relations,
-            (user, t) -> roles.hasAnyPrivilege(user, Privilege.Clazz.TABLE, t.ident().fqn())
+            (user, t) -> roles.hasAnyPrivilege(user, Securable.TABLE, t.ident().fqn())
                          // we also need to check for views which have privileges set
-                         || roles.hasAnyPrivilege(user, Privilege.Clazz.VIEW, t.ident().fqn()),
+                         || roles.hasAnyPrivilege(user, Securable.VIEW, t.ident().fqn()),
             InformationTablesTableInfo.create().expressions()
         ));
         tableDefinitions.put(InformationViewsTableInfo.IDENT, new StaticTableDefinition<>(
             informationSchemaIterables::views,
-            (user, t) -> roles.hasAnyPrivilege(user, Privilege.Clazz.VIEW, t.ident().fqn()),
+            (user, t) -> roles.hasAnyPrivilege(user, Securable.VIEW, t.ident().fqn()),
             InformationViewsTableInfo.create().expressions()
         ));
         tableDefinitions.put(InformationPartitionsTableInfo.IDENT, new StaticTableDefinition<>(
             informationSchemaIterables::partitions,
-            (user, p) -> roles.hasAnyPrivilege(user, Privilege.Clazz.TABLE, p.name().relationName().fqn()),
+            (user, p) -> roles.hasAnyPrivilege(user, Securable.TABLE, p.name().relationName().fqn()),
             InformationPartitionsTableInfo.create().expressions()
         ));
         tableDefinitions.put(InformationColumnsTableInfo.IDENT, new StaticTableDefinition<>(
             informationSchemaIterables::columns,
-            (user, c) -> (roles.hasAnyPrivilege(user, Privilege.Clazz.TABLE, c.relation().ident().fqn())
+            (user, c) -> (roles.hasAnyPrivilege(user, Securable.TABLE, c.relation().ident().fqn())
                          // we also need to check for views which have privileges set
-                         || roles.hasAnyPrivilege(user, Privilege.Clazz.VIEW, c.relation().ident().fqn())
+                         || roles.hasAnyPrivilege(user, Securable.VIEW, c.relation().ident().fqn())
                          ) && !c.ref().isDropped(),
             InformationColumnsTableInfo.create().expressions()
         ));
         tableDefinitions.put(InformationTableConstraintsTableInfo.IDENT, new StaticTableDefinition<>(
             informationSchemaIterables::constraints,
-            (user, t) -> roles.hasAnyPrivilege(user, Privilege.Clazz.TABLE, t.relationName().fqn()),
+            (user, t) -> roles.hasAnyPrivilege(user, Securable.TABLE, t.relationName().fqn()),
             InformationTableConstraintsTableInfo.create().expressions()
         ));
         tableDefinitions.put(InformationRoutinesTableInfo.IDENT, new StaticTableDefinition<>(
             informationSchemaIterables::routines,
-            (user, r) -> roles.hasAnyPrivilege(user, Privilege.Clazz.SCHEMA, r.schema()),
+            (user, r) -> roles.hasAnyPrivilege(user, Securable.SCHEMA, r.schema()),
             InformationRoutinesTableInfo.create().expressions()
         ));
         tableDefinitions.put(InformationSqlFeaturesTableInfo.IDENT, new StaticTableDefinition<>(
@@ -90,15 +90,15 @@ public class InformationSchemaTableDefinitions {
             false));
         tableDefinitions.put(InformationKeyColumnUsageTableInfo.IDENT, new StaticTableDefinition<>(
             informationSchemaIterables::keyColumnUsage,
-            (user, k) -> roles.hasAnyPrivilege(user, Privilege.Clazz.TABLE, k.getFQN()),
+            (user, k) -> roles.hasAnyPrivilege(user, Securable.TABLE, k.getFQN()),
             InformationKeyColumnUsageTableInfo.create().expressions()
         ));
         tableDefinitions.put(InformationReferentialConstraintsTableInfo.IDENT, new StaticTableDefinition<>(
             () -> completedFuture(informationSchemaIterables.referentialConstraintsInfos()),
             InformationReferentialConstraintsTableInfo.create().expressions(),
             false));
-        tableDefinitions.put(InformationCharacterSetsTable.IDENT, new StaticTableDefinition<Void>(
-            () -> completedFuture(Arrays.<Void>asList(new Void[] { null })),
+        tableDefinitions.put(InformationCharacterSetsTable.IDENT, new StaticTableDefinition<>(
+            () -> completedFuture(Arrays.asList(new Void[]{null})),
             InformationCharacterSetsTable.create().expressions(),
             false));
     }

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgRolesTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgRolesTable.java
@@ -35,6 +35,7 @@ import io.crate.role.Privilege;
 import io.crate.role.Privileges;
 import io.crate.role.Role;
 import io.crate.role.Roles;
+import io.crate.role.Securable;
 
 public final class PgRolesTable {
 
@@ -66,7 +67,7 @@ public final class PgRolesTable {
                 roles,
                 role,
                 Privilege.Type.AL,
-                Privilege.Clazz.CLUSTER,
+                Securable.CLUSTER,
                 null);
             return true;
         } catch (MissingPrivilegeException e) {

--- a/server/src/main/java/io/crate/metadata/sys/SysShardsTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/sys/SysShardsTableInfo.java
@@ -58,9 +58,9 @@ import io.crate.metadata.SystemTable;
 import io.crate.metadata.expressions.RowCollectExpressionFactory;
 import io.crate.metadata.settings.CoordinatorSessionSettings;
 import io.crate.metadata.shard.unassigned.UnassignedShard;
-import io.crate.role.Privilege;
 import io.crate.role.Role;
 import io.crate.role.Roles;
+import io.crate.role.Securable;
 import io.crate.types.DataTypes;
 
 public class SysShardsTableInfo {
@@ -247,7 +247,7 @@ public class SysShardsTableInfo {
             List<String> accessibleTables = new ArrayList<>(concreteIndices.length);
             for (String indexName : concreteIndices) {
                 String tableName = RelationName.fqnFromIndexName(indexName);
-                if (roles.hasAnyPrivilege(user, Privilege.Clazz.TABLE, tableName)) {
+                if (roles.hasAnyPrivilege(user, Securable.TABLE, tableName)) {
                     accessibleTables.add(indexName);
                 }
             }

--- a/server/src/main/java/io/crate/metadata/sys/SysTableDefinitions.java
+++ b/server/src/main/java/io/crate/metadata/sys/SysTableDefinitions.java
@@ -47,10 +47,9 @@ import io.crate.expression.reference.sys.shard.SysAllocations;
 import io.crate.expression.reference.sys.snapshot.SysSnapshots;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.SystemTable;
-import io.crate.role.Privilege;
-import io.crate.role.Privilege.Clazz;
 import io.crate.role.Privilege.Type;
 import io.crate.role.Roles;
+import io.crate.role.Securable;
 
 public class SysTableDefinitions {
 
@@ -82,7 +81,7 @@ public class SysTableDefinitions {
                     .filter(x ->
                         user.isSuperUser()
                         || user.name().equals(x.username())
-                        || roles.hasPrivilege(user, Type.AL, Clazz.CLUSTER, null))
+                        || roles.hasPrivilege(user, Type.AL, Securable.CLUSTER, null))
                     .iterator()
             ),
             sysJobsTable.expressions(),
@@ -94,7 +93,7 @@ public class SysTableDefinitions {
                     .filter(x ->
                         user.isSuperUser()
                         || user.name().equals(x.username())
-                        || roles.hasPrivilege(user, Type.AL, Clazz.CLUSTER, null))
+                        || roles.hasPrivilege(user, Type.AL, Securable.CLUSTER, null))
                     .iterator()
             ),
             sysJobsLogTable.expressions(),
@@ -135,7 +134,7 @@ public class SysTableDefinitions {
 
         tableDefinitions.put(SysAllocationsTableInfo.IDENT, new StaticTableDefinition<>(
             () -> sysAllocations,
-            (user, allocation) -> roles.hasAnyPrivilege(user, Privilege.Clazz.TABLE, allocation.fqn()),
+            (user, allocation) -> roles.hasAnyPrivilege(user, Securable.TABLE, allocation.fqn()),
             SysAllocationsTableInfo.create().expressions()
         ));
 
@@ -149,7 +148,7 @@ public class SysTableDefinitions {
         tableDefinitions.put(SysHealth.IDENT, new StaticTableDefinition<>(
             () -> TableHealth.compute(clusterService.state()),
             sysHealth.expressions(),
-            (user, tableHealth) -> roles.hasAnyPrivilege(user, Privilege.Clazz.TABLE, tableHealth.fqn()),
+            (user, tableHealth) -> roles.hasAnyPrivilege(user, Securable.TABLE, tableHealth.fqn()),
             true)
         );
         tableDefinitions.put(SysMetricsTableInfo.NAME, new StaticTableDefinition<>(

--- a/server/src/main/java/io/crate/replication/logical/metadata/Publication.java
+++ b/server/src/main/java/io/crate/replication/logical/metadata/Publication.java
@@ -44,6 +44,7 @@ import io.crate.metadata.RelationName;
 import io.crate.role.Privilege;
 import io.crate.role.Role;
 import io.crate.role.Roles;
+import io.crate.role.Securable;
 
 public class Publication implements Writeable {
 
@@ -176,7 +177,7 @@ public class Publication implements Writeable {
     }
 
     private static boolean subscriberCanRead(Roles roles, RelationName relationName, Role subscriber, String publicationName) {
-        boolean canRead = roles.hasPrivilege(subscriber, Privilege.Type.DQL, Privilege.Clazz.TABLE, relationName.fqn());
+        boolean canRead = roles.hasPrivilege(subscriber, Privilege.Type.DQL, Securable.TABLE, relationName.fqn());
         if (canRead == false) {
             if (LOGGER.isInfoEnabled()) {
                 LOGGER.info("User {} subscribed to the publication {} doesn't have DQL privilege on the table {}, this table will not be replicated.",
@@ -192,7 +193,7 @@ public class Publication implements Writeable {
             // Required privileges correspond to those we check for the pre-defined tables case in AccessControlImpl.visitCreatePublication.
 
             // Schemas.DOC_SCHEMA_NAME is a dummy parameter since we are passing fqn as ident.
-            if (!roles.hasPrivilege(publicationOwner, type, Privilege.Clazz.TABLE, relationName.fqn())) {
+            if (!roles.hasPrivilege(publicationOwner, type, Securable.TABLE, relationName.fqn())) {
                 if (LOGGER.isInfoEnabled()) {
                     LOGGER.info("User {} owning publication {} doesn't have {} privilege on the table {}, this table will not be replicated.",
                         publicationOwner.name(), publicationName, type.name(), relationName.fqn());

--- a/server/src/main/java/io/crate/role/PrivilegeIdent.java
+++ b/server/src/main/java/io/crate/role/PrivilegeIdent.java
@@ -21,30 +21,30 @@
 
 package io.crate.role;
 
+import java.io.IOException;
+import java.util.Objects;
+
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-
 import org.jetbrains.annotations.Nullable;
-import java.io.IOException;
-import java.util.Objects;
 
 public class PrivilegeIdent implements Writeable {
 
     private final Privilege.Type type;
-    private final Privilege.Clazz clazz;
+    private final Securable securable;
     @Nullable
     private final String ident;  // for CLUSTER this will be always null, otherwise schemaName, tableName etc.
 
-    public PrivilegeIdent(Privilege.Type type, Privilege.Clazz clazz, @Nullable String ident) {
+    public PrivilegeIdent(Privilege.Type type, Securable securable, @Nullable String ident) {
         this.type = type;
-        this.clazz = clazz;
+        this.securable = securable;
         this.ident = ident;
     }
 
     PrivilegeIdent(StreamInput in) throws IOException {
         type = Privilege.Type.VALUES.get(in.readInt());
-        clazz = Privilege.Clazz.VALUES.get(in.readInt());
+        securable = in.readEnum(Securable.class);
         ident = in.readOptionalString();
     }
 
@@ -52,8 +52,8 @@ public class PrivilegeIdent implements Writeable {
         return type;
     }
 
-    public Privilege.Clazz clazz() {
-        return clazz;
+    public Securable securable() {
+        return securable;
     }
 
     @Nullable
@@ -64,7 +64,7 @@ public class PrivilegeIdent implements Writeable {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeInt(type.ordinal());
-        out.writeInt(clazz.ordinal());
+        out.writeEnum(securable);
         out.writeOptionalString(ident);
     }
 
@@ -74,12 +74,12 @@ public class PrivilegeIdent implements Writeable {
         if (o == null || getClass() != o.getClass()) return false;
         PrivilegeIdent that = (PrivilegeIdent) o;
         return type == that.type &&
-               clazz == that.clazz &&
+               securable == that.securable &&
                Objects.equals(ident, that.ident);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(type, clazz, ident);
+        return Objects.hash(type, securable, ident);
     }
 }

--- a/server/src/main/java/io/crate/role/PrivilegesModifier.java
+++ b/server/src/main/java/io/crate/role/PrivilegesModifier.java
@@ -106,7 +106,7 @@ public final class PrivilegesModifier {
     /**
      * Returns a copy of the {@link RolesMetadata} including a copied list of privileges if at least one
      * privilege was replaced. Otherwise returns the NULL to indicate that nothing was changed.
-     * Privileges of class {@link Privilege.Clazz#TABLE} whose idents are matching the given source ident are replaced
+     * Privileges of {@link Securable#TABLE} whose idents are matching the given source ident are replaced
      * by a copy where the ident is changed to the given target ident.
      */
     @Nullable
@@ -120,15 +120,15 @@ public final class PrivilegesModifier {
             Set<Privilege> privileges = HashSet.newHashSet(role.privileges().size());
             for (Privilege privilege : role.privileges()) {
                 PrivilegeIdent privilegeIdent = privilege.ident();
-                if (privilegeIdent.clazz().equals(Privilege.Clazz.TABLE) == false) {
+                if (privilegeIdent.securable() != Securable.TABLE) {
                     privileges.add(privilege);
                     continue;
                 }
 
                 String ident = privilegeIdent.ident();
-                assert ident != null : "ident must not be null for privilege class 'TABLE'";
+                assert ident != null : "ident must not be null for securable 'TABLE'";
                 if (ident.equals(sourceIdent)) {
-                    privileges.add(new Privilege(privilege.state(), privilegeIdent.type(), privilegeIdent.clazz(),
+                    privileges.add(new Privilege(privilege.state(), privilegeIdent.type(), privilegeIdent.securable(),
                         targetIdent, privilege.grantor()));
                     privilegesChanged = true;
                 } else {
@@ -154,13 +154,13 @@ public final class PrivilegesModifier {
             Set<Privilege> updatedPrivileges = new HashSet<>();
             for (Privilege privilege : role.privileges()) {
                 PrivilegeIdent privilegeIdent = privilege.ident();
-                Privilege.Clazz clazz = privilegeIdent.clazz();
-                if (clazz.equals(Privilege.Clazz.TABLE) == false && clazz.equals(Privilege.Clazz.VIEW) == false) {
+                Securable securable = privilegeIdent.securable();
+                if (securable != Securable.TABLE && securable != Securable.VIEW) {
                     continue;
                 }
 
                 String ident = privilegeIdent.ident();
-                assert ident != null : "ident must not be null for privilege class 'TABLE'";
+                assert ident != null : "ident must not be null for securable 'TABLE'";
                 if (ident.equals(tableOrViewIdent)) {
                     affectedPrivileges++;
                 } else {
@@ -183,13 +183,13 @@ public final class PrivilegesModifier {
             Set<Privilege> updatedPrivileges = new HashSet<>();
             for (Privilege privilege : role.privileges()) {
                 PrivilegeIdent ident = privilege.ident();
-                if (ident.clazz() == Privilege.Clazz.TABLE) {
+                if (ident.securable() == Securable.TABLE) {
                     if (source.fqn().equals(ident.ident())) {
                         updatedPrivileges.add(
-                            new Privilege(privilege.state(), ident.type(), ident.clazz(), target.fqn(), privilege.grantor()));
+                            new Privilege(privilege.state(), ident.type(), ident.securable(), target.fqn(), privilege.grantor()));
                     } else if (target.fqn().equals(ident.ident())) {
                         updatedPrivileges.add(
-                            new Privilege(privilege.state(), ident.type(), ident.clazz(), source.fqn(), privilege.grantor()));
+                            new Privilege(privilege.state(), ident.type(), ident.securable(), source.fqn(), privilege.grantor()));
                     } else {
                         updatedPrivileges.add(privilege);
                     }

--- a/server/src/main/java/io/crate/role/Role.java
+++ b/server/src/main/java/io/crate/role/Role.java
@@ -21,8 +21,8 @@
 
 package io.crate.role;
 
-import static io.crate.role.Privilege.Clazz.CLUSTER;
-import static io.crate.role.Privilege.Clazz.SCHEMA;
+import static io.crate.role.Securable.CLUSTER;
+import static io.crate.role.Securable.SCHEMA;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -185,10 +185,10 @@ public class Role implements Writeable, ToXContent {
             if (ident.type() != type) {
                 continue;
             }
-            if (ident.clazz() == SCHEMA && OidHash.schemaOid(ident.ident()) == oid) {
+            if (ident.securable() == SCHEMA && OidHash.schemaOid(ident.ident()) == oid) {
                 return privilege.state();
             }
-            if (ident.clazz() == CLUSTER) {
+            if (ident.securable() == CLUSTER) {
                 result = privilege.state();
             }
         }
@@ -265,7 +265,7 @@ public class Role implements Writeable, ToXContent {
      * <p>
      *   "role1": {
      *     "privileges": [
-     *       {"state": 1, "type": 2, "class": 3, "ident": "some_table", "grantor": "grantor_username"},
+     *       {"state": 1, "type": 2, "securable": 3, "ident": "some_table", "grantor": "grantor_username"},
      *       ...
      *     ],
      *     "granted_roles: [{"role1", "grantor1"}, {"role2", "grantor2"}],

--- a/server/src/main/java/io/crate/role/Securable.java
+++ b/server/src/main/java/io/crate/role/Securable.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.role;
+
+public enum Securable {
+
+    CLUSTER,
+    SCHEMA,
+    TABLE,
+    VIEW
+}

--- a/server/src/main/java/io/crate/role/metadata/SysPrivilegesTableInfo.java
+++ b/server/src/main/java/io/crate/role/metadata/SysPrivilegesTableInfo.java
@@ -53,7 +53,7 @@ public class SysPrivilegesTableInfo {
             .add("grantor", STRING, x -> x.privilege.grantor())
             .add("state", STRING, x -> x.privilege.state().toString())
             .add("type", STRING, x -> x.privilege.ident().type().toString())
-            .add("class", STRING, x -> x.privilege.ident().clazz().toString())
+            .add("class", STRING, x -> x.privilege.ident().securable().toString())
             .add("ident", STRING, x -> x.privilege.ident().ident())
             .setPrimaryKeys(
                 new ColumnIdent("grantee"),

--- a/server/src/test/java/io/crate/action/sql/SessionsTest.java
+++ b/server/src/test/java/io/crate/action/sql/SessionsTest.java
@@ -53,6 +53,7 @@ import io.crate.role.Privilege;
 import io.crate.role.PrivilegeState;
 import io.crate.role.Role;
 import io.crate.role.Roles;
+import io.crate.role.Securable;
 import io.crate.role.metadata.RolesHelper;
 import io.crate.sql.tree.Declare.Hold;
 import io.crate.statistics.TableStats;
@@ -104,7 +105,7 @@ public class SessionsTest extends CrateDummyClusterServiceUnitTest {
         var ALprivilege = new Privilege(
             PrivilegeState.GRANT,
             Privilege.Type.AL,
-            Privilege.Clazz.CLUSTER,
+            Securable.CLUSTER,
             null,
             "crate"
         );

--- a/server/src/test/java/io/crate/analyze/PrivilegesAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/PrivilegesAnalyzerTest.java
@@ -21,10 +21,6 @@
 
 package io.crate.analyze;
 
-import static io.crate.role.Privilege.Clazz.CLUSTER;
-import static io.crate.role.Privilege.Clazz.SCHEMA;
-import static io.crate.role.Privilege.Clazz.TABLE;
-import static io.crate.role.Privilege.Clazz.VIEW;
 import static io.crate.role.Privilege.Type.AL;
 import static io.crate.role.Privilege.Type.DDL;
 import static io.crate.role.Privilege.Type.DML;
@@ -32,6 +28,10 @@ import static io.crate.role.Privilege.Type.DQL;
 import static io.crate.role.PrivilegeState.DENY;
 import static io.crate.role.PrivilegeState.GRANT;
 import static io.crate.role.PrivilegeState.REVOKE;
+import static io.crate.role.Securable.CLUSTER;
+import static io.crate.role.Securable.SCHEMA;
+import static io.crate.role.Securable.TABLE;
+import static io.crate.role.Securable.VIEW;
 import static io.crate.testing.Asserts.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -46,6 +46,7 @@ import io.crate.role.Privilege;
 import io.crate.role.PrivilegeState;
 import io.crate.role.Role;
 import io.crate.role.RoleManager;
+import io.crate.role.Securable;
 import io.crate.role.StubRoleManager;
 import io.crate.role.metadata.RolesHelper;
 import io.crate.sql.parser.SqlParser;
@@ -393,10 +394,10 @@ public class PrivilegesAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         );
     }
 
-    private Privilege privilegeOf(PrivilegeState state, Privilege.Type type, Privilege.Clazz clazz, String ident) {
+    private Privilege privilegeOf(PrivilegeState state, Privilege.Type type, Securable securable, String ident) {
         return new Privilege(state,
             type,
-            clazz,
+            securable,
             ident,
             GRANTOR_TEST_USER.name()
         );

--- a/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
+++ b/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
@@ -67,6 +67,7 @@ import io.crate.role.Role;
 import io.crate.role.RoleManager;
 import io.crate.role.RoleManagerService;
 import io.crate.role.RolesService;
+import io.crate.role.Securable;
 import io.crate.sql.parser.SqlParser;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
@@ -102,7 +103,7 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
                        "normal",
                        Set.of(new Privilege(PrivilegeState.GRANT,
                                             Privilege.Type.DQL,
-                                            Privilege.Clazz.SCHEMA,
+                                            Securable.SCHEMA,
                                             "custom_schema",
                                             "crate")),
                        null);
@@ -120,8 +121,8 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
             }
 
             @Override
-            public boolean hasPrivilege(Role user, Privilege.Type type, Privilege.Clazz clazz, @Nullable String ident) {
-                validationCallArguments.add(CollectionUtils.arrayAsArrayList(type, clazz, ident, user.name()));
+            public boolean hasPrivilege(Role user, Privilege.Type type, Securable securable, @Nullable String ident) {
+                validationCallArguments.add(CollectionUtils.arrayAsArrayList(type, securable, ident, user.name()));
                 if ("ddlOnly".equals(user.name())) {
                     return Privilege.Type.DDL == type;
                 }
@@ -190,12 +191,12 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
 
     private void assertAskedForCluster(Privilege.Type type, Role user) {
         assertThat(validationCallArguments).anySatisfy(
-            s -> assertThat(s).containsExactly(type, Privilege.Clazz.CLUSTER, null, user.name()));
+            s -> assertThat(s).containsExactly(type, Securable.CLUSTER, null, user.name()));
     }
 
     private void assertAskedForSchema(Privilege.Type type, String ident) {
         assertThat(validationCallArguments).anySatisfy(
-            s -> assertThat(s).containsExactly(type, Privilege.Clazz.SCHEMA, ident, normalUser.name()));
+            s -> assertThat(s).containsExactly(type, Securable.SCHEMA, ident, normalUser.name()));
     }
 
     private void assertAskedForTable(Privilege.Type type, String ident) {
@@ -204,12 +205,12 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
 
     private void assertAskedForTable(Privilege.Type type, String ident, Role user) {
         assertThat(validationCallArguments).anySatisfy(
-            s -> assertThat(s).containsExactly(type, Privilege.Clazz.TABLE, ident, user.name()));
+            s -> assertThat(s).containsExactly(type, Securable.TABLE, ident, user.name()));
     }
 
     private void assertAskedForView(Privilege.Type type, String ident) {
         assertThat(validationCallArguments).anySatisfy(
-            s -> assertThat(s).containsExactly(type, Privilege.Clazz.VIEW, ident, normalUser.name()));
+            s -> assertThat(s).containsExactly(type, Securable.VIEW, ident, normalUser.name()));
     }
 
     @Test

--- a/server/src/test/java/io/crate/auth/AccessControlMaySeeTest.java
+++ b/server/src/test/java/io/crate/auth/AccessControlMaySeeTest.java
@@ -43,9 +43,9 @@ import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.settings.CoordinatorSessionSettings;
-import io.crate.role.Privilege;
 import io.crate.role.Role;
 import io.crate.role.Roles;
+import io.crate.role.Securable;
 
 public class AccessControlMaySeeTest extends ESTestCase {
 
@@ -64,8 +64,8 @@ public class AccessControlMaySeeTest extends ESTestCase {
             }
 
             @Override
-            public boolean hasAnyPrivilege(Role user, Privilege.Clazz clazz, @Nullable String ident) {
-                validationCallArguments.add(CollectionUtils.arrayAsArrayList(clazz, ident, user.name()));
+            public boolean hasAnyPrivilege(Role user, Securable securable, @Nullable String ident) {
+                validationCallArguments.add(CollectionUtils.arrayAsArrayList(securable, ident, user.name()));
                 return true;
             }
         };
@@ -74,16 +74,16 @@ public class AccessControlMaySeeTest extends ESTestCase {
 
     private void assertAskedAnyForCluster() {
         assertThat(validationCallArguments).satisfiesExactly(
-            s -> assertThat(s).containsExactly(Privilege.Clazz.CLUSTER, null, user.name()));
+            s -> assertThat(s).containsExactly(Securable.CLUSTER, null, user.name()));
     }
 
     private void assertAskedAnyForSchema(String ident) {
         assertThat(validationCallArguments).satisfiesExactly(
-            s -> assertThat(s).containsExactly(Privilege.Clazz.SCHEMA, ident, user.name()));
+            s -> assertThat(s).containsExactly(Securable.SCHEMA, ident, user.name()));
     }
 
     private void assertAskedAnyForTable(String ident) {
-        assertThat(validationCallArguments).contains(List.of(Privilege.Clazz.TABLE, ident, user.name()));
+        assertThat(validationCallArguments).contains(List.of(Securable.TABLE, ident, user.name()));
     }
 
     @Test

--- a/server/src/test/java/io/crate/auth/user/RolePrivilegesTest.java
+++ b/server/src/test/java/io/crate/auth/user/RolePrivilegesTest.java
@@ -33,19 +33,20 @@ import org.junit.Test;
 import io.crate.role.Privilege;
 import io.crate.role.PrivilegeState;
 import io.crate.role.RolePrivileges;
+import io.crate.role.Securable;
 
 public class RolePrivilegesTest extends ESTestCase {
 
     private static final Collection<Privilege> PRIVILEGES_CLUSTER_DQL = Set.of(
-        new Privilege(PrivilegeState.GRANT, Privilege.Type.DQL, Privilege.Clazz.CLUSTER, null, "crate")
+        new Privilege(PrivilegeState.GRANT, Privilege.Type.DQL, Securable.CLUSTER, null, "crate")
     );
 
     private static final Collection<Privilege> PRIVILEGES_SCHEMA_DQL = Set.of(
-        new Privilege(PrivilegeState.GRANT, Privilege.Type.DQL, Privilege.Clazz.SCHEMA, "doc", "crate")
+        new Privilege(PrivilegeState.GRANT, Privilege.Type.DQL, Securable.SCHEMA, "doc", "crate")
     );
 
     private static final Collection<Privilege> PRIVILEGES_TABLE_DQL = Set.of(
-        new Privilege(PrivilegeState.GRANT, Privilege.Type.DQL, Privilege.Clazz.TABLE, "doc.t1", "crate")
+        new Privilege(PrivilegeState.GRANT, Privilege.Type.DQL, Securable.TABLE, "doc.t1", "crate")
     );
 
     private static final RolePrivileges USER_PRIVILEGES_CLUSTER = new RolePrivileges(PRIVILEGES_CLUSTER_DQL);
@@ -56,72 +57,72 @@ public class RolePrivilegesTest extends ESTestCase {
     @Test
     public void testMatchPrivilegesEmpty() throws Exception {
         RolePrivileges rolePrivileges = new RolePrivileges(Collections.emptyList());
-        assertThat(rolePrivileges.matchPrivilege(Privilege.Type.DDL, Privilege.Clazz.CLUSTER, null)).isMissing();
-        assertThat(rolePrivileges.matchPrivilege(Privilege.Type.DDL, Privilege.Clazz.SCHEMA, "doc")).isMissing();
-        assertThat(rolePrivileges.matchPrivilege(Privilege.Type.DDL, Privilege.Clazz.TABLE, "doc.t1")).isMissing();
-        assertThat(rolePrivileges.matchPrivilegeOfAnyType(Privilege.Clazz.CLUSTER, null)).isMissing();
-        assertThat(rolePrivileges.matchPrivilegeOfAnyType(Privilege.Clazz.SCHEMA, "doc")).isMissing();
-        assertThat(rolePrivileges.matchPrivilegeOfAnyType(Privilege.Clazz.TABLE, "doc.t1")).isMissing();
+        assertThat(rolePrivileges.matchPrivilege(Privilege.Type.DDL, Securable.CLUSTER, null)).isMissing();
+        assertThat(rolePrivileges.matchPrivilege(Privilege.Type.DDL, Securable.SCHEMA, "doc")).isMissing();
+        assertThat(rolePrivileges.matchPrivilege(Privilege.Type.DDL, Securable.TABLE, "doc.t1")).isMissing();
+        assertThat(rolePrivileges.matchPrivilegeOfAnyType(Securable.CLUSTER, null)).isMissing();
+        assertThat(rolePrivileges.matchPrivilegeOfAnyType(Securable.SCHEMA, "doc")).isMissing();
+        assertThat(rolePrivileges.matchPrivilegeOfAnyType(Securable.TABLE, "doc.t1")).isMissing();
     }
 
     @Test
     public void testMatchPrivilegeNoType() throws Exception {
-        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DDL, Privilege.Clazz.CLUSTER, null)).isMissing();
-        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DDL, Privilege.Clazz.SCHEMA, "doc")).isMissing();
-        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DDL, Privilege.Clazz.TABLE, "doc.t1")).isMissing();
-        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilegeOfAnyType(Privilege.Clazz.CLUSTER, null)).isGranted();
-        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilegeOfAnyType(Privilege.Clazz.SCHEMA, "doc")).isGranted();
-        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilegeOfAnyType(Privilege.Clazz.TABLE, "doc.t1")).isGranted();
+        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DDL, Securable.CLUSTER, null)).isMissing();
+        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DDL, Securable.SCHEMA, "doc")).isMissing();
+        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DDL, Securable.TABLE, "doc.t1")).isMissing();
+        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilegeOfAnyType(Securable.CLUSTER, null)).isGranted();
+        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilegeOfAnyType(Securable.SCHEMA, "doc")).isGranted();
+        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilegeOfAnyType(Securable.TABLE, "doc.t1")).isGranted();
     }
 
     @Test
     public void testMatchPrivilegeType() throws Exception {
-        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.CLUSTER, null)).isGranted();
-        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilegeOfAnyType(Privilege.Clazz.CLUSTER, null)).isGranted();
+        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DQL, Securable.CLUSTER, null)).isGranted();
+        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilegeOfAnyType(Securable.CLUSTER, null)).isGranted();
     }
 
     @Test
     public void testMatchPrivilegeSchema() throws Exception {
-        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.SCHEMA, "doc")).isGranted();
-        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilegeOfAnyType(Privilege.Clazz.SCHEMA, "doc")).isGranted();
-        assertThat(USER_PRIVILEGES_SCHEMA.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.SCHEMA, "doc")).isGranted();
-        assertThat(USER_PRIVILEGES_SCHEMA.matchPrivilegeOfAnyType(Privilege.Clazz.SCHEMA, "doc")).isGranted();
+        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DQL, Securable.SCHEMA, "doc")).isGranted();
+        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilegeOfAnyType(Securable.SCHEMA, "doc")).isGranted();
+        assertThat(USER_PRIVILEGES_SCHEMA.matchPrivilege(Privilege.Type.DQL, Securable.SCHEMA, "doc")).isGranted();
+        assertThat(USER_PRIVILEGES_SCHEMA.matchPrivilegeOfAnyType(Securable.SCHEMA, "doc")).isGranted();
     }
 
     @Test
     public void testMatchPrivilegeTable() throws Exception {
-        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.TABLE, "doc.t1")).isGranted();
-        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilegeOfAnyType(Privilege.Clazz.TABLE, "doc.t1")).isGranted();
-        assertThat(USER_PRIVILEGES_SCHEMA.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.TABLE, "doc.t1")).isGranted();
-        assertThat(USER_PRIVILEGES_SCHEMA.matchPrivilegeOfAnyType(Privilege.Clazz.TABLE, "doc.t1")).isGranted();
-        assertThat(USER_PRIVILEGES_TABLE.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.TABLE, "doc.t1")).isGranted();
-        assertThat(USER_PRIVILEGES_TABLE.matchPrivilegeOfAnyType(Privilege.Clazz.TABLE, "doc.t1")).isGranted();
+        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DQL, Securable.TABLE, "doc.t1")).isGranted();
+        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilegeOfAnyType(Securable.TABLE, "doc.t1")).isGranted();
+        assertThat(USER_PRIVILEGES_SCHEMA.matchPrivilege(Privilege.Type.DQL, Securable.TABLE, "doc.t1")).isGranted();
+        assertThat(USER_PRIVILEGES_SCHEMA.matchPrivilegeOfAnyType(Securable.TABLE, "doc.t1")).isGranted();
+        assertThat(USER_PRIVILEGES_TABLE.matchPrivilege(Privilege.Type.DQL, Securable.TABLE, "doc.t1")).isGranted();
+        assertThat(USER_PRIVILEGES_TABLE.matchPrivilegeOfAnyType(Securable.TABLE, "doc.t1")).isGranted();
     }
 
     @Test
     public void testMatchPrivilegeDenyResultsInNoMatch() throws Exception {
         Collection<Privilege> privileges = Set.of(
-            new Privilege(PrivilegeState.DENY, Privilege.Type.DQL, Privilege.Clazz.CLUSTER, null, "crate")
+            new Privilege(PrivilegeState.DENY, Privilege.Type.DQL, Securable.CLUSTER, null, "crate")
         );
         RolePrivileges rolePrivileges = new RolePrivileges(privileges);
-        assertThat(rolePrivileges.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.CLUSTER, null)).isDenied();
-        assertThat(rolePrivileges.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.SCHEMA, "doc")).isDenied();
-        assertThat(rolePrivileges.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.TABLE, "doc.t1")).isDenied();
-        assertThat(rolePrivileges.matchPrivilegeOfAnyType(Privilege.Clazz.CLUSTER, null)).isDenied();
-        assertThat(rolePrivileges.matchPrivilegeOfAnyType(Privilege.Clazz.SCHEMA, "doc")).isDenied();
-        assertThat(rolePrivileges.matchPrivilegeOfAnyType(Privilege.Clazz.TABLE, "doc.t1")).isDenied();
+        assertThat(rolePrivileges.matchPrivilege(Privilege.Type.DQL, Securable.CLUSTER, null)).isDenied();
+        assertThat(rolePrivileges.matchPrivilege(Privilege.Type.DQL, Securable.SCHEMA, "doc")).isDenied();
+        assertThat(rolePrivileges.matchPrivilege(Privilege.Type.DQL, Securable.TABLE, "doc.t1")).isDenied();
+        assertThat(rolePrivileges.matchPrivilegeOfAnyType(Securable.CLUSTER, null)).isDenied();
+        assertThat(rolePrivileges.matchPrivilegeOfAnyType(Securable.SCHEMA, "doc")).isDenied();
+        assertThat(rolePrivileges.matchPrivilegeOfAnyType(Securable.TABLE, "doc.t1")).isDenied();
     }
 
     @Test
     public void testMatchPrivilegeComplexSetIncludingDeny() throws Exception {
         Collection<Privilege> privileges = Set.of(
-            new Privilege(PrivilegeState.GRANT, Privilege.Type.DQL, Privilege.Clazz.CLUSTER, null, "crate"),
-            new Privilege(PrivilegeState.DENY, Privilege.Type.DQL, Privilege.Clazz.SCHEMA, "doc", "crate"),
-            new Privilege(PrivilegeState.GRANT, Privilege.Type.DQL, Privilege.Clazz.TABLE, "doc.t1", "crate")
+            new Privilege(PrivilegeState.GRANT, Privilege.Type.DQL, Securable.CLUSTER, null, "crate"),
+            new Privilege(PrivilegeState.DENY, Privilege.Type.DQL, Securable.SCHEMA, "doc", "crate"),
+            new Privilege(PrivilegeState.GRANT, Privilege.Type.DQL, Securable.TABLE, "doc.t1", "crate")
         );
         RolePrivileges rolePrivileges = new RolePrivileges(privileges);
-        assertThat(rolePrivileges.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.TABLE, "doc.t1")).isGranted();
-        assertThat(rolePrivileges.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.TABLE, "doc.t2")).isDenied();
-        assertThat(rolePrivileges.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.SCHEMA, "my_schema")).isGranted();
+        assertThat(rolePrivileges.matchPrivilege(Privilege.Type.DQL, Securable.TABLE, "doc.t1")).isGranted();
+        assertThat(rolePrivileges.matchPrivilege(Privilege.Type.DQL, Securable.TABLE, "doc.t2")).isDenied();
+        assertThat(rolePrivileges.matchPrivilege(Privilege.Type.DQL, Securable.SCHEMA, "my_schema")).isGranted();
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/HasDatabasePrivilegeFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/HasDatabasePrivilegeFunctionTest.java
@@ -36,6 +36,7 @@ import io.crate.metadata.pgcatalog.OidHash;
 import io.crate.role.Privilege;
 import io.crate.role.PrivilegeState;
 import io.crate.role.Role;
+import io.crate.role.Securable;
 import io.crate.role.metadata.RolesHelper;
 import io.crate.testing.Asserts;
 import io.crate.testing.SqlExpressions;
@@ -44,17 +45,17 @@ public class HasDatabasePrivilegeFunctionTest extends ScalarTestCase {
 
     private static final Role TEST_USER = RolesHelper.userOf("test");
     private static final Role TEST_USER_WITH_CREATE =
-        RolesHelper.userOf("testWithCreate",
-                Set.of(new Privilege(PrivilegeState.GRANT, Privilege.Type.DDL, Privilege.Clazz.SCHEMA, "doc", Role.CRATE_USER.name())),
-                null);
+        RolesHelper.userOf("testWithCreate", Set.of(
+            new Privilege(PrivilegeState.GRANT, Privilege.Type.DDL, Securable.SCHEMA, "doc", Role.CRATE_USER.name())),
+            null);
     private static final Role TEST_USER_WITH_AL_ON_CLUSTER =
-        RolesHelper.userOf("testUserWithClusterAL",
-                Set.of(new Privilege(PrivilegeState.GRANT, Privilege.Type.AL, Privilege.Clazz.CLUSTER, "crate", Role.CRATE_USER.name())),
-                null);
+        RolesHelper.userOf("testUserWithClusterAL", Set.of(
+            new Privilege(PrivilegeState.GRANT, Privilege.Type.AL, Securable.CLUSTER, "crate", Role.CRATE_USER.name())),
+            null);
     private static final Role TEST_USER_WITH_DQL_ON_SYS =
-        RolesHelper.userOf("testUserWithSysDQL",
-                Set.of(new Privilege(PrivilegeState.GRANT, Privilege.Type.DQL, Privilege.Clazz.TABLE, "sys.privileges", Role.CRATE_USER.name())),
-                null);
+        RolesHelper.userOf("testUserWithSysDQL", Set.of(
+            new Privilege(PrivilegeState.GRANT, Privilege.Type.DQL, Securable.TABLE, "sys.privileges", Role.CRATE_USER.name())),
+            null);
 
     @Before
     public void prepare() {

--- a/server/src/test/java/io/crate/expression/scalar/HasSchemaPrivilegeFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/HasSchemaPrivilegeFunctionTest.java
@@ -37,6 +37,7 @@ import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
 import io.crate.role.Privilege;
 import io.crate.role.PrivilegeState;
 import io.crate.role.Role;
+import io.crate.role.Securable;
 import io.crate.role.metadata.RolesHelper;
 import io.crate.testing.Asserts;
 import io.crate.testing.SqlExpressions;
@@ -45,12 +46,13 @@ public class HasSchemaPrivilegeFunctionTest extends ScalarTestCase {
 
     private static final Role TEST_USER = RolesHelper.userOf("test");
     private static final Role TEST_USER_WITH_AL_ON_CLUSTER =
-        RolesHelper.userOf("testUserWithClusterAL",
-            Set.of(new Privilege(PrivilegeState.GRANT, Privilege.Type.AL, Privilege.Clazz.CLUSTER, "crate", Role.CRATE_USER.name())),
-        null);
-    private static final Role TEST_USER_WITH_DQL_ON_SYS = RolesHelper.userOf("testUserWithSysDQL",
-            Set.of(new Privilege(PrivilegeState.GRANT, Privilege.Type.DQL, Privilege.Clazz.TABLE, "sys.privileges", Role.CRATE_USER.name())),
-        null);
+        RolesHelper.userOf("testUserWithClusterAL", Set.of(
+            new Privilege(PrivilegeState.GRANT, Privilege.Type.AL, Securable.CLUSTER, "crate", Role.CRATE_USER.name())),
+            null);
+    private static final Role TEST_USER_WITH_DQL_ON_SYS =
+        RolesHelper.userOf("testUserWithSysDQL", Set.of(
+            new Privilege(PrivilegeState.GRANT, Privilege.Type.DQL, Securable.TABLE, "sys.privileges", Role.CRATE_USER.name())),
+            null);
 
     @Before
     public void prepare() {
@@ -124,7 +126,7 @@ public class HasSchemaPrivilegeFunctionTest extends ScalarTestCase {
 
     @Test
     public void test_user_with_DQL_permission_has_USAGE_but_not_CREATE_privilege_for_regular_schema() {
-        Privilege usage = new Privilege(PrivilegeState.GRANT, Privilege.Type.DQL, Privilege.Clazz.SCHEMA, "doc", "crate");
+        Privilege usage = new Privilege(PrivilegeState.GRANT, Privilege.Type.DQL, Securable.SCHEMA, "doc", "crate");
         var user = RolesHelper.userOf("test", Set.of(usage), null);
         sqlExpressions = new SqlExpressions(tableSources, null, user);
         assertEvaluate("has_schema_privilege('test', 'doc', 'USAGE')", true);
@@ -140,7 +142,7 @@ public class HasSchemaPrivilegeFunctionTest extends ScalarTestCase {
     @Test
     public void test_user_with_DDL_permission_has_CREATE_but_not_USAGE_privilege_for_regular_schema() {
         // having CREATE doesn't mean having USAGE - checked in PG13 as well.
-        Privilege create = new Privilege(PrivilegeState.GRANT, Privilege.Type.DDL, Privilege.Clazz.SCHEMA, "doc", "crate");
+        Privilege create = new Privilege(PrivilegeState.GRANT, Privilege.Type.DDL, Securable.SCHEMA, "doc", "crate");
         var user = RolesHelper.userOf("test", Set.of(create), null);
         sqlExpressions = new SqlExpressions(tableSources, null, user);
         assertEvaluate("has_schema_privilege('test', 'doc', 'USAGE')", false);

--- a/server/src/test/java/io/crate/integrationtests/RoleManagementIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/RoleManagementIntegrationTest.java
@@ -41,6 +41,7 @@ import io.crate.action.sql.Sessions;
 import io.crate.exceptions.UnsupportedFeatureException;
 import io.crate.role.Privilege;
 import io.crate.role.PrivilegeState;
+import io.crate.role.Securable;
 import io.crate.role.metadata.RolesHelper;
 import io.crate.testing.Asserts;
 
@@ -54,7 +55,7 @@ public class RoleManagementIntegrationTest extends BaseRolesIntegrationTest {
         var alPriv = new Privilege(
             PrivilegeState.GRANT,
             Privilege.Type.AL,
-            Privilege.Clazz.CLUSTER,
+            Securable.CLUSTER,
             null,
             "crate");
         return sqlOperations.newSession(null, RolesHelper.userOf("the_grantor", Set.of(alPriv), null));

--- a/server/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
@@ -71,6 +71,7 @@ import io.crate.common.unit.TimeValue;
 import io.crate.expression.udf.UserDefinedFunctionService;
 import io.crate.role.Privilege;
 import io.crate.role.PrivilegeState;
+import io.crate.role.Securable;
 import io.crate.role.metadata.RolesMetadata;
 import io.crate.role.metadata.UsersMetadata;
 import io.crate.role.metadata.UsersPrivilegesMetadata;
@@ -1051,11 +1052,11 @@ public class SnapshotRestoreIntegrationTest extends IntegTestCase {
         assertThat(usersPrivilegesMetadata.getUserPrivileges("Arthur")).isEmpty();
         assertThat(usersPrivilegesMetadata.getUserPrivileges("John")).containsExactly(
             new Privilege(
-                PrivilegeState.GRANT, Privilege.Type.DQL, Privilege.Clazz.SCHEMA, "sys", "crate")
+                PrivilegeState.GRANT, Privilege.Type.DQL, Securable.SCHEMA, "sys", "crate")
         );
         assertThat(usersPrivilegesMetadata.getUserPrivileges("Ford")).containsExactly(
             new Privilege(
-                PrivilegeState.GRANT, Privilege.Type.AL, Privilege.Clazz.CLUSTER, null, "crate")
+                PrivilegeState.GRANT, Privilege.Type.AL, Securable.CLUSTER, null, "crate")
         );
 
         execute("ALTER USER \"John\" SET (password='johns-new-password')");

--- a/server/src/test/java/io/crate/integrationtests/SysPrivilegesIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysPrivilegesIntegrationTest.java
@@ -35,12 +35,13 @@ import org.junit.Test;
 import io.crate.role.Privilege;
 import io.crate.role.PrivilegeState;
 import io.crate.role.RoleManager;
+import io.crate.role.Securable;
 
 public class SysPrivilegesIntegrationTest extends BaseRolesIntegrationTest {
 
     private static final Set<Privilege> PRIVILEGES = new HashSet<>(Arrays.asList(
-        new Privilege(PrivilegeState.GRANT, Privilege.Type.DQL, Privilege.Clazz.CLUSTER, null, "crate"),
-        new Privilege(PrivilegeState.GRANT, Privilege.Type.DML, Privilege.Clazz.CLUSTER, null, "crate")));
+        new Privilege(PrivilegeState.GRANT, Privilege.Type.DQL, Securable.CLUSTER, null, "crate"),
+        new Privilege(PrivilegeState.GRANT, Privilege.Type.DML, Securable.CLUSTER, null, "crate")));
     private static final List<String> USERNAMES = Arrays.asList("ford", "arthur", "normal");
 
 

--- a/server/src/test/java/io/crate/replication/logical/action/PublicationsStateActionTest.java
+++ b/server/src/test/java/io/crate/replication/logical/action/PublicationsStateActionTest.java
@@ -48,6 +48,7 @@ import io.crate.replication.logical.metadata.RelationMetadata;
 import io.crate.role.Privilege;
 import io.crate.role.Role;
 import io.crate.role.Roles;
+import io.crate.role.Securable;
 import io.crate.sql.tree.QualifiedName;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
@@ -80,7 +81,7 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
             }
 
             @Override
-            public boolean hasPrivilege(Role user, Privilege.Type type, Privilege.Clazz clazz, @Nullable String ident) {
+            public boolean hasPrivilege(Role user, Privilege.Type type, Securable securable, @Nullable String ident) {
                 return true; // This test case doesn't check privileges.
             }
         };
@@ -122,7 +123,7 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
             }
 
             @Override
-            public boolean hasPrivilege(Role user, Privilege.Type type, Privilege.Clazz clazz, @Nullable String ident) {
+            public boolean hasPrivilege(Role user, Privilege.Type type, Securable securable, @Nullable String ident) {
                 if (user.name().equals("publisher")) {
                     return "doc.t1".equals(ident);
                 } else {
@@ -161,7 +162,7 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
             }
 
             @Override
-            public boolean hasPrivilege(Role user, Privilege.Type type, Privilege.Clazz clazz, @Nullable String ident) {
+            public boolean hasPrivilege(Role user, Privilege.Type type, Securable securable, @Nullable String ident) {
                 if (user.name().equals("subscriber")) {
                     return "doc.t1".equals(ident);
                 } else {
@@ -194,7 +195,7 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
             }
 
             @Override
-            public boolean hasPrivilege(Role user, Privilege.Type type, Privilege.Clazz clazz, @Nullable String ident) {
+            public boolean hasPrivilege(Role user, Privilege.Type type, Securable securable, @Nullable String ident) {
                 if (user.name().equals("subscriber")) {
                     return "doc.t1".equals(ident);
                 } else {
@@ -235,7 +236,7 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
             }
 
             @Override
-            public boolean hasPrivilege(Role user, Privilege.Type type, Privilege.Clazz clazz, @Nullable String ident) {
+            public boolean hasPrivilege(Role user, Privilege.Type type, Securable securable, @Nullable String ident) {
                 return true; // This test case doesn't check privileges.
             }
         };
@@ -268,7 +269,7 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
             }
 
             @Override
-            public boolean hasPrivilege(Role user, Privilege.Type type, Privilege.Clazz clazz, @Nullable String ident) {
+            public boolean hasPrivilege(Role user, Privilege.Type type, Securable securable, @Nullable String ident) {
                 return true; // This test case doesn't check privileges.
             }
         };
@@ -305,7 +306,7 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
             }
 
             @Override
-            public boolean hasPrivilege(Role user, Privilege.Type type, Privilege.Clazz clazz, @Nullable String ident) {
+            public boolean hasPrivilege(Role user, Privilege.Type type, Securable securable, @Nullable String ident) {
                 return true; // This test case doesn't check privileges.
             }
         };
@@ -339,7 +340,7 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
             }
 
             @Override
-            public boolean hasPrivilege(Role user, Privilege.Type type, Privilege.Clazz clazz, @Nullable String ident) {
+            public boolean hasPrivilege(Role user, Privilege.Type type, Securable securable, @Nullable String ident) {
                 return true; // This test case doesn't check privileges.
             }
         };

--- a/server/src/test/java/io/crate/role/PrivilegesModifierTest.java
+++ b/server/src/test/java/io/crate/role/PrivilegesModifierTest.java
@@ -44,27 +44,27 @@ import io.crate.role.metadata.RolesMetadata;
 public class PrivilegesModifierTest {
 
     private static final Privilege GRANT_DQL =
-        new Privilege(PrivilegeState.GRANT, Privilege.Type.DQL, Privilege.Clazz.CLUSTER, null, "crate");
+        new Privilege(PrivilegeState.GRANT, Privilege.Type.DQL, Securable.CLUSTER, null, "crate");
     private static final Privilege GRANT_DML =
-        new Privilege(PrivilegeState.GRANT, Privilege.Type.DML, Privilege.Clazz.CLUSTER, null, "crate");
+        new Privilege(PrivilegeState.GRANT, Privilege.Type.DML, Securable.CLUSTER, null, "crate");
     private static final Privilege REVOKE_DQL =
-        new Privilege(PrivilegeState.REVOKE, Privilege.Type.DQL, Privilege.Clazz.CLUSTER, null, "crate");
+        new Privilege(PrivilegeState.REVOKE, Privilege.Type.DQL, Securable.CLUSTER, null, "crate");
     private static final Privilege REVOKE_DML =
-        new Privilege(PrivilegeState.REVOKE, Privilege.Type.DML, Privilege.Clazz.CLUSTER, null, "crate");
+        new Privilege(PrivilegeState.REVOKE, Privilege.Type.DML, Securable.CLUSTER, null, "crate");
     public static final Privilege DENY_DQL =
-        new Privilege(PrivilegeState.DENY, Privilege.Type.DQL, Privilege.Clazz.CLUSTER, null, "crate");
+        new Privilege(PrivilegeState.DENY, Privilege.Type.DQL, Securable.CLUSTER, null, "crate");
     public static final Privilege GRANT_TABLE_DQL =
-        new Privilege(PrivilegeState.GRANT, Privilege.Type.DQL, Privilege.Clazz.TABLE, "testSchema.test", "crate");
+        new Privilege(PrivilegeState.GRANT, Privilege.Type.DQL, Securable.TABLE, "testSchema.test", "crate");
     public static final Privilege GRANT_TABLE_DDL =
-        new Privilege(PrivilegeState.GRANT, Privilege.Type.DDL, Privilege.Clazz.TABLE, "testSchema.test2", "crate");
+        new Privilege(PrivilegeState.GRANT, Privilege.Type.DDL, Securable.TABLE, "testSchema.test2", "crate");
     public static final Privilege GRANT_VIEW_DQL =
-        new Privilege(PrivilegeState.GRANT, Privilege.Type.DQL, Privilege.Clazz.VIEW, "testSchema.view1", "crate");
+        new Privilege(PrivilegeState.GRANT, Privilege.Type.DQL, Securable.VIEW, "testSchema.view1", "crate");
     public static final Privilege GRANT_VIEW_DDL =
-        new Privilege(PrivilegeState.GRANT, Privilege.Type.DDL, Privilege.Clazz.VIEW, "testSchema.view2", "crate");
+        new Privilege(PrivilegeState.GRANT, Privilege.Type.DDL, Securable.VIEW, "testSchema.view2", "crate");
     public static final Privilege GRANT_VIEW_DML =
-        new Privilege(PrivilegeState.GRANT, Privilege.Type.DML, Privilege.Clazz.VIEW, "view3", "crate");
+        new Privilege(PrivilegeState.GRANT, Privilege.Type.DML, Securable.VIEW, "view3", "crate");
     public static final Privilege GRANT_SCHEMA_DML =
-        new Privilege(PrivilegeState.GRANT, Privilege.Type.DML, Privilege.Clazz.SCHEMA, "testSchema", "crate");
+        new Privilege(PrivilegeState.GRANT, Privilege.Type.DML, Securable.SCHEMA, "testSchema", "crate");
 
     public static final Set<Privilege> PRIVILEGES = new HashSet<>(Arrays.asList(GRANT_DQL, GRANT_DML));
     public static final List<String> USERNAMES = Arrays.asList("Ford", "Arthur");
@@ -129,7 +129,8 @@ public class PrivilegesModifierTest {
         long rowCount = PrivilegesModifier.applyPrivileges(
             rolesMetadata,
             Collections.singletonList("Arthur"),
-            Collections.singletonList(new Privilege(PrivilegeState.REVOKE, Privilege.Type.DML, Privilege.Clazz.CLUSTER, null, "hoschi"))
+            Collections.singletonList(new Privilege(
+                PrivilegeState.REVOKE, Privilege.Type.DML, Securable.CLUSTER, null, "hoschi"))
         );
 
         assertThat(rowCount).isEqualTo(1L);
@@ -208,7 +209,7 @@ public class PrivilegesModifierTest {
         assertThat(otherTablePrivilege.isPresent()).isTrue();
 
         Optional<Privilege> schemaPrivilege = updatedPrivileges.stream()
-            .filter(p -> p.ident().clazz().equals(Privilege.Clazz.SCHEMA))
+            .filter(p -> p.ident().securable().equals(Securable.SCHEMA))
             .findAny();
         assertThat(schemaPrivilege.isPresent() && schemaPrivilege.get().equals(GRANT_SCHEMA_DML)).isTrue();
     }

--- a/server/src/test/java/io/crate/role/PrivilegesRequestTest.java
+++ b/server/src/test/java/io/crate/role/PrivilegesRequestTest.java
@@ -36,11 +36,11 @@ public class PrivilegesRequestTest extends ESTestCase {
     public void testStreaming() throws Exception {
         List<String> roles = List.of("ford", "arthur");
         List<Privilege> privileges = List.of(
-            new Privilege(PrivilegeState.GRANT, Privilege.Type.DQL, Privilege.Clazz.CLUSTER, null, "crate"),
-            new Privilege(PrivilegeState.GRANT, Privilege.Type.DML, Privilege.Clazz.CLUSTER, null, "crate"),
-            new Privilege(PrivilegeState.GRANT, Privilege.Type.DML, Privilege.Clazz.SCHEMA, null, "crate"),
-            new Privilege(PrivilegeState.GRANT, Privilege.Type.DDL, Privilege.Clazz.TABLE, null, "crate"),
-            new Privilege(PrivilegeState.GRANT, Privilege.Type.DML, Privilege.Clazz.VIEW, null, "crate")
+            new Privilege(PrivilegeState.GRANT, Privilege.Type.DQL, Securable.CLUSTER, null, "crate"),
+            new Privilege(PrivilegeState.GRANT, Privilege.Type.DML, Securable.CLUSTER, null, "crate"),
+            new Privilege(PrivilegeState.GRANT, Privilege.Type.DML, Securable.SCHEMA, null, "crate"),
+            new Privilege(PrivilegeState.GRANT, Privilege.Type.DDL, Securable.TABLE, null, "crate"),
+            new Privilege(PrivilegeState.GRANT, Privilege.Type.DML, Securable.VIEW, null, "crate")
         );
         GrantedRolesChange grantedRolesChange = new GrantedRolesChange(
             PrivilegeState.REVOKE, Set.of("role1", "role2"), "admin");

--- a/server/src/test/java/io/crate/role/PrivilegesTest.java
+++ b/server/src/test/java/io/crate/role/PrivilegesTest.java
@@ -38,7 +38,7 @@ public class PrivilegesTest extends ESTestCase {
 
     @Test
     public void testExceptionIsThrownIfUserHasNotRequiredPrivilege() throws Exception {
-        assertThatThrownBy(() -> ensureUserHasPrivilege(Privilege.Type.DQL, Privilege.Clazz.CLUSTER, null))
+        assertThatThrownBy(() -> ensureUserHasPrivilege(Privilege.Type.DQL, Securable.CLUSTER, null))
             .isExactlyInstanceOf(MissingPrivilegeException.class)
             .hasMessage("Missing 'DQL' privilege for user 'ford'");
     }
@@ -46,12 +46,12 @@ public class PrivilegesTest extends ESTestCase {
     @Test
     public void testNoExceptionIsThrownIfUserHasNotRequiredPrivilegeOnInformationSchema() throws Exception {
         //ensureUserHasPrivilege will not throw an exception if the schema is `information_schema`
-        ensureUserHasPrivilege(Privilege.Type.DQL, Privilege.Clazz.SCHEMA, "information_schema");
+        ensureUserHasPrivilege(Privilege.Type.DQL, Securable.SCHEMA, "information_schema");
     }
 
     @Test
     public void testExceptionIsThrownIfUserHasNotAnyPrivilege() throws Exception {
-        assertThatThrownBy(() -> ensureUserHasPrivilege(Privilege.Clazz.CLUSTER, null))
+        assertThatThrownBy(() -> ensureUserHasPrivilege(Securable.CLUSTER, null))
             .isExactlyInstanceOf(MissingPrivilegeException.class)
             .hasMessage("Missing privilege for user 'ford'");
     }
@@ -59,24 +59,24 @@ public class PrivilegesTest extends ESTestCase {
     @Test
     public void testUserWithNoPrivilegeCanAccessInformationSchema() throws Exception {
         //ensureUserHasPrivilege will not throw an exception if the schema is `information_schema`
-        ensureUserHasPrivilege(Privilege.Clazz.SCHEMA, "information_schema");
-        ensureUserHasPrivilege(Privilege.Clazz.TABLE, "information_schema.table");
-        ensureUserHasPrivilege(Privilege.Clazz.TABLE, "information_schema.views");
+        ensureUserHasPrivilege(Securable.SCHEMA, "information_schema");
+        ensureUserHasPrivilege(Securable.TABLE, "information_schema.table");
+        ensureUserHasPrivilege(Securable.TABLE, "information_schema.views");
     }
 
     @Test
     public void testUserWithNoPrivilegesCanAccessPgCatalogSchema() throws Exception {
         //ensureUserHasPrivilege will not throw an exception if the schema is `pg_catalog`
-        ensureUserHasPrivilege(Privilege.Clazz.SCHEMA, "pg_catalog");
-        ensureUserHasPrivilege(Privilege.Clazz.TABLE, "pg_catalog.pg_am");
-        ensureUserHasPrivilege(Privilege.Clazz.TABLE, "pg_catalog.pg_database");
+        ensureUserHasPrivilege(Securable.SCHEMA, "pg_catalog");
+        ensureUserHasPrivilege(Securable.TABLE, "pg_catalog.pg_am");
+        ensureUserHasPrivilege(Securable.TABLE, "pg_catalog.pg_database");
     }
 
-    private static void ensureUserHasPrivilege(Privilege.Clazz clazz, String ident) {
-        Privileges.ensureUserHasPrivilege(ROLES, USER, clazz, ident);
+    private static void ensureUserHasPrivilege(Securable securable, String ident) {
+        Privileges.ensureUserHasPrivilege(ROLES, USER, securable, ident);
     }
 
-    private static void ensureUserHasPrivilege(Privilege.Type type, Privilege.Clazz clazz, String ident) {
-        Privileges.ensureUserHasPrivilege(ROLES, USER, type, clazz, ident);
+    private static void ensureUserHasPrivilege(Privilege.Type type, Securable securable, String ident) {
+        Privileges.ensureUserHasPrivilege(ROLES, USER, type, securable, ident);
     }
 }

--- a/server/src/test/java/io/crate/role/RolesServiceTest.java
+++ b/server/src/test/java/io/crate/role/RolesServiceTest.java
@@ -78,7 +78,7 @@ public class RolesServiceTest extends CrateDummyClusterServiceUnitTest {
         var grantDDLCluster = new Privilege(
             PrivilegeState.GRANT,
             Privilege.Type.DDL,
-            Privilege.Clazz.CLUSTER,
+            Securable.CLUSTER,
             null,
             "crate"
         );
@@ -96,7 +96,7 @@ public class RolesServiceTest extends CrateDummyClusterServiceUnitTest {
         var denyDDLSys = new Privilege(
             PrivilegeState.DENY,
             Privilege.Type.DDL,
-            Privilege.Clazz.SCHEMA,
+            Securable.SCHEMA,
             "sys",
             "crate"
         );
@@ -140,7 +140,7 @@ public class RolesServiceTest extends CrateDummyClusterServiceUnitTest {
         var privilege = new Privilege(
             PrivilegeState.GRANT,
             Privilege.Type.DDL,
-            Privilege.Clazz.SCHEMA,
+            Securable.SCHEMA,
             "sys",
             "crate"
         );
@@ -164,10 +164,10 @@ public class RolesServiceTest extends CrateDummyClusterServiceUnitTest {
             }
         };
         for (var role : roles.values()) {
-            assertThat(roleService.hasPrivilege(role, Privilege.Type.DDL, Privilege.Clazz.SCHEMA, "sys"))
+            assertThat(roleService.hasPrivilege(role, Privilege.Type.DDL, Securable.SCHEMA, "sys"))
                 .as("role=" + role.name())
                 .isTrue();
-            assertThat(roleService.hasAnyPrivilege(role, Privilege.Clazz.SCHEMA, "sys"))
+            assertThat(roleService.hasAnyPrivilege(role, Securable.SCHEMA, "sys"))
                 .isTrue();
             assertThat(roleService.hasSchemaPrivilege(role, Privilege.Type.DDL, OidHash.schemaOid("sys")))
                 .isTrue();
@@ -186,35 +186,35 @@ public class RolesServiceTest extends CrateDummyClusterServiceUnitTest {
         var grantDDLCluster = new Privilege(
             PrivilegeState.GRANT,
             Privilege.Type.DDL,
-            Privilege.Clazz.CLUSTER,
+            Securable.CLUSTER,
             null,
             "crate"
         );
         var grantDDLSys = new Privilege(
             PrivilegeState.GRANT,
             Privilege.Type.DDL,
-            Privilege.Clazz.SCHEMA,
+            Securable.SCHEMA,
             "sys",
             "crate"
         );
         var grantDDLDoc = new Privilege(
             PrivilegeState.GRANT,
             Privilege.Type.DDL,
-            Privilege.Clazz.SCHEMA,
+            Securable.SCHEMA,
             "doc",
             "crate"
         );
         var denyDDLSys = new Privilege(
             PrivilegeState.DENY,
             Privilege.Type.DDL,
-            Privilege.Clazz.SCHEMA,
+            Securable.SCHEMA,
             "sys",
             "crate"
         );
         var denyDDLDoc = new Privilege(
             PrivilegeState.DENY,
             Privilege.Type.DDL,
-            Privilege.Clazz.SCHEMA,
+            Securable.SCHEMA,
             "doc",
             "crate"
         );
@@ -235,31 +235,31 @@ public class RolesServiceTest extends CrateDummyClusterServiceUnitTest {
             }
         };
 
-        assertThat(roleService.hasPrivilege(role1, Privilege.Type.DDL, Privilege.Clazz.SCHEMA, "sys")).isTrue();
-        assertThat(roleService.hasPrivilege(role1, Privilege.Type.DDL, Privilege.Clazz.SCHEMA, "doc")).isTrue();
-        assertThat(roleService.hasAnyPrivilege(role1, Privilege.Clazz.SCHEMA, "sys")).isTrue();
-        assertThat(roleService.hasAnyPrivilege(role1, Privilege.Clazz.SCHEMA, "doc")).isTrue();
+        assertThat(roleService.hasPrivilege(role1, Privilege.Type.DDL, Securable.SCHEMA, "sys")).isTrue();
+        assertThat(roleService.hasPrivilege(role1, Privilege.Type.DDL, Securable.SCHEMA, "doc")).isTrue();
+        assertThat(roleService.hasAnyPrivilege(role1, Securable.SCHEMA, "sys")).isTrue();
+        assertThat(roleService.hasAnyPrivilege(role1, Securable.SCHEMA, "doc")).isTrue();
         assertThat(roleService.hasSchemaPrivilege(role1, Privilege.Type.DDL, OidHash.schemaOid("sys"))).isTrue();
         assertThat(roleService.hasSchemaPrivilege(role1, Privilege.Type.DDL, OidHash.schemaOid("doc"))).isTrue();
 
-        assertThat(roleService.hasPrivilege(role2, Privilege.Type.DDL, Privilege.Clazz.SCHEMA, "sys")).isFalse();
-        assertThat(roleService.hasPrivilege(role2, Privilege.Type.DDL, Privilege.Clazz.SCHEMA, "doc")).isTrue();
-        assertThat(roleService.hasAnyPrivilege(role2, Privilege.Clazz.SCHEMA, "sys")).isFalse();
-        assertThat(roleService.hasAnyPrivilege(role2, Privilege.Clazz.SCHEMA, "doc")).isTrue();
+        assertThat(roleService.hasPrivilege(role2, Privilege.Type.DDL, Securable.SCHEMA, "sys")).isFalse();
+        assertThat(roleService.hasPrivilege(role2, Privilege.Type.DDL, Securable.SCHEMA, "doc")).isTrue();
+        assertThat(roleService.hasAnyPrivilege(role2, Securable.SCHEMA, "sys")).isFalse();
+        assertThat(roleService.hasAnyPrivilege(role2, Securable.SCHEMA, "doc")).isTrue();
         assertThat(roleService.hasSchemaPrivilege(role2, Privilege.Type.DDL, OidHash.schemaOid("sys"))).isFalse();
         assertThat(roleService.hasSchemaPrivilege(role2, Privilege.Type.DDL, OidHash.schemaOid("doc"))).isTrue();
 
-        assertThat(roleService.hasPrivilege(role3, Privilege.Type.DDL, Privilege.Clazz.SCHEMA, "sys")).isTrue();
-        assertThat(roleService.hasPrivilege(role3, Privilege.Type.DDL, Privilege.Clazz.SCHEMA, "doc")).isFalse();
-        assertThat(roleService.hasAnyPrivilege(role3, Privilege.Clazz.SCHEMA, "sys")).isTrue();
-        assertThat(roleService.hasAnyPrivilege(role3, Privilege.Clazz.SCHEMA, "doc")).isFalse();
+        assertThat(roleService.hasPrivilege(role3, Privilege.Type.DDL, Securable.SCHEMA, "sys")).isTrue();
+        assertThat(roleService.hasPrivilege(role3, Privilege.Type.DDL, Securable.SCHEMA, "doc")).isFalse();
+        assertThat(roleService.hasAnyPrivilege(role3, Securable.SCHEMA, "sys")).isTrue();
+        assertThat(roleService.hasAnyPrivilege(role3, Securable.SCHEMA, "doc")).isFalse();
         assertThat(roleService.hasSchemaPrivilege(role3, Privilege.Type.DDL, OidHash.schemaOid("sys"))).isTrue();
         assertThat(roleService.hasSchemaPrivilege(role3, Privilege.Type.DDL, OidHash.schemaOid("doc"))).isFalse();
 
-        assertThat(roleService.hasPrivilege(role4, Privilege.Type.DDL, Privilege.Clazz.SCHEMA, "sys")).isFalse();
-        assertThat(roleService.hasPrivilege(role4, Privilege.Type.DDL, Privilege.Clazz.SCHEMA, "doc")).isFalse();
-        assertThat(roleService.hasAnyPrivilege(role4, Privilege.Clazz.SCHEMA, "sys")).isFalse();
-        assertThat(roleService.hasAnyPrivilege(role4, Privilege.Clazz.SCHEMA, "doc")).isFalse();
+        assertThat(roleService.hasPrivilege(role4, Privilege.Type.DDL, Securable.SCHEMA, "sys")).isFalse();
+        assertThat(roleService.hasPrivilege(role4, Privilege.Type.DDL, Securable.SCHEMA, "doc")).isFalse();
+        assertThat(roleService.hasAnyPrivilege(role4, Securable.SCHEMA, "sys")).isFalse();
+        assertThat(roleService.hasAnyPrivilege(role4, Securable.SCHEMA, "doc")).isFalse();
         assertThat(roleService.hasSchemaPrivilege(role4, Privilege.Type.DDL, OidHash.schemaOid("sys"))).isFalse();
         assertThat(roleService.hasSchemaPrivilege(role4, Privilege.Type.DDL, OidHash.schemaOid("doc"))).isFalse();
     }

--- a/server/src/test/java/io/crate/role/TransportPrivilegesActionTest.java
+++ b/server/src/test/java/io/crate/role/TransportPrivilegesActionTest.java
@@ -44,11 +44,11 @@ import io.crate.role.metadata.RolesMetadata;
 public class TransportPrivilegesActionTest extends ESTestCase {
 
     private static final Privilege GRANT_DQL =
-        new Privilege(PrivilegeState.GRANT, Privilege.Type.DQL, Privilege.Clazz.CLUSTER, null, "crate");
+        new Privilege(PrivilegeState.GRANT, Privilege.Type.DQL, Securable.CLUSTER, null, "crate");
     private static final Privilege GRANT_DML =
-        new Privilege(PrivilegeState.GRANT, Privilege.Type.DML, Privilege.Clazz.CLUSTER, null, "crate");
+        new Privilege(PrivilegeState.GRANT, Privilege.Type.DML, Securable.CLUSTER, null, "crate");
     private static final Privilege DENY_DQL =
-        new Privilege(PrivilegeState.DENY, Privilege.Type.DQL, Privilege.Clazz.CLUSTER, null, "crate");
+        new Privilege(PrivilegeState.DENY, Privilege.Type.DQL, Securable.CLUSTER, null, "crate");
     private static final Set<Privilege> PRIVILEGES = new HashSet<>(Arrays.asList(GRANT_DQL, GRANT_DML));
 
     @Test

--- a/server/src/test/java/io/crate/role/metadata/RolesHelper.java
+++ b/server/src/test/java/io/crate/role/metadata/RolesHelper.java
@@ -39,6 +39,7 @@ import io.crate.role.GrantedRole;
 import io.crate.role.Privilege;
 import io.crate.role.PrivilegeState;
 import io.crate.role.Role;
+import io.crate.role.Securable;
 import io.crate.role.SecureHash;
 
 public final class RolesHelper {
@@ -73,11 +74,11 @@ public final class RolesHelper {
 
     public static final Map<String, Set<Privilege>> OLD_DUMMY_USERS_PRIVILEGES = Map.of(
         "Ford", Set.of(
-            new Privilege(PrivilegeState.GRANT, Privilege.Type.DQL, Privilege.Clazz.CLUSTER, null, "crate"),
-            new Privilege(PrivilegeState.GRANT, Privilege.Type.DML, Privilege.Clazz.SCHEMA, "doc", "crate")
+            new Privilege(PrivilegeState.GRANT, Privilege.Type.DQL, Securable.CLUSTER, null, "crate"),
+            new Privilege(PrivilegeState.GRANT, Privilege.Type.DML, Securable.SCHEMA, "doc", "crate")
         ),
         "Arthur", Set.of(
-            new Privilege(PrivilegeState.GRANT, Privilege.Type.DML, Privilege.Clazz.SCHEMA, "doc", "crate")
+            new Privilege(PrivilegeState.GRANT, Privilege.Type.DML, Securable.SCHEMA, "doc", "crate")
         ));
 
     public static UsersMetadata usersMetadataOf(Map<String, Role> users) {


### PR DESCRIPTION
- Rename `Privilege.Clazz` to `Securable`
  Move the enum from inner class of `Privilege` to top level and rename it from `Clazz` to `Securable` for better clarity of its purpose.
- Rename column `class` of sys.privileges to `securable`
