### PR TITLE
Add support for Google Cloud Storage repositories

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -174,6 +174,13 @@
       <scope>runtime</scope>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>io.crate</groupId>
+      <artifactId>repository-gcs</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+      <optional>true</optional>
+    </dependency>
 
     <dependency>
       <groupId>io.crate</groupId>

--- a/app/src/assembly/src.xml
+++ b/app/src/assembly/src.xml
@@ -95,6 +95,10 @@
       <source>../plugins/es-repository-azure/src/main/resources/plugin-descriptor.properties</source>
       <outputDirectory>plugins/es-repository-azure</outputDirectory>
     </file>
+    <file>
+      <source>../plugins/repository-gcs/src/main/resources/plugin-descriptor.properties</source>
+      <outputDirectory>plugins/repository-gcs</outputDirectory>
+    </file>
   </files>
   <dependencySets>
     <dependencySet>
@@ -119,6 +123,7 @@
 
         <exclude>io.crate:es-repository-azure</exclude>
         <exclude>com.microsoft.azure:*</exclude>
+        <exclude>io.crate:repository-gcs</exclude>
       </excludes>
     </dependencySet>
   </dependencySets>
@@ -206,6 +211,20 @@
         <includeDependencies>true</includeDependencies>
         <unpack>false</unpack>
         <outputDirectory>plugins/es-repository-azure</outputDirectory>
+      </binaries>
+    </moduleSet>
+    <moduleSet>
+      <useAllReactorProjects>true</useAllReactorProjects>
+      <includes>
+        <include>io.crate:repository-gcs</include>
+      </includes>
+      <binaries>
+        <includes>
+          <include>io.crate:repository-gcs</include>
+        </includes>
+        <includeDependencies>true</includeDependencies>
+        <unpack>false</unpack>
+        <outputDirectory>plugins/repository-gcs</outputDirectory>
       </binaries>
     </moduleSet>
     <moduleSet>

--- a/docs/appendices/release-notes/5.7.0.rst
+++ b/docs/appendices/release-notes/5.7.0.rst
@@ -100,3 +100,10 @@ User Interface
 --------------
 
 None
+
+External contributions
+----------------------
+
+- `Herman Bergwerf <https://github.com/bergwerf>`_ added support for
+  :ref:`Google Cloud Storage repositories <sql-create-repo-gcs>` to write and
+  restore snapshots on Google Cloud Storage.

--- a/docs/sql/statements/create-repository.rst
+++ b/docs/sql/statements/create-repository.rst
@@ -584,6 +584,107 @@ Parameters
   The port number of the proxy.
 
 
