### PR TITLE
Restrict `COPY FROM` using local files to superuser

### DIFF
--- a/benchmarks/src/main/java/io/crate/execution/engine/reader/CsvReaderBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/execution/engine/reader/CsvReaderBenchmark.java
@@ -141,7 +141,7 @@ public class CsvReaderBenchmark {
 
         List<Input<?>> inputs = Collections.singletonList(ctx.add(raw));
         BatchIterator<Row> batchIterator = FileReadingIterator.newInstance(
-            Collections.singletonList(fileUri),
+            List.of(FileReadingIterator.toURI(fileUri)),
             inputs,
             ctx.expressions(),
             null,

--- a/benchmarks/src/main/java/io/crate/execution/engine/reader/JsonReaderBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/execution/engine/reader/JsonReaderBenchmark.java
@@ -141,7 +141,7 @@ public class JsonReaderBenchmark {
 
         List<Input<?>> inputs = Collections.singletonList(ctx.add(raw));
         BatchIterator<Row> batchIterator = FileReadingIterator.newInstance(
-            Collections.singletonList(fileUri),
+            List.of(FileReadingIterator.toURI(fileUri)),
             inputs,
             ctx.expressions(),
             null,

--- a/docs/appendices/release-notes/5.3.9.rst
+++ b/docs/appendices/release-notes/5.3.9.rst
@@ -44,6 +44,14 @@ Version 5.3.9 - Unreleased
 See the :ref:`version_5.3.0` release notes for a full list of changes in the
 5.3 series.
 
+Security Fixes
+==============
+
+- Fixed a security issue where any CrateDB user could read/import the content of
+  any file on the host system, the CrateDB process user has read access to, by
+  using the ``COPY FROM`` command with a file URI. This access is now restricted
+  to the ``crate`` superuser only.
+
 Fixes
 =====
 

--- a/docs/sql/statements/copy-from.rst
+++ b/docs/sql/statements/copy-from.rst
@@ -207,6 +207,8 @@ For example:
 
 The files must be accessible on at least one node and the system user running
 the ``crate`` process must have read access to every file specified.
+Additionally, only the ``crate`` superuser is allowed to use the ``file://``
+scheme.
 
 By default, every node will attempt to import every file. If the file is
 accessible on multiple nodes, you can set the `shared`_ option to true in order

--- a/plugins/cr8-copy-s3/src/test/java/io/crate/copy/s3/S3FileReadingCollectorTest.java
+++ b/plugins/cr8-copy-s3/src/test/java/io/crate/copy/s3/S3FileReadingCollectorTest.java
@@ -212,7 +212,7 @@ public class S3FileReadingCollectorTest extends ESTestCase {
             inputs.add(sourceUriFailureInput);
         }
         return FileReadingIterator.newInstance(
-            fileUris,
+            fileUris.stream().map(FileReadingIterator::toURI).toList(),
             inputs,
             ctx.expressions(),
             compression,

--- a/server/src/main/java/io/crate/exceptions/UnauthorizedException.java
+++ b/server/src/main/java/io/crate/exceptions/UnauthorizedException.java
@@ -21,10 +21,18 @@
 
 package io.crate.exceptions;
 
-public class UnauthorizedException extends RuntimeException implements UnscopedException {
+import java.io.IOException;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.io.stream.StreamInput;
+
+public class UnauthorizedException extends ElasticsearchException implements UnscopedException {
 
     public UnauthorizedException(String message) {
         super(message);
     }
 
+    public UnauthorizedException(StreamInput in) throws IOException {
+        super(in);
+    }
 }

--- a/server/src/main/java/io/crate/execution/engine/collect/files/FileReadingIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/files/FileReadingIterator.java
@@ -62,7 +62,7 @@ public class FileReadingIterator implements BatchIterator<Row> {
     @VisibleForTesting
     static final int MAX_SOCKET_TIMEOUT_RETRIES = 5;
 
-    public static BatchIterator<Row> newInstance(Collection<String> fileUris,
+    public static BatchIterator<Row> newInstance(Collection<URI> fileUris,
                                                  List<Input<?>> inputs,
                                                  Iterable<LineCollectorExpression<?>> collectorExpressions,
                                                  String compression,
@@ -114,7 +114,7 @@ public class FileReadingIterator implements BatchIterator<Row> {
     private LineProcessor lineProcessor;
 
     @VisibleForTesting
-    FileReadingIterator(Collection<String> fileUris,
+    FileReadingIterator(Collection<URI> fileUris,
                         List<? extends Input<?>> inputs,
                         Iterable<LineCollectorExpression<?>> collectorExpressions,
                         String compression,
@@ -324,8 +324,7 @@ public class FileReadingIterator implements BatchIterator<Row> {
     }
 
     @Nullable
-    private FileInput toFileInput(String fileUri, Settings withClauseOptions) {
-        URI uri = toURI(fileUri);
+    private FileInput toFileInput(URI uri, Settings withClauseOptions) {
         FileInputFactory fileInputFactory = fileInputFactories.get(uri.getScheme());
         if (fileInputFactory != null) {
             try {

--- a/server/src/main/java/io/crate/execution/engine/collect/sources/FileCollectSource.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/sources/FileCollectSource.java
@@ -21,11 +21,26 @@
 
 package io.crate.execution.engine.collect.sources;
 
+import static java.util.Objects.requireNonNull;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Singleton;
+
 import io.crate.analyze.AnalyzedCopyFrom;
 import io.crate.analyze.SymbolEvaluator;
 import io.crate.common.annotations.VisibleForTesting;
 import io.crate.data.BatchIterator;
 import io.crate.data.Row;
+import io.crate.exceptions.UnauthorizedException;
 import io.crate.execution.dsl.phases.CollectPhase;
 import io.crate.execution.dsl.phases.FileUriCollectPhase;
 import io.crate.execution.engine.collect.CollectTask;
@@ -40,16 +55,7 @@ import io.crate.metadata.TransactionContext;
 import io.crate.planner.operators.SubQueryResults;
 import io.crate.types.ArrayType;
 import io.crate.types.DataTypes;
-import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.inject.Singleton;
-
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.CompletableFuture;
+import io.crate.user.UserLookup;
 
 @Singleton
 public class FileCollectSource implements CollectSource {
@@ -58,13 +64,18 @@ public class FileCollectSource implements CollectSource {
     private final Map<String, FileInputFactory> fileInputFactoryMap;
     private final InputFactory inputFactory;
     private final NodeContext nodeCtx;
+    private final UserLookup userLookup;
 
     @Inject
-    public FileCollectSource(NodeContext nodeCtx, ClusterService clusterService, Map<String, FileInputFactory> fileInputFactoryMap) {
+    public FileCollectSource(NodeContext nodeCtx,
+                             ClusterService clusterService,
+                             Map<String, FileInputFactory> fileInputFactoryMap,
+                             UserLookup userLookup) {
         this.fileInputFactoryMap = fileInputFactoryMap;
         this.nodeCtx = nodeCtx;
         this.inputFactory = new InputFactory(nodeCtx);
         this.clusterService = clusterService;
+        this.userLookup = userLookup;
     }
 
     @Override
@@ -77,7 +88,16 @@ public class FileCollectSource implements CollectSource {
             inputFactory.ctxForRefs(txnCtx, FileLineReferenceResolver::getImplementation);
         ctx.add(collectPhase.toCollect());
 
-        List<String> fileUris = targetUriToStringList(txnCtx, nodeCtx, fileUriCollectPhase.targetUri());
+        var user = requireNonNull(userLookup.findUser(txnCtx.sessionSettings().userName()), "User who invoked a statement must exist");
+        List<URI> fileUris = targetUriToStringList(txnCtx, nodeCtx, fileUriCollectPhase.targetUri()).stream()
+            .map(s -> {
+                var uri = FileReadingIterator.toURI(s);
+                if (uri.getScheme().equals("file") && user.isSuperUser() == false) {
+                    throw new UnauthorizedException("Only a superuser can read from the local file system");
+                }
+                return uri;
+            })
+            .toList();
         return CompletableFuture.completedFuture(FileReadingIterator.newInstance(
             fileUris,
             ctx.topLevelInputs(),

--- a/server/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/server/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -969,7 +969,12 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
             org.elasticsearch.cluster.coordination.NodeHealthCheckFailureException.class,
             org.elasticsearch.cluster.coordination.NodeHealthCheckFailureException::new,
             175,
-            Version.V_5_2_0);
+            Version.V_5_2_0),
+        UNAUTHORIZED_EXCEPTION(
+            io.crate.exceptions.UnauthorizedException.class,
+            io.crate.exceptions.UnauthorizedException::new,
+            177,
+            Version.V_5_3_9);
 
         final Class<? extends ElasticsearchException> exceptionClass;
         final CheckedFunction<StreamInput, ? extends ElasticsearchException, IOException> constructor;

--- a/server/src/test/java/io/crate/execution/engine/collect/MapSideDataCollectOperationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/MapSideDataCollectOperationTest.java
@@ -56,6 +56,7 @@ import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.TestingRowConsumer;
 import io.crate.types.DataTypes;
+import io.crate.user.User;
 
 
 public class MapSideDataCollectOperationTest extends CrateDummyClusterServiceUnitTest {
@@ -65,7 +66,12 @@ public class MapSideDataCollectOperationTest extends CrateDummyClusterServiceUni
 
     @Test
     public void testFileUriCollect() throws Exception {
-        FileCollectSource fileCollectSource = new FileCollectSource(createNodeContext(), clusterService, Collections.emptyMap());
+        FileCollectSource fileCollectSource = new FileCollectSource(
+            createNodeContext(),
+            clusterService,
+            Collections.emptyMap(),
+            () -> List.of(User.CRATE_USER)
+        );
 
         File tmpFile = temporaryFolder.newFile("fileUriCollectOperation.json");
         try (OutputStreamWriter writer = new OutputStreamWriter(new FileOutputStream(tmpFile), StandardCharsets.UTF_8)) {

--- a/server/src/test/java/io/crate/execution/engine/collect/files/FileReadingCollectorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/files/FileReadingCollectorTest.java
@@ -238,7 +238,7 @@ public class FileReadingCollectorTest extends ESTestCase {
             inputs.add(sourceUriFailureInput);
         }
         return FileReadingIterator.newInstance(
-            fileUris,
+            fileUris.stream().map(FileReadingIterator::toURI).toList(),
             inputs,
             ctx.expressions(),
             compression,

--- a/server/src/test/java/io/crate/execution/engine/collect/files/FileReadingIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/files/FileReadingIteratorTest.java
@@ -170,7 +170,7 @@ public class FileReadingIteratorTest extends ESTestCase {
 
         Supplier<BatchIterator<Row>> batchIteratorSupplier =
             () -> new FileReadingIterator(
-                fileUris,
+                fileUris.stream().map(FileReadingIterator::toURI).toList(),
                 inputs,
                 ctx.expressions(),
                 null,
@@ -228,7 +228,7 @@ public class FileReadingIteratorTest extends ESTestCase {
 
         Supplier<BatchIterator<Row>> batchIteratorSupplier =
             () -> new FileReadingIterator(
-                fileUris,
+                fileUris.stream().map(FileReadingIterator::toURI).toList(),
                 inputs,
                 ctx.expressions(),
                 null,
@@ -289,7 +289,7 @@ public class FileReadingIteratorTest extends ESTestCase {
 
         Supplier<BatchIterator<Row>> batchIteratorSupplier =
             () -> new FileReadingIterator(
-                fileUris,
+                fileUris.stream().map(FileReadingIterator::toURI).toList(),
                 inputs,
                 ctx.expressions(),
                 null,
@@ -340,7 +340,7 @@ public class FileReadingIteratorTest extends ESTestCase {
 
         List<Input<?>> inputs = Collections.singletonList(ctx.add(raw));
         return FileReadingIterator.newInstance(
-            fileUris,
+            fileUris.stream().map(FileReadingIterator::toURI).toList(),
             inputs,
             ctx.expressions(),
             null,

--- a/server/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
@@ -26,7 +26,7 @@ import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
@@ -68,9 +68,13 @@ import org.junit.rules.TemporaryFolder;
 
 import com.carrotsearch.randomizedtesting.LifecycleScope;
 
+import io.crate.action.sql.Sessions;
+import io.crate.exceptions.UnauthorizedException;
 import io.crate.testing.Asserts;
 import io.crate.testing.SQLResponse;
 import io.crate.testing.UseJdbc;
+import io.crate.testing.UseRandomizedSchema;
+import io.crate.user.UserLookup;
 
 @IntegTestCase.ClusterScope(numDataNodes = 2)
 public class CopyIntegrationTest extends SQLHttpIntegrationTest {
@@ -1186,5 +1190,23 @@ public class CopyIntegrationTest extends SQLHttpIntegrationTest {
                 "   )\n" +
                 ")"
             );
+    }
+
+    @UseRandomizedSchema(random = false)
+    @Test
+    public void test_copy_from_local_file_is_only_allowed_for_superusers() {
+        execute("CREATE TABLE quotes (id INT PRIMARY KEY, " +
+                "quote STRING INDEX USING FULLTEXT) WITH (number_of_replicas = 0)");
+        execute("CREATE USER test_user");
+        execute("GRANT ALL TO test_user");
+
+        var roles = cluster().getInstance(UserLookup.class);
+        var user = roles.findUser("test_user");
+        var sqlOperations = cluster().getInstance(Sessions.class);
+        try (var session = sqlOperations.createSession(null, user)) {
+            assertThatThrownBy(() -> execute("COPY quotes FROM ?", new Object[]{copyFilePath + "test_copy_from.json"}, session))
+                .isExactlyInstanceOf(UnauthorizedException.class)
+                .hasMessage("Only a superuser can read from the local file system");
+        }
     }
 }


### PR DESCRIPTION
Fixing a security issue where any user could read/import content of any file on the host system, the CrateDB process user has read access to.

(cherry picked from commit 4e857d675683095945dd524d6ba03e692c70ecd6)
