### PR TITLE
Allow jwt property in CREATE USER statement

### DIFF
--- a/server/src/main/java/io/crate/planner/node/ddl/CreateRolePlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/CreateRolePlan.java
@@ -21,7 +21,17 @@
 
 package io.crate.planner.node.ddl;
 
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Function;
+
 import io.crate.analyze.AnalyzedCreateRole;
+import io.crate.analyze.SymbolEvaluator;
+import io.crate.common.collections.Maps;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.TransactionContext;
+import io.crate.role.JwtProperties;
 import io.crate.role.RoleManager;
 import io.crate.data.Row;
 import io.crate.data.Row1;
@@ -33,8 +43,13 @@ import io.crate.planner.PlannerContext;
 import io.crate.planner.operators.SubQueryResults;
 import io.crate.role.SecureHash;
 import io.crate.role.UserActions;
+import io.crate.sql.tree.GenericProperties;
 
 public class CreateRolePlan implements Plan {
+
+    public static final String PASSWORD_PROPERTY_KEY = "password";
+    public static final String JWT_PROPERTY_KEY = "jwt";
+
 
     private final AnalyzedCreateRole createRole;
     private final RoleManager roleManager;
@@ -53,19 +68,49 @@ public class CreateRolePlan implements Plan {
     public void executeOrFail(DependencyCarrier dependencies,
                               PlannerContext plannerContext,
                               RowConsumer consumer,
-                              Row params, SubQueryResults subQueryResults) throws Exception {
-        SecureHash newPassword = UserActions.generateSecureHash(
+                              Row params,
+                              SubQueryResults subQueryResults) throws Exception {
+
+        Map<String, Object> properties = parse(
             createRole.properties(),
-            params,
             plannerContext.transactionContext(),
-            plannerContext.nodeContext());
+            plannerContext.nodeContext(),
+            params,
+            subQueryResults
+        );
+        SecureHash newPassword = UserActions.generateSecureHash(properties);
 
         if (createRole.isUser() == false && newPassword != null) {
             throw new UnsupportedOperationException("Creating a ROLE with a password is not allowed, " +
                                                     "use CREATE USER instead");
         }
 
-        roleManager.createRole(createRole.roleName(), createRole.isUser(), newPassword)
+        // Map is always not null to simplify streaming.
+        JwtProperties jwtProperties = JwtProperties.fromMap(Maps.getOrDefault(properties, JWT_PROPERTY_KEY, Map.of()));
+
+        roleManager.createRole(createRole.roleName(), createRole.isUser(), newPassword, jwtProperties)
             .whenComplete(new OneRowActionListener<>(consumer, rCount -> new Row1(rCount == null ? -1 : rCount)));
+    }
+
+    public static Map<String, Object> parse(GenericProperties<Symbol> genericProperties,
+                                               TransactionContext txnCtx,
+                                               NodeContext nodeContext,
+                                               Row params,
+                                               SubQueryResults subQueryResults) {
+        Function<? super Symbol, Object> eval = x -> SymbolEvaluator.evaluate(
+            txnCtx,
+            nodeContext,
+            x,
+            params,
+            subQueryResults
+        );
+        Map<String, Object> parsedProperties = genericProperties.map(eval).properties();
+        for (var property : parsedProperties.keySet()) {
+            if (PASSWORD_PROPERTY_KEY.equals(property) == false && JWT_PROPERTY_KEY.equals(property) == false) {
+                throw new IllegalArgumentException(
+                    String.format(Locale.ENGLISH, "\"%s\" is not a valid user property", property));
+            }
+        }
+        return parsedProperties;
     }
 }

--- a/server/src/main/java/io/crate/role/CreateRoleRequest.java
+++ b/server/src/main/java/io/crate/role/CreateRoleRequest.java
@@ -36,10 +36,18 @@ public class CreateRoleRequest extends AcknowledgedRequest<CreateRoleRequest> {
     @Nullable
     private final SecureHash secureHash;
 
-    public CreateRoleRequest(String roleName, boolean isUser, @Nullable SecureHash attributes) {
+    @Nullable
+    private final JwtProperties jwtProperties;
+
+
+    public CreateRoleRequest(String roleName,
+                             boolean isUser,
+                             @Nullable SecureHash attributes,
+                             @Nullable JwtProperties jwtProperties) {
         this.roleName = roleName;
         this.isUser = isUser;
         this.secureHash = attributes;
+        this.jwtProperties = jwtProperties;
     }
 
     public String roleName() {
@@ -55,6 +63,11 @@ public class CreateRoleRequest extends AcknowledgedRequest<CreateRoleRequest> {
         return secureHash;
     }
 
+    @Nullable
+    public JwtProperties jwtProperties() {
+        return jwtProperties;
+    }
+
     public CreateRoleRequest(StreamInput in) throws IOException {
         super(in);
         roleName = in.readString();
@@ -64,6 +77,11 @@ public class CreateRoleRequest extends AcknowledgedRequest<CreateRoleRequest> {
             this.isUser = true;
         }
         secureHash = in.readOptionalWriteable(SecureHash::readFrom);
+        if (in.getVersion().onOrAfter(Version.V_5_7_0)) {
+            this.jwtProperties = in.readOptionalWriteable(JwtProperties::readFrom);
+        } else {
+            this.jwtProperties = null;
+        }
     }
 
     @Override
@@ -74,5 +92,8 @@ public class CreateRoleRequest extends AcknowledgedRequest<CreateRoleRequest> {
             out.writeBoolean(isUser);
         }
         out.writeOptionalWriteable(secureHash);
+        if (out.getVersion().onOrAfter(Version.V_5_7_0)) {
+            out.writeOptionalWriteable(jwtProperties);
+        }
     }
 }

--- a/server/src/main/java/io/crate/role/JwtProperties.java
+++ b/server/src/main/java/io/crate/role/JwtProperties.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.role;
+
+import java.io.IOException;
+import java.util.Locale;
+import java.util.Map;
+
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import io.crate.common.collections.Maps;
+
+
+/**
+ * Represents JWT token payload.
+ * @param iss https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.1
+ * @param username is username on the third party app. Not necessarily same as CrateDB user.
+ */
+public record JwtProperties(String iss, String username) implements Writeable, ToXContent {
+
+    public static JwtProperties readFrom(StreamInput in) throws IOException {
+        return new JwtProperties(in.readString(), in.readString());
+    }
+
+    @Nullable
+    public static JwtProperties fromMap(@NotNull Map<String, Object> jwtPropertiesMap) {
+        if (jwtPropertiesMap.isEmpty() == false) {
+            String iss = Maps.get(jwtPropertiesMap, "iss");
+            ensureNotNull("iss", iss);
+            String username = Maps.get(jwtPropertiesMap, "username");
+            ensureNotNull("username", username);
+            if (jwtPropertiesMap.size() > 2) {
+                throw new IllegalArgumentException(
+                    String.format(Locale.ENGLISH, "Only 'iss' and 'username' JWT properties are allowed")
+                );
+            }
+            return new JwtProperties(iss, username);
+        }
+        return null;
+
+    }
+
+    private static void ensureNotNull(String propertyName, @Nullable String value) {
+        if (value == null) {
+            throw new IllegalArgumentException(
+                String.format(Locale.ENGLISH, "JWT property '%s' must have a non-null value", propertyName)
+            );
+        }
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(iss);
+        out.writeString(username);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject("jwt")
+            .field("iss", iss)
+            .field("username", username)
+            .endObject();
+        return builder;
+    }
+
+    public static JwtProperties fromXContent(XContentParser parser) throws IOException {
+        XContentParser.Token currentToken;
+        String iss = null;
+        String username = null;
+        while ((currentToken = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (currentToken == XContentParser.Token.FIELD_NAME) {
+                String currentFieldName = parser.currentName();
+                currentToken = parser.nextToken();
+                switch (currentFieldName) {
+                    case "iss":
+                        if (currentToken != XContentParser.Token.VALUE_STRING) {
+                            throw new ElasticsearchParseException(
+                                "failed to parse jwt, 'iss' value is not a string [{}]", currentToken);
+                        }
+                        iss = parser.text();
+                        break;
+                    case "username":
+                        if (currentToken != XContentParser.Token.VALUE_STRING) {
+                            throw new ElasticsearchParseException(
+                                "failed to parse jwt, 'username' value is not a string [{}]", currentToken);
+                        }
+                        username = parser.text();
+                        break;
+                    default:
+                        throw new ElasticsearchParseException("failed to parse jwt, unknown property '{}'", currentFieldName);
+                }
+            }
+        }
+        return new JwtProperties(iss, username);
+    }
+}

--- a/server/src/main/java/io/crate/role/RoleManager.java
+++ b/server/src/main/java/io/crate/role/RoleManager.java
@@ -41,7 +41,11 @@ public interface RoleManager extends Roles {
      * @param roleName name of the role to create
      * @return 1 if the role was created, otherwise a failed future.
      */
-    CompletableFuture<Long> createRole(String roleName, boolean isUser, @Nullable SecureHash hashedPw);
+    CompletableFuture<Long> createRole(String roleName,
+                                       boolean isUser,
+                                       @Nullable SecureHash hashedPw,
+                                       @Nullable JwtProperties jwtProperties
+    );
 
     /**
      * Delete a roles.

--- a/server/src/main/java/io/crate/role/RoleManagerService.java
+++ b/server/src/main/java/io/crate/role/RoleManagerService.java
@@ -110,8 +110,11 @@ public class RoleManagerService implements RoleManager {
 
 
     @Override
-    public CompletableFuture<Long> createRole(String roleName, boolean isUser, @Nullable SecureHash hashedPw) {
-        return transportCreateRoleAction.execute(new CreateRoleRequest(roleName, isUser, hashedPw), r -> {
+    public CompletableFuture<Long> createRole(String roleName,
+                                              boolean isUser,
+                                              @Nullable SecureHash hashedPw,
+                                              @Nullable JwtProperties jwtProperties) {
+        return transportCreateRoleAction.execute(new CreateRoleRequest(roleName, isUser, hashedPw, jwtProperties), r -> {
             if (r.doesUserExist()) {
                 throw new RoleAlreadyExistsException(roleName);
             }

--- a/server/src/main/java/io/crate/role/RolesService.java
+++ b/server/src/main/java/io/crate/role/RolesService.java
@@ -92,7 +92,7 @@ public class RolesService implements Roles, ClusterStateListener {
                         privileges = oldPrivileges;
                     }
                 }
-                roles.put(userName, new Role(userName, true, privileges, Set.of(), user.getValue()));
+                roles.put(userName, new Role(userName, true, privileges, Set.of(), user.getValue(), null));
             }
         } else if (rolesMetadata != null) {
             roles.putAll(rolesMetadata.roles());

--- a/server/src/main/java/io/crate/role/TransportCreateRoleAction.java
+++ b/server/src/main/java/io/crate/role/TransportCreateRoleAction.java
@@ -87,7 +87,7 @@ public class TransportCreateRoleAction extends TransportMasterNodeAction<CreateR
                     public ClusterState execute(ClusterState currentState) throws Exception {
                         Metadata currentMetadata = currentState.metadata();
                         Metadata.Builder mdBuilder = Metadata.builder(currentMetadata);
-                        alreadyExists = putRole(mdBuilder, request.roleName(), request.isUser(), request.secureHash());
+                        alreadyExists = putRole(mdBuilder, request.roleName(), request.isUser(), request.secureHash(), request.jwtProperties());
                         return ClusterState.builder(currentState).metadata(mdBuilder).build();
                     }
 
@@ -109,7 +109,11 @@ public class TransportCreateRoleAction extends TransportMasterNodeAction<CreateR
      * @return boolean true if the user already exists, otherwise false
      */
     @VisibleForTesting
-    static boolean putRole(Metadata.Builder mdBuilder, String roleName, boolean isUser, @Nullable SecureHash secureHash) {
+    static boolean putRole(Metadata.Builder mdBuilder,
+                           String roleName,
+                           boolean isUser,
+                           @Nullable SecureHash secureHash,
+                           @Nullable JwtProperties jwtProperties) {
         RolesMetadata oldRolesMetadata = (RolesMetadata) mdBuilder.getCustom(RolesMetadata.TYPE);
         UsersMetadata oldUsersMetadata = (UsersMetadata) mdBuilder.getCustom(UsersMetadata.TYPE);
 
@@ -117,7 +121,7 @@ public class TransportCreateRoleAction extends TransportMasterNodeAction<CreateR
         RolesMetadata newMetadata = RolesMetadata.of(mdBuilder, oldUsersMetadata, oldUserPrivilegesMetadata, oldRolesMetadata);
         boolean exists = true;
         if (newMetadata.contains(roleName) == false) {
-            newMetadata.roles().put(roleName, new Role(roleName, isUser, Set.of(), Set.of(), secureHash));
+            newMetadata.roles().put(roleName, new Role(roleName, isUser, Set.of(), Set.of(), secureHash, jwtProperties));
             exists = false;
         } else if (newMetadata.equals(oldRolesMetadata)) {
             // nothing changed, no need to update the cluster state

--- a/server/src/main/java/io/crate/role/UserActions.java
+++ b/server/src/main/java/io/crate/role/UserActions.java
@@ -21,22 +21,14 @@
 
 package io.crate.role;
 
-import io.crate.analyze.SymbolEvaluator;
 import io.crate.common.annotations.VisibleForTesting;
-import io.crate.data.Row;
-import io.crate.expression.symbol.Symbol;
-import io.crate.metadata.NodeContext;
-import io.crate.metadata.TransactionContext;
-import io.crate.planner.operators.SubQueryResults;
-import io.crate.sql.tree.GenericProperties;
+import io.crate.planner.node.ddl.CreateRolePlan;
 import io.crate.types.DataTypes;
 import org.elasticsearch.common.settings.SecureString;
 
 import org.jetbrains.annotations.Nullable;
 import java.security.GeneralSecurityException;
-import java.util.Locale;
 import java.util.Map;
-import java.util.function.Function;
 
 public final class UserActions {
 
@@ -44,11 +36,8 @@ public final class UserActions {
     }
 
     @Nullable
-    public static SecureHash generateSecureHash(GenericProperties<Symbol> userStmtProperties,
-                                                Row parameters,
-                                                TransactionContext txnCtx,
-                                                NodeContext nodeCtx) throws GeneralSecurityException, IllegalArgumentException {
-        try (SecureString pw = getUserPasswordProperty(userStmtProperties, parameters, txnCtx, nodeCtx)) {
+    public static SecureHash generateSecureHash(Map<String, Object> properties) throws GeneralSecurityException, IllegalArgumentException {
+        try (SecureString pw = getUserPasswordProperty(properties)) {
             if (pw != null) {
                 if (pw.isEmpty()) {
                     throw new IllegalArgumentException("Password must not be empty");
@@ -61,31 +50,10 @@ public final class UserActions {
 
     @VisibleForTesting
     @Nullable
-    static SecureString getUserPasswordProperty(GenericProperties<Symbol> userStmtProperties,
-                                                Row parameters,
-                                                TransactionContext txnCtx,
-                                                NodeContext nodeCtx) throws IllegalArgumentException {
-        Function<? super Symbol, Object> eval = x -> SymbolEvaluator.evaluate(
-            txnCtx,
-            nodeCtx,
-            x,
-            parameters,
-            SubQueryResults.EMPTY
-        );
-        Map<String, Object> properties = userStmtProperties.map(eval).properties();
-        final String PASSWORD_PROPERTY = "password";
-        for (var entry : properties.entrySet()) {
-            if (PASSWORD_PROPERTY.equals(entry.getKey())) {
-                String value = DataTypes.STRING.sanitizeValue(entry.getValue());
-                if (value != null) {
-                    return new SecureString(value.toCharArray());
-                }
-                // Password will be reset
-                return null;
-            } else {
-                throw new IllegalArgumentException(
-                    String.format(Locale.ENGLISH, "\"%s\" is not a valid user property", entry.getKey()));
-            }
+    static SecureString getUserPasswordProperty(Map<String, Object> properties) {
+        String value = DataTypes.STRING.sanitizeValue(properties.get(CreateRolePlan.PASSWORD_PROPERTY_KEY));
+        if (value != null) {
+            return new SecureString(value.toCharArray());
         }
         return null;
     }

--- a/server/src/main/java/io/crate/role/metadata/RolesMetadata.java
+++ b/server/src/main/java/io/crate/role/metadata/RolesMetadata.java
@@ -82,7 +82,7 @@ public class RolesMetadata extends AbstractNamedDiffable<Metadata.Custom> implem
         RolesMetadata rolesMetadata = new RolesMetadata();
         for (var user : usersMetadata.users().entrySet()) {
             var userName = user.getKey();
-            var role = new Role(userName, true, getPrivileges.apply(userName), Set.of(), user.getValue());
+            var role = new Role(userName, true, getPrivileges.apply(userName), Set.of(), user.getValue(), null);
             rolesMetadata.roles().put(userName, role);
         }
         return rolesMetadata;
@@ -221,7 +221,7 @@ public class RolesMetadata extends AbstractNamedDiffable<Metadata.Custom> implem
             }
         }
         if (affectedCount > 0) {
-            roles.put(role.name(), new Role(role.name(), role.isUser(), Set.of(), grantedRoles, role.password()));
+            roles.put(role.name(), new Role(role.name(), role.isUser(), Set.of(), grantedRoles, role.password(), role.jwtProperties()));
         }
         return affectedCount;
     }

--- a/server/src/test/java/io/crate/role/CreateRoleRequestTest.java
+++ b/server/src/test/java/io/crate/role/CreateRoleRequestTest.java
@@ -34,7 +34,11 @@ public class CreateRoleRequestTest extends ESTestCase {
     @Test
     public void testStreaming() throws Exception {
         var crr1 =
-            new CreateRoleRequest("testUser", false, SecureHash.of(new SecureString("passwd".toCharArray())));
+            new CreateRoleRequest("testUser",
+                false,
+                SecureHash.of(new SecureString("passwd".toCharArray())),
+                new JwtProperties("https:dummy.org", "test")
+            );
 
         BytesStreamOutput out = new BytesStreamOutput();
         crr1.writeTo(out);
@@ -42,6 +46,8 @@ public class CreateRoleRequestTest extends ESTestCase {
         assertThat(crr2.roleName()).isEqualTo(crr1.roleName());
         assertThat(crr2.secureHash()).isEqualTo(crr1.secureHash());
         assertThat(crr2.isUser()).isFalse();
+        assertThat(crr2.jwtProperties().iss()).isEqualTo("https:dummy.org");
+        assertThat(crr2.jwtProperties().username()).isEqualTo("test");
 
         out = new BytesStreamOutput();
         out.setVersion(Version.V_5_5_0);
@@ -52,5 +58,6 @@ public class CreateRoleRequestTest extends ESTestCase {
         assertThat(crr2.roleName()).isEqualTo(crr1.roleName());
         assertThat(crr2.secureHash()).isEqualTo(crr1.secureHash());
         assertThat(crr2.isUser()).isTrue();
+        assertThat(crr2.jwtProperties()).isNull();
     }
 }

--- a/server/src/test/java/io/crate/role/TransportRoleActionTest.java
+++ b/server/src/test/java/io/crate/role/TransportRoleActionTest.java
@@ -49,23 +49,29 @@ public class TransportRoleActionTest extends ESTestCase {
     @Test
     public void testCreateFirstUser() throws Exception {
         Metadata.Builder mdBuilder = new Metadata.Builder();
-        TransportCreateRoleAction.putRole(mdBuilder, "root", true, null);
+        TransportCreateRoleAction.putRole(mdBuilder,
+            "root",
+            true,
+            null,
+            new JwtProperties("https:dummy.org", "test"));
         RolesMetadata metadata = (RolesMetadata) mdBuilder.getCustom(RolesMetadata.TYPE);
         assertThat(metadata.roleNames()).containsExactly("root");
+        assertThat(metadata.roles().get("root").jwtProperties().iss()).isEqualTo("https:dummy.org");
+        assertThat(metadata.roles().get("root").jwtProperties().username()).isEqualTo("test");
     }
 
     @Test
     public void testCreateUserAlreadyExists() throws Exception {
         Metadata.Builder mdBuilder = new Metadata.Builder()
             .putCustom(RolesMetadata.TYPE, new RolesMetadata(SINGLE_USER_ONLY));
-        assertThat(TransportCreateRoleAction.putRole(mdBuilder, "Arthur", true, null)).isTrue();
+        assertThat(TransportCreateRoleAction.putRole(mdBuilder, "Arthur", true, null, null)).isTrue();
     }
 
     @Test
     public void testCreateUser() throws Exception {
         Metadata.Builder mdBuilder = new Metadata.Builder()
             .putCustom(RolesMetadata.TYPE, new RolesMetadata(SINGLE_USER_ONLY));
-        TransportCreateRoleAction.putRole(mdBuilder, "Trillian", true, null);
+        TransportCreateRoleAction.putRole(mdBuilder, "Trillian", true, null, null);
         RolesMetadata newMetadata = (RolesMetadata) mdBuilder.getCustom(RolesMetadata.TYPE);
         assertThat(newMetadata.roleNames()).containsExactlyInAnyOrder("Trillian", "Arthur");
     }
@@ -77,7 +83,7 @@ public class TransportRoleActionTest extends ESTestCase {
         Metadata.Builder mdBuilder = Metadata.builder()
             .putCustom(UsersMetadata.TYPE, oldUsersMetadata)
             .putCustom(RolesMetadata.TYPE, oldRolesMetadata);
-        boolean res = TransportCreateRoleAction.putRole(mdBuilder, "RoleFoo", false, null);
+        boolean res = TransportCreateRoleAction.putRole(mdBuilder, "RoleFoo", false, null, null);
         assertThat(res).isFalse();
         assertThat(roles(mdBuilder)).containsExactlyInAnyOrderEntriesOf(
             Map.of("Arthur", DUMMY_USERS.get("Arthur"),

--- a/server/src/test/java/io/crate/role/metadata/RolesHelper.java
+++ b/server/src/test/java/io/crate/role/metadata/RolesHelper.java
@@ -36,6 +36,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import io.crate.role.GrantedRole;
+import io.crate.role.JwtProperties;
 import io.crate.role.Permission;
 import io.crate.role.Policy;
 import io.crate.role.Privilege;
@@ -111,27 +112,35 @@ public final class RolesHelper {
     }
 
     public static Role userOf(String name, Set<Privilege> privileges, @Nullable SecureHash password) {
-        return new Role(name, true, privileges, Set.of(), password);
+        return new Role(name, true, privileges, Set.of(), password, null);
     }
 
     public static Role userOf(String name, Set<Privilege> privileges, Set<GrantedRole> grantedRoles, @Nullable SecureHash password) {
-        return new Role(name, true, privileges, grantedRoles, password);
+        return new Role(name, true, privileges, grantedRoles, password, null);
+    }
+
+    public static Role userOf(String name,
+                              Set<Privilege> privileges,
+                              Set<GrantedRole> grantedRoles,
+                              @Nullable SecureHash password,
+                              @Nullable JwtProperties jwtProperties) {
+        return new Role(name, true, privileges, grantedRoles, password, jwtProperties);
     }
 
     public static Role roleOf(String name) {
-        return new Role(name, false, Set.of(), Set.of(), null);
+        return new Role(name, false, Set.of(), Set.of(), null, null);
     }
 
     public static Role roleOf(String name, Set<Privilege> privileges, List<String> grantedRoles) {
-        return new Role(name, false, privileges, buildGrantedRoles(grantedRoles), null);
+        return new Role(name, false, privileges, buildGrantedRoles(grantedRoles), null, null);
     }
 
     public static Role roleOf(String name, Set<Privilege> privileges) {
-        return new Role(name, false, privileges, Set.of(), null);
+        return new Role(name, false, privileges, Set.of(), null, null);
     }
 
     public static Role roleOf(String name, List<String> grantedRoles) {
-        return new Role(name, false, Set.of(), buildGrantedRoles(grantedRoles), null);
+        return new Role(name, false, Set.of(), buildGrantedRoles(grantedRoles), null, null);
     }
 
     @NotNull

--- a/server/src/testFixtures/java/io/crate/role/StubRoleManager.java
+++ b/server/src/testFixtures/java/io/crate/role/StubRoleManager.java
@@ -36,7 +36,10 @@ public class StubRoleManager implements RoleManager {
     private final List<Role> roles = List.of(Role.CRATE_USER);
 
     @Override
-    public CompletableFuture<Long> createRole(String roleName, boolean isUser, @Nullable SecureHash hashedPw) {
+    public CompletableFuture<Long> createRole(String roleName,
+                                              boolean isUser,
+                                              @Nullable SecureHash hashedPw,
+                                              @Nullable JwtProperties jwtProperties) {
         return CompletableFuture.failedFuture(new UnsupportedFeatureException("createRole is not implemented in StubRoleManager"));
     }
 


### PR DESCRIPTION
Summary of the changes:

1. `UserActions.getUserPasswordProperty` used to evaluate/validate and then fetch password property. Now we have a new property, so I extracted properties evaluation/valdiation into separate method to do it only once in case we have both pwd and jwt specified. `ALTER ROLE` and some test changes are just reflections of that change.

2. Added url/testname sub-properites to the new `jwt` property. I had locally an itest and it worked, not adding it since `RolesMetadataTest` was enough to catch all bugs I had + I will eventually have an itest when testing full flow with token