### PR TITLE
Allow shortcut names for PostgreSQL style INTERVALs

### DIFF
--- a/docs/appendices/release-notes/5.7.0.rst
+++ b/docs/appendices/release-notes/5.7.0.rst
@@ -64,6 +64,11 @@ None
 SQL Standard and PostgreSQL Compatibility
 -----------------------------------------
 
+- Allow shortcut one-char names for PostgreSQL style
+  :ref:`INTERVALs <type-interval>`, e.g.::
+
+    SELECT '1y 2w 3d 4h 5m 6s'::INTERVAL
+
 - Added initial support for foreign data wrappers, including a ``jdbc``
   :ref:`foreign data wrapper <administration-fdw>`.
 

--- a/server/src/main/java/io/crate/interval/PGIntervalParser.java
+++ b/server/src/main/java/io/crate/interval/PGIntervalParser.java
@@ -112,13 +112,13 @@ final class PGIntervalParser {
                 // are handled for Non-ISO intervals here.
                 if (unitToken != null) {
                     switch (unitToken) {
-                        case "year", "years" -> years = nullSafeIntGet(valueToken);
+                        case "year", "years", "y" -> years = nullSafeIntGet(valueToken);
                         case "month", "months", "mon", "mons" -> months = nullSafeIntGet(valueToken);
-                        case "day", "days" -> days += nullSafeIntGet(valueToken);
-                        case "week", "weeks" -> days += nullSafeIntGet(valueToken) * 7;
-                        case "hour", "hours" -> hours = nullSafeIntGet(valueToken);
-                        case "min", "mins", "minute", "minutes" -> minutes = nullSafeIntGet(valueToken);
-                        case "sec", "secs", "second", "seconds" -> {
+                        case "day", "days", "d" -> days += nullSafeIntGet(valueToken);
+                        case "week", "weeks", "w" -> days += nullSafeIntGet(valueToken) * 7;
+                        case "hour", "hours", "h" -> hours = nullSafeIntGet(valueToken);
+                        case "min", "mins", "minute", "minutes", "m" -> minutes = nullSafeIntGet(valueToken);
+                        case "sec", "secs", "second", "seconds", "s" -> {
                             seconds = parseInteger(valueToken);
                             milliSeconds = parseMilliSeconds(valueToken);
                         }

--- a/server/src/test/java/io/crate/interval/IntervalParserTest.java
+++ b/server/src/test/java/io/crate/interval/IntervalParserTest.java
@@ -238,13 +238,13 @@ public class IntervalParserTest extends ESTestCase {
             .withPeriodType(PeriodType.yearMonthDayTime());
 
 
-        var year = randomWhiteSpaces() + randomFrom("year", "years");
+        var year = randomWhiteSpaces() + randomFrom("year", "years", "y");
         var month = randomWhiteSpaces() + randomFrom("month", "months", "mon", "mons");
-        var week = randomWhiteSpaces() + randomFrom("week", "weeks");
-        var day = randomWhiteSpaces() + randomFrom("day", "days");
-        var hour = randomWhiteSpaces() + randomFrom("hour", "hours");
-        var minute = randomWhiteSpaces() + randomFrom("minute", "minutes", "min", "mins");
-        var second = randomWhiteSpaces() + randomFrom("second", "seconds", "sec", "secs");
+        var week = randomWhiteSpaces() + randomFrom("week", "weeks", "w");
+        var day = randomWhiteSpaces() + randomFrom("day", "days", "d");
+        var hour = randomWhiteSpaces() + randomFrom("hour", "hours", "h");
+        var minute = randomWhiteSpaces() + randomFrom("minute", "minutes", "min", "mins", "m");
+        var second = randomWhiteSpaces() + randomFrom("second", "seconds", "sec", "secs", "s");
 
         year = randomBoolean() ? year : year.toUpperCase(Locale.ENGLISH);
         month = randomBoolean() ? month : month.toUpperCase(Locale.ENGLISH);


### PR DESCRIPTION
e.g.:
```
SELECT '1y 2w 3d 4h 5m 6s'::INTERVAL
```

Closes: #14211
