### PR TITLE
Fix support for joins on foreign tables

### DIFF
--- a/server/src/main/java/io/crate/execution/dsl/phases/ForeignCollectPhase.java
+++ b/server/src/main/java/io/crate/execution/dsl/phases/ForeignCollectPhase.java
@@ -40,6 +40,8 @@ public class ForeignCollectPhase extends AbstractProjectionsPhase implements Col
     private final RelationName relationName;
     private final List<Symbol> toCollect;
 
+    private DistributionInfo distributionInfo = DistributionInfo.DEFAULT_BROADCAST;
+
     public ForeignCollectPhase(UUID jobId,
                                int phaseId,
                                String handlerNode,
@@ -58,6 +60,7 @@ public class ForeignCollectPhase extends AbstractProjectionsPhase implements Col
         this.relationName = new RelationName(in);
         this.toCollect = Symbols.listFromStream(in);
         this.outputTypes = extractOutputTypes(toCollect, projections);
+        this.distributionInfo = new DistributionInfo(in);
     }
 
     @Override
@@ -66,16 +69,17 @@ public class ForeignCollectPhase extends AbstractProjectionsPhase implements Col
         out.writeString(handlerNode);
         relationName.writeTo(out);
         Symbols.toStream(toCollect, out);
+        distributionInfo.writeTo(out);
     }
 
     @Override
     public DistributionInfo distributionInfo() {
-        return DistributionInfo.DEFAULT_BROADCAST;
+        return distributionInfo;
     }
 
     @Override
     public void distributionInfo(DistributionInfo distributionInfo) {
-        throw new UnsupportedOperationException("Cannot set distributionInfo on ForeignCollectPhase");
+        this.distributionInfo = distributionInfo;
     }
 
     @Override

--- a/server/src/test/java/io/crate/integrationtests/ForeignDataWrapperITest.java
+++ b/server/src/test/java/io/crate/integrationtests/ForeignDataWrapperITest.java
@@ -251,4 +251,39 @@ public class ForeignDataWrapperITest extends IntegTestCase {
             "Dom"
         );
     }
+
+    @Test
+    public void test_can_use_joins_on_foreign_tables() throws Exception {
+        PostgresNetty postgresNetty = cluster().getInstance(PostgresNetty.class);
+        int port = postgresNetty.boundAddress().publishAddress().getPort();
+        String url = "jdbc:postgresql://127.0.0.1:" + port + '/';
+        String createServerStmt = "create server pg foreign data wrapper jdbc options (url ?)";
+        execute(createServerStmt, new Object[] { url });
+
+        String stmt = """
+            CREATE FOREIGN TABLE doc.summits (mountain text, height int)
+            SERVER pg
+            OPTIONS (schema_name 'sys', table_name 'summits')
+            """;
+        execute(stmt);
+
+        execute(
+            """
+            SELECT
+                f_summits.mountain,
+                sys_summits.country
+            FROM
+                doc.summits f_summits
+                INNER JOIN sys.summits sys_summits ON f_summits.mountain = sys_summits.mountain
+            ORDER BY
+                f_summits.height DESC
+            LIMIT 3
+            """
+        );
+        assertThat(response).hasRows(
+            "Mont Blanc| FR/IT",
+            "Monte Rosa| CH",
+            "Dom| CH"
+        );
+    }
 }


### PR DESCRIPTION
DistributionInfo handling in the ForeignCollectPhase was missing, which
prevented joins from working
