### PR TITLE
Replace Function<?, ?> with UnaryOperator<?>

### DIFF
--- a/benchmarks/src/main/java/io/crate/execution/engine/collect/collectors/LuceneBatchIteratorBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/execution/engine/collect/collectors/LuceneBatchIteratorBenchmark.java
@@ -21,8 +21,12 @@
 
 package io.crate.execution.engine.collect.collectors;
 
-import io.crate.expression.reference.doc.lucene.CollectorContext;
-import io.crate.expression.reference.doc.lucene.IntegerColumnReference;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.function.UnaryOperator;
+
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.NumericDocValuesField;
@@ -41,11 +45,8 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.infra.Blackhole;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
+import io.crate.expression.reference.doc.lucene.CollectorContext;
+import io.crate.expression.reference.doc.lucene.IntegerColumnReference;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
@@ -70,7 +71,7 @@ public class LuceneBatchIteratorBenchmark {
         indexSearcher = new IndexSearcher(DirectoryReader.open(iw));
         IntegerColumnReference columnReference = new IntegerColumnReference(columnName);
         columnRefs = Collections.singletonList(columnReference);
-        collectorContext = new CollectorContext(Set.of(), Function.identity());
+        collectorContext = new CollectorContext(Set.of(), UnaryOperator.identity());
     }
 
     @Benchmark

