### PR TITLE
Adding contributors list via contrib.rocks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -103,6 +103,8 @@ contributions!
 
 See the `developer docs`_ and the `contribution docs`_ for more information.
 
+.. image:: https://contrib.rocks/image?repo=crate/crate
+    :target: https://github.com/crate/crate/graphs/contributors
 
 Security
 ========


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
We can show an autogenerated image with all contributors' avatars to both celebrate community contributions and show at a glance amount of people who work on the project.

