### PR TITLE
Fixed issue with symbol Optimizer not optimizing params

### DIFF
--- a/server/src/main/java/io/crate/expression/symbol/SymbolType.java
+++ b/server/src/main/java/io/crate/expression/symbol/SymbolType.java
@@ -21,16 +21,17 @@
 
 package io.crate.expression.symbol;
 
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.util.List;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.Writeable;
+
 import io.crate.metadata.GeneratedReference;
 import io.crate.metadata.GeoReference;
 import io.crate.metadata.IndexReference;
 import io.crate.metadata.SimpleReference;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.Writeable;
-
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.util.List;
 
 public enum SymbolType {
 
@@ -74,5 +75,9 @@ public enum SymbolType {
 
     public boolean isValueSymbol() {
         return ordinal() == LITERAL.ordinal();
+    }
+
+    public boolean isValueOrParameterSymbol() {
+        return ordinal() == LITERAL.ordinal() || ordinal() == PARAMETER.ordinal();
     }
 }

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveArrayLengthOnReferenceCastToLiteralCastInsideOperators.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveArrayLengthOnReferenceCastToLiteralCastInsideOperators.java
@@ -51,7 +51,7 @@ public class MoveArrayLengthOnReferenceCastToLiteralCastInsideOperators implemen
         this.castCapture = new Capture<>();
         this.pattern = typeOf(Function.class)
             .with(f -> COMPARISON_OPERATORS.contains(f.name()))
-            .with(f -> f.arguments().get(1).symbolType() == SymbolType.LITERAL)
+            .with(f -> f.arguments().get(1).symbolType().isValueOrParameterSymbol())
             .with(f -> Optional.of(f.arguments().get(0)), typeOf(Function.class).capturedAs(castCapture)
                 .with(f -> f.isCast())
                 .with(f -> Optional.of(f.arguments().get(0)), typeOf(Function.class)
@@ -72,14 +72,14 @@ public class MoveArrayLengthOnReferenceCastToLiteralCastInsideOperators implemen
                         Captures captures,
                         NodeContext nodeCtx,
                         Symbol parentNode) {
-        var literal = operator.arguments().get(1);
+        var literalOrParam = operator.arguments().get(1);
         var castFunction = captures.get(castCapture);
         var function = castFunction.arguments().get(0);
         DataType<?> targetType = function.valueType();
 
         return functionResolver.apply(
             operator.name(),
-            List.of(function, literal.cast(targetType))
+            List.of(function, literalOrParam.cast(targetType))
         );
     }
 }

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveReferenceCastToLiteralCastOnAnyOperatorsWhenLeftIsReference.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveReferenceCastToLiteralCastOnAnyOperatorsWhenLeftIsReference.java
@@ -51,7 +51,7 @@ public class MoveReferenceCastToLiteralCastOnAnyOperatorsWhenLeftIsReference imp
         this.castCapture = new Capture<>();
         this.pattern = typeOf(Function.class)
             .with(f -> AnyOperator.OPERATOR_NAMES.contains(f.name()))
-            .with(f -> f.arguments().get(1).symbolType() == SymbolType.LITERAL)
+            .with(f -> f.arguments().get(1).symbolType().isValueOrParameterSymbol())
             .with(f -> Optional.of(f.arguments().get(0)), typeOf(Function.class).capturedAs(castCapture)
                 .with(f -> f.isCast())
                 .with(f -> f.arguments().get(0).symbolType() == SymbolType.REFERENCE)
@@ -68,14 +68,14 @@ public class MoveReferenceCastToLiteralCastOnAnyOperatorsWhenLeftIsReference imp
                         Captures captures,
                         NodeContext nodeCtx,
                         Symbol parentNode) {
-        var literal = operator.arguments().get(1);
+        var literalOrParam = operator.arguments().get(1);
         var castFunction = captures.get(castCapture);
         var reference = castFunction.arguments().get(0);
         DataType<?> targetType = new ArrayType<>(reference.valueType());
 
         return functionResolver.apply(
             operator.name(),
-            List.of(reference, literal.cast(targetType))
+            List.of(reference, literalOrParam.cast(targetType))
         );
     }
 }

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveReferenceCastToLiteralCastOnAnyOperatorsWhenRightIsReference.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveReferenceCastToLiteralCastOnAnyOperatorsWhenRightIsReference.java
@@ -53,7 +53,7 @@ public class MoveReferenceCastToLiteralCastOnAnyOperatorsWhenRightIsReference im
         this.castCapture = new Capture<>();
         this.pattern = typeOf(Function.class)
             .with(f -> AnyOperator.OPERATOR_NAMES.contains(f.name()))
