### PR TITLE
Revert "Temporarily disable codeproject.com from linkcheck"

### DIFF
--- a/docs/appendices/release-notes/5.5.3.rst
+++ b/docs/appendices/release-notes/5.5.3.rst
@@ -49,9 +49,10 @@ See the :ref:`version_5.5.0` release notes for a full list of changes in the
 Fixes
 =====
 
-- Forbid :ref:`renaming <sql-alter-table-rename-to>` of views and tables if the
-  target table or view already exists, and return an error message. Previously,
-  such a rename was allowed which caused the existing view or table to be lost.
+- Rejected :ref:`renaming <sql-alter-table-rename-to>` of views and tables if
+  the target table or view already exists, and return an error message.
+  Previously, such a rename was allowed which caused the existing view or table
+  to be lost.
 
 - Fixed a regression introduced in 4.2.0 that caused queries with ``UNNEST``
   with a single nested array as parameter to fail with a

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,6 +25,5 @@ extensions.append('crate.sphinx.csv')
 
 linkcheck_ignore = [
     'https://www.iso.org/obp/ui/.*',  # Breaks accessibility via JS ¯\_(ツ)_/¯
-    'https://www.codeproject.com/',   # Went down on 2024-01-10
 ]
 linkcheck_retries = 3


### PR DESCRIPTION
- Fix release note, reword
  Follows: #15316

- Revert "Temporarily disable codeproject.com from linkcheck"
  This reverts commit 331366267327dad7eea8bafa109ab6dee74758f8.
  Issues seems fixed and site is back again.

