### PR TITLE
Fixed issues with PK filter and implicit cast

### DIFF
--- a/docs/appendices/release-notes/5.5.3.rst
+++ b/docs/appendices/release-notes/5.5.3.rst
@@ -49,6 +49,13 @@ See the :ref:`version_5.5.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue, that led to no results being returned when trying to filter on
+  a :ref:`PRIMARY KEY <constraints-primary-key>` column with an implicit cast.
+  For example::
+
+    CREATE TABLE tbl(a string PRIMARY KEY);
+    SELECT * FROM tbl WHERE a = 10;
+
 - Rejected :ref:`renaming <sql-alter-table-rename-to>` of views and tables if
   the target table or view already exists, and return an error message.
   Previously, such a rename was allowed which caused the existing view or table

--- a/server/src/main/java/io/crate/planner/WhereClauseOptimizer.java
+++ b/server/src/main/java/io/crate/planner/WhereClauseOptimizer.java
@@ -49,6 +49,7 @@ import io.crate.metadata.doc.DocSysColumns;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.planner.operators.SubQueryAndParamBinder;
 import io.crate.planner.operators.SubQueryResults;
+import io.crate.planner.optimizer.symbol.Optimizer;
 
 /**
  * Used to analyze a query for primaryKey/partition "direct access" possibilities.
@@ -165,11 +166,15 @@ public final class WhereClauseOptimizer {
 
         EqualityExtractor eqExtractor = new EqualityExtractor(normalizer);
 
-        EqMatches pkMatches = eqExtractor.extractMatches(pkCols, query, txnCtx);
+        // ExpressionAnalyzer will "blindly" add cast to the column, to match the datatype of the literal.
+        // To be able to properly extract pkMatches (and therefore dockeys), so that the cast is moved to the literal,
+        // we need to optimize the casts, before the extraction of pkMatches (and the dockeys after that)
+        var optimizedCastsQuery = Optimizer.optimizeCasts(query, txnCtx, nodeCtx);
+        EqMatches pkMatches = eqExtractor.extractMatches(pkCols, optimizedCastsQuery, txnCtx);
         Set<Symbol> clusteredBy = Collections.emptySet();
         if (table.clusteredBy() != null) {
             EqualityExtractor.EqMatches clusteredByMatches = eqExtractor.extractParentMatches(
-                Collections.singletonList(table.clusteredBy()), query, txnCtx);
+                Collections.singletonList(table.clusteredBy()), optimizedCastsQuery, txnCtx);
             List<List<Symbol>> clusteredBySymbols = clusteredByMatches.matches();
             if (clusteredBySymbols != null) {
                 clusteredBy = HashSet.newHashSet(clusteredBySymbols.size());
@@ -185,7 +190,7 @@ public final class WhereClauseOptimizer {
                     table.primaryKey().size() == 1 && table.clusteredBy().equals(table.primaryKey().getFirst())));
 
         if (pkMatches.matches() == null && shouldUseDocKeys) {
-            pkMatches = eqExtractor.extractMatches(List.of(DocSysColumns.ID), query, txnCtx);
+            pkMatches = eqExtractor.extractMatches(List.of(DocSysColumns.ID), optimizedCastsQuery, txnCtx);
         }
 
         if (pkMatches.matches() == null) {
@@ -202,7 +207,7 @@ public final class WhereClauseOptimizer {
                                   partitionIndicesWithinPks);
         }
         EqMatches partitionMatches = table.isPartitioned()
-            ? eqExtractor.extractMatches(table.partitionedBy(), query, txnCtx)
+            ? eqExtractor.extractMatches(table.partitionedBy(), optimizedCastsQuery, txnCtx)
             : EqMatches.NONE;
 
         WhereClauseValidator.validate(query);

--- a/server/src/main/java/io/crate/planner/WhereClauseOptimizer.java
+++ b/server/src/main/java/io/crate/planner/WhereClauseOptimizer.java
@@ -76,7 +76,6 @@ public final class WhereClauseOptimizer {
                       DocKeys docKeys,
                       List<List<Symbol>> partitionValues,
                       Set<Symbol> clusteredByValues,
-                      DocTableInfo table,
                       boolean queryHasPkSymbolsOnly) {
             this.query = query;
             this.docKeys = docKeys;
@@ -115,7 +114,7 @@ public final class WhereClauseOptimizer {
                                               NodeContext nodeCtx) {
             SubQueryAndParamBinder binder = new SubQueryAndParamBinder(params, subQueryResults);
             Symbol boundQuery = binder.apply(query);
-            HashSet<Symbol> clusteredBy = new HashSet<>(clusteredByValues.size());
+            HashSet<Symbol> clusteredBy = HashSet.newHashSet(clusteredByValues.size());
             for (Symbol clusteredByValue : clusteredByValues) {
                 clusteredBy.add(binder.apply(clusteredByValue));
             }
@@ -173,9 +172,9 @@ public final class WhereClauseOptimizer {
                 Collections.singletonList(table.clusteredBy()), query, txnCtx);
             List<List<Symbol>> clusteredBySymbols = clusteredByMatches.matches();
             if (clusteredBySymbols != null) {
-                clusteredBy = new HashSet<>(clusteredBySymbols.size());
+                clusteredBy = HashSet.newHashSet(clusteredBySymbols.size());
                 for (List<Symbol> s : clusteredBySymbols) {
-                    clusteredBy.add(s.get(0));
+                    clusteredBy.add(s.getFirst());
                 }
             }
         }
@@ -183,7 +182,7 @@ public final class WhereClauseOptimizer {
         final DocKeys docKeys;
         final boolean shouldUseDocKeys = table.isPartitioned() == false && (
                 DocSysColumns.ID.equals(table.clusteredBy()) || (
-                    table.primaryKey().size() == 1 && table.clusteredBy().equals(table.primaryKey().get(0))));
+                    table.primaryKey().size() == 1 && table.clusteredBy().equals(table.primaryKey().getFirst())));
 
         if (pkMatches.matches() == null && shouldUseDocKeys) {
             pkMatches = eqExtractor.extractMatches(List.of(DocSysColumns.ID), query, txnCtx);
@@ -212,7 +211,6 @@ public final class WhereClauseOptimizer {
             docKeys,
             partitionMatches.matches(),
             clusteredBy,
-            table,
             pkMatches.unknowns().isEmpty()
         );
     }

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/Optimizer.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/Optimizer.java
@@ -35,8 +35,8 @@ import io.crate.exceptions.ConversionException;
 import io.crate.expression.symbol.AliasResolver;
 import io.crate.expression.symbol.FunctionCopyVisitor;
 import io.crate.expression.symbol.Symbol;
-import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.NodeContext;
+import io.crate.metadata.TransactionContext;
 import io.crate.planner.PlannerContext;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Match;
@@ -50,10 +50,15 @@ import io.crate.planner.optimizer.symbol.rule.SwapCastsInLikeOperators;
 
 public class Optimizer {
 
-    public static Symbol optimizeCasts(Symbol query, PlannerContext plannerContext) {
+
+    public static Symbol optimizeCasts(Symbol query, PlannerContext plannerCtx) {
+        return optimizeCasts(query, plannerCtx.transactionContext(), plannerCtx.nodeContext());
+    }
+
+    public static Symbol optimizeCasts(Symbol query, TransactionContext txnCtx, NodeContext nodeCtx) {
         Optimizer optimizer = new Optimizer(
-            plannerContext.transactionContext(),
-            plannerContext.nodeContext(),
+            txnCtx,
+            nodeCtx,
             List.of(
                 SwapCastsInComparisonOperators::new,
                 SwapCastsInLikeOperators::new,
@@ -73,7 +78,7 @@ public class Optimizer {
     private final NodeContext nodeCtx;
     private final Visitor visitor = new Visitor();
 
-    public Optimizer(CoordinatorTxnCtx coordinatorTxnCtx,
+    public Optimizer(TransactionContext txnCtx,
                      NodeContext nodeCtx,
                      List<Function<FunctionSymbolResolver, Rule<?>>> rules) {
         FunctionSymbolResolver functionResolver =
@@ -84,7 +89,7 @@ public class Optimizer {
                         args,
                         null,
                         null,
-                        coordinatorTxnCtx,
+                        txnCtx,
                         nodeCtx);
                 } catch (ConversionException e) {
                     return null;
@@ -110,7 +115,7 @@ public class Optimizer {
                 Symbol transformed = tryMatchAndApply(rule, node, nodeCtx);
                 if (transformed != null) {
                     if (isTraceEnabled) {
-                        LOGGER.trace("Rule '" + rule.getClass().getSimpleName() + "' transformed the symbol");
+                        LOGGER.trace("Rule '{}' transformed the symbol", rule.getClass().getSimpleName());
                     }
                     node = transformed;
                     done = false;
@@ -127,7 +132,7 @@ public class Optimizer {
         Match<T> match = rule.pattern().accept(node, Captures.empty());
         if (match.isPresent()) {
             if (LOGGER.isTraceEnabled()) {
-                LOGGER.trace("Rule '" + rule.getClass().getSimpleName() + "' matched");
+                LOGGER.trace("Rule '{}' matched", rule.getClass().getSimpleName());
             }
             return rule.apply(match.value(), match.captures(), nodeCtx, visitor.getParentFunction());
         }

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/Rule.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/Rule.java
@@ -21,24 +21,16 @@
 
 package io.crate.planner.optimizer.symbol;
 
+import org.jetbrains.annotations.Nullable;
+
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import org.elasticsearch.Version;
-
-import org.jetbrains.annotations.Nullable;
 
 public interface Rule<T> {
 
     Pattern<T> pattern();
 
     Symbol apply(T symbol, Captures captures, NodeContext nodeCtx, @Nullable Symbol parentNode);
-
-    /**
-     * @return The version all nodes in the cluster must have to be able to use this optimization.
-     */
-    default Version requiredVersion() {
-        return Version.V_4_0_0;
-    }
 }

--- a/server/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -126,7 +126,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
 
         LogicalPlan plan = e.logicalPlan("select name from users where _id = 1");
         assertThat(plan).isEqualTo(
-            "Get[doc.users | name | DocKeys{1} | (_id = 1)]");
+            "Get[doc.users | name | DocKeys{'1'} | (_id = 1)]");
     }
 
     @Test


### PR DESCRIPTION
- Minor code improvements
- Remove minNodeVersion from symbol Optimizer
  `minNodeVersion` has been introduced with: #10076 to implement a logic that checked the minimum version of the nodes currently in a CrateDB cluster, and use it to skip applying any symbol optimization rules that were introduced after that minNodeVersion. Since this mechanism hasn't been actually used since it was introduced (CrateDB: `4.2.0`), remove it, since it makes it difficult to call the symbol Optimizer from other parts of the code.

- Fixed issues with PK filter and implicit cast
  Given the following situation:
  ```
  CREATE TABLE tbl(a string PRIMARY KEY);
  INSERT INTO tbl(a) VALUES ('t');
  REFRESH TABLE t;
  SELECT * FROM tbl WHERE a = true;
  ```

  Previously, when trying to filter on the PK column with equality
  operator, but using a value of a different type (in this example
  `boolean`), then no results where returned because the dockeys where
  built incorrently. `ExpressionAnalyzer` creates an implicit cast on the
  column `a`, to match the type of the value (see: #10076 which introduced
  this concept). So the query of the `WHERE` clause becomes:
  ```
  a::boolean = true
  ```
  Because of that the value added to the dockeys is `true`, instead of `t`.
  
  To resolve this, we need to call `optimizeCasts()` before extracting
  the `pkMatches` with the use of `EqualityExtractor`, so that the cast is
  moved to the value:
  ```
  a = true::'string'
  ```
  and the `EqualityExtractor` normalizes the value to `t` which then
  is added to the list of dockeys.
  
  Fixes: #15326
