### PR TITLE
Ignore unsupported float_vector type in ArrayTypeTests

### DIFF
--- a/server/src/test/java/io/crate/types/ArrayTypeTest.java
+++ b/server/src/test/java/io/crate/types/ArrayTypeTest.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -38,7 +39,11 @@ public class ArrayTypeTest extends DataTypeTestCase<List<Object>> {
     @Override
     @SuppressWarnings("unchecked")
     public DataType<List<Object>> getType() {
-        DataType<Object> randomType = (DataType<Object>) DataTypeTesting.randomType();
+        // we don't support arrays of float vectors
+        // TODO: maybe make this a property of the DataType itself rather than a check in DataTypeAnalyzer?
+        DataType<Object> randomType = (DataType<Object>) DataTypeTesting.randomTypeExcluding(
+            Set.of(FloatVectorType.INSTANCE_ONE)
+        );
         return new ArrayType<>(randomType);
     }
 
@@ -47,12 +52,6 @@ public class ArrayTypeTest extends DataTypeTestCase<List<Object>> {
         // skip base class case. It doesn't deal with arrays:
         // - doesn't initialize sources correctly
         // - doesn't expect multi values per field
-    }
-
-    @Override
-    public void test_translog_streaming_roundtrip() throws Exception {
-        // skip base class case.
-        // TODO: fix different number of fields.
     }
 
     @Test

--- a/server/src/testFixtures/java/io/crate/testing/DataTypeTesting.java
+++ b/server/src/testFixtures/java/io/crate/testing/DataTypeTesting.java
@@ -83,6 +83,12 @@ public class DataTypeTesting {
         return RandomPicks.randomFrom(RandomizedContext.current().getRandom(), ALL_STORED_TYPES_EXCEPT_ARRAYS);
     }
 
+    public static DataType<?> randomTypeExcluding(Set<DataType<?>> excluding) {
+        Set<DataType<?>> pickFrom = ALL_STORED_TYPES_EXCEPT_ARRAYS
+            .stream().filter(t -> excluding.contains(t) == false).collect(Collectors.toSet());
+        return RandomPicks.randomFrom(RandomizedContext.current().getRandom(), pickFrom);
+    }
+
     @SuppressWarnings("unchecked")
     public static <T> Supplier<T> getDataGenerator(DataType<T> type) {
         Random random = RandomizedContext.current().getRandom();


### PR DESCRIPTION
ArrayTypeTests select a random data type to use as their child value, but
we do not support arrays of `float_vector` so this needs to be excluded
from consideration.

We also adjust DateFieldMapper to output more directly comparable
lucene Documents.

Related to #15453 