### PR TITLE
Validate `WHERE` clause before normalizing

### DIFF
--- a/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -50,7 +50,6 @@ import io.crate.analyze.relations.select.SelectAnalyzer;
 import io.crate.analyze.validator.GroupBySymbolValidator;
 import io.crate.analyze.validator.HavingSymbolValidator;
 import io.crate.analyze.validator.SemanticSortValidator;
-import io.crate.analyze.where.WhereClauseValidator;
 import io.crate.common.collections.Lists;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.exceptions.RelationUnknown;
@@ -419,15 +418,13 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
             GroupAndAggregateSemantics.validate(selectAnalysis.outputSymbols(), groupBy);
         }
 
-        boolean isDistinct = node.getSelect().isDistinct();
-        Symbol where = expressionAnalyzer.generateQuerySymbol(node.getWhere(), expressionAnalysisContext);
-        WhereClauseValidator.validate(where);
-
         var normalizer = EvaluatingNormalizer.functionOnlyNormalizer(
             nodeCtx,
             f -> expressionAnalysisContext.isEagerNormalizationAllowed() && f.signature().isDeterministic()
         );
+        Symbol where = expressionAnalyzer.generateQuerySymbol(node.getWhere(), expressionAnalysisContext);
 
+        boolean isDistinct = node.getSelect().isDistinct();
         QueriedSelectRelation relation = new QueriedSelectRelation(
             isDistinct,
             List.copyOf(context.sources().values()),

--- a/server/src/main/java/io/crate/expression/predicate/IsNullPredicate.java
+++ b/server/src/main/java/io/crate/expression/predicate/IsNullPredicate.java
@@ -90,10 +90,7 @@ public class IsNullPredicate<T> extends Scalar<Boolean, T> {
         if (arg instanceof Input<?> input) {
             return Literal.of(input.value() == null);
         }
-        if (arg instanceof Reference ref
-            // allow system columns for further error processing, for example see testSelectWhereVersionIsNullPredicate().
-            && !ref.column().isSystemColumn()
-            && !ref.isNullable()) {
+        if (arg instanceof Reference ref && !ref.isNullable()) {
             return Literal.of(false);
         }
         return symbol;

--- a/server/src/main/java/io/crate/planner/WhereClauseOptimizer.java
+++ b/server/src/main/java/io/crate/planner/WhereClauseOptimizer.java
@@ -35,7 +35,6 @@ import io.crate.analyze.where.DocKeys;
 import io.crate.analyze.where.EqualityExtractor;
 import io.crate.analyze.where.EqualityExtractor.EqMatches;
 import io.crate.analyze.where.WhereClauseAnalyzer;
-import io.crate.analyze.where.WhereClauseValidator;
 import io.crate.common.collections.Lists;
 import io.crate.data.Row;
 import io.crate.expression.eval.EvaluatingNormalizer;
@@ -210,7 +209,6 @@ public final class WhereClauseOptimizer {
             ? eqExtractor.extractMatches(table.partitionedBy(), optimizedCastsQuery, txnCtx)
             : EqMatches.NONE;
 
-        WhereClauseValidator.validate(query);
         return new DetailedQuery(
             query,
             docKeys,


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Follows https://github.com/crate/crate/pull/15401#discussion_r1465064508, as highlighted by the discussion, it adds more normalizations(`<non_null_ref> is null` to `false`) before validation which prevents system column validation(since already normalized to `false`).

This is an attempt to reverse the order of validation and normalization entirely which would also allow us to remove the following lines:
```
// allow system columns for further error processing, for example see testSelectWhereVersionIsNullPredicate().
            && !ref.column().isSystemColumn()
```

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
