### PR TITLE
Include numeric parameters when binding function return types

### DIFF
--- a/docs/appendices/release-notes/5.6.2.rst
+++ b/docs/appendices/release-notes/5.6.2.rst
@@ -52,6 +52,10 @@ Fixes
 
     SELECT * FROM t1 WHERE NOT CONCAT_WS(true, column_with_null_value, false);
 
+- Fixed a bug (present since at least :ref:`version_5.2.0`) where columns cast to
+  a numeric type with a non-default precision could return the unscaled value in
+  a multi-node cluster
+
 - Fixed an issue that caused ``SELECT`` statements with ``WHERE`` clause having
   ``primary keys`` under ``NOT`` predicate to return invalid results.
 
@@ -64,3 +68,4 @@ Fixes
 
   A ``NULLABLE`` function in this context means a function returning ``NULL``
   if and only if the input is a ``NULL``.
+

--- a/server/src/main/java/io/crate/metadata/Functions.java
+++ b/server/src/main/java/io/crate/metadata/Functions.java
@@ -474,7 +474,8 @@ public class Functions {
                                                 List<TypeSignature> declaredArgumentTypes) {
         int cnt = 0;
         for (int i = 0; i < actualArgumentTypes.size(); i++) {
-            if (declaredArgumentTypes.size() > i && actualArgumentTypes.get(i).equals(declaredArgumentTypes.get(i))) {
+            if (declaredArgumentTypes.size() > i
+                && actualArgumentTypes.get(i).equalsIgnoringParameters(declaredArgumentTypes.get(i))) {
                 cnt++;
             }
         }

--- a/server/src/main/java/io/crate/metadata/functions/BoundSignature.java
+++ b/server/src/main/java/io/crate/metadata/functions/BoundSignature.java
@@ -25,10 +25,7 @@ import java.util.List;
 
 import io.crate.types.DataType;
 
-public final class BoundSignature {
-
-    private final List<DataType<?>> argTypes;
-    private final DataType<?> returnType;
+public record BoundSignature(List<DataType<?>> argTypes, DataType<?> returnType) {
 
     public static BoundSignature sameAsUnbound(Signature signature) {
         return new BoundSignature(
@@ -37,16 +34,4 @@ public final class BoundSignature {
         );
     }
 
-    public BoundSignature(List<DataType<?>> argTypes, DataType<?> returnType) {
-        this.argTypes = argTypes;
-        this.returnType = returnType;
-    }
-
-    public List<DataType<?>> argTypes() {
-        return argTypes;
-    }
-
-    public DataType<?> returnType() {
-        return returnType;
-    }
 }

--- a/server/src/main/java/io/crate/types/NumericType.java
+++ b/server/src/main/java/io/crate/types/NumericType.java
@@ -263,6 +263,8 @@ public class NumericType extends DataType<BigDecimal> implements Streamer<BigDec
                Objects.equals(precision, that.precision);
     }
 
+
+
     @Override
     public int hashCode() {
         return Objects.hash(super.hashCode(), scale, precision);
@@ -274,5 +276,16 @@ public class NumericType extends DataType<BigDecimal> implements Streamer<BigDec
             return RamUsageEstimator.NUM_BYTES_OBJECT_HEADER;
         }
         return size(value);
+    }
+
+    @Override
+    public String toString() {
+        if (getTypeParameters().isEmpty()) {
+            return super.toString();
+        }
+        if (scale == null) {
+            return "numeric(" + precision + ")";
+        }
+        return "numeric(" + precision + "," + scale + ")";
     }
 }

--- a/server/src/main/java/io/crate/types/StringType.java
+++ b/server/src/main/java/io/crate/types/StringType.java
@@ -404,6 +404,14 @@ public class StringType extends DataType<String> implements Streamer<String> {
     }
 
     @Override
+    public String toString() {
+        if (unbound()) {
+            return super.toString();
+        }
+        return "text(" + lengthLimit + ")";
+    }
+
+    @Override
     public long valueBytes(String value) {
         return RamUsageEstimator.sizeOf(value);
     }

--- a/server/src/main/java/io/crate/types/TypeSignature.java
+++ b/server/src/main/java/io/crate/types/TypeSignature.java
@@ -156,6 +156,10 @@ public class TypeSignature implements Writeable, Accountable {
         return parameters;
     }
 
+    public boolean hasNumericParameters() {
+        return parameters.stream().anyMatch(t -> t instanceof IntegerLiteralTypeSignature);
+    }
+
     /**
      * Create the concrete {@link DataType} for this type signature.
      * Only `array` and `object` parameterized type signatures are supported.
@@ -201,7 +205,8 @@ public class TypeSignature implements Writeable, Accountable {
                 if (!parameter.type().equals(TypeSignatureType.INTEGER_LITERAL_SIGNATURE)) {
                     throw new IllegalArgumentException(
                         "The signature type of the based data type parameters can only be: "
-                        + TypeSignatureType.INTEGER_LITERAL_SIGNATURE.toString());
+                        + TypeSignatureType.INTEGER_LITERAL_SIGNATURE
+                        + " but was " + parameter.type());
                 }
                 integerLiteralParameters.add(((IntegerLiteralTypeSignature) parameter).value());
             }
@@ -231,6 +236,10 @@ public class TypeSignature implements Writeable, Accountable {
         }
         typeName.append(")");
         return typeName.toString();
+    }
+
+    public boolean equalsIgnoringParameters(TypeSignature o) {
+        return Objects.equals(baseTypeName, o.baseTypeName);
     }
 
     @Override

--- a/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -32,7 +32,6 @@ import static io.crate.testing.Asserts.isLiteral;
 import static io.crate.testing.Asserts.isReference;
 import static io.crate.testing.Asserts.toCondition;
 import static org.assertj.core.api.Assertions.anyOf;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
@@ -100,6 +99,7 @@ import io.crate.testing.T3;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
+import io.crate.types.StringType;
 import io.crate.types.TimeTZ;
 
 @SuppressWarnings("ConstantConditions")
@@ -566,7 +566,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
             .build();
 
         Symbol symbol = executor.asSymbol("count(distinct name)");
-        assertThat(symbol).isFunction("collection_count", List.of(new ArrayType<>(DataTypes.STRING)));
+        assertThat(symbol).isFunction("collection_count", List.of(new ArrayType<>(StringType.of(10))));
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/AggregateExpressionIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/AggregateExpressionIntegrationTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 
 import io.crate.testing.UseJdbc;
 
+@IntegTestCase.ClusterScope(minNumDataNodes = 2)
 public class AggregateExpressionIntegrationTest extends IntegTestCase {
 
     @Test
@@ -91,6 +92,24 @@ public class AggregateExpressionIntegrationTest extends IntegTestCase {
                 "       sum(z::numeric) " + // overflow
                 "FROM tbl");
         assertThat(response).hasRows("2.6| 3.12| 9223372036854775809");
+    }
+
+    @Test
+    public void test_numeric_agg_with_numeric_cast() {
+        execute("CREATE TABLE IF NOT EXISTS t01 (txt TEXT, val DOUBLE PRECISION)");
+        execute("INSERT INTO t01 VALUES ('a', 1.0)");
+        execute("REFRESH TABLE t01");
+        execute(
+            """
+                SELECT
+                    txt,
+                SUM(val :: NUMERIC(10, 2)) AS val2
+                FROM t01
+                GROUP BY txt
+            """);
+        assertThat(response).hasRows(
+            "a| 1.00"
+        );
     }
 
     @Test

--- a/server/src/test/java/io/crate/metadata/functions/SignatureBinderTest.java
+++ b/server/src/test/java/io/crate/metadata/functions/SignatureBinderTest.java
@@ -36,10 +36,12 @@ import org.elasticsearch.test.ESTestCase;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Test;
 
+import io.crate.execution.engine.aggregation.impl.NumericSumAggregation;
 import io.crate.types.BitStringType;
 import io.crate.types.CharacterType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
+import io.crate.types.NumericType;
 import io.crate.types.ObjectType;
 import io.crate.types.RowType;
 import io.crate.types.StringType;
@@ -551,6 +553,31 @@ public class SignatureBinderTest extends ESTestCase {
             .fails();
     }
 
+    @Test
+    public void testNumericParameters() {
+        NumericType dt = NumericType.of(10, 2);
+        assertThatSignature(NumericSumAggregation.SIGNATURE)
+            .boundTo(dt)
+            .hasReturnType(dt);
+    }
+
+    @Test
+    public void testNumericParametersWithDifferingScales() {
+        Signature foo = functionSignature()
+            .returnType(TypeSignature.parse("numeric"))
+            .argumentTypes(TypeSignature.parse("numeric"), TypeSignature.parse("numeric"))
+            .build();
+
+        BoundSignature expected = new BoundSignature(
+            List.of(NumericType.INSTANCE, NumericType.INSTANCE),
+            NumericType.of(10, 2)
+        );
+
+        assertThatSignature(foo)
+            .boundTo(NumericType.INSTANCE, NumericType.of(10, 2))
+            .hasBoundSignature(expected);
+    }
+
     private DataType<?> type(String signature) {
         TypeSignature typeSignature = TypeSignature.parse(signature);
         return typeSignature.createType();
@@ -615,12 +642,31 @@ public class SignatureBinderTest extends ESTestCase {
             assertThat(actual).isEqualTo(expected);
         }
 
+        public void hasReturnType(DataType<?> expected) {
+            BoundSignature actual = bind();
+            assertThat(actual).isNotNull();
+            assertThat(actual.returnType()).isEqualTo(expected);
+        }
+
+        public void hasBoundSignature(BoundSignature expected) {
+            BoundSignature actual = bind();
+            assertThat(actual).isNotNull();
+            assertThat(actual).isEqualTo(expected);
+        }
+
         @Nullable
         private BoundVariables bindVariables() {
             var coercionType = allowCoercion ? SignatureBinder.CoercionType.FULL : SignatureBinder.CoercionType.NONE;
             assertThat(argumentTypes).isNotNull();
             SignatureBinder signatureBinder = new SignatureBinder(function, coercionType);
             return signatureBinder.bindVariables(argumentTypes);
+        }
+
+        private BoundSignature bind() {
+            var coercionType = allowCoercion ? SignatureBinder.CoercionType.FULL : SignatureBinder.CoercionType.NONE;
+            assertThat(argumentTypes).isNotNull();
+            SignatureBinder signatureBinder = new SignatureBinder(function, coercionType);
+            return signatureBinder.bind(argumentTypes);
         }
     }
 }

--- a/server/src/test/java/io/crate/types/TypeCompatibilityTest.java
+++ b/server/src/test/java/io/crate/types/TypeCompatibilityTest.java
@@ -26,17 +26,28 @@ import static org.junit.Assert.assertThat;
 
 import org.junit.jupiter.api.Test;
 
-class TypeCompatibilityTest {
+public class TypeCompatibilityTest {
 
     @Test
-    void test_get_common_type_for_text_type_return_text_unbound_if_one_of_types_is_unbound() {
-        var commonType = TypeCompatibility.getCommonType(StringType.INSTANCE, StringType.of(1));
-        assertThat(commonType, is(StringType.INSTANCE));
+    public void test_get_common_type_for_text_type_return_text_unbound_if_one_of_types_is_unbound() {
+        assertCommonType(StringType.INSTANCE, StringType.of(1), StringType.INSTANCE);
     }
 
     @Test
-    void test_get_common_type_for_text_with_len_limit_return_text_with_highest_length() {
-        var commonType = TypeCompatibility.getCommonType(StringType.of(2), StringType.of(1));
-        assertThat(commonType, is(StringType.of(2)));
+    public void test_get_common_type_for_text_with_len_limit_return_text_with_highest_length() {
+        assertCommonType(StringType.of(2), StringType.of(1), StringType.of(2));
     }
+
+    @Test
+    public void test_numeric_highest_precision_wins() {
+        assertCommonType(NumericType.INSTANCE, NumericType.of(2, 1), NumericType.of(2, 1));
+        assertCommonType(NumericType.of(2, 1), NumericType.INSTANCE, NumericType.of(2, 1));
+        assertCommonType(NumericType.of(2, 1), NumericType.of(3, 1), NumericType.of(3, 1));
+    }
+
+    private static void assertCommonType(DataType<?> first, DataType<?> second, DataType<?> expected) {
+        var actual = TypeCompatibility.getCommonType(first, second);
+        assertThat(actual, is(expected));
+    }
+
 }


### PR DESCRIPTION
Some data types are parametrized for precision or storage length, and 
this information needs to be preserved when binding function signatures. 
This is particularly important for numeric types, where the precision 
parameter changes how values sent across the wire are interpreted by 
the receiver.

This changes SignatureBinder to include numeric parameters from input 
types when binding its return type. If there are multiple input arguments 
with different parameters, type compatibility is used to select the best 
type to use.

Fixes #15279