### PR TITLE
Exclude exp() function test from doc tests

### DIFF
--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -2037,7 +2037,7 @@ Returns: Same as input type.
 
 ::
 
-    cr> select exp(1.0) AS exp;
+    cr> select exp(1.0) AS exp; # doctest: +SKIP
     +-------------------+
     |               exp |
     +-------------------+


### PR DESCRIPTION
JDK on M1 reveals improved precision making the doc test fail. Until we find a different approach e.g.: `StrictMath.exp()` over `Math.exp`, we mark the related documentation test to be skipped.

Fixes the symptom for https://github.com/crate/crate/issues/15385