### PR TITLE
Prevent actions that affect roles and privileges during rolling upgrade

### DIFF
--- a/docs/appendices/release-notes/5.6.2.rst
+++ b/docs/appendices/release-notes/5.6.2.rst
@@ -45,6 +45,17 @@ See the :ref:`version_5.6.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that can cause errors during a rolling upgrade to >=
+  :ref:`version_5.6.0` if one of the following command is executed on relations
+  with existing privileges:
+
+  - :ref:`DROP TABLE <drop-table>`
+  - :ref:`DROP VIEW <sql-drop-view>`
+  - :ref:`RENAME TABLE <sql-alter-table-rename-to>`
+  - :ref:`SWAP TABLE <alter_cluster_swap_table>`
+
+  These commands are now rejected until all nodes are upgraded.
+
 - Fixed an issue that caused ``NullPointerException`` to be thrown when
   attempting to rename a table on cluster which has been upgraded from versions
   < :ref:`version_5.6.0` to a version >= :ref:`version_5.6.0`, and there were

--- a/server/src/test/java/io/crate/role/RoleManagerDDLModifierTest.java
+++ b/server/src/test/java/io/crate/role/RoleManagerDDLModifierTest.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
@@ -56,6 +57,7 @@ public class RoleManagerDDLModifierTest extends ESTestCase {
 
         // when
         boolean result = RoleManagerDDLModifier.transferTablePrivileges(
+            Version.CURRENT,
             mdBuilder,
             new RelationName("mySchema", "oldName"),
             new RelationName("mySchema", "newName"));


### PR DESCRIPTION
DROP TABLE/VIEW, RENAME TABLE (includes views), SWAP TABLE all touch user/roles privileges, so they must be rejected during a rolling upgrade from < `5.6.0` to >= `5.6.0`, since there is a
UsersMetadata/UserPrivilegesMedata -> RolesMedatada involved, and the nodes < `5.6.0`, cannot read `RolesMetadata`.