-            .with(f -> f.arguments().get(0).symbolType() == SymbolType.LITERAL)
+            .with(f -> f.arguments().get(0).symbolType().isValueOrParameterSymbol())
             .with(f -> Optional.of(f.arguments().get(1)), typeOf(Function.class).capturedAs(castCapture)
                 .with(f -> f.isCast())
                 .with(f -> f.arguments().get(0).symbolType() == SymbolType.REFERENCE)
@@ -70,7 +70,7 @@ public class MoveReferenceCastToLiteralCastOnAnyOperatorsWhenRightIsReference im
                         Captures captures,
                         NodeContext nodeCtx,
                         Symbol parentNode) {
-        var literal = operator.arguments().get(0);
+        var literalOrParam = operator.arguments().get(0);
         var castFunction = captures.get(castCapture);
         var reference = castFunction.arguments().get(0);
         DataType<?> targetType = reference.valueType();
@@ -81,14 +81,14 @@ public class MoveReferenceCastToLiteralCastOnAnyOperatorsWhenRightIsReference im
 
         var operatorName = operator.name();
         if (List.of(AnyEqOperator.NAME, AnyNeqOperator.NAME).contains(operatorName) == false
-            && literal.valueType().id() == ArrayType.ID) {
+            && literalOrParam.valueType().id() == ArrayType.ID) {
             // this is not supported and will fail later on with more verbose error than a cast error
             return null;
         }
 
         return functionResolver.apply(
             operator.name(),
-            List.of(literal.cast(targetType), reference)
+            List.of(literalOrParam.cast(targetType), reference)
         );
     }
 }

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveSubscriptOnReferenceCastToLiteralCastInsideOperators.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveSubscriptOnReferenceCastToLiteralCastInsideOperators.java
@@ -51,7 +51,7 @@ public class MoveSubscriptOnReferenceCastToLiteralCastInsideOperators implements
         this.castCapture = new Capture<>();
         this.pattern = typeOf(Function.class)
             .with(f -> COMPARISON_OPERATORS.contains(f.name()))
-            .with(f -> f.arguments().get(1).symbolType() == SymbolType.LITERAL)
+            .with(f -> f.arguments().get(1).symbolType().isValueOrParameterSymbol())
             .with(f -> Optional.of(f.arguments().get(0)), typeOf(Function.class).capturedAs(castCapture)
                 .with(f -> f.isCast())
                 .with(f -> Optional.of(f.arguments().get(0)), typeOf(Function.class)
@@ -71,14 +71,14 @@ public class MoveSubscriptOnReferenceCastToLiteralCastInsideOperators implements
                         Captures captures,
                         NodeContext nodeCtx,
                         Symbol parentNode) {
-        var literal = operator.arguments().get(1);
+        var literalOrParam = operator.arguments().get(1);
         var castFunction = captures.get(castCapture);
         var subscript = castFunction.arguments().get(0);
         DataType<?> targetType = subscript.valueType();
 
         return functionResolver.apply(
             operator.name(),
-            List.of(subscript, literal.cast(targetType))
+            List.of(subscript, literalOrParam.cast(targetType))
         );
     }
 }

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/rule/SwapCastsInLikeOperators.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/rule/SwapCastsInLikeOperators.java
@@ -31,7 +31,6 @@ import io.crate.expression.operator.LikeOperators;
 import io.crate.expression.scalar.cast.CastMode;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.SymbolType;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
 import io.crate.planner.optimizer.matcher.Capture;
