### PR TITLE
Add JWT token property to Credentials

### DIFF
--- a/server/src/main/java/io/crate/auth/AuthenticationMethod.java
+++ b/server/src/main/java/io/crate/auth/AuthenticationMethod.java
@@ -21,7 +21,6 @@
 
 package io.crate.auth;
 
-import org.elasticsearch.common.settings.SecureString;
 import org.jetbrains.annotations.Nullable;
 
 import io.crate.protocols.postgres.ConnectionProperties;
@@ -30,13 +29,12 @@ import io.crate.role.Role;
 public interface AuthenticationMethod {
 
     /**
-     * @param userName the userName sent with the startup message
-     * @param passwd the password in clear-text or null
+     * @param credentials contains username, password or token - depending on the used method.
      * @return the user or null; null should be handled as if it's a "guest" user
      * @throws RuntimeException if the authentication failed
      */
     @Nullable
-    Role authenticate(String userName, @Nullable SecureString passwd, ConnectionProperties connProperties);
+    Role authenticate(Credentials credentials, ConnectionProperties connProperties);
 
     /**
      * @return unique name of the authentication method

--- a/server/src/main/java/io/crate/auth/HttpAuthUpstreamHandler.java
+++ b/server/src/main/java/io/crate/auth/HttpAuthUpstreamHandler.java
@@ -112,7 +112,7 @@ public class HttpAuthUpstreamHandler extends SimpleChannelInboundHandler<Object>
             sendUnauthorized(ctx.channel(), errorMessage);
         } else {
             try {
-                Role user = authMethod.authenticate(username, credentials.password(), connectionProperties);
+                Role user = authMethod.authenticate(credentials, connectionProperties);
                 if (user != null && LOGGER.isTraceEnabled()) {
                     LOGGER.trace("Authentication succeeded user \"{}\" and method \"{}\".", username, authMethod.name());
                 }

--- a/server/src/main/java/io/crate/auth/PasswordAuthenticationMethod.java
+++ b/server/src/main/java/io/crate/auth/PasswordAuthenticationMethod.java
@@ -21,7 +21,6 @@
 
 package io.crate.auth;
 
-import org.elasticsearch.common.settings.SecureString;
 import org.jetbrains.annotations.Nullable;
 
 import io.crate.protocols.postgres.ConnectionProperties;
@@ -40,15 +39,16 @@ public class PasswordAuthenticationMethod implements AuthenticationMethod {
 
     @Nullable
     @Override
-    public Role authenticate(String userName, SecureString passwd, ConnectionProperties connProperties) {
-        Role user = roles.findUser(userName);
-        if (user != null && passwd != null && passwd.length() > 0) {
+    public Role authenticate(Credentials credentials, ConnectionProperties connProperties) {
+        assert credentials.username() != null : "User name must be not null on password authentication method";
+        Role user = roles.findUser(credentials.username());
+        if (user != null && credentials.password() != null && credentials.password().length() > 0) {
             SecureHash secureHash = user.password();
-            if (secureHash != null && secureHash.verifyHash(passwd)) {
+            if (secureHash != null && secureHash.verifyHash(credentials.password())) {
                 return user;
             }
         }
-        throw new RuntimeException("password authentication failed for user \"" + userName + "\"");
+        throw new RuntimeException("password authentication failed for user \"" + credentials.username() + "\"");
     }
 
     @Override

--- a/server/src/main/java/io/crate/auth/TrustAuthenticationMethod.java
+++ b/server/src/main/java/io/crate/auth/TrustAuthenticationMethod.java
@@ -21,8 +21,6 @@
 
 package io.crate.auth;
 
-import org.elasticsearch.common.settings.SecureString;
-
 import io.crate.protocols.postgres.ConnectionProperties;
 import io.crate.role.Role;
 import io.crate.role.Roles;
@@ -38,10 +36,11 @@ public class TrustAuthenticationMethod implements AuthenticationMethod {
     }
 
     @Override
-    public Role authenticate(String userName, SecureString passwd, ConnectionProperties connectionProperties) {
-        Role user = roles.findUser(userName);
+    public Role authenticate(Credentials credentials, ConnectionProperties connectionProperties) {
+        assert credentials.username() != null : "User name must be not null on trust authentication method";
+        Role user = roles.findUser(credentials.username());
         if (user == null) {
-            throw new RuntimeException("trust authentication failed for user \"" + userName + "\"");
+            throw new RuntimeException("trust authentication failed for user \"" + credentials.username() + "\"");
         }
         return user;
     }

--- a/server/src/main/java/io/crate/protocols/http/Headers.java
+++ b/server/src/main/java/io/crate/protocols/http/Headers.java
@@ -28,7 +28,6 @@ import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpVersion;
-import org.elasticsearch.common.settings.SecureString;
 
 import org.jetbrains.annotations.Nullable;
 import java.nio.charset.StandardCharsets;
@@ -67,11 +66,11 @@ public final class Headers {
     public static Credentials extractCredentialsFromHttpBasicAuthHeader(String authHeaderValue) {
         if (authHeaderValue == null || authHeaderValue.isEmpty()) {
             // Empty credentials.
-            return new Credentials("", new SecureString(new char[] {}));
+            return new Credentials("", new char[] {});
         }
         String username;
         // Empty password by default.
-        SecureString password = new SecureString(new char[] {});
+        char[] password = new char[] {};
         String valueWithoutBasePrefix = authHeaderValue.substring(6);
         String decodedCreds = new String(Base64.getDecoder().decode(valueWithoutBasePrefix), StandardCharsets.UTF_8);
 
@@ -82,7 +81,7 @@ public final class Headers {
             username = decodedCreds.substring(0, idx);
             String passwdStr = decodedCreds.substring(idx + 1);
             if (passwdStr.length() > 0) {
-                password = new SecureString(passwdStr.toCharArray());
+                password = passwdStr.toCharArray();
             }
         }
         return new Credentials(username, password);

--- a/server/src/main/java/io/crate/protocols/postgres/AuthenticationContext.java
+++ b/server/src/main/java/io/crate/protocols/postgres/AuthenticationContext.java
@@ -28,13 +28,13 @@ import org.elasticsearch.common.settings.SecureString;
 import org.jetbrains.annotations.Nullable;
 
 import io.crate.auth.AuthenticationMethod;
+import io.crate.auth.Credentials;
 import io.crate.common.annotations.VisibleForTesting;
 import io.crate.role.Role;
 
 class AuthenticationContext implements Closeable {
 
-    private SecureString password;
-    private final String userName;
+    private final Credentials credentials;
     private final Logger logger;
     private final AuthenticationMethod authMethod;
     private final ConnectionProperties connProperties;
@@ -47,20 +47,22 @@ class AuthenticationContext implements Closeable {
      *
      * @param authMethod The method that is used for authentication. {@link AuthenticationMethod}
      * @param connProperties Additional connection properties
-     * @param userName The name of the user to authenticate.
+     * @param credentials credentials of the user to authenticate.
      * @param logger The logger instance from {@link PostgresWireProtocol}
      */
-    AuthenticationContext(AuthenticationMethod authMethod, ConnectionProperties connProperties, String userName, Logger logger) {
+    AuthenticationContext(AuthenticationMethod authMethod,
+                          ConnectionProperties connProperties,
+                          Credentials credentials,
+                          Logger logger) {
         this.authMethod = authMethod;
         this.connProperties = connProperties;
-        this.userName = userName;
+        this.credentials = credentials;
         this.logger = logger;
-        this.password = null;
     }
 
     @Nullable
     Role authenticate() {
-        Role user = authMethod.authenticate(userName, password, connProperties);
+        Role user = authMethod.authenticate(credentials, connProperties);
         if (user != null && logger.isTraceEnabled()) {
             logger.trace("Authentication succeeded user \"{}\" and method \"{}\".", user.name(), authMethod.name());
         }
@@ -68,13 +70,14 @@ class AuthenticationContext implements Closeable {
     }
 
     void setSecurePassword(char[] secureString) {
-        this.password = new SecureString(secureString);
+        credentials.setPassword(secureString);
     }
 
     @Nullable
     @VisibleForTesting
     SecureString password() {
-        return password;
+        // For PG protocol credentials always holds password.
+        return credentials.password();
     }
 
     /**
@@ -83,8 +86,8 @@ class AuthenticationContext implements Closeable {
      */
     @Override
     public void close() {
-        if (password != null) {
-            password.close();
+        if (credentials != null) {
+            credentials.close();
         }
     }
 }

--- a/server/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
+++ b/server/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
@@ -56,6 +56,7 @@ import io.crate.action.sql.Sessions;
 import io.crate.auth.AccessControl;
 import io.crate.auth.Authentication;
 import io.crate.auth.AuthenticationMethod;
+import io.crate.auth.Credentials;
 import io.crate.auth.Protocol;
 import io.crate.common.annotations.VisibleForTesting;
 import io.crate.common.collections.Lists;
@@ -423,7 +424,12 @@ public class PostgresWireProtocol {
             );
             Messages.sendAuthenticationError(channel, errorMessage);
         } else {
-            authContext = new AuthenticationContext(authMethod, connProperties, userName, LOGGER);
+            authContext = new AuthenticationContext(
+                authMethod,
+                connProperties,
+                new Credentials(userName, null),
+                LOGGER
+            );
             if (PASSWORD_AUTH_NAME.equals(authMethod.name())) {
                 Messages.sendAuthenticationCleartextPassword(channel);
                 return;

--- a/server/src/main/java/org/elasticsearch/transport/netty4/HostBasedAuthHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/netty4/HostBasedAuthHandler.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.network.CloseableChannel;
 import org.elasticsearch.http.netty4.Netty4HttpServerTransport;
 
 import io.crate.auth.Authentication;
+import io.crate.auth.Credentials;
 import io.crate.auth.Protocol;
 import io.crate.protocols.SSL;
 import io.crate.protocols.postgres.ConnectionProperties;
@@ -67,7 +68,7 @@ public class HostBasedAuthHandler extends ChannelInboundHandlerAdapter {
             closeAndThrowException(ctx, msg, authError);
         }
         try {
-            authMethod.authenticate(userName, null, connectionProperties);
+            authMethod.authenticate(new Credentials(userName, null), connectionProperties);
             ctx.pipeline().remove(this);
             super.channelRead(ctx, msg);
         } catch (Exception e) {

--- a/server/src/test/java/io/crate/auth/ClientCertAuthTest.java
+++ b/server/src/test/java/io/crate/auth/ClientCertAuthTest.java
@@ -77,21 +77,21 @@ public class ClientCertAuthTest extends ESTestCase {
     public void testLookupValidUserWithCert() throws Exception {
         ClientCertAuth clientCertAuth = new ClientCertAuth(() -> List.of(exampleUser));
 
-        Role user = clientCertAuth.authenticate("example.com", null, sslConnWithCert);
+        Role user = clientCertAuth.authenticate(new Credentials("example.com", null), sslConnWithCert);
         assertThat(user).isEqualTo(exampleUser);
     }
 
     @Test
     public void testLookupValidUserWithCertWithDifferentCN() throws Exception {
         ClientCertAuth clientCertAuth = new ClientCertAuth(() -> List.of(RolesHelper.userOf("arthur")));
-        assertThatThrownBy(() -> clientCertAuth.authenticate("arthur", null, sslConnWithCert))
+        assertThatThrownBy(() -> clientCertAuth.authenticate(new Credentials("arthur", null), sslConnWithCert))
             .hasMessage("Common name \"example.com\" in client certificate doesn't match username \"arthur\"");
     }
 
     @Test
     public void testLookupUserWithMatchingCertThatDoesNotExist() throws Exception {
         ClientCertAuth clientCertAuth = new ClientCertAuth(List::of);
-        assertThatThrownBy(() -> clientCertAuth.authenticate("example.com", null, sslConnWithCert))
+        assertThatThrownBy(() -> clientCertAuth.authenticate(new Credentials("example.com", null), sslConnWithCert))
             .hasMessage("Client certificate authentication failed for user \"example.com\"");
     }
 
@@ -103,7 +103,7 @@ public class ClientCertAuthTest extends ESTestCase {
             InetAddresses.forString("127.0.0.1"), Protocol.POSTGRES, sslSession);
         ClientCertAuth clientCertAuth = new ClientCertAuth(() -> List.of(exampleUser));
 
-        assertThatThrownBy(() -> clientCertAuth.authenticate("example.com", null, connectionProperties))
+        assertThatThrownBy(() -> clientCertAuth.authenticate(new Credentials("example.com", null), connectionProperties))
             .hasMessage("Client certificate authentication failed for user \"example.com\"");
     }
 
@@ -112,7 +112,7 @@ public class ClientCertAuthTest extends ESTestCase {
         ClientCertAuth clientCertAuth = new ClientCertAuth(() -> List.of(exampleUser));
         ConnectionProperties conn = new ConnectionProperties(InetAddresses.forString("127.0.0.1"), Protocol.HTTP, sslSession);
 
-        assertThatThrownBy(() -> clientCertAuth.authenticate("arthur_is_wrong", null, conn))
+        assertThatThrownBy(() -> clientCertAuth.authenticate(new Credentials("arthur_is_wrong", null), conn))
             .hasMessage("Common name \"example.com\" in client certificate doesn't match username \"arthur_is_wrong\"");
     }
 }

--- a/server/src/test/java/io/crate/auth/UserAuthenticationMethodTest.java
+++ b/server/src/test/java/io/crate/auth/UserAuthenticationMethodTest.java
@@ -58,9 +58,9 @@ public class UserAuthenticationMethodTest extends ESTestCase {
     public void testTrustAuthentication() throws Exception {
         TrustAuthenticationMethod trustAuth = new TrustAuthenticationMethod(new CrateOrNullRoles());
         assertThat(trustAuth.name()).isEqualTo("trust");
-        assertThat(trustAuth.authenticate("crate", null, null).name()).isEqualTo("crate");
+        assertThat(trustAuth.authenticate(new Credentials("crate", null), null).name()).isEqualTo("crate");
 
-        assertThatThrownBy(() -> trustAuth.authenticate("cr8", null, null))
+        assertThatThrownBy(() -> trustAuth.authenticate(new Credentials("cr8", null), null))
             .hasMessage("trust authentication failed for user \"cr8\"");
     }
 
@@ -70,9 +70,9 @@ public class UserAuthenticationMethodTest extends ESTestCase {
         AuthenticationMethod alwaysOkAuthMethod = alwaysOkAuth.resolveAuthenticationType("crate", null);
 
         assertThat(alwaysOkAuthMethod.name()).isEqualTo("trust");
-        assertThat(alwaysOkAuthMethod.authenticate("crate", null, null).name()).isEqualTo("crate");
+        assertThat(alwaysOkAuthMethod.authenticate(new Credentials("crate", null), null).name()).isEqualTo("crate");
 
-        assertThatThrownBy(() -> alwaysOkAuthMethod.authenticate("cr8", null, null))
+        assertThatThrownBy(() -> alwaysOkAuthMethod.authenticate(new Credentials("cr8", null), null))
             .hasMessage("trust authentication failed for user \"cr8\"");
     }
 
@@ -80,7 +80,7 @@ public class UserAuthenticationMethodTest extends ESTestCase {
         PasswordAuthenticationMethod pwAuth = new PasswordAuthenticationMethod(new CrateOrNullRoles());
         assertThat(pwAuth.name()).isEqualTo("password");
 
-        assertThat(pwAuth.authenticate("crate", new SecureString("pw".toCharArray()), null).name()).isEqualTo("crate");
+        assertThat(pwAuth.authenticate(new Credentials("crate", "pw".toCharArray()), null).name()).isEqualTo("crate");
     }
 
     @Test
@@ -88,7 +88,7 @@ public class UserAuthenticationMethodTest extends ESTestCase {
         PasswordAuthenticationMethod pwAuth = new PasswordAuthenticationMethod(new CrateOrNullRoles());
         assertThat(pwAuth.name()).isEqualTo("password");
 
-        assertThatThrownBy(() -> pwAuth.authenticate("crate", new SecureString("wrong".toCharArray()), null))
+        assertThatThrownBy(() -> pwAuth.authenticate(new Credentials("crate", "wrong".toCharArray()), null))
             .hasMessage("password authentication failed for user \"crate\"");
 
     }
@@ -96,7 +96,7 @@ public class UserAuthenticationMethodTest extends ESTestCase {
     @Test
     public void testPasswordAuthenticationForNonExistingUser() throws Exception {
         PasswordAuthenticationMethod pwAuth = new PasswordAuthenticationMethod(new CrateOrNullRoles());
-        assertThatThrownBy(() -> pwAuth.authenticate("cr8", new SecureString("pw".toCharArray()), null))
+        assertThatThrownBy(() -> pwAuth.authenticate(new Credentials("cr8", "pw".toCharArray()), null))
             .hasMessage("password authentication failed for user \"cr8\"");
     }
 }

--- a/server/src/test/java/io/crate/protocols/postgres/AuthenticationContextTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/AuthenticationContextTest.java
@@ -34,6 +34,7 @@ import org.junit.Test;
 import io.crate.auth.AlwaysOKAuthentication;
 import io.crate.auth.Authentication;
 import io.crate.auth.AuthenticationMethod;
+import io.crate.auth.Credentials;
 import io.crate.auth.Protocol;
 import io.crate.role.Role;
 
@@ -50,7 +51,7 @@ public class AuthenticationContextTest extends ESTestCase {
             InetAddress.getByName("127.0.0.1"), Protocol.POSTGRES, null);
         AuthenticationMethod authMethod = AUTHENTICATION.resolveAuthenticationType(userName, connProperties);
         AuthenticationContext authContext = new AuthenticationContext(
-            authMethod, connProperties, userName, LogManager.getLogger(AuthenticationContextTest.class));
+            authMethod, connProperties, new Credentials(userName, null), LogManager.getLogger(AuthenticationContextTest.class));
         authContext.setSecurePassword(passwd);
         assertThat(authContext.authenticate(), is(Role.CRATE_USER));
         assertThat(authContext.password().getChars(), is(passwd));

--- a/server/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
@@ -48,7 +48,6 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.client.Client;
-import org.elasticsearch.common.settings.SecureString;
 import org.jetbrains.annotations.Nullable;
 import org.junit.After;
 import org.junit.Before;
@@ -65,6 +64,7 @@ import io.crate.action.sql.Sessions;
 import io.crate.auth.AccessControl;
 import io.crate.auth.AlwaysOKAuthentication;
 import io.crate.auth.AuthenticationMethod;
+import io.crate.auth.Credentials;
 import io.crate.exceptions.JobKilledException;
 import io.crate.execution.jobs.kill.KillJobsNodeRequest;
 import io.crate.metadata.settings.CoordinatorSessionSettings;
@@ -537,7 +537,7 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
                 chPipeline -> {},
                 (user, connectionProperties) -> new AuthenticationMethod() {
                     @Override
-                    public Role authenticate(String userName, @Nullable SecureString passwd, ConnectionProperties connProperties) {
+                    public Role authenticate(Credentials credentials, ConnectionProperties connProperties) {
                         return RolesHelper.userOf("dummy");
                     }
 


### PR DESCRIPTION
Add JWT token property to Credentials

Also
- use Credentials in PG protocol
- use Credentials in AuthenticationMethod interface

Supersedes https://github.com/crate/crate/pull/15497/

Token is stored in regular string:
1.  It doesn't contain sensitive content, no need to make it SecureString
2. To avoid extra wrap to SecureString -> unwrap before decode round trip

Also, it means no more `tokenOrPassword` on the contrary to https://github.com/crate/crate/pull/15497/