### PR TITLE
Enforce searchPath order when resolving tables and views

### DIFF
--- a/docs/appendices/release-notes/5.6.2.rst
+++ b/docs/appendices/release-notes/5.6.2.rst
@@ -107,3 +107,23 @@ Fixes
 - Fixed a race condition that could lead to ``ShardCollectContext already
   added`` errors when making a query after a table had been idle without any
   accesses for a while.
+
+- Fixed an issue when resolving relations. When resolving an unqualified name
+  (no explicit schema), it first exhausted the search path looking for tables
+  before moving on to views. Now it will correctly look for both table and view
+  in each element of the search path before moving onto the next.
+
+  For example, with a search path set to ``a, b``, a query on ``tbl`` will now
+  look for:
+
+  - table ``a.tbl``
+  - view ``a.tbl``
+  - table ``b.tbl``
+  - view ``b.tbl``
+
+  Instead of:
+
+  - table ``a.tbl``
+  - table ``b.tbl``
+  - view ``a.tbl``
+  - view ``b.tbl``

--- a/server/src/main/java/io/crate/metadata/doc/DocSchemaInfo.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocSchemaInfo.java
@@ -189,7 +189,8 @@ public class DocSchemaInfo implements SchemaInfo {
     }
 
     @Nullable
-    private ViewInfo getViewInfo(String name) {
+    @Override
+    public ViewInfo getViewInfo(String name) {
         return viewInfoFactory.create(new RelationName(schemaName, name), clusterService.state());
     }
 

--- a/server/src/main/java/io/crate/metadata/table/Operation.java
+++ b/server/src/main/java/io/crate/metadata/table/Operation.java
@@ -26,6 +26,7 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import io.crate.common.collections.MapBuilder;
 import org.elasticsearch.common.settings.Settings;
 import io.crate.common.collections.Sets;
+import io.crate.metadata.RelationInfo;
 
 import java.util.EnumSet;
 import java.util.Locale;
@@ -116,27 +117,27 @@ public enum Operation {
         return subscriptionName != null && subscriptionName.isEmpty() == false;
     }
 
-    public static void blockedRaiseException(TableInfo tableInfo, Operation operation) {
-        if (!tableInfo.supportedOperations().contains(operation)) {
+    public static void blockedRaiseException(RelationInfo relationInfo, Operation operation) {
+        if (!relationInfo.supportedOperations().contains(operation)) {
             String exceptionMessage;
             // If the only supported operation is open/close, then the table must be closed.
-            if (tableInfo.supportedOperations().equals(CLOSED_OPERATIONS)) {
+            if (relationInfo.supportedOperations().equals(CLOSED_OPERATIONS)) {
                 exceptionMessage = "The relation \"%s\" doesn't support or allow %s operations, as it is currently " +
                                    "closed.";
-            } else if (tableInfo.supportedOperations().equals(SUBSCRIBED_IN_LOGICAL_REPLICATION)) {
+            } else if (relationInfo.supportedOperations().equals(SUBSCRIBED_IN_LOGICAL_REPLICATION)) {
                 exceptionMessage = "The relation \"%s\" doesn't allow %s operations, because it is included in a " +
                                    "logical replication subscription.";
-            } else if (tableInfo.supportedOperations().equals(PUBLISHED_IN_LOGICAL_REPLICATION)) {
+            } else if (relationInfo.supportedOperations().equals(PUBLISHED_IN_LOGICAL_REPLICATION)) {
                 exceptionMessage = "The relation \"%s\" doesn't allow %s operations, because it is included in a " +
                                    "logical replication publication.";
-            } else if (tableInfo.supportedOperations().equals(SYS_READ_ONLY) ||
-                       tableInfo.supportedOperations().equals(READ_ONLY)) {
+            } else if (relationInfo.supportedOperations().equals(SYS_READ_ONLY) ||
+                relationInfo.supportedOperations().equals(READ_ONLY)) {
                 exceptionMessage = "The relation \"%s\" doesn't support or allow %s operations, as it is read-only.";
             } else {
                 exceptionMessage = "The relation \"%s\" doesn't support or allow %s operations.";
             }
-            throw new OperationOnInaccessibleRelationException(tableInfo.ident(), String.format(Locale.ENGLISH,
-                exceptionMessage, tableInfo.ident().fqn(), operation));
+            throw new OperationOnInaccessibleRelationException(relationInfo.ident(), String.format(Locale.ENGLISH,
+                exceptionMessage, relationInfo.ident().fqn(), operation));
         }
     }
 

--- a/server/src/main/java/io/crate/metadata/table/SchemaInfo.java
+++ b/server/src/main/java/io/crate/metadata/table/SchemaInfo.java
@@ -31,6 +31,11 @@ public interface SchemaInfo extends AutoCloseable {
     @Nullable
     TableInfo getTableInfo(String name);
 
+    @Nullable
+    default ViewInfo getViewInfo(String name) {
+        return null;
+    }
+
     String name();
 
     void invalidateTableCache(String tableName);

--- a/server/src/main/java/io/crate/metadata/view/ViewInfo.java
+++ b/server/src/main/java/io/crate/metadata/view/ViewInfo.java
@@ -37,6 +37,7 @@ import io.crate.metadata.Reference;
 import io.crate.metadata.RelationInfo;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
+import io.crate.metadata.SearchPath;
 import io.crate.metadata.table.Operation;
 
 public class ViewInfo implements RelationInfo {
@@ -45,13 +46,15 @@ public class ViewInfo implements RelationInfo {
     private final String definition;
     private final List<Reference> columns;
     private final String owner;
+    private final SearchPath searchPath;
 
     @VisibleForTesting
-    public ViewInfo(RelationName ident, String definition, List<Reference> columns, @Nullable String owner) {
+    public ViewInfo(RelationName ident, String definition, List<Reference> columns, @Nullable String owner, SearchPath searchPath) {
         this.ident = ident;
         this.definition = definition;
         this.columns = columns;
         this.owner = owner;
+        this.searchPath = searchPath;
     }
 
     @Override
@@ -106,5 +109,9 @@ public class ViewInfo implements RelationInfo {
     @Nullable
     public String owner() {
         return owner;
+    }
+
+    public SearchPath searchPath() {
+        return searchPath;
     }
 }

--- a/server/src/main/java/io/crate/metadata/view/ViewInfoFactory.java
+++ b/server/src/main/java/io/crate/metadata/view/ViewInfoFactory.java
@@ -89,6 +89,6 @@ public class ViewInfoFactory {
             analyzeError = true;
         }
         String viewDefinition = analyzeError ? String.format(Locale.ENGLISH, "/* Corrupted view, needs fix */\n%s", view.stmt()) : view.stmt();
-        return new ViewInfo(ident, viewDefinition, columns, view.owner());
+        return new ViewInfo(ident, viewDefinition, columns, view.owner(), view.searchPath());
     }
 }

--- a/server/src/test/java/io/crate/metadata/pgcatalog/OidHashTest.java
+++ b/server/src/test/java/io/crate/metadata/pgcatalog/OidHashTest.java
@@ -38,6 +38,7 @@ import org.junit.Test;
 
 import io.crate.metadata.RelationInfo;
 import io.crate.metadata.Schemas;
+import io.crate.metadata.SearchPath;
 import io.crate.metadata.table.ConstraintInfo;
 import io.crate.metadata.view.ViewInfo;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
@@ -47,7 +48,7 @@ import io.crate.types.TypeSignature;
 
 public class OidHashTest extends CrateDummyClusterServiceUnitTest {
 
-    private static final RelationInfo VIEW_INFO = new ViewInfo(T1, "", Collections.emptyList(), null);
+    private static final RelationInfo VIEW_INFO = new ViewInfo(T1, "", Collections.emptyList(), null, SearchPath.pathWithPGCatalogAndDoc());
     private RelationInfo t1Info;
 
     @Before


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes https://github.com/crate/crate/issues/15516.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
