### PR TITLE
Add a minor note about usage of MATCH with multiple columns

### DIFF
--- a/docs/general/dql/fulltext.rst
+++ b/docs/general/dql/fulltext.rst
@@ -335,7 +335,9 @@ columns:
 * use a composite index column on your table. See
   :ref:`sql-ddl-composite-index`.
 
-* use the :ref:`predicates_match` predicate on multiple columns.
+* use the :ref:`predicates_match` predicate on multiple columns. Note, that
+  each of those columns must be indexed using ``FULLTEXT`` to have the same
+  effect as using ``MATCH`` against a composite index.
 
 When querying multiple columns, there are many ways how the relevance a.k.a.
 :ref:`_score <sql_administration_system_column_score>` can be computed. These


### PR DESCRIPTION
Popped up while reviewing Academy content where `MATCH(name, description)` is used without explicitly saying that those are indexed with FULLTEXT.

I played around locally and without FULLTEXT columns fall to exact match logic ie no fulltext logic/zero matches.

It sometimes works as "true fulltext" with `best fields` if at least some columns are FULLTEXT and matches are in those FT columns but listing all those combinations is too verbose. 

The shortest would be just explicitly say "make all cols fulltext if want to be same as composite index"