### PR TITLE
Update jdk to 21.0.2

### DIFF
--- a/docs/appendices/release-notes/5.6.1.rst
+++ b/docs/appendices/release-notes/5.6.1.rst
@@ -47,6 +47,9 @@ See the :ref:`version_5.6.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Added a workaround for a change in JDK 21.0.2 which caused many operations to
+  get stuck.
+
 - Fixed an issue that led to errors when
   :ref:`privileges <administration-privileges>` are defined for users, when
   performing a rolling upgrade of a cluster from a version before

--- a/pom.xml
+++ b/pom.xml
@@ -236,7 +236,7 @@
     <!-- see surefire plugin configuration for explanation -->
     <skipRunTests>false</skipRunTests>
 
-    <versions.jdk>21.0.1</versions.jdk>
+    <versions.jdk>21.0.2</versions.jdk>
     <versions.annotations>24.1.0</versions.annotations>
     <versions.log4j>2.22.0</versions.log4j>
     <versions.assertj>3.25.1</versions.assertj>

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
@@ -256,6 +256,22 @@ public class EsExecutors {
             }
         }
 
+        // Methods below are due to https://bugs.openjdk.org/browse/JDK-8323659
+
+        @Override
+        public void put(E e) {
+            super.offer(e);
+        }
+
+        @Override
+        public boolean add(E e) {
+            return super.offer(e);
+        }
+
+        @Override
+        public boolean offer(E e, long timeout, TimeUnit unit) {
+            return super.offer(e);
+        }
     }
 
     /**


### PR DESCRIPTION
21.0.2 introduced a change to the `LinkedTransferQueue` which caused
`ExecutorScalingQueue` to break.

See https://bugs.openjdk.org/browse/JDK-8323659

It also turned out that our pinning of the JDK to 21.0.1 wasn't strict. It uses https://github.com/linux-china/toolchains-maven-plugin/, which in turn uses the API of https://github.com/foojayio/discoapi - which in turn is happy to return 21.0.2 if 21.0.1 gets requested:


```
http "https://api.foojay.io/disco/v3.0/packages?distribution=temurin&latest=overall&release_status=ga&directly_downloadable=true&operating_system=linux&architecture=x64&version=21.0.1"
{
  "result": [
    {
      "id": "0f37fa613f69450f7f878c376e7d33e3",
      "archive_type": "tar.gz",
      "distribution": "temurin",
      "major_version": 21,
      "java_version": "21.0.2",
      "distribution_version": "21.0.2",
      "jdk_version": 21,
      "latest_build_available": true,
      "release_status": "ga",
      "term_of_support": "lts",
      "operating_system": "linux",
      "lib_c_type": "glibc",
      "architecture": "x64",
      "fpu": "unknown",
      "package_type": "jre",
      "javafx_bundled": false,
      "directly_downloadable": true,
      "filename": "OpenJDK21U-jre_x64_linux_hotspot_21.0.2_13.tar.gz",
      "links": {
        "pkg_info_uri": "https://api.foojay.io/disco/v3.0/ids/0f37fa613f69450f7f878c376e7d33e3",
        "pkg_download_redirect": "https://api.foojay.io/disco/v3.0/ids/0f37fa613f69450f7f878c376e7d33e3/redirect"
      },
      "free_use_in_production": true,
      "tck_tested": "yes",
      "tck_cert_uri": "https://adoptium.net/temurin/tck-affidavit/",
      "aqavit_certified": "yes",
      "aqavit_cert_uri": "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.2%2B13/OpenJDK21U-jre_x64_linux_hotspot_21.0.2_13.tap.zip",
      "size": 52914261,
      "feature": []
    },
...
```

Due to that, the 5.6.0 release is broken - as 21.0.2 was bundled.
We'll need a seperate solution for the pinning.