### PR TITLE
Deduplicate extraction of values from the parsed source

### DIFF
--- a/server/src/main/java/io/crate/expression/ValueExtractors.java
+++ b/server/src/main/java/io/crate/expression/ValueExtractors.java
@@ -34,7 +34,7 @@ import io.crate.types.DataType;
 
 public final class ValueExtractors {
 
-    public static Object fromMap(Map<String, Object> map, ColumnIdent column) {
+    public static Object fromMap(Map<String, ?> map, ColumnIdent column) {
         Object o = map.get(column.name());
         if (column.isRoot()) {
             return o;

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/DocCollectorExpression.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/DocCollectorExpression.java
@@ -95,7 +95,7 @@ public class DocCollectorExpression extends LuceneCollectorExpression<Map<String
         @Override
         public Object value() {
             // correct type detection is ensured by the source parser
-            return sourceLookup.get(ref.column().path());
+            return sourceLookup.get(ref.column());
         }
     }
 }

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/SourceLookup.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/SourceLookup.java
@@ -33,6 +33,7 @@ import io.crate.execution.engine.fetch.ReaderContext;
 import io.crate.expression.ValueExtractors;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
+import io.crate.metadata.doc.DocSysColumns;
 
 public final class SourceLookup {
 
@@ -63,7 +64,10 @@ public final class SourceLookup {
 
     public Object get(ColumnIdent columnIdent) {
         ensureSourceParsed();
-        return ValueExtractors.fromMap(source, columnIdent);
+        ColumnIdent column = columnIdent.name().equals(DocSysColumns.Names.DOC)
+            ? columnIdent.shiftRight()
+            : columnIdent;
+        return ValueExtractors.fromMap(source, column);
     }
 
     public Map<String, Object> sourceAsMap() {

--- a/server/src/test/java/io/crate/expression/reference/doc/lucene/SourceLookupTest.java
+++ b/server/src/test/java/io/crate/expression/reference/doc/lucene/SourceLookupTest.java
@@ -22,7 +22,6 @@
 package io.crate.expression.reference.doc.lucene;
 
 import static io.crate.testing.Asserts.assertThat;
-import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 
 import java.util.Arrays;
@@ -32,12 +31,15 @@ import java.util.Map;
 
 import org.junit.Test;
 
+import io.crate.expression.ValueExtractors;
+import io.crate.metadata.ColumnIdent;
+
 public class SourceLookupTest {
 
     @Test
     public void testExtractValueFromNestedObject() {
         Map<String, Map<String, Integer>> map = singletonMap("x", singletonMap("y", 10));
-        Object o = SourceLookup.extractValue(map, Arrays.asList("x", "y"), 0);
+        Object o = ValueExtractors.fromMap(map, ColumnIdent.fromPath("x.y"));
         assertThat(o).isEqualTo(10);
     }
 
@@ -48,7 +50,7 @@ public class SourceLookupTest {
             singletonMap("y", singletonMap("z", 10)),
             singletonMap("y", singletonMap("z", 20))
         ));
-        Object o = SourceLookup.extractValue(m, Arrays.asList("x", "y", "z"), 0);
+        Object o = ValueExtractors.fromMap(m, ColumnIdent.fromPath("x.y.z"));
         assertThat((Collection<Integer>) o).containsExactly(10, 20);
     }
 
@@ -56,13 +58,13 @@ public class SourceLookupTest {
     @Test
     public void testExtractValueFromNestedObjectWithListAsLeaf() {
         Map<String, List<Integer>> m = singletonMap("x", Arrays.asList(10, 20));
-        Object o = SourceLookup.extractValue(m, singletonList("x"), 0);
+        Object o = ValueExtractors.fromMap(m, ColumnIdent.fromPath("x"));
         assertThat((Collection<Integer>) o).containsExactly(10, 20);
     }
 
     @Test
     public void test_extractValue_from_object_with_unknown_subscript_returns_null() {
         Map<String, Map<String, Integer>> m = singletonMap("x", singletonMap("a", 1)); // such that x['a'] = 1
-        assertThat(SourceLookup.extractValue(m, Arrays.asList("x", "a", "a"), 0)).isNull(); // x['a']['a'] should return null
+        assertThat(ValueExtractors.fromMap(m, ColumnIdent.fromPath("x.a.a"))).isNull(); // x['a']['a'] should return null
     }
 }


### PR DESCRIPTION
https://github.com/crate/crate/pull/14668#discussion_r1331115565

Use same code path for fetching values from the source/ for fetching values on PKLookup.

We had in the past issue where we had to align fixes in source parser and pklookup separately.