### PR TITLE
Declare scalar functions not yet marked nullable as nullable

### DIFF
--- a/server/src/main/java/io/crate/expression/scalar/ArrayAvgFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayAvgFunction.java
@@ -23,6 +23,7 @@
 package io.crate.expression.scalar;
 
 import io.crate.expression.scalar.array.ArraySummationFunctions;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.ArrayType;
 import io.crate.types.DataTypes;
@@ -100,7 +101,7 @@ public class ArrayAvgFunction {
                 NAME,
                 new ArrayType(DataTypes.NUMERIC).getTypeSignature(),
                 DataTypes.NUMERIC.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) -> new UnaryScalar<>(
                 signature,
                 boundSignature,
@@ -113,7 +114,7 @@ public class ArrayAvgFunction {
                 NAME,
                 new ArrayType(DataTypes.FLOAT).getTypeSignature(),
                 DataTypes.FLOAT.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) -> new UnaryScalar<>(
                 signature,
                 boundSignature,
@@ -126,7 +127,7 @@ public class ArrayAvgFunction {
                 NAME,
                 new ArrayType(DataTypes.DOUBLE).getTypeSignature(),
                 DataTypes.DOUBLE.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) -> new UnaryScalar<>(
                 signature,
                 boundSignature,
@@ -142,7 +143,7 @@ public class ArrayAvgFunction {
                         NAME,
                         new ArrayType(supportedType).getTypeSignature(),
                         DataTypes.NUMERIC.getTypeSignature()
-                    ),
+                    ).withFeature(Scalar.Feature.NULLABLE),
                     (signature, boundSignature) -> new UnaryScalar<>(
                         signature,
                         boundSignature,

--- a/server/src/main/java/io/crate/expression/scalar/ExtractFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/ExtractFunctions.java
@@ -45,6 +45,7 @@ import org.joda.time.DurationFieldType;
 import org.joda.time.Period;
 import org.joda.time.chrono.ISOChronology;
 
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.sql.tree.Extract;
 import io.crate.types.DataTypes;
@@ -82,7 +83,7 @@ public class ExtractFunctions {
                         functionNameFrom(entry.extractField()),
                         argType.getTypeSignature(),
                         DataTypes.INTEGER.getTypeSignature()
-                    ),
+                    ).withFeature(Scalar.Feature.NULLABLE),
                     (signature, boundSignature) ->
                         new UnaryScalar<Number, Long>(signature, boundSignature, argType, dtf::get)
                 );
@@ -93,7 +94,7 @@ public class ExtractFunctions {
                     functionNameFrom(EPOCH),
                     argType.getTypeSignature(),
                     DataTypes.DOUBLE.getTypeSignature()
-                ),
+                ).withFeature(Scalar.Feature.NULLABLE),
                 (signature, boundSignature) ->
                     new UnaryScalar<>(signature, boundSignature, argType, v -> (double) v / 1000)
             );
@@ -117,7 +118,7 @@ public class ExtractFunctions {
                     functionNameFrom(entry.extractField()),
                     DataTypes.INTERVAL.getTypeSignature(),
                     DataTypes.INTEGER.getTypeSignature()
-                ),
+                ).withFeature(Scalar.Feature.NULLABLE),
                 (signature, boundSignature) ->
                     new UnaryScalar<Number, Period>(signature, boundSignature, DataTypes.INTERVAL, function::apply)
             );
@@ -128,7 +129,7 @@ public class ExtractFunctions {
                 functionNameFrom(EPOCH),
                 DataTypes.INTERVAL.getTypeSignature(),
                 DataTypes.DOUBLE.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new UnaryScalar<>(signature, boundSignature, DataTypes.INTERVAL, ExtractFunctions::toMillis)
         );

