### PR TITLE
Revert "Normalize `<non_null_ref> is null` to `false`"

### DIFF
--- a/docs/appendices/release-notes/5.5.4.rst
+++ b/docs/appendices/release-notes/5.5.4.rst
@@ -59,16 +59,6 @@ Fixes
   clause having an equality condition on a primary key to return ``NULL`` when
   selecting an object sub-column of ``ARRAY(OBJECT)`` type.
 
-- Fixed an issue that caused queries to return invalid results when the
-  ``WHERE`` clause involving ``primary key`` columns have the following
-  form::
-
-    SELECT * FROM t WHERE NOT(pk_col != 1 AND pk_col IS NULL);
-
-  An equivalent query that returned valid results::
-
-    SELECT * FROM t WHERE pk_col = 1 OR pk_col IS NOT NULL;
-
 - Fixed an issue that caused failure of a statement, mixing correlated subquery
   and sub-select. An example::
 

--- a/docs/appendices/release-notes/5.6.1.rst
+++ b/docs/appendices/release-notes/5.6.1.rst
@@ -66,16 +66,6 @@ Fixes
   clause having an equality condition on a primary key to return ``NULL`` when
   selecting an object sub-column of ``ARRAY(OBJECT)`` type.
 
-- Fixed an issue that caused queries to return invalid results when the
-  ``WHERE`` clause involving ``primary key`` columns have the following
-  form::
-
-    SELECT * FROM t WHERE NOT(pk_col != 1 AND pk_col IS NULL);
-
-  An equivalent query that returned valid results::
-
-    SELECT * FROM t WHERE pk_col = 1 OR pk_col IS NOT NULL;
-
 - Fixed an issue that caused failure of a statement, mixing correlated subquery
   and sub-select. An example::
 

--- a/server/src/main/java/io/crate/expression/predicate/IsNullPredicate.java
+++ b/server/src/main/java/io/crate/expression/predicate/IsNullPredicate.java
@@ -90,12 +90,6 @@ public class IsNullPredicate<T> extends Scalar<Boolean, T> {
         if (arg instanceof Input<?> input) {
             return Literal.of(input.value() == null);
         }
-        if (arg instanceof Reference ref
-            // allow system columns for further error processing, for example see testSelectWhereVersionIsNullPredicate().
-            && !ref.column().isSystemColumn()
-            && !ref.isNullable()) {
-            return Literal.of(false);
-        }
         return symbol;
     }
 
@@ -111,6 +105,9 @@ public class IsNullPredicate<T> extends Scalar<Boolean, T> {
         List<Symbol> arguments = function.arguments();
         assert arguments.size() == 1 : "`<expression> IS NULL` function must have one argument";
         if (arguments.get(0) instanceof Reference ref) {
+            if (!ref.isNullable()) {
+                return new MatchNoDocsQuery("`x IS NULL` on column that is NOT NULL can't match");
+            }
             Query refExistsQuery = refExistsQuery(ref, context, true);
             return refExistsQuery == null ? null : Queries.not(refExistsQuery);
         }

--- a/server/src/main/java/io/crate/expression/predicate/NotPredicate.java
+++ b/server/src/main/java/io/crate/expression/predicate/NotPredicate.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.lucene.search.Queries;
 
@@ -186,6 +187,9 @@ public class NotPredicate extends Scalar<Boolean, Boolean> {
                 // Ignored objects have no field names in the index, need function filter fallback
                 if (ref.columnPolicy() == ColumnPolicy.IGNORED) {
                     return null;
+                }
+                if (!ref.isNullable()) {
+                    return new MatchAllDocsQuery();
                 }
                 return IsNullPredicate.refExistsQuery(ref, context, true);
             }

--- a/server/src/test/java/io/crate/expression/predicate/IsNullPredicateTest.java
+++ b/server/src/test/java/io/crate/expression/predicate/IsNullPredicateTest.java
@@ -130,10 +130,5 @@ public class IsNullPredicateTest extends ScalarTestCase {
     public void testEvaluateWithInputThatReturnsNull() throws Exception {
         assertEvaluate("name is null", true, Literal.of(DataTypes.STRING, null));
     }
-
-    @Test
-    public void test_normalize_not_null_ref_to_false() {
-        assertNormalize("b is null", isLiteral(false));
-    }
 }
 

--- a/server/src/test/java/io/crate/expression/predicate/NotPredicateTest.java
+++ b/server/src/test/java/io/crate/expression/predicate/NotPredicateTest.java
@@ -76,9 +76,4 @@ public class NotPredicateTest extends ScalarTestCase {
             assertThat(result).isEmpty();
         }
     }
-
-    @Test
-    public void test_normalize_not_null_ref_to_true() {
-        assertNormalize("b is not null", isLiteral(true));
-    }
 }

--- a/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -733,12 +733,6 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
         assertThat(query).isExactlyInstanceOf(MatchAllDocsQuery.class);
     }
 
-    @Test
-    public void test_is_null_on_not_null_ref() {
-        Query query = convert("x is null");
-        assertThat(query).isExactlyInstanceOf(MatchNoDocsQuery.class);
-    }
-
     // tracks a bug: https://github.com/crate/crate/issues/15202
     @Test
     public void test_neq_operator_on_nullable_and_not_nullable_args_filters_nulls() throws Exception {

--- a/server/src/test/java/io/crate/planner/WhereClauseOptimizerTest.java
+++ b/server/src/test/java/io/crate/planner/WhereClauseOptimizerTest.java
@@ -27,7 +27,6 @@ import static java.util.Collections.singletonList;
 
 import java.util.List;
 
-import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -215,13 +214,5 @@ public class WhereClauseOptimizerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(query.docKeys()).hasToString("Optional[DocKeys{'10'; 't'}]");
         query = optimize("delete from t_pk where _id = 10 OR _id = true");
         assertThat(query.docKeys()).hasToString("Optional[DocKeys{'10'; 't'}]");
-    }
-
-    // tracks a bug: https://github.com/crate/crate/issues/15395
-    @Test
-    public void test_filter_on_pk_with_or_is_not_null_on_pk() {
-        WhereClauseOptimizer.DetailedQuery query = optimize("select * from t_pk where not(a != 1 and a is null)");
-        assertThat(query.query()).isLiteral(true);
-        Assertions.assertThat(query.docKeys().isPresent()).isFalse();
     }
 }

--- a/server/src/testFixtures/java/io/crate/expression/scalar/ScalarTestCase.java
+++ b/server/src/testFixtures/java/io/crate/expression/scalar/ScalarTestCase.java
@@ -84,7 +84,6 @@ public abstract class ScalarTestCase extends CrateDummyClusterServiceUnitTest {
             "  tags array(text)," +
             "  age int," +
             "  a int," +
-            "  b int not null," +
             "  ip ip," +
             "  c byte," +
             "  x bigint," +


### PR DESCRIPTION
This reverts commit 9c4876523ce39835eb22e0ec7fe8915d30e780bd.

Follows: #15401

The optimization doesn't handle properly the case of OUTER JOINS where we want data to be retrieved, produce `NULL` for the columns of the outer table, and be filtered out later on.
