### PR TITLE
Don't override non-deterministic sub-column on replica if it's already computed

### DIFF
--- a/server/src/main/java/io/crate/execution/dml/Indexer.java
+++ b/server/src/main/java/io/crate/execution/dml/Indexer.java
@@ -984,15 +984,21 @@ public class Indexer {
                     root = new HashMap<>();
                     extendedValues.add(root);
                 } else {
+                    assert valueIdx < insertValues.length : "Target columns and values must have the same size";
                     root = (Map<String, Object>) insertValues[valueIdx];
                 }
                 ColumnIdent child = column.shiftRight();
                 Object value = synthetic.value();
+                // We don't override value if it exists.
+                // It's needed when:
+                // - users explicitly provide the whole object (including generated sub-column), then we take user provided value.
+                // - when upsert/update takes existing value from the existing document, it needs to take the whole object as is.
                 Maps.mergeInto(
                     root,
                     child.name(),
                     child.path(),
-                    value
+                    value,
+                    Map::putIfAbsent
                 );
             }
         }


### PR DESCRIPTION
Don't override sub-column value if it exists.

It's needed when:

- users explicitly provide the whole object (including generated sub-column), then we take user provided value

- when upsert/update takes existing value from the existing document, it needs to take the whole object as is.

Follow up to https://github.com/crate/crate/commit/42fbef6de34df0df62462c9080a8502719be6c89

No change entry, because https://github.com/crate/crate/commit/42fbef6de34df0df62462c9080a8502719be6c89 fixed replication of non-deterministic sub-columns for INSERTS and UPDATE/UPSERT on table with non-deterministic sub-columns was not possible before that commit anyway. 
