### PR TITLE
Fix PK Lookup with cast on the PK column

### DIFF
--- a/docs/appendices/release-notes/5.6.2.rst
+++ b/docs/appendices/release-notes/5.6.2.rst
@@ -45,6 +45,20 @@ See the :ref:`version_5.6.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that would cause no results being returned when filtering on a
+  :ref:`PRIMARY KEY <constraints-primary-key>` column, wrapped with a
+  :ref:`CAST <sql-type-cast>`, e.g.::
+
+    CREATE TABLE tbl(a INTEGER, PRIMARY KEY(a), b INTEGER);
+    INSERT INTO tbl(a) VALUES (1, 11);
+    REFRESH TABLE tbl;
+    SELECT * FROM tbl WHERE CAST(t.a AS BOOLEAN)= true;
+
+  Same issue, previously, would cause no rows to be updated or deleted, e.g. ::
+
+    UPDATE tbl SET b = b + 1 WHERE CAST(t.a AS BOOLEAN)= true;
+    DELETE FROM tbl WHERE CAST(t.a AS BOOLEAN)= true;
+
 - Fixed an issue that can cause errors during a rolling upgrade to >=
   :ref:`version_5.6.0` if one of the following command is executed on relations
   with existing privileges:

--- a/server/src/main/java/io/crate/analyze/where/EqualityExtractor.java
+++ b/server/src/main/java/io/crate/analyze/where/EqualityExtractor.java
@@ -407,7 +407,6 @@ public class EqualityExtractor {
             Symbol firstArg = arguments.get(0);
 
             if (functionName.equals(EqOperator.NAME)) {
-                firstArg = Symbols.unwrapReferenceFromCast(firstArg);
                 if (firstArg instanceof Reference ref && SymbolVisitors.any(Symbols.IS_COLUMN, arguments.get(1)) == false) {
                     Comparison comparison = context.comparisons.get(ref.column());
                     if (comparison != null) {
@@ -417,7 +416,6 @@ public class EqualityExtractor {
                 }
             } else if (functionName.equals(AnyEqOperator.NAME) && arguments.get(1).symbolType().isValueSymbol()) {
                 // ref = any ([1,2,3])
-                firstArg = Symbols.unwrapReferenceFromCast(firstArg);
                 if (firstArg instanceof Reference ref) {
                     Comparison comparison = context.comparisons.get(ref.column());
                     if (comparison != null) {

--- a/server/src/test/java/io/crate/analyze/where/EqualityExtractorTest.java
+++ b/server/src/test/java/io/crate/analyze/where/EqualityExtractorTest.java
@@ -333,12 +333,14 @@ public class EqualityExtractorTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
-    public void test_primary_key_comparison_is_detected_inside_cast_function() throws Exception {
+    public void test_primary_key_comparison_is_not_detected_inside_cast_function() throws Exception {
         Symbol query = query("cast(x as bigint) = 0");
         List<List<Symbol>> matches = analyzeExactX(query);
-        assertThat(matches).hasSize(1);
-        assertThat(matches).satisfiesExactlyInAnyOrder(
-            s -> assertThat(s).satisfiesExactly(isLiteral(0L)));
+        assertThat(matches).isNull();
+
+        query = query("cast(x as bigint) = any([1, 2, 3])");
+        matches = analyzeExactX(query);
+        assertThat(matches).isNull();
     }
 
     @Test


### PR DESCRIPTION
Previously, we ignored a CAST wrapping the PK column, when trying to extract dockeys to be used in a `Get` plan, but there are cases, where the equality with a `CAST` cannot be succesfully translated to valid dockeys. For example a cast to `boolean` cannot be translated to all valid numeric values that could match, Given:
```
CREATE TABLE t(a INTEGER, PRIMARY KEY(a));
INSERT INTO t(a) VALUES (1);
REFRESH TABLE t;
```
The following query:
```
SELECT * FROM t WHERE (CAST(t.a AS BOOLEAN)= true);
```
would result into a `Get` plan with a dockey `true`, which would never match numeric values for column `a`.

Therefore, don't unwrap the `CAST`, and resort to a `Collect` plan which would return the correct resuts (once of course, the table is refreshed).

Fixes: #15537
