### PR TITLE
Introduce Credentials for holding fields of all authentication types

### DIFF
--- a/server/src/main/java/io/crate/auth/AuthenticationMethod.java
+++ b/server/src/main/java/io/crate/auth/AuthenticationMethod.java
@@ -28,6 +28,11 @@ import io.crate.role.Role;
 
 public interface AuthenticationMethod {
 
+    /**
+     * @param credentials contains username, password or token - depending on the used method.
+     * @return the user or null; null should be handled as if it's a "guest" user
+     * @throws RuntimeException if the authentication failed
+     */
     @Nullable
     Role authenticate(Credentials credentials, ConnectionProperties connProperties);
 

--- a/server/src/main/java/io/crate/auth/AuthenticationMethod.java
+++ b/server/src/main/java/io/crate/auth/AuthenticationMethod.java
@@ -21,7 +21,6 @@
 
 package io.crate.auth;
 
-import org.elasticsearch.common.settings.SecureString;
 import org.jetbrains.annotations.Nullable;
 
 import io.crate.protocols.postgres.ConnectionProperties;
@@ -29,14 +28,8 @@ import io.crate.role.Role;
 
 public interface AuthenticationMethod {
 
-    /**
-     * @param userName the userName sent with the startup message
-     * @param passwd the password in clear-text or null
-     * @return the user or null; null should be handled as if it's a "guest" user
-     * @throws RuntimeException if the authentication failed
-     */
     @Nullable
-    Role authenticate(String userName, @Nullable SecureString passwd, ConnectionProperties connProperties);
+    Role authenticate(Credentials credentials, ConnectionProperties connProperties);
 
     /**
      * @return unique name of the authentication method

--- a/server/src/main/java/io/crate/auth/Credentials.java
+++ b/server/src/main/java/io/crate/auth/Credentials.java
@@ -40,7 +40,7 @@ public class Credentials {
 
     private final String jwtToken;
 
-    public static Credentials of(@NotNull String username, @Nullable SecureString password) {
+    public static Credentials of(@NotNull String username, @Nullable char[] password) {
         return new Credentials(username, password, null);
     }
 

--- a/server/src/main/java/io/crate/auth/Credentials.java
+++ b/server/src/main/java/io/crate/auth/Credentials.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.auth;
+
+import org.elasticsearch.common.settings.SecureString;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Holder for all authentication methods.
+ * username is used for password, cert and trust methods and null otherwise.
+ * password is used for password method and null otherwise.
+ * jwtToken is used for jwt method and null otherwise.
+ */
+public class Credentials {
+
+    private final String username;
+
+    // Non-final as Postgres protocol might inject password later after creation.
+    private SecureString password;
+
+    private final String jwtToken;
+
+    public static Credentials of(@NotNull String username, @Nullable SecureString password) {
+        return new Credentials(username, password, null);
+    }
+
+    public static Credentials of(@NotNull String jwtToken) {
+        return new Credentials(null, null, jwtToken);
+    }
+
+    private Credentials(@Nullable String username, @Nullable SecureString password, @Nullable String jwtToken) {
+        this.username = username;
+        this.password = password;
+        this.jwtToken = jwtToken;
+    }
+
+    public void setPassword(@NotNull SecureString password) {
+        this.password = password;
+    }
+
+    @Nullable
+    public String username() {
+        return username;
+    }
+
+    @Nullable
+    public SecureString password() {
+        return password;
+    }
+
+    @Nullable
+    public String jwtToken() {
+        return jwtToken;
+    }
+}

--- a/server/src/main/java/io/crate/auth/Credentials.java
+++ b/server/src/main/java/io/crate/auth/Credentials.java
@@ -48,7 +48,7 @@ public class Credentials {
         return new Credentials(null, null, jwtToken);
     }
 
-    private Credentials(@Nullable String username, @Nullable SecureString password, @Nullable String jwtToken) {
+    private Credentials(@Nullable String username, @Nullable char[] password, @Nullable char[] jwtToken) {
         this.username = username;
         this.password = password;
         this.jwtToken = jwtToken;

--- a/server/src/main/java/io/crate/auth/Credentials.java
+++ b/server/src/main/java/io/crate/auth/Credentials.java
@@ -54,8 +54,8 @@ public class Credentials {
         this.jwtToken = jwtToken;
     }
 
-    public void setPassword(@NotNull SecureString password) {
-        this.password = password;
+    public void setPassword(@NotNull char[] password) {
+        this.password = new SecureString(password);
     }
 
     @Nullable

--- a/server/src/main/java/io/crate/auth/HttpAuthUpstreamHandler.java
+++ b/server/src/main/java/io/crate/auth/HttpAuthUpstreamHandler.java
@@ -36,13 +36,11 @@ import javax.net.ssl.SSLSession;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.network.InetAddresses;
-import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.http.netty4.Netty4HttpServerTransport;
 import org.jetbrains.annotations.Nullable;
 
 import io.crate.common.annotations.VisibleForTesting;
-import io.crate.common.collections.Tuple;
 import io.crate.protocols.SSL;
 import io.crate.protocols.http.Headers;
 import io.crate.protocols.postgres.ConnectionProperties;
@@ -96,9 +94,8 @@ public class HttpAuthUpstreamHandler extends SimpleChannelInboundHandler<Object>
 
     private void handleHttpRequest(ChannelHandlerContext ctx, HttpRequest request) {
         SSLSession session = getSession(ctx.channel());
-        Tuple<String, SecureString> credentials = credentialsFromRequest(request, session, settings);
-        String username = credentials.v1();
-        SecureString password = credentials.v2();
+        Credentials credentials = credentialsFromRequest(request, session, settings);
+        String username = credentials.username();
         if (username.equals(authorizedUser)) {
             ctx.fireChannelRead(request);
             return;
@@ -115,7 +112,7 @@ public class HttpAuthUpstreamHandler extends SimpleChannelInboundHandler<Object>
             sendUnauthorized(ctx.channel(), errorMessage);
         } else {
             try {
-                Role user = authMethod.authenticate(username, password, connectionProperties);
+                Role user = authMethod.authenticate(credentials, connectionProperties);
                 if (user != null && LOGGER.isTraceEnabled()) {
                     LOGGER.trace("Authentication succeeded user \"{}\" and method \"{}\".", username, authMethod.name());
                 }
@@ -166,7 +163,7 @@ public class HttpAuthUpstreamHandler extends SimpleChannelInboundHandler<Object>
     }
 
     @VisibleForTesting
-    static Tuple<String, SecureString> credentialsFromRequest(HttpRequest request, @Nullable SSLSession session, Settings settings) {
+    static Credentials credentialsFromRequest(HttpRequest request, @Nullable SSLSession session, Settings settings) {
         String username = null;
         if (request.headers().contains(HttpHeaderNames.AUTHORIZATION.toString())) {
             // Prefer Http Basic Auth
@@ -186,7 +183,7 @@ public class HttpAuthUpstreamHandler extends SimpleChannelInboundHandler<Object>
                 username = AuthSettings.AUTH_TRUST_HTTP_DEFAULT_HEADER.get(settings);
             }
         }
-        return new Tuple<>(username, null);
+        return Credentials.of(username, null);
     }
 
     private InetAddress addressFromRequestOrChannel(HttpRequest request, Channel channel) {

--- a/server/src/main/java/io/crate/auth/HttpAuthUpstreamHandler.java
+++ b/server/src/main/java/io/crate/auth/HttpAuthUpstreamHandler.java
@@ -183,7 +183,7 @@ public class HttpAuthUpstreamHandler extends SimpleChannelInboundHandler<Object>
                 username = AuthSettings.AUTH_TRUST_HTTP_DEFAULT_HEADER.get(settings);
             }
         }
-        return Credentials.of(username, null);
+        return new Credentials(username, null);
     }
 
     private InetAddress addressFromRequestOrChannel(HttpRequest request, Channel channel) {

--- a/server/src/main/java/io/crate/auth/PasswordAuthenticationMethod.java
+++ b/server/src/main/java/io/crate/auth/PasswordAuthenticationMethod.java
@@ -21,7 +21,6 @@
 
 package io.crate.auth;
 
-import org.elasticsearch.common.settings.SecureString;
 import org.jetbrains.annotations.Nullable;
 
 import io.crate.protocols.postgres.ConnectionProperties;
@@ -40,15 +39,16 @@ public class PasswordAuthenticationMethod implements AuthenticationMethod {
 
     @Nullable
     @Override
-    public Role authenticate(String userName, SecureString passwd, ConnectionProperties connProperties) {
-        Role user = roles.findUser(userName);
-        if (user != null && passwd != null && passwd.length() > 0) {
+    public Role authenticate(Credentials credentials, ConnectionProperties connProperties) {
+        assert credentials.username() != null : "User name must be not null on password authentication method";
+        Role user = roles.findUser(credentials.username());
+        if (user != null && credentials.password() != null && credentials.password().length() > 0) {
             SecureHash secureHash = user.password();
-            if (secureHash != null && secureHash.verifyHash(passwd)) {
+            if (secureHash != null && secureHash.verifyHash(credentials.password())) {
                 return user;
             }
         }
-        throw new RuntimeException("password authentication failed for user \"" + userName + "\"");
+        throw new RuntimeException("password authentication failed for user \"" + credentials.username() + "\"");
     }
 
     @Override

--- a/server/src/main/java/io/crate/auth/PasswordAuthenticationMethod.java
+++ b/server/src/main/java/io/crate/auth/PasswordAuthenticationMethod.java
@@ -42,9 +42,9 @@ public class PasswordAuthenticationMethod implements AuthenticationMethod {
     public Role authenticate(Credentials credentials, ConnectionProperties connProperties) {
         assert credentials.username() != null : "User name must be not null on password authentication method";
         Role user = roles.findUser(credentials.username());
-        if (user != null && credentials.password() != null && credentials.password().length() > 0) {
+        if (user != null && credentials.passwordOrToken() != null && credentials.passwordOrToken().length() > 0) {
             SecureHash secureHash = user.password();
-            if (secureHash != null && secureHash.verifyHash(credentials.password())) {
+            if (secureHash != null && secureHash.verifyHash(credentials.passwordOrToken())) {
                 return user;
             }
         }

--- a/server/src/main/java/io/crate/auth/TrustAuthenticationMethod.java
+++ b/server/src/main/java/io/crate/auth/TrustAuthenticationMethod.java
@@ -21,8 +21,6 @@
 
 package io.crate.auth;
 
-import org.elasticsearch.common.settings.SecureString;
-
 import io.crate.protocols.postgres.ConnectionProperties;
 import io.crate.role.Role;
 import io.crate.role.Roles;
@@ -38,10 +36,11 @@ public class TrustAuthenticationMethod implements AuthenticationMethod {
     }
 
     @Override
-    public Role authenticate(String userName, SecureString passwd, ConnectionProperties connectionProperties) {
-        Role user = roles.findUser(userName);
+    public Role authenticate(Credentials credentials, ConnectionProperties connectionProperties) {
+        assert credentials.username() != null : "User name must be not null on trust authentication method";
+        Role user = roles.findUser(credentials.username());
         if (user == null) {
-            throw new RuntimeException("trust authentication failed for user \"" + userName + "\"");
+            throw new RuntimeException("trust authentication failed for user \"" + credentials.username() + "\"");
         }
         return user;
     }

--- a/server/src/main/java/io/crate/protocols/http/Headers.java
+++ b/server/src/main/java/io/crate/protocols/http/Headers.java
@@ -28,7 +28,6 @@ import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpVersion;
-import org.elasticsearch.common.settings.SecureString;
 
 import org.jetbrains.annotations.Nullable;
 import java.nio.charset.StandardCharsets;
@@ -38,8 +37,8 @@ import java.util.regex.Pattern;
 public final class Headers {
 
     private static final Pattern USER_AGENT_BROWSER_PATTERN = Pattern.compile("(Mozilla|Chrome|Safari|Opera|Android|AppleWebKit)+?[/\\s][\\d.]+");
-    private static final SecureString EMPTY_PASSWORD = new SecureString(new char[] {});
-    private static final Credentials EMPTY_CREDENTIALS = Credentials.of("", EMPTY_PASSWORD);
+    private static final char[] EMPTY_PASSWORD = new char[] {};
+    private static final Credentials EMPTY_CREDENTIALS = new Credentials("", EMPTY_PASSWORD);
 
     static boolean isBrowser(@Nullable String headerValue) {
         if (headerValue == null) {
@@ -73,7 +72,7 @@ public final class Headers {
             return EMPTY_CREDENTIALS;
         }
         String username;
-        SecureString password = EMPTY_PASSWORD;
+        char[] password = EMPTY_PASSWORD;
         String valueWithoutBasePrefix = authHeaderValue.substring(6);
         String decodedCreds = new String(Base64.getDecoder().decode(valueWithoutBasePrefix), StandardCharsets.UTF_8);
 
@@ -84,9 +83,9 @@ public final class Headers {
             username = decodedCreds.substring(0, idx);
             String passwdStr = decodedCreds.substring(idx + 1);
             if (passwdStr.length() > 0) {
-                password = new SecureString(passwdStr.toCharArray());
+                password = passwdStr.toCharArray();
             }
         }
-        return Credentials.of(username, password);
+        return new Credentials(username, password);
     }
 }

--- a/server/src/main/java/io/crate/protocols/http/Headers.java
+++ b/server/src/main/java/io/crate/protocols/http/Headers.java
@@ -21,13 +21,13 @@
 
 package io.crate.protocols.http;
 
+import io.crate.auth.Credentials;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpVersion;
-import io.crate.common.collections.Tuple;
 import org.elasticsearch.common.settings.SecureString;
 
 import org.jetbrains.annotations.Nullable;
@@ -39,7 +39,7 @@ public final class Headers {
 
     private static final Pattern USER_AGENT_BROWSER_PATTERN = Pattern.compile("(Mozilla|Chrome|Safari|Opera|Android|AppleWebKit)+?[/\\s][\\d.]+");
     private static final SecureString EMPTY_PASSWORD = new SecureString(new char[] {});
-    private static final Tuple<String, SecureString> EMPTY_CREDENTIALS_TUPLE = new Tuple<>("", EMPTY_PASSWORD);
+    private static final Credentials EMPTY_CREDENTIALS = Credentials.of("", EMPTY_PASSWORD);
 
     static boolean isBrowser(@Nullable String headerValue) {
         if (headerValue == null) {
@@ -66,9 +66,11 @@ public final class Headers {
         }
     }
 
-    public static Tuple<String, SecureString> extractCredentialsFromHttpBasicAuthHeader(String authHeaderValue) {
+
+
+    public static Credentials extractCredentialsFromHttpBasicAuthHeader(String authHeaderValue) {
         if (authHeaderValue == null || authHeaderValue.isEmpty()) {
-            return EMPTY_CREDENTIALS_TUPLE;
+            return EMPTY_CREDENTIALS;
         }
         String username;
         SecureString password = EMPTY_PASSWORD;
@@ -85,6 +87,6 @@ public final class Headers {
                 password = new SecureString(passwdStr.toCharArray());
             }
         }
-        return new Tuple<>(username, password);
+        return Credentials.of(username, password);
     }
 }

--- a/server/src/main/java/io/crate/protocols/postgres/AuthenticationContext.java
+++ b/server/src/main/java/io/crate/protocols/postgres/AuthenticationContext.java
@@ -85,8 +85,8 @@ class AuthenticationContext implements Closeable {
      */
     @Override
     public void close() {
-        if (credentials.password() != null) {
-            credentials.password().close();
+        if (credentials != null) {
+            credentials.close();
         }
     }
 }

--- a/server/src/main/java/io/crate/protocols/postgres/AuthenticationContext.java
+++ b/server/src/main/java/io/crate/protocols/postgres/AuthenticationContext.java
@@ -76,7 +76,8 @@ class AuthenticationContext implements Closeable {
     @Nullable
     @VisibleForTesting
     SecureString password() {
-        return credentials.password();
+        // For PG protocol credentials always holds password.
+        return credentials.passwordOrToken();
     }
 
     /**

--- a/server/src/main/java/io/crate/protocols/postgres/AuthenticationContext.java
+++ b/server/src/main/java/io/crate/protocols/postgres/AuthenticationContext.java
@@ -70,7 +70,7 @@ class AuthenticationContext implements Closeable {
     }
 
     void setSecurePassword(char[] secureString) {
-        credentials.setPassword(new SecureString(secureString));
+        credentials.setPassword(secureString);
     }
 
     @Nullable

--- a/server/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
+++ b/server/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
@@ -426,7 +426,7 @@ public class PostgresWireProtocol {
         } else {
             authContext = new AuthenticationContext(
                 authMethod, connProperties,
-                Credentials.of(userName, null),
+                new Credentials(userName, null),
                 LOGGER
             );
             if (PASSWORD_AUTH_NAME.equals(authMethod.name())) {

--- a/server/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
+++ b/server/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
@@ -56,6 +56,7 @@ import io.crate.action.sql.Sessions;
 import io.crate.auth.AccessControl;
 import io.crate.auth.Authentication;
 import io.crate.auth.AuthenticationMethod;
+import io.crate.auth.Credentials;
 import io.crate.auth.Protocol;
 import io.crate.common.annotations.VisibleForTesting;
 import io.crate.common.collections.Lists;
@@ -423,7 +424,11 @@ public class PostgresWireProtocol {
             );
             Messages.sendAuthenticationError(channel, errorMessage);
         } else {
-            authContext = new AuthenticationContext(authMethod, connProperties, userName, LOGGER);
+            authContext = new AuthenticationContext(
+                authMethod, connProperties,
+                Credentials.of(userName, null),
+                LOGGER
+            );
             if (PASSWORD_AUTH_NAME.equals(authMethod.name())) {
                 Messages.sendAuthenticationCleartextPassword(channel);
                 return;

--- a/server/src/main/java/io/crate/rest/action/SqlHttpHandler.java
+++ b/server/src/main/java/io/crate/rest/action/SqlHttpHandler.java
@@ -294,7 +294,7 @@ public class SqlHttpHandler extends SimpleChannelInboundHandler<FullHttpRequest>
     }
 
     Role userFromAuthHeader(@Nullable String authHeaderValue) {
-        String username = Headers.extractCredentialsFromHttpBasicAuthHeader(authHeaderValue).v1();
+        String username = Headers.extractCredentialsFromHttpBasicAuthHeader(authHeaderValue).username();
         // Fallback to trusted user from configuration
         if (username == null || username.isEmpty()) {
             username = AuthSettings.AUTH_TRUST_HTTP_DEFAULT_HEADER.get(settings);

--- a/server/src/main/java/org/elasticsearch/transport/netty4/HostBasedAuthHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/netty4/HostBasedAuthHandler.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.network.CloseableChannel;
 import org.elasticsearch.http.netty4.Netty4HttpServerTransport;
 
 import io.crate.auth.Authentication;
+import io.crate.auth.Credentials;
 import io.crate.auth.Protocol;
 import io.crate.protocols.SSL;
 import io.crate.protocols.postgres.ConnectionProperties;
@@ -67,7 +68,7 @@ public class HostBasedAuthHandler extends ChannelInboundHandlerAdapter {
             closeAndThrowException(ctx, msg, authError);
         }
         try {
-            authMethod.authenticate(userName, null, connectionProperties);
+            authMethod.authenticate(Credentials.of(userName, null), connectionProperties);
             ctx.pipeline().remove(this);
             super.channelRead(ctx, msg);
         } catch (Exception e) {

--- a/server/src/main/java/org/elasticsearch/transport/netty4/HostBasedAuthHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/netty4/HostBasedAuthHandler.java
@@ -68,7 +68,7 @@ public class HostBasedAuthHandler extends ChannelInboundHandlerAdapter {
             closeAndThrowException(ctx, msg, authError);
         }
         try {
-            authMethod.authenticate(Credentials.of(userName, null), connectionProperties);
+            authMethod.authenticate(new Credentials(userName, null), connectionProperties);
             ctx.pipeline().remove(this);
             super.channelRead(ctx, msg);
         } catch (Exception e) {

--- a/server/src/test/java/io/crate/auth/ClientCertAuthTest.java
+++ b/server/src/test/java/io/crate/auth/ClientCertAuthTest.java
@@ -77,21 +77,21 @@ public class ClientCertAuthTest extends ESTestCase {
     public void testLookupValidUserWithCert() throws Exception {
         ClientCertAuth clientCertAuth = new ClientCertAuth(() -> List.of(exampleUser));
 
-        Role user = clientCertAuth.authenticate(Credentials.of("example.com", null), sslConnWithCert);
+        Role user = clientCertAuth.authenticate(new Credentials("example.com", null), sslConnWithCert);
         assertThat(user).isEqualTo(exampleUser);
     }
 
     @Test
     public void testLookupValidUserWithCertWithDifferentCN() throws Exception {
         ClientCertAuth clientCertAuth = new ClientCertAuth(() -> List.of(RolesHelper.userOf("arthur")));
-        assertThatThrownBy(() -> clientCertAuth.authenticate(Credentials.of("arthur", null), sslConnWithCert))
+        assertThatThrownBy(() -> clientCertAuth.authenticate(new Credentials("arthur", null), sslConnWithCert))
             .hasMessage("Common name \"example.com\" in client certificate doesn't match username \"arthur\"");
     }
 
     @Test
     public void testLookupUserWithMatchingCertThatDoesNotExist() throws Exception {
         ClientCertAuth clientCertAuth = new ClientCertAuth(List::of);
-        assertThatThrownBy(() -> clientCertAuth.authenticate(Credentials.of("example.com", null), sslConnWithCert))
+        assertThatThrownBy(() -> clientCertAuth.authenticate(new Credentials("example.com", null), sslConnWithCert))
             .hasMessage("Client certificate authentication failed for user \"example.com\"");
     }
 
@@ -103,7 +103,7 @@ public class ClientCertAuthTest extends ESTestCase {
             InetAddresses.forString("127.0.0.1"), Protocol.POSTGRES, sslSession);
         ClientCertAuth clientCertAuth = new ClientCertAuth(() -> List.of(exampleUser));
 
-        assertThatThrownBy(() -> clientCertAuth.authenticate(Credentials.of("example.com", null), connectionProperties))
+        assertThatThrownBy(() -> clientCertAuth.authenticate(new Credentials("example.com", null), connectionProperties))
             .hasMessage("Client certificate authentication failed for user \"example.com\"");
     }
 
@@ -112,7 +112,7 @@ public class ClientCertAuthTest extends ESTestCase {
         ClientCertAuth clientCertAuth = new ClientCertAuth(() -> List.of(exampleUser));
         ConnectionProperties conn = new ConnectionProperties(InetAddresses.forString("127.0.0.1"), Protocol.HTTP, sslSession);
 
-        assertThatThrownBy(() -> clientCertAuth.authenticate(Credentials.of("arthur_is_wrong", null), conn))
+        assertThatThrownBy(() -> clientCertAuth.authenticate(new Credentials("arthur_is_wrong", null), conn))
             .hasMessage("Common name \"example.com\" in client certificate doesn't match username \"arthur_is_wrong\"");
     }
 }

--- a/server/src/test/java/io/crate/auth/ClientCertAuthTest.java
+++ b/server/src/test/java/io/crate/auth/ClientCertAuthTest.java
@@ -77,21 +77,21 @@ public class ClientCertAuthTest extends ESTestCase {
     public void testLookupValidUserWithCert() throws Exception {
         ClientCertAuth clientCertAuth = new ClientCertAuth(() -> List.of(exampleUser));
 
-        Role user = clientCertAuth.authenticate("example.com", null, sslConnWithCert);
+        Role user = clientCertAuth.authenticate(Credentials.of("example.com", null), sslConnWithCert);
         assertThat(user).isEqualTo(exampleUser);
     }
 
     @Test
     public void testLookupValidUserWithCertWithDifferentCN() throws Exception {
         ClientCertAuth clientCertAuth = new ClientCertAuth(() -> List.of(RolesHelper.userOf("arthur")));
-        assertThatThrownBy(() -> clientCertAuth.authenticate("arthur", null, sslConnWithCert))
+        assertThatThrownBy(() -> clientCertAuth.authenticate(Credentials.of("arthur", null), sslConnWithCert))
             .hasMessage("Common name \"example.com\" in client certificate doesn't match username \"arthur\"");
     }
 
     @Test
     public void testLookupUserWithMatchingCertThatDoesNotExist() throws Exception {
         ClientCertAuth clientCertAuth = new ClientCertAuth(List::of);
-        assertThatThrownBy(() -> clientCertAuth.authenticate("example.com", null, sslConnWithCert))
+        assertThatThrownBy(() -> clientCertAuth.authenticate(Credentials.of("example.com", null), sslConnWithCert))
             .hasMessage("Client certificate authentication failed for user \"example.com\"");
     }
 
@@ -103,7 +103,7 @@ public class ClientCertAuthTest extends ESTestCase {
             InetAddresses.forString("127.0.0.1"), Protocol.POSTGRES, sslSession);
         ClientCertAuth clientCertAuth = new ClientCertAuth(() -> List.of(exampleUser));
 
-        assertThatThrownBy(() -> clientCertAuth.authenticate("example.com", null, connectionProperties))
+        assertThatThrownBy(() -> clientCertAuth.authenticate(Credentials.of("example.com", null), connectionProperties))
             .hasMessage("Client certificate authentication failed for user \"example.com\"");
     }
 
@@ -112,7 +112,7 @@ public class ClientCertAuthTest extends ESTestCase {
         ClientCertAuth clientCertAuth = new ClientCertAuth(() -> List.of(exampleUser));
         ConnectionProperties conn = new ConnectionProperties(InetAddresses.forString("127.0.0.1"), Protocol.HTTP, sslSession);
 
-        assertThatThrownBy(() -> clientCertAuth.authenticate("arthur_is_wrong", null, conn))
+        assertThatThrownBy(() -> clientCertAuth.authenticate(Credentials.of("arthur_is_wrong", null), conn))
             .hasMessage("Common name \"example.com\" in client certificate doesn't match username \"arthur_is_wrong\"");
     }
 }

--- a/server/src/test/java/io/crate/auth/HttpAuthUpstreamHandlerTest.java
+++ b/server/src/test/java/io/crate/auth/HttpAuthUpstreamHandlerTest.java
@@ -237,7 +237,7 @@ public class HttpAuthUpstreamHandlerTest extends ESTestCase {
         when(session.getPeerCertificates()).thenReturn(new Certificate[] { ssc.cert() });
 
         HttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/_sql");
-        String userName = HttpAuthUpstreamHandler.credentialsFromRequest(request, session, Settings.EMPTY).v1();
+        String userName = HttpAuthUpstreamHandler.credentialsFromRequest(request, session, Settings.EMPTY).username();
 
         assertThat(userName).isEqualTo("localhost");
     }

--- a/server/src/test/java/io/crate/auth/UserAuthenticationMethodTest.java
+++ b/server/src/test/java/io/crate/auth/UserAuthenticationMethodTest.java
@@ -58,9 +58,9 @@ public class UserAuthenticationMethodTest extends ESTestCase {
     public void testTrustAuthentication() throws Exception {
         TrustAuthenticationMethod trustAuth = new TrustAuthenticationMethod(new CrateOrNullRoles());
         assertThat(trustAuth.name()).isEqualTo("trust");
-        assertThat(trustAuth.authenticate(Credentials.of("crate", null), null).name()).isEqualTo("crate");
+        assertThat(trustAuth.authenticate(new Credentials("crate", null), null).name()).isEqualTo("crate");
 
-        assertThatThrownBy(() -> trustAuth.authenticate(Credentials.of("cr8", null), null))
+        assertThatThrownBy(() -> trustAuth.authenticate(new Credentials("cr8", null), null))
             .hasMessage("trust authentication failed for user \"cr8\"");
     }
 
@@ -70,9 +70,9 @@ public class UserAuthenticationMethodTest extends ESTestCase {
         AuthenticationMethod alwaysOkAuthMethod = alwaysOkAuth.resolveAuthenticationType("crate", null);
 
         assertThat(alwaysOkAuthMethod.name()).isEqualTo("trust");
-        assertThat(alwaysOkAuthMethod.authenticate(Credentials.of("crate", null), null).name()).isEqualTo("crate");
+        assertThat(alwaysOkAuthMethod.authenticate(new Credentials("crate", null), null).name()).isEqualTo("crate");
 
-        assertThatThrownBy(() -> alwaysOkAuthMethod.authenticate(Credentials.of("cr8", null), null))
+        assertThatThrownBy(() -> alwaysOkAuthMethod.authenticate(new Credentials("cr8", null), null))
             .hasMessage("trust authentication failed for user \"cr8\"");
     }
 
@@ -80,7 +80,7 @@ public class UserAuthenticationMethodTest extends ESTestCase {
         PasswordAuthenticationMethod pwAuth = new PasswordAuthenticationMethod(new CrateOrNullRoles());
         assertThat(pwAuth.name()).isEqualTo("password");
 
-        assertThat(pwAuth.authenticate(Credentials.of("crate", new SecureString("pw".toCharArray())), null).name()).isEqualTo("crate");
+        assertThat(pwAuth.authenticate(new Credentials("crate", "pw".toCharArray()), null).name()).isEqualTo("crate");
     }
 
     @Test
@@ -88,7 +88,7 @@ public class UserAuthenticationMethodTest extends ESTestCase {
         PasswordAuthenticationMethod pwAuth = new PasswordAuthenticationMethod(new CrateOrNullRoles());
         assertThat(pwAuth.name()).isEqualTo("password");
 
-        assertThatThrownBy(() -> pwAuth.authenticate(Credentials.of("crate", new SecureString("wrong".toCharArray())), null))
+        assertThatThrownBy(() -> pwAuth.authenticate(new Credentials("crate", "wrong".toCharArray()), null))
             .hasMessage("password authentication failed for user \"crate\"");
 
     }
@@ -96,7 +96,7 @@ public class UserAuthenticationMethodTest extends ESTestCase {
     @Test
     public void testPasswordAuthenticationForNonExistingUser() throws Exception {
         PasswordAuthenticationMethod pwAuth = new PasswordAuthenticationMethod(new CrateOrNullRoles());
-        assertThatThrownBy(() -> pwAuth.authenticate(Credentials.of("cr8", new SecureString("pw".toCharArray())), null))
+        assertThatThrownBy(() -> pwAuth.authenticate(new Credentials("cr8", "pw".toCharArray()), null))
             .hasMessage("password authentication failed for user \"cr8\"");
     }
 }

--- a/server/src/test/java/io/crate/auth/UserAuthenticationMethodTest.java
+++ b/server/src/test/java/io/crate/auth/UserAuthenticationMethodTest.java
@@ -58,9 +58,9 @@ public class UserAuthenticationMethodTest extends ESTestCase {
     public void testTrustAuthentication() throws Exception {
         TrustAuthenticationMethod trustAuth = new TrustAuthenticationMethod(new CrateOrNullRoles());
         assertThat(trustAuth.name()).isEqualTo("trust");
-        assertThat(trustAuth.authenticate("crate", null, null).name()).isEqualTo("crate");
+        assertThat(trustAuth.authenticate(Credentials.of("crate", null), null).name()).isEqualTo("crate");
 
-        assertThatThrownBy(() -> trustAuth.authenticate("cr8", null, null))
+        assertThatThrownBy(() -> trustAuth.authenticate(Credentials.of("cr8", null), null))
             .hasMessage("trust authentication failed for user \"cr8\"");
     }
 
@@ -70,9 +70,9 @@ public class UserAuthenticationMethodTest extends ESTestCase {
         AuthenticationMethod alwaysOkAuthMethod = alwaysOkAuth.resolveAuthenticationType("crate", null);
 
         assertThat(alwaysOkAuthMethod.name()).isEqualTo("trust");
-        assertThat(alwaysOkAuthMethod.authenticate("crate", null, null).name()).isEqualTo("crate");
+        assertThat(alwaysOkAuthMethod.authenticate(Credentials.of("crate", null), null).name()).isEqualTo("crate");
 
-        assertThatThrownBy(() -> alwaysOkAuthMethod.authenticate("cr8", null, null))
+        assertThatThrownBy(() -> alwaysOkAuthMethod.authenticate(Credentials.of("cr8", null), null))
             .hasMessage("trust authentication failed for user \"cr8\"");
     }
 
@@ -80,7 +80,7 @@ public class UserAuthenticationMethodTest extends ESTestCase {
         PasswordAuthenticationMethod pwAuth = new PasswordAuthenticationMethod(new CrateOrNullRoles());
         assertThat(pwAuth.name()).isEqualTo("password");
 
-        assertThat(pwAuth.authenticate("crate", new SecureString("pw".toCharArray()), null).name()).isEqualTo("crate");
+        assertThat(pwAuth.authenticate(Credentials.of("crate", new SecureString("pw".toCharArray())), null).name()).isEqualTo("crate");
     }
 
     @Test
@@ -88,7 +88,7 @@ public class UserAuthenticationMethodTest extends ESTestCase {
         PasswordAuthenticationMethod pwAuth = new PasswordAuthenticationMethod(new CrateOrNullRoles());
         assertThat(pwAuth.name()).isEqualTo("password");
 
-        assertThatThrownBy(() -> pwAuth.authenticate("crate", new SecureString("wrong".toCharArray()), null))
+        assertThatThrownBy(() -> pwAuth.authenticate(Credentials.of("crate", new SecureString("wrong".toCharArray())), null))
             .hasMessage("password authentication failed for user \"crate\"");
 
     }
@@ -96,7 +96,7 @@ public class UserAuthenticationMethodTest extends ESTestCase {
     @Test
     public void testPasswordAuthenticationForNonExistingUser() throws Exception {
         PasswordAuthenticationMethod pwAuth = new PasswordAuthenticationMethod(new CrateOrNullRoles());
-        assertThatThrownBy(() -> pwAuth.authenticate("cr8", new SecureString("pw".toCharArray()), null))
+        assertThatThrownBy(() -> pwAuth.authenticate(Credentials.of("cr8", new SecureString("pw".toCharArray())), null))
             .hasMessage("password authentication failed for user \"cr8\"");
     }
 }

--- a/server/src/test/java/io/crate/protocols/http/HeadersTest.java
+++ b/server/src/test/java/io/crate/protocols/http/HeadersTest.java
@@ -27,10 +27,9 @@ import static io.crate.protocols.http.Headers.isBrowser;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
-import org.elasticsearch.common.settings.SecureString;
 import org.junit.Test;
 
-import io.crate.common.collections.Tuple;
+import io.crate.auth.Credentials;
 
 public class HeadersTest {
 
@@ -50,28 +49,28 @@ public class HeadersTest {
 
     @Test
     public void testExtractUsernamePasswordFromHttpBasicAuthHeader() {
-        Tuple<String, SecureString> creds = extractCredentialsFromHttpBasicAuthHeader("");
-        assertThat(creds.v1(), is(""));
-        assertThat(creds.v2().toString(), is(""));
+        Credentials creds = extractCredentialsFromHttpBasicAuthHeader("");
+        assertThat(creds.username(), is(""));
+        assertThat(creds.password().toString(), is(""));
 
         creds = extractCredentialsFromHttpBasicAuthHeader(null);
-        assertThat(creds.v1(), is(""));
-        assertThat(creds.v2().toString(), is(""));
+        assertThat(creds.username(), is(""));
+        assertThat(creds.password().toString(), is(""));
 
         creds = extractCredentialsFromHttpBasicAuthHeader("Basic QXJ0aHVyOkV4Y2FsaWJ1cg==");
-        assertThat(creds.v1(), is("Arthur"));
-        assertThat(creds.v2().toString(), is("Excalibur"));
+        assertThat(creds.username(), is("Arthur"));
+        assertThat(creds.password().toString(), is("Excalibur"));
 
         creds = extractCredentialsFromHttpBasicAuthHeader("Basic QXJ0aHVyOjp0ZXN0OnBhc3N3b3JkOg==");
-        assertThat(creds.v1(), is("Arthur"));
-        assertThat(creds.v2().toString(), is(":test:password:"));
+        assertThat(creds.username(), is("Arthur"));
+        assertThat(creds.password().toString(), is(":test:password:"));
 
         creds = extractCredentialsFromHttpBasicAuthHeader("Basic QXJ0aHVyOg==");
-        assertThat(creds.v1(), is("Arthur"));
-        assertThat(creds.v2().toString(), is(""));
+        assertThat(creds.username(), is("Arthur"));
+        assertThat(creds.password().toString(), is(""));
 
         creds = extractCredentialsFromHttpBasicAuthHeader("Basic OnBhc3N3b3Jk");
-        assertThat(creds.v1(), is(""));
-        assertThat(creds.v2().toString(), is("password"));
+        assertThat(creds.username(), is(""));
+        assertThat(creds.password().toString(), is("password"));
     }
 }

--- a/server/src/test/java/io/crate/protocols/http/HeadersTest.java
+++ b/server/src/test/java/io/crate/protocols/http/HeadersTest.java
@@ -51,26 +51,26 @@ public class HeadersTest {
     public void testExtractUsernamePasswordFromHttpBasicAuthHeader() {
         Credentials creds = extractCredentialsFromHttpBasicAuthHeader("");
         assertThat(creds.username(), is(""));
-        assertThat(creds.password().toString(), is(""));
+        assertThat(creds.passwordOrToken().toString(), is(""));
 
         creds = extractCredentialsFromHttpBasicAuthHeader(null);
         assertThat(creds.username(), is(""));
-        assertThat(creds.password().toString(), is(""));
+        assertThat(creds.passwordOrToken().toString(), is(""));
 
         creds = extractCredentialsFromHttpBasicAuthHeader("Basic QXJ0aHVyOkV4Y2FsaWJ1cg==");
         assertThat(creds.username(), is("Arthur"));
-        assertThat(creds.password().toString(), is("Excalibur"));
+        assertThat(creds.passwordOrToken().toString(), is("Excalibur"));
 
         creds = extractCredentialsFromHttpBasicAuthHeader("Basic QXJ0aHVyOjp0ZXN0OnBhc3N3b3JkOg==");
         assertThat(creds.username(), is("Arthur"));
-        assertThat(creds.password().toString(), is(":test:password:"));
+        assertThat(creds.passwordOrToken().toString(), is(":test:password:"));
 
         creds = extractCredentialsFromHttpBasicAuthHeader("Basic QXJ0aHVyOg==");
         assertThat(creds.username(), is("Arthur"));
-        assertThat(creds.password().toString(), is(""));
+        assertThat(creds.passwordOrToken().toString(), is(""));
 
         creds = extractCredentialsFromHttpBasicAuthHeader("Basic OnBhc3N3b3Jk");
         assertThat(creds.username(), is(""));
-        assertThat(creds.password().toString(), is("password"));
+        assertThat(creds.passwordOrToken().toString(), is("password"));
     }
 }

--- a/server/src/test/java/io/crate/protocols/postgres/AuthenticationContextTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/AuthenticationContextTest.java
@@ -53,7 +53,7 @@ public class AuthenticationContextTest extends ESTestCase {
         AuthenticationContext authContext = new AuthenticationContext(
             authMethod,
             connProperties,
-            Credentials.of(userName, null),
+            new Credentials(userName, null),
             LogManager.getLogger(AuthenticationContextTest.class)
         );
         authContext.setSecurePassword(passwd);

--- a/server/src/test/java/io/crate/protocols/postgres/AuthenticationContextTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/AuthenticationContextTest.java
@@ -34,6 +34,7 @@ import org.junit.Test;
 import io.crate.auth.AlwaysOKAuthentication;
 import io.crate.auth.Authentication;
 import io.crate.auth.AuthenticationMethod;
+import io.crate.auth.Credentials;
 import io.crate.auth.Protocol;
 import io.crate.role.Role;
 
@@ -50,7 +51,11 @@ public class AuthenticationContextTest extends ESTestCase {
             InetAddress.getByName("127.0.0.1"), Protocol.POSTGRES, null);
         AuthenticationMethod authMethod = AUTHENTICATION.resolveAuthenticationType(userName, connProperties);
         AuthenticationContext authContext = new AuthenticationContext(
-            authMethod, connProperties, userName, LogManager.getLogger(AuthenticationContextTest.class));
+            authMethod,
+            connProperties,
+            Credentials.of(userName, null),
+            LogManager.getLogger(AuthenticationContextTest.class)
+        );
         authContext.setSecurePassword(passwd);
         assertThat(authContext.authenticate(), is(Role.CRATE_USER));
         assertThat(authContext.password().getChars(), is(passwd));

--- a/server/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
@@ -48,7 +48,6 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.client.Client;
-import org.elasticsearch.common.settings.SecureString;
 import org.jetbrains.annotations.Nullable;
 import org.junit.After;
 import org.junit.Before;
@@ -65,6 +64,7 @@ import io.crate.action.sql.Sessions;
 import io.crate.auth.AccessControl;
 import io.crate.auth.AlwaysOKAuthentication;
 import io.crate.auth.AuthenticationMethod;
+import io.crate.auth.Credentials;
 import io.crate.exceptions.JobKilledException;
 import io.crate.execution.jobs.kill.KillJobsNodeRequest;
 import io.crate.metadata.settings.CoordinatorSessionSettings;
@@ -537,7 +537,7 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
                 chPipeline -> {},
                 (user, connectionProperties) -> new AuthenticationMethod() {
                     @Override
-                    public Role authenticate(String userName, @Nullable SecureString passwd, ConnectionProperties connProperties) {
+                    public Role authenticate(Credentials credentials, ConnectionProperties connProperties) {
                         return RolesHelper.userOf("dummy");
                     }
 


### PR DESCRIPTION
Introduce Credentials for holding fields of all authentication types.

Helps to:
- get rid of Tuple usage in `Headers`.  Also, simplifies changing `Headers.extractCredentialsFromHttpBasicAuthHeader` to more generic `Headers.extractCredentialsFromHttpAuthHeader` in the future -> will be used in _sql as well in `SqlHttpHandler.userFromAuthHeader`. 

To avoid smh like https://github.com/crate/crate/commit/55b6948a226f4c0e5e88adc224149ebf3681c795#diff-5b82e41e26846b781b81276ddfdf3918cab8c0e965e2fa2a872c09b2c067877aR101

- unify `AuthenticationMethod` signature to be relevant for all auth types. 
   Once we have JWT, we won't have to change `AuthenticationMethod` signature to smth like 
   `authenticate(username, tokenOrPassword, ConnectionProperties connProperties)` and encapsulate multiple things into single field. Will use dedicated field for JWT instead.


