### PR TITLE
Fixed TRIM/LTRIM/RTRIM/BTRIM on null 2nd arg

### DIFF
--- a/docs/appendices/release-notes/5.6.2.rst
+++ b/docs/appendices/release-notes/5.6.2.rst
@@ -45,9 +45,14 @@ See the :ref:`version_5.6.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed :ref:`trim <scalar-trim>`, :ref:`ltrim <scalar-ltrim>`,
+  :ref:`rtrim <scalar-rtrim>`, and :ref:`btrim <scalar-btrim>` scalar functions
+  to return ``NULL`, instead of the original string, when the ``trimmingText``
+  argument is ``NULL``, complying with PostgreSQL behaviour for these functions.
+
 - Fixed a regression introduced in 5.6.0 that caused
   :ref:`concat_ws <scalar-concat-ws>` returning the wrong result when used on a
-  column with NULL values in the WHERE-clause combined with a NOT-predicate.
+  column with ``NULL`` values in the WHERE-clause combined with a NOT-predicate.
   An example::
 
     SELECT * FROM t1 WHERE NOT CONCAT_WS(true, column_with_null_value, false);

--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -480,6 +480,8 @@ Removes the longest string containing characters from ``str_arg_1`` (``' '`` by
 default) from the start, end, or both ends (``BOTH`` is the default) of
 ``str_arg_2``.
 
+If any of the two strings is ``NULL``, the result is ``NULL``.
+
 Synopsis::
 
     trim([ [ {LEADING | TRAILING | BOTH} ] [ str_arg_1 ] FROM ] str_arg_2)
@@ -523,6 +525,8 @@ Examples::
 Removes set of characters which are matching ``trimmingText`` (``' '`` by
 default) to the left of ``text``.
 
+If any of the arguments is ``NULL``, the result is ``NULL``.
+
 ::
 
     cr> select ltrim('xxxzzzabcba', 'xz') AS ltrim;
@@ -541,6 +545,8 @@ default) to the left of ``text``.
 
 Removes set of characters which are matching ``trimmingText`` (``' '`` by
 default) to the right of ``text``.
+
+If any of the arguments is ``NULL``, the result is ``NULL``.
 
 ::
 
@@ -561,6 +567,8 @@ default) to the right of ``text``.
 A combination of :ref:`ltrim <scalar-ltrim>` and :ref:`rtrim <scalar-rtrim>`,
 removing the longest string matching ``trimmingText`` from both the start and
 end of ``text``.
+
+If any of the arguments is ``NULL``, the result is ``NULL``.
 
 ::
 

--- a/server/src/main/java/io/crate/expression/scalar/string/TrimFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/TrimFunctions.java
@@ -192,7 +192,7 @@ public final class TrimFunctions {
             }
 
             String charsToTrim = (String) ((Input<?>) charsToTrimSymbol).value();
-            if (charsToTrim.length() == 1) {
+            if (charsToTrim != null && charsToTrim.length() == 1) {
                 return new OneCharTrimFunction(signature, boundSignature, charsToTrim.charAt(0));
             }
             return this;
@@ -208,7 +208,7 @@ public final class TrimFunctions {
 
             String charsToTrimArg = args[1].value();
             if (charsToTrimArg == null) {
-                return target;
+                return null;
             }
 
             TrimMode mode = TrimMode.of(args[2].value());
@@ -257,9 +257,10 @@ public final class TrimFunctions {
 
             if (args.length == 2) {
                 String passedTrimmingText = args[1].value();
-                if (passedTrimmingText != null) {
-                    return trimFunction.apply(target, passedTrimmingText);
+                if (passedTrimmingText == null) {
+                    return null;
                 }
+                return trimFunction.apply(target, passedTrimmingText);
             }
 
             return trimFunction.apply(target, " ");

--- a/server/src/test/java/io/crate/expression/scalar/string/TrimFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/string/TrimFunctionTest.java
@@ -150,8 +150,20 @@ public class TrimFunctionTest extends ScalarTestCase {
         assertEvaluateNull("trim(name)", Literal.of(DataTypes.STRING, null));
         assertEvaluateNull("ltrim(name)", Literal.of(DataTypes.STRING, null));
         assertEvaluateNull("rtrim(name)", Literal.of(DataTypes.STRING, null));
-        assertEvaluateNull("ltrim(name, null)", Literal.of(DataTypes.STRING, null));
-        assertEvaluateNull("rtrim(name, null)", Literal.of(DataTypes.STRING, null));
+        assertEvaluateNull("btrim(name)", Literal.of(DataTypes.STRING, null));
+
+        assertEvaluateNull("trim('foo' FROM name)", Literal.of(DataTypes.STRING, null));
+        assertEvaluateNull("ltrim(name, 'foo')", Literal.of(DataTypes.STRING, null));
+        assertEvaluateNull("rtrim(name, 'foo')", Literal.of(DataTypes.STRING, null));
+        assertEvaluateNull("btrim(name, 'foo')", Literal.of(DataTypes.STRING, null));
+    }
+
+    @Test
+    public void test_evaluate_null_second_arg_on_nonnull_input() {
+        assertEvaluateNull("trim(NULL FROM name)", Literal.of("foo"));
+        assertEvaluateNull("ltrim(name, null)", Literal.of("foo"));
+        assertEvaluateNull("rtrim(name, null)", Literal.of("foo"));
+        assertEvaluateNull("btrim(name, null)", Literal.of("foo"));
     }
 
     @Test


### PR DESCRIPTION
Return `NULL` not only if the input string to trim is `NULL`, but also if the `trimmingText` argument of the functions is `NULL`, thus complying with PostgreSQL behaviour.

Fixes: #15527