@@ -52,7 +51,7 @@ public class SwapCastsInLikeOperators implements Rule<Function> {
         this.castCapture = new Capture<>();
         this.pattern = typeOf(Function.class)
             .with(f -> LIKE_OPERATORS.contains(f.name()))
-            .with(f -> f.arguments().get(1).symbolType() == SymbolType.LITERAL)
+            .with(f -> f.arguments().get(1).symbolType().isValueOrParameterSymbol())
             .with(f -> Optional.of(f.arguments().get(0)), typeOf(Function.class).capturedAs(castCapture)
                 .with(f -> f.isCast())
                 .with(f -> f.arguments().get(0) instanceof Reference ref && ref.valueType().id() == StringType.ID)
@@ -66,12 +65,12 @@ public class SwapCastsInLikeOperators implements Rule<Function> {
 
     @Override
     public Symbol apply(Function likeFunction, Captures captures, NodeContext nodeCtx, Symbol parentNode) {
-        var literal = likeFunction.arguments().get(1);
+        var literalOrParam = likeFunction.arguments().get(1);
         var castFunction = captures.get(castCapture);
         var reference = castFunction.arguments().get(0);
         CastMode castMode = castFunction.castMode();
         assert castMode != null : "Pattern matched, function must be a cast";
-        Symbol castedLiteral = literal.cast(StringType.INSTANCE, castMode);
+        Symbol castedLiteral = literalOrParam.cast(StringType.INSTANCE, castMode);
         List<Symbol> newArgs;
         if (likeFunction.arguments().size() == 3) {
             // Don't lose ESCAPE character.

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -1821,7 +1821,7 @@ public class TransportSQLActionTest extends IntegTestCase {
                 createTable.append(", ");
             }
         }
-        createTable.append(")");
+        createTable.append(") WITH (refresh_interval = 0)");
         execute(createTable.toString());
 
         String insert = "INSERT INTO tbl VALUES ("
@@ -1862,12 +1862,12 @@ public class TransportSQLActionTest extends IntegTestCase {
 
         execute(selectParams.toString(), args);
         assertThat(response)
-            .as(selectParams.toString() + " with values " + Arrays.toString(args) + " must return a record")
+            .as(selectParams + " with values " + Arrays.toString(args) + " must return a record")
             .hasRowCount(1L);
 
         execute(selectInlineValues.toString());
         assertThat(response)
-            .as(selectInlineValues.toString() + " must return a record")
+            .as(selectInlineValues + " must return a record")
             .hasRowCount(1L);
     }
 

--- a/server/src/test/java/io/crate/planner/optimizer/symbol/OptimizerTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/symbol/OptimizerTest.java
@@ -24,9 +24,11 @@ package io.crate.planner.optimizer.symbol;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.isFunction;
 import static io.crate.testing.Asserts.isLiteral;
+import static io.crate.testing.Asserts.isReference;
 
 import org.junit.Test;
 
+import io.crate.expression.operator.EqOperator;
 import io.crate.expression.operator.GtOperator;
 import io.crate.expression.symbol.Symbol;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
@@ -52,5 +54,17 @@ public class OptimizerTest extends CrateDummyClusterServiceUnitTest {
         Symbol symbol = Optimizer.optimizeCasts(e.asSymbol("strCol::bigint > 3"), e.getPlannerContext(clusterService.state()));
 
         assertThat(symbol).isFunction(GtOperator.NAME, isFunction("cast"), isLiteral(3L));
+    }
+
+    @Test
+    public void test_implicit_cast_is_swapped_between_column_and_parameter() throws Exception {
+        SQLExecutor e = SQLExecutor.builder(clusterService)
+            .addTable("create table tbl (bytecol byte)")
+            .build();
+
+        // The symbol to optimize, because of ExpressionAnalyzer cast logic is
+        // _cast(bytcol, smallint) = 3
+        Symbol symbol = Optimizer.optimizeCasts(e.asSymbol("bytecol = 3::short"), e.getPlannerContext(clusterService.state()));
+        assertThat(symbol).isFunction(EqOperator.NAME, isReference("bytecol"), isFunction("_cast"));
     }
 }


### PR DESCRIPTION
Previously, the rules of symbol `Optimizer` were only matching literals, therfore expressions like `_cast(col as long) = $1` where not optimized. The issue was exposed by: #15552, where we removed the explicit call to unwrap casts, which caused
`TransportSqlActionTest#test_primary_key_lookups_returns_inserted_records` to fail frequently on the parameterized select.
