### PR TITLE
Ensure equi-join condition refers to two columns from two different relations

### DIFF
--- a/docs/appendices/release-notes/5.5.3.rst
+++ b/docs/appendices/release-notes/5.5.3.rst
@@ -112,3 +112,9 @@ Fixes
         modification_date TIMESTAMP AS current_timestamp
     )
     INSERT INTO tbl (id, a) VALUES (1, 2) ON CONFLICT (id) DO UPDATE SET a = 3;
+
+- Fixed an issue that caused joins with the join conditions that referred to
+  columns from a single table only from returning invalid results. i.e.::
+
+    SELECT * FROM t1 INNER JOIN t2 ON t1.col = t1.col;
+

--- a/server/src/test/java/io/crate/planner/operators/EquiJoinDetectorTest.java
+++ b/server/src/test/java/io/crate/planner/operators/EquiJoinDetectorTest.java
@@ -101,4 +101,13 @@ public class EquiJoinDetectorTest extends CrateDummyClusterServiceUnitTest {
         Symbol joinCondition = sqlExpressions.asSymbol("NOT (t1.a = t2.b)");
         assertThat(EquiJoinDetector.isHashJoinPossible(JoinType.INNER, joinCondition), is(false));
     }
+
+    @Test
+    public void test_not_hash_join_possible_if_join_condition_refers_to_columns_from_a_single_relation() {
+        Symbol joinCondition = sqlExpressions.asSymbol("t1.a + t1.a = t1.a + t1.a");
+        assertThat(EquiJoinDetector.isHashJoinPossible(JoinType.INNER, joinCondition), is(false));
+
+        joinCondition = sqlExpressions.asSymbol("t1.x = t1.i");
+        assertThat(EquiJoinDetector.isHashJoinPossible(JoinType.INNER, joinCondition), is(false));
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes https://github.com/crate/crate/issues/15324. Occurs on `3.0`, possibly before. 

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
