### PR TITLE
Add information_schema.user_mapping_options

### DIFF
--- a/docs/admin/fdw.rst
+++ b/docs/admin/fdw.rst
@@ -118,7 +118,7 @@ The JDBC foreign data wrapper supports the following ``OPTIONS`` for use with
 
 Example::
 
-  CREATE USER MAPPING USER SERVER my_postgresql OPTIONS ("user" 'trillian', password 'secret');
+  CREATE USER MAPPING FOR USER SERVER my_postgresql OPTIONS ("user" 'trillian', password 'secret');
 
 
 .. seealso::

--- a/docs/general/information-schema.rst
+++ b/docs/general/information-schema.rst
@@ -84,6 +84,7 @@ number of replicas.
     | information_schema | table_constraints       | BASE TABLE |             NULL | NULL               |
     | information_schema | table_partitions        | BASE TABLE |             NULL | NULL               |
     | information_schema | tables                  | BASE TABLE |             NULL | NULL               |
+    | information_schema | user_mapping_options    | BASE TABLE |             NULL | NULL               |
     | information_schema | user_mappings           | BASE TABLE |             NULL | NULL               |
     | information_schema | views                   | BASE TABLE |             NULL | NULL               |
     | pg_catalog         | pg_am                   | BASE TABLE |             NULL | NULL               |
@@ -136,7 +137,7 @@ number of replicas.
     | sys                | summits                 | BASE TABLE |             NULL | NULL               |
     | sys                | users                   | BASE TABLE |             NULL | NULL               |
     +--------------------+-------------------------+------------+------------------+--------------------+
-    SELECT 69 rows in set (... sec)
+    SELECT 70 rows in set (... sec)
 
 
 The table also contains additional information such as the specified
@@ -867,22 +868,22 @@ In CrateDB there is always a single entry listing `UTF8`::
       - Not implemented, this column is always null.
     * - ``character_set_name``
       - ``TEXT``
-      - Name of the character set
+      - Name of the character set.
     * - ``character_repertoire``
       - ``TEXT``
-      - Character repertoire
+      - Character repertoire.
     * - ``form_of_use``
       - ``TEXT``
-      - Character encoding form, same as ``character_set_name``
+      - Character encoding form, same as ``character_set_name``.
     * - ``default_collate_catalog``
       - ``TEXT``
-      - Name of the database containing the default collation (Always ``crate``)
+      - Name of the database containing the default collation (Always ``crate``).
     * - ``default_collate_schema``
       - ``TEXT``
-      - Name of the schema containing the default collation (Always ``NULL``)
+      - Name of the schema containing the default collation (Always ``NULL``).
     * - ``default_collate_name``
       - ``TEXT``
-      - Name of the default collation (Always ``NULL``)
+      - Name of the default collation (Always ``NULL``).
 
 
 .. _foreign_servers:
@@ -904,7 +905,7 @@ See :ref:`administration-fdw`.
      - Name of the database of the foreign server. Always ``crate``.
    * - ``foreign_server_name``
      - ``TEXT``
-     - Name of the foreign server
+     - Name of the foreign server.
    * - ``foreign_data_wrapper_catalog``
      - ``TEXT``
      - Name of the database that contains the foreign-data wrapper. Always
@@ -979,7 +980,7 @@ See :ref:`administration-fdw`.
        ``crate``.
    * - ``foreign_server_name``
      - ``TEXT``
-     - Name of the foreign server
+     - Name of the foreign server.
 
 .. _foreign_table_options:
 
@@ -1009,7 +1010,7 @@ See :ref:`administration-fdw`.
      - Name of an option.
    * - ``option_value``
      - ``TEXT``
-     - Value of the option cast to string
+     - Value of the option cast to string.
 
 .. _user_mappings:
 
@@ -1027,10 +1028,41 @@ See :ref:`administration-fdw`.
      - Description
    * - ``authorization_identifier``
      - ``TEXT``
