### PR TITLE
Notify pgwire clients that `standard_conforming_strings` is `on`

### DIFF
--- a/docs/appendices/release-notes/5.6.3.rst
+++ b/docs/appendices/release-notes/5.6.3.rst
@@ -63,5 +63,11 @@ Fixes
 
      SELECT '1 yeAR 2 WeeKs 3 DAYS'::INTERVAL
 
+- Fixed an issue that caused ``CrateDB`` to fail to notify client applications
+  connecting via :ref:`PostgreSQL Wire Protocol <interface-postgresql>` that
+  :ref:`standard_conforming_strings <conf-session-standard_conforming_strings>`
+  is set to ``on`` which caused the clients to treat all query strings as non
+  standard conforming.
+
 - Fixed ``NullPointerException`` thrown when joining tables with ``USING``
   clause which contains columns not existing in either or both tables.

--- a/server/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
+++ b/server/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
@@ -501,6 +501,7 @@ public class PostgresWireProtocol {
         Messages.sendParameterStatus(channel, "datestyle", sessionSettings.dateStyle());
         Messages.sendParameterStatus(channel, "TimeZone", "UTC");
         Messages.sendParameterStatus(channel, "integer_datetimes", "on");
+        Messages.sendParameterStatus(channel, "standard_conforming_strings", "on");
     }
 
     /**


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes https://github.com/crate/crate/issues/15566. The bug was triggered because `standard_conforming_strings` was considered `false` by JDBC client and taking different execution path.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
