### PR TITLE
Revert "Pin java to 21.0.1 in GHA"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Maven Java
         uses: actions/setup-java@v3
         with:
-          java-version: "21.0.1"
+          java-version: "21"
           distribution: "temurin"
           cache: maven
 
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Maven Java
         uses: actions/setup-java@v3
         with:
-          java-version: "21.0.1"
+          java-version: "21"
           distribution: "temurin"
           cache: maven
       - name: Run forbiddenapis:check


### PR DESCRIPTION
This reverts commit 8c9b373b92379eca6582695eabeee977871b9554.

No longer needed after https://github.com/crate/crate/pull/15408
