### PR TITLE
Remove custom findUser in RolesService

### DIFF
--- a/server/src/main/java/io/crate/role/RolesService.java
+++ b/server/src/main/java/io/crate/role/RolesService.java
@@ -52,16 +52,6 @@ public class RolesService implements Roles, ClusterStateListener {
         return roles.values();
     }
 
-    @Nullable
-    @Override
-    public Role findUser(String userName) {
-        Role role = roles.get(userName);
-        if (role != null && role.isUser()) {
-            return role;
-        }
-        return null;
-    }
-
     @Override
     @Nullable
     public Role findRole(String roleName) {


### PR DESCRIPTION
The default implementation is the same
(It uses `findRole`, so the hash lookup optimization applies too)
