### PR TITLE
Update packaging related release notes, note RPM change

### DIFF
--- a/docs/appendices/release-notes/5.2.11.rst
+++ b/docs/appendices/release-notes/5.2.11.rst
@@ -70,6 +70,10 @@ Packaging Changes
 
     - The ``crate.yml`` configuration file is in ``/etc/crate/``
 
+    - The default environment configuration file at RPM packages changed to
+      ``/etc/default/crate`` to be consistent with the DEB package. The old
+      location at ``/etc/sysconfig/crate`` is not supported anymore.
+
   If you haven't made any significant configuration changes the new packages
   should keep working out of the box.
 

--- a/docs/appendices/release-notes/5.3.8.rst
+++ b/docs/appendices/release-notes/5.3.8.rst
@@ -68,6 +68,10 @@ Packaging Changes
 
     - The ``crate.yml`` configuration file is in ``/etc/crate/``
 
+    - The default environment configuration file at RPM packages changed to
+      ``/etc/default/crate`` to be consistent with the DEB package. The old
+      location at ``/etc/sysconfig/crate`` is not supported anymore.
+
   If you haven't made any significant configuration changes the new packages
   should keep working out of the box.
 

--- a/docs/appendices/release-notes/5.4.7.rst
+++ b/docs/appendices/release-notes/5.4.7.rst
@@ -69,6 +69,10 @@ Packaging Changes
 
     - The ``crate.yml`` configuration file is in ``/etc/crate/``
 
+    - The default environment configuration file at RPM packages changed to
+      ``/etc/default/crate`` to be consistent with the DEB package. The old
+      location at ``/etc/sysconfig/crate`` is not supported anymore.
+
   If you haven't made any significant configuration changes the new packages
   should keep working out of the box.
 

--- a/docs/appendices/release-notes/5.5.2.rst
+++ b/docs/appendices/release-notes/5.5.2.rst
@@ -70,6 +70,10 @@ Packaging Changes
 
     - The ``crate.yml`` configuration file is in ``/etc/crate/``
 
+    - The default environment configuration file at RPM packages changed to
+      ``/etc/default/crate`` to be consistent with the DEB package. The old
+      location at ``/etc/sysconfig/crate`` is not supported anymore.
+
   If you haven't made any significant configuration changes the new packages
   should keep working out of the box.
 


### PR DESCRIPTION
Update releated release notes to mention a change in the RPM packages.
The default environment config file location changed from `/etc/sysconfig/crate` to `/etc/default/crate` to be consistent with the debian packages.

Relates to https://github.com/crate/crate-tutorials/issues/107.