### PR TITLE
Don't mark concat_ws as Nullable 

### DIFF
--- a/docs/appendices/release-notes/5.6.2.rst
+++ b/docs/appendices/release-notes/5.6.2.rst
@@ -45,4 +45,9 @@ See the :ref:`version_5.6.0` release notes for a full list of changes in the
 Fixes
 =====
 
-None
+- Fixed a regression introduced in 5.6.0 that caused
+  :ref:`concat_ws <scalar-concat-ws>` returning the wrong result when used on a
+  column with NULL values in the WHERE-clause combined with a NOT-predicate.
+  An example::
+
+    SELECT * FROM t1 WHERE NOT CONCAT_WS(true, column_with_null_value, false);

--- a/server/src/main/java/io/crate/expression/scalar/ConcatWsFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ConcatWsFunction.java
@@ -39,7 +39,6 @@ public class ConcatWsFunction extends Scalar<String, String> {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
             )
-            .withFeature(Feature.NULLABLE)
             .withVariableArity(),
             ConcatWsFunction::new
         );

--- a/server/src/test/java/io/crate/lucene/ThreeValuedLogicQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/ThreeValuedLogicQueryBuilderTest.java
@@ -74,6 +74,13 @@ public class ThreeValuedLogicQueryBuilderTest extends LuceneQueryBuilderTest {
     }
 
     @Test
+    public void test_negated_concat_ws_with_three_valued_logic() {
+        // Important, y is nullable column.
+        assertThat(convert("NOT CONCAT_WS('dummy', y, false)")).hasToString(
+            "+(+*:* -concat_ws('dummy', y, 'f')) #(NOT concat_ws('dummy', y, 'f'))");
+    }
+
+    @Test
     public void test_nullif() {
         assertThat(convert("NULLIF(2, x) != 1")).hasToString(
             "+(+*:* -(nullif(2, x) = 1)) #(NOT (nullif(2, x) = 1))");


### PR DESCRIPTION
Fixes https://github.com/crate/crate/issues/15459

Don't mark `concat_ws` as `NULLABLE`. 

Otherwise `FieldExistsQuery` breaks the query for cases when column contains NULL-s.
[Optimization](https://github.com/crate/crate/blob/master/server/src/main/java/io/crate/expression/predicate/NotPredicate.java#L214-L222) works only for functions with semantics
"at least one arg is NULL -> return NULL" and `concat_ws` is not like that.

Fixes a regression, introduced by https://github.com/crate/crate/commit/4428eb1555069f2325277ee99bd271af651b8425