### PR TITLE
Update related release notes to mention the public CVE and reporter

### DIFF
--- a/docs/appendices/release-notes/5.3.9.rst
+++ b/docs/appendices/release-notes/5.3.9.rst
@@ -42,5 +42,8 @@ Security Fixes
 - Fixed a security issue where any CrateDB user could read/import the content of
   any file on the host system, the CrateDB process user has read access to, by
   using the ``COPY FROM`` command with a file URI. This access is now restricted
-  to the ``crate`` superuser only.
+  to the ``crate`` superuser only. See
+  `CVE-2024-24565 <https://www.cve.org/CVERecord?id=CVE-2024-24565>`_ for more
+  details. (Thanks to `@Tu0Laj1 <https://github.com/Tu0Laj1>`_ for reporting
+  this issue)
 

--- a/docs/appendices/release-notes/5.4.8.rst
+++ b/docs/appendices/release-notes/5.4.8.rst
@@ -42,4 +42,7 @@ Security Fixes
 - Fixed a security issue where any CrateDB user could read/import the content of
   any file on the host system, the CrateDB process user has read access to, by
   using the ``COPY FROM`` command with a file URI. This access is now restricted
-  to the ``crate`` superuser only.
+  to the ``crate`` superuser only. See
+  `CVE-2024-24565 <https://www.cve.org/CVERecord?id=CVE-2024-24565>`_ for more
+  details. (Thanks to `@Tu0Laj1 <https://github.com/Tu0Laj1>`_ for reporting
+  this issue)

--- a/docs/appendices/release-notes/5.5.4.rst
+++ b/docs/appendices/release-notes/5.5.4.rst
@@ -43,7 +43,10 @@ Security Fixes
 - Fixed a security issue where any CrateDB user could read/import the content of
   any file on the host system, the CrateDB process user has read access to, by
   using the ``COPY FROM`` command with a file URI. This access is now restricted
-  to the ``crate`` superuser only.
+  to the ``crate`` superuser only. See
+  `CVE-2024-24565 <https://www.cve.org/CVERecord?id=CVE-2024-24565>`_ for more
+  details. (Thanks to `@Tu0Laj1 <https://github.com/Tu0Laj1>`_ for reporting
+  this issue)
 
 Fixes
 =====

--- a/docs/appendices/release-notes/5.6.1.rst
+++ b/docs/appendices/release-notes/5.6.1.rst
@@ -42,7 +42,10 @@ Security Fixes
 - Fixed a security issue where any CrateDB user could read/import the content of
   any file on the host system, the CrateDB process user has read access to, by
   using the ``COPY FROM`` command with a file URI. This access is now restricted
-  to the ``crate`` superuser only.
+  to the ``crate`` superuser only. See
+  `CVE-2024-24565 <https://www.cve.org/CVERecord?id=CVE-2024-24565>`_ for more
+  details. (Thanks to `@Tu0Laj1 <https://github.com/Tu0Laj1>`_ for reporting
+  this issue)
 
 Fixes
 =====


### PR DESCRIPTION
Relates to https://github.com/crate/crate/security/advisories/GHSA-475g-vj6c-xf96.