### PR TITLE
Remove cr> prefix from exp() function doc

### DIFF
--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -2037,7 +2037,7 @@ Returns: Same as input type.
 
 ::
 
-    cr> select exp(1.0) AS exp; # doctest: +SKIP
+    > select exp(1.0) AS exp;
     +-------------------+
     |               exp |
     +-------------------+
@@ -2045,6 +2045,8 @@ Returns: Same as input type.
     +-------------------+
     SELECT 1 row in set (... sec)
 
+.. test skipped because java.lang.Math.exp() can return with different
+   precision on different CPUs (e.g.: Apple M1)
 
 .. _scalar-floor:
 


### PR DESCRIPTION
The exp() function can return different values on different CPU architectures,
and so we'd like to skip testing it as it may fail unexpectedly on different
machines.  However, the standard doctest skip directive does not get stripped
from our `cr>` doctest lines, as the strip function is part of the core sphinx
library and so does not know anything about the crate extension.  This means
that skip directives get displayed in the final docs, which can be confusing.

Instead, we change the `cr>` prefix to just plain `>`, which keeps formatting
consistent but stops the doctest from running.