### PR TITLE
Add support of JWT token authentication 

### DIFF
--- a/docs/admin/auth/hba.rst
+++ b/docs/admin/auth/hba.rst
@@ -97,6 +97,10 @@ For example, a host based configuration can look like this:
             protocol: http
             address: 127.0.0.1
             ssl: off
+          g:
+            user: john
+            method: jwt
+            protocol: http
           z:
             method: password
 
@@ -141,6 +145,10 @@ the user ``trinity`` can authenticate to CrateDB over HTTP from the
 authentication method is specified, the ``trust`` method will be used by
 default.
 
+``{user: john, method: jwt, protocol: http}`` means
+that the user ``john`` can authenticate to CrateDB over HTTP protocol using the
+:ref:`JWT <auth_jwt>` method.
+
 And finally the entry ``{method: password}`` means that any existing user (or
 superuser) can authenticate to CrateDB from any IP address using the
 ``password`` method for both HTTP and PostgreSQL wire protocol.
@@ -148,6 +156,14 @@ superuser) can authenticate to CrateDB from any IP address using the
 .. NOTE::
 
    For general help managing users and roles, see :ref:`administration_user_management`.
+
+.. NOTE::
+
+   User in the HBA entry for ``method: jwt`` must match the user created by
+   :ref:`ref-create-user` statement. ``CREATE USER`` is case insensitive when
+   name is provided without quotes, see :ref:`sql_lexical_keywords_identifiers`.
+   Thus, if HBA entry has username with uppercase symbols, use ``CREATE USER``
+   with quotes.
 
 
 .. _admin_hba_user:

--- a/docs/admin/auth/methods.rst
+++ b/docs/admin/auth/methods.rst
@@ -108,6 +108,45 @@ applies to the PostgreSQL wire protocol, as there the username isn't optional.
 Please consult the relevant client documentations for instructions on how to
 connect using SSL with client certificate.
 
+.. _auth_jwt:
+
+JWT authentication method
+=========================
+
+JWT authentication allows to delegate part of the authentication process to an
+external service.
+
+The external service is responsible for issuing a `JWT`_ access token for the
+user. The user then provides this token, prefixed with ``Bearer`` in the
+``Authorization`` HTTP header to CrateDB.
+CrateDB will validate the token and match it to a user created with ``CREATE
+USER`` with ``JWT`` properties that match those of the provided ``JWT`` token.
+
+Token must contain the following claims:
+``kid`` - `Key ID`_.
+``iss`` - URL of the `JWK endpoint`_.
+``username`` - user name in a third party app.
+
+``iss`` and  ``username`` values must match the values created by
+``CREATE USER`` statement. See :ref:`create-user-jwt` for details.
+
+It's recommended to have ``exp`` (`expiration date`_ as epoch seconds) in the
+header. If it's provided, the token's expiration date will be checked against
+the local system's time in UTC.
+
+Supported signing algorithms are RSA-256, RSA-384 and RSA-512.
+The algorithm to verify the signature is decided on the JWK endpoint's ``alg``
+value. If the ``alg`` value is not provided, RSA-256 is used (default).
+
+It's recommended to have the ``alg`` (`Algorithm parameter`_)  in the header.
+If it's provided both in the token and in the response from the JWK endpoint,
+both values are compared and in case of a mismatch the token is rejected.
+
+.. NOTE::
+
+   JWT is supported only for the HTTP protocol. An :ref:`HBA <admin_hba>` entry
+   for ``jwt`` MUST be combined with ``protocol: http``.
+
 .. SEEALSO::
 
   :ref:`admin_hba`
@@ -117,4 +156,9 @@ connect using SSL with client certificate.
 .. _PBKDF2: https://en.wikipedia.org/wiki/PBKDF2
 .. _SHA-512 hash algorithm: https://en.wikipedia.org/wiki/SHA-2
 .. _HTTP Basic Authentication: https://en.wikipedia.org/wiki/Basic_access_authentication
+.. _JWK endpoint: https://datatracker.ietf.org/doc/html/rfc7517
 .. _BASE64: https://en.wikipedia.org/wiki/Base64
+.. _JWT: https://datatracker.ietf.org/doc/html/rfc7519
+.. _Key ID: https://datatracker.ietf.org/doc/html/rfc7517#section-4.5
+.. _expiration date: https://www.rfc-editor.org/rfc/rfc7519#section-4.1.4
+.. _Algorithm parameter: https://datatracker.ietf.org/doc/html/rfc7517#section-4.4

--- a/docs/appendices/release-notes/5.7.0.rst
+++ b/docs/appendices/release-notes/5.7.0.rst
@@ -104,6 +104,8 @@ Administration and Operations
 - Added ``jwt`` column to :ref:`sys.users<sys-users>` table which lists JWT
   authentication specific properties of the user.
 
+- Added support for :ref:`JWT token authentication <auth_jwt>`.
+
 User Interface
 --------------
 

--- a/docs/config/node.rst
+++ b/docs/config/node.rst
@@ -601,10 +601,10 @@ The meaning of the fields of the are as follows:
   | *Runtime:* ``no``
 
   | The authentication method to use when a connection matches this entry.
-  | Valid values are ``trust``, ``cert``, and ``password``. If no method is
-  | specified, the ``trust`` method is used by default.
-  | See :ref:`auth_trust`, :ref:`auth_cert` and :ref:`auth_password` for more
-  | information about these methods.
+  | Valid values are ``trust``, ``cert``, ``password`` and ``jwt``. If no
+  | method is specified, the ``trust`` method is used by default.
+  | See :ref:`auth_trust`, :ref:`auth_cert`, :ref:`auth_password` and
+  | :ref:`auth_jwt` for more information about these methods.
 
 .. _auth.host_based.config.${order}.protocol:
 

--- a/docs/sql/statements/create-user.rst
+++ b/docs/sql/statements/create-user.rst
@@ -82,6 +82,8 @@ The following ``user_parameter`` are supported to define a new user account:
 
 .. vale off
 
+.. _create-user-jwt:
+
 :jwt:
   JWT properties map ('iss' and 'username') entered as string literal. e.g.::
 
@@ -92,6 +94,10 @@ The following ``user_parameter`` are supported to define a new user account:
   ``username`` is a user name in a third party app.
 
   Combination of ``iss`` and ``username`` must be unique.
+
+.. SEEALSO::
+
+  :ref:`auth_jwt`
 
 .. vale on
 

--- a/pom.xml
+++ b/pom.xml
@@ -262,6 +262,8 @@
     <versions.commonsmath>3.6.1</versions.commonsmath>
     <versions.jaxb_api>2.3.1</versions.jaxb_api>
     <versions.graalvm>23.0.3</versions.graalvm>
+    <versions.jwt>4.4.0</versions.jwt>
+    <versions.jwks-rsa>0.22.1</versions.jwks-rsa>
 
     <versions.google.gax>2.43.0</versions.google.gax>
     <versions.google.auth>1.23.0</versions.google.auth>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -409,5 +409,18 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>com.auth0</groupId>
+      <artifactId>java-jwt</artifactId>
+      <version>${versions.jwt}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.auth0</groupId>
+      <artifactId>jwks-rsa</artifactId>
+      <version>${versions.jwks-rsa}</version>
+
+    </dependency>
+
   </dependencies>
 </project>

--- a/server/src/main/java/io/crate/auth/AlwaysOKAuthentication.java
+++ b/server/src/main/java/io/crate/auth/AlwaysOKAuthentication.java
@@ -24,6 +24,7 @@ package io.crate.auth;
 import io.crate.role.Roles;
 import io.crate.protocols.postgres.ConnectionProperties;
 import org.elasticsearch.common.inject.Inject;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Fallback if host-based authentication is disabled
@@ -39,7 +40,7 @@ public class AlwaysOKAuthentication implements Authentication {
     }
 
     @Override
