### PR TITLE
Close SecureString password when created in HTTP

### DIFF
--- a/server/src/main/java/io/crate/auth/Credentials.java
+++ b/server/src/main/java/io/crate/auth/Credentials.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.auth;
+
+import java.io.Closeable;
+import org.elasticsearch.common.settings.SecureString;
+import org.jetbrains.annotations.Nullable;
+
+public record Credentials(@Nullable String username, @Nullable SecureString password) implements Closeable {
+
+    @Override
+    public void close() {
+        if (password != null) {
+            password.close();
+        }
+    }
+}

--- a/server/src/test/java/io/crate/auth/HttpAuthUpstreamHandlerTest.java
+++ b/server/src/test/java/io/crate/auth/HttpAuthUpstreamHandlerTest.java
@@ -237,7 +237,7 @@ public class HttpAuthUpstreamHandlerTest extends ESTestCase {
         when(session.getPeerCertificates()).thenReturn(new Certificate[] { ssc.cert() });
 
         HttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/_sql");
-        String userName = HttpAuthUpstreamHandler.credentialsFromRequest(request, session, Settings.EMPTY).v1();
+        String userName = HttpAuthUpstreamHandler.credentialsFromRequest(request, session, Settings.EMPTY).username();
 
         assertThat(userName).isEqualTo("localhost");
     }

--- a/server/src/test/java/io/crate/protocols/http/HeadersTest.java
+++ b/server/src/test/java/io/crate/protocols/http/HeadersTest.java
@@ -27,10 +27,9 @@ import static io.crate.protocols.http.Headers.isBrowser;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
-import org.elasticsearch.common.settings.SecureString;
 import org.junit.Test;
 
-import io.crate.common.collections.Tuple;
+import io.crate.auth.Credentials;
 
 public class HeadersTest {
 
@@ -50,28 +49,28 @@ public class HeadersTest {
 
     @Test
     public void testExtractUsernamePasswordFromHttpBasicAuthHeader() {
-        Tuple<String, SecureString> creds = extractCredentialsFromHttpBasicAuthHeader("");
-        assertThat(creds.v1(), is(""));
-        assertThat(creds.v2().toString(), is(""));
+        Credentials creds = extractCredentialsFromHttpBasicAuthHeader("");
+        assertThat(creds.username(), is(""));
+        assertThat(creds.password().toString(), is(""));
 
         creds = extractCredentialsFromHttpBasicAuthHeader(null);
-        assertThat(creds.v1(), is(""));
-        assertThat(creds.v2().toString(), is(""));
+        assertThat(creds.username(), is(""));
+        assertThat(creds.password().toString(), is(""));
 
         creds = extractCredentialsFromHttpBasicAuthHeader("Basic QXJ0aHVyOkV4Y2FsaWJ1cg==");
-        assertThat(creds.v1(), is("Arthur"));
-        assertThat(creds.v2().toString(), is("Excalibur"));
+        assertThat(creds.username(), is("Arthur"));
+        assertThat(creds.password().toString(), is("Excalibur"));
 
         creds = extractCredentialsFromHttpBasicAuthHeader("Basic QXJ0aHVyOjp0ZXN0OnBhc3N3b3JkOg==");
-        assertThat(creds.v1(), is("Arthur"));
-        assertThat(creds.v2().toString(), is(":test:password:"));
+        assertThat(creds.username(), is("Arthur"));
+        assertThat(creds.password().toString(), is(":test:password:"));
 
         creds = extractCredentialsFromHttpBasicAuthHeader("Basic QXJ0aHVyOg==");
-        assertThat(creds.v1(), is("Arthur"));
-        assertThat(creds.v2().toString(), is(""));
+        assertThat(creds.username(), is("Arthur"));
+        assertThat(creds.password().toString(), is(""));
 
         creds = extractCredentialsFromHttpBasicAuthHeader("Basic OnBhc3N3b3Jk");
-        assertThat(creds.v1(), is(""));
-        assertThat(creds.v2().toString(), is("password"));
+        assertThat(creds.username(), is(""));
+        assertThat(creds.password().toString(), is("password"));
     }
 }


### PR DESCRIPTION
Not a bug fix since SecureString will be cleaned up eventually by GC.
Just a faster cleanup of resources - similar to PG protocol which explicitly closes password object.