### PR TITLE
Revert read/writeEnum() to read/write enum ordinals

### DIFF
--- a/docs/appendices/release-notes/5.6.1.rst
+++ b/docs/appendices/release-notes/5.6.1.rst
@@ -47,4 +47,7 @@ See the :ref:`version_5.6.0` release notes for a full list of changes in the
 Fixes
 =====
 
-None
+- Fixed an issue that led to errors when
+  :ref:`privileges <administration-privileges>` are defined for users, when
+  performing a rolling upgrade of a cluster from a version before
+  :ref:`version_5.6.0` to :ref:`version_5.6.0`.

--- a/server/src/main/java/io/crate/role/Privilege.java
+++ b/server/src/main/java/io/crate/role/Privilege.java
@@ -117,7 +117,7 @@ public class Privilege implements Writeable, ToXContent {
     }
 
     public Privilege(StreamInput in) throws IOException {
-        policy = in.readEnum(Policy.class);
+        policy = Policy.VALUES.get(in.readInt());
         subject = new Subject(in);
         grantor = in.readString();
     }
@@ -158,7 +158,7 @@ public class Privilege implements Writeable, ToXContent {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeEnum(policy);
+        out.writeInt(policy.ordinal());
         subject.writeTo(out);
         out.writeString(grantor);
     }

--- a/server/src/main/java/io/crate/role/Subject.java
+++ b/server/src/main/java/io/crate/role/Subject.java
@@ -37,16 +37,16 @@ public record Subject(Permission permission, Securable securable, @Nullable Stri
 
     Subject(StreamInput in) throws IOException {
         this(
-            in.readEnum(Permission.class),
-            in.readEnum(Securable.class),
+            Permission.VALUES.get(in.readInt()),
+            Securable.VALUES.get(in.readInt()),
             in.readOptionalString()
         );
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeEnum(permission);
-        out.writeEnum(securable);
+        out.writeInt(permission.ordinal());
+        out.writeInt(securable.ordinal());
         out.writeOptionalString(ident);
     }
 }


### PR DESCRIPTION
Revert `readEnum()`/`writeEnum()`, which use `readVInt()`/`writeVInt()` whereas before we were using `readInt()`/`writeInt()` to read and write the enum ordinal, this causes streaming issues in a mixed cluster state, where there are 5.6.0 nodes and nodes < 5.6.0.

Follows: #15332
Follows: #15334
Follows: #15335
