### PR TITLE
Add a Metadata.contains(RelationName)

### DIFF
--- a/server/src/main/java/io/crate/planner/consumer/CreateTableAsPlan.java
+++ b/server/src/main/java/io/crate/planner/consumer/CreateTableAsPlan.java
@@ -89,12 +89,19 @@ public final class CreateTableAsPlan implements Plan {
             subQueryResults
         );
         tableCreator.create(boundCreateTable, plannerContext.clusterState().nodes().getMinNodeVersion())
-            .thenRun(() -> postponedInsertPlan.get().execute(
-                dependencies,
-                plannerContext,
-                consumer,
-                params,
-                subQueryResults));
+            .whenComplete((rowCount, err) -> {
+                if (err == null) {
+                    postponedInsertPlan.get().execute(
+                        dependencies,
+                        plannerContext,
+                        consumer,
+                        params,
+                        subQueryResults
+                    );
+                } else {
+                    consumer.accept(null, err);
+                }
+            });
     }
 }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -70,6 +70,9 @@ import com.carrotsearch.hppc.cursors.ObjectCursor;
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 
 import io.crate.common.annotations.VisibleForTesting;
+import io.crate.metadata.PartitionName;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.view.ViewsMetadata;
 
 public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, ToXContentFragment {
 
@@ -1104,5 +1107,20 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
                 return Builder.fromXContent(parser, preserveUnknownCustoms);
             }
         };
+    }
+
+    public boolean contains(RelationName tableName) {
+        if (indices.containsKey(tableName.indexNameOrAlias())) {
+            return true;
+        }
+        if (templates.containsKey(PartitionName.templateName(tableName.schema(), tableName.name()))) {
+            return true;
+        }
+        ViewsMetadata views = custom(ViewsMetadata.TYPE);
+        if (views != null && views.contains(tableName)) {
+            return true;
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
This is in preparation for CREATE FOREIGN TABLE which will introduce a
new type of relation that is in the same namespace as regular tables and
views and needs conflict handling.

This doesn't add a `Schemas.contains` because the exists state needs to
happen atomically in a cluster state update task to avoid race
conditions.

Relates to https://github.com/crate/crate/issues/12686
