### PR TITLE
added regexpMatchScalar

### DIFF
--- a/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
+++ b/server/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
@@ -64,6 +64,7 @@ import io.crate.expression.scalar.postgres.PgEncodingToCharFunction;
 import io.crate.expression.scalar.postgres.PgGetUserByIdFunction;
 import io.crate.expression.scalar.postgres.PgPostmasterStartTime;
 import io.crate.expression.scalar.regex.RegexpReplaceFunction;
+import io.crate.expression.scalar.regex.RegexpMatchScalar;
 import io.crate.expression.scalar.string.AsciiFunction;
 import io.crate.expression.scalar.string.ChrFunction;
 import io.crate.expression.scalar.string.EncodeDecodeFunction;
@@ -113,6 +114,7 @@ public class ScalarFunctionModule extends AbstractFunctionModule<FunctionImpleme
         FormatFunction.register(this);
         SubstrFunction.register(this);
         RegexpReplaceFunction.register(this);
+        RegexpMatchScalar.register(this);
 
         ArithmeticFunctions.register(this);
         BitwiseFunctions.register(this);

--- a/server/src/main/java/io/crate/expression/scalar/regex/RegexpMatchScalar.java
+++ b/server/src/main/java/io/crate/expression/scalar/regex/RegexpMatchScalar.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar.regex;
+
+import static io.crate.expression.RegexpFlags.isGlobal;
+import static io.crate.expression.RegexpFlags.isPcrePattern;
+import static io.crate.expression.RegexpFlags.parseFlags;
+
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Pattern;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.ConstantScoreQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.RegexpQuery;
+import org.apache.lucene.util.automaton.ByteRunAutomaton;
+import org.apache.lucene.util.automaton.RegExp;
+
+import io.crate.data.Input;
+import io.crate.expression.RegexpFlags;
+import io.crate.expression.operator.Operator;
+import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.expression.symbol.Literal;
+import io.crate.lucene.match.CrateRegexQuery;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.Reference;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.BoundSignature;
+import io.crate.metadata.functions.Signature;
+import io.crate.types.DataTypes;
+
+public class RegexpMatchScalar extends Scalar<Boolean, String> {
+    public static final String NAME = "regexp_match_scalar";
+
+    public static void register(ScalarFunctionModule module) {
+        module.register(
+            Signature.scalar(
+                NAME,
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature(),
+                Operator.RETURN_TYPE.getTypeSignature()
+            ),
+            RegexpMatchScalar::new
+        );
+
+        module.register(
+            Signature.scalar(
+                NAME,
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature(),
+                Operator.RETURN_TYPE.getTypeSignature()
+            ),
+            RegexpMatchScalar::new
+        );
+    }
+
+    public RegexpMatchScalar(Signature signature, BoundSignature boundSignature) {
+        super(signature, boundSignature);
+    }
+
+    @Override
+    public Boolean evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<String>[] args) {
+        assert args.length == 2 || args.length == 3 : "number of args must be 2 or 3";
+        String source = args[0].value();
+        if (source == null) {
+            return null;
+        }
+
+        String pattern = args[1].value();
+        if (pattern == null) {
+            return null;
+        }
+
+        String flags;
+
+        if (args.length == 3) {
+            flags = (String) args[2].value();
+            if (!isGlobal(flags)) {
+                pattern = Pattern.compile(pattern, parseFlags(flags)).pattern();
+            }
+        }
+
+        if (isPcrePattern(pattern)) {
+            return source.matches(pattern);
+        } else {
+            RegExp regexp = new RegExp(pattern);
+            ByteRunAutomaton regexpRunAutomaton = new ByteRunAutomaton(regexp.toAutomaton());
+            byte[] bytes = source.getBytes(StandardCharsets.UTF_8);
+            return regexpRunAutomaton.run(bytes, 0, bytes.length);
+        }
+
+
+    }
+
+    @Override
+    public Query toQuery(Reference ref, Literal<?> literal) {
+        String pattern = (String) literal.value();
+        int flags = 0;
+
+        String flagsStr = null;
+        int flagSeparatorIndex = pattern.lastIndexOf('/');
+        if (flagSeparatorIndex != -1 && flagSeparatorIndex < pattern.length() - 1) {
+            pattern = pattern.substring(0, flagSeparatorIndex);
+            flagsStr = pattern.substring(flagSeparatorIndex + 1);
+            flags = parseFlags(flagsStr);
+        }
+
+        Term term = new Term(ref.storageIdent(), pattern);
+        if (RegexpFlags.isPcrePattern(pattern)) {
+            if(!isGlobal(flagsStr)) {
+                return new CrateRegexQuery(term, flags);
+            } else {
+                return new CrateRegexQuery(term);
+            }
+        } else {
+            return new ConstantScoreQuery(new RegexpQuery(term, RegExp.ALL));
+        }
+    }
+}

--- a/server/src/test/java/io/crate/expression/scalar/regex/regexpMatchScalartest.java
+++ b/server/src/test/java/io/crate/expression/scalar/regex/regexpMatchScalartest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar.regex;
+
+import static io.crate.testing.Asserts.isLiteral;
+
+import org.junit.Test;
+
+import io.crate.expression.scalar.ScalarTestCase;
+import io.crate.types.DataTypes;
+
+public class regexpMatchScalartest extends ScalarTestCase {
+
+    @Test
+    public void testNormalize() throws Exception {
+        assertNormalize("'foo bar' ~ '([A-Z][^ ]+ ?){2}'", isLiteral(true));
+        assertNormalize("'Foo Bar' ~ '([A-Z][^ ]+ ?){2}'", isLiteral(true));
+        assertNormalize("'' ~ ''", isLiteral(true));
+    }
+
+    @Test
+    public void testNullValues() throws Exception {
+        assertNormalize("null ~ 'foo'", isLiteral(null, DataTypes.BOOLEAN));
+        assertNormalize("'foo' ~ null", isLiteral(null, DataTypes.BOOLEAN));
+        assertNormalize("null ~ null", isLiteral(null, DataTypes.BOOLEAN));
+    }
+
+    @Test
+    public void testEvaluate() throws Exception {
+        assertEvaluate("'foo bar' ~ '([A-Z][^ ]+ ?){2}'", true);
+        assertEvaluate("'Foo Bar' ~ '([A-Z][^ ]+ ?){2}'", true);
+        assertEvaluate("'1000 $' ~ '(<1-9999>) $|€'", true);
+        assertEvaluate("'10000 $' ~ '(<1-9999>) $|€'", false);
+        assertEvaluate("'' ~ ''", true);
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Added RegexpMatchScalar

Submitting this pull request as a solution to the following issue: https://github.com/crate/crate/issues/15117

- Created a class, implementing it similar to the existing RegexpMatchOperator.
- Instead inherited it from Scalar instead of Operator
- Had it support the use of flags.
- Updated ScalarFunctionModule.java to register it as a function


## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [✓] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [✓] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
