### PR TITLE
Apply additional `null` filter if the query is equivalent to `null`

### DIFF
--- a/docs/appendices/release-notes/5.6.1.rst
+++ b/docs/appendices/release-notes/5.6.1.rst
@@ -76,3 +76,13 @@ Fixes
 
 - Fixed an issue that caused filtering by ``primary keys`` under ``NOT``
   predicate to return invalid results.
+
+- Fixed an issue that caused ``SELECT`` statements with ``WHERE`` clause having
+  ``NOT`` predicate whose argument consists of ``NULLABLE`` scalar functions
+  with ``NULL`` argument that could evaluate to ``NULL`` to return invalid
+  results. An example ::
+
+    SELECT * FROM t WHERE (col % NULL) != 1;
+
+  A ``NULLABLE`` function in this context means a function returning ``NULL``
+  if and only if the input is a ``NULL``.

--- a/server/src/main/java/io/crate/expression/predicate/NotPredicate.java
+++ b/server/src/main/java/io/crate/expression/predicate/NotPredicate.java
@@ -130,6 +130,16 @@ public class NotPredicate extends Scalar<Boolean, Boolean> {
         }
 
         @Override
+        public Void visitLiteral(Literal<?> symbol, NullabilityContext context) {
+            // if an arg is a null literal and all its parents are nullable
+            // then we need to enforce 3vl logic, ex) `<ref> % null != 1`, it is equivalent to a `null`.
+            if (symbol.symbolType().isValueSymbol() && symbol.value() == null && context.isNullable) {
+                context.enforceThreeValuedLogic = true;
+            }
+            return null;
+        }
+
+        @Override
         public Void visitFunction(Function function, NullabilityContext context) {
             String functionName = function.name();
             if (CAST_FUNCTIONS.contains(functionName)) {

--- a/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -786,4 +786,10 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
         Query query = convert("not (y is not null)");
         assertThat(query).hasToString("+(+*:* -FieldExistsQuery [field=y])");
     }
+
+    @Test
+    public void test_not_operator_on_query_equivalent_to_null() {
+        Query query = convert("(y % null != 1)");
+        assertThat(query).hasToString("+(+*:* -((y % NULL) = 1)) #(NOT ((y % NULL) = 1))");
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes https://github.com/crate/crate/issues/15500, https://github.com/crate/crate/issues/15499, https://github.com/crate/crate/issues/15498.

When rewriting not(A) to U - A we missed a case where the query could result in a `null`. Adding an extra `null` filter to catch the `null`.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
