### PR TITLE
Adjust "machine data" mention

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,7 +5,7 @@ CrateDB Reference
 =================
 
 CrateDB is a distributed SQL database that makes it simple to store and analyze
-massive amounts of machine data in real-time.
+massive amounts of data in real-time.
 
 .. NOTE::
 


### PR DESCRIPTION
## About

Within the documentation, this patch removes "machine" from "machine data" based on @stephanec76's request to clarify CrateDB is not exclusively about machine data.
