### PR TITLE
Move column stats generation method into Samples class

### DIFF
--- a/server/src/test/java/io/crate/statistics/TransportAnalyzeActionTest.java
+++ b/server/src/test/java/io/crate/statistics/TransportAnalyzeActionTest.java
@@ -21,8 +21,7 @@
 
 package io.crate.statistics;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static io.crate.testing.Asserts.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -63,7 +62,7 @@ public class TransportAnalyzeActionTest extends ESTestCase {
                 0,
                 null)
         );
-        var stats = TransportAnalyzeAction.createTableStats(samples, references);
-        assertThat(stats.numDocs, is(2L));
+        var stats = samples.createTableStats(references);
+        assertThat(stats.numDocs).isEqualTo(2L);
     }
 }


### PR DESCRIPTION
A simple refactoring that makes the internal state of Samples entirely private,
isolating the impact of any future changes in its representation.