-     - Name of the user being mapped
+     - Name of the user being mapped.
    * - ``foreign_server_catalog``
      - ``TEXT``
      - Name of the database of the foreign server. Always ``crate``.
    * - ``foreign_server_name``
      - ``TEXT``
-     - Name of the foreign server for this user mapping
+     - Name of the foreign server for this user mapping.
+
+.. _user_mapping_options:
+
+``user_mapping_options``
+------------------------
+
+Lists the options for user mappings created for foreign servers.
+See :ref:`administration-fdw`.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Column Name
+     - Return Type
+     - Description
+   * - ``authorization_identifier``
+     - ``TEXT``
+     - Name of the user being mapped.
+   * - ``foreign_server_catalog``
+     - ``TEXT``
+     - Name of the database of the foreign server. Always ``crate``.
+   * - ``foreign_server_name``
+     - ``TEXT``
+     - Name of the foreign server for this user mapping.
+   * - ``option_name``
+     - ``TEXT``
+     - Name of an option.
+   * - ``option_value``
+     - ``TEXT``
+     - Value of the option. The value is visible only to the user being mapped
+       and to superusers otherwise it will show as a ``NULL``.

--- a/docs/sql/statements/create-foreign-table.rst
+++ b/docs/sql/statements/create-foreign-table.rst
@@ -54,9 +54,8 @@ Do not raise an error if the table already exists.
 -----------
 
 :option value:
-
-Key value pairs defining foreign data wrapper specific options for the server.
-See :ref:`administration-fdw` for the foreign data wrapper specific options.
+  Key value pairs defining foreign data wrapper specific options for the server
+  .See :ref:`administration-fdw` for the foreign data wrapper specific options.
 
 .. seealso::
 

--- a/docs/sql/statements/create-server.rst
+++ b/docs/sql/statements/create-server.rst
@@ -56,10 +56,9 @@ Do not raise an error if the server already exists.
 -----------
 
 :option value:
-
-Key value pairs defining foreign data wrapper specific options for the server.
-For example, for the ``jdbc`` foreign data wrapper you can define a ``url``
-property to define the connection string::
+  Key value pairs defining foreign data wrapper specific options for the server
+  .For example, for the ``jdbc`` foreign data wrapper you can define a ``url``
+  property to define the connection string::
 
     CREATE SERVER pg FOREIGN DATA WRAPPER jdbc
     OPTIONS (url 'jdbc:postgresql://example.com:5432')

--- a/docs/sql/statements/create-user-mapping.rst
+++ b/docs/sql/statements/create-user-mapping.rst
@@ -39,7 +39,8 @@ more details.
 
 Creating a user mapping requires ``AL`` permission on cluster level.
 
-User mappings are visible in the :ref:`user_mappings` table.
+User mappings are visible in the :ref:`user_mappings` table and the options in
+:ref:`user_mapping_options`.
 
 Parameters
 ==========

--- a/docs/sql/statements/drop-server.rst
+++ b/docs/sql/statements/drop-server.rst
@@ -31,9 +31,8 @@ Parameters
 ==========
 
 :name:
-
-The name of the server to drop. Separate multiple names by comma to drop
-multiple servers at once.
+  The name of the server to drop. Separate multiple names by comma to drop
+  multiple servers at once.
 
 
 Clauses
@@ -51,7 +50,7 @@ any servers listed don't exist.
 ----------------------
 
 ``RESTRICT`` causes ``DROP SERVER`` to raise an error if any foreign table or
-user mappings for the given servers exist. This is the default
+user mappings for the given servers exist. This is the default.
 
 ``CASCADE`` instead causes ``DROP SERVER`` to also delete all foreign tables and
 mapped users using the given servers.

--- a/server/src/main/java/io/crate/execution/engine/collect/sources/InformationSchemaIterables.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/sources/InformationSchemaIterables.java
@@ -67,6 +67,7 @@ import io.crate.metadata.RoutineInfos;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.blob.BlobSchemaInfo;
 import io.crate.metadata.information.InformationSchemaInfo;
