### PR TITLE
Do not use PkLookUp if any pk cols are under NOT predicate

### DIFF
--- a/docs/appendices/release-notes/5.6.1.rst
+++ b/docs/appendices/release-notes/5.6.1.rst
@@ -70,3 +70,6 @@ Fixes
         AND
           tbl.x IN (SELECT generate_series from generate_series(1, 1))
     ) FROM tbl t;
+
+- Fixed an issue that caused filtering by ``primary keys`` under ``NOT``
+  predicate to return invalid results.

--- a/server/src/test/java/io/crate/analyze/where/ColumnsUnderNotPredicateFinderTest.java
+++ b/server/src/test/java/io/crate/analyze/where/ColumnsUnderNotPredicateFinderTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.analyze.where;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import io.crate.metadata.ColumnIdent;
+
+public class ColumnsUnderNotPredicateFinderTest extends EqualityExtractorTest {
+
+    @Test
+    public void test_can_find_x_from_x_neq_1() {
+        var query = query("x != 1 or x = 1");
+        var columns = List.of(new ColumnIdent("x"));
+        assertThat(new EqualityExtractor.ColumnsUnderNotPredicateFinder().find(query, columns)).isTrue();
+    }
+
+    @Test
+    public void test_can_find_x_from_not_x_neq_1() {
+        var query = query("not(x != 1) or x = 1");
+        var columns = List.of(new ColumnIdent("x"));
+        assertThat(new EqualityExtractor.ColumnsUnderNotPredicateFinder().find(query, columns)).isTrue();
+    }
+
+    @Test
+    public void test_x_is_not_under_not() {
+        var query = query("i != 1 or x = 1");
+        var columns = List.of(new ColumnIdent("x"));
+        assertThat(new EqualityExtractor.ColumnsUnderNotPredicateFinder().find(query, columns)).isFalse();
+    }
+
+    @Test
+    public void test_can_find_x_under_not_over_larger_query() {
+        var query = query("not(i != 1 or x = 1)");
+        var columns = List.of(new ColumnIdent("x"));
+        assertThat(new EqualityExtractor.ColumnsUnderNotPredicateFinder().find(query, columns)).isTrue();
+    }
+
+    @Test
+    public void test_x_is_under_not_but_is_not_interested_column() {
+        var query = query("not(i != 1 or x = 1)");
+        assertThat(new EqualityExtractor.ColumnsUnderNotPredicateFinder().find(query, List.of())).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes https://github.com/crate/crate/issues/15458 and https://github.com/crate/crate/issues/15395.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