+.. _sql-create-repo-gcs:
+
+``gcs``
+-------
+
+A ``gcs`` repository stores snapshots on the `Google Cloud Storage`_ service.
+
+Parameters
+''''''''''
+
+.. _sql-create-repo-gcs-account:
+
+**bucket**
+  | *Type:* ``text``
+  | *Required*
+
+  Name of the `Google Cloud Storage`_ bucket used for storing snapshots.
+  The bucket must already exist before the repository is created.
+
+
+.. _sql-create-repo-gcs-private_key_id:
+
+**private_key_id**
+  | *Type:* ``text``
+  | *Required*
+
+  The Private key id for the `Google Service account`_ from the json
+  `Google Service account credentials`_.
+
+  .. NOTE::
+
+    This parameter will be masked (shown as ``[xxxxx]``) when querying
+    :ref:`sys.repositories <sys-repositories>` table.
+
+
+.. _sql-create-repo-gcs-private_key:
+
+**private_key**
+  | *Type:* ``text``
+  | *Required*
+
+  The private key in `PKCS 8`_ format for the `Google Service account`_ from
+  the json `Google Service account credentials`_.
+
+  .. NOTE::
+
+    This parameter will be masked (shown as ``[xxxxx]``) when querying
+    :ref:`sys.repositories <sys-repositories>` table.
+
+.. _sql-create-repo-gcs-client_id:
+
+**client_id**
+  | *Type:* ``text``
+  | *Required*
+
+  The client id for the `Google Service account`_ from the json
+  `Google Service account credentials`_.
+
+  .. NOTE::
+
+    This parameter will be masked (shown as ``[xxxxx]``) when querying
+    :ref:`sys.repositories <sys-repositories>` table.
+
+.. _sql-create-repo-gcs-client_email:
+
+**client_email**
+  | *Type:* ``text``
+  | *Required*
+
+  The client email for the `Google Service account`_ from the json
+  `Google Service account credentials`_.
+
+  .. NOTE::
+
+    This parameter will be masked (shown as ``[xxxxx]``) when querying
+    :ref:`sys.repositories <sys-repositories>` table.
+
+.. _sql-create-repo-gcs-base_path:
+
+**base_path**
+  | *Type:* ``text``
+  | *Default:* ``root directory``
+
+  The container path to use for snapshots.
+
+.. _sql-create-repo-gcs-endpoint:
+
+**endpoint**
+ | *Type:* ``text``
+ | *Required:* ``false``
+
+ Endpoint root url to connect to an alternative storage provider.
+
+.. _sql-create-repo-gcs-token_uri:
+
+**token_uri**
+ | *Type:* ``text``
+ | *Required:* ``false``
+
+ Endpoint oauth token URI to connect to an alternative oauth provider.
+
 .. _sql-create-repo-url:
 
 ``url``
@@ -630,3 +731,7 @@ Parameters
 .. _IAM roles: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html
 .. _plugins: https://github.com/crate/crate/blob/master/devs/docs/plugins.rst
 .. _regional endpoint: https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints
+.. _Google Cloud Storage: https://cloud.google.com/storage/
+.. _Google Service account: https://cloud.google.com/iam/docs/overview#service_account
+.. _Google Service account credentials: https://cloud.google.com/storage/docs/authentication?hl=en
+.. _PKCS 8: https://en.wikipedia.org/wiki/PKCS_8

--- a/plugins/es-repository-azure/pom.xml
+++ b/plugins/es-repository-azure/pom.xml
@@ -52,6 +52,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${versions.guava}</version>
+    </dependency>
+
+    <dependency>
       <groupId>io.crate</groupId>
       <artifactId>crate-server</artifactId>
       <version>${project.version}</version>

--- a/plugins/repository-gcs/pom.xml
+++ b/plugins/repository-gcs/pom.xml
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to Crate.io GmbH ("Crate") under one or more contributor
+  ~ license agreements.  See the NOTICE file distributed with this work for
+  ~ additional information regarding copyright ownership.  Crate licenses
+  ~ this file to you under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.  You may
+  ~ obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  ~
+  ~ However, if you have executed another commercial license agreement
+  ~ with Crate these terms will supersede the license and you may use the
+  ~ software solely pursuant to the terms of the relevant commercial agreement.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.crate</groupId>
+        <artifactId>crate</artifactId>
+        <version>5.7.0</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>repository-gcs</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.crate</groupId>
+            <artifactId>crate-server</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>${versions.annotations}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.api</groupId>
+            <artifactId>gax</artifactId>
+            <version>${versions.google.gax}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.auth</groupId>
+            <artifactId>google-auth-library-credentials</artifactId>
+            <version>${versions.google.auth}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.auth</groupId>
+            <artifactId>google-auth-library-oauth2-http</artifactId>
+            <version>${versions.google.oauth2}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-storage</artifactId>
+            <version>${versions.google.cloud}</version>
+        </dependency>
+
+        <!-- Pin version of external dependencies -->
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${versions.guava}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${versions.jackson}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.http-client</groupId>
+            <artifactId>google-http-client-gson</artifactId>
+            <version>${versions.google.gson}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+            <version>${versions.google.errorprone}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.j2objc</groupId>
+            <artifactId>j2objc-annotations</artifactId>
+            <version>${versions.google.j2objc}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.checkerframework</groupId>
+            <artifactId>checker-qual</artifactId>
+            <version>${versions.checkerframework}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-context</artifactId>
+            <version>${versions.grpc}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.crate</groupId>
+            <artifactId>crate-server</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+            <classifier>tests</classifier>
+        </dependency>
+        <dependency>
+            <groupId>io.crate</groupId>
+            <artifactId>crate-libs-dex</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+            <classifier>tests</classifier>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${versions.assertj}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${versions.junit5}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>${versions.junit5}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.carrotsearch.randomizedtesting</groupId>
+            <artifactId>randomizedtesting-runner</artifactId>
+            <version>${versions.randomizedrunner}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-test-framework</artifactId>
+            <version>${versions.lucene}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${versions.mockito}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>${versions.jdbc}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/plugins/repository-gcs/src/main/java/io/crate/gcs/GCSBlobContainer.java
+++ b/plugins/repository-gcs/src/main/java/io/crate/gcs/GCSBlobContainer.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.gcs;
+
+import static com.google.cloud.storage.Storage.BlobListOption.currentDirectory;
+import static com.google.cloud.storage.Storage.BlobListOption.prefix;
+
+import org.elasticsearch.common.blobstore.BlobContainer;
+import org.elasticsearch.common.blobstore.BlobMetadata;
+import org.elasticsearch.common.blobstore.BlobPath;
+import org.elasticsearch.common.blobstore.support.AbstractBlobContainer;
+import org.elasticsearch.common.blobstore.support.PlainBlobMetadata;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.channels.Channels;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
+import com.google.cloud.ReadChannel;
+import com.google.cloud.WriteChannel;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.StorageException;
+
+
+public class GCSBlobContainer extends AbstractBlobContainer {
+
+    private final GCSBlobStore blobStore;
+
+    public GCSBlobContainer(BlobPath path, GCSBlobStore blobStore) {
+        super(path);
+        this.blobStore = blobStore;
+    }
+
+    @Override
+    public boolean blobExists(String blobName) throws StorageException {
+        return getBlob(blobName) != null;
+    }
+
+    @Nullable
+    private Blob getBlob(String blobName) throws StorageException {
+        return blobStore.storage().get(blobStore.bucketName(), buildKey(blobName));
+    }
+
+    @Override
+    public InputStream readBlob(String blobName) throws StorageException, IOException {
+        Blob blob = getBlob(blobName);
+        if (blob != null) {
+            final ReadChannel channel = blob.reader();
+            return Channels.newInputStream(channel);
+        } else {
+            throw new IOException("blob `" + blobName + "` does not exist");
+        }
+    }
+
+    private String buildKey(String blobName) {
+        return path().buildAsString() + blobName;
+    }
+
+    @Override
+    public InputStream readBlob(String blobName, long position, long length) throws IOException {
+        if (position < 0L) {
+            throw new IllegalArgumentException("position must be non-negative");
+        }
+        if (length < 0) {
+            throw new IllegalArgumentException("length must be non-negative");
+        }
+        if (length == 0) {
+            return new ByteArrayInputStream(new byte[0]);
+        } else {
+            Blob blob = getBlob(blobName);
+            if (blob != null) {
+                final ReadChannel channel = blob.reader();
+                channel.seek(position);
+                channel.limit(Math.addExact(position, length - 1));
+                return Channels.newInputStream(channel);
+            } else {
+                throw new IOException("blob `" + blobName + "` does not exist");
+            }
+        }
+    }
+
+    @Override
+    public void writeBlob(String blobName, InputStream inputStream,
+                          long blobSize, boolean failIfAlreadyExists) throws IOException {
+        Blob blob = createBlob(blobName, failIfAlreadyExists);
+        try (WriteChannel channel = blob.writer()) {
+            final OutputStream outputStream = Channels.newOutputStream(channel);
+            inputStream.transferTo(outputStream);
+        }
+    }
+
+    @Override
+    public void delete() {
+        String basePath = path().buildAsString();
+        var blobs = blobStore.storage().list(blobStore.bucketName(), prefix(basePath));
+        for (Blob blob : blobs.iterateAll()) {
+            blob.delete();
+        }
+    }
+
+    @Override
+    public void deleteBlobsIgnoringIfNotExists(List<String> blobNames) {
+        for (var blobName : blobNames) {
+            final Blob blob = getBlob(blobName);
+            if (blob != null) {
+                blob.delete();
+            }
+        }
+    }
+
+    @Override
+    public Map<String, BlobContainer> children() throws IOException {
+        String prefix = path().buildAsString();
+        var result = new HashMap<String, BlobContainer>();
+        var blobs = blobStore.storage().list(blobStore.bucketName(), currentDirectory(), prefix(prefix));
+        for (var blob : blobs.iterateAll()) {
+            if (blob.isDirectory()) {
+                assert blob.getName().startsWith(prefix);
+                assert blob.getName().endsWith("/");
+                final String suffixName = blob.getName().substring(prefix.length(), blob.getName().length() - 1);
+                if (suffixName.isEmpty() == false) {
+                    result.put(suffixName, new GCSBlobContainer(path().add(suffixName), blobStore));
+                }
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public Map<String, BlobMetadata> listBlobs() {
+        return listBlobsByPrefix("");
+    }
+
+    @Override
+    public Map<String, BlobMetadata> listBlobsByPrefix(String blobNamePrefix) {
+        String prefix = buildKey(blobNamePrefix);
+        var blobs = blobStore.storage().list(blobStore.bucketName(), prefix(prefix));
+        var result = new HashMap<String, BlobMetadata>();
+        for (var blob : blobs.iterateAll()) {
+            var name = blob.getName().substring(prefix.length());
+            result.put(name, new PlainBlobMetadata(name, blob.getSize()));
+        }
+        return result;
+    }
+
+    private Blob createBlob(String blobName, boolean failIfAlreadyExists) throws IOException {
+        Blob blob = getBlob(blobName);
+        if (blob != null) {
+            if (failIfAlreadyExists) {
+                throw new IOException("blob `" + blobName + "` already exists");
+            } else {
+                return blob;
+            }
+        }
+        var blobInfo = BlobInfo.newBuilder(blobStore.bucketName(), buildKey(blobName)).build();
+        return blobStore.storage().create(blobInfo, new byte[]{});
+    }
+
+}

--- a/plugins/repository-gcs/src/main/java/io/crate/gcs/GCSBlobStore.java
+++ b/plugins/repository-gcs/src/main/java/io/crate/gcs/GCSBlobStore.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.gcs;
+
+import java.io.IOException;
+
+import org.elasticsearch.common.blobstore.BlobContainer;
+import org.elasticsearch.common.blobstore.BlobPath;
+import org.elasticsearch.common.blobstore.BlobStore;
+
+import com.google.cloud.storage.Storage;
+
+
+public class GCSBlobStore implements BlobStore {
+
+    private final Storage storage;
+    private final String bucketName;
+
+    GCSBlobStore(Storage storage, String bucketName) {
+        this.storage = storage;
+        this.bucketName = bucketName;
+    }
+
+    public Storage storage() {
+        return storage;
+    }
+
+    public String bucketName() {
+        return bucketName;
+    }
+
+    @Override
+    public BlobContainer blobContainer(BlobPath path) {
+        return new GCSBlobContainer(path, this);
+    }
+
+    @Override
+    public void close() throws IOException {
+        try {
+            storage.close();
+        } catch (Exception e) {
+            throw new IOException(e);
+        }
+    }
+}

--- a/plugins/repository-gcs/src/main/java/io/crate/gcs/GCSRepository.java
+++ b/plugins/repository-gcs/src/main/java/io/crate/gcs/GCSRepository.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.gcs;
+
+import java.net.URI;
+import org.elasticsearch.cluster.metadata.RepositoryMetadata;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.blobstore.BlobPath;
+import org.elasticsearch.common.blobstore.BlobStore;
+import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Setting.Property;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.indices.recovery.RecoverySettings;
+import org.elasticsearch.repositories.blobstore.BlobStoreRepository;
+
+import com.google.auth.oauth2.ServiceAccountCredentials;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+
+/**
+ * Google Cloud Storage implementation of the BlobStoreRepository
+ * <p>
+ * This repository supports the following settings
+ * <dl>
+ * <dt>{@code bucket}</dt><dd>Bucket name</dd>
+ * <dt>{@code base_path}</dt><dd>Base path (blob name prefix) in the bucket</dd>
+ * <dt>{@code private_key_id}</dt><dd>Private key in PKCS 8 format from the google service account credentials.</dd>
+ * <dt>{@code private_key}</dt><dd>Private key from the google service account credentials.</dd>
+ * <dt>{@code client_id}</dt><dd>client id from the google service account credentials.</dd>
+ * <dt>{@code client_email}</dt><dd>client email from the google service account credentials.</dd>
+ * <dt>{@code token_uri}</dt><dd>Endpoint oauth token URI, only used for testing to connect to an alternative oauth provider.</dd>
+ * <dt>{@code endpoint}</dt><dd>Endpoint root URL, only used for testing to connect to an alternative storage.</dd>
+ * </dl>
+ */
+public class GCSRepository extends BlobStoreRepository {
+
+    static final Setting<String> BUCKET_SETTING =
+        Setting.simpleString("bucket", Property.NodeScope);
+
+    static final Setting<String> BASE_PATH_SETTING =
+        Setting.simpleString("base_path", "", Property.NodeScope);
+
+    static final Setting<SecureString> PROJECT_ID_SETTING =
+        Setting.maskedString("project_id");
+
+    static final Setting<SecureString> PRIVATE_KEY_ID_SETTING =
+        Setting.maskedString("private_key_id");
+
+    static final Setting<SecureString> PRIVATE_KEY_SETTING =
+        Setting.maskedString("private_key");
+
+    static final Setting<SecureString> CLIENT_EMAIL_SETTING =
+        Setting.maskedString("client_email");
+
+    static final Setting<SecureString> CLIENT_ID_SETTING =
+        Setting.maskedString("client_id");
+
+    static final Setting<String> ENDPOINT_SETTING =
+        Setting.simpleString("endpoint", Property.NodeScope);
+
+    static final Setting<String> TOKEN_URI_SETTING =
+        Setting.simpleString("token_uri", "https://oauth2.googleapis.com/token", Property.NodeScope);
+
+    public GCSRepository(RepositoryMetadata metadata,
+                         NamedXContentRegistry namedXContentRegistry,
+                         ClusterService clusterService,
+                         RecoverySettings recoverySettings) {
+        super(metadata, namedXContentRegistry, clusterService,
+            recoverySettings, buildBasePath(metadata));
+    }
+
+    private static BlobPath buildBasePath(RepositoryMetadata metadata) {
+        final String basePath = BASE_PATH_SETTING.get(metadata.settings());
+        return Strings.hasLength(basePath)
+            ? new BlobPath().add(basePath)
+            : BlobPath.cleanPath();
+    }
+
+    @Override
+    protected BlobStore createBlobStore() throws Exception {
+        Settings settings = metadata.settings();
+
+        var credentials = ServiceAccountCredentials
+            .newBuilder()
+            .setClientId(CLIENT_ID_SETTING.get(settings).toString())
+            .setClientEmail(CLIENT_EMAIL_SETTING.get(settings).toString())
+            .setPrivateKeyId(PRIVATE_KEY_ID_SETTING.get(settings).toString())
+            .setPrivateKeyString(privateKey())
+            .setTokenServerUri(tokenUri())
+            .setProjectId(PROJECT_ID_SETTING.get(settings).toString())
+            .build();
+
+        StorageOptions.Builder storageBuilder = StorageOptions
+            .newBuilder()
+            .setCredentials(credentials);
+
+        if (ENDPOINT_SETTING.exists(settings)) {
+            storageBuilder.setHost(ENDPOINT_SETTING.get(settings));
+        }
+
+        Storage storage = storageBuilder.setCredentials(credentials)
+                .build()
+                .getService();
+
+        return new GCSBlobStore(storage, BUCKET_SETTING.get(settings));
+    }
+
+    private String privateKey() {
+        SecureString secureString = PRIVATE_KEY_SETTING.get(metadata.settings());
+        return secureString.toString().replaceAll("\\\\n", "\n");
+    }
+
+    private URI tokenUri() {
+        return URI.create(TOKEN_URI_SETTING.get(metadata.settings()));
+    }
+}

--- a/plugins/repository-gcs/src/main/java/io/crate/gcs/GCSRepositoryPlugin.java
+++ b/plugins/repository-gcs/src/main/java/io/crate/gcs/GCSRepositoryPlugin.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.gcs;
+
+import java.util.List;
+import java.util.Map;
+
+import org.elasticsearch.cluster.metadata.RepositoryMetadata;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.indices.recovery.RecoverySettings;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.plugins.RepositoryPlugin;
+import org.elasticsearch.repositories.Repository;
+
+import io.crate.analyze.repositories.TypeSettings;
+
+
+/**
+ * A plugin to add Google Cloud Storage as a repository.
+ */
+public class GCSRepositoryPlugin extends Plugin implements RepositoryPlugin {
+
+    @Override
+    public List<Setting<?>> getSettings() {
+        return List.of(
+            GCSRepository.BUCKET_SETTING,
+            GCSRepository.BASE_PATH_SETTING,
+            GCSRepository.PROJECT_ID_SETTING,
+            GCSRepository.PRIVATE_KEY_ID_SETTING,
+            GCSRepository.PRIVATE_KEY_SETTING,
+            GCSRepository.CLIENT_EMAIL_SETTING,
+            GCSRepository.CLIENT_ID_SETTING,
+            GCSRepository.ENDPOINT_SETTING,
+            GCSRepository.TOKEN_URI_SETTING
+            );
+    }
+
+    @Override
+    public Map<String, Repository.Factory> getRepositories(
+        Environment environment, NamedXContentRegistry namedXContentRegistry,
+        ClusterService clusterService, RecoverySettings recoverySettings) {
+        return Map.of(
+            "gcs", new Repository.Factory() {
+                @Override
+                public TypeSettings settings() {
+                    return new TypeSettings(
+                        // Required settings
+                        List.of(
+                            GCSRepository.BUCKET_SETTING,
+                            GCSRepository.PROJECT_ID_SETTING,
+                            GCSRepository.PRIVATE_KEY_ID_SETTING,
+                            GCSRepository.PRIVATE_KEY_SETTING,
+                            GCSRepository.CLIENT_ID_SETTING,
+                            GCSRepository.CLIENT_EMAIL_SETTING
+                        ),
+                        // Optional settings
+                        List.of(
+                            GCSRepository.BASE_PATH_SETTING,
+                            GCSRepository.ENDPOINT_SETTING,
+                            GCSRepository.TOKEN_URI_SETTING
+                        )
+                    );
+                }
+
+                @Override
+                public Repository create(RepositoryMetadata metadata) {
+                    return new GCSRepository(metadata, namedXContentRegistry, clusterService, recoverySettings);
+                }
+            }
+        );
+    }
+}

--- a/plugins/repository-gcs/src/main/resources/plugin-descriptor.properties
+++ b/plugins/repository-gcs/src/main/resources/plugin-descriptor.properties
@@ -1,0 +1,3 @@
+name=repository-gcs
+description="CrateDB Google Cloud Storage Repository Plugin"
+classname=io.crate.gcs.GCSRepositoryPlugin

--- a/plugins/repository-gcs/src/test/java/io/crate/gcs/FakeOAuth2HttpHandler.java
+++ b/plugins/repository-gcs/src/test/java/io/crate/gcs/FakeOAuth2HttpHandler.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package io.crate.gcs;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.io.IOException;
+
+import org.elasticsearch.rest.RestStatus;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+
+public class FakeOAuth2HttpHandler implements HttpHandler {
+
+    private static final byte[] BUFFER = new byte[1024];
+
+    @Override
+    public void handle(final HttpExchange exchange) throws IOException {
+        try {
+            while (exchange.getRequestBody().read(BUFFER) >= 0) ;
+            byte[] response = ("{\"access_token\":\"foo\",\"token_type\":\"Bearer\",\"expires_in\":3600}").getBytes(UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(RestStatus.OK.getStatus(), response.length);
+            exchange.getResponseBody().write(response);
+        } finally {
+            int read = exchange.getRequestBody().read();
+            assert read == -1 : "Request body should have been fully read here but saw [" + read + "]";
+            exchange.close();
+        }
+    }
+}

--- a/plugins/repository-gcs/src/test/java/io/crate/gcs/GCSHttpHandler.java
+++ b/plugins/repository-gcs/src/test/java/io/crate/gcs/GCSHttpHandler.java
@@ -1,0 +1,412 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package io.crate.gcs;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.io.BufferedReader;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.BiFunction;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.zip.GZIPInputStream;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.io.Streams;
+import org.elasticsearch.common.regex.Regex;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.bytes.CompositeBytesReference;
+import org.elasticsearch.rest.RestStatus;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+
+import io.crate.common.collections.Tuple;
+import io.netty.handler.codec.http.QueryStringDecoder;
+
+/**
+ * Minimal HTTP handler that acts as a Google Cloud Storage compliant server
+ */
+public class GCSHttpHandler implements HttpHandler {
+
+    private static final Logger logger = LogManager.getLogger(GCSHttpHandler.class);
+
+    private static final Pattern RANGE_MATCHER = Pattern.compile("bytes=([0-9]*)-([0-9]*)");
+
+    private final ConcurrentMap<String, BytesReference> blobs;
+    private final String bucket;
+
+    public GCSHttpHandler(final String bucket) {
+        this.bucket = Objects.requireNonNull(bucket);
+        this.blobs = new ConcurrentHashMap<>();
+    }
+
+    @Override
+    public void handle(final HttpExchange exchange) throws IOException {
+        final String request = exchange.getRequestMethod() + " " + exchange.getRequestURI().toString();
+
+        if (request.startsWith("GET") || request.startsWith("HEAD") || request.startsWith("DELETE")) {
+            int read = exchange.getRequestBody().read();
+            assert read == -1 : "Request body should have been empty but saw [" + read + "]";
+        }
+        try {
+            // Request body is closed in the finally block
+            final BytesReference requestBody = Streams.readFully(noCloseStream(exchange.getRequestBody()));
+            if (Regex.simpleMatch("GET /storage/v1/b/" + bucket + "/o/*", request)) {
+                final String key = exchange.getRequestURI().getPath().replace("/storage/v1/b/" + bucket + "/o/", "");
+                final BytesReference blob = blobs.get(key);
+                if (blob == null) {
+                    exchange.sendResponseHeaders(RestStatus.NOT_FOUND.getStatus(), -1);
+                } else {
+                    final byte[] response = buildBlobInfoJson(key, blob.length()).getBytes(UTF_8);
+                    exchange.getResponseHeaders().add("Content-Type", "application/json; charset=utf-8");
+                    exchange.sendResponseHeaders(RestStatus.OK.getStatus(), response.length);
+                    exchange.getResponseBody().write(response);
+                }
+            } else if (Regex.simpleMatch("GET /storage/v1/b/" + bucket + "/o*", request)) {
+                // List Objects https://cloud.google.com/storage/docs/json_api/v1/objects/list
+                final Map<String, String> params = decodeQueryString(exchange.getRequestURI());
+                final String prefix = params.getOrDefault("prefix", "");
+                final String delimiter = params.get("delimiter");
+
+                final Set<String> prefixes = new HashSet<>();
+                final List<String> listOfBlobs = new ArrayList<>();
+
+                for (final Map.Entry<String, BytesReference> blob : blobs.entrySet()) {
+                    final String blobName = blob.getKey();
+                    if (prefix.isEmpty() || blobName.startsWith(prefix)) {
+                        int delimiterPos = (delimiter != null) ? blobName.substring(prefix.length()).indexOf(delimiter) : -1;
+                        if (delimiterPos > -1) {
+                            prefixes.add("\"" + blobName.substring(0, prefix.length() + delimiterPos + 1) + "\"");
+                        } else {
+                            listOfBlobs.add(buildBlobInfoJson(blobName, blob.getValue().length()));
+                        }
+                    }
+                }
+
+                byte[] response = ("{\"kind\":\"storage#objects\",\"items\":[" +
+                    String.join(",", listOfBlobs) +
+                    "],\"prefixes\":[" +
+                    String.join(",", prefixes) +
+                    "]}").getBytes(UTF_8);
+
+                exchange.getResponseHeaders().add("Content-Type", "application/json; charset=utf-8");
+                exchange.sendResponseHeaders(RestStatus.OK.getStatus(), response.length);
+                exchange.getResponseBody().write(response);
+
+            } else if (Regex.simpleMatch("GET /storage/v1/b/" + bucket + "*", request)) {
+                // GET Bucket https://cloud.google.com/storage/docs/json_api/v1/buckets/get
+                throw new UnsupportedOperationException("GET Bucket not supported");
+            } else if (Regex.simpleMatch("GET /download/storage/v1/b/" + bucket + "/o/*", request)) {
+                // Download Object https://cloud.google.com/storage/docs/request-body
+                BytesReference blob = blobs.get(exchange.getRequestURI().getPath().replace("/download/storage/v1/b/" + bucket + "/o/", ""));
+                if (blob != null) {
+                    final String range = exchange.getRequestHeaders().getFirst("Range");
+                    final int offset;
+                    final int end;
+                    if (range == null) {
+                        offset = 0;
+                        end = blob.length() - 1;
+                    } else {
+                        Matcher matcher = RANGE_MATCHER.matcher(range);
+                        if (matcher.find() == false) {
+                            throw new AssertionError("Range bytes header does not match expected format: " + range);
+                        }
+                        offset = Integer.parseInt(matcher.group(1));
+                        end = Integer.parseInt(matcher.group(2));
+                    }
+                    BytesReference response = blob;
+                    exchange.getResponseHeaders().add("Content-Type", "application/octet-stream");
+                    final int bufferedLength = response.length();
+                    if (offset > 0 || bufferedLength > end) {
+                        response = response.slice(offset, Math.min(end + 1 - offset, bufferedLength - offset));
+                    }
+                    exchange.sendResponseHeaders(RestStatus.OK.getStatus(), response.length());
+                    response.writeTo(exchange.getResponseBody());
+                } else {
+                    exchange.sendResponseHeaders(RestStatus.NOT_FOUND.getStatus(), -1);
+                }
+
+            } else if (Regex.simpleMatch("POST /batch/storage/v1", request)) {
+                // Batch https://cloud.google.com/storage/docs/json_api/v1/how-tos/batch
+                final String uri = "/storage/v1/b/" + bucket + "/o/";
+                final StringBuilder batch = new StringBuilder();
+                for (String line : readAllLines(requestBody.streamInput())) {
+                    if (line.length() == 0 || line.startsWith("--") || line.toLowerCase(Locale.ROOT).startsWith("content")) {
+                        batch.append(line).append("\r\n");
+                    } else if (line.startsWith("DELETE")) {
+                        final String name = line.substring(line.indexOf(uri) + uri.length(), line.lastIndexOf(" HTTP"));
+                        if (Strings.hasText(name)) {
+                            blobs.remove(URLDecoder.decode(name, UTF_8.name()));
+                            batch.append("HTTP/1.1 204 NO_CONTENT").append("\r\n");
+                            batch.append("\r\n");
+                        }
+                    }
+                }
+                byte[] response = batch.toString().getBytes(UTF_8);
+                exchange.getResponseHeaders().add("Content-Type", exchange.getRequestHeaders().getFirst("Content-Type"));
+                exchange.sendResponseHeaders(RestStatus.OK.getStatus(), response.length);
+                exchange.getResponseBody().write(response);
+
+            } else if (Regex.simpleMatch("POST /upload/storage/v1/b/" + bucket + "/*uploadType=multipart*", request)) {
+                // Multipart upload
+                Optional<Tuple<String, BytesReference>> content = parseMultipartRequestBody(requestBody.streamInput());
+                if (content.isPresent()) {
+                    blobs.put(content.get().v1(), content.get().v2());
+
+                    byte[] response = ("{\"bucket\":\"" + bucket + "\",\"name\":\"" + content.get().v1() + "\"}").getBytes(UTF_8);
+                    exchange.getResponseHeaders().add("Content-Type", "application/json");
+                    exchange.sendResponseHeaders(RestStatus.OK.getStatus(), response.length);
+                    exchange.getResponseBody().write(response);
+                } else {
+                    throw new AssertionError("Could not read multi-part request to [" + request + "] with headers ["
+                        + new HashMap<>(exchange.getRequestHeaders()) + "]");
+                }
+
+            } else if (Regex.simpleMatch("POST /upload/storage/v1/b/" + bucket + "/*uploadType=resumable*", request)) {
+                // Resumable upload initialization https://cloud.google.com/storage/docs/json_api/v1/how-tos/resumable-upload
+                final Map<String, String> params = decodeQueryString(exchange.getRequestURI());
+                final String blobName = params.get("name");
+                blobs.put(blobName, BytesArray.EMPTY);
+
+                byte[] response = requestBody.utf8ToString().getBytes(UTF_8);
+                exchange.getResponseHeaders().add("Content-Type", "application/json");
+                exchange.getResponseHeaders().add("Location", httpServerUrl(exchange) + "/upload/storage/v1/b/" + bucket + "/o?"
+                    + "uploadType=resumable"
+                    + "&upload_id=" + UUIDs.randomBase64UUID()
+                    + "&test_blob_name=" + blobName); // not a Google Storage parameter, but it allows to pass the blob name
+                exchange.sendResponseHeaders(RestStatus.OK.getStatus(), response.length);
+                exchange.getResponseBody().write(response);
+
+            } else if (Regex.simpleMatch("PUT /upload/storage/v1/b/" + bucket + "/o?*uploadType=resumable*", request)) {
+                // Resumable upload https://cloud.google.com/storage/docs/json_api/v1/how-tos/resumable-upload
+                final Map<String, String> params = decodeQueryString(exchange.getRequestURI());
+
+                final String blobName = params.get("test_blob_name");
+                if (blobs.containsKey(blobName) == false) {
+                    exchange.sendResponseHeaders(RestStatus.NOT_FOUND.getStatus(), -1);
+                    return;
+                }
+                BytesReference blob = blobs.get(blobName);
+                final String range = exchange.getRequestHeaders().getFirst("Content-Range");
+                final Integer limit = getContentRangeLimit(range);
+                final int start = getContentRangeStart(range);
+                final int end = getContentRangeEnd(range);
+
+                blob = CompositeBytesReference.of(blob, requestBody);
+                blobs.put(blobName, blob);
+
+                if (limit == null) {
+                    exchange.getResponseHeaders().add("Range", String.format(Locale.ROOT, "bytes=%d/%d", start, end));
+                    exchange.getResponseHeaders().add("Content-Length", "0");
+                    exchange.sendResponseHeaders(308 /* Resume Incomplete */, -1);
+                } else {
+                    if (limit > blob.length()) {
+                        throw new AssertionError("Requesting more bytes than available for blob");
+                    }
+                    exchange.sendResponseHeaders(RestStatus.OK.getStatus(), -1);
+                }
+            } else if (Regex.simpleMatch("DELETE /storage/v1/b/" + bucket + "/o/*", request)) {
+                // DELETE bucket https://cloud.google.com/storage/docs/json_api/v1/buckets/delete
+                var key = exchange.getRequestURI().getPath().replace("/storage/v1/b/" + bucket + "/o/", "");
+                var blob = blobs.remove(key);
+                if (blob == null) {
+                    exchange.sendResponseHeaders(RestStatus.NOT_FOUND.getStatus(), -1);
+                } else {
+                    exchange.sendResponseHeaders(RestStatus.OK.getStatus(), 0);
+                }
+            } else {
+                exchange.sendResponseHeaders(RestStatus.NOT_FOUND.getStatus(), -1);
+            }
+        } finally {
+            int read = exchange.getRequestBody().read();
+            assert read == -1 : "Request body should have been fully read here but saw [" + read + "]";
+            exchange.close();
+        }
+    }
+
+    private String buildBlobInfoJson(String blobName, int size) {
+        return "{\"kind\":\"storage#object\","
+            + "\"bucket\":\"" + bucket + "\","
+            + "\"name\":\"" + blobName + "\","
+            + "\"id\":\"" + blobName + "\","
+            + "\"size\":\"" + size + "\""
+            + "}";
+    }
+
+    public Map<String, BytesReference> blobs() {
+        return blobs;
+    }
+
+    private String httpServerUrl(final HttpExchange exchange) {
+        return "http://" + exchange.getRequestHeaders().get("HOST").get(0);
+    }
+
+    private static final Pattern NAME_PATTERN = Pattern.compile("\"name\":\"([^\"]*)\"");
+
+    public static Optional<Tuple<String, BytesReference>> parseMultipartRequestBody(final InputStream requestBody) throws IOException {
+        Tuple<String, BytesReference> content = null;
+        final BytesReference fullRequestBody;
+        try (InputStream in = new GZIPInputStream(requestBody)) {
+            fullRequestBody = Streams.readFully(in);
+        }
+        String name = null;
+        boolean skippedEmptyLine = false;
+        int startPos = 0;
+        int endPos = 0;
+        while (startPos < fullRequestBody.length()) {
+            do {
+                endPos = fullRequestBody.indexOf((byte) '\r', endPos + 1);
+            } while (endPos >= 0 && fullRequestBody.get(endPos + 1) != '\n');
+            boolean markAndContinue = false;
+            final String bucketPrefix = "{\"bucket\":";
+            if (startPos > 0) {
+                startPos += 2;
+            }
+            if (name == null || skippedEmptyLine == false) {
+                if ((skippedEmptyLine == false && endPos == startPos)
+                    || (fullRequestBody.get(startPos) == '-' && fullRequestBody.get(startPos + 1) == '-')) {
+                    markAndContinue = true;
+                } else {
+                    final String start = fullRequestBody.slice(startPos, Math.min(endPos - startPos, bucketPrefix.length())).utf8ToString();
+                    if (start.toLowerCase(Locale.ROOT).startsWith("content")) {
+                        markAndContinue = true;
+                    } else if (start.startsWith(bucketPrefix)) {
+                        markAndContinue = true;
+                        final String line = fullRequestBody.slice(
+                            startPos + bucketPrefix.length(), endPos - startPos - bucketPrefix.length()).utf8ToString();
+                        Matcher matcher = NAME_PATTERN.matcher(line);
+                        if (matcher.find()) {
+                            name = matcher.group(1);
+                        }
+                    }
+                }
+                skippedEmptyLine = markAndContinue && endPos == startPos;
+                startPos = endPos;
+            } else {
+                while (isEndOfPart(fullRequestBody, endPos) == false) {
+                    endPos = fullRequestBody.indexOf((byte) '\r', endPos + 1);
+                }
+                content = new Tuple<>(name, fullRequestBody.slice(startPos, endPos - startPos));
+                break;
+            }
+        }
+        if (content == null) {
+            final InputStream stream = fullRequestBody.streamInput();
+            logger.warn(() -> new ParameterizedMessage("Failed to find multi-part upload in [{}]", new BufferedReader(
+                new InputStreamReader(stream)).lines().collect(Collectors.joining("\n"))));
+        }
+        return Optional.ofNullable(content);
+    }
+
+    private static final byte[] END_OF_PARTS_MARKER = "\r\n--__END_OF_PART__".getBytes(UTF_8);
+
+    private static boolean isEndOfPart(BytesReference fullRequestBody, int endPos) {
+        for (int i = 0; i < END_OF_PARTS_MARKER.length; i++) {
+            final byte b = END_OF_PARTS_MARKER[i];
+            if (fullRequestBody.get(endPos + i) != b) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static final Pattern PATTERN_CONTENT_RANGE = Pattern.compile("bytes ([^/]*)/([0-9\\*]*)");
+    private static final Pattern PATTERN_CONTENT_RANGE_BYTES = Pattern.compile("([0-9]*)-([0-9]*)");
+
+    private static Integer parse(final Pattern pattern, final String contentRange, final BiFunction<String, String, Integer> fn) {
+        final Matcher matcher = pattern.matcher(contentRange);
+        if (matcher.matches() == false || matcher.groupCount() != 2) {
+            throw new IllegalArgumentException("Unable to parse content range header");
+        }
+        return fn.apply(matcher.group(1), matcher.group(2));
+    }
+
+    public static Integer getContentRangeLimit(final String contentRange) {
+        return parse(PATTERN_CONTENT_RANGE, contentRange, (bytes, limit) -> "*".equals(limit) ? null : Integer.parseInt(limit));
+    }
+
+    public static int getContentRangeStart(final String contentRange) {
+        return parse(PATTERN_CONTENT_RANGE, contentRange,
+            (bytes, limit) -> parse(PATTERN_CONTENT_RANGE_BYTES, bytes,
+                (start, end) -> Integer.parseInt(start)));
+    }
+
+    public static int getContentRangeEnd(final String contentRange) {
+        return parse(PATTERN_CONTENT_RANGE, contentRange,
+            (bytes, limit) -> parse(PATTERN_CONTENT_RANGE_BYTES, bytes,
+                (start, end) -> Integer.parseInt(end)));
+    }
+
+    public static InputStream noCloseStream(InputStream stream) {
+        return new FilterInputStream(stream) {
+            @Override
+            public void close() {
+                // noop
+            }
+        };
+    }
+
+    public static List<String> readAllLines(InputStream input) throws IOException {
+        final List<String> lines = new ArrayList<>();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                lines.add(line);
+            }
+        }
+        return lines;
+    }
+
+    private static Map<String, String> decodeQueryString(URI uri) {
+        var result = new HashMap<String, String>();
+        for (var entry : new QueryStringDecoder(uri).parameters().entrySet()) {
+            result.put(entry.getKey(), entry.getValue().get(0));
+        }
+        return result;
+    }
+}

--- a/plugins/repository-gcs/src/test/java/io/crate/gcs/GCSSnapshotIntegrationTest.java
+++ b/plugins/repository-gcs/src/test/java/io/crate/gcs/GCSSnapshotIntegrationTest.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.gcs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.IntegTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.sun.net.httpserver.HttpServer;
+
+@IntegTestCase.ClusterScope(scope = IntegTestCase.Scope.TEST)
+public class GCSSnapshotIntegrationTest extends IntegTestCase {
+
+    // This is an arbitrary rsa key in pkcs8 format for testing
+    // which is not used in the real world. It can be generated with
+    // the command `openssl genrsa -out keypair.pem 2048`
+    private static final String PKCS8_PRIVATE_KEY = """
+        -----BEGIN PRIVATE KEY-----
+        MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC9iMiyCPtIJz8a
+        tYrijSfRaCAmGAJQ2SZYrOQ7OSta+fbsvgtmYkKpy0HS1RuLpS5j1pTKqwWtxkJp
+        f110TuS3D6JNhrEWDZkQDoaaFE9JWXQo9lROEtSzgcpk74i6Fz5yBaehgMV4pHQP
+        9SqZN+PU/m/rGInSgFy6m2BRznyYKy1fXYaIF351rF/AtAiimndDbS80e4risQN7
+        WjgKDTd1UFfg4kEC0TQeaqif4N/J2kTQq6Fvm10a6TwwgL4wuuJ9b8AZmbWLH2Ck
+        t3kC3E8ZyLiC2bOCRA7DEMMndK72Bms1JreAGVjJVqa37b3clFOdKdrQKGzLzLL2
+        7eX1v4uFAgMBAAECggEBAJlBAQb0PDsbgOsX4DVP7eJlT5l90GGPNHJ/WgyJLYVi
+        mUbUZGNlEII61/6iUqOX7OrNl4JIx068APdNBUQGhul+ur31Kzupwxo4pJ3xziqB
+        Kmv0wjZfA54iVIVJKkVOhi+sYt80QHhMgYxlsQwzJQYUtmpibQ7IvDIncLq1PAnN
+        ejbEVMBvRquUOxL6ctO6sBtrsUUWhlXqxpsDJMUoIFzRrhRuOQP5YWCi4OpRbvII
+        qqUnl+lPofsHRjvt1sKR5RxiMklBggUAcMReNapViMz7Bz3hRSLjDKjE2q8aaDas
+        ezeZqYI0mbQSSjoBXaHTHP6I4TOOMuoCvkkuhtpF1AECgYEA8QoOCGbXWArjrXWR
+        gAmXIlRxVDZHmyMAjArkEKwCmgJu1G1nxN7jY+x93qGUuikO3xlhH/Wo8kBn12jc
+        XyrEOo5qIOuTqSBwuA+INLbwQRyeX3iP0CALyKNZEAlAa1uS22XUU4m7x7hqMq8L
+        yqi7g/QiQG1gBWQcJzxUeKmD1ScCgYEAyUxZ8vn3JkmSZ0hnJKobbd7FsBc1bV6t
+        2veGipLZRjyIateEASdlSPVOLD+ZoPlCmg4VCDJV6xx4a+Af89BHeBi5zVi/z3oh
+        GqV/rpzfcMJnKIiMCbOmHKMIsBWZj+NRT6KzAOP6fqDJ1V3ZzBN087+52IxLAC1O
+        CEU0P38vvXMCgYAnohecmgxelavKIcLC4tDO/EOGLUao46B7Zm8Jrr7ew/elRjgB
+        zwRkscYgjUD/OzEOzgWCU8pryttIOB3EKCwL1M7uis3EyWi/Ww5yXII0spf36sL6
+        3coSO4mxcVP+Uxhaquu2sLcHp/MOUmoF8KikkcfwAAwB1uwqJ2lcTcM3kQKBgBik
+        jzJupXH7eb/JHk9fv8HgjsTy4miEObZfrQnT1mOBz5V80r0tbHnVBf/mvVD2ks+3
+        P53kQ55nutpB8sdvTQCHzl80KS8mHV1cu1fN/pCYS/arWLFrW7+PueWMj2MNCgw8
+        t7s5LZZI6syDE8Gm9B9O7lpzOk9IPJBIoI/Ray+/AoGBANYLcri2nHdlgJJtibko
+        GlTJmBlNP/0gJe5FQYB5tnDO9yqDXXCAhMNrVQc3WmhVvX7UtaUL9zaq3cYO9PT5
+        UEij2bajHWK+vdYDdj/mvnPBrIZshPWau2h1lNGV/FjsUvxi2K4rvjXIpKBnom1L
+        aXHxlsqXzR0B4pnnvS7L6VI9
+        -----END PRIVATE KEY-----
+        """;
+
+    private static final String BUCKET_NAME = "bucket";
+
+    private HttpServer oauthServer;
+    private HttpServer gcsServer;
+    private GCSHttpHandler gcsHandler;
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        var plugins = new ArrayList<>(super.nodePlugins());
+        plugins.add(GCSRepositoryPlugin.class);
+        return plugins;
+    }
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+
+        this.oauthServer = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+        this.oauthServer.createContext("/token", new FakeOAuth2HttpHandler());
+        this.oauthServer.start();
+
+        this.gcsServer = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+        this.gcsHandler = new GCSHttpHandler(BUCKET_NAME);
+        this.gcsServer.createContext("/", gcsHandler);
+        this.gcsServer.start();
+    }
+
+    @Override
+    @After
+    public void tearDown() throws Exception {
+        super.tearDown();
+
+        oauthServer.stop(1);
+        gcsServer.stop(1);
+    }
+
+    @Test
+    public void create_restore_drop_snapshot() {
+        execute("create table t1 (x int)");
+        assertThat(response.rowCount()).isEqualTo(1L);
+
+        int numberOfDocs = randomIntBetween(0, 500);
+        Object[][] rows = new Object[numberOfDocs][];
+        for (int i = 0; i < numberOfDocs; i++) {
+            rows[i] = new Object[]{randomInt()};
+        }
+        execute("insert into t1 (x) values (?)", rows);
+        execute("refresh table t1");
+
+        execute("create repository r1 type gcs with (" +
+                "bucket = '" + BUCKET_NAME + "', " +
+                "project_id = 'my-project', " +
+                "endpoint = '" + gscServerUrl() + "'," +
+                "token_uri = '" + oauthServerUrl() + "'," +
+                "base_path = 'path', " +
+                "private_key_id = 'id123'," +
+                "private_key = '" + PKCS8_PRIVATE_KEY + "'," +
+                "client_id = 'id123'," +
+                "client_email = 'bla@foobar.com')");
+
+        assertThat(response.rowCount()).isEqualTo(1L);
+
+        execute("create snapshot r1.s1 all with (wait_for_completion = true)");
+
+        execute("drop table t1");
+
+        execute("restore snapshot r1.s1 all with (wait_for_completion = true)");
+        execute("refresh table t1");
+
+        execute("select count(*) from t1");
+        assertThat(response.rows()[0][0]).isEqualTo((long) numberOfDocs);
+
+        execute("drop snapshot r1.s1");
+        gcsHandler.blobs().keySet().forEach(x -> assertThat(x).doesNotEndWith("dat"));
+    }
+
+    private String oauthServerUrl() {
+        InetSocketAddress address = oauthServer.getAddress();
+        return "http://" + address.getAddress().getCanonicalHostName() + ":" + address.getPort() + "/token";
+    }
+
+    private String gscServerUrl() {
+        InetSocketAddress address = gcsServer.getAddress();
+        return "http://" + address.getAddress().getCanonicalHostName() + ":" + address.getPort();
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -262,6 +262,18 @@
     <versions.jaxb_api>2.3.1</versions.jaxb_api>
     <versions.graalvm>23.0.2</versions.graalvm>
 
+    <versions.google.gax>2.29.0</versions.google.gax>
+    <versions.google.auth>1.17.0</versions.google.auth>
+    <versions.google.oauth2>1.17.0</versions.google.oauth2>
+    <versions.google.cloud>2.22.4</versions.google.cloud>
+
+    <versions.guava>32.0.1-jre</versions.guava>
+    <versions.google.gson>1.43.1</versions.google.gson>
+    <versions.google.errorprone>2.19.1</versions.google.errorprone>
+    <versions.google.j2objc>2.8</versions.google.j2objc>
+    <versions.checkerframework>3.35.0</versions.checkerframework>
+    <versions.grpc>1.55.1</versions.grpc>
+
     <versions.hamcrest>2.2</versions.hamcrest>
     <versions.mockito>4.11.0</versions.mockito>
     <versions.jdbc>42.7.1</versions.jdbc>
@@ -310,6 +322,7 @@
     <module>plugins/es-repository-s3</module>
     <module>plugins/es-repository-url</module>
     <module>plugins/es-repository-azure</module>
+    <module>plugins/repository-gcs</module>
     <module>plugins/dns-discovery</module>
     <module>plugins/cr8-copy-s3</module>
     <module>extensions/functions</module>


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This adds support for repositories to write and restore snapshots to the Google Cloud Storage.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
