### PR TITLE
Restrict `COPY FROM` using local files to superuser

### DIFF
--- a/benchmarks/src/main/java/io/crate/execution/engine/reader/CsvReaderBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/execution/engine/reader/CsvReaderBenchmark.java
@@ -141,7 +141,7 @@ public class CsvReaderBenchmark {
 
         List<Input<?>> inputs = Collections.singletonList(ctx.add(raw));
         BatchIterator<Row> batchIterator = FileReadingIterator.newInstance(
-            Collections.singletonList(fileUri),
+            List.of(FileReadingIterator.toURI(fileUri)),
             inputs,
             ctx.expressions(),
             null,

--- a/benchmarks/src/main/java/io/crate/execution/engine/reader/JsonReaderBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/execution/engine/reader/JsonReaderBenchmark.java
@@ -141,7 +141,7 @@ public class JsonReaderBenchmark {
 
         List<Input<?>> inputs = Collections.singletonList(ctx.add(raw));
         BatchIterator<Row> batchIterator = FileReadingIterator.newInstance(
-            Collections.singletonList(fileUri),
+            List.of(FileReadingIterator.toURI(fileUri)),
             inputs,
             ctx.expressions(),
             null,

--- a/docs/appendices/release-notes/5.4.8.rst
+++ b/docs/appendices/release-notes/5.4.8.rst
@@ -43,6 +43,13 @@ Version 5.4.8 - Unreleased
 See the :ref:`version_5.4.0` release notes for a full list of changes in the
 5.4 series.
 
+Security Fixes
+==============
+
+- Fixed a security issue where any CrateDB user could read/import the content of
+  any file on the host system, the CrateDB process user has read access to, by
+  using the ``COPY FROM`` command with a file URI. This access is now restricted
+  to the ``crate`` superuser only.
 
 Fixes
 =====

--- a/docs/sql/statements/copy-from.rst
+++ b/docs/sql/statements/copy-from.rst
@@ -207,6 +207,8 @@ For example:
 
 The files must be accessible on at least one node and the system user running
 the ``crate`` process must have read access to every file specified.
+Additionally, only the ``crate`` superuser is allowed to use the ``file://``
+scheme.
 
 By default, every node will attempt to import every file. If the file is
 accessible on multiple nodes, you can set the `shared`_ option to true in order

--- a/plugins/cr8-copy-s3/src/test/java/io/crate/copy/s3/S3FileReadingCollectorTest.java
+++ b/plugins/cr8-copy-s3/src/test/java/io/crate/copy/s3/S3FileReadingCollectorTest.java
@@ -217,7 +217,7 @@ public class S3FileReadingCollectorTest extends ESTestCase {
             inputs.add(sourceUriFailureInput);
         }
         return FileReadingIterator.newInstance(
-            fileUris,
+            fileUris.stream().map(FileReadingIterator::toURI).toList(),
             inputs,
             ctx.expressions(),
             compression,

--- a/server/src/main/java/io/crate/exceptions/UnauthorizedException.java
+++ b/server/src/main/java/io/crate/exceptions/UnauthorizedException.java
@@ -21,10 +21,18 @@
 
 package io.crate.exceptions;
 
-public class UnauthorizedException extends RuntimeException implements UnscopedException {
+import java.io.IOException;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.io.stream.StreamInput;
+
+public class UnauthorizedException extends ElasticsearchException implements UnscopedException {
 
     public UnauthorizedException(String message) {
         super(message);
     }
 
+    public UnauthorizedException(StreamInput in) throws IOException {
+        super(in);
+    }
 }

--- a/server/src/main/java/io/crate/execution/engine/collect/files/FileReadingIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/files/FileReadingIterator.java
@@ -67,7 +67,7 @@ public class FileReadingIterator implements BatchIterator<Row> {
     @VisibleForTesting
     static final int MAX_SOCKET_TIMEOUT_RETRIES = 5;
 
-    public static BatchIterator<Row> newInstance(Collection<String> fileUris,
+    public static BatchIterator<Row> newInstance(Collection<URI> fileUris,
                                                  List<Input<?>> inputs,
                                                  Iterable<LineCollectorExpression<?>> collectorExpressions,
                                                  String compression,
@@ -125,7 +125,7 @@ public class FileReadingIterator implements BatchIterator<Row> {
     private final Iterator<TimeValue> backOffPolicy;
 
     @VisibleForTesting
-    FileReadingIterator(Collection<String> fileUris,
+    FileReadingIterator(Collection<URI> fileUris,
                         List<? extends Input<?>> inputs,
                         Iterable<LineCollectorExpression<?>> collectorExpressions,
                         String compression,
@@ -360,8 +360,7 @@ public class FileReadingIterator implements BatchIterator<Row> {
     }
 
     @Nullable
-    private FileInput toFileInput(String fileUri, Settings withClauseOptions) {
-        URI uri = toURI(fileUri);
+    private FileInput toFileInput(URI uri, Settings withClauseOptions) {
         FileInputFactory fileInputFactory = fileInputFactories.get(uri.getScheme());
         if (fileInputFactory != null) {
             try {

--- a/server/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/server/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -969,7 +969,12 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
             org.elasticsearch.cluster.coordination.NodeHealthCheckFailureException.class,
             org.elasticsearch.cluster.coordination.NodeHealthCheckFailureException::new,
             175,
-            Version.V_5_2_0);
+            Version.V_5_2_0),
+        UNAUTHORIZED_EXCEPTION(
+            io.crate.exceptions.UnauthorizedException.class,
+            io.crate.exceptions.UnauthorizedException::new,
+            177,
+            Version.V_5_4_8);
 
         final Class<? extends ElasticsearchException> exceptionClass;
         final CheckedFunction<StreamInput, ? extends ElasticsearchException, IOException> constructor;

--- a/server/src/test/java/io/crate/execution/engine/collect/MapSideDataCollectOperationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/MapSideDataCollectOperationTest.java
@@ -56,6 +56,7 @@ import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.types.DataTypes;
+import io.crate.user.User;
 
 
 public class MapSideDataCollectOperationTest extends CrateDummyClusterServiceUnitTest {
@@ -69,7 +70,8 @@ public class MapSideDataCollectOperationTest extends CrateDummyClusterServiceUni
             createNodeContext(),
             clusterService,
             Collections.emptyMap(),
-            THREAD_POOL
+            THREAD_POOL,
+            () -> List.of(User.CRATE_USER)
             );
 
         File tmpFile = temporaryFolder.newFile("fileUriCollectOperation.json");

--- a/server/src/test/java/io/crate/execution/engine/collect/files/FileReadingCollectorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/files/FileReadingCollectorTest.java
@@ -243,7 +243,7 @@ public class FileReadingCollectorTest extends ESTestCase {
             inputs.add(sourceUriFailureInput);
         }
         return FileReadingIterator.newInstance(
-            fileUris,
+            fileUris.stream().map(FileReadingIterator::toURI).toList(),
             inputs,
             ctx.expressions(),
             compression,

--- a/server/src/test/java/io/crate/execution/engine/collect/files/FileReadingIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/files/FileReadingIteratorTest.java
@@ -196,7 +196,7 @@ public class FileReadingIteratorTest extends ESTestCase {
 
         Supplier<BatchIterator<Row>> batchIteratorSupplier =
             () -> new FileReadingIterator(
-                fileUris,
+                fileUris.stream().map(FileReadingIterator::toURI).toList(),
                 inputs,
                 ctx.expressions(),
                 null,
@@ -255,7 +255,7 @@ public class FileReadingIteratorTest extends ESTestCase {
 
         Supplier<BatchIterator<Row>> batchIteratorSupplier =
             () -> new FileReadingIterator(
-                fileUris,
+                fileUris.stream().map(FileReadingIterator::toURI).toList(),
                 inputs,
                 ctx.expressions(),
                 null,
@@ -317,7 +317,7 @@ public class FileReadingIteratorTest extends ESTestCase {
 
         Supplier<BatchIterator<Row>> batchIteratorSupplier =
             () -> new FileReadingIterator(
-                fileUris,
+                fileUris.stream().map(FileReadingIterator::toURI).toList(),
                 inputs,
                 ctx.expressions(),
                 null,
@@ -411,7 +411,7 @@ public class FileReadingIteratorTest extends ESTestCase {
         List<Input<?>> inputs = Collections.singletonList(ctx.add(raw));
 
         var fi = new FileReadingIterator(
-            fileUris,
+            fileUris.stream().map(FileReadingIterator::toURI).toList(),
             inputs,
             ctx.expressions(),
             null,
@@ -477,7 +477,7 @@ public class FileReadingIteratorTest extends ESTestCase {
 
         List<Input<?>> inputs = Collections.singletonList(ctx.add(raw));
         return FileReadingIterator.newInstance(
-            fileUris,
+            fileUris.stream().map(FileReadingIterator::toURI).toList(),
             inputs,
             ctx.expressions(),
             null,


### PR DESCRIPTION
Fixing a security issue where any user could read/import content of any file on the host system, the CrateDB process user has read access to.

(cherry picked from commit 4e857d675683095945dd524d6ba03e692c70ecd6)