+import io.crate.metadata.information.UserMappingOptionsTableInfo;
 import io.crate.metadata.information.UserMappingsTableInfo.UserMapping;
 import io.crate.metadata.pgcatalog.OidHash;
 import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
@@ -375,6 +376,12 @@ public class InformationSchemaIterables implements ClusterStateListener {
         Metadata metadata = clusterService.state().metadata();
         ServersMetadata servers = metadata.custom(ServersMetadata.TYPE, ServersMetadata.EMPTY);
         return servers.getUserMappings();
+    }
+
+    public Iterable<UserMappingOptionsTableInfo.UserMappingOptions> userMappingOptions() {
+        Metadata metadata = clusterService.state().metadata();
+        ServersMetadata servers = metadata.custom(ServersMetadata.TYPE, ServersMetadata.EMPTY);
+        return servers.getUserMappingOptions();
     }
 
     public Iterable<ForeignTable> foreignTables() {

--- a/server/src/main/java/io/crate/fdw/CreateUserMappingRequest.java
+++ b/server/src/main/java/io/crate/fdw/CreateUserMappingRequest.java
@@ -22,23 +22,23 @@
 package io.crate.fdw;
 
 import java.io.IOException;
-import java.util.Map;
 
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.settings.Settings;
 
 public class CreateUserMappingRequest extends AcknowledgedRequest<CreateUserMappingRequest> {
 
     private final boolean ifNotExists;
     private final String userName;
     private final String server;
-    private final Map<String, Object> options;
+    private final Settings options;
 
     public CreateUserMappingRequest(boolean ifNotExists,
                                     String userName,
                                     String server,
-                                    Map<String, Object> options) {
+                                    Settings options) {
         this.ifNotExists = ifNotExists;
         this.userName = userName;
         this.server = server;
@@ -49,7 +49,7 @@ public class CreateUserMappingRequest extends AcknowledgedRequest<CreateUserMapp
         this.ifNotExists = in.readBoolean();
         this.userName = in.readString();
         this.server = in.readString();
-        this.options = in.readMap(StreamInput::readString, StreamInput::readGenericValue);
+        this.options = Settings.readSettingsFromStream(in);
     }
 
     @Override
@@ -57,7 +57,7 @@ public class CreateUserMappingRequest extends AcknowledgedRequest<CreateUserMapp
         out.writeBoolean(ifNotExists);
         out.writeString(userName);
         out.writeString(server);
-        out.writeMap(options, StreamOutput::writeString, StreamOutput::writeGenericValue);
+        Settings.writeSettingsToStream(out, options);
     }
 
     public boolean ifNotExists() {
@@ -72,7 +72,7 @@ public class CreateUserMappingRequest extends AcknowledgedRequest<CreateUserMapp
         return server;
     }
 
-    public Map<String, Object> options() {
+    public Settings options() {
         return options;
     }
 }

--- a/server/src/main/java/io/crate/metadata/information/InformationSchemaInfo.java
+++ b/server/src/main/java/io/crate/metadata/information/InformationSchemaInfo.java
@@ -59,6 +59,7 @@ public class InformationSchemaInfo implements SchemaInfo {
             .put(ForeignTableTableInfo.NAME, ForeignTableTableInfo.create())
             .put(ForeignTableOptionsTableInfo.NAME, ForeignTableOptionsTableInfo.create())
             .put(UserMappingsTableInfo.NAME, UserMappingsTableInfo.create())
+            .put(UserMappingOptionsTableInfo.NAME, UserMappingOptionsTableInfo.create())
             .immutableMap();
     }
 

--- a/server/src/main/java/io/crate/metadata/information/UserMappingOptionsTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/information/UserMappingOptionsTableInfo.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.metadata.information;
+
+import io.crate.Constants;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.SystemTable;
+import io.crate.types.DataTypes;
+
+public class UserMappingOptionsTableInfo {
+
+    public static final String NAME = "user_mapping_options";
+    public static final RelationName IDENT = new RelationName(InformationSchemaInfo.NAME, NAME);
+
+    public record UserMappingOptions(String userName, String serverName, String optionName, String optionValue) {
+    }
+
+    public static SystemTable<UserMappingOptions> create() {
+        return SystemTable.<UserMappingOptions>builder(IDENT)
+            .add("authorization_identifier", DataTypes.STRING, UserMappingOptions::userName)
+            .add("foreign_server_catalog", DataTypes.STRING, ignored -> Constants.DB_NAME)
+            .add("foreign_server_name", DataTypes.STRING, UserMappingOptions::serverName)
+            .add("option_name", DataTypes.STRING, UserMappingOptions::optionName)
+            .add("option_value", DataTypes.STRING, UserMappingOptions::optionValue)
+            .build();
+    }
+}

--- a/server/src/main/java/io/crate/planner/CreateUserMappingPlan.java
+++ b/server/src/main/java/io/crate/planner/CreateUserMappingPlan.java
@@ -22,13 +22,11 @@
 package io.crate.planner;
 
 import java.util.Locale;
-import java.util.Map;
-import java.util.Map.Entry;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
 
 import io.crate.analyze.AnalyzedCreateUserMapping;
 import io.crate.analyze.SymbolEvaluator;
@@ -69,32 +67,33 @@ public class CreateUserMappingPlan implements Plan {
         ServersMetadata serversMetadata = metadata.custom(ServersMetadata.TYPE, ServersMetadata.EMPTY);
         ServersMetadata.Server server = serversMetadata.get(createUserMapping.serverName());
         var supportedUserOptions = Lists.map(foreignDataWrappers.get(server.fdw()).optionalUserOptions(), Setting::getKey);
-        createUserMapping.options().keySet().forEach(
-            option -> {
-                if (!supportedUserOptions.contains(option.toLowerCase(Locale.ROOT))) {
-                    throw new IllegalArgumentException(
-                        String.format(
-                            Locale.ENGLISH,
-                            "Invalid option '%s' provided, the supported options are: %s",
-                            option,
-                            supportedUserOptions)
-                    );
-                }
-            });
 
         Function<Symbol, Object> toValue = new SymbolEvaluator(
             plannerContext.transactionContext(),
             plannerContext.nodeContext(),
             subQueryResults
         ).bind(params);
-        Map<String, Object> options = createUserMapping.options().entrySet().stream()
-            .collect(Collectors.toMap(Entry::getKey, entry -> toValue.apply(entry.getValue())));
+        Settings.Builder optionsBuilder = Settings.builder();
+        createUserMapping.options().forEach((optionName, option) -> {
+            optionName = optionName.toLowerCase(Locale.ROOT);
+            if (supportedUserOptions.contains(optionName)) {
+                optionsBuilder.put(optionName, toValue.apply(option));
+            } else {
+                throw new IllegalArgumentException(
+                        String.format(
+                                Locale.ENGLISH,
+                                "Invalid option '%s' provided, the supported options are: %s",
+                                optionName,
+                                supportedUserOptions)
+                );
+            }
+        });
 
         var request = new CreateUserMappingRequest(
             createUserMapping.ifNotExists(),
             createUserMapping.user().name(),
             createUserMapping.serverName(),
-            options
+            optionsBuilder.build()
         );
         dependencies.client()
             .execute(TransportCreateUserMappingAction.ACTION, request)

--- a/server/src/test/java/io/crate/fdw/ServersMetadataTest.java
+++ b/server/src/test/java/io/crate/fdw/ServersMetadataTest.java
@@ -41,12 +41,17 @@ public class ServersMetadataTest extends ESTestCase {
 
     @Test
     public void test_xcontent_roundtrip() throws Exception {
-        Map<String, Map<String, Object>> pg1Users = Map.of(
+        Map<String, Settings> pg1Users = Map.of(
             "crate",
-            Map.of(
-                "user", "trillian",
-                "password", "secret"
-            )
+            Settings.builder()
+                .put("user", "trillian")
+                .put("password", "secret")
+                .build(),
+            "dummy",
+            Settings.builder()
+                .put("user", "dummy")
+                .put("password", "123")
+                .build()
         );
         Settings pg1Options = Settings.builder()
             .put("url", "jdbc:postgresql://localhost:5432")

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -75,6 +75,7 @@ public class InformationSchemaTest extends IntegTestCase {
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| crate| table_constraints| information_schema| BASE TABLE| NULL",
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| crate| table_partitions| information_schema| BASE TABLE| NULL",
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| crate| tables| information_schema| BASE TABLE| NULL",
+            "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| crate| user_mapping_options| information_schema| BASE TABLE| NULL",
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| crate| user_mappings| information_schema| BASE TABLE| NULL",
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| crate| views| information_schema| BASE TABLE| NULL",
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| crate| pg_am| pg_catalog| BASE TABLE| NULL",
@@ -207,13 +208,13 @@ public class InformationSchemaTest extends IntegTestCase {
     @Test
     public void testSearchInformationSchemaTablesRefresh() {
         execute("select * from information_schema.tables");
-        assertThat(response.rowCount()).isEqualTo(65L);
+        assertThat(response.rowCount()).isEqualTo(66L);
 
         execute("create table t4 (col1 integer, col2 string) with(number_of_replicas=0)");
         ensureYellow(getFqn("t4"));
 
         execute("select * from information_schema.tables");
-        assertThat(response.rowCount()).isEqualTo(66L);
+        assertThat(response.rowCount()).isEqualTo(67L);
     }
 
     @Test
@@ -569,7 +570,7 @@ public class InformationSchemaTest extends IntegTestCase {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertThat(response.rowCount()).isEqualTo(1007);
+        assertThat(response.rowCount()).isEqualTo(1012);
     }
 
     @Test
@@ -890,7 +891,7 @@ public class InformationSchemaTest extends IntegTestCase {
         execute("create table t3 (id integer, col1 string) clustered into 3 shards with(number_of_replicas=0)");
         execute("select count(*) from information_schema.tables");
         assertThat(response.rowCount()).isEqualTo(1);
-        assertThat(response.rows()[0][0]).isEqualTo(68L);
+        assertThat(response.rows()[0][0]).isEqualTo(69L);
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
@@ -549,6 +549,7 @@ public class PrivilegesIntegrationTest extends BaseRolesIntegrationTest {
             "table_partitions_pkey",
             "tables",
             "tables_pkey",
+            "user_mapping_options",
             "user_mappings",
             "views",
             "views_pkey"
@@ -647,7 +648,7 @@ public class PrivilegesIntegrationTest extends BaseRolesIntegrationTest {
         //make sure a new user has default accesses to pg tables with information and pg catalog schema related entries
         try (Session testUserSession = testUserSession()) {
             execute("select * from pg_catalog.pg_attribute order by attname", null, testUserSession);
-            assertThat(response).hasRowCount(559L);
+            assertThat(response).hasRowCount(564L);
 
             //create a table with an attribute that a new user is not privileged to access
             executeAsSuperuser("create table test_schema.my_table (my_col int)");

--- a/server/src/test/java/io/crate/integrationtests/TableSettingsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TableSettingsTest.java
@@ -102,7 +102,7 @@ public class TableSettingsTest extends IntegTestCase {
     public void testFilterOnNull() throws Exception {
         execute("select * from information_schema.tables " +
                 "where settings IS NULL");
-        assertEquals(65L, response.rowCount());
+        assertEquals(66L, response.rowCount());
         execute("select * from information_schema.tables " +
                 "where table_name = 'settings_table' and settings['warmer']['enabled'] IS NULL");
         assertEquals(0, response.rowCount());


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Exposes user mapping options main logic to check are 1) converting to/from xcontent and 2) masking option values (to protect the pw).

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