--- a/benchmarks/src/main/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorBenchmark.java
@@ -25,7 +25,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.document.Document;
@@ -102,7 +102,7 @@ public class OrderedLuceneBatchIteratorBenchmark {
             iw.commit();
             iw.forceMerge(1, true);
             indexSearcher = new IndexSearcher(DirectoryReader.open(iw, true, true));
-            collectorContext = new CollectorContext(Set.of(), Function.identity());
+            collectorContext = new CollectorContext(Set.of(), UnaryOperator.identity());
             reference = new SimpleReference(
                 new ReferenceIdent(new RelationName(Schemas.DOC_SCHEMA_NAME, "dummyTable"), columnName),
                 RowGranularity.DOC,

--- a/libs/es-x-content/src/main/java/org/elasticsearch/common/xcontent/XContentBuilderExtension.java
+++ b/libs/es-x-content/src/main/java/org/elasticsearch/common/xcontent/XContentBuilderExtension.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.common.xcontent;
 
 import java.util.Map;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 /**
  * This interface provides a way for non-JDK classes to plug in a way to serialize to xcontent.
@@ -72,10 +72,10 @@ public interface XContentBuilderExtension {
      * <pre>
      * {@code
      *     final DateTimeFormatter datePrinter = ISODateTimeFormat.dateTime().withZone(DateTimeZone.UTC);
-     *     Map<Class<?>, Function<Object, Object>> transformers = new HashMap<>();
+     *     Map<Class<?>, UnaryOperator<Object>> transformers = new HashMap<>();
      *     transformers.put(Date.class, d -> datePrinter.print(((Date) d).getTime()));
      * }
      * </pre>
      */
-    Map<Class<?>, Function<Object, Object>> getDateTransformers();
+    Map<Class<?>, UnaryOperator<Object>> getDateTransformers();
 }

--- a/plugins/es-analysis-common/src/main/java/org/elasticsearch/analysis/common/MultiplexerTokenFilterFactory.java
+++ b/plugins/es-analysis-common/src/main/java/org/elasticsearch/analysis/common/MultiplexerTokenFilterFactory.java
@@ -19,6 +19,12 @@
 
 package org.elasticsearch.analysis.common;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+
 import org.apache.lucene.analysis.TokenFilter;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.miscellaneous.ConditionalTokenFilter;
@@ -32,11 +38,6 @@ import org.elasticsearch.index.analysis.AbstractTokenFilterFactory;
 import org.elasticsearch.index.analysis.CharFilterFactory;
 import org.elasticsearch.index.analysis.TokenFilterFactory;
 import org.elasticsearch.index.analysis.TokenizerFactory;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.function.Function;
 
 public class MultiplexerTokenFilterFactory extends AbstractTokenFilterFactory {
 
@@ -89,7 +90,7 @@ public class MultiplexerTokenFilterFactory extends AbstractTokenFilterFactory {
 
             @Override
             public TokenStream create(TokenStream tokenStream) {
-                List<Function<TokenStream, TokenStream>> functions = new ArrayList<>();
+                List<UnaryOperator<TokenStream>> functions = new ArrayList<>();
                 for (TokenFilterFactory tff : filters) {
                     functions.add(tff::create);
                 }
@@ -139,7 +140,7 @@ public class MultiplexerTokenFilterFactory extends AbstractTokenFilterFactory {
         /**
          * Creates a MultiplexTokenFilter on the given input with a set of filters
          */
-        MultiplexTokenFilter(TokenStream input, List<Function<TokenStream, TokenStream>> filters) {
+        MultiplexTokenFilter(TokenStream input, List<UnaryOperator<TokenStream>> filters) {
             super(input);
             TokenStream source = new MultiplexerFilter(input);
             for (int i = 0; i < filters.size(); i++) {

--- a/server/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
@@ -34,6 +34,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import org.elasticsearch.common.UUIDs;
 import org.jetbrains.annotations.Nullable;
@@ -226,7 +227,7 @@ public class TableElementsAnalyzer implements FieldProvider<Reference> {
 
         public Reference build(Map<ColumnIdent, RefBuilder> columns,
                                RelationName tableName,
-                               Function<Symbol, Symbol> bindParameter,
+                               UnaryOperator<Symbol> bindParameter,
                                Function<Symbol, Object> toValue) {
             if (builtReference != null) {
                 return builtReference;

--- a/server/src/main/java/io/crate/analyze/expressions/ValueNormalizer.java
+++ b/server/src/main/java/io/crate/analyze/expressions/ValueNormalizer.java
@@ -24,7 +24,7 @@ package io.crate.analyze.expressions;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.exceptions.ColumnValidationException;
@@ -61,7 +61,7 @@ public final class ValueNormalizer {
     public static Symbol normalizeInputForReference(Symbol valueSymbol,
                                                     Reference reference,
                                                     TableInfo tableInfo,
-                                                    Function<Symbol, Symbol> normalizer) {
+                                                    UnaryOperator<Symbol> normalizer) {
         assert valueSymbol != null : "valueSymbol must not be null";
 
         DataType<?> targetType = getTargetType(valueSymbol, reference);

--- a/server/src/main/java/io/crate/execution/dsl/phases/RoutedCollectPhase.java
+++ b/server/src/main/java/io/crate/execution/dsl/phases/RoutedCollectPhase.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -243,7 +243,7 @@ public class RoutedCollectPhase extends AbstractProjectionsPhase implements Coll
      */
     public RoutedCollectPhase normalize(EvaluatingNormalizer normalizer, @NotNull TransactionContext txnCtx) {
         RoutedCollectPhase result = this;
-        Function<Symbol, Symbol> normalize = s -> normalizer.normalize(s, txnCtx);
+        UnaryOperator<Symbol> normalize = s -> normalizer.normalize(s, txnCtx);
         List<Symbol> newToCollect = Lists.map(toCollect, normalize);
         boolean changed = !newToCollect.equals(toCollect);
         Symbol newWhereClause = normalizer.normalize(where, txnCtx);

--- a/server/src/main/java/io/crate/execution/dsl/projection/builder/ProjectionBuilder.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/builder/ProjectionBuilder.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.function.UnaryOperator;
 
 import org.elasticsearch.common.settings.Settings;
 import org.jetbrains.annotations.Nullable;
@@ -62,7 +63,7 @@ public class ProjectionBuilder {
 
     public AggregationProjection aggregationProjection(Collection<? extends Symbol> inputs,
                                                        Collection<Function> aggregates,
-                                                       java.util.function.Function<Symbol, Symbol> subQueryAndParamBinder,
+                                                       UnaryOperator<Symbol> subQueryAndParamBinder,
                                                        AggregateMode mode,
                                                        RowGranularity granularity,
                                                        SearchPath searchPath) {
@@ -81,7 +82,7 @@ public class ProjectionBuilder {
         Collection<? extends Symbol> inputs,
         Collection<? extends Symbol> keys,
         Collection<Function> values,
-        java.util.function.Function<Symbol, Symbol> subQueryAndParamBinder,
+        UnaryOperator<Symbol> subQueryAndParamBinder,
         AggregateMode mode,
         RowGranularity requiredGranularity,
         SearchPath searchPath) {
@@ -106,7 +107,7 @@ public class ProjectionBuilder {
                                                    AggregateMode mode,
                                                    InputColumns.SourceSymbols sourceSymbols,
                                                    SearchPath searchPath,
-                                                   java.util.function.Function<Symbol, Symbol> subQueryAndParamBinder) {
+                                                   UnaryOperator<Symbol> subQueryAndParamBinder) {
         ArrayList<Aggregation> aggregations = new ArrayList<>(functions.size());
         for (Function function : functions) {
             assert function.signature().getKind() == FunctionType.AGGREGATE :

--- a/server/src/main/java/io/crate/execution/engine/FirstColumnConsumers.java
+++ b/server/src/main/java/io/crate/execution/engine/FirstColumnConsumers.java
@@ -29,6 +29,7 @@ import java.util.function.BiConsumer;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collector;
 
 import io.crate.data.Row;
@@ -64,8 +65,8 @@ public class FirstColumnConsumers {
         }
 
         @Override
-        public Function<List<Object>, List<Object>> finisher() {
-            return Function.identity();
+        public UnaryOperator<List<Object>> finisher() {
+            return UnaryOperator.identity();
         }
 
         @Override

--- a/server/src/main/java/io/crate/execution/engine/pipeline/MapRowUsingInputs.java
+++ b/server/src/main/java/io/crate/execution/engine/pipeline/MapRowUsingInputs.java
@@ -21,14 +21,14 @@
 
 package io.crate.execution.engine.pipeline;
 
+import java.util.List;
+import java.util.RandomAccess;
+import java.util.function.UnaryOperator;
+
 import io.crate.data.Input;
 import io.crate.data.Row;
 import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.expression.InputRow;
-
-import java.util.List;
-import java.util.RandomAccess;
-import java.util.function.Function;
 
 /**
  * Function that transforms a Row using the supplied {@link Input}s and {@link CollectExpression}s.
@@ -46,7 +46,7 @@ import java.util.function.Function;
  *
  * Note that the returned row is a shared object and re-used between calls.
  */
-public final class MapRowUsingInputs implements Function<Row, Row> {
+public final class MapRowUsingInputs implements UnaryOperator<Row> {
 
     private final List<? extends CollectExpression<Row, ?>> expressions;
     private final Row resultRow;

--- a/server/src/main/java/io/crate/expression/eval/NullEliminator.java
+++ b/server/src/main/java/io/crate/expression/eval/NullEliminator.java
@@ -21,6 +21,8 @@
 
 package io.crate.expression.eval;
 
+import java.util.function.UnaryOperator;
+
 import io.crate.expression.operator.Operators;
 import io.crate.expression.predicate.NotPredicate;
 import io.crate.expression.symbol.Function;
@@ -63,17 +65,16 @@ public final class NullEliminator {
      * @param symbol The query symbol to operate on.
      * @param postProcessor A function applied only on function symbols which changed due to NULL replacement.
      */
-    public static Symbol eliminateNullsIfPossible(Symbol symbol,
-                                                  java.util.function.Function<Symbol, Symbol> postProcessor) {
+    public static Symbol eliminateNullsIfPossible(Symbol symbol, UnaryOperator<Symbol> postProcessor) {
         return symbol.accept(VISITOR, new Context(postProcessor));
     }
 
     private static class Context {
-        private final java.util.function.Function<Symbol, Symbol> postProcessor;
+        private final UnaryOperator<Symbol> postProcessor;
         boolean insideLogicalOperator = false;
         boolean nullReplacement = false;
 
-        public Context(java.util.function.Function<Symbol, Symbol> postProcessor) {
+        public Context(UnaryOperator<Symbol> postProcessor) {
             this.postProcessor = postProcessor;
         }
     }

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/CollectorContext.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/CollectorContext.java
@@ -22,7 +22,7 @@
 package io.crate.expression.reference.doc.lucene;
 
 import java.util.Set;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import io.crate.metadata.Reference;
 
@@ -30,15 +30,15 @@ public class CollectorContext {
 
     private final int readerId;
     private final Set<Reference> droppedColumns;
-    private final Function<String, String> lookupNameBySourceKey;
+    private final UnaryOperator<String> lookupNameBySourceKey;
 
     private SourceLookup sourceLookup;
 
-    public CollectorContext(Set<Reference> droppedColumns, Function<String, String> lookupNameBySourceKey) {
+    public CollectorContext(Set<Reference> droppedColumns, UnaryOperator<String> lookupNameBySourceKey) {
         this(-1, droppedColumns, lookupNameBySourceKey);
     }
 
-    public CollectorContext(int readerId, Set<Reference> droppedColumns, Function<String, String> lookupNameBySourceKey) {
+    public CollectorContext(int readerId, Set<Reference> droppedColumns, UnaryOperator<String> lookupNameBySourceKey) {
         this.readerId = readerId;
         this.droppedColumns = droppedColumns;
         this.lookupNameBySourceKey = lookupNameBySourceKey;

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/SourceLookup.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/SourceLookup.java
@@ -28,7 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.RandomAccess;
 import java.util.Set;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import org.elasticsearch.common.bytes.BytesReference;
 
@@ -44,7 +44,7 @@ public final class SourceLookup {
     private Map<String, Object> source;
     private boolean docVisited = false;
 
-    SourceLookup(Set<Reference> droppedColumns, Function<String, String> lookupNameBySourceKey) {
+    SourceLookup(Set<Reference> droppedColumns, UnaryOperator<String> lookupNameBySourceKey) {
         sourceParser = new SourceParser(droppedColumns, lookupNameBySourceKey);
     }
 

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/SourceParser.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/SourceParser.java
@@ -34,7 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
 import org.elasticsearch.common.bytes.BytesReference;
@@ -77,9 +77,9 @@ public final class SourceParser {
     public static final String UNKNOWN_COLUMN_PREFIX = "_u_";
     private final Map<String, Object> requiredColumns = new HashMap<>();
     private final Set<String> droppedColumns;
-    private final Function<String, String> lookupNameBySourceKey;
+    private final UnaryOperator<String> lookupNameBySourceKey;
 
-    public SourceParser(Set<Reference> droppedColumns, Function<String, String> lookupNameBySourceKey) {
+    public SourceParser(Set<Reference> droppedColumns, UnaryOperator<String> lookupNameBySourceKey) {
         // Use a Set of string fqn instead of ColumnIdent to avoid creating ColumnIdent objects to call `contains`
         this.droppedColumns = droppedColumns.stream().map(r -> r.column().fqn()).collect(Collectors.toUnmodifiableSet());
         this.lookupNameBySourceKey = lookupNameBySourceKey;
@@ -160,7 +160,7 @@ public final class SourceParser {
                                      @Nullable DataType<?> type,
                                      @Nullable Map<String, Object> requiredColumns,
                                      Set<String> droppedColumns,
-                                     Function<String, String> lookupNameBySourceKey,
+                                     UnaryOperator<String> lookupNameBySourceKey,
                                      StringBuilder colPath) throws IOException {
         if (type instanceof GeoPointType || type instanceof FloatVectorType) {
             return type.implicitCast(parser.list());
@@ -189,7 +189,7 @@ public final class SourceParser {
     private static Map<String, Object> parseObject(XContentParser parser,
                                                    @Nullable Map<String, Object> requiredColumns,
                                                    Set<String> droppedColumns,
-                                                   Function<String, String> lookupNameBySourceKey,
+                                                   UnaryOperator<String> lookupNameBySourceKey,
                                                    StringBuilder colPath,
                                                    boolean includeUnknown) throws IOException {
         var parseAllFields = false;
@@ -280,7 +280,7 @@ public final class SourceParser {
                                      @Nullable DataType<?> type,
                                      @Nullable Map<String, Object> requiredColumns,
                                      Set<String> droppedColumns,
-                                     Function<String, String> lookupNameBySourceKey,
+                                     UnaryOperator<String> lookupNameBySourceKey,
                                      StringBuilder colPath,
                                      boolean includeUnknown) throws IOException {
         return switch (parser.currentToken()) {

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/TruncFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/TruncFunction.java
@@ -25,7 +25,7 @@ import static io.crate.metadata.functions.Signature.scalar;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
@@ -62,7 +62,7 @@ public final class TruncFunction {
                         type,
                         n -> {
                             double val = ((Number) n).doubleValue();
-                            Function<Double, Double> f = val >= 0 ? Math::floor : Math::ceil;
+                            UnaryOperator<Double> f = val >= 0 ? Math::floor : Math::ceil;
                             return (Number) returnType.sanitizeValue(f.apply(val));
                         }
                     )

--- a/server/src/main/java/io/crate/expression/scalar/string/EncodeDecodeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/EncodeDecodeFunction.java
@@ -21,18 +21,18 @@
 
 package io.crate.expression.scalar.string;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Locale;
+import java.util.function.BinaryOperator;
+import java.util.function.UnaryOperator;
+
 import io.crate.common.Hex;
 import io.crate.common.Octal;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.arithmetic.BinaryScalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
-
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
-import java.util.Locale;
-import java.util.function.BinaryOperator;
-import java.util.function.Function;
 
 public class EncodeDecodeFunction {
 
@@ -151,10 +151,10 @@ public class EncodeDecodeFunction {
             return Octal.encode(bytea.getBytes(StandardCharsets.UTF_8));
         }, text -> Hex.HEX_FLAG + Hex.encodeHexString(Octal.decode(text)));
 
-        private final Function<String, String> encode;
-        private final Function<String, String> decode;
+        private final UnaryOperator<String> encode;
+        private final UnaryOperator<String> decode;
 
-        Format(Function<String, String> encode, Function<String, String> decode) {
+        Format(UnaryOperator<String> encode, UnaryOperator<String> decode) {
             this.encode = encode;
             this.decode = decode;
         }

--- a/server/src/main/java/io/crate/expression/scalar/string/HashFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/HashFunctions.java
@@ -21,18 +21,19 @@
 
 package io.crate.expression.scalar.string;
 
+import java.nio.charset.StandardCharsets;
+import java.security.DigestException;
+import java.security.MessageDigest;
+import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
+
+import org.elasticsearch.common.hash.MessageDigests;
+
 import io.crate.common.Hex;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.UnaryScalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
-import org.elasticsearch.common.hash.MessageDigests;
-
-import java.nio.charset.StandardCharsets;
-import java.security.DigestException;
-import java.security.MessageDigest;
-import java.util.function.Function;
-import java.util.function.Supplier;
 
 public final class HashFunctions {
 
@@ -41,7 +42,7 @@ public final class HashFunctions {
         register(module, "sha1", HashMethod.SHA1::digest);
     }
 
-    private static void register(ScalarFunctionModule module, String name, Function<String, String> func) {
+    private static void register(ScalarFunctionModule module, String name, UnaryOperator<String> func) {
         module.register(
             Signature.scalar(
                 name,

--- a/server/src/main/java/io/crate/expression/symbol/AggregateMode.java
+++ b/server/src/main/java/io/crate/expression/symbol/AggregateMode.java
@@ -21,14 +21,15 @@
 
 package io.crate.expression.symbol;
 
-import io.crate.data.breaker.RamAccounting;
-import io.crate.execution.engine.aggregation.AggregationFunction;
-import io.crate.types.DataType;
+import java.io.IOException;
+import java.util.List;
+
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
-import java.io.IOException;
-import java.util.List;
+import io.crate.data.breaker.RamAccounting;
+import io.crate.execution.engine.aggregation.AggregationFunction;
+import io.crate.types.DataType;
 
 public enum AggregateMode {
     ITER_PARTIAL {

--- a/server/src/main/java/io/crate/expression/tablefunctions/RangeIterable.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/RangeIterable.java
@@ -22,13 +22,14 @@
 package io.crate.expression.tablefunctions;
 
 
-import io.crate.data.Row;
-import io.crate.data.RowN;
-
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
+
+import io.crate.data.Row;
+import io.crate.data.RowN;
 
 
 public final class RangeIterable<T> implements Iterable<Row> {
@@ -36,7 +37,7 @@ public final class RangeIterable<T> implements Iterable<Row> {
     private final Object [] columns;
     private final RowN row;
     private final T endInclusive;
-    private final Function<T, T> nextValue;
+    private final UnaryOperator<T> nextValue;
     private final Comparator<T> comparator;
     private final Function<T, Object> resultExtractor;
     private final boolean reversed;
@@ -44,7 +45,7 @@ public final class RangeIterable<T> implements Iterable<Row> {
 
     public RangeIterable(T startInclusive,
                          T endInclusive,
-                         Function<T, T> nextValue,
+                         UnaryOperator<T> nextValue,
                          Comparator<T> comparator,
                          Function<T, Object> valueExtractor) {
         columns = new Object[]{ null };

--- a/server/src/main/java/io/crate/planner/operators/Eval.java
+++ b/server/src/main/java/io/crate/planner/operators/Eval.java
@@ -27,7 +27,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.SequencedCollection;
 import java.util.Set;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -116,7 +116,7 @@ public final class Eval extends ForwardingLogicalPlan {
             return null;
         }
         LogicalPlan newSource = fetchRewrite.newPlan();
-        Function<Symbol, Symbol> mapToFetchStubs = fetchRewrite.mapToFetchStubs();
+        UnaryOperator<Symbol> mapToFetchStubs = fetchRewrite.mapToFetchStubs();
         LinkedHashMap<Symbol, Symbol> newReplacedOutputs = new LinkedHashMap<>();
         ArrayList<Symbol> newOutputs = new ArrayList<>();
         for (Symbol sourceOutput : newSource.outputs()) {

--- a/server/src/main/java/io/crate/planner/operators/Fetch.java
+++ b/server/src/main/java/io/crate/planner/operators/Fetch.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.SequencedCollection;
 import java.util.Set;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -135,7 +135,7 @@ public final class Fetch extends ForwardingLogicalPlan {
             plannerContext
         );
         ReaderAllocations readerAllocations = plannerContext.buildReaderAllocations();
-        Function<Symbol, Symbol> paramBinder = new SubQueryAndParamBinder(params, subQueryResults);
+        UnaryOperator<Symbol> paramBinder = new SubQueryAndParamBinder(params, subQueryResults);
         FetchPhase fetchPhase = new FetchPhase(
             plannerContext.nextExecutionPhaseId(),
             readerAllocations.nodeReaders().keySet(),

--- a/server/src/main/java/io/crate/planner/operators/FetchRewrite.java
+++ b/server/src/main/java/io/crate/planner/operators/FetchRewrite.java
@@ -25,7 +25,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import io.crate.expression.symbol.FetchMarker;
 import io.crate.expression.symbol.InputColumn;
@@ -108,7 +108,7 @@ public final class FetchRewrite {
     /**
      * @return A function that converts any symbol within a symbol-tree that is present in `replacedOutputs` from the key to the value.
      */
-    public Function<Symbol, Symbol> mapToFetchStubs() {
+    public UnaryOperator<Symbol> mapToFetchStubs() {
         return s -> MapBackedSymbolReplacer.convert(s, replacedOutputs);
     }
 }

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
 
 import org.elasticsearch.Version;
 
@@ -209,7 +210,7 @@ public class LogicalPlanner {
         AnalyzedRelation relation = selectSymbol.relation();
 
         final int fetchSize;
-        final java.util.function.Function<LogicalPlan, LogicalPlan> maybeApplySoftLimit;
+        final UnaryOperator<LogicalPlan> maybeApplySoftLimit;
         ResultType resultType = selectSymbol.getResultType();
         switch (resultType) {
             case SINGLE_COLUMN_EXISTS:

--- a/server/src/main/java/io/crate/planner/operators/Order.java
+++ b/server/src/main/java/io/crate/planner/operators/Order.java
@@ -30,7 +30,7 @@ import java.util.Map;
 import java.util.SequencedCollection;
 import java.util.Set;
 import java.util.function.Consumer;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -107,7 +107,7 @@ public class Order extends ForwardingLogicalPlan {
             // e.g. OrderBy [x + y] where the source provides [x, y]
             // We need to extend replacedOutputs in this case because it must always contain entries for all outputs
             LinkedHashMap<Symbol, Symbol> newReplacedOutputs = new LinkedHashMap<>(replacedOutputs);
-            Function<Symbol, Symbol> mapToFetchStubs = fetchRewrite.mapToFetchStubs();
+            UnaryOperator<Symbol> mapToFetchStubs = fetchRewrite.mapToFetchStubs();
             for (int i = newSource.outputs().size(); i < newOrderBy.outputs.size(); i++) {
                 Symbol extraOutput = newOrderBy.outputs.get(i);
                 newReplacedOutputs.put(extraOutput, mapToFetchStubs.apply(extraOutput));

--- a/server/src/main/java/io/crate/planner/operators/Rename.java
+++ b/server/src/main/java/io/crate/planner/operators/Rename.java
@@ -30,7 +30,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.SequencedCollection;
 import java.util.Set;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -169,7 +169,7 @@ public final class Rename extends ForwardingLogicalPlan implements FieldResolver
             }
         }
         LinkedHashMap<Symbol, Symbol> replacedOutputs = new LinkedHashMap<>();
-        Function<Symbol, Symbol> convertChildrenToScopedSymbols = s -> MapBackedSymbolReplacer.convert(s, childToParentMap);
+        UnaryOperator<Symbol> convertChildrenToScopedSymbols = s -> MapBackedSymbolReplacer.convert(s, childToParentMap);
         for (var entry : fetchRewrite.replacedOutputs().entrySet()) {
             Symbol key = entry.getKey();
             Symbol value = entry.getValue();

--- a/server/src/main/java/io/crate/planner/operators/RewriteInsertFromSubQueryToInsertFromValues.java
+++ b/server/src/main/java/io/crate/planner/operators/RewriteInsertFromSubQueryToInsertFromValues.java
@@ -21,6 +21,11 @@
 
 package io.crate.planner.operators;
 
+import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.matcher.Patterns.source;
+
+import java.util.function.UnaryOperator;
+
 import io.crate.expression.tablefunctions.ValuesFunction;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
@@ -29,11 +34,6 @@ import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-
-import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
-import static io.crate.planner.optimizer.matcher.Patterns.source;
-
-import java.util.function.Function;
 
 public class RewriteInsertFromSubQueryToInsertFromValues implements Rule<Insert> {
 
@@ -57,7 +57,7 @@ public class RewriteInsertFromSubQueryToInsertFromValues implements Rule<Insert>
                              PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
-                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
+                             UnaryOperator<LogicalPlan> resolvePlan) {
         TableFunction tableFunction = captures.get(this.capture);
         var relation = tableFunction.relation();
         if (relation.function().name().equals(ValuesFunction.NAME)) {

--- a/server/src/main/java/io/crate/planner/operators/SubQueryAndParamBinder.java
+++ b/server/src/main/java/io/crate/planner/operators/SubQueryAndParamBinder.java
@@ -21,6 +21,9 @@
 
 package io.crate.planner.operators;
 
+import java.util.Locale;
+import java.util.function.UnaryOperator;
+
 import io.crate.data.Row;
 import io.crate.exceptions.ConversionException;
 import io.crate.expression.symbol.FunctionCopyVisitor;
@@ -32,10 +35,7 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 
-import java.util.Locale;
-
-public class SubQueryAndParamBinder extends FunctionCopyVisitor<Void>
-    implements java.util.function.Function<Symbol, Symbol> {
+public class SubQueryAndParamBinder extends FunctionCopyVisitor<Void> implements UnaryOperator<Symbol> {
 
     private final Row params;
     private final SubQueryResults subQueryResults;

--- a/server/src/main/java/io/crate/planner/optimizer/Optimizer.java
+++ b/server/src/main/java/io/crate/planner/optimizer/Optimizer.java
@@ -24,8 +24,8 @@ package io.crate.planner.optimizer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
 
 import org.elasticsearch.Version;
 import org.jetbrains.annotations.Nullable;
@@ -95,7 +95,7 @@ public class Optimizer {
         // trying to re-apply the rules as long as at least one plan was transformed.
         boolean done = false;
         int numIterations = 0;
-        Function<LogicalPlan, LogicalPlan> resolvePlan = Function.identity();
+        UnaryOperator<LogicalPlan> resolvePlan = UnaryOperator.identity();
         Version minVersion = minNodeVersionInCluster.get();
         while (!done && numIterations < 10_000) {
             done = true;
@@ -123,7 +123,7 @@ public class Optimizer {
                                                    PlanStats planStats,
                                                    NodeContext nodeCtx,
                                                    TransactionContext txnCtx,
-                                                   Function<LogicalPlan, LogicalPlan> resolvePlan,
+                                                   UnaryOperator<LogicalPlan> resolvePlan,
                                                    OptimizerTracer tracer) {
         Match<T> match = rule.pattern().accept(node, Captures.empty(), resolvePlan);
         if (match.isPresent()) {

--- a/server/src/main/java/io/crate/planner/optimizer/Rule.java
+++ b/server/src/main/java/io/crate/planner/optimizer/Rule.java
@@ -21,7 +21,9 @@
 
 package io.crate.planner.optimizer;
 
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
+
+import org.elasticsearch.Version;
 
 import io.crate.common.StringUtils;
 import io.crate.metadata.NodeContext;
@@ -30,7 +32,6 @@ import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import org.elasticsearch.Version;
 
 public interface Rule<T> {
 
@@ -49,7 +50,7 @@ public interface Rule<T> {
                       PlanStats planStats,
                       TransactionContext txnCtx,
                       NodeContext nodeCtx,
-                      Function<LogicalPlan, LogicalPlan> resolvePlan);
+                      UnaryOperator<LogicalPlan> resolvePlan);
 
     /**
      * @return The version all nodes in the cluster must have to be able to use this optimization.

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/GroupReferenceResolver.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/GroupReferenceResolver.java
@@ -22,13 +22,14 @@
 package io.crate.planner.optimizer.iterative;
 
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import io.crate.planner.operators.LogicalPlan;
 
 /**
  * The GroupReferenceResolver resolves a GroupReference to the referenced LogicalPlan
  */
-public interface GroupReferenceResolver extends Function<LogicalPlan, LogicalPlan> {
+public interface GroupReferenceResolver extends UnaryOperator<LogicalPlan> {
 
     static GroupReferenceResolver from(Function<GroupReference, LogicalPlan> resolver) {
         return node -> {

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/IterativeOptimizer.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/IterativeOptimizer.java
@@ -24,8 +24,8 @@ package io.crate.planner.optimizer.iterative;
 import static io.crate.planner.optimizer.Optimizer.removeExcludedRules;
 
 import java.util.List;
-import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
 
 import org.elasticsearch.Version;
 
@@ -60,7 +60,7 @@ public class IterativeOptimizer {
         // Memo is used to have a mutable view over the tree so it can change nodes without
         // having to re-build the full tree all the time.`GroupReference` is used as place-holder
         // or proxy that must be resolved to the real plan node
-        Function<LogicalPlan, LogicalPlan> groupReferenceResolver = node -> {
+        UnaryOperator<LogicalPlan> groupReferenceResolver = node -> {
             if (node instanceof GroupReference g) {
                 return memo.resolve(g.groupId());
             }
@@ -166,7 +166,7 @@ public class IterativeOptimizer {
 
     private record Context(
         Memo memo,
-        Function<LogicalPlan, LogicalPlan> groupReferenceResolver,
+        UnaryOperator<LogicalPlan> groupReferenceResolver,
         List<Rule<?>> rules,
         CoordinatorTxnCtx txnCtx,
         PlanStats planStats,

--- a/server/src/main/java/io/crate/planner/optimizer/joinorder/JoinGraph.java
+++ b/server/src/main/java/io/crate/planner/optimizer/joinorder/JoinGraph.java
@@ -27,7 +27,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import io.crate.analyze.relations.QuerySplitter;
 import io.crate.common.collections.Lists;
@@ -136,15 +136,15 @@ public record JoinGraph(
         return result;
     }
 
-    public static JoinGraph create(LogicalPlan plan, Function<LogicalPlan, LogicalPlan> resolvePlan) {
+    public static JoinGraph create(LogicalPlan plan, UnaryOperator<LogicalPlan> resolvePlan) {
         return plan.accept(new GraphBuilder(resolvePlan), new HashMap<>());
     }
 
     private static class GraphBuilder extends LogicalPlanVisitor<Map<Symbol, LogicalPlan>, JoinGraph> {
 
-        private final Function<LogicalPlan, LogicalPlan> resolvePlan;
+        private final UnaryOperator<LogicalPlan> resolvePlan;
 
-        GraphBuilder(Function<LogicalPlan, LogicalPlan> resolvePlan) {
+        GraphBuilder(UnaryOperator<LogicalPlan> resolvePlan) {
             this.resolvePlan = resolvePlan;
         }
 

--- a/server/src/main/java/io/crate/planner/optimizer/matcher/CapturePattern.java
+++ b/server/src/main/java/io/crate/planner/optimizer/matcher/CapturePattern.java
@@ -21,7 +21,7 @@
 
 package io.crate.planner.optimizer.matcher;
 
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import io.crate.planner.operators.LogicalPlan;
 
@@ -36,7 +36,7 @@ class CapturePattern<T> extends Pattern<T> {
     }
 
     @Override
-    public Match<T> accept(Object object, Captures captures, Function<LogicalPlan, LogicalPlan> resolvePlan) {
+    public Match<T> accept(Object object, Captures captures, UnaryOperator<LogicalPlan> resolvePlan) {
         Match<T> match = pattern.accept(object, captures, resolvePlan);
         return match.flatMap(val -> Match.of(val, captures.add(Captures.of(capture, val))));
     }

--- a/server/src/main/java/io/crate/planner/optimizer/matcher/Pattern.java
+++ b/server/src/main/java/io/crate/planner/optimizer/matcher/Pattern.java
@@ -24,6 +24,7 @@ package io.crate.planner.optimizer.matcher;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
 
 import io.crate.planner.operators.LogicalPlan;
 
@@ -45,10 +46,10 @@ public abstract class Pattern<T> {
         return new CapturePattern<>(capture, this);
     }
 
-    public abstract Match<T> accept(Object object, Captures captures, Function<LogicalPlan, LogicalPlan> resolvePlan);
+    public abstract Match<T> accept(Object object, Captures captures, UnaryOperator<LogicalPlan> resolvePlan);
 
     public Match<T> accept(Object object, Captures captures) {
-        return accept(object, captures, Function.identity());
+        return accept(object, captures, UnaryOperator.identity());
     }
 
 }

--- a/server/src/main/java/io/crate/planner/optimizer/matcher/TypeOfPattern.java
+++ b/server/src/main/java/io/crate/planner/optimizer/matcher/TypeOfPattern.java
@@ -21,7 +21,7 @@
 
 package io.crate.planner.optimizer.matcher;
 
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import io.crate.planner.operators.LogicalPlan;
 
@@ -34,7 +34,7 @@ class TypeOfPattern<T> extends Pattern<T> {
     }
 
     @Override
-    public Match<T> accept(Object object, Captures captures, Function<LogicalPlan, LogicalPlan> resolvePlan) {
+    public Match<T> accept(Object object, Captures captures, UnaryOperator<LogicalPlan> resolvePlan) {
         if (expectedClass.isInstance(object)) {
             return Match.of(expectedClass.cast(object), captures);
         } else {

--- a/server/src/main/java/io/crate/planner/optimizer/matcher/WithPattern.java
+++ b/server/src/main/java/io/crate/planner/optimizer/matcher/WithPattern.java
@@ -23,6 +23,7 @@ package io.crate.planner.optimizer.matcher;
 
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import io.crate.planner.operators.LogicalPlan;
 
@@ -39,7 +40,7 @@ class WithPattern<T, U, V> extends Pattern<T> {
     }
 
     @Override
-    public Match<T> accept(Object object, Captures captures, Function<LogicalPlan, LogicalPlan> resolvePlan) {
+    public Match<T> accept(Object object, Captures captures, UnaryOperator<LogicalPlan> resolvePlan) {
         Match<T> match = firstPattern.accept(object, captures, resolvePlan);
         return match.flatMap(matchedValue -> {
             Optional<?> optProperty = getProperty.apply(matchedValue)

--- a/server/src/main/java/io/crate/planner/optimizer/matcher/WithPropertyPattern.java
+++ b/server/src/main/java/io/crate/planner/optimizer/matcher/WithPropertyPattern.java
@@ -21,8 +21,8 @@
 
 package io.crate.planner.optimizer.matcher;
 
-import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
 
 import io.crate.planner.operators.LogicalPlan;
 
@@ -37,7 +37,7 @@ public class WithPropertyPattern<T> extends Pattern<T> {
     }
 
     @Override
-    public Match<T> accept(Object object, Captures captures, Function<LogicalPlan, LogicalPlan> resolvePlan) {
+    public Match<T> accept(Object object, Captures captures, UnaryOperator<LogicalPlan> resolvePlan) {
         Match<T> match = pattern.accept(object, captures, resolvePlan);
         return match.flatMap(matchedValue -> {
             if (propertyPredicate.test(matchedValue)) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/DeduplicateOrder.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/DeduplicateOrder.java
@@ -21,20 +21,20 @@
 
 package io.crate.planner.optimizer.rule;
 
-import io.crate.metadata.NodeContext;
-import io.crate.metadata.TransactionContext;
-import io.crate.planner.optimizer.costs.PlanStats;
-import io.crate.planner.operators.LogicalPlan;
-import io.crate.planner.operators.Order;
-import io.crate.planner.optimizer.Rule;
-import io.crate.planner.optimizer.matcher.Capture;
-import io.crate.planner.optimizer.matcher.Captures;
-import io.crate.planner.optimizer.matcher.Pattern;
-
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 import static io.crate.planner.optimizer.matcher.Patterns.source;
 
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
+
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.Order;
+import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
+import io.crate.planner.optimizer.matcher.Capture;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Pattern;
 
 /**
  * Transforms
@@ -71,7 +71,7 @@ public final class DeduplicateOrder implements Rule<Order> {
                              PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
-                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
+                             UnaryOperator<LogicalPlan> resolvePlan) {
         Order childOrder = captures.get(this.childOrder);
         return plan.replaceSources(childOrder.sources());
     }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/EliminateCrossJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/EliminateCrossJoin.java
@@ -29,7 +29,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.PriorityQueue;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -65,7 +65,7 @@ public class EliminateCrossJoin implements Rule<JoinPlan> {
                              PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
-                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
+                             UnaryOperator<LogicalPlan> resolvePlan) {
         if (join.getRelationNames().size() >= 3) {
             var joinGraph = JoinGraph.create(join, resolvePlan);
             if (joinGraph.hasCrossJoin()) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MergeAggregateAndCollectToCount.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MergeAggregateAndCollectToCount.java
@@ -24,7 +24,7 @@ package io.crate.planner.optimizer.rule;
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 import static io.crate.planner.optimizer.matcher.Patterns.source;
 
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import io.crate.common.collections.Lists;
 import io.crate.execution.engine.aggregation.impl.CountAggregation;
@@ -67,7 +67,7 @@ public final class MergeAggregateAndCollectToCount implements Rule<HashAggregate
                        PlanStats planStats,
                        TransactionContext txnCtx,
                        NodeContext nodeCtx,
-                       Function<LogicalPlan, LogicalPlan> resolvePlan) {
+                       UnaryOperator<LogicalPlan> resolvePlan) {
         Collect collect = captures.get(collectCapture);
         var countAggregate = Lists.getOnlyElement(aggregate.aggregates());
         if (countAggregate.filter() != null) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MergeAggregateRenameAndCollectToCount.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MergeAggregateRenameAndCollectToCount.java
@@ -24,7 +24,7 @@ package io.crate.planner.optimizer.rule;
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 import static io.crate.planner.optimizer.matcher.Patterns.source;
 
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import io.crate.common.collections.Lists;
 import io.crate.execution.engine.aggregation.impl.CountAggregation;
@@ -79,7 +79,7 @@ public class MergeAggregateRenameAndCollectToCount implements Rule<HashAggregate
                              PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
-                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
+                             UnaryOperator<LogicalPlan> resolvePlan) {
         Collect collect = captures.get(collectCapture);
         Rename rename = captures.get(renameCapture);
         var countAggregate = Lists.getOnlyElement(aggregate.aggregates());

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MergeFilterAndCollect.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MergeFilterAndCollect.java
@@ -21,6 +21,11 @@
 
 package io.crate.planner.optimizer.rule;
 
+import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.matcher.Patterns.source;
+
+import java.util.function.UnaryOperator;
+
 import io.crate.analyze.WhereClause;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
@@ -32,11 +37,6 @@ import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-
-import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
-import static io.crate.planner.optimizer.matcher.Patterns.source;
-
-import java.util.function.Function;
 
 public class MergeFilterAndCollect implements Rule<Filter> {
 
@@ -60,7 +60,7 @@ public class MergeFilterAndCollect implements Rule<Filter> {
                              PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
-                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
+                             UnaryOperator<LogicalPlan> resolvePlan) {
         Collect collect = captures.get(collectCapture);
         WhereClause newWhere = collect.where().add(filter.query());
         return new Collect(

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MergeFilters.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MergeFilters.java
@@ -21,22 +21,22 @@
 
 package io.crate.planner.optimizer.rule;
 
+import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.matcher.Patterns.source;
+
+import java.util.function.UnaryOperator;
+
 import io.crate.expression.operator.AndOperator;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
-import io.crate.planner.operators.LogicalPlan;
-import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.operators.Filter;
+import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-
-import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
-import static io.crate.planner.optimizer.matcher.Patterns.source;
-
-import java.util.function.Function;
 
 /**
  * Transforms
@@ -75,7 +75,7 @@ public class MergeFilters implements Rule<Filter> {
                         PlanStats planStats,
                         TransactionContext txnCtx,
                         NodeContext nodeCtx,
-                        Function<LogicalPlan, LogicalPlan> resolvePlan) {
+                        UnaryOperator<LogicalPlan> resolvePlan) {
         Filter childFilter = captures.get(child);
         Symbol parentQuery = plan.query();
         Symbol childQuery = childFilter.query();

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoop.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoop.java
@@ -27,7 +27,7 @@ import static io.crate.planner.optimizer.rule.MoveFilterBeneathJoin.getNewSource
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import io.crate.analyze.relations.QuerySplitter;
 import io.crate.expression.operator.AndOperator;
@@ -36,14 +36,14 @@ import io.crate.metadata.NodeContext;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.TransactionContext;
 import io.crate.planner.consumer.RelationNameCollector;
-import io.crate.planner.optimizer.costs.PlanStats;
-import io.crate.sql.tree.JoinType;
 import io.crate.planner.operators.HashJoin;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.NestedLoopJoin;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
+import io.crate.sql.tree.JoinType;
 
 public class MoveConstantJoinConditionsBeneathNestedLoop implements Rule<NestedLoopJoin> {
 
@@ -67,7 +67,7 @@ public class MoveConstantJoinConditionsBeneathNestedLoop implements Rule<NestedL
                              PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
-                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
+                             UnaryOperator<LogicalPlan> resolvePlan) {
         var conditions = nl.joinCondition();
         var allConditions = QuerySplitter.split(conditions);
         var constantConditions = new HashMap<Set<RelationName>, Symbol>(allConditions.size());

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathCorrelatedJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathCorrelatedJoin.java
@@ -27,7 +27,7 @@ import static io.crate.planner.optimizer.matcher.Patterns.source;
 
 import java.util.HashSet;
 import java.util.List;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import io.crate.analyze.relations.QuerySplitter;
 import io.crate.expression.operator.AndOperator;
@@ -64,7 +64,7 @@ public final class MoveFilterBeneathCorrelatedJoin implements Rule<Filter> {
                              PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
-                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
+                             UnaryOperator<LogicalPlan> resolvePlan) {
         var join = captures.get(joinCapture);
         var splitQuery = QuerySplitter.split(filter.query());
         assert join.sources().size() == 1 : "CorrelatedJoin operator must have 1 children, the input plan";

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathEval.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathEval.java
@@ -25,7 +25,7 @@ import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 import static io.crate.planner.optimizer.matcher.Patterns.source;
 import static io.crate.planner.optimizer.rule.Util.transpose;
 
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
@@ -60,7 +60,7 @@ public final class MoveFilterBeneathEval implements Rule<Filter> {
                              PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
-                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
+                             UnaryOperator<LogicalPlan> resolvePlan) {
         // A filter can do full evaluation as well and "Eval" never adds columns, so this is safe.
         Eval eval = captures.get(evalCapture);
         return transpose(plan, eval);

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathGroupBy.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathGroupBy.java
@@ -27,7 +27,7 @@ import static io.crate.planner.optimizer.rule.Util.transpose;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import io.crate.expression.operator.AndOperator;
 import io.crate.expression.symbol.Symbol;
@@ -79,7 +79,7 @@ public final class MoveFilterBeneathGroupBy implements Rule<Filter> {
                              PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
-                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
+                             UnaryOperator<LogicalPlan> resolvePlan) {
         // Since something like `SELECT x, sum(y) FROM t GROUP BY x HAVING y > 10` is not valid
         // (y would have to be declared as group key) any parts of a HAVING that is not an aggregation can be moved.
         Symbol predicate = filter.query();

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathJoin.java
@@ -32,7 +32,7 @@ import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -116,7 +116,7 @@ public final class MoveFilterBeneathJoin implements Rule<Filter> {
                              PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
-                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
+                             UnaryOperator<LogicalPlan> resolvePlan) {
         var join = captures.get(joinCapture);
         var query = filter.query();
         if (!WhereClause.canMatch(query)) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathOrder.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathOrder.java
@@ -21,22 +21,22 @@
 
 package io.crate.planner.optimizer.rule;
 
-import io.crate.metadata.NodeContext;
-import io.crate.metadata.TransactionContext;
-import io.crate.planner.optimizer.costs.PlanStats;
-import io.crate.planner.operators.Filter;
-import io.crate.planner.operators.LogicalPlan;
-import io.crate.planner.operators.Order;
-import io.crate.planner.optimizer.Rule;
-import io.crate.planner.optimizer.matcher.Capture;
-import io.crate.planner.optimizer.matcher.Captures;
-import io.crate.planner.optimizer.matcher.Pattern;
-
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 import static io.crate.planner.optimizer.matcher.Patterns.source;
 import static io.crate.planner.optimizer.rule.Util.transpose;
 
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
+
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.operators.Filter;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.Order;
+import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
+import io.crate.planner.optimizer.matcher.Capture;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Pattern;
 
 /**
  * Transforms
@@ -84,7 +84,7 @@ public final class MoveFilterBeneathOrder implements Rule<Filter> {
                              PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
-                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
+                             UnaryOperator<LogicalPlan> resolvePlan) {
         return transpose(filter, captures.get(orderCapture));
     }
 }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathProjectSet.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathProjectSet.java
@@ -28,7 +28,7 @@ import static io.crate.planner.optimizer.rule.Util.transpose;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import io.crate.expression.operator.AndOperator;
 import io.crate.expression.symbol.Symbol;
@@ -67,7 +67,7 @@ public final class MoveFilterBeneathProjectSet implements Rule<Filter> {
                              PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
-                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
+                             UnaryOperator<LogicalPlan> resolvePlan) {
         var projectSet = captures.get(projectSetCapture);
 
         var queryParts = AndOperator.split(filter.query());

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathRename.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathRename.java
@@ -21,6 +21,12 @@
 
 package io.crate.planner.optimizer.rule;
 
+import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.matcher.Patterns.source;
+
+import java.util.List;
+import java.util.function.UnaryOperator;
+
 import io.crate.expression.symbol.FieldReplacer;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
@@ -32,12 +38,6 @@ import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-
-import java.util.List;
-import java.util.function.Function;
-
-import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
-import static io.crate.planner.optimizer.matcher.Patterns.source;
 
 public class MoveFilterBeneathRename implements Rule<Filter> {
 
@@ -61,7 +61,7 @@ public class MoveFilterBeneathRename implements Rule<Filter> {
                              PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
-                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
+                             UnaryOperator<LogicalPlan> resolvePlan) {
         Rename rename = captures.get(renameCapture);
         Filter newFilter = new Filter(
             rename.source(),

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathUnion.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathUnion.java
@@ -21,24 +21,24 @@
 
 package io.crate.planner.optimizer.rule;
 
+import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.matcher.Patterns.source;
+
+import java.util.List;
+import java.util.function.UnaryOperator;
+
 import io.crate.expression.symbol.FieldReplacer;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
-import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.Union;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-
-import java.util.List;
-import java.util.function.Function;
-
-import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
-import static io.crate.planner.optimizer.matcher.Patterns.source;
 
 public final class MoveFilterBeneathUnion implements Rule<Filter> {
 
@@ -62,7 +62,7 @@ public final class MoveFilterBeneathUnion implements Rule<Filter> {
                              PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
-                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
+                             UnaryOperator<LogicalPlan> resolvePlan) {
         Union union = captures.get(unionCapture);
         LogicalPlan lhs = union.sources().get(0);
         LogicalPlan rhs = union.sources().get(1);

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathWindowAgg.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathWindowAgg.java
@@ -21,6 +21,16 @@
 
 package io.crate.planner.optimizer.rule;
 
+import static io.crate.planner.operators.LogicalPlanner.extractColumns;
+import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.matcher.Patterns.source;
+import static io.crate.planner.optimizer.rule.Util.transpose;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
+
 import io.crate.analyze.WindowDefinition;
 import io.crate.expression.operator.AndOperator;
 import io.crate.expression.symbol.Symbol;
@@ -36,16 +46,6 @@ import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.function.Function;
-import java.util.function.Predicate;
-
-import static io.crate.planner.operators.LogicalPlanner.extractColumns;
-import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
-import static io.crate.planner.optimizer.matcher.Patterns.source;
-import static io.crate.planner.optimizer.rule.Util.transpose;
 
 public final class MoveFilterBeneathWindowAgg implements Rule<Filter> {
 
@@ -69,7 +69,7 @@ public final class MoveFilterBeneathWindowAgg implements Rule<Filter> {
                              PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
-                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
+                             UnaryOperator<LogicalPlan> resolvePlan) {
         WindowAgg windowAgg = captures.get(windowAggCapture);
         WindowDefinition windowDefinition = windowAgg.windowDefinition();
         List<WindowFunction> windowFunctions = windowAgg.windowFunctions();

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveLimitBeneathEval.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveLimitBeneathEval.java
@@ -25,7 +25,7 @@ import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 import static io.crate.planner.optimizer.matcher.Patterns.source;
 import static io.crate.planner.optimizer.rule.Util.transpose;
 
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
@@ -60,7 +60,7 @@ public class MoveLimitBeneathEval implements Rule<Limit> {
                              PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
-                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
+                             UnaryOperator<LogicalPlan> resolvePlan) {
         Eval eval = captures.get(evalCapture);
         return transpose(limit, eval);
     }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveLimitBeneathRename.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveLimitBeneathRename.java
@@ -25,7 +25,7 @@ import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 import static io.crate.planner.optimizer.matcher.Patterns.source;
 import static io.crate.planner.optimizer.rule.Util.transpose;
 
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
@@ -60,7 +60,7 @@ public class MoveLimitBeneathRename implements Rule<Limit> {
                              PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
-                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
+                             UnaryOperator<LogicalPlan> resolvePlan) {
         Rename rename = captures.get(renameCapture);
         return transpose(limit, rename);
     }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathEval.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathEval.java
@@ -21,6 +21,14 @@
 
 package io.crate.planner.optimizer.rule;
 
+import static io.crate.planner.operators.LogicalPlanner.extractColumns;
+import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.matcher.Patterns.source;
+import static io.crate.planner.optimizer.rule.Util.transpose;
+
+import java.util.List;
+import java.util.function.UnaryOperator;
+
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
@@ -32,14 +40,6 @@ import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-
-import java.util.List;
-import java.util.function.Function;
-
-import static io.crate.planner.operators.LogicalPlanner.extractColumns;
-import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
-import static io.crate.planner.optimizer.matcher.Patterns.source;
-import static io.crate.planner.optimizer.rule.Util.transpose;
 
 public final class MoveOrderBeneathEval implements Rule<Order> {
 
@@ -63,7 +63,7 @@ public final class MoveOrderBeneathEval implements Rule<Order> {
                              PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
-                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
+                             UnaryOperator<LogicalPlan> resolvePlan) {
         Eval eval = captures.get(evalCapture);
         List<Symbol> outputsOfSourceOfEval = eval.source().outputs();
         List<Symbol> orderBySymbols = plan.orderBy().orderBySymbols();

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathNestedLoop.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathNestedLoop.java
@@ -29,7 +29,7 @@ import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import io.crate.analyze.OrderBy;
 import io.crate.expression.symbol.FieldsVisitor;
@@ -83,7 +83,7 @@ public final class MoveOrderBeneathNestedLoop implements Rule<Order> {
                              PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
-                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
+                             UnaryOperator<LogicalPlan> resolvePlan) {
         NestedLoopJoin nestedLoop = captures.get(nlCapture);
         Set<RelationName> relationsInOrderBy =
             Collections.newSetFromMap(new IdentityHashMap<>());

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathRename.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathRename.java
@@ -21,6 +21,13 @@
 
 package io.crate.planner.optimizer.rule;
 
+import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.matcher.Patterns.source;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+
 import io.crate.analyze.OrderBy;
 import io.crate.expression.symbol.FieldReplacer;
 import io.crate.expression.symbol.Symbol;
@@ -34,12 +41,6 @@ import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-
-import java.util.List;
-import java.util.function.Function;
-
-import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
-import static io.crate.planner.optimizer.matcher.Patterns.source;
 
 /**
  * <pre>
@@ -82,7 +83,7 @@ public final class MoveOrderBeneathRename implements Rule<Order> {
                              PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
-                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
+                             UnaryOperator<LogicalPlan> resolvePlan) {
         Rename rename = captures.get(renameCapture);
         Function<? super Symbol, ? extends Symbol> mapField = FieldReplacer.bind(rename::resolveField);
         OrderBy mappedOrderBy = plan.orderBy().map(mapField);

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathUnion.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathUnion.java
@@ -21,23 +21,23 @@
 
 package io.crate.planner.optimizer.rule;
 
+import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.matcher.Patterns.source;
+
+import java.util.List;
+import java.util.function.UnaryOperator;
+
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
-import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.Order;
 import io.crate.planner.operators.Union;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-
-import java.util.List;
-import java.util.function.Function;
-
-import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
-import static io.crate.planner.optimizer.matcher.Patterns.source;
 
 public final class MoveOrderBeneathUnion implements Rule<Order> {
 
@@ -61,7 +61,7 @@ public final class MoveOrderBeneathUnion implements Rule<Order> {
                              PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
-                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
+                             UnaryOperator<LogicalPlan> resolvePlan) {
         Union union = captures.get(unionCapture);
         List<LogicalPlan> unionSources = union.sources();
         assert unionSources.size() == 2 : "A UNION must have exactly 2 unionSources";

--- a/server/src/main/java/io/crate/planner/optimizer/rule/OptimizeCollectWhereClauseAccess.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/OptimizeCollectWhereClauseAccess.java
@@ -24,7 +24,7 @@ package io.crate.planner.optimizer.rule;
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 
 import java.util.Optional;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import io.crate.analyze.WhereClause;
 import io.crate.analyze.relations.DocTableRelation;
@@ -68,7 +68,7 @@ public final class OptimizeCollectWhereClauseAccess implements Rule<Collect> {
                              PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
-                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
+                             UnaryOperator<LogicalPlan> resolvePlan) {
         var relation = (DocTableRelation) collect.relation();
         var normalizer = new EvaluatingNormalizer(nodeCtx, RowGranularity.CLUSTER, null, relation);
         WhereClause where = collect.where();

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RemoveRedundantEval.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RemoveRedundantEval.java
@@ -21,18 +21,18 @@
 
 package io.crate.planner.optimizer.rule;
 
+import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
+
+import java.util.function.UnaryOperator;
+
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
-import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.operators.Eval;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-
-import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
-
-import java.util.function.Function;
 
 /**
  * Eliminates any Eval nodes that have the same output as their source
@@ -57,7 +57,7 @@ public final class RemoveRedundantEval implements Rule<Eval> {
                              PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
-                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
+                             UnaryOperator<LogicalPlan> resolvePlan) {
         return plan.source();
     }
 }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/ReorderHashJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/ReorderHashJoin.java
@@ -23,7 +23,7 @@ package io.crate.planner.optimizer.rule;
 
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
@@ -50,7 +50,7 @@ public class ReorderHashJoin implements Rule<HashJoin> {
                              PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
-                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
+                             UnaryOperator<LogicalPlan> resolvePlan) {
         var lhStats = planStats.get(plan.lhs());
         var rhStats = planStats.get(plan.rhs());
         boolean expectedRowsAvailable = lhStats.numDocs() != -1 && rhStats.numDocs() != -1;

--- a/server/src/main/java/io/crate/planner/optimizer/rule/ReorderNestedLoopJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/ReorderNestedLoopJoin.java
@@ -23,7 +23,7 @@ package io.crate.planner.optimizer.rule;
 
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
@@ -52,7 +52,7 @@ public class ReorderNestedLoopJoin implements Rule<NestedLoopJoin> {
                              PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
-                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
+                             UnaryOperator<LogicalPlan> resolvePlan) {
         // We move the smaller table to the right side since benchmarking
         // revealed that this improves performance in most cases.
         var lhStats = planStats.get(nestedLoop.lhs());

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoin.java
@@ -28,7 +28,7 @@ import static io.crate.planner.optimizer.rule.MoveFilterBeneathJoin.getNewSource
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -121,7 +121,7 @@ public final class RewriteFilterOnOuterJoinToInnerJoin implements Rule<Filter> {
                              PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
-                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
+                             UnaryOperator<LogicalPlan> resolvePlan) {
         final var symbolEvaluator = new NullSymbolEvaluator(txnCtx, nodeCtx);
         JoinPlan join = captures.get(nlCapture);
         Symbol query = filter.query();

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteGroupByKeysLimitToLimitDistinct.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteGroupByKeysLimitToLimitDistinct.java
@@ -24,7 +24,7 @@ package io.crate.planner.optimizer.rule;
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 import static io.crate.planner.optimizer.matcher.Patterns.source;
 
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import org.elasticsearch.Version;
 
@@ -171,7 +171,7 @@ public final class RewriteGroupByKeysLimitToLimitDistinct implements Rule<Limit>
                              PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
-                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
+                             UnaryOperator<LogicalPlan> resolvePlan) {
         GroupHashAggregate groupBy = captures.get(groupCapture);
         if (!eagerTerminateIsLikely(limit, groupBy, planStats)) {
             return null;

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteJoinPlan.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteJoinPlan.java
@@ -23,7 +23,7 @@ package io.crate.planner.optimizer.rule;
 
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
@@ -59,7 +59,7 @@ public class RewriteJoinPlan implements Rule<JoinPlan> {
                              PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
-                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
+                             UnaryOperator<LogicalPlan> resolvePlan) {
 
         if (txnCtx.sessionSettings().hashJoinsEnabled() &&
             EquiJoinDetector.isHashJoinPossible(join.joinType(), join.joinCondition())) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteNestedLoopJoinToHashJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteNestedLoopJoinToHashJoin.java
@@ -23,7 +23,7 @@ package io.crate.planner.optimizer.rule;
 
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
@@ -53,7 +53,7 @@ public class RewriteNestedLoopJoinToHashJoin implements Rule<NestedLoopJoin> {
                              PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
-                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
+                             UnaryOperator<LogicalPlan> resolvePlan) {
         if (txnCtx.sessionSettings().hashJoinsEnabled() &&
             EquiJoinDetector.isHashJoinPossible(nl.joinType(), nl.joinCondition())) {
             return new HashJoin(

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteToQueryThenFetch.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteToQueryThenFetch.java
@@ -27,7 +27,7 @@ import static io.crate.planner.optimizer.matcher.Patterns.source;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.expression.symbol.Symbols;
@@ -80,7 +80,7 @@ public final class RewriteToQueryThenFetch implements Rule<Limit> {
                              PlanStats planStats,
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
-                             Function<LogicalPlan, LogicalPlan> resolvePlan) {
+                             UnaryOperator<LogicalPlan> resolvePlan) {
         if (Symbols.containsColumn(limit.outputs(), DocSysColumns.FETCHID)) {
             return null;
         }

--- a/server/src/main/java/io/crate/planner/statement/CopyToPlan.java
+++ b/server/src/main/java/io/crate/planner/statement/CopyToPlan.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import org.elasticsearch.common.settings.Settings;
 
@@ -186,7 +187,7 @@ public final class CopyToPlan implements Plan {
                                                          planStats,
                                                          context.transactionContext(),
                                                          context.nodeContext(),
-                                                         Function.identity());
+                                                         UnaryOperator.identity());
             return plan == null ? collect : plan;
         }
         return collect;

--- a/server/src/main/java/io/crate/replication/logical/repository/LogicalReplicationRepository.java
+++ b/server/src/main/java/io/crate/replication/logical/repository/LogicalReplicationRepository.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -255,7 +256,7 @@ public class LogicalReplicationRepository extends AbstractLifecycleComponent imp
                                  final Metadata clusterMetadata,
                                  SnapshotInfo snapshotInfo,
                                  Version repositoryMetaVersion,
-                                 Function<ClusterState, ClusterState> stateTransformer,
+                                 UnaryOperator<ClusterState> stateTransformer,
                                  final ActionListener<RepositoryData> listener) {
         throw new UnsupportedOperationException("Operation not permitted");
     }

--- a/server/src/main/java/io/crate/server/xcontent/ServerXContentExtension.java
+++ b/server/src/main/java/io/crate/server/xcontent/ServerXContentExtension.java
@@ -38,7 +38,7 @@ import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -172,8 +172,8 @@ public class ServerXContentExtension implements XContentBuilderExtension {
     }
 
     @Override
-    public Map<Class<?>, Function<Object, Object>> getDateTransformers() {
-        Map<Class<?>, Function<Object, Object>> transformers = new HashMap<>();
+    public Map<Class<?>, UnaryOperator<Object>> getDateTransformers() {
+        Map<Class<?>, UnaryOperator<Object>> transformers = new HashMap<>();
         transformers.put(Date.class, d -> DEFAULT_DATE_PRINTER.print(((Date) d).getTime()));
         transformers.put(DateTime.class, d -> DEFAULT_DATE_PRINTER.print((DateTime) d));
         transformers.put(MutableDateTime.class, d -> DEFAULT_DATE_PRINTER.print((MutableDateTime) d));

--- a/server/src/main/java/org/elasticsearch/common/bytes/AbstractBytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/AbstractBytesReference.java
@@ -19,15 +19,15 @@
 
 package org.elasticsearch.common.bytes;
 
-import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.BytesRefIterator;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.function.ToIntBiFunction;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefIterator;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 
 public abstract class AbstractBytesReference implements BytesReference {
 

--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -42,8 +42,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.jetbrains.annotations.Nullable;
-
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchParseException;
@@ -59,6 +57,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.jetbrains.annotations.Nullable;
 
 import io.crate.common.Booleans;
 import io.crate.common.StringUtils;
@@ -1234,13 +1233,13 @@ public class Setting<T> implements ToXContentObject {
     }
 
     public static Setting<String> simpleString(String key, Setting<String> fallback, Property... properties) {
-        return simpleString(key, fallback, Function.identity(), properties);
+        return simpleString(key, fallback, UnaryOperator.identity(), properties);
     }
 
     public static Setting<String> simpleString(
             final String key,
             final Setting<String> fallback,
-            final Function<String, String> parser,
+            final UnaryOperator<String> parser,
             final Property... properties) {
         return new Setting<>(key, fallback, parser, DataTypes.STRING, properties);
     }

--- a/server/src/main/java/org/elasticsearch/index/analysis/PreConfiguredCharFilter.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/PreConfiguredCharFilter.java
@@ -19,14 +19,14 @@
 
 package org.elasticsearch.index.analysis;
 
+import java.io.Reader;
+import java.util.function.BiFunction;
+import java.util.function.UnaryOperator;
+
 import org.apache.lucene.analysis.CharFilter;
 import org.apache.lucene.analysis.TokenFilter;
 import org.elasticsearch.Version;
 import org.elasticsearch.indices.analysis.PreBuiltCacheFactory.CachingStrategy;
-
-import java.io.Reader;
-import java.util.function.BiFunction;
-import java.util.function.Function;
 
 /**
  * Provides pre-configured, shared {@link CharFilter}s.
@@ -36,7 +36,7 @@ public class PreConfiguredCharFilter extends PreConfiguredAnalysisComponent<Char
     /**
      * Create a pre-configured char filter that may not vary at all.
      */
-    public static PreConfiguredCharFilter singleton(String name, boolean useFilterForMultitermQueries, Function<Reader, Reader> create) {
+    public static PreConfiguredCharFilter singleton(String name, boolean useFilterForMultitermQueries, UnaryOperator<Reader> create) {
         return new PreConfiguredCharFilter(
             name,
             CachingStrategy.ONE,

--- a/server/src/main/java/org/elasticsearch/index/analysis/PreConfiguredTokenFilter.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/PreConfiguredTokenFilter.java
@@ -19,14 +19,14 @@
 
 package org.elasticsearch.index.analysis;
 
+import java.util.function.BiFunction;
+import java.util.function.UnaryOperator;
+
 import org.apache.lucene.analysis.TokenFilter;
 import org.apache.lucene.analysis.TokenStream;
 import org.elasticsearch.Version;
 import org.elasticsearch.indices.analysis.PreBuiltCacheFactory;
 import org.elasticsearch.indices.analysis.PreBuiltCacheFactory.CachingStrategy;
-
-import java.util.function.BiFunction;
-import java.util.function.Function;
 
 /**
  * Provides pre-configured, shared {@link TokenFilter}s.
@@ -35,8 +35,9 @@ public final class PreConfiguredTokenFilter extends PreConfiguredAnalysisCompone
     /**
      * Create a pre-configured token filter that may not vary at all.
      */
-    public static PreConfiguredTokenFilter singleton(String name, boolean useFilterForMultitermQueries,
-            Function<TokenStream, TokenStream> create) {
+    public static PreConfiguredTokenFilter singleton(String name,
+                                                     boolean useFilterForMultitermQueries,
+                                                     UnaryOperator<TokenStream> create) {
         return new PreConfiguredTokenFilter(
             name,
             useFilterForMultitermQueries,

--- a/server/src/main/java/org/elasticsearch/index/engine/NoOpEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/NoOpEngine.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexCommit;
@@ -50,7 +50,7 @@ public final class NoOpEngine extends ReadOnlyEngine {
     private final DocsStats docsStats;
 
     public NoOpEngine(EngineConfig config) {
-        super(config, null, null, true, Function.identity(), true);
+        super(config, null, null, true, UnaryOperator.identity(), true);
         Directory directory = store.directory();
         try (DirectoryReader reader = openDirectory(directory, config.getIndexSettings().isSoftDeleteEnabled())) {
             this.docsStats = docsStats(reader);

--- a/server/src/main/java/org/elasticsearch/index/engine/ReadOnlyEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/ReadOnlyEngine.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 
 import org.apache.lucene.index.DirectoryReader;
@@ -86,7 +87,7 @@ public class ReadOnlyEngine extends Engine {
      * @param requireCompleteHistory indicates whether this engine permits an incomplete history (i.e. LCP &lt; MSN)
      */
     public ReadOnlyEngine(EngineConfig config, SeqNoStats seqNoStats, TranslogStats translogStats, boolean obtainLock,
-                          Function<DirectoryReader, DirectoryReader> readerWrapperFunction, boolean requireCompleteHistory) {
+                          UnaryOperator<DirectoryReader> readerWrapperFunction, boolean requireCompleteHistory) {
         super(config);
         this.requireCompleteHistory = requireCompleteHistory;
         try {
@@ -161,7 +162,7 @@ public class ReadOnlyEngine extends Engine {
 
 
     protected final ElasticsearchDirectoryReader wrapReader(DirectoryReader reader,
-                                                            Function<DirectoryReader, DirectoryReader> readerWrapperFunction) throws IOException {
+                                                            UnaryOperator<DirectoryReader> readerWrapperFunction) throws IOException {
         if (engineConfig.getIndexSettings().isSoftDeleteEnabled()) {
             reader = new SoftDeletesDirectoryReaderWrapper(reader, Lucene.SOFT_DELETES_FIELD);
         }

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -50,10 +50,9 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.LongSupplier;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
-
-import org.jetbrains.annotations.Nullable;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
@@ -154,6 +153,7 @@ import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.repositories.Repository;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.jetbrains.annotations.Nullable;
 
 import com.carrotsearch.hppc.ObjectLongMap;
 
@@ -3365,7 +3365,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             // we must create both new read-only engine and new read-write engine under engineMutex to ensure snapshotStoreMetadata,
             // acquireXXXCommit and close works.
             final Engine readOnlyEngine =
-                new ReadOnlyEngine(newEngineConfig(replicationTracker), seqNoStats, translogStats, false, Function.identity(), true) {
+                new ReadOnlyEngine(newEngineConfig(replicationTracker), seqNoStats, translogStats, false, UnaryOperator.identity(), true) {
                     @Override
                     public IndexCommitRef acquireLastIndexCommit(boolean flushFirst) {
                         synchronized (engineMutex) {

--- a/server/src/main/java/org/elasticsearch/repositories/Repository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/Repository.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import org.apache.lucene.index.IndexCommit;
 import org.elasticsearch.Version;
@@ -139,8 +140,8 @@ public interface Repository extends LifecycleComponent {
      * @param listener              listener to be invoked with the new {@link RepositoryData} after completing the snapshot
      */
     void finalizeSnapshot(ShardGenerations shardGenerations, long repositoryStateId, Metadata clusterMetadata,
-                          SnapshotInfo snapshotInfo, Version repositoryMetaVersion, Function<ClusterState, ClusterState> stateTransformer,
-                          ActionListener<RepositoryData> listener);
+                          SnapshotInfo snapshotInfo, Version repositoryMetaVersion,
+                          UnaryOperator<ClusterState> stateTransformer, ActionListener<RepositoryData> listener);
 
     /**
      * Deletes snapshots

--- a/server/src/test/java/io/crate/analyze/where/NullEliminatorTest.java
+++ b/server/src/test/java/io/crate/analyze/where/NullEliminatorTest.java
@@ -23,7 +23,7 @@ package io.crate.analyze.where;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -56,7 +56,7 @@ public class NullEliminatorTest extends CrateDummyClusterServiceUnitTest {
                        s -> normalizer.normalize(s, CoordinatorTxnCtx.systemTransactionContext()));
     }
 
-    private void assertReplaced(String expression, String expectedString, Function<Symbol, Symbol> postProcessor) {
+    private void assertReplaced(String expression, String expectedString, UnaryOperator<Symbol> postProcessor) {
         Symbol query = sqlExpressions.asSymbol(expression);
         Symbol replacedQuery = NullEliminator.eliminateNullsIfPossible(query, postProcessor);
         assertThat(replacedQuery.toString()).isEqualTo(expectedString);

--- a/server/src/test/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIteratorTest.java
@@ -37,7 +37,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.NumericDocValuesField;
@@ -165,7 +165,7 @@ public class DocValuesGroupByOptimizedIteratorTest extends CrateDummyClusterServ
             null,
             null,
             new MatchAllDocsQuery(),
-            new CollectorContext(Set.of(), Function.identity())
+            new CollectorContext(Set.of(), UnaryOperator.identity())
         );
 
         var rowConsumer = new TestingRowConsumer();
@@ -244,7 +244,7 @@ public class DocValuesGroupByOptimizedIteratorTest extends CrateDummyClusterServ
             null,
             null,
             new MatchAllDocsQuery(),
-            new CollectorContext(Set.of(), Function.identity())
+            new CollectorContext(Set.of(), UnaryOperator.identity())
         );
 
         var rowConsumer = new TestingRowConsumer();
@@ -372,7 +372,7 @@ public class DocValuesGroupByOptimizedIteratorTest extends CrateDummyClusterServ
             (expressions) -> expressions.get(0).value(),
             (key, cells) -> cells[0] = key,
             new MatchAllDocsQuery(),
-            new CollectorContext(Set.of(), Function.identity())
+            new CollectorContext(Set.of(), UnaryOperator.identity())
         );
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/collect/GroupByOptimizedIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/GroupByOptimizedIteratorTest.java
@@ -38,7 +38,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.document.Document;
@@ -146,7 +146,7 @@ public class GroupByOptimizedIteratorTest extends CrateDummyClusterServiceUnitTe
             Version.CURRENT,
             new InputRow(Collections.singletonList(inExpr)),
             new MatchAllDocsQuery(),
-            new CollectorContext(Set.of(), Function.identity()),
+            new CollectorContext(Set.of(), UnaryOperator.identity()),
             AggregateMode.ITER_FINAL
         );
     }

--- a/server/src/test/java/io/crate/execution/engine/collect/collectors/LuceneBatchIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/collectors/LuceneBatchIteratorTest.java
@@ -25,7 +25,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.document.Document;
@@ -75,7 +75,7 @@ public class LuceneBatchIteratorTest {
                 new MatchAllDocsQuery(),
                 null,
                 false,
-                new CollectorContext(Set.of(), Function.identity()),
+                new CollectorContext(Set.of(), UnaryOperator.identity()),
                 columnRefs,
                 columnRefs
             )

--- a/server/src/test/java/io/crate/execution/engine/collect/collectors/LuceneOrderedDocCollectorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/collectors/LuceneOrderedDocCollectorTest.java
@@ -31,10 +31,8 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 import java.util.stream.StreamSupport;
-
-import org.jetbrains.annotations.Nullable;
 
 import org.apache.lucene.analysis.core.KeywordAnalyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
@@ -69,6 +67,7 @@ import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.shard.ShardId;
 import org.hamcrest.Matchers;
+import org.jetbrains.annotations.Nullable;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -393,7 +392,7 @@ public class LuceneOrderedDocCollectorTest extends RandomizedTest {
             doDocScores,
             2,
             RamAccounting.NO_ACCOUNTING,
-            new CollectorContext(Set.of(), Function.identity()),
+            new CollectorContext(Set.of(), UnaryOperator.identity()),
             f -> null,
             new Sort(SortField.FIELD_SCORE),
             columnReferences,

--- a/server/src/test/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorFactoryTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorFactoryTest.java
@@ -35,7 +35,7 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 
@@ -240,7 +240,7 @@ public class OrderedLuceneBatchIteratorFactoryTest extends ESTestCase {
     }
 
     private LuceneOrderedDocCollector createOrderedCollector(IndexSearcher searcher, int shardId) {
-        CollectorContext collectorContext = new CollectorContext(Set.of(), Function.identity());
+        CollectorContext collectorContext = new CollectorContext(Set.of(), UnaryOperator.identity());
         List<LuceneCollectorExpression<?>> expressions = Collections.singletonList(
             new OrderByCollectorExpression(reference, orderBy, o -> o));
         return new LuceneOrderedDocCollector(

--- a/server/src/test/java/io/crate/expression/reference/doc/DocLevelExpressionsTest.java
+++ b/server/src/test/java/io/crate/expression/reference/doc/DocLevelExpressionsTest.java
@@ -22,7 +22,7 @@
 package io.crate.expression.reference.doc;
 
 import java.util.Set;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 import java.util.stream.StreamSupport;
 
 import org.apache.lucene.index.DirectoryReader;
@@ -72,7 +72,7 @@ public abstract class DocLevelExpressionsTest extends CrateDummyClusterServiceUn
         insertValues(writer);
         DirectoryReader directoryReader = DirectoryReader.open(writer, true, true);
         readerContext = directoryReader.leaves().get(0);
-        ctx = new CollectorContext(Set.of(), Function.identity());
+        ctx = new CollectorContext(Set.of(), UnaryOperator.identity());
     }
 
     @After

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionClassLifecycleTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionClassLifecycleTest.java
@@ -52,7 +52,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import org.apache.lucene.util.Constants;
 import org.elasticsearch.Build;
@@ -118,7 +118,7 @@ public class TransportSQLActionClassLifecycleTest extends IntegTestCase {
 
         var schemas = cluster().getDataNodeInstance(Schemas.class);
         DocTableInfo table = schemas.getTableInfo(new RelationName(sqlExecutor.getCurrentSchema(), "characters"));
-        Function<String, String> mapName = s -> {
+        UnaryOperator<String> mapName = s -> {
             var ref = table.getReference(ColumnIdent.fromPath(s));
             return ref.storageIdent();
         };
@@ -141,7 +141,7 @@ public class TransportSQLActionClassLifecycleTest extends IntegTestCase {
 
         var schemas = cluster().getDataNodeInstance(Schemas.class);
         DocTableInfo table = schemas.getTableInfo(new RelationName(sqlExecutor.getCurrentSchema(), "characters"));
-        Function<String, String> mapName = s -> {
+        UnaryOperator<String> mapName = s -> {
             var ref = table.getReference(ColumnIdent.fromPath(s));
             return ref.storageIdent();
         };

--- a/server/src/test/java/io/crate/integrationtests/disruption/seqno/ConcurrentSeqNoVersioningIT.java
+++ b/server/src/test/java/io/crate/integrationtests/disruption/seqno/ConcurrentSeqNoVersioningIT.java
@@ -45,7 +45,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -689,7 +689,7 @@ public class ConcurrentSeqNoVersioningIT extends AbstractDisruptionTestCase {
         }
     }
 
-    private static Function<Object, Object> missingResponseGenerator() {
+    private static UnaryOperator<Object> missingResponseGenerator() {
         return input -> new FailureHistoryOutput();
     }
 

--- a/server/src/test/java/io/crate/planner/optimizer/rule/EliminateCrossJoinTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/EliminateCrossJoinTest.java
@@ -23,11 +23,10 @@ package io.crate.planner.optimizer.rule;
 
 import static io.crate.common.collections.Iterables.getOnlyElement;
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -110,7 +109,7 @@ public class EliminateCrossJoinTest extends CrateDummyClusterServiceUnitTest {
             "  └ Collect[doc.b | [y] | true]"
         );
 
-        JoinGraph joinGraph = JoinGraph.create(join, Function.identity());
+        JoinGraph joinGraph = JoinGraph.create(join, UnaryOperator.identity());
         assertThat(joinGraph.nodes()).containsExactly(a, b);
         assertThat(joinGraph.edges()).hasSize(2);
 
@@ -151,7 +150,7 @@ public class EliminateCrossJoinTest extends CrateDummyClusterServiceUnitTest {
             "  └ Collect[doc.c | [z] | true]"
         );
 
-        JoinGraph joinGraph = JoinGraph.create(join, Function.identity());
+        JoinGraph joinGraph = JoinGraph.create(join, UnaryOperator.identity());
         // This builds the following graph:
         // [a]--[a.x = b.y]--[b]--[b.y = c.z]--[c]
         assertThat(joinGraph.nodes()).containsExactly(a, b, c);
@@ -206,7 +205,7 @@ public class EliminateCrossJoinTest extends CrateDummyClusterServiceUnitTest {
             "  └ Collect[doc.d | [w] | true]"
         );
 
-        JoinGraph joinGraph = JoinGraph.create(topJoin, Function.identity());
+        JoinGraph joinGraph = JoinGraph.create(topJoin, UnaryOperator.identity());
 
         assertThat(EliminateCrossJoin.reorder(joinGraph, List.of(a, c, b, d))).isEqualTo(
             "Join[INNER | (y = w)]\n" +
@@ -246,7 +245,7 @@ public class EliminateCrossJoinTest extends CrateDummyClusterServiceUnitTest {
             "    └ Collect[doc.c | [z] | true]"
         );
 
-        JoinGraph joinGraph = JoinGraph.create(filter, Function.identity());
+        JoinGraph joinGraph = JoinGraph.create(filter, UnaryOperator.identity());
 
         assertThat(EliminateCrossJoin.reorder(joinGraph, List.of(c, b, a))).hasOperators(
             "Filter[(x > 1)]",
@@ -259,7 +258,7 @@ public class EliminateCrossJoinTest extends CrateDummyClusterServiceUnitTest {
 
         var secondFilter = new Filter(filter, e.asSymbol("b.y < 10"));
 
-        joinGraph = JoinGraph.create(secondFilter, Function.identity());
+        joinGraph = JoinGraph.create(secondFilter, UnaryOperator.identity());
 
         assertThat(EliminateCrossJoin.reorder(joinGraph, List.of(c, b, a))).hasOperators(
             "Filter[(y < 10)]",
@@ -285,7 +284,7 @@ public class EliminateCrossJoinTest extends CrateDummyClusterServiceUnitTest {
             "  └ Collect[doc.c | [z] | true]"
         );
 
-        var joinGraph = JoinGraph.create(join, Function.identity());
+        var joinGraph = JoinGraph.create(join, UnaryOperator.identity());
         var originalOrder = joinGraph.nodes();
         assertThat(originalOrder).isEqualTo(List.of(a, b, c));
         var newOrder = EliminateCrossJoin.eliminateCrossJoin(joinGraph);
@@ -302,7 +301,7 @@ public class EliminateCrossJoinTest extends CrateDummyClusterServiceUnitTest {
                                 e.planStats(),
                                 CoordinatorTxnCtx.systemTransactionContext(),
                                 e.nodeCtx,
-                                Function.identity());
+                                UnaryOperator.identity());
 
         assertThat(result).hasOperators(
             "Eval[x, y, z]",
@@ -338,7 +337,7 @@ public class EliminateCrossJoinTest extends CrateDummyClusterServiceUnitTest {
                                 e.planStats(),
                                 CoordinatorTxnCtx.systemTransactionContext(),
                                 e.nodeCtx,
-                                Function.identity());
+                                UnaryOperator.identity());
 
         assertThat(result).isNull();
 
@@ -356,7 +355,7 @@ public class EliminateCrossJoinTest extends CrateDummyClusterServiceUnitTest {
                             e.planStats(),
                             CoordinatorTxnCtx.systemTransactionContext(),
                             e.nodeCtx,
-                            Function.identity());
+                            UnaryOperator.identity());
 
         assertThat(result).isNull();
     }
@@ -384,7 +383,7 @@ public class EliminateCrossJoinTest extends CrateDummyClusterServiceUnitTest {
                                 e.planStats(),
                                 CoordinatorTxnCtx.systemTransactionContext(),
                                 e.nodeCtx,
-                                Function.identity());
+                                UnaryOperator.identity());
 
         assertThat(result).isNull();
     }
@@ -431,7 +430,7 @@ public class EliminateCrossJoinTest extends CrateDummyClusterServiceUnitTest {
             "  └ Collect[doc.d | [w] | true]"
         );
 
-        var graph = JoinGraph.create(thirdJoin, Function.identity());
+        var graph = JoinGraph.create(thirdJoin, UnaryOperator.identity());
         assertThat(graph.size()).isEqualTo(4);
         assertThat(graph.edges()).hasSize(4);
         assertThat(graph.nodes().get(0)).isEqualTo(rename_a);
@@ -457,7 +456,7 @@ public class EliminateCrossJoinTest extends CrateDummyClusterServiceUnitTest {
             "  └ Collect[doc.c | [z] | true]"
         );
 
-        JoinGraph joinGraph = JoinGraph.create(join, Function.identity());
+        JoinGraph joinGraph = JoinGraph.create(join, UnaryOperator.identity());
         assertThat(joinGraph.nodes()).containsExactly(order, b, c);
 
         var reordered = EliminateCrossJoin.reorder(joinGraph, List.of(c, b, order));
@@ -487,7 +486,7 @@ public class EliminateCrossJoinTest extends CrateDummyClusterServiceUnitTest {
             "  └ Collect[doc.d | [w] | true]"
         );
 
-        JoinGraph joinGraph = JoinGraph.create(secondJoin, Function.identity());
+        JoinGraph joinGraph = JoinGraph.create(secondJoin, UnaryOperator.identity());
         assertThat(joinGraph.nodes()).containsExactly(union, c, d);
 
         var reordered = EliminateCrossJoin.reorder(joinGraph, List.of(union, d, c));
@@ -516,7 +515,7 @@ public class EliminateCrossJoinTest extends CrateDummyClusterServiceUnitTest {
             "  └ Collect[doc.b | [y] | true]"
         );
 
-        JoinGraph joinGraph = JoinGraph.create(join, Function.identity());
+        JoinGraph joinGraph = JoinGraph.create(join, UnaryOperator.identity());
         assertThat(joinGraph.nodes()).containsExactly(a, b);
         assertThat(joinGraph.edges()).hasSize(2);
         assertThat(joinGraph.filters()).hasSize(1);

--- a/server/src/test/java/io/crate/planner/optimizer/rule/MergeFiltersTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/MergeFiltersTest.java
@@ -25,7 +25,7 @@ import static io.crate.testing.Asserts.assertThat;
 
 import java.util.Collections;
 import java.util.Map;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -78,7 +78,7 @@ public class MergeFiltersTest extends CrateDummyClusterServiceUnitTest {
                                                  planStats,
                                                  CoordinatorTxnCtx.systemTransactionContext(),
                                                  e.nodeCtx,
-                                                 Function.identity());
+                                                 UnaryOperator.identity());
         assertThat(mergedFilter.query()).isSQL("((doc.t2.y > 10) AND (doc.t1.x > 10))");
     }
 }

--- a/server/src/test/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoopTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathNestedLoopTest.java
@@ -26,7 +26,7 @@ import static org.junit.Assert.assertThat;
 
 import java.util.Collections;
 import java.util.Map;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import org.hamcrest.Matchers;
 import org.junit.Before;
@@ -88,7 +88,7 @@ public class MoveConstantJoinConditionsBeneathNestedLoopTest extends CrateDummyC
                                                 planStats,
                                                 CoordinatorTxnCtx.systemTransactionContext(),
                                                 sqlExpressions.nodeCtx,
-                                                Function.identity());
+                                                UnaryOperator.identity());
 
         assertThat(result.joinCondition(), is(nonConstantPart));
         assertThat(result.lhs(), is(c1));

--- a/server/src/test/java/io/crate/planner/optimizer/rule/MoveFilterBeneathJoinTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/MoveFilterBeneathJoinTest.java
@@ -24,7 +24,7 @@ package io.crate.planner.optimizer.rule;
 import static io.crate.testing.Asserts.assertThat;
 
 import java.util.Map;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -98,7 +98,7 @@ public class MoveFilterBeneathJoinTest extends CrateDummyClusterServiceUnitTest 
                                 planStats,
                                 CoordinatorTxnCtx.systemTransactionContext(),
                                 sqlExpressions.nodeCtx,
-                                Function.identity());
+                                UnaryOperator.identity());
 
         assertThat(result).hasOperators(
             "Join[INNER | (a = b)]",
@@ -137,7 +137,7 @@ public class MoveFilterBeneathJoinTest extends CrateDummyClusterServiceUnitTest 
                                 planStats,
                                 CoordinatorTxnCtx.systemTransactionContext(),
                                 sqlExpressions.nodeCtx,
-                                Function.identity());
+                                UnaryOperator.identity());
 
         assertThat(result).hasOperators(
             "Join[INNER | (b = c)]",
@@ -178,7 +178,7 @@ public class MoveFilterBeneathJoinTest extends CrateDummyClusterServiceUnitTest 
                                 planStats,
                                 CoordinatorTxnCtx.systemTransactionContext(),
                                 sqlExpressions.nodeCtx,
-                                Function.identity());
+                                UnaryOperator.identity());
 
         assertThat(result).hasOperators(
             "Join[INNER | (b = c)]",
@@ -224,7 +224,7 @@ public class MoveFilterBeneathJoinTest extends CrateDummyClusterServiceUnitTest 
                                 planStats,
                                 CoordinatorTxnCtx.systemTransactionContext(),
                                 sqlExpressions.nodeCtx,
-                                Function.identity());
+                                UnaryOperator.identity());
 
         assertThat(result).isNull();
     }
@@ -263,7 +263,7 @@ public class MoveFilterBeneathJoinTest extends CrateDummyClusterServiceUnitTest 
                                 planStats,
                                 CoordinatorTxnCtx.systemTransactionContext(),
                                 sqlExpressions.nodeCtx,
-                                Function.identity());
+                                UnaryOperator.identity());
 
         assertThat(result).hasOperators(
             "Filter[(a > 1)]",
@@ -309,7 +309,7 @@ public class MoveFilterBeneathJoinTest extends CrateDummyClusterServiceUnitTest 
             planStats,
             CoordinatorTxnCtx.systemTransactionContext(),
             sqlExpressions.nodeCtx,
-            Function.identity());
+            UnaryOperator.identity());
 
         assertThat(result).hasOperators(
             "Join[INNER | (a = c)]",
@@ -344,7 +344,7 @@ public class MoveFilterBeneathJoinTest extends CrateDummyClusterServiceUnitTest 
             planStats,
             CoordinatorTxnCtx.systemTransactionContext(),
             sqlExpressions.nodeCtx,
-            Function.identity());
+            UnaryOperator.identity());
 
         assertThat(result).hasOperators(
             "Join[LEFT | (a = b)]",
@@ -377,7 +377,7 @@ public class MoveFilterBeneathJoinTest extends CrateDummyClusterServiceUnitTest 
             planStats,
             CoordinatorTxnCtx.systemTransactionContext(),
             sqlExpressions.nodeCtx,
-            Function.identity());
+            UnaryOperator.identity());
 
         assertThat(result).isNull();
     }
@@ -405,7 +405,7 @@ public class MoveFilterBeneathJoinTest extends CrateDummyClusterServiceUnitTest 
             planStats,
             CoordinatorTxnCtx.systemTransactionContext(),
             sqlExpressions.nodeCtx,
-            Function.identity());
+            UnaryOperator.identity());
 
         assertThat(result).hasOperators(
             "Join[RIGHT | (a = b)]",
@@ -438,7 +438,7 @@ public class MoveFilterBeneathJoinTest extends CrateDummyClusterServiceUnitTest 
             planStats,
             CoordinatorTxnCtx.systemTransactionContext(),
             sqlExpressions.nodeCtx,
-            Function.identity());
+            UnaryOperator.identity());
 
         assertThat(result).isNull();
     }
@@ -483,7 +483,7 @@ public class MoveFilterBeneathJoinTest extends CrateDummyClusterServiceUnitTest 
             planStats,
             CoordinatorTxnCtx.systemTransactionContext(),
             sqlExpressions.nodeCtx,
-            Function.identity());
+            UnaryOperator.identity());
 
         assertThat(result).hasOperators(
             "Join[CROSS]",
@@ -520,7 +520,7 @@ public class MoveFilterBeneathJoinTest extends CrateDummyClusterServiceUnitTest 
             planStats,
             CoordinatorTxnCtx.systemTransactionContext(),
             sqlExpressions.nodeCtx,
-            Function.identity());
+            UnaryOperator.identity());
 
         assertThat(result).hasOperators(
             "Join[LEFT | (a = c)]",
@@ -559,7 +559,7 @@ public class MoveFilterBeneathJoinTest extends CrateDummyClusterServiceUnitTest 
             planStats,
             CoordinatorTxnCtx.systemTransactionContext(),
             sqlExpressions.nodeCtx,
-            Function.identity());
+            UnaryOperator.identity());
 
         assertThat(result).hasOperators(
             "Join[RIGHT | (b = c)]",

--- a/server/src/test/java/io/crate/planner/optimizer/rule/MoveFilterBeneathWindowAggTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/MoveFilterBeneathWindowAggTest.java
@@ -25,7 +25,7 @@ package io.crate.planner.optimizer.rule;
 import static io.crate.testing.Asserts.assertThat;
 
 import java.util.List;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -75,7 +75,7 @@ public class MoveFilterBeneathWindowAggTest extends CrateDummyClusterServiceUnit
             e.planStats(),
             CoordinatorTxnCtx.systemTransactionContext(),
             e.nodeCtx,
-            Function.identity()
+            UnaryOperator.identity()
         );
 
         assertThat(newPlan).isNull();
@@ -103,7 +103,7 @@ public class MoveFilterBeneathWindowAggTest extends CrateDummyClusterServiceUnit
             e.planStats(),
             CoordinatorTxnCtx.systemTransactionContext(),
             e.nodeCtx,
-            Function.identity()
+            UnaryOperator.identity()
         );
 
         assertThat(newPlan).isNull();
@@ -130,7 +130,7 @@ public class MoveFilterBeneathWindowAggTest extends CrateDummyClusterServiceUnit
             e.planStats(),
             CoordinatorTxnCtx.systemTransactionContext(),
             e.nodeCtx,
-            Function.identity()
+            UnaryOperator.identity()
         );
         var expectedPlan =
             """
@@ -164,7 +164,7 @@ public class MoveFilterBeneathWindowAggTest extends CrateDummyClusterServiceUnit
             e.planStats(),
             CoordinatorTxnCtx.systemTransactionContext(),
             e.nodeCtx,
-            Function.identity()
+            UnaryOperator.identity()
         );
         var expectedPlan =
             """
@@ -199,7 +199,7 @@ public class MoveFilterBeneathWindowAggTest extends CrateDummyClusterServiceUnit
             e.planStats(),
             CoordinatorTxnCtx.systemTransactionContext(),
             e.nodeCtx,
-            Function.identity()
+            UnaryOperator.identity()
         );
         assertThat(newPlan).isNull();
     }

--- a/server/src/test/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoinTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoinTest.java
@@ -24,7 +24,7 @@ package io.crate.planner.optimizer.rule;
 import static io.crate.testing.Asserts.assertThat;
 
 import java.util.Map;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -92,7 +92,7 @@ public class RewriteFilterOnOuterJoinToInnerJoinTest extends CrateDummyClusterSe
             planStats,
             CoordinatorTxnCtx.systemTransactionContext(),
             sqlExpressions.nodeCtx,
-            Function.identity());
+            UnaryOperator.identity());
 
         assertThat(result).hasOperators(
             "Join[INNER | (a = b)]",
@@ -125,7 +125,7 @@ public class RewriteFilterOnOuterJoinToInnerJoinTest extends CrateDummyClusterSe
             planStats,
             CoordinatorTxnCtx.systemTransactionContext(),
             sqlExpressions.nodeCtx,
-            Function.identity());
+            UnaryOperator.identity());
 
         assertThat(result).isNull();
     }
@@ -153,7 +153,7 @@ public class RewriteFilterOnOuterJoinToInnerJoinTest extends CrateDummyClusterSe
             planStats,
             CoordinatorTxnCtx.systemTransactionContext(),
             sqlExpressions.nodeCtx,
-            Function.identity());
+            UnaryOperator.identity());
 
         assertThat(result).isNull();
     }
@@ -181,7 +181,7 @@ public class RewriteFilterOnOuterJoinToInnerJoinTest extends CrateDummyClusterSe
             planStats,
             CoordinatorTxnCtx.systemTransactionContext(),
             sqlExpressions.nodeCtx,
-            Function.identity());
+            UnaryOperator.identity());
 
         assertThat(result).hasOperators(
             "Join[INNER | (a = b)]",
@@ -214,7 +214,7 @@ public class RewriteFilterOnOuterJoinToInnerJoinTest extends CrateDummyClusterSe
             planStats,
             CoordinatorTxnCtx.systemTransactionContext(),
             sqlExpressions.nodeCtx,
-            Function.identity());
+            UnaryOperator.identity());
 
         assertThat(result).isNull();
     }
@@ -242,7 +242,7 @@ public class RewriteFilterOnOuterJoinToInnerJoinTest extends CrateDummyClusterSe
             planStats,
             CoordinatorTxnCtx.systemTransactionContext(),
             sqlExpressions.nodeCtx,
-            Function.identity());
+            UnaryOperator.identity());
 
         assertThat(result).isNull();
     }
@@ -270,7 +270,7 @@ public class RewriteFilterOnOuterJoinToInnerJoinTest extends CrateDummyClusterSe
             planStats,
             CoordinatorTxnCtx.systemTransactionContext(),
             sqlExpressions.nodeCtx,
-            Function.identity());
+            UnaryOperator.identity());
 
         assertThat(result).hasOperators(
             "Filter[((a > 1) AND (b > 1))]",

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/DeterministicTaskQueue.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/DeterministicTaskQueue.java
@@ -31,7 +31,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -200,13 +200,13 @@ public class DeterministicTaskQueue {
      * @return A <code>ExecutorService</code> that uses this task queue.
      */
     public ExecutorService getExecutorService() {
-        return getExecutorService(Function.identity());
+        return getExecutorService(UnaryOperator.identity());
     }
 
     /**
      * @return A <code>ExecutorService</code> that uses this task queue and wraps <code>Runnable</code>s in the given wrapper.
      */
-    public ExecutorService getExecutorService(Function<Runnable, Runnable> runnableWrapper) {
+    public ExecutorService getExecutorService(UnaryOperator<Runnable> runnableWrapper) {
         return new ExecutorService() {
 
             @Override
@@ -280,13 +280,13 @@ public class DeterministicTaskQueue {
      * @return A <code>ThreadPool</code> that uses this task queue.
      */
     public ThreadPool getThreadPool() {
-        return getThreadPool(Function.identity());
+        return getThreadPool(UnaryOperator.identity());
     }
 
     /**
      * @return A <code>ThreadPool</code> that uses this task queue and wraps <code>Runnable</code>s in the given wrapper.
      */
-    public ThreadPool getThreadPool(Function<Runnable, Runnable> runnableWrapper) {
+    public ThreadPool getThreadPool(UnaryOperator<Runnable> runnableWrapper) {
         return new ThreadPool(settings) {
 
             {

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/LinearizabilityChecker.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/LinearizabilityChecker.java
@@ -35,6 +35,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -182,7 +183,7 @@ public class LinearizabilityChecker {
          *
          * @param missingResponseGenerator a function from invocation input to response output, used to generate the corresponding response
          */
-        public void complete(Function<Object, Object> missingResponseGenerator) {
+        public void complete(UnaryOperator<Object> missingResponseGenerator) {
             final Map<Integer, Event> uncompletedInvocations = new HashMap<>();
             for (Event event : events) {
                 if (event.type == EventType.INVOCATION) {
@@ -229,7 +230,7 @@ public class LinearizabilityChecker {
      * @param missingResponseGenerator used to complete the history with missing responses
      * @return true iff the history is linearizable w.r.t. the given spec
      */
-    public boolean isLinearizable(SequentialSpec spec, History history, Function<Object, Object> missingResponseGenerator) {
+    public boolean isLinearizable(SequentialSpec spec, History history, UnaryOperator<Object> missingResponseGenerator) {
         return isLinearizable(spec, history, missingResponseGenerator, () -> false);
     }
 
@@ -244,7 +245,7 @@ public class LinearizabilityChecker {
      */
     public boolean isLinearizable(SequentialSpec spec,
                                   History history,
-                                  Function<Object, Object> missingResponseGenerator,
+                                  UnaryOperator<Object> missingResponseGenerator,
                                   BooleanSupplier terminateEarly) {
         history = history.clone(); // clone history before completing it
         history.complete(missingResponseGenerator); // complete history
@@ -312,7 +313,7 @@ public class LinearizabilityChecker {
     /**
      * Return a visual representation of the history
      */
-    public static String visualize(SequentialSpec spec, History history, Function<Object, Object> missingResponseGenerator) {
+    public static String visualize(SequentialSpec spec, History history, UnaryOperator<Object> missingResponseGenerator) {
         history = history.clone();
         history.complete(missingResponseGenerator);
         final Collection<List<Event>> partitions = spec.partition(history.copyEvents());

--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -97,6 +97,7 @@ import java.util.function.IntSupplier;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 import java.util.function.ToLongBiFunction;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 
@@ -2004,7 +2005,7 @@ public class InternalEngineTests extends EngineTestCase {
             delete.startTime(),
             seqNo,
             term);
-        Function<Engine.Index, Engine.Index> indexWithCurrentTerm = index -> new Engine.Index(
+        UnaryOperator<Engine.Index> indexWithCurrentTerm = index -> new Engine.Index(
             index.uid(),
             index.parsedDoc(),
             UNASSIGNED_SEQ_NO,
@@ -2017,7 +2018,7 @@ public class InternalEngineTests extends EngineTestCase {
             index.isRetry(),
             index.getIfSeqNo(),
             index.getIfPrimaryTerm());
-        Function<Engine.Delete, Engine.Delete> deleteWithCurrentTerm = delete -> new Engine.Delete(
+        UnaryOperator<Engine.Delete> deleteWithCurrentTerm = delete -> new Engine.Delete(
             delete.id(),
             delete.uid(),
             UNASSIGNED_SEQ_NO,

--- a/server/src/test/java/org/elasticsearch/index/engine/ReadOnlyEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/ReadOnlyEngineTests.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.fail;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
@@ -80,7 +80,7 @@ public class ReadOnlyEngineTests extends EngineTestCase {
                 globalCheckpoint.set(randomLongBetween(globalCheckpoint.get(), engine.getPersistedLocalCheckpoint()));
                 engine.flush();
                 readOnlyEngine = new ReadOnlyEngine(engine.engineConfig, engine.getSeqNoStats(globalCheckpoint.get()),
-                    engine.getTranslogStats(), false, Function.identity(), true);
+                    engine.getTranslogStats(), false, UnaryOperator.identity(), true);
                 lastSeqNoStats = engine.getSeqNoStats(globalCheckpoint.get());
                 lastDocIds = getDocIds(engine, true);
                 assertThat(readOnlyEngine.getPersistedLocalCheckpoint(), equalTo(lastSeqNoStats.getLocalCheckpoint()));
@@ -170,7 +170,7 @@ public class ReadOnlyEngineTests extends EngineTestCase {
                 globalCheckpoint.set(engine.getPersistedLocalCheckpoint());
                 engine.syncTranslog();
                 engine.flushAndClose();
-                readOnlyEngine = new ReadOnlyEngine(engine.engineConfig, null , null, true, Function.identity(), true);
+                readOnlyEngine = new ReadOnlyEngine(engine.engineConfig, null , null, true, UnaryOperator.identity(), true);
                 Engine.CommitId flush = readOnlyEngine.flush(randomBoolean(), true);
                 assertThat(readOnlyEngine.flush(randomBoolean(), true), is(flush));
             } finally {
@@ -199,7 +199,7 @@ public class ReadOnlyEngineTests extends EngineTestCase {
                 engine.flushAndClose();
 
                 assertThatThrownBy(
-                    () -> new ReadOnlyEngine(config, null, null, true, Function.identity(), true) {
+                    () -> new ReadOnlyEngine(config, null, null, true, UnaryOperator.identity(), true) {
                         @Override
                         protected boolean assertMaxSeqNoEqualsToGlobalCheckpoint(final long maxSeqNo,
                                 final long globalCheckpoint) {
@@ -230,7 +230,7 @@ public class ReadOnlyEngineTests extends EngineTestCase {
                 globalCheckpoint::get);
             store.createEmpty(Version.CURRENT.luceneVersion);
             try (ReadOnlyEngine readOnlyEngine = new ReadOnlyEngine(
-                config, null, new TranslogStats(0, 0, 0, 0), true, Function.identity(), true)
+                config, null, new TranslogStats(0, 0, 0, 0), true, UnaryOperator.identity(), true)
             ) {
                 assertThatThrownBy(() -> readOnlyEngine.index(null))
                     .isExactlyInstanceOf(UnsupportedOperationException.class);
@@ -263,7 +263,7 @@ public class ReadOnlyEngineTests extends EngineTestCase {
                 globalCheckpoint::get
             );
             store.createEmpty(Version.CURRENT.luceneVersion);
-            try (ReadOnlyEngine readOnlyEngine = new ReadOnlyEngine(config, null , new TranslogStats(0, 0, 0, 0), true, Function.identity(), true)) {
+            try (ReadOnlyEngine readOnlyEngine = new ReadOnlyEngine(config, null , new TranslogStats(0, 0, 0, 0), true, UnaryOperator.identity(), true)) {
                 globalCheckpoint.set(randomNonNegativeLong());
                 try {
                     readOnlyEngine.verifyEngineBeforeIndexClosing();
@@ -317,7 +317,7 @@ public class ReadOnlyEngineTests extends EngineTestCase {
                 engine.syncTranslog();
                 engine.flushAndClose();
             }
-            try (ReadOnlyEngine readOnlyEngine = new ReadOnlyEngine(config, null, null, true, Function.identity(), true)) {
+            try (ReadOnlyEngine readOnlyEngine = new ReadOnlyEngine(config, null, null, true, UnaryOperator.identity(), true)) {
                 TranslogHandler translogHandler = new TranslogHandler(xContentRegistry(), config.getIndexSettings());
                 readOnlyEngine.recoverFromTranslog(translogHandler, randomNonNegativeLong());
                 int opsRecovered = translogHandler.run(
@@ -376,7 +376,7 @@ public class ReadOnlyEngineTests extends EngineTestCase {
                 engine.flush(true, true);
             }
 
-            try (ReadOnlyEngine readOnlyEngine = new ReadOnlyEngine(config, null, null, true, Function.identity(), true)) {
+            try (ReadOnlyEngine readOnlyEngine = new ReadOnlyEngine(config, null, null, true, UnaryOperator.identity(), true)) {
                 assertThat(readOnlyEngine.getTranslogStats().estimatedNumberOfOperations(), equalTo(softDeletesEnabled ? 0 : numDocs));
                 assertThat(readOnlyEngine.getTranslogStats().getUncommittedOperations(), equalTo(0));
                 assertThat(readOnlyEngine.getTranslogStats().getTranslogSizeInBytes(), greaterThan(0L));

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -57,6 +57,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.LongFunction;
 import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -4068,7 +4069,7 @@ public class IndexShardTests extends IndexShardTestCase {
             shard.indexSettings.getIndexMetadata(),
             List.of(idxSettings -> Optional.of(
                 engineConfig ->
-                    new ReadOnlyEngine(engineConfig, null, null, true, Function.identity(), true) {
+                    new ReadOnlyEngine(engineConfig, null, null, true, UnaryOperator.identity(), true) {
 
                         @Override
                         protected void ensureMaxSeqNoEqualsToGlobalCheckpoint(SeqNoStats seqNoStats) {

--- a/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryRestoreTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryRestoreTests.java
@@ -30,7 +30,7 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
 import org.apache.lucene.store.Directory;
@@ -189,7 +189,7 @@ public class BlobStoreRepositoryRestoreTests extends IndexShardTestCase {
                     new SnapshotInfo(snapshot.getSnapshotId(), shardGenerations.indices().stream()
                         .map(IndexId::getName).collect(Collectors.toList()), 0L, null, 1L, 6,
                         Collections.emptyList(), true),
-                    Version.CURRENT, Function.identity(), f));
+                    Version.CURRENT, UnaryOperator.identity(), f));
             assertThatThrownBy(() -> snapshotShard(shard, snapshotWithSameName, repository))
                 .isExactlyInstanceOf(IndexShardSnapshotFailedException.class)
                 .hasMessageContaining("Duplicate snapshot name");

--- a/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryTest.java
+++ b/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryTest.java
@@ -38,7 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executor;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
 import org.elasticsearch.Version;
@@ -189,7 +189,7 @@ public class BlobStoreRepositoryTest extends IntegTestCase {
 
     private static void writeIndexGen(BlobStoreRepository repository, RepositoryData repositoryData, long generation) throws Exception {
         TestFutureUtils.<RepositoryData, Exception>get(
-            f -> repository.writeIndexGen(repositoryData, generation, Version.CURRENT, Function.identity(), f));
+            f -> repository.writeIndexGen(repositoryData, generation, Version.CURRENT, UnaryOperator.identity(), f));
     }
 
 
@@ -249,8 +249,8 @@ public class BlobStoreRepositoryTest extends IntegTestCase {
                 builder.put(new IndexId(randomAlphaOfLength(8), UUIDs.randomBase64UUID()), 0, "1");
             }
             final ShardGenerations shardGenerations = builder.build();
-            final Map<IndexId, String> indexLookup = shardGenerations.indices().stream().collect(Collectors.toMap(Function.identity(), ind -> randomAlphaOfLength(256)));
-            final Map<String, String> newIdentifiers = indexLookup.values().stream().collect(Collectors.toMap(Function.identity(), ignored -> UUIDs.randomBase64UUID(random())));
+            final Map<IndexId, String> indexLookup = shardGenerations.indices().stream().collect(Collectors.toMap(UnaryOperator.identity(), ind -> randomAlphaOfLength(256)));
+            final Map<String, String> newIdentifiers = indexLookup.values().stream().collect(Collectors.toMap(UnaryOperator.identity(), ignored -> UUIDs.randomBase64UUID(random())));
             repoData = repoData.addSnapshot(snapshotId,
                                             randomFrom(SnapshotState.SUCCESS, SnapshotState.PARTIAL, SnapshotState.FAILED), Version.CURRENT, shardGenerations,
                                             indexLookup,

--- a/server/src/test/java/org/elasticsearch/snapshots/InternalSnapshotsInfoServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/InternalSnapshotsInfoServiceTests.java
@@ -40,8 +40,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterState;
@@ -375,7 +375,7 @@ public class InternalSnapshotsInfoServiceTests extends ESTestCase {
         assertThat(snapshotsInfoService.numberOfFailedSnapshotShardSizes()).isEqualTo(0);
     }
 
-    private void applyClusterState(final String reason, final Function<ClusterState, ClusterState> applier) {
+    private void applyClusterState(final String reason, final UnaryOperator<ClusterState> applier) {
         TestFutureUtils.get(future -> clusterService.getClusterApplierService().onNewClusterState(reason,
             () -> applier.apply(clusterService.state()),
             new ClusterApplier.ClusterApplyListener() {

--- a/server/src/test/java/org/elasticsearch/snapshots/mockstore/MockEventuallyConsistentRepositoryTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/mockstore/MockEventuallyConsistentRepositoryTests.java
@@ -30,7 +30,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.Metadata;
@@ -176,7 +176,7 @@ public class MockEventuallyConsistentRepositoryTests extends ESTestCase {
                     Metadata.EMPTY_METADATA,
                     new SnapshotInfo(snapshotId, Collections.emptyList(), 0L, null, 1L, 5, Collections.emptyList(), true),
                     Version.CURRENT,
-                    Function.identity(),
+                    UnaryOperator.identity(),
                     f
                 ));
 
@@ -188,7 +188,7 @@ public class MockEventuallyConsistentRepositoryTests extends ESTestCase {
                 Metadata.EMPTY_METADATA,
                 new SnapshotInfo(snapshotId, Collections.emptyList(), 0L, null, 1L, 6, Collections.emptyList(), true),
                 Version.CURRENT,
-                Function.identity(),
+                UnaryOperator.identity(),
                 fut
             );
             assertThat(fut).failsWithin(5, TimeUnit.SECONDS)
@@ -206,7 +206,7 @@ public class MockEventuallyConsistentRepositoryTests extends ESTestCase {
                     Metadata.EMPTY_METADATA,
                     new SnapshotInfo(snapshotId, Collections.emptyList(), 0L, null, 2L, 5, Collections.emptyList(), true),
                     Version.CURRENT,
-                    Function.identity(),
+                    UnaryOperator.identity(),
                     f
                 ));
         }

--- a/server/src/testFixtures/java/org/elasticsearch/index/shard/RestoreOnlyRepository.java
+++ b/server/src/testFixtures/java/org/elasticsearch/index/shard/RestoreOnlyRepository.java
@@ -27,7 +27,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import org.apache.lucene.index.IndexCommit;
 import org.elasticsearch.Version;
@@ -115,7 +115,7 @@ public abstract class RestoreOnlyRepository implements Repository {
                                  final Metadata clusterMetadata,
                                  SnapshotInfo snapshotInfo,
                                  Version repositoryMetaVersion,
-                                 Function<ClusterState, ClusterState> stateTransformer,
+                                 UnaryOperator<ClusterState> stateTransformer,
                                  final ActionListener<RepositoryData> listener) {
         listener.onResponse(null);
     }

--- a/server/src/testFixtures/java/org/elasticsearch/test/DiffableTestUtils.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/DiffableTestUtils.java
@@ -19,6 +19,14 @@
 
 package org.elasticsearch.test;
 
+import static org.elasticsearch.test.AbstractWireSerializingTestCase.NUMBER_OF_TEST_RUNS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+
+import java.io.IOException;
+import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
+
 import org.elasticsearch.cluster.Diff;
 import org.elasticsearch.cluster.Diffable;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
@@ -27,14 +35,6 @@ import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
-
-import java.io.IOException;
-import java.util.function.Function;
-import java.util.function.Supplier;
-
-import static org.elasticsearch.test.AbstractWireSerializingTestCase.NUMBER_OF_TEST_RUNS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
 
 /**
  * Utilities that simplify testing of diffable classes
@@ -76,7 +76,7 @@ public final class DiffableTestUtils {
      * diffs over the wire and appling these diffs on the other side.
      */
     public static <T extends Diffable<T>> void testDiffableSerialization(Supplier<T> testInstance,
-                                                                         Function<T, T> modifier,
+                                                                         UnaryOperator<T> modifier,
                                                                          NamedWriteableRegistry namedWriteableRegistry,
                                                                          Reader<T> reader,
                                                                          Reader<Diff<T>> diffReader) throws IOException {


### PR DESCRIPTION
In some cases it saves us from fqn names to avoid
clash with our `io.crate.expression.symbol.Function`