### PR TITLE
Rename Privilege.Type to Permission

### DIFF
--- a/libs/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
@@ -1352,11 +1352,11 @@ public final class SqlFormatter {
             }
         }
 
-        private void appendPrivilegesList(List<String> privilegeTypes) {
+        private void appendPrivilegesList(List<String> permissions) {
             int j = 0;
-            for (String privilegeType : privilegeTypes) {
-                builder.append(privilegeType);
-                if (j < privilegeTypes.size() - 1) {
+            for (String permission : permissions) {
+                builder.append(permission);
+                if (j < permissions.size() - 1) {
                     builder.append(", ");
                 }
                 j++;

--- a/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -598,8 +598,8 @@ class AstBuilder extends SqlBaseParserBaseVisitor<Node> {
         if (context.ALL() != null) {
             return new GrantPrivilege(usernames, securableAndIdent.securable, securableAndIdent.idents);
         } else {
-            List<String> privilegeTypes = identsToStrings(context.priviliges.ident());
-            return new GrantPrivilege(usernames, privilegeTypes, securableAndIdent.securable, securableAndIdent.idents);
+            List<String> permissions = identsToStrings(context.priviliges.ident());
+            return new GrantPrivilege(usernames, permissions, securableAndIdent.securable, securableAndIdent.idents);
         }
     }
 
@@ -613,8 +613,8 @@ class AstBuilder extends SqlBaseParserBaseVisitor<Node> {
         if (context.ALL() != null) {
             return new DenyPrivilege(usernames, securableAndIdent.securable, securableAndIdent.idents);
         } else {
-            List<String> privilegeTypes = identsToStrings(context.priviliges.ident());
-            return new DenyPrivilege(usernames, privilegeTypes, securableAndIdent.securable, securableAndIdent.idents);
+            List<String> permissions = identsToStrings(context.priviliges.ident());
+            return new DenyPrivilege(usernames, permissions, securableAndIdent.securable, securableAndIdent.idents);
         }
     }
 
@@ -628,8 +628,8 @@ class AstBuilder extends SqlBaseParserBaseVisitor<Node> {
         if (context.ALL() != null) {
             return new RevokePrivilege(usernames, securableAndIdent.securable, securableAndIdent.idents);
         } else {
-            List<String> privilegeTypes = identsToStrings(context.privileges.ident());
-            return new RevokePrivilege(usernames, privilegeTypes, securableAndIdent.securable, securableAndIdent.idents);
+            List<String> permissions = identsToStrings(context.privileges.ident());
+            return new RevokePrivilege(usernames, permissions, securableAndIdent.securable, securableAndIdent.idents);
         }
     }
 

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/GrantPrivilege.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/GrantPrivilege.java
@@ -31,10 +31,10 @@ public final class GrantPrivilege extends PrivilegeStatement {
     }
 
     public GrantPrivilege(List<String> userNames,
-                          List<String> privilegeTypes,
+                          List<String> permissions,
                           String securable,
                           List<QualifiedName> tableOrSchemaNames) {
-        super(userNames, privilegeTypes, securable, tableOrSchemaNames);
+        super(userNames, permissions, securable, tableOrSchemaNames);
     }
 
 
@@ -47,7 +47,7 @@ public final class GrantPrivilege extends PrivilegeStatement {
     public String toString() {
         return "GrantPrivilege{" +
                "allPrivileges=" + all +
-               "privilegeTypes=" + privilegeTypes +
+               "permissions=" + permissions +
                ", userNames=" + userNames +
                '}';
     }

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/PrivilegeStatement.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/PrivilegeStatement.java
@@ -29,29 +29,29 @@ public abstract sealed class PrivilegeStatement extends Statement
     permits GrantPrivilege, RevokePrivilege, DenyPrivilege {
 
     protected final List<String> userNames;
-    protected final List<String> privilegeTypes;
+    protected final List<String> permissions;
     private final List<QualifiedName> tableOrSchemaNames;
     private final String securable;
     protected final boolean all;
 
     protected PrivilegeStatement(List<String> userNames, String securable, List<QualifiedName> tableOrSchemaNames) {
         this.userNames = userNames;
-        privilegeTypes = Collections.emptyList();
+        permissions = Collections.emptyList();
         all = true;
         this.securable = securable;
         this.tableOrSchemaNames = tableOrSchemaNames;
     }
 
-    protected PrivilegeStatement(List<String> userNames, List<String> privilegeTypes, String securable, List<QualifiedName> tableOrSchemaNames) {
+    protected PrivilegeStatement(List<String> userNames, List<String> permissions, String securable, List<QualifiedName> tableOrSchemaNames) {
         this.userNames = userNames;
-        this.privilegeTypes = privilegeTypes;
+        this.permissions = permissions;
         this.all = false;
         this.securable = securable;
         this.tableOrSchemaNames = tableOrSchemaNames;
     }
 
     public List<String> privileges() {
-        return privilegeTypes;
+        return permissions;
     }
 
     public List<String> userNames() {
@@ -77,12 +77,12 @@ public abstract sealed class PrivilegeStatement extends Statement
         PrivilegeStatement that = (PrivilegeStatement) o;
         return all == that.all &&
                Objects.equals(userNames, that.userNames) &&
-               Objects.equals(privilegeTypes, that.privilegeTypes);
+               Objects.equals(permissions, that.permissions);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(userNames, privilegeTypes, all);
+        return Objects.hash(userNames, permissions, all);
     }
 
 }

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/RevokePrivilege.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/RevokePrivilege.java
@@ -31,10 +31,10 @@ public final class RevokePrivilege extends PrivilegeStatement {
     }
 
     public RevokePrivilege(List<String> userNames,
-                           List<String> privilegeTypes,
+                           List<String> permissions,
                            String securable,
                            List<QualifiedName> tableOrSchemaNames) {
-        super(userNames, privilegeTypes, securable, tableOrSchemaNames);
+        super(userNames, permissions, securable, tableOrSchemaNames);
     }
 
     @Override
@@ -46,7 +46,7 @@ public final class RevokePrivilege extends PrivilegeStatement {
     public String toString() {
         return "RevokePrivilege{" +
                "allPrivileges=" + all +
-               "privilegeTypes=" + privilegeTypes +
+               "permissions=" + permissions +
                ", userNames=" + userNames +
                '}';
     }

--- a/server/src/main/java/io/crate/action/sql/Sessions.java
+++ b/server/src/main/java/io/crate/action/sql/Sessions.java
@@ -49,7 +49,7 @@ import io.crate.metadata.settings.CoordinatorSessionSettings;
 import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Planner;
 import io.crate.protocols.postgres.KeyData;
-import io.crate.role.Privilege.Type;
+import io.crate.role.Permission;
 import io.crate.role.Role;
 import io.crate.role.Securable;
 import io.crate.statistics.TableStats;
@@ -211,7 +211,7 @@ public class Sessions {
     public Iterable<Cursor> getCursors(Role user) {
         return () -> sessions.values().stream()
             .filter(session ->
-                nodeCtx.roles().hasPrivilege(user, Type.AL, Securable.CLUSTER, null)
+                nodeCtx.roles().hasPrivilege(user, Permission.AL, Securable.CLUSTER, null)
                 || session.sessionSettings().sessionUser().equals(user))
             .flatMap(session -> StreamSupport.stream(session.cursors.spliterator(), false))
             .iterator();

--- a/server/src/main/java/io/crate/exceptions/MissingPrivilegeException.java
+++ b/server/src/main/java/io/crate/exceptions/MissingPrivilegeException.java
@@ -21,16 +21,16 @@
 
 package io.crate.exceptions;
 
-import io.crate.role.Privilege;
-
 import java.util.Locale;
+
+import io.crate.role.Permission;
 
 public class MissingPrivilegeException extends UnauthorizedException {
 
     private static final String MESSAGE_TMPL = "Missing '%s' privilege for user '%s'";
 
-    public MissingPrivilegeException(String userName, Privilege.Type type) {
-        super(String.format(Locale.ENGLISH, MESSAGE_TMPL, type, userName));
+    public MissingPrivilegeException(String userName, Permission permission) {
+        super(String.format(Locale.ENGLISH, MESSAGE_TMPL, permission, userName));
     }
 
     public MissingPrivilegeException(String userName) {

--- a/server/src/main/java/io/crate/expression/scalar/HasSchemaPrivilegeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/HasSchemaPrivilegeFunction.java
@@ -32,7 +32,7 @@ import io.crate.common.FourFunction;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 import io.crate.metadata.pgcatalog.PgCatalogTableDefinitions;
-import io.crate.role.Privilege;
+import io.crate.role.Permission;
 import io.crate.role.Role;
 import io.crate.role.Roles;
 import io.crate.role.Securable;
@@ -42,56 +42,55 @@ public class HasSchemaPrivilegeFunction extends HasPrivilegeFunction {
 
     public static final String NAME = "has_schema_privilege";
 
-    private static final FourFunction<Roles, Role, Object, Collection<Privilege.Type>, Boolean> CHECK_BY_SCHEMA_NAME =
-        (roles, user, schema, privileges) -> {
+    private static final FourFunction<Roles, Role, Object, Collection<Permission>, Boolean> CHECK_BY_SCHEMA_NAME =
+        (roles, user, schema, permissions) -> {
             String schemaName = (String) schema;
             boolean result = false;
-            for (Privilege.Type type: privileges) {
+            for (Permission permission : permissions) {
                 // USAGE is allowed for public schemas
-                if (type == Privilege.Type.DQL && PgCatalogTableDefinitions.isPgCatalogOrInformationSchema(schemaName)) {
+                if (permission == Permission.DQL && PgCatalogTableDefinitions.isPgCatalogOrInformationSchema(schemaName)) {
                     return true;
                 }
                 // Last argument is null as it's not used for Privilege.Securable.SCHEMA
-                result |= roles.hasPrivilege(user, type, Securable.SCHEMA, schemaName);
+                result |= roles.hasPrivilege(user, permission, Securable.SCHEMA, schemaName);
             }
             return result;
         };
 
-    private static final FourFunction<Roles, Role, Object, Collection<Privilege.Type>, Boolean> CHECK_BY_SCHEMA_OID =
-        (roles, user, schema, privileges) -> {
+    private static final FourFunction<Roles, Role, Object, Collection<Permission>, Boolean> CHECK_BY_SCHEMA_OID =
+        (roles, user, schema, permissions) -> {
             Integer schemaOid = (Integer) schema;
             boolean result = false;
-            for (Privilege.Type type: privileges) {
+            for (Permission permission : permissions) {
                 // USAGE is allowed for public schemas
-                if (type == Privilege.Type.DQL && PgCatalogTableDefinitions.isPgCatalogOrInformationSchema(schemaOid)) {
+                if (permission == Permission.DQL && PgCatalogTableDefinitions.isPgCatalogOrInformationSchema(schemaOid)) {
                     return true;
                 }
-                result |= roles.hasSchemaPrivilege(user, type, schemaOid); // Returns true if has any privilege out of 2 possible
+                result |= roles.hasSchemaPrivilege(user, permission, schemaOid); // Returns true if has any privilege out of 2 possible
             }
             return result;
         };
 
     /**
-     * @param privilege is a comma separated list.
-     * Valid privileges are 'CREATE' and 'USAGE' which map to DDL and DQL respectively.
-     * Case of the privilege string is not significant, and extra whitespace is allowed between privilege names.
-     * Repetition of the valid argument is allowed.
+     * @param permissionNames is a comma separated list.
+     * Valid permissionNames are 'CREATE' and 'USAGE' which map to DDL and DQL respectively.
+     * Extra whitespaces between privilege names and repetition of a valid argument are allowed.
      *
-     * @see HasPrivilegeFunction#parsePrivileges(String)
+     * @see HasPrivilegeFunction#parsePermissions(String)
      */
     @Nullable
-    protected Collection<Privilege.Type> parsePrivileges(String privilege) {
-        Collection<Privilege.Type> toCheck = new HashSet<>();
-        String[] privileges = privilege.toLowerCase(Locale.ENGLISH).split(",");
-        for (String p : privileges) {
+    protected Collection<Permission> parsePermissions(String permissionNames) {
+        Collection<Permission> toCheck = new HashSet<>();
+        String[] permissions = permissionNames.toLowerCase(Locale.ENGLISH).split(",");
+        for (String p : permissions) {
             p = p.trim();
             if (p.equals("create")) {
-                toCheck.add(Privilege.Type.DDL);
+                toCheck.add(Permission.DDL);
             } else if (p.equals("usage")) {
-                toCheck.add(Privilege.Type.DQL);
+                toCheck.add(Permission.DQL);
             } else {
                 // Same error as PG
-                throw new IllegalArgumentException(String.format(Locale.ENGLISH, "Unrecognized privilege type: %s", p));
+                throw new IllegalArgumentException(String.format(Locale.ENGLISH, "Unrecognized permission: %s", p));
             }
         }
         return toCheck;
@@ -168,7 +167,7 @@ public class HasSchemaPrivilegeFunction extends HasPrivilegeFunction {
     protected HasSchemaPrivilegeFunction(Signature signature,
                                          BoundSignature boundSignature,
                                          BiFunction<Roles, Object, Role> getUser,
-                                         FourFunction<Roles, Role, Object, Collection<Privilege.Type>, Boolean> checkPrivilege) {
+                                         FourFunction<Roles, Role, Object, Collection<Permission>, Boolean> checkPrivilege) {
         super(signature, boundSignature, getUser, checkPrivilege);
     }
 }

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgRolesTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgRolesTable.java
@@ -31,7 +31,7 @@ import static io.crate.types.DataTypes.TIMESTAMPZ;
 import io.crate.exceptions.MissingPrivilegeException;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.SystemTable;
-import io.crate.role.Privilege;
+import io.crate.role.Permission;
 import io.crate.role.Privileges;
 import io.crate.role.Role;
 import io.crate.role.Roles;
@@ -66,7 +66,7 @@ public final class PgRolesTable {
             Privileges.ensureUserHasPrivilege(
                 roles,
                 role,
-                Privilege.Type.AL,
+                Permission.AL,
                 Securable.CLUSTER,
                 null);
             return true;

--- a/server/src/main/java/io/crate/metadata/sys/SysTableDefinitions.java
+++ b/server/src/main/java/io/crate/metadata/sys/SysTableDefinitions.java
@@ -47,7 +47,7 @@ import io.crate.expression.reference.sys.shard.SysAllocations;
 import io.crate.expression.reference.sys.snapshot.SysSnapshots;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.SystemTable;
-import io.crate.role.Privilege.Type;
+import io.crate.role.Permission;
 import io.crate.role.Roles;
 import io.crate.role.Securable;
 
@@ -81,7 +81,7 @@ public class SysTableDefinitions {
                     .filter(x ->
                         user.isSuperUser()
                         || user.name().equals(x.username())
-                        || roles.hasPrivilege(user, Type.AL, Securable.CLUSTER, null))
+                        || roles.hasPrivilege(user, Permission.AL, Securable.CLUSTER, null))
                     .iterator()
             ),
             sysJobsTable.expressions(),
@@ -93,7 +93,7 @@ public class SysTableDefinitions {
                     .filter(x ->
                         user.isSuperUser()
                         || user.name().equals(x.username())
-                        || roles.hasPrivilege(user, Type.AL, Securable.CLUSTER, null))
+                        || roles.hasPrivilege(user, Permission.AL, Securable.CLUSTER, null))
                     .iterator()
             ),
             sysJobsLogTable.expressions(),

--- a/server/src/main/java/io/crate/replication/logical/metadata/Publication.java
+++ b/server/src/main/java/io/crate/replication/logical/metadata/Publication.java
@@ -41,7 +41,7 @@ import org.elasticsearch.index.IndexSettings;
 
 import io.crate.metadata.IndexParts;
 import io.crate.metadata.RelationName;
-import io.crate.role.Privilege;
+import io.crate.role.Permission;
 import io.crate.role.Role;
 import io.crate.role.Roles;
 import io.crate.role.Securable;
@@ -177,7 +177,7 @@ public class Publication implements Writeable {
     }
 
     private static boolean subscriberCanRead(Roles roles, RelationName relationName, Role subscriber, String publicationName) {
-        boolean canRead = roles.hasPrivilege(subscriber, Privilege.Type.DQL, Securable.TABLE, relationName.fqn());
+        boolean canRead = roles.hasPrivilege(subscriber, Permission.DQL, Securable.TABLE, relationName.fqn());
         if (canRead == false) {
             if (LOGGER.isInfoEnabled()) {
                 LOGGER.info("User {} subscribed to the publication {} doesn't have DQL privilege on the table {}, this table will not be replicated.",
@@ -188,15 +188,15 @@ public class Publication implements Writeable {
     }
 
     private static boolean userCanPublish(Roles roles, RelationName relationName, Role publicationOwner, String publicationName) {
-        for (Privilege.Type type: Privilege.Type.READ_WRITE_DEFINE) {
+        for (Permission permission : Permission.READ_WRITE_DEFINE) {
             // This check is triggered only on ALL TABLES case.
             // Required privileges correspond to those we check for the pre-defined tables case in AccessControlImpl.visitCreatePublication.
 
             // Schemas.DOC_SCHEMA_NAME is a dummy parameter since we are passing fqn as ident.
-            if (!roles.hasPrivilege(publicationOwner, type, Securable.TABLE, relationName.fqn())) {
+            if (!roles.hasPrivilege(publicationOwner, permission, Securable.TABLE, relationName.fqn())) {
                 if (LOGGER.isInfoEnabled()) {
                     LOGGER.info("User {} owning publication {} doesn't have {} privilege on the table {}, this table will not be replicated.",
-                        publicationOwner.name(), publicationName, type.name(), relationName.fqn());
+                        publicationOwner.name(), publicationName, permission.name(), relationName.fqn());
                 }
                 return false;
             }

--- a/server/src/main/java/io/crate/role/Permission.java
+++ b/server/src/main/java/io/crate/role/Permission.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.  You may
  * obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
@@ -19,35 +19,18 @@
  * software solely pursuant to the terms of the relevant commercial agreement.
  */
 
-package io.crate.sql.tree;
+package io.crate.role;
 
 import java.util.List;
 
-public final class DenyPrivilege extends PrivilegeStatement {
+public enum Permission {
+    DQL,
+    DML,
+    DDL,
+    /**
+     * Administration Language
+     */
+    AL;
 
-    public DenyPrivilege(List<String> userNames, String securable, List<QualifiedName> tableOrSchemaNames) {
-        super(userNames, securable, tableOrSchemaNames);
-    }
-
-    public DenyPrivilege(List<String> userNames,
-                         List<String> permissions,
-                         String securable,
-                         List<QualifiedName> tableOrSchemaNames) {
-        super(userNames, permissions, securable, tableOrSchemaNames);
-    }
-
-
-    @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
-        return visitor.visitDenyPrivilege(this, context);
-    }
-
-    @Override
-    public String toString() {
-        return "DenyPrivilege{" +
-               "allPrivileges=" + all +
-               "permissions=" + permissions +
-               ", userNames=" + userNames +
-               '}';
-    }
+    public static final List<Permission> READ_WRITE_DEFINE = List.of(DQL, DML, DDL);
 }

--- a/server/src/main/java/io/crate/role/PrivilegeIdent.java
+++ b/server/src/main/java/io/crate/role/PrivilegeIdent.java
@@ -31,25 +31,25 @@ import org.jetbrains.annotations.Nullable;
 
 public class PrivilegeIdent implements Writeable {
 
-    private final Privilege.Type type;
+    private final Permission permission;
     private final Securable securable;
     @Nullable
     private final String ident;  // for CLUSTER this will be always null, otherwise schemaName, tableName etc.
 
-    public PrivilegeIdent(Privilege.Type type, Securable securable, @Nullable String ident) {
-        this.type = type;
+    public PrivilegeIdent(Permission permission, Securable securable, @Nullable String ident) {
+        this.permission = permission;
         this.securable = securable;
         this.ident = ident;
     }
 
     PrivilegeIdent(StreamInput in) throws IOException {
-        type = Privilege.Type.VALUES.get(in.readInt());
+        permission = in.readEnum(Permission.class);
         securable = in.readEnum(Securable.class);
         ident = in.readOptionalString();
     }
 
-    public Privilege.Type type() {
-        return type;
+    public Permission permission() {
+        return permission;
     }
 
     public Securable securable() {
@@ -63,7 +63,7 @@ public class PrivilegeIdent implements Writeable {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeInt(type.ordinal());
+        out.writeEnum(permission);
         out.writeEnum(securable);
         out.writeOptionalString(ident);
     }
@@ -73,13 +73,13 @@ public class PrivilegeIdent implements Writeable {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         PrivilegeIdent that = (PrivilegeIdent) o;
-        return type == that.type &&
+        return permission == that.permission &&
                securable == that.securable &&
                Objects.equals(ident, that.ident);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(type, securable, ident);
+        return Objects.hash(permission, securable, ident);
     }
 }

--- a/server/src/main/java/io/crate/role/Privileges.java
+++ b/server/src/main/java/io/crate/role/Privileges.java
@@ -41,26 +41,26 @@ public final class Privileges {
      */
     public static void ensureUserHasPrivilege(Roles roles,
                                               Role user,
-                                              Privilege.Type type,
+                                              Permission permission,
                                               Securable securable,
                                               @Nullable String ident) throws MissingPrivilegeException {
         assert roles != null : "Roles must not be null when trying to validate privileges";
         assert user != null : "User must not be null when trying to validate privileges";
-        assert type != null : "Privilege type must not be null";
+        assert permission != null : "Permission must not be null";
 
         // information_schema and pg_catalog should not be protected
         if (isInformationSchema(securable, ident) || isPgCatalogSchema(securable, ident)) {
             return;
         }
         //noinspection PointlessBooleanExpression
-        if (roles.hasPrivilege(user, type, securable, ident) == false) {
+        if (roles.hasPrivilege(user, permission, securable, ident) == false) {
             boolean objectIsVisibleToUser = roles.hasAnyPrivilege(user, securable, ident);
             if (objectIsVisibleToUser) {
-                throw new MissingPrivilegeException(user.name(), type);
+                throw new MissingPrivilegeException(user.name(), permission);
             } else {
                 switch (securable) {
                     case CLUSTER:
-                        throw new MissingPrivilegeException(user.name(), type);
+                        throw new MissingPrivilegeException(user.name(), permission);
                     case SCHEMA:
                         throw new SchemaUnknownException(ident);
                     case TABLE:

--- a/server/src/main/java/io/crate/role/PrivilegesModifier.java
+++ b/server/src/main/java/io/crate/role/PrivilegesModifier.java
@@ -128,7 +128,7 @@ public final class PrivilegesModifier {
                 String ident = privilegeIdent.ident();
                 assert ident != null : "ident must not be null for securable 'TABLE'";
                 if (ident.equals(sourceIdent)) {
-                    privileges.add(new Privilege(privilege.state(), privilegeIdent.type(), privilegeIdent.securable(),
+                    privileges.add(new Privilege(privilege.state(), privilegeIdent.permission(), privilegeIdent.securable(),
                         targetIdent, privilege.grantor()));
                     privilegesChanged = true;
                 } else {
@@ -186,10 +186,10 @@ public final class PrivilegesModifier {
                 if (ident.securable() == Securable.TABLE) {
                     if (source.fqn().equals(ident.ident())) {
                         updatedPrivileges.add(
-                            new Privilege(privilege.state(), ident.type(), ident.securable(), target.fqn(), privilege.grantor()));
+                            new Privilege(privilege.state(), ident.permission(), ident.securable(), target.fqn(), privilege.grantor()));
                     } else if (target.fqn().equals(ident.ident())) {
                         updatedPrivileges.add(
-                            new Privilege(privilege.state(), ident.type(), ident.securable(), source.fqn(), privilege.grantor()));
+                            new Privilege(privilege.state(), ident.permission(), ident.securable(), source.fqn(), privilege.grantor()));
                     } else {
                         updatedPrivileges.add(privilege);
                     }

--- a/server/src/main/java/io/crate/role/Role.java
+++ b/server/src/main/java/io/crate/role/Role.java
@@ -178,11 +178,11 @@ public class Role implements Writeable, ToXContent {
         return grantedRoles;
     }
 
-    public PrivilegeState matchSchema(Privilege.Type type, int oid) {
+    public PrivilegeState matchSchema(Permission permission, int oid) {
         PrivilegeState result = PrivilegeState.REVOKE;
         for (var privilege : privileges) {
             PrivilegeIdent ident = privilege.ident();
-            if (ident.type() != type) {
+            if (ident.permission() != permission) {
                 continue;
             }
             if (ident.securable() == SCHEMA && OidHash.schemaOid(ident.ident()) == oid) {
@@ -265,7 +265,7 @@ public class Role implements Writeable, ToXContent {
      * <p>
      *   "role1": {
      *     "privileges": [
-     *       {"state": 1, "type": 2, "securable": 3, "ident": "some_table", "grantor": "grantor_username"},
+     *       {"state": 1, "permission": 2, "securable": 3, "ident": "some_table", "grantor": "grantor_username"},
      *       ...
      *     ],
      *     "granted_roles: [{"role1", "grantor1"}, {"role2", "grantor2"}],

--- a/server/src/main/java/io/crate/role/RolePrivileges.java
+++ b/server/src/main/java/io/crate/role/RolePrivileges.java
@@ -119,18 +119,18 @@ public class RolePrivileges implements Iterable<Privilege> {
      * If none is found for the current {@link Securable}, try to find one on the upper securable.
      * If a privilege with a {@link PrivilegeState#DENY} state is found, false is returned.
      */
-    public PrivilegeState matchPrivilege(@Nullable Privilege.Type type, Securable securable, @Nullable String ident) {
-        Privilege foundPrivilege = privilegeByIdent.get(new PrivilegeIdent(type, securable, ident));
+    public PrivilegeState matchPrivilege(@Nullable Permission permission, Securable securable, @Nullable String ident) {
+        Privilege foundPrivilege = privilegeByIdent.get(new PrivilegeIdent(permission, securable, ident));
         if (foundPrivilege == null) {
             switch (securable) {
                 case SCHEMA:
-                    foundPrivilege = privilegeByIdent.get(new PrivilegeIdent(type, Securable.CLUSTER, null));
+                    foundPrivilege = privilegeByIdent.get(new PrivilegeIdent(permission, Securable.CLUSTER, null));
                     break;
                 case TABLE, VIEW:
                     String schemaIdent = new IndexParts(ident).getSchema();
-                    foundPrivilege = privilegeByIdent.get(new PrivilegeIdent(type, Securable.SCHEMA, schemaIdent));
+                    foundPrivilege = privilegeByIdent.get(new PrivilegeIdent(permission, Securable.SCHEMA, schemaIdent));
                     if (foundPrivilege == null) {
-                        foundPrivilege = privilegeByIdent.get(new PrivilegeIdent(type, Securable.CLUSTER, null));
+                        foundPrivilege = privilegeByIdent.get(new PrivilegeIdent(permission, Securable.CLUSTER, null));
                     }
                     break;
                 default:

--- a/server/src/main/java/io/crate/role/metadata/SysPrivilegesTableInfo.java
+++ b/server/src/main/java/io/crate/role/metadata/SysPrivilegesTableInfo.java
@@ -52,7 +52,7 @@ public class SysPrivilegesTableInfo {
             .add("grantee", STRING, x -> x.grantee)
             .add("grantor", STRING, x -> x.privilege.grantor())
             .add("state", STRING, x -> x.privilege.state().toString())
-            .add("type", STRING, x -> x.privilege.ident().type().toString())
+            .add("type", STRING, x -> x.privilege.ident().permission().toString())
             .add("class", STRING, x -> x.privilege.ident().securable().toString())
             .add("ident", STRING, x -> x.privilege.ident().ident())
             .setPrimaryKeys(

--- a/server/src/test/java/io/crate/action/sql/SessionsTest.java
+++ b/server/src/test/java/io/crate/action/sql/SessionsTest.java
@@ -49,6 +49,7 @@ import io.crate.metadata.NodeContext;
 import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Planner;
 import io.crate.protocols.postgres.KeyData;
+import io.crate.role.Permission;
 import io.crate.role.Privilege;
 import io.crate.role.PrivilegeState;
 import io.crate.role.Role;
@@ -104,7 +105,7 @@ public class SessionsTest extends CrateDummyClusterServiceUnitTest {
 
         var ALprivilege = new Privilege(
             PrivilegeState.GRANT,
-            Privilege.Type.AL,
+            Permission.AL,
             Securable.CLUSTER,
             null,
             "crate"

--- a/server/src/test/java/io/crate/analyze/PrivilegesAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/PrivilegesAnalyzerTest.java
@@ -21,10 +21,10 @@
 
 package io.crate.analyze;
 
-import static io.crate.role.Privilege.Type.AL;
-import static io.crate.role.Privilege.Type.DDL;
-import static io.crate.role.Privilege.Type.DML;
-import static io.crate.role.Privilege.Type.DQL;
+import static io.crate.role.Permission.AL;
+import static io.crate.role.Permission.DDL;
+import static io.crate.role.Permission.DML;
+import static io.crate.role.Permission.DQL;
 import static io.crate.role.PrivilegeState.DENY;
 import static io.crate.role.PrivilegeState.GRANT;
 import static io.crate.role.PrivilegeState.REVOKE;
@@ -42,6 +42,7 @@ import io.crate.exceptions.RelationUnknown;
 import io.crate.exceptions.UnsupportedFeatureException;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.settings.CoordinatorSessionSettings;
+import io.crate.role.Permission;
 import io.crate.role.Privilege;
 import io.crate.role.PrivilegeState;
 import io.crate.role.Role;
@@ -394,9 +395,10 @@ public class PrivilegesAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         );
     }
 
-    private Privilege privilegeOf(PrivilegeState state, Privilege.Type type, Securable securable, String ident) {
-        return new Privilege(state,
-            type,
+    private Privilege privilegeOf(PrivilegeState state, Permission permission, Securable securable, String ident) {
+        return new Privilege(
+            state,
+            permission,
             securable,
             ident,
             GRANTOR_TEST_USER.name()

--- a/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
+++ b/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
@@ -22,7 +22,7 @@
 package io.crate.auth;
 
 import static io.crate.expression.udf.UdfUnitTest.DUMMY_LANG;
-import static io.crate.role.Privilege.Type.READ_WRITE_DEFINE;
+import static io.crate.role.Permission.READ_WRITE_DEFINE;
 import static io.crate.role.Role.CRATE_USER;
 import static io.crate.role.metadata.RolesHelper.userOf;
 import static java.util.Collections.singletonList;
@@ -61,6 +61,7 @@ import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Plan;
 import io.crate.planner.operators.SubQueryResults;
 import io.crate.protocols.postgres.TransactionState;
+import io.crate.role.Permission;
 import io.crate.role.Privilege;
 import io.crate.role.PrivilegeState;
 import io.crate.role.Role;
@@ -102,7 +103,7 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
         normalUser = userOf(
                        "normal",
                        Set.of(new Privilege(PrivilegeState.GRANT,
-                                            Privilege.Type.DQL,
+                                            Permission.DQL,
                                             Securable.SCHEMA,
                                             "custom_schema",
                                             "crate")),
@@ -121,10 +122,10 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
             }
 
             @Override
-            public boolean hasPrivilege(Role user, Privilege.Type type, Securable securable, @Nullable String ident) {
+            public boolean hasPrivilege(Role user, Permission type, Securable securable, @Nullable String ident) {
                 validationCallArguments.add(CollectionUtils.arrayAsArrayList(type, securable, ident, user.name()));
                 if ("ddlOnly".equals(user.name())) {
-                    return Privilege.Type.DDL == type;
+                    return Permission.DDL == type;
                 }
                 return true;
             }
@@ -185,32 +186,32 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
             SqlParser.createStatement(stmt), new CoordinatorSessionSettings(user), ParamTypeHints.EMPTY, e.cursors);
     }
 
-    private void assertAskedForCluster(Privilege.Type type) {
-        assertAskedForCluster(type, normalUser);
+    private void assertAskedForCluster(Permission permission) {
+        assertAskedForCluster(permission, normalUser);
     }
 
-    private void assertAskedForCluster(Privilege.Type type, Role user) {
+    private void assertAskedForCluster(Permission permission, Role user) {
         assertThat(validationCallArguments).anySatisfy(
-            s -> assertThat(s).containsExactly(type, Securable.CLUSTER, null, user.name()));
+            s -> assertThat(s).containsExactly(permission, Securable.CLUSTER, null, user.name()));
     }
 
-    private void assertAskedForSchema(Privilege.Type type, String ident) {
+    private void assertAskedForSchema(Permission permission, String ident) {
         assertThat(validationCallArguments).anySatisfy(
-            s -> assertThat(s).containsExactly(type, Securable.SCHEMA, ident, normalUser.name()));
+            s -> assertThat(s).containsExactly(permission, Securable.SCHEMA, ident, normalUser.name()));
     }
 
-    private void assertAskedForTable(Privilege.Type type, String ident) {
-        assertAskedForTable(type, ident, normalUser);
+    private void assertAskedForTable(Permission permission, String ident) {
+        assertAskedForTable(permission, ident, normalUser);
     }
 
-    private void assertAskedForTable(Privilege.Type type, String ident, Role user) {
+    private void assertAskedForTable(Permission permission, String ident, Role user) {
         assertThat(validationCallArguments).anySatisfy(
-            s -> assertThat(s).containsExactly(type, Securable.TABLE, ident, user.name()));
+            s -> assertThat(s).containsExactly(permission, Securable.TABLE, ident, user.name()));
     }
 
-    private void assertAskedForView(Privilege.Type type, String ident) {
+    private void assertAskedForView(Permission permission, String ident) {
         assertThat(validationCallArguments).anySatisfy(
-            s -> assertThat(s).containsExactly(type, Securable.VIEW, ident, normalUser.name()));
+            s -> assertThat(s).containsExactly(permission, Securable.VIEW, ident, normalUser.name()));
     }
 
     @Test
@@ -236,13 +237,13 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void test_set_global_statements_can_be_executed_with_al_cluster_privileges() throws Exception {
         analyze("set global stats.enabled = true");
-        assertAskedForCluster(Privilege.Type.AL);
+        assertAskedForCluster(Permission.AL);
     }
 
     @Test
     public void test_reset_requires_AL_privileges() throws Exception {
         analyze("reset global stats.enabled");
-        assertAskedForCluster(Privilege.Type.AL);
+        assertAskedForCluster(Permission.AL);
     }
 
     @Test
@@ -255,106 +256,106 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testAlterTable() throws Exception {
         analyze("alter table users set (number_of_replicas=1)");
-        assertAskedForTable(Privilege.Type.DDL, "doc.users");
+        assertAskedForTable(Permission.DDL, "doc.users");
     }
 
     @Test
     public void testCopyFrom() throws Exception {
         analyze("copy users from 'file:///tmp'");
-        assertAskedForTable(Privilege.Type.DML, "doc.users");
+        assertAskedForTable(Permission.DML, "doc.users");
     }
 
     @Test
     public void testCopyTo() throws Exception {
         analyze("copy users to DIRECTORY '/tmp'");
-        assertAskedForTable(Privilege.Type.DQL, "doc.users");
+        assertAskedForTable(Permission.DQL, "doc.users");
     }
 
     @Test
     public void testCreateTable() throws Exception {
         analyze("create table my_schema.my_table (id int)");
-        assertAskedForSchema(Privilege.Type.DDL, "my_schema");
+        assertAskedForSchema(Permission.DDL, "my_schema");
     }
 
     @Test
     public void testCreateBlobTable() throws Exception {
         analyze("create blob table myblobs");
-        assertAskedForSchema(Privilege.Type.DDL, "blob");
+        assertAskedForSchema(Permission.DDL, "blob");
     }
 
     @Test
     public void testCreateRepository() throws Exception {
         analyze("create repository new_repository TYPE fs with (location='/tmp', compress=True)");
-        assertAskedForCluster(Privilege.Type.DDL);
+        assertAskedForCluster(Permission.DDL);
     }
 
     @Test
     public void testDropRepository() throws Exception {
         analyze("drop repository my_repo");
-        assertAskedForCluster(Privilege.Type.DDL);
+        assertAskedForCluster(Permission.DDL);
     }
 
     @Test
     public void testCreateSnapshot() throws Exception {
         analyze("create snapshot my_repo.my_snapshot table users");
-        assertAskedForCluster(Privilege.Type.DDL);
+        assertAskedForCluster(Permission.DDL);
     }
 
     @Test
     public void testRestoreSnapshot() throws Exception {
         analyze("restore snapshot my_repo.my_snapshot table my_table");
-        assertAskedForCluster(Privilege.Type.DDL);
+        assertAskedForCluster(Permission.DDL);
     }
 
     @Test
     public void testDropSnapshot() throws Exception {
         analyze("drop snapshot my_repo.my_snap_1");
-        assertAskedForCluster(Privilege.Type.DDL);
+        assertAskedForCluster(Permission.DDL);
     }
 
     @Test
     public void testDelete() throws Exception {
         analyze("delete from users");
-        assertAskedForTable(Privilege.Type.DML, "doc.users");
+        assertAskedForTable(Permission.DML, "doc.users");
     }
 
     @Test
     public void testInsertFromValues() throws Exception {
         analyze("insert into users (id) values (1)");
-        assertAskedForTable(Privilege.Type.DML, "doc.users");
+        assertAskedForTable(Permission.DML, "doc.users");
     }
 
     @Test
     public void testInsertFromSubquery() throws Exception {
         analyze("insert into users (id) ( select id from parted )");
-        assertAskedForTable(Privilege.Type.DML, "doc.users");
-        assertAskedForTable(Privilege.Type.DQL, "doc.parted");
+        assertAskedForTable(Permission.DML, "doc.users");
+        assertAskedForTable(Permission.DQL, "doc.parted");
     }
 
     @Test
     public void testUpdate() throws Exception {
         analyze("update users set name = 'ford' where id = 1");
-        assertAskedForTable(Privilege.Type.DML, "doc.users");
+        assertAskedForTable(Permission.DML, "doc.users");
     }
 
     @Test
     public void testSelectSingleRelation() throws Exception {
         analyze("select * from sys.cluster");
-        assertAskedForTable(Privilege.Type.DQL, "sys.cluster");
+        assertAskedForTable(Permission.DQL, "sys.cluster");
     }
 
     @Test
     public void testSelectMultiRelation() throws Exception {
         analyze("select * from sys.cluster, users");
-        assertAskedForTable(Privilege.Type.DQL, "sys.cluster");
-        assertAskedForTable(Privilege.Type.DQL, "doc.users");
+        assertAskedForTable(Permission.DQL, "sys.cluster");
+        assertAskedForTable(Permission.DQL, "doc.users");
     }
 
     @Test
     public void testSelectUnion() throws Exception {
         analyze("select name from sys.cluster union all select name from users");
-        assertAskedForTable(Privilege.Type.DQL, "sys.cluster");
-        assertAskedForTable(Privilege.Type.DQL, "doc.users");
+        assertAskedForTable(Permission.DQL, "sys.cluster");
+        assertAskedForTable(Permission.DQL, "doc.users");
     }
 
     /**
@@ -365,8 +366,8 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testSelectUnionWithOrderBy() throws Exception {
         analyze("select name from sys.cluster union all select name from users order by 1");
-        assertAskedForTable(Privilege.Type.DQL, "sys.cluster");
-        assertAskedForTable(Privilege.Type.DQL, "doc.users");
+        assertAskedForTable(Permission.DQL, "sys.cluster");
+        assertAskedForTable(Permission.DQL, "doc.users");
     }
 
     @Test
@@ -374,93 +375,93 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
         analyze("select * from (" +
                 " select users.id from users join parted on users.id = parted.id::long order by users.name limit 2" +
                 ") as users_parted order by users_parted.id");
-        assertAskedForTable(Privilege.Type.DQL, "doc.users");
-        assertAskedForTable(Privilege.Type.DQL, "doc.parted");
+        assertAskedForTable(Permission.DQL, "doc.users");
+        assertAskedForTable(Permission.DQL, "doc.parted");
     }
 
     @Test
     public void test_select_with_scalar_subselect_in_select() {
         analyze("SELECT 1, array(SELECT users.id FROM USERS), 2");
-        assertAskedForTable(Privilege.Type.DQL, "doc.users");
+        assertAskedForTable(Permission.DQL, "doc.users");
     }
 
     @Test
     public void test_select_with_scalar_subselect_in_where() {
         analyze("SELECT generate_series(1, 10, 1) WHERE EXISTS " +
                 "(SELECT u.a + 10 FROM (SELECT users.id AS a FROM USERS) u)");
-        assertAskedForTable(Privilege.Type.DQL, "doc.users");
+        assertAskedForTable(Permission.DQL, "doc.users");
     }
 
     @Test
     public void test_select_with_scalar_subselect_in_order_by() {
         analyze("SELECT generate_series(1, 10, 1) ORDER BY " +
                 "(SELECT u.a + 10 FROM (SELECT users.id AS a FROM USERS) u)");
-        assertAskedForTable(Privilege.Type.DQL, "doc.users");
+        assertAskedForTable(Permission.DQL, "doc.users");
     }
 
     @Test
     public void test_select_with_scalar_subselect_in_group_by() {
         analyze("SELECT count(*) FROM (SELECT * FROM GENERATE_SERIES(1,10,1) AS g) gs " +
                 "GROUP BY gs.g + (SELECT u.a + 10 FROM (SELECT users.id AS a FROM USERS) u)");
-        assertAskedForTable(Privilege.Type.DQL, "doc.users");
+        assertAskedForTable(Permission.DQL, "doc.users");
     }
 
     @Test
     public void test_select_with_scalar_subselect_in_having() {
         analyze("SELECT count(*) FROM parted GROUP BY id HAVING id > " +
                 "(SELECT u.a + 10 FROM (SELECT users.id AS a FROM USERS) u)");
-        assertAskedForTable(Privilege.Type.DQL, "doc.parted");
-        assertAskedForTable(Privilege.Type.DQL, "doc.users");
+        assertAskedForTable(Permission.DQL, "doc.parted");
+        assertAskedForTable(Permission.DQL, "doc.users");
     }
 
     @Test
     public void testCreateFunction() throws Exception {
         analyze("create function bar()" +
                 " returns long language dummy_lang AS 'function() { return 1; }'");
-        assertAskedForSchema(Privilege.Type.DDL, "doc");
+        assertAskedForSchema(Permission.DDL, "doc");
     }
 
     @Test
     public void testDropFunction() throws Exception {
         analyze("drop function bar(long, object)");
-        assertAskedForSchema(Privilege.Type.DDL, "doc");
+        assertAskedForSchema(Permission.DDL, "doc");
     }
 
     @Test
     public void testDropTable() throws Exception {
         analyze("drop table users");
-        assertAskedForTable(Privilege.Type.DDL, "doc.users");
+        assertAskedForTable(Permission.DDL, "doc.users");
     }
 
     @Test
     public void testDropBlobTable() throws Exception {
         analyze("drop blob table blobs");
-        assertAskedForTable(Privilege.Type.DDL, "blob.blobs");
+        assertAskedForTable(Permission.DDL, "blob.blobs");
     }
 
     @Test
     public void testCreateAnalyzer() throws Exception {
         analyze("create analyzer a1 (tokenizer lowercase)");
-        assertAskedForCluster(Privilege.Type.DDL);
+        assertAskedForCluster(Permission.DDL);
     }
 
     @Test
     public void testRefresh() throws Exception {
         analyze("refresh table users, parted partition (date = 1395874800000)");
-        assertAskedForTable(Privilege.Type.DQL, "doc.users");
-        assertAskedForTable(Privilege.Type.DQL, "doc.parted");
+        assertAskedForTable(Permission.DQL, "doc.users");
+        assertAskedForTable(Permission.DQL, "doc.parted");
     }
 
     @Test
     public void testRenameTable() throws Exception {
         analyze("alter table users rename to users_new");
-        assertAskedForTable(Privilege.Type.DDL, "doc.users");
+        assertAskedForTable(Permission.DDL, "doc.users");
     }
 
     @Test
     public void testAlterBlobTable() throws Exception {
         analyze("alter blob table blobs set (number_of_replicas=1)");
-        assertAskedForTable(Privilege.Type.DDL, "blob.blobs");
+        assertAskedForTable(Permission.DDL, "blob.blobs");
     }
 
     @Test
@@ -473,31 +474,31 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testAddColumn() throws Exception {
         analyze("alter table users add column foo string");
-        assertAskedForTable(Privilege.Type.DDL, "doc.users");
+        assertAskedForTable(Permission.DDL, "doc.users");
     }
 
     @Test
     public void test_drop_column() {
         analyze("alter table users drop column floats");
-        assertAskedForTable(Privilege.Type.DDL, "doc.users");
+        assertAskedForTable(Permission.DDL, "doc.users");
     }
 
     @Test
     public void test_rename_column() {
         analyze("alter table users rename column floats to flts");
-        assertAskedForTable(Privilege.Type.DDL, "doc.users");
+        assertAskedForTable(Permission.DDL, "doc.users");
     }
 
     @Test
     public void testOpenCloseTable() throws Exception {
         analyze("alter table users close");
-        assertAskedForTable(Privilege.Type.DDL, "doc.users");
+        assertAskedForTable(Permission.DDL, "doc.users");
     }
 
     @Test
     public void testShowTable() throws Exception {
         analyze("show create table users");
-        assertAskedForTable(Privilege.Type.DQL, "doc.users");
+        assertAskedForTable(Permission.DQL, "doc.users");
     }
 
     @Test
@@ -511,33 +512,33 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testExplainSelect() throws Exception {
         analyze("explain select * from users");
-        assertAskedForTable(Privilege.Type.DQL, "doc.users");
+        assertAskedForTable(Permission.DQL, "doc.users");
     }
 
     @Test
     public void testExplainCopyFrom() throws Exception {
         analyze("explain copy users from 'file:///tmp'");
-        assertAskedForTable(Privilege.Type.DML, "doc.users");
+        assertAskedForTable(Permission.DML, "doc.users");
     }
 
     @Test
     public void testUserWithDDLCanCreateViewOnTablesWhereDQLPermissionsAreAvailable() {
         analyze("create view xx.v1 as select * from doc.users");
-        assertAskedForSchema(Privilege.Type.DDL, "xx");
-        assertAskedForTable(Privilege.Type.DQL, "doc.users");
+        assertAskedForSchema(Permission.DDL, "xx");
+        assertAskedForTable(Permission.DQL, "doc.users");
     }
 
     @Test
     public void testQueryOnViewRequiresOwnerToHavePrivilegesOnInvolvedRelations() {
         analyze("select * from doc.v1");
-        assertAskedForView(Privilege.Type.DQL, "doc.v1");
-        assertAskedForTable(Privilege.Type.DQL, "doc.users", superUser);
+        assertAskedForView(Permission.DQL, "doc.v1");
+        assertAskedForTable(Permission.DQL, "doc.users", superUser);
     }
 
     @Test
     public void testDroppingAViewRequiresDDLPermissionOnView() {
         analyze("drop view doc.v1");
-        assertAskedForView(Privilege.Type.DDL, "doc.v1");
+        assertAskedForView(Permission.DDL, "doc.v1");
     }
 
     @Test
@@ -549,13 +550,13 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testFunctionsBoundToSchemaRequirePermissions() {
         analyze("select * from custom_schema.foo(1)");
-        assertAskedForSchema(Privilege.Type.DQL, "custom_schema");
+        assertAskedForSchema(Permission.DQL, "custom_schema");
     }
 
     @Test
     public void testPermissionCheckIsDoneOnSchemaAndTableNotOnTableAlias() {
         analyze("select * from doc.users as t");
-        assertAskedForTable(Privilege.Type.DQL, "doc.users");
+        assertAskedForTable(Permission.DQL, "doc.users");
     }
 
     @Test
@@ -569,53 +570,53 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void test_alter_cluster_reroute_retry_works_for_normal_user_with_AL_privileges() {
         analyze("alter cluster reroute retry failed", normalUser);
-        assertAskedForCluster(Privilege.Type.AL);
+        assertAskedForCluster(Permission.AL);
     }
 
     @Test
     public void test_alter_cluster_gc_dangling_artifacts_works_for_normal_user_with_AL_privileges() {
         analyze("alter cluster gc dangling artifacts", normalUser);
-        assertAskedForCluster(Privilege.Type.AL);
+        assertAskedForCluster(Permission.AL);
     }
 
     @Test
     public void test_alter_cluster_swap_table_works_for_normal_user_with_AL_privileges() {
         // pre-configured user has all privileges
         analyze("alter cluster swap table doc.t1 to doc.t2 with (drop_source = true)", normalUser);
-        assertAskedForCluster(Privilege.Type.AL);
+        assertAskedForCluster(Permission.AL);
     }
 
     @Test
     public void test_alter_cluster_swap_table_works_for_normal_user_with_no_AI_with_DDL_on_both_tables() {
         analyze("alter cluster swap table doc.t1 to doc.t2 with (drop_source = true)", ddlOnlyUser);
-        assertAskedForCluster(Privilege.Type.AL, ddlOnlyUser); // first checks AL and if user doesn't have it, checks both DDL-s
-        assertAskedForTable(Privilege.Type.DDL, "doc.t2", ddlOnlyUser);
-        assertAskedForTable(Privilege.Type.DDL, "doc.t1", ddlOnlyUser);
+        assertAskedForCluster(Permission.AL, ddlOnlyUser); // first checks AL and if user doesn't have it, checks both DDL-s
+        assertAskedForTable(Permission.DDL, "doc.t2", ddlOnlyUser);
+        assertAskedForTable(Permission.DDL, "doc.t1", ddlOnlyUser);
     }
 
     @Test
     public void test_a_user_with_al_on_cluster_privileges_can_create_other_users() {
         analyze("create user joe");
-        assertAskedForCluster(Privilege.Type.AL);
+        assertAskedForCluster(Permission.AL);
     }
 
     @Test
     public void test_a_user_with_al_on_cluster_can_delete_users() {
         analyze("drop user joe");
-        assertAskedForCluster(Privilege.Type.AL);
+        assertAskedForCluster(Permission.AL);
     }
 
     @Test
     public void test_a_user_with_al_on_cluster_can_grant_privileges_he_has_to_other_users() {
         analyze("GRANT DQL ON SCHEMA foo TO joe");
-        assertAskedForCluster(Privilege.Type.AL);
-        assertAskedForSchema(Privilege.Type.DQL, "foo");
+        assertAskedForCluster(Permission.AL);
+        assertAskedForSchema(Permission.DQL, "foo");
     }
 
     @Test
     public void test_a_user_with_al_can_revoke_privileges_from_users() {
         analyze("REVOKE DQL ON SCHEMA foo FROM joe");
-        assertAskedForCluster(Privilege.Type.AL);
+        assertAskedForCluster(Permission.AL);
     }
 
     @Test
@@ -690,14 +691,14 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void test_create_table_as_requires_DDL_on_target_and_DQL_on_source() {
         analyze("create table target_schema.target_table as (select * from sys.cluster)");
-        assertAskedForSchema(Privilege.Type.DDL, "target_schema");
-        assertAskedForTable(Privilege.Type.DQL, "sys.cluster");
+        assertAskedForSchema(Permission.DDL, "target_schema");
+        assertAskedForTable(Permission.DQL, "sys.cluster");
     }
 
     @Test
     public void test_optimize_table_is_allowed_with_ddl_privileges_on_table() {
         analyze("optimize table users");
-        assertAskedForTable(Privilege.Type.DDL, "doc.users");
+        assertAskedForTable(Permission.DDL, "doc.users");
     }
 
     @Test
@@ -709,10 +710,10 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void test_create_publication_asks_cluster_AL_and_all_for_each_table() {
         analyze("create publication pub1 FOR TABLE t1, t2", normalUser);
-        assertAskedForCluster(Privilege.Type.AL);
-        for (Privilege.Type type: READ_WRITE_DEFINE) {
-            assertAskedForTable(type, "doc.t1");
-            assertAskedForTable(type, "doc.t2");
+        assertAskedForCluster(Permission.AL);
+        for (Permission permission : READ_WRITE_DEFINE) {
+            assertAskedForTable(permission, "doc.t1");
+            assertAskedForTable(permission, "doc.t2");
         }
     }
 
@@ -724,7 +725,7 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
             .setUserManager(roleManager)
             .build();
         analyze("DROP PUBLICATION pub1", normalUser);
-        assertAskedForCluster(Privilege.Type.AL);
+        assertAskedForCluster(Permission.AL);
     }
 
     @Test
@@ -735,16 +736,16 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
             .setUserManager(roleManager)
             .build();
         analyze("ALTER PUBLICATION pub1 ADD TABLE t2", normalUser);
-        assertAskedForCluster(Privilege.Type.AL);
-        for (Privilege.Type type: READ_WRITE_DEFINE) {
-            assertAskedForTable(type, "doc.t2");
+        assertAskedForCluster(Permission.AL);
+        for (Permission permission : READ_WRITE_DEFINE) {
+            assertAskedForTable(permission, "doc.t2");
         }
     }
 
     @Test
     public void test_create_subscription_asks_cluster_AL() {
         analyze("create subscription sub1 CONNECTION 'postgresql://user@localhost/crate:5432' PUBLICATION pub1", normalUser);
-        assertAskedForCluster(Privilege.Type.AL);
+        assertAskedForCluster(Permission.AL);
     }
 
     @Test
@@ -755,7 +756,7 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
             .setUserManager(roleManager)
             .build();
         analyze("DROP SUBSCRIPTION sub1", normalUser);
-        assertAskedForCluster(Privilege.Type.AL);
+        assertAskedForCluster(Permission.AL);
     }
 
     @Test
@@ -766,19 +767,19 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
             .setUserManager(roleManager)
             .build();
         analyze("ALTER SUBSCRIPTION sub1 DISABLE", normalUser);
-        assertAskedForCluster(Privilege.Type.AL);
+        assertAskedForCluster(Permission.AL);
     }
 
     @Test
     public void test_anaylze_works_for_normal_user_with_AL_privileges() {
         analyze("ANALYZE", normalUser);
-        assertAskedForCluster(Privilege.Type.AL);
+        assertAskedForCluster(Permission.AL);
     }
 
     @Test
     public void test_declare_cursor_for_non_super_users() {
         analyze("DECLARE this_cursor NO SCROLL CURSOR FOR SELECT * FROM sys.summits;", normalUser);
-        assertAskedForTable(Privilege.Type.DQL, "sys.summits");
+        assertAskedForTable(Permission.DQL, "sys.summits");
     }
 
     @Test

--- a/server/src/test/java/io/crate/auth/user/RolePrivilegesTest.java
+++ b/server/src/test/java/io/crate/auth/user/RolePrivilegesTest.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
 
+import io.crate.role.Permission;
 import io.crate.role.Privilege;
 import io.crate.role.PrivilegeState;
 import io.crate.role.RolePrivileges;
@@ -38,15 +39,15 @@ import io.crate.role.Securable;
 public class RolePrivilegesTest extends ESTestCase {
 
     private static final Collection<Privilege> PRIVILEGES_CLUSTER_DQL = Set.of(
-        new Privilege(PrivilegeState.GRANT, Privilege.Type.DQL, Securable.CLUSTER, null, "crate")
+        new Privilege(PrivilegeState.GRANT, Permission.DQL, Securable.CLUSTER, null, "crate")
     );
 
     private static final Collection<Privilege> PRIVILEGES_SCHEMA_DQL = Set.of(
-        new Privilege(PrivilegeState.GRANT, Privilege.Type.DQL, Securable.SCHEMA, "doc", "crate")
+        new Privilege(PrivilegeState.GRANT, Permission.DQL, Securable.SCHEMA, "doc", "crate")
     );
 
     private static final Collection<Privilege> PRIVILEGES_TABLE_DQL = Set.of(
-        new Privilege(PrivilegeState.GRANT, Privilege.Type.DQL, Securable.TABLE, "doc.t1", "crate")
+        new Privilege(PrivilegeState.GRANT, Permission.DQL, Securable.TABLE, "doc.t1", "crate")
     );
 
     private static final RolePrivileges USER_PRIVILEGES_CLUSTER = new RolePrivileges(PRIVILEGES_CLUSTER_DQL);
@@ -57,9 +58,9 @@ public class RolePrivilegesTest extends ESTestCase {
     @Test
     public void testMatchPrivilegesEmpty() throws Exception {
         RolePrivileges rolePrivileges = new RolePrivileges(Collections.emptyList());
-        assertThat(rolePrivileges.matchPrivilege(Privilege.Type.DDL, Securable.CLUSTER, null)).isMissing();
-        assertThat(rolePrivileges.matchPrivilege(Privilege.Type.DDL, Securable.SCHEMA, "doc")).isMissing();
-        assertThat(rolePrivileges.matchPrivilege(Privilege.Type.DDL, Securable.TABLE, "doc.t1")).isMissing();
+        assertThat(rolePrivileges.matchPrivilege(Permission.DDL, Securable.CLUSTER, null)).isMissing();
+        assertThat(rolePrivileges.matchPrivilege(Permission.DDL, Securable.SCHEMA, "doc")).isMissing();
+        assertThat(rolePrivileges.matchPrivilege(Permission.DDL, Securable.TABLE, "doc.t1")).isMissing();
         assertThat(rolePrivileges.matchPrivilegeOfAnyType(Securable.CLUSTER, null)).isMissing();
         assertThat(rolePrivileges.matchPrivilegeOfAnyType(Securable.SCHEMA, "doc")).isMissing();
         assertThat(rolePrivileges.matchPrivilegeOfAnyType(Securable.TABLE, "doc.t1")).isMissing();
@@ -67,47 +68,47 @@ public class RolePrivilegesTest extends ESTestCase {
 
     @Test
     public void testMatchPrivilegeNoType() throws Exception {
-        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DDL, Securable.CLUSTER, null)).isMissing();
-        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DDL, Securable.SCHEMA, "doc")).isMissing();
-        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DDL, Securable.TABLE, "doc.t1")).isMissing();
+        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Permission.DDL, Securable.CLUSTER, null)).isMissing();
+        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Permission.DDL, Securable.SCHEMA, "doc")).isMissing();
+        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Permission.DDL, Securable.TABLE, "doc.t1")).isMissing();
         assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilegeOfAnyType(Securable.CLUSTER, null)).isGranted();
         assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilegeOfAnyType(Securable.SCHEMA, "doc")).isGranted();
         assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilegeOfAnyType(Securable.TABLE, "doc.t1")).isGranted();
     }
 
     @Test
-    public void testMatchPrivilegeType() throws Exception {
-        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DQL, Securable.CLUSTER, null)).isGranted();
+    public void testMatchPermission() throws Exception {
+        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Permission.DQL, Securable.CLUSTER, null)).isGranted();
         assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilegeOfAnyType(Securable.CLUSTER, null)).isGranted();
     }
 
     @Test
     public void testMatchPrivilegeSchema() throws Exception {
-        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DQL, Securable.SCHEMA, "doc")).isGranted();
+        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Permission.DQL, Securable.SCHEMA, "doc")).isGranted();
         assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilegeOfAnyType(Securable.SCHEMA, "doc")).isGranted();
-        assertThat(USER_PRIVILEGES_SCHEMA.matchPrivilege(Privilege.Type.DQL, Securable.SCHEMA, "doc")).isGranted();
+        assertThat(USER_PRIVILEGES_SCHEMA.matchPrivilege(Permission.DQL, Securable.SCHEMA, "doc")).isGranted();
         assertThat(USER_PRIVILEGES_SCHEMA.matchPrivilegeOfAnyType(Securable.SCHEMA, "doc")).isGranted();
     }
 
     @Test
     public void testMatchPrivilegeTable() throws Exception {
-        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DQL, Securable.TABLE, "doc.t1")).isGranted();
+        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Permission.DQL, Securable.TABLE, "doc.t1")).isGranted();
         assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilegeOfAnyType(Securable.TABLE, "doc.t1")).isGranted();
-        assertThat(USER_PRIVILEGES_SCHEMA.matchPrivilege(Privilege.Type.DQL, Securable.TABLE, "doc.t1")).isGranted();
+        assertThat(USER_PRIVILEGES_SCHEMA.matchPrivilege(Permission.DQL, Securable.TABLE, "doc.t1")).isGranted();
         assertThat(USER_PRIVILEGES_SCHEMA.matchPrivilegeOfAnyType(Securable.TABLE, "doc.t1")).isGranted();
-        assertThat(USER_PRIVILEGES_TABLE.matchPrivilege(Privilege.Type.DQL, Securable.TABLE, "doc.t1")).isGranted();
+        assertThat(USER_PRIVILEGES_TABLE.matchPrivilege(Permission.DQL, Securable.TABLE, "doc.t1")).isGranted();
         assertThat(USER_PRIVILEGES_TABLE.matchPrivilegeOfAnyType(Securable.TABLE, "doc.t1")).isGranted();
     }
 
     @Test
     public void testMatchPrivilegeDenyResultsInNoMatch() throws Exception {
         Collection<Privilege> privileges = Set.of(
-            new Privilege(PrivilegeState.DENY, Privilege.Type.DQL, Securable.CLUSTER, null, "crate")
+            new Privilege(PrivilegeState.DENY, Permission.DQL, Securable.CLUSTER, null, "crate")
         );
         RolePrivileges rolePrivileges = new RolePrivileges(privileges);
-        assertThat(rolePrivileges.matchPrivilege(Privilege.Type.DQL, Securable.CLUSTER, null)).isDenied();
-        assertThat(rolePrivileges.matchPrivilege(Privilege.Type.DQL, Securable.SCHEMA, "doc")).isDenied();
-        assertThat(rolePrivileges.matchPrivilege(Privilege.Type.DQL, Securable.TABLE, "doc.t1")).isDenied();
+        assertThat(rolePrivileges.matchPrivilege(Permission.DQL, Securable.CLUSTER, null)).isDenied();
+        assertThat(rolePrivileges.matchPrivilege(Permission.DQL, Securable.SCHEMA, "doc")).isDenied();
+        assertThat(rolePrivileges.matchPrivilege(Permission.DQL, Securable.TABLE, "doc.t1")).isDenied();
         assertThat(rolePrivileges.matchPrivilegeOfAnyType(Securable.CLUSTER, null)).isDenied();
         assertThat(rolePrivileges.matchPrivilegeOfAnyType(Securable.SCHEMA, "doc")).isDenied();
         assertThat(rolePrivileges.matchPrivilegeOfAnyType(Securable.TABLE, "doc.t1")).isDenied();
@@ -116,13 +117,13 @@ public class RolePrivilegesTest extends ESTestCase {
     @Test
     public void testMatchPrivilegeComplexSetIncludingDeny() throws Exception {
         Collection<Privilege> privileges = Set.of(
-            new Privilege(PrivilegeState.GRANT, Privilege.Type.DQL, Securable.CLUSTER, null, "crate"),
-            new Privilege(PrivilegeState.DENY, Privilege.Type.DQL, Securable.SCHEMA, "doc", "crate"),
-            new Privilege(PrivilegeState.GRANT, Privilege.Type.DQL, Securable.TABLE, "doc.t1", "crate")
+            new Privilege(PrivilegeState.GRANT, Permission.DQL, Securable.CLUSTER, null, "crate"),
+            new Privilege(PrivilegeState.DENY, Permission.DQL, Securable.SCHEMA, "doc", "crate"),
+            new Privilege(PrivilegeState.GRANT, Permission.DQL, Securable.TABLE, "doc.t1", "crate")
         );
         RolePrivileges rolePrivileges = new RolePrivileges(privileges);
-        assertThat(rolePrivileges.matchPrivilege(Privilege.Type.DQL, Securable.TABLE, "doc.t1")).isGranted();
-        assertThat(rolePrivileges.matchPrivilege(Privilege.Type.DQL, Securable.TABLE, "doc.t2")).isDenied();
-        assertThat(rolePrivileges.matchPrivilege(Privilege.Type.DQL, Securable.SCHEMA, "my_schema")).isGranted();
+        assertThat(rolePrivileges.matchPrivilege(Permission.DQL, Securable.TABLE, "doc.t1")).isGranted();
+        assertThat(rolePrivileges.matchPrivilege(Permission.DQL, Securable.TABLE, "doc.t2")).isDenied();
+        assertThat(rolePrivileges.matchPrivilege(Permission.DQL, Securable.SCHEMA, "my_schema")).isGranted();
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/HasDatabasePrivilegeFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/HasDatabasePrivilegeFunctionTest.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 import io.crate.Constants;
 import io.crate.exceptions.MissingPrivilegeException;
 import io.crate.metadata.pgcatalog.OidHash;
+import io.crate.role.Permission;
 import io.crate.role.Privilege;
 import io.crate.role.PrivilegeState;
 import io.crate.role.Role;
@@ -46,15 +47,15 @@ public class HasDatabasePrivilegeFunctionTest extends ScalarTestCase {
     private static final Role TEST_USER = RolesHelper.userOf("test");
     private static final Role TEST_USER_WITH_CREATE =
         RolesHelper.userOf("testWithCreate", Set.of(
-            new Privilege(PrivilegeState.GRANT, Privilege.Type.DDL, Securable.SCHEMA, "doc", Role.CRATE_USER.name())),
+            new Privilege(PrivilegeState.GRANT, Permission.DDL, Securable.SCHEMA, "doc", Role.CRATE_USER.name())),
             null);
     private static final Role TEST_USER_WITH_AL_ON_CLUSTER =
         RolesHelper.userOf("testUserWithClusterAL", Set.of(
-            new Privilege(PrivilegeState.GRANT, Privilege.Type.AL, Securable.CLUSTER, "crate", Role.CRATE_USER.name())),
+            new Privilege(PrivilegeState.GRANT, Permission.AL, Securable.CLUSTER, "crate", Role.CRATE_USER.name())),
             null);
     private static final Role TEST_USER_WITH_DQL_ON_SYS =
         RolesHelper.userOf("testUserWithSysDQL", Set.of(
-            new Privilege(PrivilegeState.GRANT, Privilege.Type.DQL, Securable.TABLE, "sys.privileges", Role.CRATE_USER.name())),
+            new Privilege(PrivilegeState.GRANT, Permission.DQL, Securable.TABLE, "sys.privileges", Role.CRATE_USER.name())),
             null);
 
     @Before
@@ -95,11 +96,11 @@ public class HasDatabasePrivilegeFunctionTest extends ScalarTestCase {
         assertThatThrownBy(
             () -> assertEvaluate("has_database_privilege('test', 'pg_catalog', 'TEMP , CREATE , SELECT')", null))
             .isExactlyInstanceOf(IllegalArgumentException.class)
-            .hasMessage("Unrecognized privilege type: select");
+            .hasMessage("Unrecognized permission: select");
         assertThatThrownBy(
             () -> assertEvaluate("has_database_privilege('test', 'pg_catalog', '')", null))
             .isExactlyInstanceOf(IllegalArgumentException.class)
-            .hasMessage("Unrecognized privilege type: ");
+            .hasMessage("Unrecognized permission: ");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/HasSchemaPrivilegeFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/HasSchemaPrivilegeFunctionTest.java
@@ -34,6 +34,7 @@ import io.crate.exceptions.MissingPrivilegeException;
 import io.crate.metadata.information.InformationSchemaInfo;
 import io.crate.metadata.pgcatalog.OidHash;
 import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
+import io.crate.role.Permission;
 import io.crate.role.Privilege;
 import io.crate.role.PrivilegeState;
 import io.crate.role.Role;
@@ -47,11 +48,11 @@ public class HasSchemaPrivilegeFunctionTest extends ScalarTestCase {
     private static final Role TEST_USER = RolesHelper.userOf("test");
     private static final Role TEST_USER_WITH_AL_ON_CLUSTER =
         RolesHelper.userOf("testUserWithClusterAL", Set.of(
-            new Privilege(PrivilegeState.GRANT, Privilege.Type.AL, Securable.CLUSTER, "crate", Role.CRATE_USER.name())),
+            new Privilege(PrivilegeState.GRANT, Permission.AL, Securable.CLUSTER, "crate", Role.CRATE_USER.name())),
             null);
     private static final Role TEST_USER_WITH_DQL_ON_SYS =
         RolesHelper.userOf("testUserWithSysDQL", Set.of(
-            new Privilege(PrivilegeState.GRANT, Privilege.Type.DQL, Securable.TABLE, "sys.privileges", Role.CRATE_USER.name())),
+            new Privilege(PrivilegeState.GRANT, Permission.DQL, Securable.TABLE, "sys.privileges", Role.CRATE_USER.name())),
             null);
 
     @Before
@@ -91,11 +92,11 @@ public class HasSchemaPrivilegeFunctionTest extends ScalarTestCase {
         assertThatThrownBy(
             () -> assertEvaluate("has_schema_privilege('test', 'pg_catalog', ' USAGE, CREATE, SELECT')", null))
             .isExactlyInstanceOf(IllegalArgumentException.class)
-            .hasMessage("Unrecognized privilege type: select");
+            .hasMessage("Unrecognized permission: select");
         assertThatThrownBy(
             () -> assertEvaluate("has_schema_privilege('test', 'pg_catalog', '')", null))
             .isExactlyInstanceOf(IllegalArgumentException.class)
-            .hasMessage("Unrecognized privilege type: ");
+            .hasMessage("Unrecognized permission: ");
     }
 
     @Test
@@ -126,7 +127,7 @@ public class HasSchemaPrivilegeFunctionTest extends ScalarTestCase {
 
     @Test
     public void test_user_with_DQL_permission_has_USAGE_but_not_CREATE_privilege_for_regular_schema() {
-        Privilege usage = new Privilege(PrivilegeState.GRANT, Privilege.Type.DQL, Securable.SCHEMA, "doc", "crate");
+        Privilege usage = new Privilege(PrivilegeState.GRANT, Permission.DQL, Securable.SCHEMA, "doc", "crate");
         var user = RolesHelper.userOf("test", Set.of(usage), null);
         sqlExpressions = new SqlExpressions(tableSources, null, user);
         assertEvaluate("has_schema_privilege('test', 'doc', 'USAGE')", true);
@@ -142,7 +143,7 @@ public class HasSchemaPrivilegeFunctionTest extends ScalarTestCase {
     @Test
     public void test_user_with_DDL_permission_has_CREATE_but_not_USAGE_privilege_for_regular_schema() {
         // having CREATE doesn't mean having USAGE - checked in PG13 as well.
-        Privilege create = new Privilege(PrivilegeState.GRANT, Privilege.Type.DDL, Securable.SCHEMA, "doc", "crate");
+        Privilege create = new Privilege(PrivilegeState.GRANT, Permission.DDL, Securable.SCHEMA, "doc", "crate");
         var user = RolesHelper.userOf("test", Set.of(create), null);
         sqlExpressions = new SqlExpressions(tableSources, null, user);
         assertEvaluate("has_schema_privilege('test', 'doc', 'USAGE')", false);

--- a/server/src/test/java/io/crate/integrationtests/RoleManagementIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/RoleManagementIntegrationTest.java
@@ -39,6 +39,7 @@ import org.junit.Test;
 import io.crate.action.sql.Session;
 import io.crate.action.sql.Sessions;
 import io.crate.exceptions.UnsupportedFeatureException;
+import io.crate.role.Permission;
 import io.crate.role.Privilege;
 import io.crate.role.PrivilegeState;
 import io.crate.role.Securable;
@@ -54,7 +55,7 @@ public class RoleManagementIntegrationTest extends BaseRolesIntegrationTest {
         Sessions sqlOperations = cluster().getInstance(Sessions.class);
         var alPriv = new Privilege(
             PrivilegeState.GRANT,
-            Privilege.Type.AL,
+            Permission.AL,
             Securable.CLUSTER,
             null,
             "crate");

--- a/server/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
@@ -69,6 +69,7 @@ import org.junit.rules.TemporaryFolder;
 
 import io.crate.common.unit.TimeValue;
 import io.crate.expression.udf.UserDefinedFunctionService;
+import io.crate.role.Permission;
 import io.crate.role.Privilege;
 import io.crate.role.PrivilegeState;
 import io.crate.role.Securable;
@@ -1052,11 +1053,11 @@ public class SnapshotRestoreIntegrationTest extends IntegTestCase {
         assertThat(usersPrivilegesMetadata.getUserPrivileges("Arthur")).isEmpty();
         assertThat(usersPrivilegesMetadata.getUserPrivileges("John")).containsExactly(
             new Privilege(
-                PrivilegeState.GRANT, Privilege.Type.DQL, Securable.SCHEMA, "sys", "crate")
+                PrivilegeState.GRANT, Permission.DQL, Securable.SCHEMA, "sys", "crate")
         );
         assertThat(usersPrivilegesMetadata.getUserPrivileges("Ford")).containsExactly(
             new Privilege(
-                PrivilegeState.GRANT, Privilege.Type.AL, Securable.CLUSTER, null, "crate")
+                PrivilegeState.GRANT, Permission.AL, Securable.CLUSTER, null, "crate")
         );
 
         execute("ALTER USER \"John\" SET (password='johns-new-password')");

--- a/server/src/test/java/io/crate/integrationtests/SysPrivilegesIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysPrivilegesIntegrationTest.java
@@ -32,6 +32,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Before;
 import org.junit.Test;
 
+import io.crate.role.Permission;
 import io.crate.role.Privilege;
 import io.crate.role.PrivilegeState;
 import io.crate.role.RoleManager;
@@ -40,8 +41,8 @@ import io.crate.role.Securable;
 public class SysPrivilegesIntegrationTest extends BaseRolesIntegrationTest {
 
     private static final Set<Privilege> PRIVILEGES = new HashSet<>(Arrays.asList(
-        new Privilege(PrivilegeState.GRANT, Privilege.Type.DQL, Securable.CLUSTER, null, "crate"),
-        new Privilege(PrivilegeState.GRANT, Privilege.Type.DML, Securable.CLUSTER, null, "crate")));
+        new Privilege(PrivilegeState.GRANT, Permission.DQL, Securable.CLUSTER, null, "crate"),
+        new Privilege(PrivilegeState.GRANT, Permission.DML, Securable.CLUSTER, null, "crate")));
     private static final List<String> USERNAMES = Arrays.asList("ford", "arthur", "normal");
 
 

--- a/server/src/test/java/io/crate/replication/logical/action/PublicationsStateActionTest.java
+++ b/server/src/test/java/io/crate/replication/logical/action/PublicationsStateActionTest.java
@@ -45,7 +45,7 @@ import io.crate.metadata.RelationName;
 import io.crate.metadata.Schemas;
 import io.crate.replication.logical.metadata.Publication;
 import io.crate.replication.logical.metadata.RelationMetadata;
-import io.crate.role.Privilege;
+import io.crate.role.Permission;
 import io.crate.role.Role;
 import io.crate.role.Roles;
 import io.crate.role.Securable;
@@ -81,7 +81,7 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
             }
 
             @Override
-            public boolean hasPrivilege(Role user, Privilege.Type type, Securable securable, @Nullable String ident) {
+            public boolean hasPrivilege(Role user, Permission permission, Securable securable, @Nullable String ident) {
                 return true; // This test case doesn't check privileges.
             }
         };
@@ -123,7 +123,7 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
             }
 
             @Override
-            public boolean hasPrivilege(Role user, Privilege.Type type, Securable securable, @Nullable String ident) {
+            public boolean hasPrivilege(Role user, Permission permission, Securable securable, @Nullable String ident) {
                 if (user.name().equals("publisher")) {
                     return "doc.t1".equals(ident);
                 } else {
@@ -162,7 +162,7 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
             }
 
             @Override
-            public boolean hasPrivilege(Role user, Privilege.Type type, Securable securable, @Nullable String ident) {
+            public boolean hasPrivilege(Role user, Permission permission, Securable securable, @Nullable String ident) {
                 if (user.name().equals("subscriber")) {
                     return "doc.t1".equals(ident);
                 } else {
@@ -195,7 +195,7 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
             }
 
             @Override
-            public boolean hasPrivilege(Role user, Privilege.Type type, Securable securable, @Nullable String ident) {
+            public boolean hasPrivilege(Role user, Permission permission, Securable securable, @Nullable String ident) {
                 if (user.name().equals("subscriber")) {
                     return "doc.t1".equals(ident);
                 } else {
@@ -236,7 +236,7 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
             }
 
             @Override
-            public boolean hasPrivilege(Role user, Privilege.Type type, Securable securable, @Nullable String ident) {
+            public boolean hasPrivilege(Role user, Permission permission, Securable securable, @Nullable String ident) {
                 return true; // This test case doesn't check privileges.
             }
         };
@@ -269,7 +269,7 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
             }
 
             @Override
-            public boolean hasPrivilege(Role user, Privilege.Type type, Securable securable, @Nullable String ident) {
+            public boolean hasPrivilege(Role user, Permission permission, Securable securable, @Nullable String ident) {
                 return true; // This test case doesn't check privileges.
             }
         };
@@ -306,7 +306,7 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
             }
 
             @Override
-            public boolean hasPrivilege(Role user, Privilege.Type type, Securable securable, @Nullable String ident) {
+            public boolean hasPrivilege(Role user, Permission permission, Securable securable, @Nullable String ident) {
                 return true; // This test case doesn't check privileges.
             }
         };
@@ -340,7 +340,7 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
             }
 
             @Override
-            public boolean hasPrivilege(Role user, Privilege.Type type, Securable securable, @Nullable String ident) {
+            public boolean hasPrivilege(Role user, Permission permission, Securable securable, @Nullable String ident) {
                 return true; // This test case doesn't check privileges.
             }
         };

--- a/server/src/test/java/io/crate/role/PrivilegesModifierTest.java
+++ b/server/src/test/java/io/crate/role/PrivilegesModifierTest.java
@@ -44,27 +44,27 @@ import io.crate.role.metadata.RolesMetadata;
 public class PrivilegesModifierTest {
 
     private static final Privilege GRANT_DQL =
-        new Privilege(PrivilegeState.GRANT, Privilege.Type.DQL, Securable.CLUSTER, null, "crate");
+        new Privilege(PrivilegeState.GRANT, Permission.DQL, Securable.CLUSTER, null, "crate");
     private static final Privilege GRANT_DML =
-        new Privilege(PrivilegeState.GRANT, Privilege.Type.DML, Securable.CLUSTER, null, "crate");
+        new Privilege(PrivilegeState.GRANT, Permission.DML, Securable.CLUSTER, null, "crate");
     private static final Privilege REVOKE_DQL =
-        new Privilege(PrivilegeState.REVOKE, Privilege.Type.DQL, Securable.CLUSTER, null, "crate");
+        new Privilege(PrivilegeState.REVOKE, Permission.DQL, Securable.CLUSTER, null, "crate");
     private static final Privilege REVOKE_DML =
-        new Privilege(PrivilegeState.REVOKE, Privilege.Type.DML, Securable.CLUSTER, null, "crate");
+        new Privilege(PrivilegeState.REVOKE, Permission.DML, Securable.CLUSTER, null, "crate");
     public static final Privilege DENY_DQL =
-        new Privilege(PrivilegeState.DENY, Privilege.Type.DQL, Securable.CLUSTER, null, "crate");
+        new Privilege(PrivilegeState.DENY, Permission.DQL, Securable.CLUSTER, null, "crate");
     public static final Privilege GRANT_TABLE_DQL =
-        new Privilege(PrivilegeState.GRANT, Privilege.Type.DQL, Securable.TABLE, "testSchema.test", "crate");
+        new Privilege(PrivilegeState.GRANT, Permission.DQL, Securable.TABLE, "testSchema.test", "crate");
     public static final Privilege GRANT_TABLE_DDL =
-        new Privilege(PrivilegeState.GRANT, Privilege.Type.DDL, Securable.TABLE, "testSchema.test2", "crate");
+        new Privilege(PrivilegeState.GRANT, Permission.DDL, Securable.TABLE, "testSchema.test2", "crate");
     public static final Privilege GRANT_VIEW_DQL =
-        new Privilege(PrivilegeState.GRANT, Privilege.Type.DQL, Securable.VIEW, "testSchema.view1", "crate");
+        new Privilege(PrivilegeState.GRANT, Permission.DQL, Securable.VIEW, "testSchema.view1", "crate");
     public static final Privilege GRANT_VIEW_DDL =
-        new Privilege(PrivilegeState.GRANT, Privilege.Type.DDL, Securable.VIEW, "testSchema.view2", "crate");
+        new Privilege(PrivilegeState.GRANT, Permission.DDL, Securable.VIEW, "testSchema.view2", "crate");
     public static final Privilege GRANT_VIEW_DML =
-        new Privilege(PrivilegeState.GRANT, Privilege.Type.DML, Securable.VIEW, "view3", "crate");
+        new Privilege(PrivilegeState.GRANT, Permission.DML, Securable.VIEW, "view3", "crate");
     public static final Privilege GRANT_SCHEMA_DML =
-        new Privilege(PrivilegeState.GRANT, Privilege.Type.DML, Securable.SCHEMA, "testSchema", "crate");
+        new Privilege(PrivilegeState.GRANT, Permission.DML, Securable.SCHEMA, "testSchema", "crate");
 
     public static final Set<Privilege> PRIVILEGES = new HashSet<>(Arrays.asList(GRANT_DQL, GRANT_DML));
     public static final List<String> USERNAMES = Arrays.asList("Ford", "Arthur");
@@ -130,7 +130,7 @@ public class PrivilegesModifierTest {
             rolesMetadata,
             Collections.singletonList("Arthur"),
             Collections.singletonList(new Privilege(
-                PrivilegeState.REVOKE, Privilege.Type.DML, Securable.CLUSTER, null, "hoschi"))
+                PrivilegeState.REVOKE, Permission.DML, Securable.CLUSTER, null, "hoschi"))
         );
 
         assertThat(rowCount).isEqualTo(1L);

--- a/server/src/test/java/io/crate/role/PrivilegesRequestTest.java
+++ b/server/src/test/java/io/crate/role/PrivilegesRequestTest.java
@@ -36,11 +36,11 @@ public class PrivilegesRequestTest extends ESTestCase {
     public void testStreaming() throws Exception {
         List<String> roles = List.of("ford", "arthur");
         List<Privilege> privileges = List.of(
-            new Privilege(PrivilegeState.GRANT, Privilege.Type.DQL, Securable.CLUSTER, null, "crate"),
-            new Privilege(PrivilegeState.GRANT, Privilege.Type.DML, Securable.CLUSTER, null, "crate"),
-            new Privilege(PrivilegeState.GRANT, Privilege.Type.DML, Securable.SCHEMA, null, "crate"),
-            new Privilege(PrivilegeState.GRANT, Privilege.Type.DDL, Securable.TABLE, null, "crate"),
-            new Privilege(PrivilegeState.GRANT, Privilege.Type.DML, Securable.VIEW, null, "crate")
+            new Privilege(PrivilegeState.GRANT, Permission.DQL, Securable.CLUSTER, null, "crate"),
+            new Privilege(PrivilegeState.GRANT, Permission.DML, Securable.CLUSTER, null, "crate"),
+            new Privilege(PrivilegeState.GRANT, Permission.DML, Securable.SCHEMA, null, "crate"),
+            new Privilege(PrivilegeState.GRANT, Permission.DDL, Securable.TABLE, null, "crate"),
+            new Privilege(PrivilegeState.GRANT, Permission.DML, Securable.VIEW, null, "crate")
         );
         GrantedRolesChange grantedRolesChange = new GrantedRolesChange(
             PrivilegeState.REVOKE, Set.of("role1", "role2"), "admin");

--- a/server/src/test/java/io/crate/role/PrivilegesTest.java
+++ b/server/src/test/java/io/crate/role/PrivilegesTest.java
@@ -38,7 +38,7 @@ public class PrivilegesTest extends ESTestCase {
 
     @Test
     public void testExceptionIsThrownIfUserHasNotRequiredPrivilege() throws Exception {
-        assertThatThrownBy(() -> ensureUserHasPrivilege(Privilege.Type.DQL, Securable.CLUSTER, null))
+        assertThatThrownBy(() -> ensureUserHasPrivilege(Permission.DQL, Securable.CLUSTER, null))
             .isExactlyInstanceOf(MissingPrivilegeException.class)
             .hasMessage("Missing 'DQL' privilege for user 'ford'");
     }
@@ -46,7 +46,7 @@ public class PrivilegesTest extends ESTestCase {
     @Test
     public void testNoExceptionIsThrownIfUserHasNotRequiredPrivilegeOnInformationSchema() throws Exception {
         //ensureUserHasPrivilege will not throw an exception if the schema is `information_schema`
-        ensureUserHasPrivilege(Privilege.Type.DQL, Securable.SCHEMA, "information_schema");
+        ensureUserHasPrivilege(Permission.DQL, Securable.SCHEMA, "information_schema");
     }
 
     @Test
@@ -76,7 +76,7 @@ public class PrivilegesTest extends ESTestCase {
         Privileges.ensureUserHasPrivilege(ROLES, USER, securable, ident);
     }
 
-    private static void ensureUserHasPrivilege(Privilege.Type type, Securable securable, String ident) {
-        Privileges.ensureUserHasPrivilege(ROLES, USER, type, securable, ident);
+    private static void ensureUserHasPrivilege(Permission permission, Securable securable, String ident) {
+        Privileges.ensureUserHasPrivilege(ROLES, USER, permission, securable, ident);
     }
 }

--- a/server/src/test/java/io/crate/role/RolesServiceTest.java
+++ b/server/src/test/java/io/crate/role/RolesServiceTest.java
@@ -77,7 +77,7 @@ public class RolesServiceTest extends CrateDummyClusterServiceUnitTest {
         var docOid = OidHash.schemaOid("doc");
         var grantDDLCluster = new Privilege(
             PrivilegeState.GRANT,
-            Privilege.Type.DDL,
+            Permission.DDL,
             Securable.CLUSTER,
             null,
             "crate"
@@ -90,12 +90,12 @@ public class RolesServiceTest extends CrateDummyClusterServiceUnitTest {
                 return role1;
             }
         };
-        assertThat(roleService.hasSchemaPrivilege(role1, Privilege.Type.DDL, sysOid)).isTrue();
-        assertThat(roleService.hasSchemaPrivilege(role1, Privilege.Type.DDL, docOid)).isTrue();
+        assertThat(roleService.hasSchemaPrivilege(role1, Permission.DDL, sysOid)).isTrue();
+        assertThat(roleService.hasSchemaPrivilege(role1, Permission.DDL, docOid)).isTrue();
 
         var denyDDLSys = new Privilege(
             PrivilegeState.DENY,
-            Privilege.Type.DDL,
+            Permission.DDL,
             Securable.SCHEMA,
             "sys",
             "crate"
@@ -107,8 +107,8 @@ public class RolesServiceTest extends CrateDummyClusterServiceUnitTest {
                 return role2;
             }
         };
-        assertThat(roleService.hasSchemaPrivilege(role2, Privilege.Type.DDL, sysOid)).isFalse();
-        assertThat(roleService.hasSchemaPrivilege(role2, Privilege.Type.DDL, docOid)).isTrue();
+        assertThat(roleService.hasSchemaPrivilege(role2, Permission.DDL, sysOid)).isFalse();
+        assertThat(roleService.hasSchemaPrivilege(role2, Permission.DDL, docOid)).isTrue();
     }
 
     @Test
@@ -139,7 +139,7 @@ public class RolesServiceTest extends CrateDummyClusterServiceUnitTest {
          */
         var privilege = new Privilege(
             PrivilegeState.GRANT,
-            Privilege.Type.DDL,
+            Permission.DDL,
             Securable.SCHEMA,
             "sys",
             "crate"
@@ -164,12 +164,12 @@ public class RolesServiceTest extends CrateDummyClusterServiceUnitTest {
             }
         };
         for (var role : roles.values()) {
-            assertThat(roleService.hasPrivilege(role, Privilege.Type.DDL, Securable.SCHEMA, "sys"))
+            assertThat(roleService.hasPrivilege(role, Permission.DDL, Securable.SCHEMA, "sys"))
                 .as("role=" + role.name())
                 .isTrue();
             assertThat(roleService.hasAnyPrivilege(role, Securable.SCHEMA, "sys"))
                 .isTrue();
-            assertThat(roleService.hasSchemaPrivilege(role, Privilege.Type.DDL, OidHash.schemaOid("sys")))
+            assertThat(roleService.hasSchemaPrivilege(role, Permission.DDL, OidHash.schemaOid("sys")))
                 .isTrue();
         }
     }
@@ -185,35 +185,35 @@ public class RolesServiceTest extends CrateDummyClusterServiceUnitTest {
          */
         var grantDDLCluster = new Privilege(
             PrivilegeState.GRANT,
-            Privilege.Type.DDL,
+            Permission.DDL,
             Securable.CLUSTER,
             null,
             "crate"
         );
         var grantDDLSys = new Privilege(
             PrivilegeState.GRANT,
-            Privilege.Type.DDL,
+            Permission.DDL,
             Securable.SCHEMA,
             "sys",
             "crate"
         );
         var grantDDLDoc = new Privilege(
             PrivilegeState.GRANT,
-            Privilege.Type.DDL,
+            Permission.DDL,
             Securable.SCHEMA,
             "doc",
             "crate"
         );
         var denyDDLSys = new Privilege(
             PrivilegeState.DENY,
-            Privilege.Type.DDL,
+            Permission.DDL,
             Securable.SCHEMA,
             "sys",
             "crate"
         );
         var denyDDLDoc = new Privilege(
             PrivilegeState.DENY,
-            Privilege.Type.DDL,
+            Permission.DDL,
             Securable.SCHEMA,
             "doc",
             "crate"
@@ -235,32 +235,32 @@ public class RolesServiceTest extends CrateDummyClusterServiceUnitTest {
             }
         };
 
-        assertThat(roleService.hasPrivilege(role1, Privilege.Type.DDL, Securable.SCHEMA, "sys")).isTrue();
-        assertThat(roleService.hasPrivilege(role1, Privilege.Type.DDL, Securable.SCHEMA, "doc")).isTrue();
+        assertThat(roleService.hasPrivilege(role1, Permission.DDL, Securable.SCHEMA, "sys")).isTrue();
+        assertThat(roleService.hasPrivilege(role1, Permission.DDL, Securable.SCHEMA, "doc")).isTrue();
         assertThat(roleService.hasAnyPrivilege(role1, Securable.SCHEMA, "sys")).isTrue();
         assertThat(roleService.hasAnyPrivilege(role1, Securable.SCHEMA, "doc")).isTrue();
-        assertThat(roleService.hasSchemaPrivilege(role1, Privilege.Type.DDL, OidHash.schemaOid("sys"))).isTrue();
-        assertThat(roleService.hasSchemaPrivilege(role1, Privilege.Type.DDL, OidHash.schemaOid("doc"))).isTrue();
+        assertThat(roleService.hasSchemaPrivilege(role1, Permission.DDL, OidHash.schemaOid("sys"))).isTrue();
+        assertThat(roleService.hasSchemaPrivilege(role1, Permission.DDL, OidHash.schemaOid("doc"))).isTrue();
 
-        assertThat(roleService.hasPrivilege(role2, Privilege.Type.DDL, Securable.SCHEMA, "sys")).isFalse();
-        assertThat(roleService.hasPrivilege(role2, Privilege.Type.DDL, Securable.SCHEMA, "doc")).isTrue();
+        assertThat(roleService.hasPrivilege(role2, Permission.DDL, Securable.SCHEMA, "sys")).isFalse();
+        assertThat(roleService.hasPrivilege(role2, Permission.DDL, Securable.SCHEMA, "doc")).isTrue();
         assertThat(roleService.hasAnyPrivilege(role2, Securable.SCHEMA, "sys")).isFalse();
         assertThat(roleService.hasAnyPrivilege(role2, Securable.SCHEMA, "doc")).isTrue();
-        assertThat(roleService.hasSchemaPrivilege(role2, Privilege.Type.DDL, OidHash.schemaOid("sys"))).isFalse();
-        assertThat(roleService.hasSchemaPrivilege(role2, Privilege.Type.DDL, OidHash.schemaOid("doc"))).isTrue();
+        assertThat(roleService.hasSchemaPrivilege(role2, Permission.DDL, OidHash.schemaOid("sys"))).isFalse();
+        assertThat(roleService.hasSchemaPrivilege(role2, Permission.DDL, OidHash.schemaOid("doc"))).isTrue();
 
-        assertThat(roleService.hasPrivilege(role3, Privilege.Type.DDL, Securable.SCHEMA, "sys")).isTrue();
-        assertThat(roleService.hasPrivilege(role3, Privilege.Type.DDL, Securable.SCHEMA, "doc")).isFalse();
+        assertThat(roleService.hasPrivilege(role3, Permission.DDL, Securable.SCHEMA, "sys")).isTrue();
+        assertThat(roleService.hasPrivilege(role3, Permission.DDL, Securable.SCHEMA, "doc")).isFalse();
         assertThat(roleService.hasAnyPrivilege(role3, Securable.SCHEMA, "sys")).isTrue();
         assertThat(roleService.hasAnyPrivilege(role3, Securable.SCHEMA, "doc")).isFalse();
-        assertThat(roleService.hasSchemaPrivilege(role3, Privilege.Type.DDL, OidHash.schemaOid("sys"))).isTrue();
-        assertThat(roleService.hasSchemaPrivilege(role3, Privilege.Type.DDL, OidHash.schemaOid("doc"))).isFalse();
+        assertThat(roleService.hasSchemaPrivilege(role3, Permission.DDL, OidHash.schemaOid("sys"))).isTrue();
+        assertThat(roleService.hasSchemaPrivilege(role3, Permission.DDL, OidHash.schemaOid("doc"))).isFalse();
 
-        assertThat(roleService.hasPrivilege(role4, Privilege.Type.DDL, Securable.SCHEMA, "sys")).isFalse();
-        assertThat(roleService.hasPrivilege(role4, Privilege.Type.DDL, Securable.SCHEMA, "doc")).isFalse();
+        assertThat(roleService.hasPrivilege(role4, Permission.DDL, Securable.SCHEMA, "sys")).isFalse();
+        assertThat(roleService.hasPrivilege(role4, Permission.DDL, Securable.SCHEMA, "doc")).isFalse();
         assertThat(roleService.hasAnyPrivilege(role4, Securable.SCHEMA, "sys")).isFalse();
         assertThat(roleService.hasAnyPrivilege(role4, Securable.SCHEMA, "doc")).isFalse();
-        assertThat(roleService.hasSchemaPrivilege(role4, Privilege.Type.DDL, OidHash.schemaOid("sys"))).isFalse();
-        assertThat(roleService.hasSchemaPrivilege(role4, Privilege.Type.DDL, OidHash.schemaOid("doc"))).isFalse();
+        assertThat(roleService.hasSchemaPrivilege(role4, Permission.DDL, OidHash.schemaOid("sys"))).isFalse();
+        assertThat(roleService.hasSchemaPrivilege(role4, Permission.DDL, OidHash.schemaOid("doc"))).isFalse();
     }
 }

--- a/server/src/test/java/io/crate/role/TransportPrivilegesActionTest.java
+++ b/server/src/test/java/io/crate/role/TransportPrivilegesActionTest.java
@@ -44,11 +44,11 @@ import io.crate.role.metadata.RolesMetadata;
 public class TransportPrivilegesActionTest extends ESTestCase {
 
     private static final Privilege GRANT_DQL =
-        new Privilege(PrivilegeState.GRANT, Privilege.Type.DQL, Securable.CLUSTER, null, "crate");
+        new Privilege(PrivilegeState.GRANT, Permission.DQL, Securable.CLUSTER, null, "crate");
     private static final Privilege GRANT_DML =
-        new Privilege(PrivilegeState.GRANT, Privilege.Type.DML, Securable.CLUSTER, null, "crate");
+        new Privilege(PrivilegeState.GRANT, Permission.DML, Securable.CLUSTER, null, "crate");
     private static final Privilege DENY_DQL =
-        new Privilege(PrivilegeState.DENY, Privilege.Type.DQL, Securable.CLUSTER, null, "crate");
+        new Privilege(PrivilegeState.DENY, Permission.DQL, Securable.CLUSTER, null, "crate");
     private static final Set<Privilege> PRIVILEGES = new HashSet<>(Arrays.asList(GRANT_DQL, GRANT_DML));
 
     @Test

--- a/server/src/test/java/io/crate/role/metadata/RolesHelper.java
+++ b/server/src/test/java/io/crate/role/metadata/RolesHelper.java
@@ -36,6 +36,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import io.crate.role.GrantedRole;
+import io.crate.role.Permission;
 import io.crate.role.Privilege;
 import io.crate.role.PrivilegeState;
 import io.crate.role.Role;
@@ -74,11 +75,11 @@ public final class RolesHelper {
 
     public static final Map<String, Set<Privilege>> OLD_DUMMY_USERS_PRIVILEGES = Map.of(
         "Ford", Set.of(
-            new Privilege(PrivilegeState.GRANT, Privilege.Type.DQL, Securable.CLUSTER, null, "crate"),
-            new Privilege(PrivilegeState.GRANT, Privilege.Type.DML, Securable.SCHEMA, "doc", "crate")
+            new Privilege(PrivilegeState.GRANT, Permission.DQL, Securable.CLUSTER, null, "crate"),
+            new Privilege(PrivilegeState.GRANT, Permission.DML, Securable.SCHEMA, "doc", "crate")
         ),
         "Arthur", Set.of(
-            new Privilege(PrivilegeState.GRANT, Privilege.Type.DML, Securable.SCHEMA, "doc", "crate")
+            new Privilege(PrivilegeState.GRANT, Permission.DML, Securable.SCHEMA, "doc", "crate")
         ));
 
     public static UsersMetadata usersMetadataOf(Map<String, Role> users) {


### PR DESCRIPTION
Move the enum from inner class of Privilege to top level and rename it from Type to Permission for better clarity of its purpose.
