### PR TITLE
Pin java to 21.0.1 in GHA

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Maven Java
         uses: actions/setup-java@v3
         with:
-          java-version: "21"
+          java-version: "21.0.1"
           distribution: "temurin"
           cache: maven
 
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Maven Java
         uses: actions/setup-java@v3
         with:
-          java-version: "21"
+          java-version: "21.0.1"
           distribution: "temurin"
           cache: maven
       - name: Run forbiddenapis:check


### PR DESCRIPTION
Looks like 21.0.2 causes test failures as seen in https://github.com/crate/crate/pull/15408
They're also reproducable locally. Until they're fixed we should ensure
GHA uses a working version.
