### PR TITLE
Fix issue with duplicate units for psql style INTERVALs

### DIFF
--- a/docs/appendices/release-notes/5.6.3.rst
+++ b/docs/appendices/release-notes/5.6.3.rst
@@ -48,6 +48,11 @@ Fixes
 =====
 
 - Fixed an issue with PostgreSQL style :ref:`INTERVALs <type-interval>`, which
+  allowed duplicate unit definitions, e.g.::
+
+     SELECT '1 year 3 days 2 years'::INTERVAL
+
+- Fixed an issue with PostgreSQL style :ref:`INTERVALs <type-interval>`, which
   didn't allow units next to values without whitespace separation, e.g.::
 
      SELECT '1year 2weeks 3day'::INTERVAL

--- a/server/src/test/java/io/crate/interval/IntervalParserTest.java
+++ b/server/src/test/java/io/crate/interval/IntervalParserTest.java
@@ -233,6 +233,22 @@ public class IntervalParserTest extends ESTestCase {
     }
 
     @Test
+    public void test_invalid_duplicate_units() {
+        assertThatThrownBy(() -> IntervalParser.apply("1 week 2 mons 3 days 4w"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Invalid interval format: 1 week 2 mons 3 days 4w");
+        assertThatThrownBy(() -> IntervalParser.apply("1y 11:22:33 11:22:33"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Invalid interval format: 1y 11:22:33 11:22:33");
+        assertThatThrownBy(() -> IntervalParser.apply("2sec 11:22:33"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Invalid interval format: 2sec 11:22:33");
+        assertThatThrownBy(() -> IntervalParser.apply("1 years 2 mons 3 days 2 years"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Invalid interval format: 1 years 2 mons 3 days 2 years");
+    }
+
+    @Test
     public void test_normalization() {
         var expected = new Period(1, 2, 0, 827, 4, 40, 43, 0)
             .withPeriodType(PeriodType.yearMonthDayTime());


### PR DESCRIPTION
Disallow duplicate units in the interval strings, as this can be ambiguous and also not conforming with PostgreSQL behaviour.