--- a/server/src/main/java/io/crate/expression/scalar/TripleScalar.java
+++ b/server/src/main/java/io/crate/expression/scalar/TripleScalar.java
@@ -45,6 +45,7 @@ public final class TripleScalar<R, T> extends Scalar<R, T> {
                         DataType<T> type,
                         ThreeParametersFunction<T, T, T, R> func) {
         super(signature, boundSignature);
+        assert signature.hasFeature(Feature.NULLABLE) : "A TriScalar is NULLABLE by definition";
         assert boundSignature.argTypes().stream().allMatch(t -> t.id() == type.id()) :
             "All argument types of the bound signature must match the type argument";
         this.type = type;

--- a/server/src/main/java/io/crate/expression/scalar/UnaryScalar.java
+++ b/server/src/main/java/io/crate/expression/scalar/UnaryScalar.java
@@ -47,6 +47,7 @@ public class UnaryScalar<R, T> extends Scalar<R, T> {
                        DataType<T> type,
                        Function<T, R> func) {
         super(signature, boundSignature);
+        assert signature.hasFeature(Feature.NULLABLE) : "A UnaryScalar is NULLABLE by definition";
         assert boundSignature.argTypes().get(0).id() == type.id() :
             "The bound argument type of the signature must match the type argument";
         this.type = type;

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/AbsFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/AbsFunction.java
@@ -23,6 +23,7 @@ package io.crate.expression.scalar.arithmetic;
 
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.UnaryScalar;
+import io.crate.metadata.Scalar;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 
@@ -36,7 +37,8 @@ public final class AbsFunction {
         for (var type : DataTypes.NUMERIC_PRIMITIVE_TYPES) {
             var typeSignature = type.getTypeSignature();
             module.register(
-                scalar(NAME, typeSignature, typeSignature),
+                scalar(NAME, typeSignature, typeSignature)
+                    .withFeature(Scalar.Feature.NULLABLE),
                 (signature, boundSignature) -> {
                     DataType<?> argType = boundSignature.argTypes().get(0);
                     return new UnaryScalar<>(

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/ArithmeticFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/ArithmeticFunctions.java
@@ -21,6 +21,9 @@
 
 package io.crate.expression.scalar.arithmetic;
 
+import static io.crate.metadata.Scalar.DETERMINISTIC_ONLY;
+import static io.crate.metadata.Scalar.Feature.NULLABLE;
+
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
@@ -55,7 +58,7 @@ public class ArithmeticFunctions {
             BigDecimal::add
         ),
         SUBTRACT(
-            Scalar.DETERMINISTIC_ONLY,
+            DETERMINISTIC_ONLY,
             Math::subtractExact,
                 (arg0, arg1) -> arg0 - arg1,
             Math::subtractExact,
@@ -63,7 +66,7 @@ public class ArithmeticFunctions {
             BigDecimal::subtract
         ),
         MULTIPLY(
-            Scalar.DETERMINISTIC_ONLY,
+            DETERMINISTIC_ONLY,
             Math::multiplyExact,
                 (arg0, arg1) -> arg0 * arg1,
             Math::multiplyExact,
@@ -71,7 +74,7 @@ public class ArithmeticFunctions {
             BigDecimal::multiply
         ),
         DIVIDE(
-            Scalar.DETERMINISTIC_ONLY,
+            DETERMINISTIC_ONLY,
                 (arg0, arg1) -> arg0 / arg1,
                 (arg0, arg1) -> arg0 / arg1,
                 (arg0, arg1) -> arg0 / arg1,
@@ -79,7 +82,7 @@ public class ArithmeticFunctions {
                 (arg0, arg1) -> arg0.divide(arg1, MathContext.DECIMAL64)
         ),
         MODULUS(
-            Scalar.DETERMINISTIC_ONLY,
+            DETERMINISTIC_ONLY,
                 (arg0, arg1) -> arg0 % arg1,
                 (arg0, arg1) -> arg0 % arg1,
                 (arg0, arg1) -> arg0 % arg1,
@@ -87,7 +90,7 @@ public class ArithmeticFunctions {
             BigDecimal::remainder
         ),
         MOD(
-            Scalar.DETERMINISTIC_ONLY,
+            DETERMINISTIC_ONLY,
                 (arg0, arg1) -> arg0 % arg1,
                 (arg0, arg1) -> arg0 % arg1,
                 (arg0, arg1) -> arg0 % arg1,
@@ -127,21 +130,25 @@ public class ArithmeticFunctions {
         for (var op : Operations.values()) {
             module.register(
                 Signature.scalar(
-                    op.toString(),
-                    DataTypes.INTEGER.getTypeSignature(),
-                    DataTypes.INTEGER.getTypeSignature(),
-                    DataTypes.INTEGER.getTypeSignature()
-                ).withFeatures(op.features),
+                        op.toString(),
+                        DataTypes.INTEGER.getTypeSignature(),
+                        DataTypes.INTEGER.getTypeSignature(),
+                        DataTypes.INTEGER.getTypeSignature()
+                    )
+                    .withFeatures(op.features)
+                    .withFeature(NULLABLE),
                 (signature, boundSignature) ->
                     new BinaryScalar<>(op.integerFunction, signature, boundSignature, DataTypes.INTEGER)
             );
             module.register(
                 Signature.scalar(
-                    op.toString(),
-                    DataTypes.LONG.getTypeSignature(),
-                    DataTypes.LONG.getTypeSignature(),
-                    DataTypes.LONG.getTypeSignature()
-                ).withFeatures(op.features),
+                        op.toString(),
+                        DataTypes.LONG.getTypeSignature(),
+                        DataTypes.LONG.getTypeSignature(),
+                        DataTypes.LONG.getTypeSignature()
+                    )
+                    .withFeatures(op.features)
+                    .withFeature(NULLABLE),
                 (signature, boundSignature) ->
                     new BinaryScalar<>(op.longFunction, signature, boundSignature, DataTypes.LONG)
             );
@@ -149,11 +156,13 @@ public class ArithmeticFunctions {
                 for (var type : List.of(DataTypes.TIMESTAMP, DataTypes.TIMESTAMPZ)) {
                     module.register(
                         Signature.scalar(
-                            op.toString(),
-                            type.getTypeSignature(),
-                            type.getTypeSignature(),
-                            type.getTypeSignature()
-                        ).withFeatures(op.features),
+                                op.toString(),
+                                type.getTypeSignature(),
+                                type.getTypeSignature(),
+                                type.getTypeSignature()
+                            )
+                            .withFeatures(op.features)
+                            .withFeature(NULLABLE),
                         (signature, boundSignature) ->
                             new BinaryScalar<>(op.longFunction, signature, boundSignature, type)
                     );
@@ -161,31 +170,37 @@ public class ArithmeticFunctions {
             }
             module.register(
                 Signature.scalar(
-                    op.toString(),
-                    DataTypes.FLOAT.getTypeSignature(),
-                    DataTypes.FLOAT.getTypeSignature(),
-                    DataTypes.FLOAT.getTypeSignature()
-                ).withFeatures(op.features),
+                        op.toString(),
+                        DataTypes.FLOAT.getTypeSignature(),
+                        DataTypes.FLOAT.getTypeSignature(),
+                        DataTypes.FLOAT.getTypeSignature()
+                    )
+                    .withFeatures(op.features)
+                    .withFeature(NULLABLE),
                 (signature, boundSignature) ->
                     new BinaryScalar<>(op.floatFunction, signature, boundSignature, DataTypes.FLOAT)
             );
             module.register(
                 Signature.scalar(
-                    op.toString(),
-                    DataTypes.DOUBLE.getTypeSignature(),
-                    DataTypes.DOUBLE.getTypeSignature(),
-                    DataTypes.DOUBLE.getTypeSignature()
-                ).withFeatures(op.features),
+                        op.toString(),
+                        DataTypes.DOUBLE.getTypeSignature(),
+                        DataTypes.DOUBLE.getTypeSignature(),
+                        DataTypes.DOUBLE.getTypeSignature()
+                    )
+                    .withFeatures(op.features)
+                    .withFeature(NULLABLE),
                 (signature, boundSignature) ->
                     new BinaryScalar<>(op.doubleFunction, signature, boundSignature, DataTypes.DOUBLE)
             );
             module.register(
                 Signature.scalar(
-                    op.toString(),
-                    DataTypes.NUMERIC.getTypeSignature(),
-                    DataTypes.NUMERIC.getTypeSignature(),
-                    DataTypes.NUMERIC.getTypeSignature()
-                ).withFeatures(op.features),
+                        op.toString(),
+                        DataTypes.NUMERIC.getTypeSignature(),
+                        DataTypes.NUMERIC.getTypeSignature(),
+                        DataTypes.NUMERIC.getTypeSignature()
+                    )
+                    .withFeatures(op.features)
+                    .withFeature(NULLABLE),
                 (signature, boundSignature) ->
                     new BinaryScalar<>(op.bdFunction, signature, boundSignature, DataTypes.NUMERIC)
             );
@@ -193,11 +208,13 @@ public class ArithmeticFunctions {
 
         module.register(
             Signature.scalar(
-                Names.POWER,
-                DataTypes.DOUBLE.getTypeSignature(),
-                DataTypes.DOUBLE.getTypeSignature(),
-                DataTypes.DOUBLE.getTypeSignature()
-            ).withFeatures(Scalar.DETERMINISTIC_ONLY),
+                    Names.POWER,
+                    DataTypes.DOUBLE.getTypeSignature(),
+                    DataTypes.DOUBLE.getTypeSignature(),
+                    DataTypes.DOUBLE.getTypeSignature()
+                )
+                .withFeatures(DETERMINISTIC_ONLY)
+                .withFeature(NULLABLE),
             (signature, boundSignature) ->
                 new BinaryScalar<>(Math::pow, signature, boundSignature, DataTypes.DOUBLE)
         );

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/BinaryScalar.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/BinaryScalar.java
@@ -41,6 +41,7 @@ public final class BinaryScalar<T> extends Scalar<T, T> {
                         BoundSignature boundSignature,
                         DataType<T> type) {
         super(signature, boundSignature);
+        assert signature.hasFeature(Feature.NULLABLE) : "A BinaryScalar is NULLABLE by definition";
         assert boundSignature.argTypes().stream().allMatch(t -> t.id() == type.id()) :
             "All bound argument types of the signature must match the type argument";
         this.func = func;

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/CeilFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/CeilFunction.java
@@ -23,6 +23,7 @@ package io.crate.expression.scalar.arithmetic;
 
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.UnaryScalar;
+import io.crate.metadata.Scalar;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 
@@ -42,7 +43,8 @@ public final class CeilFunction {
             assert returnType != null : "Could not get integral type of " + type;
             for (var name : List.of(CEIL, CEILING)) {
                 module.register(
-                    scalar(name, typeSignature, returnType.getTypeSignature()),
+                    scalar(name, typeSignature, returnType.getTypeSignature())
+                        .withFeature(Scalar.Feature.NULLABLE),
                     (signature, boundSignature) ->
                         new UnaryScalar<>(
                             signature,

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/ExpFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/ExpFunction.java
@@ -23,6 +23,7 @@ package io.crate.expression.scalar.arithmetic;
 
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.UnaryScalar;
+import io.crate.metadata.Scalar;
 import io.crate.types.DataTypes;
 
 import static io.crate.metadata.functions.Signature.scalar;
@@ -35,7 +36,8 @@ public class ExpFunction {
         for (var type : DataTypes.NUMERIC_PRIMITIVE_TYPES) {
             var typeSignature = type.getTypeSignature();
             module.register(
-                scalar(NAME, typeSignature, typeSignature),
+                scalar(NAME, typeSignature, typeSignature)
+                    .withFeature(Scalar.Feature.NULLABLE),
                 (declaredSignature, boundSignature) ->
                     new UnaryScalar<>(
                         declaredSignature,

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/FloorFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/FloorFunction.java
@@ -23,6 +23,7 @@ package io.crate.expression.scalar.arithmetic;
 
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.UnaryScalar;
+import io.crate.metadata.Scalar;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 
@@ -38,7 +39,8 @@ public final class FloorFunction {
             DataType<?> returnType = DataTypes.getIntegralReturnType(type);
             assert returnType != null : "Could not get integral type of " + type;
             module.register(
-                scalar(NAME, typeSignature, returnType.getTypeSignature()),
+                scalar(NAME, typeSignature, returnType.getTypeSignature())
+                    .withFeature(Scalar.Feature.NULLABLE),
                 (signature, boundSignature) ->
                     new UnaryScalar<>(
                         signature,

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/NegateFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/NegateFunctions.java
@@ -25,6 +25,7 @@ import java.math.BigDecimal;
 
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.UnaryScalar;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 import io.crate.types.TypeSignature;
@@ -39,7 +40,7 @@ public final class NegateFunctions {
                 NAME,
                 TypeSignature.parse("double precision"),
                 TypeSignature.parse("double precision")
-            )
+            ).withFeature(Scalar.Feature.NULLABLE)
                 .withForbiddenCoercion(),
             (signature, boundSignature) ->
                 new UnaryScalar<>(signature, boundSignature, DataTypes.DOUBLE, x -> x * -1)
@@ -49,7 +50,7 @@ public final class NegateFunctions {
                 NAME,
                 DataTypes.FLOAT.getTypeSignature(),
                 DataTypes.FLOAT.getTypeSignature()
-            )
+            ).withFeature(Scalar.Feature.NULLABLE)
                 .withForbiddenCoercion(),
             (signature, boundSignature) ->
                 new UnaryScalar<>(signature, boundSignature, DataTypes.FLOAT, x -> x * -1)
@@ -59,7 +60,7 @@ public final class NegateFunctions {
                 NAME,
                 TypeSignature.parse("integer"),
                 TypeSignature.parse("integer")
-            )
+            ).withFeature(Scalar.Feature.NULLABLE)
                 .withForbiddenCoercion(),
             (signature, boundSignature) ->
                 new UnaryScalar<>(signature, boundSignature, DataTypes.INTEGER, x -> x * -1)
@@ -69,7 +70,7 @@ public final class NegateFunctions {
                 NAME,
                 TypeSignature.parse("bigint"),
                 TypeSignature.parse("bigint")
-            )
+            ).withFeature(Scalar.Feature.NULLABLE)
                 .withForbiddenCoercion(),
             (signature, boundSignature) ->
                 new UnaryScalar<>(signature, boundSignature, DataTypes.LONG, x -> x * -1)
@@ -79,7 +80,7 @@ public final class NegateFunctions {
                 NAME,
                 TypeSignature.parse("smallint"),
                 TypeSignature.parse("smallint")
-            )
+            ).withFeature(Scalar.Feature.NULLABLE)
                 .withForbiddenCoercion(),
             (signature, boundSignature) ->
                 new UnaryScalar<>(signature, boundSignature, DataTypes.SHORT, x -> (short) (x * -1))
@@ -89,7 +90,7 @@ public final class NegateFunctions {
                 NAME,
                 DataTypes.NUMERIC.getTypeSignature(),
                 DataTypes.NUMERIC.getTypeSignature()
-            )
+            ).withFeature(Scalar.Feature.NULLABLE)
                 .withForbiddenCoercion(),
             (signature, boundSignature) ->
                 new UnaryScalar<>(signature, boundSignature, DataTypes.NUMERIC, BigDecimal::negate)

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/RadiansDegreesFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/RadiansDegreesFunctions.java
@@ -23,6 +23,7 @@ package io.crate.expression.scalar.arithmetic;
 
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.UnaryScalar;
+import io.crate.metadata.Scalar;
 import io.crate.types.DataTypes;
 
 import static io.crate.metadata.functions.Signature.scalar;
@@ -35,7 +36,7 @@ public class RadiansDegreesFunctions {
                 "radians",
                 DataTypes.DOUBLE.getTypeSignature(),
                 DataTypes.DOUBLE.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new UnaryScalar<>(signature, boundSignature, DataTypes.DOUBLE, Math::toRadians));
 
@@ -44,7 +45,7 @@ public class RadiansDegreesFunctions {
                 "degrees",
                 DataTypes.DOUBLE.getTypeSignature(),
                 DataTypes.DOUBLE.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new UnaryScalar<>(signature, boundSignature, DataTypes.DOUBLE, Math::toDegrees));
     }

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/RoundFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/RoundFunction.java
@@ -23,6 +23,7 @@ package io.crate.expression.scalar.arithmetic;
 
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.UnaryScalar;
+import io.crate.metadata.Scalar;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 
@@ -38,7 +39,8 @@ public final class RoundFunction {
             DataType<?> returnType = DataTypes.getIntegralReturnType(type);
             assert returnType != null : "Could not get integral type of " + type;
             module.register(
-                scalar(NAME, typeSignature, returnType.getTypeSignature()),
+                scalar(NAME, typeSignature, returnType.getTypeSignature())
+                    .withFeature(Scalar.Feature.NULLABLE),
                 (signature, boundSignature) -> {
                     if (returnType.equals(DataTypes.INTEGER)) {
                         return new UnaryScalar<>(

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/TrigonometricFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/TrigonometricFunctions.java
@@ -47,8 +47,9 @@ public final class TrigonometricFunctions {
                 "atan2",
                 DataTypes.DOUBLE.getTypeSignature(),
                 DataTypes.DOUBLE.getTypeSignature(),
-                DataTypes.DOUBLE.getTypeSignature()
-            ).withFeatures(Scalar.DETERMINISTIC_ONLY),
+                DataTypes.DOUBLE.getTypeSignature())
+                .withFeatures(Scalar.DETERMINISTIC_ONLY)
+                .withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new BinaryScalar<>(
                     Math::atan2,
@@ -74,7 +75,7 @@ public final class TrigonometricFunctions {
     private static double checkRange(double value) {
         if (value < -1.0 || value > 1.0) {
             throw new IllegalArgumentException("input value " + value + " is out of range. " +
-                                               "Values must be in range of [-1.0, 1.0]");
+                "Values must be in range of [-1.0, 1.0]");
         }
         return value;
     }

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/TruncFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/TruncFunction.java
@@ -50,11 +50,13 @@ public final class TruncFunction {
 
             // trunc(number)
             module.register(
-                scalar(
-                    NAME,
-                    type.getTypeSignature(),
-                    returnType.getTypeSignature()
-                ).withForbiddenCoercion(),
+                Signature.scalar(
+                        NAME,
+                        type.getTypeSignature(),
+                        returnType.getTypeSignature()
+                    )
+                    .withForbiddenCoercion()
+                    .withFeature(Scalar.Feature.NULLABLE),
                 (signature, boundSignature) ->
                     new UnaryScalar<>(
                         signature,
@@ -76,7 +78,7 @@ public final class TruncFunction {
                 DataTypes.DOUBLE.getTypeSignature(),
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.DOUBLE.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.NULLABLE),
             TruncFunction::createTruncWithMode
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/bitwise/BitwiseFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/bitwise/BitwiseFunctions.java
@@ -51,8 +51,14 @@ public class BitwiseFunctions {
                                      DataType<T> type,
                                      BinaryOperator<T> operator) {
         TypeSignature typeSignature = type.getTypeSignature();
-        Signature scalar = Signature.scalar(name.toLowerCase(Locale.ENGLISH), typeSignature, typeSignature, typeSignature)
-            .withFeatures(Scalar.DETERMINISTIC_ONLY);
+        Signature scalar = Signature.scalar(
+                name.toLowerCase(Locale.ENGLISH),
+                typeSignature,
+                typeSignature,
+                typeSignature
+            )
+            .withFeatures(Scalar.DETERMINISTIC_ONLY)
+            .withFeature(Scalar.Feature.NULLABLE);
         module.register(scalar, (signature, boundSignature) -> new BinaryScalar<>(operator, signature, boundSignature, type));
     }
 

--- a/server/src/main/java/io/crate/expression/scalar/geo/AreaFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/geo/AreaFunction.java
@@ -24,6 +24,7 @@ package io.crate.expression.scalar.geo;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.UnaryScalar;
 import io.crate.geo.GeoJSONUtils;
+import io.crate.metadata.Scalar;
 import io.crate.types.DataTypes;
 import io.crate.types.GeoShapeType;
 import org.locationtech.spatial4j.context.jts.JtsSpatialContext;
@@ -59,7 +60,7 @@ public final class AreaFunction {
                 FUNCTION_NAME,
                 DataTypes.GEO_SHAPE.getTypeSignature(),
                 DataTypes.DOUBLE.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new UnaryScalar<>(
                     signature,

--- a/server/src/main/java/io/crate/expression/scalar/geo/CoordinateFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/geo/CoordinateFunction.java
@@ -23,6 +23,7 @@ package io.crate.expression.scalar.geo;
 
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.UnaryScalar;
+import io.crate.metadata.Scalar;
 import io.crate.types.DataTypes;
 
 import static io.crate.metadata.functions.Signature.scalar;
@@ -35,7 +36,7 @@ public final class CoordinateFunction {
                 "latitude",
                 DataTypes.GEO_POINT.getTypeSignature(),
                 DataTypes.DOUBLE.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new UnaryScalar<>(
                     signature,
@@ -49,7 +50,7 @@ public final class CoordinateFunction {
                 "longitude",
                 DataTypes.GEO_POINT.getTypeSignature(),
                 DataTypes.DOUBLE.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new UnaryScalar<>(
                     signature,

--- a/server/src/main/java/io/crate/expression/scalar/geo/GeoHashFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/geo/GeoHashFunction.java
@@ -23,6 +23,7 @@ package io.crate.expression.scalar.geo;
 
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.UnaryScalar;
+import io.crate.metadata.Scalar;
 import io.crate.types.DataTypes;
 import io.crate.types.GeoPointType;
 import org.elasticsearch.common.geo.GeoHashUtils;
@@ -38,7 +39,7 @@ public final class GeoHashFunction {
                 "geohash",
                 DataTypes.GEO_POINT.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new UnaryScalar<>(
                     signature,

--- a/server/src/main/java/io/crate/expression/scalar/object/ObjectKeysFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/object/ObjectKeysFunction.java
@@ -23,6 +23,7 @@ package io.crate.expression.scalar.object;
 
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.UnaryScalar;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
@@ -36,7 +37,7 @@ public final class ObjectKeysFunction {
                 "object_keys",
                 DataTypes.UNTYPED_OBJECT.getTypeSignature(),
                 DataTypes.STRING_ARRAY.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
             new UnaryScalar<>(
                 signature,

--- a/server/src/main/java/io/crate/expression/scalar/postgres/PgGetUserByIdFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/postgres/PgGetUserByIdFunction.java
@@ -27,6 +27,7 @@ import static io.crate.role.Role.CRATE_USER;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.UnaryScalar;
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
 import io.crate.types.DataTypes;
 
@@ -39,7 +40,7 @@ public class PgGetUserByIdFunction {
                 name,
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new UnaryScalar<>(
                     signature,

--- a/server/src/main/java/io/crate/expression/scalar/string/AsciiFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/AsciiFunction.java
@@ -23,6 +23,7 @@ package io.crate.expression.scalar.string;
 
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.UnaryScalar;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
@@ -34,7 +35,7 @@ public final class AsciiFunction {
                 "ascii",
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.INTEGER.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new UnaryScalar<>(signature, boundSignature, DataTypes.STRING, AsciiFunction::ascii)
         );

--- a/server/src/main/java/io/crate/expression/scalar/string/EncodeDecodeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/EncodeDecodeFunction.java
@@ -31,6 +31,7 @@ import io.crate.common.Hex;
 import io.crate.common.Octal;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.arithmetic.BinaryScalar;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
@@ -43,7 +44,7 @@ public class EncodeDecodeFunction {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new BinaryScalar<>(
                         new Encode(),
@@ -58,7 +59,7 @@ public class EncodeDecodeFunction {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new BinaryScalar<>(
                         new Decode(),

--- a/server/src/main/java/io/crate/expression/scalar/string/HashFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/HashFunctions.java
@@ -32,6 +32,7 @@ import org.elasticsearch.common.hash.MessageDigests;
 import io.crate.common.Hex;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.UnaryScalar;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
@@ -48,7 +49,7 @@ public final class HashFunctions {
                 name,
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new UnaryScalar<>(signature, boundSignature, DataTypes.STRING, func)
         );

--- a/server/src/main/java/io/crate/expression/scalar/string/InitCapFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/InitCapFunction.java
@@ -23,6 +23,7 @@ package io.crate.expression.scalar.string;
 
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.UnaryScalar;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
@@ -34,7 +35,7 @@ public final class InitCapFunction {
                 "initcap",
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new UnaryScalar<>(
                     signature,

--- a/server/src/main/java/io/crate/expression/scalar/string/LengthFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/LengthFunction.java
@@ -23,6 +23,7 @@ package io.crate.expression.scalar.string;
 
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.UnaryScalar;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
@@ -44,7 +45,7 @@ public final class LengthFunction {
                 name,
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.INTEGER.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) -> new UnaryScalar<>(signature, boundSignature, DataTypes.STRING, func)
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/string/QuoteIdentFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/QuoteIdentFunction.java
@@ -27,6 +27,7 @@ import io.crate.common.annotations.VisibleForTesting;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.UnaryScalar;
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
 import io.crate.sql.Identifiers;
@@ -43,7 +44,7 @@ public final class QuoteIdentFunction {
                 FQNAME,
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new UnaryScalar<>(
                     signature,

--- a/server/src/main/java/io/crate/expression/scalar/string/ReplaceFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/ReplaceFunction.java
@@ -23,6 +23,7 @@ package io.crate.expression.scalar.string;
 
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.TripleScalar;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 import org.elasticsearch.common.Strings;
@@ -40,7 +41,7 @@ public final class ReplaceFunction {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new TripleScalar<>(
                     signature,

--- a/server/src/main/java/io/crate/expression/scalar/string/StringCaseFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/StringCaseFunction.java
@@ -23,6 +23,7 @@ package io.crate.expression.scalar.string;
 
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.UnaryScalar;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
@@ -36,7 +37,7 @@ public final class StringCaseFunction {
                 "upper",
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new UnaryScalar<>(
                     signature,
@@ -50,7 +51,7 @@ public final class StringCaseFunction {
                 "lower",
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new UnaryScalar<>(
                     signature,

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetPartkeydefFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetPartkeydefFunction.java
@@ -23,6 +23,7 @@ package io.crate.expression.scalar.systeminformation;
 
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
 import io.crate.types.DataTypes;
@@ -39,7 +40,7 @@ public class PgGetPartkeydefFunction {
                 FQN,
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
             new UnaryScalar<>(
                 signature,

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetSerialSequenceFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetSerialSequenceFunction.java
@@ -24,6 +24,7 @@ package io.crate.expression.scalar.systeminformation;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.arithmetic.BinaryScalar;
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
 import io.crate.types.DataTypes;
@@ -40,7 +41,7 @@ public class PgGetSerialSequenceFunction {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) -> new BinaryScalar<>(
                         (table,column) -> null,
                         signature,

--- a/server/src/test/java/io/crate/execution/engine/pipeline/MapRowUsingInputsTest.java
+++ b/server/src/test/java/io/crate/execution/engine/pipeline/MapRowUsingInputsTest.java
@@ -60,11 +60,13 @@ public class MapRowUsingInputsTest extends ESTestCase {
         InputFactory.Context<CollectExpression<Row, ?>> ctx = inputFactory.ctxForInputColumns(txnCtx);
         var addFunction = new Function(
             Signature.scalar(
-                ArithmeticFunctions.Names.ADD,
-                DataTypes.LONG.getTypeSignature(),
-                DataTypes.LONG.getTypeSignature(),
-                DataTypes.LONG.getTypeSignature()
-            ).withFeatures(Scalar.DETERMINISTIC_AND_COMPARISON_REPLACEMENT),
+                    ArithmeticFunctions.Names.ADD,
+                    DataTypes.LONG.getTypeSignature(),
+                    DataTypes.LONG.getTypeSignature(),
+                    DataTypes.LONG.getTypeSignature()
+                )
+                .withFeatures(Scalar.DETERMINISTIC_AND_COMPARISON_REPLACEMENT)
+                .withFeature(Scalar.Feature.NULLABLE),
             List.of(new InputColumn(0, DataTypes.LONG), Literal.of(2L)),
             DataTypes.LONG
         );

--- a/server/src/test/java/io/crate/expression/InputFactoryTest.java
+++ b/server/src/test/java/io/crate/expression/InputFactoryTest.java
@@ -66,11 +66,13 @@ public class InputFactoryTest extends CrateDummyClusterServiceUnitTest {
     private TransactionContext txnCtx = CoordinatorTxnCtx.systemTransactionContext();
     private Function add = new Function(
         Signature.scalar(
-            ArithmeticFunctions.Names.ADD,
-            DataTypes.INTEGER.getTypeSignature(),
-            DataTypes.INTEGER.getTypeSignature(),
-            DataTypes.INTEGER.getTypeSignature()
-        ).withFeatures(Scalar.DETERMINISTIC_AND_COMPARISON_REPLACEMENT),
+                ArithmeticFunctions.Names.ADD,
+                DataTypes.INTEGER.getTypeSignature(),
+                DataTypes.INTEGER.getTypeSignature(),
+                DataTypes.INTEGER.getTypeSignature()
+            )
+            .withFeatures(Scalar.DETERMINISTIC_AND_COMPARISON_REPLACEMENT)
+            .withFeature(Scalar.Feature.NULLABLE),
         List.of(new InputColumn(1, DataTypes.INTEGER), Literal.of(10)),
         DataTypes.INTEGER
     );


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
We recently introduced the concept of `nullable`/`non_nullable`/`conditional` functions and some are marked wrong. Even after this PR is merged there maybe few more but looking at the current usage of the nullability, the impact seems minor to my understanding.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
