### PR TITLE
Backport test cases only from #15280

### DIFF
--- a/server/src/testFixtures/java/io/crate/testing/QueryTester.java
+++ b/server/src/testFixtures/java/io/crate/testing/QueryTester.java
@@ -45,6 +45,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 
 import io.crate.analyze.relations.DocTableRelation;
 import io.crate.common.collections.Iterables;
+import io.crate.common.collections.Lists2;
 import io.crate.data.Input;
 import io.crate.execution.dml.IndexItem;
 import io.crate.execution.dml.Indexer;
@@ -149,6 +150,23 @@ public final class QueryTester implements AutoCloseable {
                 null
             );
             var item = new IndexItem.StaticItem("dummy-id", List.of(), new Object[] { value }, -1L, -1L);
+            ParsedDocument parsedDocument = indexer.index(item);
+            indexEnv.writer().addDocument(parsedDocument.doc());
+            return this;
+        }
+
+        public Builder indexValues(List<String> columns, Object ... values) throws IOException {
+            MapperService mapperService = indexEnv.mapperService();
+            Indexer indexer = new Indexer(
+                table.concreteIndices()[0],
+                table,
+                plannerContext.transactionContext(),
+                plannerContext.nodeContext(),
+                mapperService::getLuceneFieldType,
+                Lists2.map(columns, c -> table.getReference(ColumnIdent.fromPath(c))),
+                null
+            );
+            var item = new IndexItem.StaticItem("dummy-id", List.of(), values, -1L, -1L);
             ParsedDocument parsedDocument = indexer.index(item);
             indexEnv.writer().addDocument(parsedDocument.doc());
             return this;


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Back-porting only these two test scenarios from #15280 that fails on `5.5.0` but passes on `5.5.2` with different but equivalent Lucene queries.

## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
