### PR TITLE
Keep correlated subquery data on multi phase execution

### DIFF
--- a/docs/appendices/release-notes/5.5.4.rst
+++ b/docs/appendices/release-notes/5.5.4.rst
@@ -61,3 +61,14 @@ Fixes
 
     SELECT * FROM t WHERE pk_col = 1 OR pk_col IS NOT NULL;
 
+- Fixed an issue that caused failure of a statement, mixing correlated subquery
+  and sub-select. An example::
+
+    CREATE TABLE tbl(x INT);
+    INSERT INTO tbl(x) VALUES (1);
+    SELECT (
+       SELECT x FROM tbl
+          WHERE t.x = tbl.x
+        AND
+          tbl.x IN (SELECT generate_series from generate_series(1, 1))
+    ) FROM tbl t;

--- a/docs/appendices/release-notes/5.6.1.rst
+++ b/docs/appendices/release-notes/5.6.1.rst
@@ -69,3 +69,14 @@ Fixes
 
     SELECT * FROM t WHERE pk_col = 1 OR pk_col IS NOT NULL;
 
+- Fixed an issue that caused failure of a statement, mixing correlated subquery
+  and sub-select. An example::
+
+    CREATE TABLE tbl(x INT);
+    INSERT INTO tbl(x) VALUES (1);
+    SELECT (
+       SELECT x FROM tbl
+          WHERE t.x = tbl.x
+        AND
+          tbl.x IN (SELECT generate_series from generate_series(1, 1))
+    ) FROM tbl t;

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -508,7 +508,15 @@ public class LogicalPlanner {
             MultiPhaseExecutor.execute(logicalPlan.dependencies(), executor, plannerContext, params)
                 .whenComplete((valueBySubQuery, failure) -> {
                     if (failure == null) {
-                        doExecute(logicalPlan, executor, plannerContext, consumer, params, valueBySubQuery, false);
+                        doExecute(
+                            logicalPlan,
+                            executor,
+                            plannerContext,
+                            consumer,
+                            params,
+                            SubQueryResults.merge(subQueryResults, valueBySubQuery),
+                            false
+                        );
                     } else {
                         consumer.accept(null, failure);
                     }

--- a/server/src/main/java/io/crate/planner/operators/SubQueryResults.java
+++ b/server/src/main/java/io/crate/planner/operators/SubQueryResults.java
@@ -96,4 +96,26 @@ public class SubQueryResults {
     public void bindOuterColumnInputRow(Row inputRow) {
         this.inputRow = inputRow;
     }
+
+    public static SubQueryResults merge(SubQueryResults subQueryResults1, SubQueryResults subQueryResults2) {
+        // Correlated subquery related fields.
+        Row mergedRow = subQueryResults1.inputRow;
+        ObjectIntMap<OuterColumn> mergedBoundOuterColumns = subQueryResults1.boundOuterColumns;
+        if (mergedRow.equals(Row.EMPTY)) {
+            mergedRow = subQueryResults2.inputRow;
+        }
+        if (mergedBoundOuterColumns.equals(EMPTY_OUTER_COLUMNS)) {
+            mergedBoundOuterColumns = subQueryResults2.boundOuterColumns;
+        }
+
+        // Regular sub-select field.
+        Map<SelectSymbol, Object> mergedValuesBySubQuery = subQueryResults1.valuesBySubQuery;
+        if (mergedValuesBySubQuery.isEmpty()) {
+            mergedValuesBySubQuery = subQueryResults2.valuesBySubQuery;
+        }
+
+        SubQueryResults combinedSubQueryResults = new SubQueryResults(mergedValuesBySubQuery, mergedBoundOuterColumns);
+        combinedSubQueryResults.bindOuterColumnInputRow(mergedRow);
+        return combinedSubQueryResults;
+    }
 }

--- a/server/src/test/java/io/crate/integrationtests/CorrelatedSubqueryITest.java
+++ b/server/src/test/java/io/crate/integrationtests/CorrelatedSubqueryITest.java
@@ -447,4 +447,24 @@ public class CorrelatedSubqueryITest extends IntegTestCase {
             """);
         assertThat(response).hasRowCount(24L);
     }
+
+    /**
+     * Tests a bug https://github.com/crate/crate/issues/15398.
+     */
+    @Test
+    public void test_can_mix_correlated_qubquery_and_sub_select() {
+        execute("CREATE TABLE tbl(x int)");
+        execute("INSERT INTO tbl(x) VALUES (1)");
+        refresh();
+        execute(
+            """
+           SELECT (
+               SELECT x FROM tbl
+                  WHERE t.x = tbl.x
+                AND
+                  tbl.x IN (SELECT generate_series from generate_series(1, 1))
+          ) FROM tbl t
+            """);
+        assertThat(response).hasRows("1");
+    }
 }


### PR DESCRIPTION
If correlated subquery has regular sub-select in the scope, MultiPhaseExecution logic gets regular sub-select's results and uses them for CorrelatedJoin execution.

In order not to lose correlated join related payload, we create a new SubQueryResults which holds both
correlated join and sub-select data

Resolves https://github.com/crate/crate/issues/15398