-    public AuthenticationMethod resolveAuthenticationType(String user, ConnectionProperties connectionProperties) {
+    public AuthenticationMethod resolveAuthenticationType(@Nullable String user, ConnectionProperties connectionProperties) {
         return new TrustAuthenticationMethod(roles);
     }
 }

--- a/server/src/main/java/io/crate/auth/AuthenticationHttpAuthHandlerRegistry.java
+++ b/server/src/main/java/io/crate/auth/AuthenticationHttpAuthHandlerRegistry.java
@@ -22,6 +22,7 @@
 package io.crate.auth;
 
 import io.crate.netty.channel.PipelineRegistry;
+import io.crate.role.Roles;
 
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
@@ -36,11 +37,12 @@ public class AuthenticationHttpAuthHandlerRegistry {
     @Inject
     public AuthenticationHttpAuthHandlerRegistry(Settings settings,
                                                  PipelineRegistry pipelineRegistry,
-                                                 Authentication authentication) {
+                                                 Authentication authentication,
+                                                 Roles roles) {
         PipelineRegistry.ChannelPipelineItem pipelineItem = new PipelineRegistry.ChannelPipelineItem(
             "blob_handler",
             "auth_handler",
-            ignored -> new HttpAuthUpstreamHandler(settings, authentication)
+            ignored -> new HttpAuthUpstreamHandler(settings, authentication, roles)
         );
         pipelineRegistry.addBefore(pipelineItem);
     }

--- a/server/src/main/java/io/crate/auth/JWTAuthenticationMethod.java
+++ b/server/src/main/java/io/crate/auth/JWTAuthenticationMethod.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.auth;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.security.PublicKey;
+import java.security.interfaces.RSAPublicKey;
+import java.util.Locale;
+import java.util.function.Function;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import com.auth0.jwk.Jwk;
+import com.auth0.jwk.JwkException;
+import com.auth0.jwk.JwkProvider;
+import com.auth0.jwk.JwkProviderBuilder;
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.auth0.jwt.interfaces.Verification;
+
+import io.crate.protocols.postgres.ConnectionProperties;
+import io.crate.role.Role;
+import io.crate.role.Roles;
+
+public class JWTAuthenticationMethod implements AuthenticationMethod {
+
+    public static final String NAME = "jwt";
+
+    private final Roles roles;
+
+    private final Function<String, JwkProvider> urlToJwkProvider;
+
+
+    public JWTAuthenticationMethod(Roles roles, Function<String, JwkProvider> urlToJwkProvider) {
+        this.roles = roles;
+        this.urlToJwkProvider = urlToJwkProvider;
+    }
+
+    @Override
+    public @Nullable Role authenticate(Credentials credentials, ConnectionProperties connProperties) {
+        var username = credentials.username();
+        assert username != null : "User name must be resolved before authentication attempt";
+        var decodedJWT = credentials.decodedToken();
+        assert decodedJWT != null : "Token must be not null on jwt auth";
+
+        Role user = roles.findUser(username);
+        if (user == null) {
+            throw new RuntimeException("jwt authentication failed for user \"" + username + "\"");
+        }
+
+        try {
+            JwkProvider jwkProvider = urlToJwkProvider.apply(decodedJWT.getIssuer());
+            Algorithm algorithm = resolveAlgorithm(jwkProvider, decodedJWT);
+
+            var jwtProperties = user.jwtProperties();
+            assert jwtProperties != null : "Resolved user must have jwt properties";
+            // Expiration date is checked by default(if provided in token)
+            Verification verification = JWT.require(algorithm)
+                // withers below are not needed for payload signature check.
+                // It's an extra step on top of signature verification to double check that user metadata matches token payload.
+                .withIssuer(jwtProperties.iss())
+                .withClaim("username", jwtProperties.username());
+
+            JWTVerifier verifier = verification.build();
+            verifier.verify(decodedJWT);
+
+        } catch (Exception e) {
+            throw new RuntimeException(
+                String.format(
+                    Locale.ENGLISH,
+                    "jwt authentication failed for user %s. Reason: %s",
+                    username,
+                    e.getMessage()
+                )
+            );
+        }
+
+        return user;
+    }
+
+
+    public static JwkProvider jwkProvider(@NotNull String issuer) {
+        URL jwkUrl;
+        try {
+            /*
+             We cannot use JwkProviderBuilder constructor with String.
+             It adds hard coded WELL_KNOWN_JWKS_PATH (/.well-known/jwks.json) to the url.
+             JWK URL not necessarily ends with that suffix, for example:
+             Microsoft: "jwks_uri":" https://login.microsoftonline.com/common/discovery/v2.0/keys"
+             Google: "jwks_uri": "https://www.googleapis.com/oauth2/v3/certs",
+             Taken from https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration
+             and https://accounts.google.com/.well-known/openid-configuration correspondingly
+            */
+
+            URI uri = new URI(issuer).normalize();
+            jwkUrl = uri.toURL();
+        } catch (MalformedURLException | URISyntaxException e) {
+            throw new IllegalArgumentException("Invalid jwks uri", e);
+        }
+
+        return new JwkProviderBuilder(jwkUrl).build();
+    }
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    /**
+     * Resolved algorithm based on the endpoint info.
+     * Cannot resolve algorithm based on the token header as it's optional and unsafe.
+     * If token has "alg" claim, it's checked against JWK info and in case of mismatch, error is thrown.
+     * If JWK info doesn't have "alg" (it's optional for endpoint response as well), we fall back to RSA256.
+     */
+    private static Algorithm resolveAlgorithm(JwkProvider jwkProvider,
+                                              @NotNull DecodedJWT decodedJWT) throws JwkException {
+        Jwk jwk = jwkProvider.get(decodedJWT.getKeyId());
+        PublicKey publicKey = jwk.getPublicKey();
+        if (publicKey instanceof RSAPublicKey == false) {
+            throw new UnsupportedOperationException("Only RSA algorithm is supported for JWT");
+        }
+        RSAPublicKey rsaPublicKey = (RSAPublicKey) publicKey;
+
+        // Default.
+        if (jwk.getAlgorithm() == null) {
+            return Algorithm.RSA256(new LoadedRSAKeyProvider(rsaPublicKey));
+        }
+
+        // Try to validate resolved info with token (if both JWK and token are not null).
+        if (decodedJWT.getAlgorithm() != null && decodedJWT.equals(jwk.getAlgorithm()) == false) {
+            throw new IllegalArgumentException("Jwt token has algorithm not matching with the algorithm of the public key.");
+        }
+
+        return switch (jwk.getAlgorithm()) {
+            case "RS256" -> Algorithm.RSA256(new LoadedRSAKeyProvider(rsaPublicKey));
+            case "RS384" -> Algorithm.RSA384(new LoadedRSAKeyProvider(rsaPublicKey));
+            case "RS512" -> Algorithm.RSA512(new LoadedRSAKeyProvider(rsaPublicKey));
+            default ->
+                throw new RuntimeException(
+                    String.format(
+                        Locale.ENGLISH,
+                        "Unsupported algorithm %s",
+                        jwk.getAlgorithm()
+                    )
+                );
+        };
+
+    }
+}

--- a/server/src/main/java/io/crate/auth/LoadedRSAKeyProvider.java
+++ b/server/src/main/java/io/crate/auth/LoadedRSAKeyProvider.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.  You may
  * obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
@@ -21,12 +21,32 @@
 
 package io.crate.auth;
 
-import io.crate.protocols.postgres.ConnectionProperties;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
 
-import org.jetbrains.annotations.Nullable;
+import com.auth0.jwt.interfaces.RSAKeyProvider;
 
-public interface Authentication {
+public class LoadedRSAKeyProvider implements RSAKeyProvider {
 
-    @Nullable
-    AuthenticationMethod resolveAuthenticationType(@Nullable String user, ConnectionProperties connectionProperties);
+    private final RSAPublicKey rsaPublicKey;
+
+
+    public LoadedRSAKeyProvider(RSAPublicKey rsaPublicKey) {
+        this.rsaPublicKey = rsaPublicKey;
+    }
+
+    @Override
+    public RSAPublicKey getPublicKeyById(String keyId) {
+        return rsaPublicKey;
+    }
+
+    @Override
+    public RSAPrivateKey getPrivateKey() {
+        return null;
+    }
+
+    @Override
+    public String getPrivateKeyId() {
+        return null;
+    }
 }

--- a/server/src/main/java/io/crate/protocols/http/Headers.java
+++ b/server/src/main/java/io/crate/protocols/http/Headers.java
@@ -32,6 +32,7 @@ import io.netty.handler.codec.http.HttpVersion;
 import org.jetbrains.annotations.Nullable;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.Locale;
 import java.util.regex.Pattern;
 
 public final class Headers {
@@ -63,15 +64,30 @@ public final class Headers {
         }
     }
 
-    public static Credentials extractCredentialsFromHttpBasicAuthHeader(String authHeaderValue) {
+    /**
+     * An entry point for HTTP authentication, forwards to either Basic or JWT, depending on header.
+     * @param authHeaderValue contains authentication schema (basic or bearer) and auth payload (token or password) separated by space.
+     * Authentication schema is case-insensitive: <a href="https://datatracker.ietf.org/doc/html/rfc7235?ref=blog.teknkl.com#section-2.1">spec</a>
+     */
+    public static Credentials extractCredentialsFromHttpAuthHeader(String authHeaderValue) {
         if (authHeaderValue == null || authHeaderValue.isEmpty()) {
             // Empty credentials.
-            return new Credentials("", new char[] {});
+            return new Credentials(null, null);
         }
+        String[] splitHeader = authHeaderValue.split(" ");
+        assert splitHeader.length == 2 :
+            "Header must contain only authentication schema and base64 encoded value, separated by a whitespace";
+        return switch (splitHeader[0].toLowerCase(Locale.ENGLISH)) {
+            case "basic" -> extractCredentialsFromHttpBasicAuthHeader(splitHeader[1]);
+            case "bearer" -> new Credentials(splitHeader[1]);
+            default ->
+                    throw new IllegalArgumentException("Only basic or bearer HTTP Authentication schemas are allowed.");
+        };
+    }
+
+    private static Credentials extractCredentialsFromHttpBasicAuthHeader(String valueWithoutBasePrefix) {
         String username;
-        // Empty password by default.
-        char[] password = new char[] {};
-        String valueWithoutBasePrefix = authHeaderValue.substring(6);
+        char[] password = null;
         String decodedCreds = new String(Base64.getDecoder().decode(valueWithoutBasePrefix), StandardCharsets.UTF_8);
 
         int idx = decodedCreds.indexOf(':');
@@ -80,7 +96,7 @@ public final class Headers {
         } else {
             username = decodedCreds.substring(0, idx);
             String passwdStr = decodedCreds.substring(idx + 1);
-            if (passwdStr.length() > 0) {
+            if (!passwdStr.isEmpty()) {
                 password = passwdStr.toCharArray();
             }
         }

--- a/server/src/main/java/io/crate/rest/action/SqlHttpHandler.java
+++ b/server/src/main/java/io/crate/rest/action/SqlHttpHandler.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -55,6 +56,7 @@ import io.crate.action.sql.parser.SQLRequestParser;
 import io.crate.auth.AccessControl;
 import io.crate.auth.AuthSettings;
 import io.crate.auth.Credentials;
+import io.crate.auth.HttpAuthUpstreamHandler;
 import io.crate.breaker.TypedRowAccounting;
 import io.crate.common.annotations.VisibleForTesting;
 import io.crate.data.breaker.BlockBasedRamAccounting;
@@ -294,8 +296,21 @@ public class SqlHttpHandler extends SimpleChannelInboundHandler<FullHttpRequest>
             });
     }
 
+    /**
+     * Doesn't do authentication as it's already done
+     * in {@link HttpAuthUpstreamHandler} which is registered before this handler
+     * Checks user existence and if not possible to resolve from header (basic or jwt),
+     * returns trusted user from configuration.
+     */
     Role userFromAuthHeader(@Nullable String authHeaderValue) {
-        try (Credentials credentials = Headers.extractCredentialsFromHttpBasicAuthHeader(authHeaderValue)) {
+        try (Credentials credentials = Headers.extractCredentialsFromHttpAuthHeader(authHeaderValue)) {
+            Predicate<Role> rolePredicate = credentials.jwtPropertyMatch();
+            if (rolePredicate != null) {
+                Role role = roles.findUser(rolePredicate);
+                if (role != null) {
+                    credentials.setUsername(role.name());
+                }
+            }
             String username = credentials.username();
             // Fallback to trusted user from configuration
             if (username == null || username.isEmpty()) {

--- a/server/src/main/java/io/crate/role/Roles.java
+++ b/server/src/main/java/io/crate/role/Roles.java
@@ -28,6 +28,7 @@ import static io.crate.role.Policy.REVOKE;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -57,6 +58,20 @@ public interface Roles {
         Role role = findRole(userName);
         if (role != null && role.isUser()) {
             return role;
+        }
+        return null;
+    }
+
+    /**
+     * Finds a user by given predicate
+     */
+    @Nullable
+    default Role findUser(Predicate<Role> predicate) {
+        for (var role : roles()) {
+            if (predicate.test(role)) {
+                return role;
+            }
+
         }
         return null;
     }

--- a/server/src/test/java/io/crate/auth/CredentialsTest.java
+++ b/server/src/test/java/io/crate/auth/CredentialsTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.auth;
+
+import static io.crate.testing.auth.RsaKeys.PRIVATE_KEY_256;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.security.KeyFactory;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Base64;
+import java.util.Map;
+
+import org.elasticsearch.test.ESTestCase;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+
+public class CredentialsTest extends ESTestCase {
+
+    private static RSAPrivateKey privateKey;
+
+    @BeforeClass
+    public static void prepareSigningKey() throws Exception {
+        PKCS8EncodedKeySpec privateKeySpec = new PKCS8EncodedKeySpec(Base64.getDecoder().decode(PRIVATE_KEY_256));
+        KeyFactory kf = KeyFactory.getInstance("RSA");
+        privateKey = (RSAPrivateKey) kf.generatePrivate(privateKeySpec);
+    }
+
+    @Test
+    @SuppressWarnings("resource")
+    public void test_checks_presence_of_public_key_id() {
+        String jwt = JWT.create()
+            .withHeader(Map.of("typ", "JWT", "alg", "RS256"))
+            .sign(Algorithm.RSA256(null, privateKey));
+        assertThatThrownBy(() -> new Credentials(jwt))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("The JWT token must contain a public key id (kid)");
+    }
+
+    @Test
+    @SuppressWarnings("resource")
+    public void test_checks_presence_of_issuer() {
+        String jwt = JWT.create()
+            .withHeader(Map.of("typ", "JWT", "alg", "RS256", "kid", "1"))
+            .sign(Algorithm.RSA256(null, privateKey));
+        assertThatThrownBy(() -> new Credentials(jwt))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("The JWT token must contain an issuer (iss)");
+    }
+
+    @Test
+    @SuppressWarnings("resource")
+    public void test_checks_presence_of_username() {
+        String jwt = JWT.create()
+            .withHeader(Map.of("typ", "JWT", "alg", "RS256", "kid", "1"))
+            .withIssuer("test_issuer")
+            .sign(Algorithm.RSA256(null, privateKey));
+        assertThatThrownBy(() -> new Credentials(jwt))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("The JWT token must contain a 'username' claim");
+    }
+}

--- a/server/src/test/java/io/crate/auth/HttpAuthUpstreamHandlerTest.java
+++ b/server/src/test/java/io/crate/auth/HttpAuthUpstreamHandlerTest.java
@@ -22,8 +22,14 @@
 package io.crate.auth;
 
 import static io.crate.auth.HttpAuthUpstreamHandler.WWW_AUTHENTICATE_REALM_MESSAGE;
+import static io.crate.role.metadata.RolesHelper.JWT_TOKEN;
+import static io.crate.role.metadata.RolesHelper.JWT_USER;
 import static io.crate.testing.Asserts.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.nio.charset.StandardCharsets;
@@ -39,7 +45,10 @@ import org.elasticsearch.test.ESTestCase;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import io.crate.protocols.postgres.ConnectionProperties;
 import io.crate.role.Role;
+import io.crate.role.Roles;
+import io.crate.role.StubRoleManager;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
@@ -122,7 +131,7 @@ public class HttpAuthUpstreamHandlerTest extends ESTestCase {
     @Test
     public void testAuthorized() throws Exception {
         HttpAuthUpstreamHandler handler = new HttpAuthUpstreamHandler(
-            Settings.EMPTY, new AlwaysOKAuthentication(() -> List.of(Role.CRATE_USER)));
+            Settings.EMPTY, new AlwaysOKAuthentication(() -> List.of(Role.CRATE_USER)), new StubRoleManager());
         EmbeddedChannel ch = new EmbeddedChannel(handler);
 
         DefaultHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/_sql");
@@ -134,7 +143,7 @@ public class HttpAuthUpstreamHandlerTest extends ESTestCase {
 
     @Test
     public void testNotNoHbaConfig() throws Exception {
-        HttpAuthUpstreamHandler handler = new HttpAuthUpstreamHandler(Settings.EMPTY, authService);
+        HttpAuthUpstreamHandler handler = new HttpAuthUpstreamHandler(Settings.EMPTY, authService, new StubRoleManager());
         EmbeddedChannel ch = new EmbeddedChannel(handler);
 
         DefaultHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/_sql");
@@ -155,7 +164,7 @@ public class HttpAuthUpstreamHandlerTest extends ESTestCase {
      */
     @Test
     public void test_real_ip_header_is_ignored_by_default() {
-        HttpAuthUpstreamHandler handler = new HttpAuthUpstreamHandler(Settings.EMPTY, authService);
+        HttpAuthUpstreamHandler handler = new HttpAuthUpstreamHandler(Settings.EMPTY, authService, new StubRoleManager());
         EmbeddedChannel ch = new EmbeddedChannel(handler);
 
         DefaultHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/_sql");
@@ -177,7 +186,7 @@ public class HttpAuthUpstreamHandlerTest extends ESTestCase {
         var settings = Settings.builder()
             .put(AuthSettings.AUTH_TRUST_HTTP_SUPPORT_X_REAL_IP.getKey(), true)
             .build();
-        HttpAuthUpstreamHandler handler = new HttpAuthUpstreamHandler(settings, authService);
+        HttpAuthUpstreamHandler handler = new HttpAuthUpstreamHandler(settings, authService, new StubRoleManager());
         EmbeddedChannel ch = new EmbeddedChannel(handler);
 
         DefaultHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/_sql");
@@ -199,7 +208,7 @@ public class HttpAuthUpstreamHandlerTest extends ESTestCase {
         var settings = Settings.builder()
             .put(AuthSettings.AUTH_TRUST_HTTP_SUPPORT_X_REAL_IP.getKey(), true)
             .build();
-        HttpAuthUpstreamHandler handler = new HttpAuthUpstreamHandler(settings, authService);
+        HttpAuthUpstreamHandler handler = new HttpAuthUpstreamHandler(settings, authService, new StubRoleManager());
         EmbeddedChannel ch = new EmbeddedChannel(handler);
 
         DefaultHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/_sql");
@@ -218,7 +227,7 @@ public class HttpAuthUpstreamHandlerTest extends ESTestCase {
 
     @Test
     public void testUnauthorizedUser() throws Exception {
-        HttpAuthUpstreamHandler handler = new HttpAuthUpstreamHandler(Settings.EMPTY, authService);
+        HttpAuthUpstreamHandler handler = new HttpAuthUpstreamHandler(Settings.EMPTY, authService, new StubRoleManager());
         EmbeddedChannel ch = new EmbeddedChannel(handler);
 
         HttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/_sql");
@@ -246,7 +255,7 @@ public class HttpAuthUpstreamHandlerTest extends ESTestCase {
     public void testUserAuthenticationWithDisabledHBA() throws Exception {
         Authentication authServiceNoHBA = new AlwaysOKAuthentication(() -> List.of(Role.CRATE_USER));
 
-        HttpAuthUpstreamHandler handler = new HttpAuthUpstreamHandler(Settings.EMPTY, authServiceNoHBA);
+        HttpAuthUpstreamHandler handler = new HttpAuthUpstreamHandler(Settings.EMPTY, authServiceNoHBA, new StubRoleManager());
         EmbeddedChannel ch = new EmbeddedChannel(handler);
 
         HttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/_sql");
@@ -260,7 +269,7 @@ public class HttpAuthUpstreamHandlerTest extends ESTestCase {
     @Test
     public void testUnauthorizedUserWithDisabledHBA() throws Exception {
         Authentication authServiceNoHBA = new AlwaysOKAuthentication(List::of);
-        HttpAuthUpstreamHandler handler = new HttpAuthUpstreamHandler(Settings.EMPTY, authServiceNoHBA);
+        HttpAuthUpstreamHandler handler = new HttpAuthUpstreamHandler(Settings.EMPTY, authServiceNoHBA, new StubRoleManager());
         EmbeddedChannel ch = new EmbeddedChannel(handler);
 
         HttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/_sql");
@@ -272,4 +281,67 @@ public class HttpAuthUpstreamHandlerTest extends ESTestCase {
         assertThat(handler.authorized()).isFalse();
         assertUnauthorized(ch.readOutbound(), "trust authentication failed for user \"Aladdin\"\n");
     }
+
+    @Test
+    public void test_user_authentication_with_jwt_token() throws Exception {
+        Roles roles = () -> List.of(JWT_USER);
+        Authentication authentication = mock(Authentication.class);
+        AuthenticationMethod jwtAuth = mock(JWTAuthenticationMethod.class);
+        when(authentication.resolveAuthenticationType(eq(JWT_USER.name()), any(ConnectionProperties.class)))
+            .thenReturn(jwtAuth);
+        when(jwtAuth.authenticate(any(Credentials.class),any(ConnectionProperties.class))).thenReturn(JWT_USER);
+
+        HttpAuthUpstreamHandler handler = new HttpAuthUpstreamHandler(Settings.EMPTY, authentication, roles);
+        EmbeddedChannel ch = new EmbeddedChannel(handler);
+
+        HttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/_sql");
+        request.headers().add(HttpHeaderNames.AUTHORIZATION.toString(), "Bearer " + JWT_TOKEN);
+
+        ch.writeInbound(request);
+        ch.releaseInbound();
+
+        assertThat(handler.authorized()).isTrue();
+    }
+
+    @Test
+    public void test_user_authentication_with_jwt_token_user_not_found() throws Exception {
+        HttpAuthUpstreamHandler handler = new HttpAuthUpstreamHandler(Settings.EMPTY, authService, () -> List.of());
+        EmbeddedChannel ch = new EmbeddedChannel(handler);
+
+        HttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/_sql");
+        request.headers().add(HttpHeaderNames.AUTHORIZATION.toString(), "Bearer " + JWT_TOKEN);
+
+        ch.writeInbound(request);
+        ch.releaseInbound();
+
+        assertThat(handler.authorized()).isFalse();
+    }
+
+    @Test
+    public void test_user_authentication_with_jwt_token_verified_per_request() throws Exception {
+        Roles roles = () -> List.of(JWT_USER);
+        Authentication authentication = mock(Authentication.class);
+        AuthenticationMethod jwtAuth = mock(JWTAuthenticationMethod.class);
+        when(authentication.resolveAuthenticationType(eq(JWT_USER.name()), any(ConnectionProperties.class)))
+            .thenReturn(jwtAuth);
+        when(jwtAuth.authenticate(any(Credentials.class),any(ConnectionProperties.class))).thenReturn(JWT_USER);
+
+        HttpAuthUpstreamHandler handler = new HttpAuthUpstreamHandler(Settings.EMPTY, authentication, roles);
+        EmbeddedChannel ch = new EmbeddedChannel(handler);
+
+        HttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/_sql");
+        request.headers().add(HttpHeaderNames.AUTHORIZATION.toString(), "Bearer " + JWT_TOKEN);
+
+        ch.writeInbound(request);
+        ch.releaseInbound();
+
+        assertThat(handler.authorized()).isTrue();
+
+        HttpRequest request2 = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/_sql");
+        request2.headers().add(HttpHeaderNames.AUTHORIZATION.toString(), "Bearer " + JWT_TOKEN);
+        ch.writeInbound(request2);
+        ch.releaseInbound();
+        verify(jwtAuth, times(2)).authenticate(any(Credentials.class), any(ConnectionProperties.class));
+    }
+
 }

--- a/server/src/test/java/io/crate/auth/JwtAuthenticationIntegrationTest.java
+++ b/server/src/test/java/io/crate/auth/JwtAuthenticationIntegrationTest.java
@@ -1,0 +1,213 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.auth;
+
+import static io.crate.testing.Asserts.assertThat;
+import static io.crate.testing.auth.RsaKeys.PRIVATE_KEY_256;
+import static io.crate.testing.auth.RsaKeys.PUBLIC_KEY_256;
+
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyFactory;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.EncodedKeySpec;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.http.HttpServerTransport;
+import org.elasticsearch.test.IntegTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.fasterxml.jackson.core.JsonGenerator;
+
+import io.crate.http.HttpTestServer;
+import io.crate.testing.UseJdbc;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpRequest;
+
+@UseJdbc(value = 0) // jwt is supported only for http
+public class JwtAuthenticationIntegrationTest extends IntegTestCase {
+
+    private static final Base64.Decoder BASE_64_DECODER = Base64.getDecoder();
+
+    private static final Base64.Encoder BASE_64_URL_ENCODER = Base64.getUrlEncoder();
+    private static final String KID = "1";
+
+    /**
+     * Imitates a JWK endpoint response with pre-generated public key.
+     * Public key format is aligned with
+     * https://console.cratedb-dev.cloud/api/v2/meta/jwk/
+     * https://login.microsoftonline.com/common/discovery/v2.0/keys
+     * https://www.googleapis.com/oauth2/v3/certs
+     * and looks like:
+     * {
+     *   "keys":[
+     *     {
+     *       "e":"...",
+     *       "kid":"...",
+     *       "kty":"RSA",
+     *        "n":"..."
+     *     }
+     *    ]
+     * }
+     */
+    private static final BiConsumer<HttpRequest, JsonGenerator> jwkRequestHandler =
+        (HttpRequest msg, JsonGenerator generator) -> {
+            try {
+                KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+                EncodedKeySpec publicKeySpec = new X509EncodedKeySpec(BASE_64_DECODER.decode(PUBLIC_KEY_256));
+                RSAPublicKey publicKey = (RSAPublicKey) keyFactory.generatePublic(publicKeySpec);
+
+                generator.writeStartObject();
+                generator.writeArrayFieldStart("keys");
+                generator.writeStartObject();
+                generator.writeStringField("e", BASE_64_URL_ENCODER.encodeToString(publicKey.getPublicExponent().toByteArray()));
+                generator.writeStringField("kid", KID);
+                generator.writeStringField("kty", "RSA");
+                generator.writeStringField("n", BASE_64_URL_ENCODER.encodeToString(publicKey.getModulus().toByteArray()));
+                generator.writeEndObject();
+                generator.writeEndArray();
+                generator.writeEndObject();
+                generator.close();
+            } catch (Exception e) {
+                throw new RuntimeException(e.getCause());
+            }
+        };
+    private HttpTestServer testServer;
+    private RSAPrivateKey privateKey;
+
+    @Override
+    protected boolean addMockHttpTransport() {
+        return false;
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put("auth.host_based.enabled", true)
+            .put("auth.host_based.config",
+                "a", new String[]{"user", "method", "protocol"}, new String[]{"John", "jwt", "http"})
+            .put("auth.host_based.config",
+                "b", new String[]{"user", "method"}, new String[]{"John", "password"})
+            .build();
+    }
+
+    @Before
+    public void init() throws Exception {
+        KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+        // Prepare private key.
+        PKCS8EncodedKeySpec privateKeySpec = new PKCS8EncodedKeySpec(BASE_64_DECODER.decode(PRIVATE_KEY_256));
+        privateKey = (RSAPrivateKey) keyFactory.generatePrivate(privateKeySpec);
+    }
+
+    @After
+    public void cleanUp() {
+        execute("DROP USER IF EXISTS \"John\"");
+        if (testServer != null) {
+            testServer.shutDown();
+        }
+    }
+
+    @Test
+    public void test_can_authenticate_with_jwt_token() throws Exception {
+        testServer = new HttpTestServer(0, false, jwkRequestHandler);
+        testServer.run();
+
+        // We use random port for the test suite (assigned by kernel)
+        // Port affects url --> affects signature --> need to re-compute payload.
+        String iss = String.format(Locale.ENGLISH, "http://localhost:%d/keys", testServer.boundPort());
+        String appUsername = "cloud_user";
+        String jwt = JWT.create()
+            .withHeader(Map.of("typ", "JWT", "alg", "RS256", "kid", KID))
+            .withIssuer(iss)
+            .withClaim("username", appUsername)
+            .sign(Algorithm.RSA256(null, privateKey));
+
+        // Important to surround name with quotes if name used in HBA is not in lowercase
+        // Otherwise CREATE USER saves it in lowercase whereas HBA entry was created for "John"
+        execute("CREATE USER \"John\" " +
+            "WITH (jwt = {\"iss\" = '" + iss + "', \"username\" = '" + appUsername + "'})"
+        );
+
+
+        HttpServerTransport httpTransport = cluster().getInstance(HttpServerTransport.class);
+        InetSocketAddress address = httpTransport.boundAddress().publishAddress().address();
+        String uri = String.format(Locale.ENGLISH, "http://%s:%s/", address.getHostName(), address.getPort());
+        HttpGet request = new HttpGet(uri);
+        request.setHeader(HttpHeaderNames.AUTHORIZATION.toString(), "Bearer " + jwt);
+        request.setHeader(HttpHeaderNames.ORIGIN.toString(), "http://example.com");
+        request.setHeader(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD.toString(), "GET");
+        CloseableHttpClient httpClient = HttpClients.createDefault();
+        CloseableHttpResponse resp = httpClient.execute(request);
+        String bodyAsString = EntityUtils.toString(resp.getEntity(), StandardCharsets.UTF_8);
+        assertThat(bodyAsString).containsIgnoringWhitespaces("""
+                                                {
+                                                  "ok" : true,
+                                                  "status" : 200
+                                                  """);
+
+    }
+
+    @Test
+    public void test_body_jwk_endpoint_not_responding_contains_error() throws Exception {
+        // HttpTestServer is not started in this test, use dummy port
+        String iss = String.format(Locale.ENGLISH, "http://localhost:%d/keys", 1234);
+        String appUsername = "cloud_user";
+        String jwt = JWT.create()
+            .withHeader(Map.of("typ", "JWT", "alg", "RS256", "kid", KID))
+            .withIssuer(iss)
+            .withClaim("username", appUsername)
+            .sign(Algorithm.RSA256(null, privateKey));
+
+        execute("CREATE USER \"John\" " +
+            "WITH (jwt = {\"iss\" = '" + iss + "', \"username\" = '" + appUsername + "'})"
+        );
+
+        HttpServerTransport httpTransport = cluster().getInstance(HttpServerTransport.class);
+        InetSocketAddress address = httpTransport.boundAddress().publishAddress().address();
+        String uri = String.format(Locale.ENGLISH, "http://%s:%s/", address.getHostName(), address.getPort());
+        HttpGet request = new HttpGet(uri);
+        request.setHeader(HttpHeaderNames.AUTHORIZATION.toString(), "Bearer " + jwt);
+        request.setHeader(HttpHeaderNames.ORIGIN.toString(), "http://example.com");
+        request.setHeader(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD.toString(), "GET");
+        CloseableHttpClient httpClient = HttpClients.createDefault();
+        CloseableHttpResponse resp = httpClient.execute(request);
+        String bodyAsString = EntityUtils.toString(resp.getEntity(), StandardCharsets.UTF_8);
+        assertThat(bodyAsString).contains("jwt authentication failed for user John. Reason: Cannot obtain jwks from url");
+    }
+}

--- a/server/src/test/java/io/crate/auth/UserAuthenticationMethodTest.java
+++ b/server/src/test/java/io/crate/auth/UserAuthenticationMethodTest.java
@@ -21,24 +21,51 @@
 
 package io.crate.auth;
 
+import static io.crate.role.metadata.RolesHelper.JWT_TOKEN;
+import static io.crate.role.metadata.RolesHelper.JWT_USER;
+import static io.crate.testing.auth.RsaKeys.PRIVATE_KEY_256;
+import static io.crate.testing.auth.RsaKeys.PUBLIC_KEY_256;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.spec.EncodedKeySpec;
 import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
 
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
 
+import com.auth0.jwk.Jwk;
+import com.auth0.jwk.JwkProvider;
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+
+import io.crate.role.JwtProperties;
 import io.crate.role.Role;
 import io.crate.role.Roles;
 import io.crate.role.SecureHash;
 import io.crate.role.metadata.RolesHelper;
 
 public class UserAuthenticationMethodTest extends ESTestCase {
+
+    private static final String KID = "1";
+
 
     private static class CrateOrNullRoles implements Roles {
 
@@ -98,5 +125,156 @@ public class UserAuthenticationMethodTest extends ESTestCase {
         PasswordAuthenticationMethod pwAuth = new PasswordAuthenticationMethod(new CrateOrNullRoles());
         assertThatThrownBy(() -> pwAuth.authenticate(new Credentials("cr8", "pw".toCharArray()), null))
             .hasMessage("password authentication failed for user \"cr8\"");
+    }
+
+    @Test
+    public void test_jwt_authentication() throws Exception {
+        Roles roles = () -> List.of(JWT_USER);
+        JWTAuthenticationMethod jwtAuth = new JWTAuthenticationMethod(
+            roles,
+            jwkProviderFunction(null)
+        );
+        assertThat(jwtAuth.name()).isEqualTo("jwt");
+
+        Credentials credentials = new Credentials(JWT_TOKEN);
+        assertThat(credentials.username()).isNull();
+        credentials.setUsername(JWT_USER.name());
+
+        Role authenticatedRole = jwtAuth.authenticate(credentials, null);
+        assertThat(authenticatedRole).isNotNull();
+        assertThat(authenticatedRole.name()).isEqualTo(JWT_USER.name());
+    }
+
+    @Test
+    @SuppressWarnings("resource")
+    public void test_jwt_authentication_token_expired() throws Exception {
+        PKCS8EncodedKeySpec privateKeySpec = new PKCS8EncodedKeySpec(Base64.getDecoder().decode(PRIVATE_KEY_256));
+        KeyFactory kf = KeyFactory.getInstance("RSA");
+        RSAPrivateKey privateKey = (RSAPrivateKey) kf.generatePrivate(privateKeySpec);
+
+        String jwt = JWT.create()
+            .withHeader(Map.of("typ", "JWT", "alg", "RS256", "kid", KID))
+            .withIssuer(JWT_USER.jwtProperties().iss())
+            .withClaim("username", JWT_USER.jwtProperties().username())
+            .withExpiresAt(LocalDateTime.now(ZoneOffset.UTC).minusDays(1).toInstant(ZoneOffset.UTC))
+            .sign(Algorithm.RSA256(null, privateKey));
+
+        Roles roles = () -> List.of(JWT_USER);
+
+        JWTAuthenticationMethod jwtAuth = new JWTAuthenticationMethod(
+            roles,
+            jwkProviderFunction(null)
+        );
+
+        Credentials credentials = new Credentials(jwt);
+        credentials.setUsername(JWT_USER.name());
+
+        assertThatThrownBy(
+                () -> jwtAuth.authenticate(credentials, null))
+            .isExactlyInstanceOf(RuntimeException.class)
+            .hasMessageContaining("jwt authentication failed for user John. Reason: The Token has expired");
+    }
+
+    @Test
+    @SuppressWarnings("resource")
+    public void test_token_algo_and_jwk_algo_mistmatch_error_thrown() throws Exception {
+        Roles roles = () -> List.of(JWT_USER);
+        JWTAuthenticationMethod jwtAuth = new JWTAuthenticationMethod(
+            roles,
+            jwkProviderFunction("RS384")
+        );
+
+        Credentials credentials = new Credentials(JWT_TOKEN);
+        assertThat(credentials.username()).isNull();
+        credentials.setUsername(JWT_USER.name());
+
+        assertThatThrownBy(
+            () -> jwtAuth.authenticate(credentials, null))
+            .isExactlyInstanceOf(RuntimeException.class)
+            .hasMessage("jwt authentication failed for user John. Reason: Jwt token has algorithm not matching with the algorithm of the public key.");
+    }
+
+    @Test
+    @SuppressWarnings("resource")
+    public void test_jwt_authentication_user_not_found_throws_an_error() throws Exception {
+        // Testing a scenario when user is looked up by iss/username, name is set to Credentials
+        // but during authentication user cannot be found by name (for example, could be dropped in a meantime).
+        JWTAuthenticationMethod jwtAuth = new JWTAuthenticationMethod(List::of, null);
+
+        Credentials credentials = new Credentials(JWT_TOKEN);
+        credentials.setUsername(JWT_USER.name());
+
+        assertThatThrownBy(
+            () -> jwtAuth.authenticate(credentials, null))
+            .isExactlyInstanceOf(RuntimeException.class)
+            .hasMessage("jwt authentication failed for user \"John\"");
+    }
+
+    @Test
+    @SuppressWarnings("resource")
+    public void test_jwt_authentication_malformed_endpoint_throws_an_error() throws Exception {
+        PKCS8EncodedKeySpec privateKeySpec = new PKCS8EncodedKeySpec(Base64.getDecoder().decode(PRIVATE_KEY_256));
+        KeyFactory kf = KeyFactory.getInstance("RSA");
+        RSAPrivateKey privateKey = (RSAPrivateKey) kf.generatePrivate(privateKeySpec);
+        // Not using pre-generated JWT_TOKEN as it has a valid url.
+        String jwt = JWT.create()
+            .withHeader(Map.of("typ", "JWT", "kid", "1"))
+            .withIssuer("https-:\\bad_url")
+            .withClaim("username", "app_user")
+            .sign(Algorithm.RSA256(null, privateKey));
+
+        JWTAuthenticationMethod jwtAuth = new JWTAuthenticationMethod(
+            () -> List.of(JWT_USER),
+            JWTAuthenticationMethod::jwkProvider
+        );
+
+        Credentials credentials = new Credentials(jwt);
+        credentials.setUsername(JWT_USER.name());
+
+        assertThatThrownBy(
+            () -> jwtAuth.authenticate(credentials, null))
+            .isExactlyInstanceOf(RuntimeException.class)
+            .hasMessage("jwt authentication failed for user John. Reason: Invalid jwks uri");
+    }
+
+    @Test
+    @SuppressWarnings("resource")
+    public void test_jwt_authentication_claim_mismatch_throws_an_error() throws Exception {
+        Role userWithModifiedJwtProperty = new Role(
+            JWT_USER.name(),
+            true,
+            Set.of(),
+            Set.of(),
+            null,
+            new JwtProperties("dummy", "dummy")
+        );
+        Roles roles = () -> List.of(userWithModifiedJwtProperty);
+        JWTAuthenticationMethod jwtAuth = new JWTAuthenticationMethod(
+            roles,
+            jwkProviderFunction(null)
+        );
+
+        Credentials credentials = new Credentials(JWT_TOKEN);
+        credentials.setUsername(JWT_USER.name());
+
+        assertThatThrownBy(
+            () -> jwtAuth.authenticate(credentials, null))
+            .isExactlyInstanceOf(RuntimeException.class)
+            .hasMessage("jwt authentication failed for user John. Reason: The Claim 'iss' value doesn't match the required issuer.");
+    }
+
+    private static Function<String, JwkProvider> jwkProviderFunction(String algorithm) throws Exception {
+        EncodedKeySpec publicKeySpec = new X509EncodedKeySpec(Base64.getDecoder().decode(PUBLIC_KEY_256));
+        KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+        PublicKey publicKey = keyFactory.generatePublic(publicKeySpec);
+
+        JwkProvider mockJwkProvider = mock(JwkProvider.class);
+
+        Jwk mockJwk = mock(Jwk.class);
+
+        when(mockJwkProvider.get(KID)).thenReturn(mockJwk);
+        when(mockJwk.getPublicKey()).thenReturn(publicKey);
+        when(mockJwk.getAlgorithm()).thenReturn(algorithm);
+        return ignored -> mockJwkProvider;
     }
 }

--- a/server/src/test/java/io/crate/http/HttpTestServer.java
+++ b/server/src/test/java/io/crate/http/HttpTestServer.java
@@ -118,6 +118,15 @@ public class HttpTestServer {
         channel = bootstrap.bind(new InetSocketAddress(port)).sync().channel();
     }
 
+    /**
+     * @return actual port, assigned by kernel.
+     * Can be different from "port" property if "port = 0"
+     */
+    public int boundPort() {
+        InetSocketAddress localAddress = (InetSocketAddress) channel.localAddress();
+        return localAddress.getPort();
+    }
+
     public void shutDown() {
         channel.close().awaitUninterruptibly();
         if (group != null) {

--- a/server/src/test/java/io/crate/protocols/http/HeadersTest.java
+++ b/server/src/test/java/io/crate/protocols/http/HeadersTest.java
@@ -24,10 +24,8 @@ package io.crate.protocols.http;
 import static io.crate.protocols.http.Headers.extractCredentialsFromHttpAuthHeader;
 import static io.crate.protocols.http.Headers.isAcceptJson;
 import static io.crate.protocols.http.Headers.isBrowser;
+import static io.crate.testing.Asserts.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
 
 import org.junit.Test;
 
@@ -37,43 +35,43 @@ public class HeadersTest {
 
     @Test
     public void testIsBrowser() {
-        assertThat(isBrowser(null), is(false));
-        assertThat(isBrowser("some header"), is(false));
-        assertThat(isBrowser("Mozilla/5.0 (X11; Linux x86_64)"), is(true));
+        assertThat(isBrowser(null)).isFalse();
+        assertThat(isBrowser("some header")).isFalse();
+        assertThat(isBrowser("Mozilla/5.0 (X11; Linux x86_64)")).isTrue();
     }
 
     @Test
     public void testIsAcceptJson() {
-        assertThat(isAcceptJson(null), is(false));
-        assertThat(isAcceptJson("text/html"), is(false));
-        assertThat(isAcceptJson("application/json"), is(true));
+        assertThat(isAcceptJson(null)).isFalse();
+        assertThat(isAcceptJson("text/html")).isFalse();
+        assertThat(isAcceptJson("application/json")).isTrue();
     }
 
     @Test
     public void testExtractUsernamePasswordFromHttpBasicAuthHeader() {
         Credentials creds = extractCredentialsFromHttpAuthHeader("");
-        assertThat(creds.username(), is(nullValue()));
-        assertThat(creds.password(), is(nullValue()));
+        assertThat(creds.username()).isNull();
+        assertThat(creds.password()).isNull();
 
         creds = extractCredentialsFromHttpAuthHeader(null);
-        assertThat(creds.username(), is(nullValue()));
-        assertThat(creds.password(), is(nullValue()));
+        assertThat(creds.username()).isNull();
+        assertThat(creds.password()).isNull();
 
         creds = extractCredentialsFromHttpAuthHeader("Basic QXJ0aHVyOkV4Y2FsaWJ1cg==");
-        assertThat(creds.username(), is("Arthur"));
-        assertThat(creds.password().toString(), is("Excalibur"));
+        assertThat(creds.username()).isEqualTo("Arthur");
+        assertThat(creds.password()).hasToString("Excalibur");
 
         creds = extractCredentialsFromHttpAuthHeader("Basic QXJ0aHVyOjp0ZXN0OnBhc3N3b3JkOg==");
-        assertThat(creds.username(), is("Arthur"));
-        assertThat(creds.password().toString(), is(":test:password:"));
+        assertThat(creds.username()).isEqualTo("Arthur");
+        assertThat(creds.password()).hasToString(":test:password:");
 
         creds = extractCredentialsFromHttpAuthHeader("Basic QXJ0aHVyOg==");
-        assertThat(creds.username(), is("Arthur"));
-        assertThat(creds.password(), is(nullValue()));
+        assertThat(creds.username()).isEqualTo("Arthur");
+        assertThat(creds.password()).isNull();
 
         creds = extractCredentialsFromHttpAuthHeader("Basic OnBhc3N3b3Jk");
-        assertThat(creds.username(), is(""));
-        assertThat(creds.password().toString(), is("password"));
+        assertThat(creds.username()).isEmpty();
+        assertThat(creds.password()).hasToString("password");
         creds.close();
     }
 

--- a/server/src/test/java/io/crate/role/metadata/RolesHelper.java
+++ b/server/src/test/java/io/crate/role/metadata/RolesHelper.java
@@ -47,6 +47,41 @@ import io.crate.role.SecureHash;
 
 public final class RolesHelper {
 
+
+    /**
+     * Base64 encoded token, which represents header/payload shown below (signed by RsaKeys.PRIVATE_KEY_256).
+     * Header:
+     * {
+     *   "alg": "RS256",
+     *   "typ": "JWT",
+     *   "kid": "1"
+     * }
+     * Payload:
+     * {
+     *   "iss": "https://console.cratedb-dev.cloud/api/v2/meta/jwk/",
+     *   "username": "cloud_user"
+     * }
+     */
+    public static final String JWT_TOKEN = """
+        eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IjEifQ.eyJpc3MiOiJod\
+        HRwczovL2NvbnNvbGUuY3JhdGVkYi1kZXYuY2xvdWQvYXBpL3YyL21ldGEvandrL\
+        yIsInVzZXJuYW1lIjoiY2xvdWRfdXNlciJ9.sbawfydZA66n6T8hCvioLYpBrqov\
+        p0BuMCIhStrqGKpDiw2JLeB6e3Tb3a9T9nuMF0S7HHMXHKXrypPCuBxeJsR4jck9m\
+        DeVyPZ1i4daNK-wezF0n-OLPJAV_lOvgv_exi2mpi2Ws7tfS3Ht3ZY8aQIOtnZjwW\
+        1O2GAljToLfRopUzJ8f6MZtZw2UKfkHvWZUalCcA5WWTqqzBx8hELswJ_VkUyYWYq\
+        wFgjaHsn2xF8nrS7_qF8OhD59_gCEUOzqIN0z2ctjSxRbFQ6VUewqQwMYVJTP7Lyl\
+        c89wlemQGx6JVk7wqejbLeCJqiHJXZFUe69A5MsWK8SZXDTfQoGWow\
+        """;
+
+    public static Role JWT_USER = userOf(
+        "John",
+        Set.of(),
+        new HashSet<>(),
+        getSecureHash("johns-pwd"),
+        new JwtProperties("https://console.cratedb-dev.cloud/api/v2/meta/jwk/", "cloud_user")
+    );
+
+
     public static final Map<String, Role> SINGLE_USER_ONLY = Collections.singletonMap("Arthur", userOf("Arthur"));
 
     public static final Map<String, Role> DUMMY_USERS = Map.of(

--- a/server/src/testFixtures/java/io/crate/testing/auth/RsaKeys.java
+++ b/server/src/testFixtures/java/io/crate/testing/auth/RsaKeys.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.testing.auth;
+
+/**
+ * Pre-generated keys used in different tests to avoid expensive key pair generation.
+ * Taken from https://jwt.io/#debugger-io (RSA-256).
+ */
+public class RsaKeys {
+    public static final String PRIVATE_KEY_256 = """
+        MIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQC7VJTUt9Us8cKj\
+        MzEfYyjiWA4R4/M2bS1GB4t7NXp98C3SC6dVMvDuictGeurT8jNbvJZHtCSuYEvu\
+        NMoSfm76oqFvAp8Gy0iz5sxjZmSnXyCdPEovGhLa0VzMaQ8s+CLOyS56YyCFGeJZ\
+        qgtzJ6GR3eqoYSW9b9UMvkBpZODSctWSNGj3P7jRFDO5VoTwCQAWbFnOjDfH5Ulg\
+        p2PKSQnSJP3AJLQNFNe7br1XbrhV//eO+t51mIpGSDCUv3E0DDFcWDTH9cXDTTlR\
+        ZVEiR2BwpZOOkE/Z0/BVnhZYL71oZV34bKfWjQIt6V/isSMahdsAASACp4ZTGtwi\
+        VuNd9tybAgMBAAECggEBAKTmjaS6tkK8BlPXClTQ2vpz/N6uxDeS35mXpqasqskV\
+        laAidgg/sWqpjXDbXr93otIMLlWsM+X0CqMDgSXKejLS2jx4GDjI1ZTXg++0AMJ8\
+        sJ74pWzVDOfmCEQ/7wXs3+cbnXhKriO8Z036q92Qc1+N87SI38nkGa0ABH9CN83H\
+        mQqt4fB7UdHzuIRe/me2PGhIq5ZBzj6h3BpoPGzEP+x3l9YmK8t/1cN0pqI+dQwY\
+        dgfGjackLu/2qH80MCF7IyQaseZUOJyKrCLtSD/Iixv/hzDEUPfOCjFDgTpzf3cw\
+        ta8+oE4wHCo1iI1/4TlPkwmXx4qSXtmw4aQPz7IDQvECgYEA8KNThCO2gsC2I9PQ\
+        DM/8Cw0O983WCDY+oi+7JPiNAJwv5DYBqEZB1QYdj06YD16XlC/HAZMsMku1na2T\
+        N0driwenQQWzoev3g2S7gRDoS/FCJSI3jJ+kjgtaA7Qmzlgk1TxODN+G1H91HW7t\
+        0l7VnL27IWyYo2qRRK3jzxqUiPUCgYEAx0oQs2reBQGMVZnApD1jeq7n4MvNLcPv\
+        t8b/eU9iUv6Y4Mj0Suo/AU8lYZXm8ubbqAlwz2VSVunD2tOplHyMUrtCtObAfVDU\
+        AhCndKaA9gApgfb3xw1IKbuQ1u4IF1FJl3VtumfQn//LiH1B3rXhcdyo3/vIttEk\
+        48RakUKClU8CgYEAzV7W3COOlDDcQd935DdtKBFRAPRPAlspQUnzMi5eSHMD/ISL\
+        DY5IiQHbIH83D4bvXq0X7qQoSBSNP7Dvv3HYuqMhf0DaegrlBuJllFVVq9qPVRnK\
+        xt1Il2HgxOBvbhOT+9in1BzA+YJ99UzC85O0Qz06A+CmtHEy4aZ2kj5hHjECgYEA\
+        mNS4+A8Fkss8Js1RieK2LniBxMgmYml3pfVLKGnzmng7H2+cwPLhPIzIuwytXywh\
+        2bzbsYEfYx3EoEVgMEpPhoarQnYPukrJO4gwE2o5Te6T5mJSZGlQJQj9q4ZB2Dfz\
+        et6INsK0oG8XVGXSpQvQh3RUYekCZQkBBFcpqWpbIEsCgYAnM3DQf3FJoSnXaMhr\
+        VBIovic5l0xFkEHskAjFTevO86Fsz1C2aSeRKSqGFoOQ0tmJzBEs1R6KqnHInicD\
+        TQrKhArgLXX4v3CddjfTRJkFWDbE/CkvKZNOrcf1nhaGCPspRJj2KUkj1Fhl9Cnc\
+        dn/RsYEONbwQSjIfMPkvxF+8HQ==\
+        """;
+
+    public static final String PUBLIC_KEY_256 = """
+        MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAu1SU1LfVLPHCozMxH2Mo\
+        4lgOEePzNm0tRgeLezV6ffAt0gunVTLw7onLRnrq0/IzW7yWR7QkrmBL7jTKEn5u\
+        +qKhbwKfBstIs+bMY2Zkp18gnTxKLxoS2tFczGkPLPgizskuemMghRniWaoLcyeh\
+        kd3qqGElvW/VDL5AaWTg0nLVkjRo9z+40RQzuVaE8AkAFmxZzow3x+VJYKdjykkJ\
+        0iT9wCS0DRTXu269V264Vf/3jvredZiKRkgwlL9xNAwxXFg0x/XFw005UWVRIkdg\
+        cKWTjpBP2dPwVZ4WWC+9aGVd+Gyn1o0CLelf4rEjGoXbAAEgAqeGUxrcIlbjXfbc\
+        mwIDAQAB\
+        """;
+
+}


### PR DESCRIPTION
Summary of the changes:

1. Added new authentication method `jwt` to `HostBasedAuthentication`.
    - Currently only HTTP, node won't be started if it has entries with `jwt` and no protocol or non-http protocol

2. Turned `Credentials` token (introduced in https://github.com/crate/crate/commit/ffc7f8a3d9fe53bf8d1a38f8f2a2feecfcc62732) from String to `DecodedJWT`.

   Reason - we have to do unsafe decode to do CrateDB user lookup. If we pass through String token in `Credentials`, we would need to do `verify(String)` which does decoding again. See also https://github.com/auth0/java-jwt/issues/279. 

    It's fine to use unsafe decoded data, as we verify signature and double check claims at the end of workflow. 

    `withIssuer`/`withClaim` essentially check authenticated user's metadata with token data.
   
3. Limited supported algorithms to RSA, all 3 256/384/512 but no ECDSA.
    - [Microsoft](https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration) and [Google](https://accounts.google.com/.well-known/openid-configuration) support only RSA256. RSA384/512 are also supported in our case because it's same effort as not supporting them - we anyway have `RSAKeyProvider`, so code is same. 
    
4. Added possibility to fetch user from Bearer token in _sql endpoint. 
    - It's not authentication, same with password.
    Same like we don't check password, we don't verify signature there. Only try to get user from header and if not found, fall back to default setting. See `SqlHttpHandler` change.
    
  TODO:
  - [x] docs
  - [x] full integration test (including setting up an endpoint returning public key)
    