### PR TITLE
Fix NPE thrown when USING clause contained unknown columns

### DIFF
--- a/docs/appendices/release-notes/5.6.3.rst
+++ b/docs/appendices/release-notes/5.6.3.rst
@@ -47,4 +47,5 @@ See the :ref:`version_5.6.0` release notes for a full list of changes in the
 Fixes
 =====
 
-None
+- Fixed ``NullPointerException`` thrown when joining tables with ``USING``
+  clause which contains columns not existing in either or both tables.

--- a/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -315,9 +315,11 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
 
         for (var joinColumn : joinUsing.getColumns()) {
 
+            boolean joinColumnExistsInLeft = false;
             for (var leftOutput : leftOutputs) {
                 var columnIdent = Symbols.pathFromSymbol(leftOutput);
                 if (columnIdent.name().equals(joinColumn)) {
+                    joinColumnExistsInLeft = true;
                     if (lhsOutputs.put(joinColumn, leftOutput) != null) {
                         throw new IllegalArgumentException(String.format(Locale.ENGLISH,
                                                                          "common column name %s appears more than once in left table", joinColumn));
@@ -325,14 +327,16 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
                 }
             }
 
-            if (lhsOutputs.isEmpty()) {
+            if (!joinColumnExistsInLeft) {
                 throw new IllegalArgumentException(String.format(Locale.ENGLISH,
                                                                  "column %s specified in USING clause does not exist in left table", joinColumn));
             }
 
+            boolean joinColumnExistsInRight = false;
             for (Symbol rightOutput : rightOutputs) {
                 var columnIdent = Symbols.pathFromSymbol(rightOutput);
                 if (columnIdent.name().equals(joinColumn)) {
+                    joinColumnExistsInRight = true;
                     if (rhsOutputs.put(joinColumn, rightOutput) != null) {
                         throw new IllegalArgumentException(String.format(Locale.ENGLISH,
                                                                          "common column name %s appears more than once in right table", joinColumn));
@@ -348,7 +352,7 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
                 }
             }
 
-            if (rhsOutputs.isEmpty()) {
+            if (!joinColumnExistsInRight) {
                 throw new IllegalArgumentException(String.format(Locale.ENGLISH,
                                                                  "column %s specified in USING clause does not exist in right table", joinColumn));
             }

--- a/server/src/test/java/io/crate/planner/operators/JoinTest.java
+++ b/server/src/test/java/io/crate/planner/operators/JoinTest.java
@@ -986,6 +986,28 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
 
     }
 
+    @Test
+    public void test_using_clause_specifying_multiple_columns_with_a_non_existing_column_raises_error() throws IOException {
+        var executor = SQLExecutor.builder(clusterService, 2, Randomness.get(), List.of())
+            .addTable("CREATE TABLE j1 (x INT, y INT)")
+            .addTable("CREATE TABLE j2 (x INT)")
+            .build();
+
+        assertThatThrownBy(() -> executor.analyze("SELECT * FROM j1 JOIN j2 USING(x, y)"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("column y specified in USING clause does not exist in right table");
+
+        // left and right sides swapped
+        assertThatThrownBy(() -> executor.analyze("SELECT * FROM j2 JOIN j1 USING(x, y)"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("column y specified in USING clause does not exist in left table");
+
+        // column unknown from both sides
+        assertThatThrownBy(() -> executor.analyze("SELECT * FROM j2 JOIN j1 USING(x, z)"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("column z specified in USING clause does not exist in left table");
+    }
+
     /**
      * Verifies a bug fix (and regression that was introduced with 5.2.4)
      * See https://github.com/crate/crate/issues/13808


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes https://github.com/crate/crate/issues/15568

also improves the exceptions thrown when left and right tables are swapped and column unknown from both sides:
```
cr> select sh.primary from sys.shards sh join information_schema.table_partitions tp using (partition_ident, primary);
ColumnUnknownException[Column primary unknown]

cr> select sh.primary from sys.shards sh join information_schema.table_partitions tp using (partition_ident, x);
ColumnUnknownException[Column x unknown]
```
Please see the added tests for the new behaviours.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
