### PR TITLE
Move Scalar/BinaryScalar to expression.scalar package

### DIFF
--- a/extensions/lang-js/src/main/java/io/crate/operation/language/JavaScriptLanguage.java
+++ b/extensions/lang-js/src/main/java/io/crate/operation/language/JavaScriptLanguage.java
@@ -24,7 +24,7 @@ package io.crate.operation.language;
 import io.crate.expression.udf.UDFLanguage;
 import io.crate.expression.udf.UserDefinedFunctionMetadata;
 import io.crate.expression.udf.UserDefinedFunctionService;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataType;

--- a/extensions/lang-js/src/main/java/io/crate/operation/language/JavaScriptUserDefinedFunction.java
+++ b/extensions/lang-js/src/main/java/io/crate/operation/language/JavaScriptUserDefinedFunction.java
@@ -33,7 +33,7 @@ import io.crate.common.collections.Lists;
 import io.crate.data.Input;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/analyze/GeneratedColumnExpander.java
+++ b/server/src/main/java/io/crate/analyze/GeneratedColumnExpander.java
@@ -52,7 +52,7 @@ import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.GeneratedReference;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.SearchPath;
 
 public final class GeneratedColumnExpander {

--- a/server/src/main/java/io/crate/analyze/expressions/ValueNormalizer.java
+++ b/server/src/main/java/io/crate/analyze/expressions/ValueNormalizer.java
@@ -35,7 +35,7 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.TableInfo;
 import io.crate.protocols.postgres.parser.PgArrayParsingException;

--- a/server/src/main/java/io/crate/execution/dsl/projection/builder/InputColumns.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/builder/InputColumns.java
@@ -83,7 +83,7 @@ public final class InputColumns extends DefaultTraversalSymbolVisitor<InputColum
             int i = 0;
             for (Symbol input : inputs) {
                 // only non-literals should be replaced with input columns.
-                // otherwise {@link io.crate.metadata.Scalar#compile} won't do anything which
+                // otherwise {@link io.crate.expression.scalar.Scalar#compile} won't do anything which
                 // results in poor performance of some scalar implementations
                 add(i, input);
 

--- a/server/src/main/java/io/crate/expression/BaseImplementationSymbolVisitor.java
+++ b/server/src/main/java/io/crate/expression/BaseImplementationSymbolVisitor.java
@@ -36,7 +36,7 @@ import io.crate.expression.symbol.SymbolVisitor;
 import io.crate.expression.symbol.VoidReference;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 

--- a/server/src/main/java/io/crate/expression/FunctionExpression.java
+++ b/server/src/main/java/io/crate/expression/FunctionExpression.java
@@ -24,7 +24,7 @@ package io.crate.expression;
 import io.crate.data.Input;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 
 import java.util.Arrays;
 

--- a/server/src/main/java/io/crate/expression/operator/CIDROperator.java
+++ b/server/src/main/java/io/crate/expression/operator/CIDROperator.java
@@ -34,7 +34,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.metadata.IndexType;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/operator/GtOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/GtOperator.java
@@ -21,7 +21,7 @@
 
 package io.crate.expression.operator;
 
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 

--- a/server/src/main/java/io/crate/expression/operator/GteOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/GteOperator.java
@@ -21,7 +21,7 @@
 
 package io.crate.expression.operator;
 
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 

--- a/server/src/main/java/io/crate/expression/operator/LikeOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/LikeOperator.java
@@ -36,7 +36,7 @@ import io.crate.lucene.LuceneQueryBuilder;
 import io.crate.metadata.IndexType;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/operator/LikeOperators.java
+++ b/server/src/main/java/io/crate/expression/operator/LikeOperators.java
@@ -32,7 +32,7 @@ import io.crate.expression.operator.any.AnyLikeOperator;
 import io.crate.expression.operator.any.AnyNotLikeOperator;
 import io.crate.expression.operator.any.AnyOperator;
 import io.crate.lucene.match.CrateRegexQuery;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 

--- a/server/src/main/java/io/crate/expression/operator/LtOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/LtOperator.java
@@ -21,7 +21,7 @@
 
 package io.crate.expression.operator;
 
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 

--- a/server/src/main/java/io/crate/expression/operator/LteOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/LteOperator.java
@@ -21,7 +21,7 @@
 
 package io.crate.expression.operator;
 
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 

--- a/server/src/main/java/io/crate/expression/operator/Operator.java
+++ b/server/src/main/java/io/crate/expression/operator/Operator.java
@@ -26,7 +26,7 @@ import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/predicate/IsNullPredicate.java
+++ b/server/src/main/java/io/crate/expression/predicate/IsNullPredicate.java
@@ -49,7 +49,7 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.lucene.LuceneQueryBuilder.Context;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/predicate/MatchPredicate.java
+++ b/server/src/main/java/io/crate/expression/predicate/MatchPredicate.java
@@ -59,7 +59,7 @@ import io.crate.lucene.LuceneQueryBuilder;
 import io.crate.lucene.LuceneQueryBuilder.Context;
 import io.crate.lucene.match.MatchQueries;
 import io.crate.metadata.FunctionImplementation;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 import io.crate.server.xcontent.LoggingDeprecationHandler;

--- a/server/src/main/java/io/crate/expression/predicate/NotPredicate.java
+++ b/server/src/main/java/io/crate/expression/predicate/NotPredicate.java
@@ -42,7 +42,7 @@ import io.crate.expression.symbol.SymbolVisitor;
 import io.crate.lucene.LuceneQueryBuilder;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/AgeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/AgeFunction.java
@@ -34,7 +34,6 @@ import org.joda.time.PeriodType;
 import io.crate.data.Input;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/ArrayAppendFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayAppendFunction.java
@@ -28,7 +28,6 @@ import java.util.List;
 
 import io.crate.data.Input;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/ArrayAvgFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayAvgFunction.java
@@ -23,7 +23,6 @@
 package io.crate.expression.scalar;
 
 import io.crate.expression.scalar.array.ArraySummationFunctions;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.ArrayType;
 import io.crate.types.DataTypes;

--- a/server/src/main/java/io/crate/expression/scalar/ArrayCatFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayCatFunction.java
@@ -29,7 +29,6 @@ import java.util.List;
 
 import io.crate.data.Input;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/ArrayDifferenceFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayDifferenceFunction.java
@@ -36,7 +36,6 @@ import org.jetbrains.annotations.Nullable;
 import io.crate.data.Input;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/ArrayLowerFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayLowerFunction.java
@@ -30,7 +30,6 @@ import org.jetbrains.annotations.Nullable;
 
 import io.crate.data.Input;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/ArrayMaxFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayMaxFunction.java
@@ -28,7 +28,6 @@ import java.util.List;
 
 import io.crate.data.Input;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/ArrayMinFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayMinFunction.java
@@ -28,7 +28,6 @@ import java.util.List;
 
 import io.crate.data.Input;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/ArrayPositionFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayPositionFunction.java
@@ -29,7 +29,6 @@ import java.util.Objects;
 
 import io.crate.data.Input;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/ArraySetFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArraySetFunction.java
@@ -28,7 +28,6 @@ import java.util.List;
 
 import io.crate.data.Input;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/ArraySliceFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArraySliceFunction.java
@@ -29,7 +29,6 @@ import java.util.List;
 
 import io.crate.data.Input;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/ArraySumFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArraySumFunction.java
@@ -30,7 +30,6 @@ import java.util.function.Function;
 import io.crate.data.Input;
 import io.crate.expression.scalar.array.ArraySummationFunctions;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/ArrayToStringFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayToStringFunction.java
@@ -30,7 +30,6 @@ import java.util.StringJoiner;
 import io.crate.data.Input;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/ArrayUniqueFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayUniqueFunction.java
@@ -32,7 +32,6 @@ import java.util.Set;
 
 import io.crate.data.Input;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/ArrayUnnestFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayUnnestFunction.java
@@ -30,7 +30,6 @@ import io.crate.data.Input;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/ArrayUpperFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayUpperFunction.java
@@ -48,7 +48,6 @@ import io.crate.lucene.LuceneQueryBuilder;
 import io.crate.lucene.LuceneQueryBuilder.Context;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/CollectionAverageFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/CollectionAverageFunction.java
@@ -27,7 +27,6 @@ import java.util.List;
 
 import io.crate.data.Input;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/CollectionCountFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/CollectionCountFunction.java
@@ -27,7 +27,6 @@ import java.util.List;
 
 import io.crate.data.Input;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/ConcatFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ConcatFunction.java
@@ -29,7 +29,6 @@ import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/ConcatWsFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ConcatWsFunction.java
@@ -23,7 +23,6 @@ package io.crate.expression.scalar;
 
 import io.crate.data.Input;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/CurrentDatabaseFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/CurrentDatabaseFunction.java
@@ -25,7 +25,6 @@ import io.crate.Constants;
 import io.crate.data.Input;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/CurrentDateFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/CurrentDateFunction.java
@@ -25,7 +25,6 @@ import java.util.EnumSet;
 
 import io.crate.data.Input;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/DateBinFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/DateBinFunction.java
@@ -29,7 +29,6 @@ import org.joda.time.Period;
 import io.crate.data.Input;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/DateFormatFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/DateFormatFunction.java
@@ -28,7 +28,6 @@ import org.joda.time.DateTimeZone;
 
 import io.crate.data.Input;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/DateTruncFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/DateTruncFunction.java
@@ -36,7 +36,6 @@ import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/DoubleScalar.java
+++ b/server/src/main/java/io/crate/expression/scalar/DoubleScalar.java
@@ -25,7 +25,6 @@ import java.util.function.DoubleUnaryOperator;
 
 import io.crate.data.Input;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/ExtractFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/ExtractFunctions.java
@@ -45,7 +45,6 @@ import org.joda.time.DurationFieldType;
 import org.joda.time.Period;
 import org.joda.time.chrono.ISOChronology;
 
-import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.sql.tree.Extract;
 import io.crate.types.DataTypes;

--- a/server/src/main/java/io/crate/expression/scalar/FormatFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/FormatFunction.java
@@ -27,7 +27,6 @@ import java.util.Locale;
 
 import io.crate.data.Input;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/GenRandomTextUUIDFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/GenRandomTextUUIDFunction.java
@@ -27,7 +27,6 @@ import org.elasticsearch.common.UUIDs;
 
 import io.crate.data.Input;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/HasPrivilegeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/HasPrivilegeFunction.java
@@ -34,7 +34,6 @@ import io.crate.data.Input;
 import io.crate.exceptions.MissingPrivilegeException;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/Ignore3vlFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/Ignore3vlFunction.java
@@ -30,7 +30,6 @@ import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
 import io.crate.lucene.LuceneQueryBuilder.Context;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/KnnMatch.java
+++ b/server/src/main/java/io/crate/expression/scalar/KnnMatch.java
@@ -35,7 +35,6 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.lucene.LuceneQueryBuilder.Context;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/NullOrEmptyFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/NullOrEmptyFunction.java
@@ -37,7 +37,6 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.lucene.LuceneQueryBuilder.Context;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/PiFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/PiFunction.java
@@ -23,7 +23,6 @@ package io.crate.expression.scalar;
 
 import io.crate.data.Input;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/Scalar.java
+++ b/server/src/main/java/io/crate/expression/scalar/Scalar.java
@@ -59,7 +59,7 @@ import io.crate.role.Roles;
  *
  * <ul>
  *     <li>{@link io.crate.expression.scalar.UnaryScalar}</li>
- *     <li>{@link io.crate.expression.scalar.arithmetic.BinaryScalar}</li>
+ *     <li>{@link io.crate.expression.scalar.BinaryScalar}</li>
  *     <li>{@link io.crate.expression.scalar.DoubleScalar}</li>
  *     <li>{@link io.crate.expression.scalar.TripleScalar}</li>
  * </ul>

--- a/server/src/main/java/io/crate/expression/scalar/Scalar.java
+++ b/server/src/main/java/io/crate/expression/scalar/Scalar.java
@@ -19,7 +19,7 @@
  * software solely pursuant to the terms of the relevant commercial agreement.
  */
 
-package io.crate.metadata;
+package io.crate.expression.scalar;
 
 import java.util.Collection;
 import java.util.EnumSet;
@@ -31,6 +31,9 @@ import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.lucene.FunctionToQuery;
+import io.crate.metadata.FunctionImplementation;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 import io.crate.role.Roles;

--- a/server/src/main/java/io/crate/expression/scalar/StringToArrayFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/StringToArrayFunction.java
@@ -31,7 +31,6 @@ import org.jetbrains.annotations.Nullable;
 
 import io.crate.data.Input;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/SubscriptFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/SubscriptFunction.java
@@ -50,7 +50,6 @@ import io.crate.lucene.LuceneQueryBuilder.Context;
 import io.crate.metadata.IndexType;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/SubscriptObjectFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/SubscriptObjectFunction.java
@@ -32,7 +32,6 @@ import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/SubscriptRecordFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/SubscriptRecordFunction.java
@@ -24,7 +24,6 @@ package io.crate.expression.scalar;
 import io.crate.data.Input;
 import io.crate.data.Row;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/SubstrFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/SubstrFunction.java
@@ -31,7 +31,6 @@ import io.crate.common.annotations.VisibleForTesting;
 import io.crate.data.Input;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/TripleScalar.java
+++ b/server/src/main/java/io/crate/expression/scalar/TripleScalar.java
@@ -23,7 +23,6 @@ package io.crate.expression.scalar;
 
 import io.crate.data.Input;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/UnaryScalar.java
+++ b/server/src/main/java/io/crate/expression/scalar/UnaryScalar.java
@@ -25,7 +25,6 @@ import java.util.function.Function;
 
 import io.crate.data.Input;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/AbsFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/AbsFunction.java
@@ -23,7 +23,7 @@ package io.crate.expression.scalar.arithmetic;
 
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.UnaryScalar;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/ArithmeticFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/ArithmeticFunctions.java
@@ -21,11 +21,11 @@
 
 package io.crate.expression.scalar.arithmetic;
 
-import static io.crate.metadata.Scalar.DETERMINISTIC_ONLY;
-import static io.crate.metadata.Scalar.Feature.NULLABLE;
+import static io.crate.expression.scalar.Scalar.DETERMINISTIC_ONLY;
+import static io.crate.expression.scalar.Scalar.Feature.NULLABLE;
 
 import io.crate.expression.scalar.ScalarFunctionModule;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/ArithmeticFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/ArithmeticFunctions.java
@@ -24,6 +24,7 @@ package io.crate.expression.scalar.arithmetic;
 import static io.crate.expression.scalar.Scalar.DETERMINISTIC_ONLY;
 import static io.crate.expression.scalar.Scalar.Feature.NULLABLE;
 
+import io.crate.expression.scalar.BinaryScalar;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/ArrayFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/ArrayFunction.java
@@ -29,7 +29,7 @@ import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.FunctionType;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/BinaryScalar.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/BinaryScalar.java
@@ -25,7 +25,7 @@ import java.util.function.BinaryOperator;
 
 import io.crate.data.Input;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/BinaryScalar.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/BinaryScalar.java
@@ -19,7 +19,7 @@
  * software solely pursuant to the terms of the relevant commercial agreement.
  */
 
-package io.crate.expression.scalar.arithmetic;
+package io.crate.expression.scalar;
 
 import java.util.function.BinaryOperator;
 

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/CeilFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/CeilFunction.java
@@ -23,7 +23,7 @@ package io.crate.expression.scalar.arithmetic;
 
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.UnaryScalar;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/ExpFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/ExpFunction.java
@@ -23,7 +23,7 @@ package io.crate.expression.scalar.arithmetic;
 
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.UnaryScalar;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.types.DataTypes;
 
 import static io.crate.metadata.functions.Signature.scalar;

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/FloorFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/FloorFunction.java
@@ -23,7 +23,7 @@ package io.crate.expression.scalar.arithmetic;
 
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.UnaryScalar;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/IntervalArithmeticFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/IntervalArithmeticFunctions.java
@@ -29,7 +29,7 @@ import org.joda.time.PeriodType;
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/IntervalTimestampArithmeticScalar.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/IntervalTimestampArithmeticScalar.java
@@ -31,7 +31,7 @@ import org.joda.time.Period;
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/LogFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/LogFunction.java
@@ -26,7 +26,7 @@ import static io.crate.metadata.functions.Signature.scalar;
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/MapFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/MapFunction.java
@@ -31,7 +31,7 @@ import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.FunctionType;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/NegateFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/NegateFunctions.java
@@ -25,7 +25,7 @@ import java.math.BigDecimal;
 
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.UnaryScalar;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 import io.crate.types.TypeSignature;

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/RadiansDegreesFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/RadiansDegreesFunctions.java
@@ -23,7 +23,7 @@ package io.crate.expression.scalar.arithmetic;
 
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.UnaryScalar;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.types.DataTypes;
 
 import static io.crate.metadata.functions.Signature.scalar;

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/RandomFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/RandomFunction.java
@@ -32,7 +32,7 @@ import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/RoundFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/RoundFunction.java
@@ -23,7 +23,7 @@ package io.crate.expression.scalar.arithmetic;
 
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.UnaryScalar;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/SquareRootFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/SquareRootFunction.java
@@ -23,7 +23,7 @@ package io.crate.expression.scalar.arithmetic;
 
 import io.crate.expression.scalar.DoubleScalar;
 import io.crate.expression.scalar.ScalarFunctionModule;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.types.DataTypes;
 
 import static io.crate.metadata.functions.Signature.scalar;

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/SubtractTimestampScalar.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/SubtractTimestampScalar.java
@@ -29,7 +29,7 @@ import org.joda.time.PeriodType;
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/TrigonometricFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/TrigonometricFunctions.java
@@ -21,6 +21,7 @@
 
 package io.crate.expression.scalar.arithmetic;
 
+import io.crate.expression.scalar.BinaryScalar;
 import io.crate.expression.scalar.DoubleScalar;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.Scalar;

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/TrigonometricFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/TrigonometricFunctions.java
@@ -23,7 +23,7 @@ package io.crate.expression.scalar.arithmetic;
 
 import io.crate.expression.scalar.DoubleScalar;
 import io.crate.expression.scalar.ScalarFunctionModule;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.types.DataTypes;
 import io.crate.types.DoubleType;
 

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/TruncFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/TruncFunction.java
@@ -31,7 +31,7 @@ import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.UnaryScalar;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/bitwise/BitwiseFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/bitwise/BitwiseFunctions.java
@@ -24,7 +24,7 @@ package io.crate.expression.scalar.bitwise;
 import io.crate.common.TriConsumer;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.arithmetic.BinaryScalar;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.sql.tree.BitString;
 import io.crate.types.BitStringType;

--- a/server/src/main/java/io/crate/expression/scalar/bitwise/BitwiseFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/bitwise/BitwiseFunctions.java
@@ -23,7 +23,7 @@ package io.crate.expression.scalar.bitwise;
 
 import io.crate.common.TriConsumer;
 import io.crate.expression.scalar.ScalarFunctionModule;
-import io.crate.expression.scalar.arithmetic.BinaryScalar;
+import io.crate.expression.scalar.BinaryScalar;
 import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.sql.tree.BitString;

--- a/server/src/main/java/io/crate/expression/scalar/cast/ExplicitCastFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/cast/ExplicitCastFunction.java
@@ -29,7 +29,7 @@ import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/cast/ImplicitCastFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/cast/ImplicitCastFunction.java
@@ -33,7 +33,7 @@ import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/cast/TryCastFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/cast/TryCastFunction.java
@@ -28,7 +28,7 @@ import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/conditional/CaseFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/conditional/CaseFunction.java
@@ -30,7 +30,7 @@ import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.FunctionType;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/conditional/CoalesceFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/conditional/CoalesceFunction.java
@@ -26,7 +26,7 @@ import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/conditional/ConditionalCompareFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/conditional/ConditionalCompareFunction.java
@@ -25,7 +25,7 @@ import java.util.Comparator;
 
 import io.crate.data.Input;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/conditional/IfFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/conditional/IfFunction.java
@@ -26,7 +26,7 @@ import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/conditional/NullIfFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/conditional/NullIfFunction.java
@@ -26,7 +26,7 @@ import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/formatting/ToCharFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/formatting/ToCharFunction.java
@@ -34,7 +34,7 @@ import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/geo/AreaFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/geo/AreaFunction.java
@@ -24,7 +24,7 @@ package io.crate.expression.scalar.geo;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.UnaryScalar;
 import io.crate.geo.GeoJSONUtils;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.types.DataTypes;
 import io.crate.types.GeoShapeType;
 import org.locationtech.spatial4j.context.jts.JtsSpatialContext;

--- a/server/src/main/java/io/crate/expression/scalar/geo/CoordinateFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/geo/CoordinateFunction.java
@@ -23,7 +23,7 @@ package io.crate.expression.scalar.geo;
 
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.UnaryScalar;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.types.DataTypes;
 
 import static io.crate.metadata.functions.Signature.scalar;

--- a/server/src/main/java/io/crate/expression/scalar/geo/DistanceFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/geo/DistanceFunction.java
@@ -49,7 +49,7 @@ import io.crate.lucene.LuceneQueryBuilder;
 import io.crate.lucene.LuceneQueryBuilder.Context;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/geo/GeoHashFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/geo/GeoHashFunction.java
@@ -23,7 +23,7 @@ package io.crate.expression.scalar.geo;
 
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.UnaryScalar;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.types.DataTypes;
 import io.crate.types.GeoPointType;
 import org.elasticsearch.common.geo.GeoHashUtils;

--- a/server/src/main/java/io/crate/expression/scalar/geo/IntersectsFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/geo/IntersectsFunction.java
@@ -32,7 +32,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.geo.GeoJSONUtils;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/geo/WithinFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/geo/WithinFunction.java
@@ -51,7 +51,7 @@ import io.crate.geo.GeoJSONUtils;
 import io.crate.lucene.LuceneQueryBuilder.Context;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/object/ObjectKeysFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/object/ObjectKeysFunction.java
@@ -23,7 +23,7 @@ package io.crate.expression.scalar.object;
 
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.UnaryScalar;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 

--- a/server/src/main/java/io/crate/expression/scalar/object/ObjectMergeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/object/ObjectMergeFunction.java
@@ -26,7 +26,7 @@ import java.util.Map;
 
 import io.crate.data.Input;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/postgres/CurrentSettingFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/postgres/CurrentSettingFunction.java
@@ -29,7 +29,7 @@ import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/postgres/PgBackendPidFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/postgres/PgBackendPidFunction.java
@@ -32,7 +32,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/postgres/PgEncodingToCharFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/postgres/PgEncodingToCharFunction.java
@@ -27,7 +27,7 @@ import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/postgres/PgGetUserByIdFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/postgres/PgGetUserByIdFunction.java
@@ -27,7 +27,7 @@ import static io.crate.role.Role.CRATE_USER;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.UnaryScalar;
 import io.crate.metadata.FunctionName;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
 import io.crate.types.DataTypes;
 

--- a/server/src/main/java/io/crate/expression/scalar/postgres/PgPostmasterStartTime.java
+++ b/server/src/main/java/io/crate/expression/scalar/postgres/PgPostmasterStartTime.java
@@ -28,7 +28,7 @@ import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/regex/RegexpReplaceFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/regex/RegexpReplaceFunction.java
@@ -35,7 +35,7 @@ import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/string/AsciiFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/AsciiFunction.java
@@ -23,7 +23,7 @@ package io.crate.expression.scalar.string;
 
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.UnaryScalar;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 

--- a/server/src/main/java/io/crate/expression/scalar/string/ChrFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/ChrFunction.java
@@ -24,7 +24,7 @@ package io.crate.expression.scalar.string;
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/string/EncodeDecodeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/EncodeDecodeFunction.java
@@ -31,7 +31,7 @@ import io.crate.common.Hex;
 import io.crate.common.Octal;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.arithmetic.BinaryScalar;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 

--- a/server/src/main/java/io/crate/expression/scalar/string/EncodeDecodeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/EncodeDecodeFunction.java
@@ -30,7 +30,7 @@ import java.util.function.UnaryOperator;
 import io.crate.common.Hex;
 import io.crate.common.Octal;
 import io.crate.expression.scalar.ScalarFunctionModule;
-import io.crate.expression.scalar.arithmetic.BinaryScalar;
+import io.crate.expression.scalar.BinaryScalar;
 import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;

--- a/server/src/main/java/io/crate/expression/scalar/string/HashFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/HashFunctions.java
@@ -32,7 +32,7 @@ import org.elasticsearch.common.hash.MessageDigests;
 import io.crate.common.Hex;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.UnaryScalar;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 

--- a/server/src/main/java/io/crate/expression/scalar/string/InitCapFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/InitCapFunction.java
@@ -23,7 +23,7 @@ package io.crate.expression.scalar.string;
 
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.UnaryScalar;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 

--- a/server/src/main/java/io/crate/expression/scalar/string/LengthFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/LengthFunction.java
@@ -23,7 +23,7 @@ package io.crate.expression.scalar.string;
 
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.UnaryScalar;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 

--- a/server/src/main/java/io/crate/expression/scalar/string/ParseURIFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/ParseURIFunction.java
@@ -30,7 +30,7 @@ import java.util.Map;
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/string/ParseURLFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/ParseURLFunction.java
@@ -38,7 +38,7 @@ import org.elasticsearch.common.Strings;
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/string/QuoteIdentFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/QuoteIdentFunction.java
@@ -27,7 +27,7 @@ import io.crate.common.annotations.VisibleForTesting;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.UnaryScalar;
 import io.crate.metadata.FunctionName;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
 import io.crate.sql.Identifiers;

--- a/server/src/main/java/io/crate/expression/scalar/string/ReplaceFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/ReplaceFunction.java
@@ -23,7 +23,7 @@ package io.crate.expression.scalar.string;
 
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.TripleScalar;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 import org.elasticsearch.common.Strings;

--- a/server/src/main/java/io/crate/expression/scalar/string/StringCaseFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/StringCaseFunction.java
@@ -23,7 +23,7 @@ package io.crate.expression.scalar.string;
 
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.UnaryScalar;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 

--- a/server/src/main/java/io/crate/expression/scalar/string/StringLeftRightFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/StringLeftRightFunction.java
@@ -27,7 +27,7 @@ import java.util.function.BiFunction;
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/string/StringPaddingFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/StringPaddingFunction.java
@@ -27,7 +27,7 @@ import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.ThreeParametersFunction;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/string/StringRepeatFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/StringRepeatFunction.java
@@ -24,7 +24,7 @@ package io.crate.expression.scalar.string;
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/string/StringSplitPartFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/StringSplitPartFunction.java
@@ -24,7 +24,7 @@ package io.crate.expression.scalar.string;
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/string/TranslateFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/TranslateFunction.java
@@ -29,7 +29,7 @@ import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/string/TrimFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/TrimFunctions.java
@@ -30,7 +30,7 @@ import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/ColDescriptionFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/ColDescriptionFunction.java
@@ -25,7 +25,7 @@ import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/CurrentSchemaFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/CurrentSchemaFunction.java
@@ -32,7 +32,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/CurrentSchemasFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/CurrentSchemasFunction.java
@@ -29,7 +29,7 @@ import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/FormatTypeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/FormatTypeFunction.java
@@ -25,7 +25,7 @@ import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/ObjDescriptionFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/ObjDescriptionFunction.java
@@ -25,7 +25,7 @@ import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/PgFunctionIsVisibleFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/PgFunctionIsVisibleFunction.java
@@ -24,7 +24,7 @@ package io.crate.expression.scalar.systeminformation;
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetExpr.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetExpr.java
@@ -25,7 +25,7 @@ import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetFunctionResultFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetFunctionResultFunction.java
@@ -24,7 +24,7 @@ package io.crate.expression.scalar.systeminformation;
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetPartkeydefFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetPartkeydefFunction.java
@@ -23,7 +23,7 @@ package io.crate.expression.scalar.systeminformation;
 
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.FunctionName;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
 import io.crate.types.DataTypes;

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetSerialSequenceFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetSerialSequenceFunction.java
@@ -22,7 +22,7 @@
 package io.crate.expression.scalar.systeminformation;
 
 import io.crate.expression.scalar.ScalarFunctionModule;
-import io.crate.expression.scalar.arithmetic.BinaryScalar;
+import io.crate.expression.scalar.BinaryScalar;
 import io.crate.metadata.FunctionName;
 import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetSerialSequenceFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetSerialSequenceFunction.java
@@ -24,7 +24,7 @@ package io.crate.expression.scalar.systeminformation;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.expression.scalar.arithmetic.BinaryScalar;
 import io.crate.metadata.FunctionName;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
 import io.crate.types.DataTypes;

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/PgTypeofFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/PgTypeofFunction.java
@@ -27,7 +27,7 @@ import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/VersionFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/VersionFunction.java
@@ -31,7 +31,7 @@ import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/timestamp/CurrentTimeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/timestamp/CurrentTimeFunction.java
@@ -28,7 +28,7 @@ import java.util.Locale;
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/timestamp/CurrentTimestampFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/timestamp/CurrentTimestampFunction.java
@@ -29,7 +29,7 @@ import java.util.Locale;
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/timestamp/NowFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/timestamp/NowFunction.java
@@ -28,7 +28,7 @@ import java.util.EnumSet;
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/scalar/timestamp/TimezoneFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/timestamp/TimezoneFunction.java
@@ -30,7 +30,7 @@ import java.util.Locale;
 import io.crate.data.Input;
 import io.crate.expression.scalar.ScalarFunctionModule;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/tablefunctions/EmptyRowTableFunction.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/EmptyRowTableFunction.java
@@ -26,7 +26,7 @@ import java.util.List;
 import io.crate.data.Input;
 import io.crate.data.Row;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/tablefunctions/MatchesFunction.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/MatchesFunction.java
@@ -42,7 +42,7 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolType;
 import io.crate.legacy.LegacySettings;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/tablefunctions/TableFunctionFactory.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/TableFunctionFactory.java
@@ -30,7 +30,7 @@ import io.crate.data.Row;
 import io.crate.data.Row1;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/tablefunctions/UnnestFunction.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/UnnestFunction.java
@@ -34,7 +34,7 @@ import io.crate.data.Input;
 import io.crate.data.Row;
 import io.crate.legacy.LegacySettings;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/expression/udf/UDFLanguage.java
+++ b/server/src/main/java/io/crate/expression/udf/UDFLanguage.java
@@ -21,7 +21,7 @@
 
 package io.crate.expression.udf;
 
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 

--- a/server/src/main/java/io/crate/expression/udf/UserDefinedFunctionService.java
+++ b/server/src/main/java/io/crate/expression/udf/UserDefinedFunctionService.java
@@ -65,7 +65,7 @@ import io.crate.metadata.GeneratedReference;
 import io.crate.metadata.IndexParts;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.doc.DocTableInfoFactory;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/metadata/functions/Signature.java
+++ b/server/src/main/java/io/crate/metadata/functions/Signature.java
@@ -41,7 +41,7 @@ import io.crate.common.collections.Lists;
 import io.crate.common.collections.Sets;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.FunctionType;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.TypeSignature;

--- a/server/src/main/java/io/crate/metadata/tablefunctions/TableFunctionImplementation.java
+++ b/server/src/main/java/io/crate/metadata/tablefunctions/TableFunctionImplementation.java
@@ -26,7 +26,7 @@ import io.crate.data.Row;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/main/java/io/crate/planner/selectivity/SelectivityFunctions.java
+++ b/server/src/main/java/io/crate/planner/selectivity/SelectivityFunctions.java
@@ -43,7 +43,7 @@ import io.crate.expression.symbol.SymbolVisitor;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.statistics.ColumnStats;
 import io.crate.statistics.MostCommonValues;

--- a/server/src/main/java/io/crate/role/scalar/UserFunction.java
+++ b/server/src/main/java/io/crate/role/scalar/UserFunction.java
@@ -29,7 +29,7 @@ import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/test/java/io/crate/execution/engine/pipeline/MapRowUsingInputsTest.java
+++ b/server/src/test/java/io/crate/execution/engine/pipeline/MapRowUsingInputsTest.java
@@ -43,7 +43,7 @@ import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.CoordinatorTxnCtx;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;

--- a/server/src/test/java/io/crate/expression/InputFactoryTest.java
+++ b/server/src/test/java/io/crate/expression/InputFactoryTest.java
@@ -51,7 +51,7 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.RelationName;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;

--- a/server/src/test/java/io/crate/expression/scalar/ScalarNullabilityTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ScalarNullabilityTest.java
@@ -33,7 +33,6 @@ import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.FunctionProvider;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;

--- a/server/src/test/java/io/crate/expression/symbol/FunctionTest.java
+++ b/server/src/test/java/io/crate/expression/symbol/FunctionTest.java
@@ -38,7 +38,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
 
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.testing.TestingHelpers;
 import io.crate.types.DataType;

--- a/server/src/test/java/io/crate/expression/tablefunctions/AbstractTableFunctionsTest.java
+++ b/server/src/test/java/io/crate/expression/tablefunctions/AbstractTableFunctionsTest.java
@@ -49,7 +49,7 @@ import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.SimpleReference;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.table.Operation;

--- a/server/src/test/java/io/crate/expression/tablefunctions/MatchesFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/tablefunctions/MatchesFunctionTest.java
@@ -26,7 +26,7 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.junit.Test;
 
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 
 
 public class MatchesFunctionTest extends AbstractTableFunctionsTest {

--- a/server/src/test/java/io/crate/expression/udf/UdfUnitTest.java
+++ b/server/src/test/java/io/crate/expression/udf/UdfUnitTest.java
@@ -30,7 +30,7 @@ import org.junit.Before;
 
 import io.crate.data.Input;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocTableInfoFactory;
 import io.crate.metadata.functions.BoundSignature;

--- a/server/src/test/java/io/crate/integrationtests/UserDefinedFunctionsIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/UserDefinedFunctionsIntegrationTest.java
@@ -49,7 +49,7 @@ import io.crate.expression.udf.UserDefinedFunctionService;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.FunctionType;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;

--- a/server/src/test/java/io/crate/metadata/doc/DocSchemaInfoTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocSchemaInfoTest.java
@@ -49,7 +49,7 @@ import io.crate.expression.udf.UserDefinedFunctionService;
 import io.crate.expression.udf.UserDefinedFunctionsMetadata;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.RelationName;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;

--- a/server/src/testFixtures/java/io/crate/expression/scalar/ScalarTestCase.java
+++ b/server/src/testFixtures/java/io/crate/expression/scalar/ScalarTestCase.java
@@ -50,7 +50,6 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.RelationName;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.SearchPath;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocSchemaInfo;

--- a/server/src/testFixtures/java/io/crate/testing/Asserts.java
+++ b/server/src/testFixtures/java/io/crate/testing/Asserts.java
@@ -42,7 +42,7 @@ import io.crate.execution.dsl.projection.Projection;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.RelationName;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.role.Policy;
 import io.crate.sql.tree.ColumnPolicy;

--- a/server/src/testFixtures/java/io/crate/testing/SleepScalarFunction.java
+++ b/server/src/testFixtures/java/io/crate/testing/SleepScalarFunction.java
@@ -23,7 +23,7 @@ package io.crate.testing;
 
 import io.crate.data.Input;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.expression.scalar.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
See https://github.com/crate/crate/pull/15452#issuecomment-1911159722

## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
