### PR TITLE
Integrate open-search google cloud plugin retry logic

### DIFF
--- a/docs/sql/statements/create-repository.rst
+++ b/docs/sql/statements/create-repository.rst
@@ -594,7 +594,7 @@ A ``gcs`` repository stores snapshots on the `Google Cloud Storage`_ service.
 Parameters
 ''''''''''
 
-.. _sql-create-repo-gcs-account:
+.. _sql-create-repo-gcs-bucket:
 
 **bucket**
   | *Type:* ``text``
@@ -668,6 +668,51 @@ Parameters
   | *Default:* ``root directory``
 
   The container path to use for snapshots.
+
+.. _sql-create-repo-gcs-compress:
+
+**compress**
+  | *Type:*    ``boolean``
+  | *Default:* ``true``
+
+  Whether CrateDB should compress the metadata part of the snapshot or not.
+
+
+.. _sql-create-repo-gcs-chunk_size:
+
+**chunk_size**
+  | *Type:*    ``bigint`` or ``text``
+  | *Default:* ``null``
+
+  Defines the maximum size of any single file that comprises the snapshot. If
+  set to ``null``, the default value 5 Terabyte is used. You can specify the
+  chunk size with units (e.g., ``1g``, ``5m``, or ``9k``). If no unit is
+  specified, the unit defaults to bytes.
+
+.. _sql-create-repo-gcs-connect_timeout:
+
+**connect_timeout**
+  | *Type:*    ``text``
+  | *Default:* ``0``
+
+  Defines the timeout to establish a connection to the Google Cloud Storage
+  service. The value should specify the unit. For example, a value of 5s
+  specifies a 5 second timeout. The value of -1 corresponds to an infinite
+  timeout. The default value ``0`` indicates to use the default value of ``20s``
+  from the Google Cloud Storage library.
+
+
+.. _sql-create-repo-gcs-read_timeout:
+
+**read_timeout**
+  | *Type:*    ```text``
+  | *Default:* ``0``
+
+  Defines the timeout to read data from an established connection. The
+  value should specify the unit. For example, a value of 5s specifies a 5
+  second timeout. The value of -1 corresponds to an infinite timeout.
+  The default value ``0`` indicates to use the default value of ``20s``
+  from the Google Cloud Storage library.
 
 .. _sql-create-repo-gcs-endpoint:
 

--- a/plugins/repository-gcs/pom.xml
+++ b/plugins/repository-gcs/pom.xml
@@ -66,7 +66,19 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-storage</artifactId>
-            <version>${versions.google.cloud}</version>
+            <version>${versions.google.cloud.storage}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-core-http</artifactId>
+            <version>${versions.google.cloud.core.http}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-core</artifactId>
+            <version>${versions.google.cloud.core}</version>
         </dependency>
 
         <!-- Pin version of external dependencies -->

--- a/plugins/repository-gcs/src/main/java/io/crate/gcs/GCSBlobStore.java
+++ b/plugins/repository-gcs/src/main/java/io/crate/gcs/GCSBlobStore.java
@@ -21,31 +21,80 @@
 
 package io.crate.gcs;
 
-import java.io.IOException;
+import com.google.api.gax.paging.Page;
+import com.google.cloud.BatchResult;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.Storage.BlobListOption;
+import com.google.cloud.storage.StorageBatch;
+import com.google.cloud.storage.StorageException;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.elasticsearch.cluster.metadata.RepositoryMetadata;
 import org.elasticsearch.common.blobstore.BlobContainer;
+import org.elasticsearch.common.blobstore.BlobMetadata;
 import org.elasticsearch.common.blobstore.BlobPath;
 import org.elasticsearch.common.blobstore.BlobStore;
+import org.elasticsearch.common.blobstore.support.PlainBlobMetadata;
+import org.elasticsearch.common.io.Streams;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
 
-import com.google.cloud.storage.Storage;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.channels.Channels;
+import java.nio.file.FileAlreadyExistsException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.net.HttpURLConnection.HTTP_GONE;
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
+import static java.net.HttpURLConnection.HTTP_PRECON_FAILED;
+
+import io.crate.common.collections.Iterables;
 
 
+/**
+ * Bassed on https://github.com/opensearch-project/OpenSearch/blob/main/plugins/repository-gcs/src/main/java/org/opensearch/repositories/gcs/GoogleCloudStorageBlobStore.java
+ */
 public class GCSBlobStore implements BlobStore {
 
-    private final Storage storage;
+    private static final Logger LOGGER = LogManager.getLogger(GCSBlobStore.class);
+
+    // The recommended maximum size of a blob that should be uploaded in a single
+    // request. Larger files should be uploaded over multiple requests (this is
+    // called "resumable upload")
+    // https://cloud.google.com/storage/docs/json_api/v1/how-tos/resumable-upload
+    public static final int LARGE_BLOB_THRESHOLD_BYTE_SIZE = Math.toIntExact(new ByteSizeValue(5, ByteSizeUnit.MB).getBytes());
+
     private final String bucketName;
+    private final GCSService storageService;
+    private final RepositoryMetadata metadata;
+    private final int bufferSize;
 
-    GCSBlobStore(Storage storage, String bucketName) {
-        this.storage = storage;
+    public GCSBlobStore(
+        String bucketName,
+        GCSService storageService,
+        RepositoryMetadata metadata,
+        int bufferSize) {
         this.bucketName = bucketName;
+        this.storageService = storageService;
+        this.metadata = metadata;
+        this.bufferSize = bufferSize;
     }
 
-    public Storage storage() {
-        return storage;
-    }
-
-    public String bucketName() {
-        return bucketName;
+    private Storage client() {
+        return storageService.client(metadata);
     }
 
     @Override
@@ -55,10 +104,248 @@ public class GCSBlobStore implements BlobStore {
 
     @Override
     public void close() throws IOException {
-        try {
-            storage.close();
-        } catch (Exception e) {
-            throw new IOException(e);
+        storageService.closeRepositoryClient(metadata.name());
+    }
+
+    /**
+     * List blobs in the specific bucket under the specified path. The path root is removed.
+     *
+     * @param path base path of the blobs to list
+     * @return a map of blob names and their metadata
+     */
+    Map<String, BlobMetadata> listBlobs(String path) throws IOException {
+        return listBlobsByPrefix(path, "");
+    }
+
+    /**
+     * List all blobs in the specific bucket with names prefixed
+     *
+     * @param path   base path of the blobs to list. This path is removed from the
+     *               names of the blobs returned.
+     * @param prefix prefix of the blobs to list.
+     * @return a map of blob names and their metadata.
+     */
+    Map<String, BlobMetadata> listBlobsByPrefix(String path, String prefix) {
+        String pathPrefix = buildKey(path, prefix);
+        var result = new HashMap<String, BlobMetadata>();
+        for (var blob : client().list(bucketName, BlobListOption.currentDirectory(), BlobListOption.prefix(pathPrefix)).iterateAll()) {
+            assert blob.getName().startsWith(path);
+            if (blob.isDirectory() == false) {
+                final String suffixName = blob.getName().substring(path.length());
+                result.put(suffixName, new PlainBlobMetadata(suffixName, blob.getSize()));
+            }
+        }
+        return result;
+    }
+
+    Map<String, BlobContainer> listChildren(BlobPath path) {
+        final String pathStr = path.buildAsString();
+        var result = new HashMap<String, BlobContainer>();
+        for (var blob : client().list(bucketName, BlobListOption.currentDirectory(), BlobListOption.prefix(pathStr)).iterateAll()) {
+            if (blob.isDirectory()) {
+                assert blob.getName().startsWith(pathStr);
+                assert blob.getName().endsWith("/");
+                // Strip path prefix and trailing slash
+                final String suffixName = blob.getName().substring(pathStr.length(), blob.getName().length() - 1);
+                if (suffixName.isEmpty() == false) {
+                    result.put(suffixName, new GCSBlobContainer(path.add(suffixName), this));
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Returns true if the blob exists in the specific bucket
+     *
+     * @param blobName name of the blob
+     * @return true iff the blob exists
+     */
+    boolean blobExists(String blobName) {
+        final BlobId blobId = BlobId.of(bucketName, blobName);
+        final Blob blob = client().get(blobId);
+        return blob != null;
+    }
+
+    /**
+     * Returns an {@link java.io.InputStream} for the given blob name
+     *
+     * @param blobName name of the blob
+     * @return the InputStream used to read the blob's content
+     */
+    InputStream readBlob(String blobName) throws IOException {
+        return new GCSRetryingInputStream(client(), BlobId.of(bucketName, blobName));
+    }
+
+    /**
+     * Returns an {@link java.io.InputStream} for the given blob's position and length
+     *
+     * @param blobName name of the blob
+     * @param position starting position to read from
+     * @param length   length of bytes to read
+     * @return the InputStream used to read the blob's content
+     */
+    InputStream readBlob(String blobName, long position, long length) throws IOException {
+        if (position < 0L) {
+            throw new IllegalArgumentException("position must be non-negative");
+        }
+        if (length < 0) {
+            throw new IllegalArgumentException("length must be non-negative");
+        }
+        if (length == 0) {
+            return new ByteArrayInputStream(new byte[0]);
+        } else {
+            return new GCSRetryingInputStream(
+                client(),
+                BlobId.of(bucketName, blobName),
+                position,
+                Math.addExact(position, length - 1)
+            );
         }
     }
+
+    /**
+     * Writes a blob in the specific bucket
+     *
+     * @param inputStream         content of the blob to be written
+     * @param blobSize            expected size of the blob to be written
+     * @param failIfAlreadyExists whether to throw a FileAlreadyExistsException if the given blob already exists
+     */
+    void writeBlob(String blobName, InputStream inputStream, long blobSize, boolean failIfAlreadyExists) throws IOException {
+        final BlobInfo blobInfo = BlobInfo.newBuilder(bucketName, blobName).build();
+        if (blobSize > getLargeBlobThresholdInBytes()) {
+            writeBlobResumable(blobInfo, inputStream, blobSize, failIfAlreadyExists);
+        } else {
+            writeBlobMultipart(blobInfo, inputStream, blobSize, failIfAlreadyExists);
+        }
+    }
+
+    long getLargeBlobThresholdInBytes() {
+        return LARGE_BLOB_THRESHOLD_BYTE_SIZE;
+    }
+
+    /**
+     * Uploads a blob using the "resumable upload" method (multiple requests, which
+     * can be independently retried in case of failure, see
+     * https://cloud.google.com/storage/docs/json_api/v1/how-tos/resumable-upload
+     *
+     * @param blobInfo            the info for the blob to be uploaded
+     * @param inputStream         the stream containing the blob data
+     * @param size                expected size of the blob to be written
+     * @param failIfAlreadyExists whether to throw a FileAlreadyExistsException if the given blob already exists
+     */
+    private void writeBlobResumable(BlobInfo blobInfo, InputStream inputStream, long size, boolean failIfAlreadyExists) throws IOException {
+        // We retry 410 GONE errors to cover the unlikely but possible scenario where a resumable upload session becomes broken and
+        // needs to be restarted from scratch. Given how unlikely a 410 error should be according to SLAs we retry only twice.
+        assert inputStream.markSupported();
+        inputStream.mark(Integer.MAX_VALUE);
+        final byte[] buffer = new byte[size < bufferSize ? Math.toIntExact(size) : bufferSize];
+        StorageException storageException = null;
+        final Storage.BlobWriteOption[] writeOptions = failIfAlreadyExists
+            ? new Storage.BlobWriteOption[]{Storage.BlobWriteOption.doesNotExist()}
+            : new Storage.BlobWriteOption[0];
+        for (int retry = 0; retry < 3; ++retry) {
+            try (var writeChannel = client().writer(blobInfo, writeOptions)) {
+                Streams.copy(inputStream, Channels.newOutputStream(writeChannel), buffer);
+                return;
+            } catch (final StorageException se) {
+                final int errorCode = se.getCode();
+                if (errorCode == HTTP_GONE) {
+                    LOGGER.warn(() -> new ParameterizedMessage("Retrying broken resumable upload session for blob {}", blobInfo), se);
+                    storageException = se;
+                    inputStream.reset();
+                    continue;
+                } else if (failIfAlreadyExists && errorCode == HTTP_PRECON_FAILED) {
+                    throw new FileAlreadyExistsException(blobInfo.getBlobId().getName(), null, se.getMessage());
+                }
+                if (storageException != null) {
+                    se.addSuppressed(storageException);
+                }
+                throw se;
+            }
+        }
+        throw storageException;
+    }
+
+    /**
+     * Uploads a blob using the "multipart upload" method (a single
+     * 'multipart/related' request containing both data and metadata. The request is
+     * gziped), see:
+     * https://cloud.google.com/storage/docs/json_api/v1/how-tos/multipart-upload
+     *
+     * @param blobInfo            the info for the blob to be uploaded
+     * @param inputStream         the stream containing the blob data
+     * @param blobSize            the size
+     * @param failIfAlreadyExists whether to throw a FileAlreadyExistsException if the given blob already exists
+     */
+    private void writeBlobMultipart(BlobInfo blobInfo, InputStream inputStream, long blobSize, boolean failIfAlreadyExists)
+        throws IOException {
+        assert blobSize <= getLargeBlobThresholdInBytes() : "large blob uploads should use the resumable upload method";
+        byte[] buffer = new byte[Math.toIntExact(blobSize)];
+        inputStream.readNBytes(buffer, 0, buffer.length);
+        try {
+            final Storage.BlobTargetOption[] targetOptions = failIfAlreadyExists
+                ? new Storage.BlobTargetOption[]{Storage.BlobTargetOption.doesNotExist()}
+                : new Storage.BlobTargetOption[0];
+            client().create(blobInfo, buffer, targetOptions);
+        } catch (StorageException se) {
+            if (failIfAlreadyExists && se.getCode() == HTTP_PRECON_FAILED) {
+                throw new FileAlreadyExistsException(blobInfo.getBlobId().getName(), null, se.getMessage());
+            }
+            throw se;
+        }
+    }
+
+    void deleteDirectory(String pathStr) throws IOException {
+        Page<Blob> page = client().list(bucketName, BlobListOption.prefix(pathStr));
+        do {
+            deleteBlobsIgnoringIfNotExists(Iterables.transform(page.getValues(), Blob::getName));
+            page = page.getNextPage();
+        } while (page != null);
+    }
+
+    void deleteBlobsIgnoringIfNotExists(Iterable<String> blobNames) throws IOException {
+        Iterator<String> blobNamesIt = blobNames.iterator();
+        if (!blobNamesIt.hasNext()) {
+            return;
+        }
+        List<BlobId> failedBlobs = Collections.synchronizedList(new ArrayList<>());
+        try {
+            final AtomicReference<StorageException> ioe = new AtomicReference<>();
+            final StorageBatch batch = client().batch();
+            for (String blobName : blobNames) {
+                BlobId blob = BlobId.of(bucketName, blobName);
+                batch.delete(blob).notify(new BatchResult.Callback<Boolean, StorageException>() {
+                    @Override
+                    public void success(Boolean result) {
+                    }
+
+                    @Override
+                    public void error(StorageException exception) {
+                        if (exception.getCode() != HTTP_NOT_FOUND) {
+                            failedBlobs.add(blob);
+                            if (ioe.compareAndSet(null, exception) == false) {
+                                ioe.get().addSuppressed(exception);
+                            }
+                        }
+                    }
+                });
+            }
+            batch.submit();
+
+            final StorageException exception = ioe.get();
+            if (exception != null) {
+                throw exception;
+            }
+        } catch (final Exception e) {
+            throw new IOException("Exception when deleting blobs [" + failedBlobs + "]", e);
+        }
+        assert failedBlobs.isEmpty();
+    }
+
+    private static String buildKey(String keyPath, String s) {
+        assert s != null;
+        return keyPath + s;
+    }
+
 }

--- a/plugins/repository-gcs/src/main/java/io/crate/gcs/GCSClientSettings.java
+++ b/plugins/repository-gcs/src/main/java/io/crate/gcs/GCSClientSettings.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package io.crate.gcs;
+
+import java.net.URI;
+
+import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+
+import com.google.auth.oauth2.ServiceAccountCredentials;
+
+import io.crate.common.unit.TimeValue;
+import io.crate.exceptions.InvalidArgumentException;
+
+/**
+ * Based on https://github.com/opensearch-project/OpenSearch/blob/main/plugins/repository-gcs/src/main/java/org/opensearch/repositories/gcs/GoogleCloudStorageClientSettings.java
+ */
+public record GCSClientSettings(
+    ServiceAccountCredentials credentials,
+    String endpoint,
+    String projectId,
+    TimeValue connectTimeout,
+    TimeValue readTimeout,
+    URI tokenUri
+) {
+
+    static final Setting<SecureString> PRIVATE_KEY_ID_SETTING = Setting.maskedString("private_key_id");
+
+    static final Setting<SecureString> PRIVATE_KEY_SETTING = Setting.maskedString("private_key");
+
+    static final Setting<SecureString> CLIENT_EMAIL_SETTING = Setting.maskedString("client_email");
+
+    static final Setting<SecureString> CLIENT_ID_SETTING = Setting.maskedString("client_id");
+
+    static final Setting<String> ENDPOINT_SETTING = Setting.simpleString("endpoint", Setting.Property.NodeScope);
+
+    static final Setting<String> PROJECT_ID_SETTING = Setting.simpleString("project_id", Setting.Property.NodeScope);
+
+    static final Setting<String> TOKEN_URI_SETTING = Setting.simpleString(
+        "token_uri", "https://oauth2.googleapis.com/token", Setting.Property.NodeScope);
+
+    /** The timeout to establish a connection. The default value is 0 which uses the Google Cloud Storage standard value
+     * of 20 seconds */
+    static final Setting<TimeValue> CONNECT_TIMEOUT_SETTING = Setting.timeSetting(
+        "connect_timeout", TimeValue.ZERO, TimeValue.MINUS_ONE, Setting.Property.NodeScope);
+
+    /** The timeout to read data from an established connection. The default value is 0 which uses the Google Cloud
+     * Storage standard value of 20 seconds */
+    static final Setting<TimeValue> READ_TIMEOUT_SETTING = Setting.timeSetting(
+        "read_timeout", TimeValue.ZERO, TimeValue.MINUS_ONE, Setting.Property.NodeScope);
+
+
+    static GCSClientSettings fromSettings(final Settings settings) {
+        return new GCSClientSettings(
+            loadCredentials(settings),
+            ENDPOINT_SETTING.get(settings),
+            PROJECT_ID_SETTING.get(settings),
+            CONNECT_TIMEOUT_SETTING.get(settings),
+            READ_TIMEOUT_SETTING.get(settings),
+            tokenUri(settings)
+        );
+    }
+
+    static ServiceAccountCredentials loadCredentials(Settings settings) {
+        try {
+            return ServiceAccountCredentials
+                .newBuilder()
+                .setClientId(CLIENT_ID_SETTING.get(settings).toString())
+                .setClientEmail(CLIENT_EMAIL_SETTING.get(settings).toString())
+                .setPrivateKeyId(PRIVATE_KEY_ID_SETTING.get(settings).toString())
+                .setPrivateKeyString(privateKey(settings))
+                .setTokenServerUri(tokenUri(settings))
+                .setProjectId(PROJECT_ID_SETTING.get(settings))
+                .build();
+        } catch (Exception e) {
+            throw new InvalidArgumentException(e.getMessage());
+        }
+    }
+
+    private static URI tokenUri(Settings settings) {
+        return URI.create(TOKEN_URI_SETTING.get(settings));
+    }
+
+    private static String privateKey(Settings settings) {
+        SecureString secureString = PRIVATE_KEY_SETTING.get(settings);
+        return secureString.toString().replaceAll("\\\\n", "\n");
+    }
+}

--- a/plugins/repository-gcs/src/main/java/io/crate/gcs/GCSRepositoryPlugin.java
+++ b/plugins/repository-gcs/src/main/java/io/crate/gcs/GCSRepositoryPlugin.java
@@ -38,22 +38,32 @@ import io.crate.analyze.repositories.TypeSettings;
 
 
 /**
- * A plugin to add Google Cloud Storage as a repository.
+ * Based on https://github.com/opensearch-project/OpenSearch/blob/main/plugins/repository-gcs/src/main/java/org/opensearch/repositories/gcs/GoogleCloudStoragePlugin.java
  */
 public class GCSRepositoryPlugin extends Plugin implements RepositoryPlugin {
+
+    private final GCSService service;
+
+    public GCSRepositoryPlugin() {
+        this.service = new GCSService();
+    }
 
     @Override
     public List<Setting<?>> getSettings() {
         return List.of(
+            GCSRepository.COMPRESS_SETTING,
             GCSRepository.BUCKET_SETTING,
             GCSRepository.BASE_PATH_SETTING,
-            GCSRepository.PROJECT_ID_SETTING,
-            GCSRepository.PRIVATE_KEY_ID_SETTING,
-            GCSRepository.PRIVATE_KEY_SETTING,
-            GCSRepository.CLIENT_EMAIL_SETTING,
-            GCSRepository.CLIENT_ID_SETTING,
-            GCSRepository.ENDPOINT_SETTING,
-            GCSRepository.TOKEN_URI_SETTING
+            GCSRepository.CHUNK_SIZE_SETTING,
+            GCSClientSettings.PROJECT_ID_SETTING,
+            GCSClientSettings.PRIVATE_KEY_ID_SETTING,
+            GCSClientSettings.PRIVATE_KEY_SETTING,
+            GCSClientSettings.CLIENT_EMAIL_SETTING,
+            GCSClientSettings.CLIENT_ID_SETTING,
+            GCSClientSettings.ENDPOINT_SETTING,
+            GCSClientSettings.TOKEN_URI_SETTING,
+            GCSClientSettings.CONNECT_TIMEOUT_SETTING,
+            GCSClientSettings.READ_TIMEOUT_SETTING
             );
     }
 
@@ -69,24 +79,28 @@ public class GCSRepositoryPlugin extends Plugin implements RepositoryPlugin {
                         // Required settings
                         List.of(
                             GCSRepository.BUCKET_SETTING,
-                            GCSRepository.PROJECT_ID_SETTING,
-                            GCSRepository.PRIVATE_KEY_ID_SETTING,
-                            GCSRepository.PRIVATE_KEY_SETTING,
-                            GCSRepository.CLIENT_ID_SETTING,
-                            GCSRepository.CLIENT_EMAIL_SETTING
+                            GCSClientSettings.PROJECT_ID_SETTING,
+                            GCSClientSettings.PRIVATE_KEY_ID_SETTING,
+                            GCSClientSettings.PRIVATE_KEY_SETTING,
+                            GCSClientSettings.CLIENT_ID_SETTING,
+                            GCSClientSettings.CLIENT_EMAIL_SETTING
                         ),
                         // Optional settings
                         List.of(
+                            GCSRepository.CHUNK_SIZE_SETTING,
+                            GCSRepository.COMPRESS_SETTING,
                             GCSRepository.BASE_PATH_SETTING,
-                            GCSRepository.ENDPOINT_SETTING,
-                            GCSRepository.TOKEN_URI_SETTING
+                            GCSClientSettings.ENDPOINT_SETTING,
+                            GCSClientSettings.TOKEN_URI_SETTING,
+                            GCSClientSettings.CONNECT_TIMEOUT_SETTING,
+                            GCSClientSettings.READ_TIMEOUT_SETTING
                         )
                     );
                 }
 
                 @Override
                 public Repository create(RepositoryMetadata metadata) {
-                    return new GCSRepository(metadata, namedXContentRegistry, clusterService, recoverySettings);
+                    return new GCSRepository(metadata, namedXContentRegistry, clusterService, service, recoverySettings);
                 }
             }
         );

--- a/plugins/repository-gcs/src/main/java/io/crate/gcs/GCSRetryingInputStream.java
+++ b/plugins/repository-gcs/src/main/java/io/crate/gcs/GCSRetryingInputStream.java
@@ -1,0 +1,279 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package io.crate.gcs;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.nio.file.NoSuchFileException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+
+import com.google.api.client.http.HttpResponse;
+import com.google.api.services.storage.Storage.Objects.Get;
+import com.google.cloud.BaseService;
+import com.google.cloud.RetryHelper;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageException;
+import com.google.cloud.storage.spi.v1.HttpStorageRpc;
+
+import io.crate.common.SuppressForbidden;
+import io.crate.common.io.IOUtils;
+
+/**
+ * Wrapper around reads from GCS that will retry blob downloads that fail part-way through, resuming from where the failure occurred.
+ * This should be handled by the SDK but it isn't today. This should be revisited in the future (e.g. before removing
+ * the {@code LegacyESVersion#V_7_0_0} version constant) and removed if the SDK handles retries itself in the future.
+ * Based on https://github.com/opensearch-project/OpenSearch/blob/main/plugins/repository-gcs/src/main/java/org/opensearch/repositories/gcs/GoogleCloudStorageRetryingInputStream.java
+ */
+class GCSRetryingInputStream extends InputStream {
+
+    private static final Logger LOGGER = LogManager.getLogger(GCSRetryingInputStream.class);
+
+    static final int MAX_SUPPRESSED_EXCEPTIONS = 10;
+
+    private final Storage client;
+    private final com.google.api.services.storage.Storage storage;
+
+    private final BlobId blobId;
+
+    private final long start;
+    private final long end;
+
+    private final int maxAttempts;
+
+    private InputStream currentStream;
+    private int attempt = 1;
+    private List<StorageException> failures = new ArrayList<>(MAX_SUPPRESSED_EXCEPTIONS);
+    private long currentOffset;
+    private boolean closed;
+
+    GCSRetryingInputStream(Storage client, BlobId blobId) throws IOException {
+        this(client, blobId, 0, Long.MAX_VALUE - 1);
+    }
+
+    // both start and end are inclusive bounds, following the definition in https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.35
+    GCSRetryingInputStream(Storage client, BlobId blobId, long start, long end) throws IOException {
+        if (start < 0L) {
+            throw new IllegalArgumentException("start must be non-negative");
+        }
+        if (end < start || end == Long.MAX_VALUE) {
+            throw new IllegalArgumentException("end must be >= start and not Long.MAX_VALUE");
+        }
+        this.client = client;
+        this.blobId = blobId;
+        this.start = start;
+        this.end = end;
+        this.maxAttempts = client.getOptions().getRetrySettings().getMaxAttempts();
+        storage = getStorage(client);
+        currentStream = openStream();
+    }
+
+    @SuppressForbidden(reason = "Reflection usage")
+    private static com.google.api.services.storage.Storage getStorage(Storage client) {
+        assert client.getOptions().getRpc() instanceof HttpStorageRpc;
+        assert Stream.of(client.getOptions().getRpc().getClass().getDeclaredFields()).anyMatch(f -> f.getName().equals("storage"));
+        try {
+            final Field storageField = client.getOptions().getRpc().getClass().getDeclaredField("storage");
+            storageField.setAccessible(true);
+            return (com.google.api.services.storage.Storage) storageField.get(client.getOptions().getRpc());
+        } catch (Exception e) {
+            throw new IllegalStateException("storage could not be set up", e);
+        }
+    }
+
+    private InputStream openStream() throws IOException {
+        try {
+            try {
+                return RetryHelper.runWithRetries(() -> {
+                    try {
+                        final Get get = storage.objects().get(blobId.getBucket(), blobId.getName());
+                        get.setReturnRawInputStream(true);
+
+                        if (currentOffset > 0 || start > 0 || end < Long.MAX_VALUE - 1) {
+                            get.getRequestHeaders().setRange("bytes=" + Math.addExact(start, currentOffset) + "-" + end);
+                        }
+                        final HttpResponse resp = get.executeMedia();
+                        final Long contentLength = resp.getHeaders().getContentLength();
+                        InputStream content = resp.getContent();
+                        if (contentLength != null) {
+                            content = new ContentLengthValidatingInputStream(content, contentLength);
+                        }
+                        return content;
+                    } catch (IOException e) {
+                        throw StorageException.translate(e);
+                    }
+                }, client.getOptions().getRetrySettings(), BaseService.EXCEPTION_HANDLER, client.getOptions().getClock());
+            } catch (RetryHelper.RetryHelperException e) {
+                throw StorageException.translateAndThrow(e);
+            }
+        } catch (StorageException e) {
+            if (e.getCode() == 404) {
+                throw addSuppressedExceptions(
+                    new NoSuchFileException("Blob object [" + blobId.getName() + "] not found: " + e.getMessage())
+                );
+            }
+            throw addSuppressedExceptions(e);
+        }
+    }
+
+    // Google's SDK ignores the Content-Length header when no bytes are sent, see NetHttpResponse.SizeValidatingInputStream
+    // We have to implement our own validation logic here
+    static final class ContentLengthValidatingInputStream extends FilterInputStream {
+        private final long contentLength;
+
+        private long read = 0L;
+
+        ContentLengthValidatingInputStream(InputStream in, long contentLength) {
+            super(in);
+            this.contentLength = contentLength;
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            final int n = in.read(b, off, len);
+            if (n == -1) {
+                checkContentLengthOnEOF();
+            } else {
+                read += n;
+            }
+            return n;
+        }
+
+        @Override
+        public int read() throws IOException {
+            final int n = in.read();
+            if (n == -1) {
+                checkContentLengthOnEOF();
+            } else {
+                read++;
+            }
+            return n;
+        }
+
+        @Override
+        public long skip(long len) throws IOException {
+            final long n = in.skip(len);
+            read += n;
+            return n;
+        }
+
+        private void checkContentLengthOnEOF() throws IOException {
+            if (read < contentLength) {
+                throw new IOException("Connection closed prematurely: read = " + read + ", Content-Length = " + contentLength);
+            }
+        }
+    }
+
+    @Override
+    public int read() throws IOException {
+        ensureOpen();
+        while (true) {
+            try {
+                final int result = currentStream.read();
+                currentOffset += 1;
+                return result;
+            } catch (IOException e) {
+                reopenStreamOrFail(StorageException.translate(e));
+            }
+        }
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        ensureOpen();
+        while (true) {
+            try {
+                final int bytesRead = currentStream.read(b, off, len);
+                if (bytesRead == -1) {
+                    return -1;
+                }
+                currentOffset += bytesRead;
+                return bytesRead;
+            } catch (IOException e) {
+                reopenStreamOrFail(StorageException.translate(e));
+            }
+        }
+    }
+
+    private void ensureOpen() {
+        if (closed) {
+            assert false : "using GoogleCloudStorageRetryingInputStream after close";
+            throw new IllegalStateException("using GoogleCloudStorageRetryingInputStream after close");
+        }
+    }
+
+    // TODO: check that object did not change when stream is reopened (e.g. based on etag)
+    private void reopenStreamOrFail(StorageException e) throws IOException {
+        if (attempt >= maxAttempts) {
+            throw addSuppressedExceptions(e);
+        }
+        LOGGER.debug(
+            new ParameterizedMessage(
+                "failed reading [{}] at offset [{}], attempt [{}] of [{}], retrying",
+                blobId,
+                currentOffset,
+                attempt,
+                maxAttempts
+            ),
+            e
+        );
+        attempt += 1;
+        if (failures.size() < MAX_SUPPRESSED_EXCEPTIONS) {
+            failures.add(e);
+        }
+        IOUtils.closeWhileHandlingException(currentStream);
+        currentStream = openStream();
+    }
+
+    @Override
+    public void close() throws IOException {
+        currentStream.close();
+        closed = true;
+    }
+
+    @Override
+    public long skip(long n) {
+        throw new UnsupportedOperationException("GoogleCloudStorageRetryingInputStream does not support seeking");
+    }
+
+    @Override
+    public void reset() {
+        throw new UnsupportedOperationException("GoogleCloudStorageRetryingInputStream does not support seeking");
+    }
+
+    private <T extends Exception> T addSuppressedExceptions(T e) {
+        for (StorageException failure : failures) {
+            e.addSuppressed(failure);
+        }
+        return e;
+    }
+}

--- a/plugins/repository-gcs/src/main/java/io/crate/gcs/GCSService.java
+++ b/plugins/repository-gcs/src/main/java/io/crate/gcs/GCSService.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package io.crate.gcs;
+
+import java.net.URI;
+import java.util.HashMap;
+
+import org.elasticsearch.cluster.metadata.RepositoryMetadata;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.Settings;
+
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.auth.oauth2.ServiceAccountCredentials;
+import com.google.cloud.http.HttpTransportOptions;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+
+import io.crate.common.unit.TimeValue;
+
+/**
+ * Based on https://github.com/opensearch-project/OpenSearch/blob/main/plugins/repository-gcs/src/main/java/org/opensearch/repositories/gcs/GoogleCloudStorageService.java
+ */
+public class GCSService {
+
+    private volatile HashMap<String, Storage> clientCache = new HashMap<>();
+
+    public Storage client(RepositoryMetadata metadata) {
+        final Storage storage = clientCache.get(metadata.name());
+        if (storage != null) {
+            return storage;
+        }
+
+        synchronized (this) {
+            final Storage existing = clientCache.get(metadata.name());
+
+            if (existing != null) {
+                return existing;
+            }
+
+            Storage newClient = createClient(metadata.settings());
+            clientCache.put(metadata.name(), newClient);
+            return newClient;
+        }
+    }
+
+    synchronized void closeRepositoryClient(String repositoryName) {
+        clientCache.remove(repositoryName);
+    }
+
+    /**
+     * Creates a client that can be used to manage Google Cloud Storage objects. The client is thread-safe.
+     *
+     * @param settings client settings to use, including secure settings
+     * @return a new client storage instance that can be used to manage objects
+     * (blobs)
+     */
+    private Storage createClient(Settings settings) {
+        GCSClientSettings clientSettings = GCSClientSettings.fromSettings(settings);
+        HttpTransport httpTransport = new NetHttpTransport.Builder().build();
+
+        HttpTransportOptions httpTransportOptions = new HttpTransportOptions(
+            HttpTransportOptions.newBuilder()
+                .setConnectTimeout(toTimeout(clientSettings.connectTimeout()))
+                .setReadTimeout(toTimeout(clientSettings.readTimeout()))
+                .setHttpTransportFactory(() -> httpTransport)
+        );
+        StorageOptions storageOptions = createStorageOptions(clientSettings, httpTransportOptions);
+        return storageOptions.getService();
+    }
+
+    StorageOptions createStorageOptions(GCSClientSettings clientSettings,
+                                        HttpTransportOptions httpTransportOptions) {
+        StorageOptions.Builder storageOptionsBuilder = StorageOptions.newBuilder()
+            .setTransportOptions(httpTransportOptions);
+        if (Strings.hasLength(clientSettings.endpoint())) {
+            storageOptionsBuilder.setHost(clientSettings.endpoint());
+        }
+        if (Strings.hasLength(clientSettings.projectId())) {
+            storageOptionsBuilder.setProjectId(clientSettings.projectId());
+        }
+        ServiceAccountCredentials serviceAccountCredentials = clientSettings.credentials();
+        // override token server URI
+        final URI tokenServerUri = clientSettings.tokenUri();
+        if (Strings.hasLength(tokenServerUri.toString())) {
+            // Rebuild the service account credentials in order to use a custom Token url.
+            // This is mostly used for testing purpose.
+            serviceAccountCredentials = serviceAccountCredentials.toBuilder().setTokenServerUri(tokenServerUri).build();
+        }
+        storageOptionsBuilder.setCredentials(serviceAccountCredentials);
+        return storageOptionsBuilder.build();
+    }
+
+    /**
+     * Converts timeout values from the settings to a timeout value for the Google
+     * Cloud SDK
+     **/
+    static Integer toTimeout(TimeValue timeout) {
+        // Null or zero in settings means the default timeout
+        if (timeout == null || TimeValue.ZERO.equals(timeout)) {
+            // negative value means using the default value
+            return -1;
+        }
+        // -1 means infinite timeout
+        if (TimeValue.MINUS_ONE.equals(timeout)) {
+            // 0 is the infinite timeout expected by Google Cloud SDK
+            return 0;
+        }
+        return Math.toIntExact(timeout.millis());
+    }
+}

--- a/plugins/repository-gcs/src/test/java/io/crate/gcs/GCSBlobContainerRetriesTests.java
+++ b/plugins/repository-gcs/src/test/java/io/crate/gcs/GCSBlobContainerRetriesTests.java
@@ -1,0 +1,741 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.gcs;
+
+import static io.crate.gcs.GCSHttpHandler.decodeQueryString;
+import static io.crate.gcs.GCSHttpHandler.getContentRangeEnd;
+import static io.crate.gcs.GCSHttpHandler.getContentRangeLimit;
+import static io.crate.gcs.GCSHttpHandler.getContentRangeStart;
+import static io.crate.gcs.GCSHttpHandler.parseMultipartRequestBody;
+import static io.crate.gcs.GCSSnapshotIntegrationTest.PKCS8_PRIVATE_KEY;
+import static io.crate.gcs.GCSClientSettings.CLIENT_EMAIL_SETTING;
+import static io.crate.gcs.GCSClientSettings.CLIENT_ID_SETTING;
+import static io.crate.gcs.GCSClientSettings.ENDPOINT_SETTING;
+import static io.crate.gcs.GCSClientSettings.PRIVATE_KEY_ID_SETTING;
+import static io.crate.gcs.GCSClientSettings.PRIVATE_KEY_SETTING;
+import static io.crate.gcs.GCSClientSettings.PROJECT_ID_SETTING;
+import static io.crate.gcs.GCSClientSettings.READ_TIMEOUT_SETTING;
+import static io.crate.gcs.GCSClientSettings.TOKEN_URI_SETTING;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.lucene.tests.util.LuceneTestCase.expectThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.elasticsearch.repositories.ESBlobStoreTestCase.randomBytes;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketTimeoutException;
+import java.nio.file.NoSuchFileException;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.annotation.Nullable;
+
+import org.apache.http.ConnectionClosedException;
+import org.apache.http.HttpStatus;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.elasticsearch.cluster.metadata.RepositoryMetadata;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.blobstore.BlobContainer;
+import org.elasticsearch.common.blobstore.BlobPath;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.Streams;
+import org.elasticsearch.common.lucene.store.ByteArrayIndexInput;
+import org.elasticsearch.common.lucene.store.InputStreamIndexInput;
+import org.elasticsearch.common.network.InetAddresses;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.CountDown;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.test.IntegTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.threeten.bp.Duration;
+
+import com.google.api.gax.retrying.RetrySettings;
+import com.google.cloud.http.HttpTransportOptions;
+import com.google.cloud.storage.StorageException;
+import com.google.cloud.storage.StorageOptions;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+
+import io.crate.common.SuppressForbidden;
+import io.crate.common.collections.Tuple;
+import io.crate.common.unit.TimeValue;
+
+@SuppressForbidden(reason = "use a http server")
+public class GCSBlobContainerRetriesTests extends IntegTestCase {
+
+    static final long MAX_RANGE_VAL = Long.MAX_VALUE - 1;
+
+    HttpServer httpServer;
+
+    @Before
+    public void setUp() throws Exception {
+        httpServer = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+        httpServer.start();
+        super.setUp();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        httpServer.stop(0);
+        super.tearDown();
+    }
+
+    @Test
+    public void testReadNonexistentBlobThrowsNoSuchFileException() {
+        final BlobContainer blobContainer = createBlobContainer(between(1, 5), null);
+        final long position = randomLongBetween(0, MAX_RANGE_VAL);
+        final int length = randomIntBetween(1, Math.toIntExact(Math.min(Integer.MAX_VALUE, MAX_RANGE_VAL - position)));
+        final Exception exception = expectThrows(NoSuchFileException.class, () -> {
+            if (randomBoolean()) {
+                Streams.readFully(blobContainer.readBlob("read_nonexistent_blob"));
+            } else {
+                Streams.readFully(blobContainer.readBlob("read_nonexistent_blob", 0, 1));
+            }
+        });
+        assertThat(exception.getMessage().toLowerCase(Locale.ROOT)).contains("blob object [read_nonexistent_blob] not found");
+
+        assertThat(
+            expectThrows(
+                NoSuchFileException.class,
+                () -> Streams.readFully(blobContainer.readBlob("read_nonexistent_blob", position, length))
+            ).getMessage().toLowerCase(Locale.ROOT))
+            .contains("blob object [read_nonexistent_blob] not found");
+    }
+
+    @Test
+    public void testReadBlobWithRetries() throws Exception {
+        final int maxRetries = randomInt(5);
+        final CountDown countDown = new CountDown(maxRetries + 1);
+
+        final byte[] bytes = randomBlobContent();
+        httpServer.createContext(downloadStorageEndpoint("read_blob_max_retries"), exchange -> {
+            Streams.readFully(exchange.getRequestBody());
+            if (countDown.countDown()) {
+                final int rangeStart = getRangeStart(exchange);
+                assertThat(rangeStart).isLessThan(bytes.length);
+                exchange.getResponseHeaders().add("Content-Type", bytesContentType());
+                exchange.sendResponseHeaders(HttpStatus.SC_OK, bytes.length - rangeStart);
+                exchange.getResponseBody().write(bytes, rangeStart, bytes.length - rangeStart);
+                exchange.close();
+                return;
+            }
+            if (randomBoolean()) {
+                exchange.sendResponseHeaders(
+                    randomFrom(
+                        HttpStatus.SC_INTERNAL_SERVER_ERROR,
+                        HttpStatus.SC_BAD_GATEWAY,
+                        HttpStatus.SC_SERVICE_UNAVAILABLE,
+                        HttpStatus.SC_GATEWAY_TIMEOUT
+                    ),
+                    -1
+                );
+            } else if (randomBoolean()) {
+                sendIncompleteContent(exchange, bytes);
+            }
+            if (randomBoolean()) {
+                exchange.close();
+            }
+        });
+
+        final TimeValue readTimeout = TimeValue.timeValueSeconds(between(1, 3));
+        final BlobContainer blobContainer = createBlobContainer(maxRetries, readTimeout);
+        try (InputStream inputStream = blobContainer.readBlob("read_blob_max_retries")) {
+            final int readLimit;
+            final InputStream wrappedStream;
+            if (randomBoolean()) {
+                // read stream only partly
+                readLimit = randomIntBetween(0, bytes.length);
+                wrappedStream = Streams.limitStream(inputStream, readLimit);
+            } else {
+                readLimit = bytes.length;
+                wrappedStream = inputStream;
+            }
+            final byte[] bytesRead = BytesReference.toBytes(Streams.readFully(wrappedStream));
+            logger.info("maxRetries={}, readLimit={}, byteSize={}, bytesRead={}", maxRetries, readLimit, bytes.length, bytesRead.length);
+            assertThat(Arrays.copyOfRange(bytes, 0, readLimit)).isEqualTo(bytesRead);
+            if (readLimit < bytes.length) {
+                // we might have completed things based on an incomplete response, and we're happy with that
+            } else {
+                assertThat(countDown.isCountedDown()).isTrue();
+            }
+        }
+    }
+
+    @Test
+    public void testReadRangeBlobWithRetries() throws Exception {
+        final int maxRetries = randomInt(5);
+        final CountDown countDown = new CountDown(maxRetries + 1);
+
+        final byte[] bytes = randomBlobContent();
+        httpServer.createContext(downloadStorageEndpoint("read_range_blob_max_retries"), exchange -> {
+            Streams.readFully(exchange.getRequestBody());
+            if (countDown.countDown()) {
+                final int rangeStart = getRangeStart(exchange);
+                assertThat(rangeStart).isLessThan(bytes.length);
+                assertThat(getRangeEnd(exchange).isPresent()).isTrue();
+                final int rangeEnd = getRangeEnd(exchange).get();
+                assertThat(rangeEnd).isGreaterThan(rangeStart);
+                // adapt range end to be compliant to https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.35
+                final int effectiveRangeEnd = Math.min(bytes.length - 1, rangeEnd);
+                final int length = (effectiveRangeEnd - rangeStart) + 1;
+                exchange.getResponseHeaders().add("Content-Type", bytesContentType());
+                exchange.sendResponseHeaders(HttpStatus.SC_OK, length);
+                exchange.getResponseBody().write(bytes, rangeStart, length);
+                exchange.close();
+                return;
+            }
+            if (randomBoolean()) {
+                exchange.sendResponseHeaders(
+                    randomFrom(
+                        HttpStatus.SC_INTERNAL_SERVER_ERROR,
+                        HttpStatus.SC_BAD_GATEWAY,
+                        HttpStatus.SC_SERVICE_UNAVAILABLE,
+                        HttpStatus.SC_GATEWAY_TIMEOUT
+                    ),
+                    -1
+                );
+            } else if (randomBoolean()) {
+                sendIncompleteContent(exchange, bytes);
+            }
+            if (randomBoolean()) {
+                exchange.close();
+            }
+        });
+
+        final TimeValue readTimeout = TimeValue.timeValueMillis(between(100, 500));
+        final BlobContainer blobContainer = createBlobContainer(maxRetries, readTimeout);
+        final int position = randomIntBetween(0, bytes.length - 1);
+        final int length = randomIntBetween(0, randomBoolean() ? bytes.length : Integer.MAX_VALUE);
+        try (InputStream inputStream = blobContainer.readBlob("read_range_blob_max_retries", position, length)) {
+            final int readLimit;
+            final InputStream wrappedStream;
+            if (randomBoolean()) {
+                // read stream only partly
+                readLimit = randomIntBetween(0, length);
+                wrappedStream = Streams.limitStream(inputStream, readLimit);
+            } else {
+                readLimit = length;
+                wrappedStream = inputStream;
+            }
+            final byte[] bytesRead = BytesReference.toBytes(Streams.readFully(wrappedStream));
+            logger.info(
+                "maxRetries={}, position={}, length={}, readLimit={}, byteSize={}, bytesRead={}",
+                maxRetries,
+                position,
+                length,
+                readLimit,
+                bytes.length,
+                bytesRead.length
+            );
+            assertThat(Arrays.copyOfRange(bytes, position, Math.min(bytes.length, position + readLimit))).isEqualTo(bytesRead);
+            if (readLimit == 0 || (readLimit < length && readLimit == bytesRead.length)) {
+                // we might have completed things based on an incomplete response, and we're happy with that
+            } else {
+                assertThat(countDown.isCountedDown()).isTrue();
+            }
+        }
+    }
+
+    @Test
+    public void testReadBlobWithReadTimeouts() {
+        final int maxRetries = randomInt(5);
+        final TimeValue readTimeout = TimeValue.timeValueMillis(between(100, 200));
+        final BlobContainer blobContainer = createBlobContainer(maxRetries, readTimeout);
+
+        // HTTP server does not send a response
+        httpServer.createContext(downloadStorageEndpoint("read_blob_unresponsive"), exchange -> {
+        });
+
+        Exception exception = expectThrows(
+            unresponsiveExceptionType(),
+            () -> Streams.readFully(blobContainer.readBlob("read_blob_unresponsive"))
+        );
+        assertThat(exception.getMessage().toLowerCase(Locale.ROOT)).contains("read timed out");
+        assertThat(exception.getCause()).isInstanceOfAny(SocketTimeoutException.class);
+
+        // HTTP server sends a partial response
+        final byte[] bytes = randomBlobContent();
+        httpServer.createContext(downloadStorageEndpoint("read_blob_incomplete"), exchange -> sendIncompleteContent(exchange, bytes));
+
+        final int position = randomIntBetween(0, bytes.length - 1);
+        final int length = randomIntBetween(1, randomBoolean() ? bytes.length : Integer.MAX_VALUE);
+        exception = expectThrows(Exception.class, () -> {
+            try (
+                InputStream stream = randomBoolean()
+                    ? blobContainer.readBlob("read_blob_incomplete")
+                    : blobContainer.readBlob("read_blob_incomplete", position, length)
+            ) {
+                Streams.readFully(stream);
+            }
+        });
+        assertThat(exception).isInstanceOfAny(SocketTimeoutException.class, ConnectionClosedException.class, RuntimeException.class);
+        assertThat(exception.getMessage().toLowerCase(Locale.ROOT))
+            .containsAnyOf("read timed out",
+                "premature end of chunk coded message body: closing chunk expected",
+                "Read timed out",
+                "unexpected end of file from server");
+        assertThat(exception.getSuppressed().length).isEqualTo(maxRetries);
+    }
+
+    @Test
+    public void testReadBlobWithNoHttpResponse() {
+        final TimeValue readTimeout = TimeValue.timeValueMillis(between(100, 200));
+        final BlobContainer blobContainer = createBlobContainer(randomInt(5), readTimeout);
+
+        // HTTP server closes connection immediately
+        httpServer.createContext(downloadStorageEndpoint("read_blob_no_response"), HttpExchange::close);
+
+        Exception exception = expectThrows(unresponsiveExceptionType(), () -> {
+            if (randomBoolean()) {
+                Streams.readFully(blobContainer.readBlob("read_blob_no_response"));
+            } else {
+                Streams.readFully(blobContainer.readBlob("read_blob_no_response", 0, 1));
+            }
+        });
+        assertThat(exception.getMessage().toLowerCase(Locale.ROOT))
+            .containsAnyOf("the target server failed to respond", "unexpected end of file from server");
+    }
+
+    @Test
+    public void testReadBlobWithPrematureConnectionClose() {
+        final int maxRetries = randomInt(20);
+        final BlobContainer blobContainer = createBlobContainer(maxRetries, null);
+
+        // HTTP server sends a partial response
+        final byte[] bytes = randomBlobContent(1);
+        httpServer.createContext(downloadStorageEndpoint("read_blob_incomplete"), exchange -> {
+            sendIncompleteContent(exchange, bytes);
+            exchange.close();
+        });
+
+        final Exception exception = expectThrows(Exception.class, () -> {
+            try (
+                InputStream stream = randomBoolean()
+                    ? blobContainer.readBlob("read_blob_incomplete", 0, 1)
+                    : blobContainer.readBlob("read_blob_incomplete")
+            ) {
+                Streams.readFully(stream);
+            }
+        });
+        assertThat(exception.getMessage().toLowerCase(Locale.ROOT))
+            .containsAnyOf(
+                "premature end of chunk coded message body: closing chunk expected",
+                "premature end of content-length delimited message body", "connection closed prematurely"
+            );
+        assertThat(exception.getSuppressed().length).isEqualTo(Math.min(10, maxRetries));
+    }
+
+    @Test
+    public void testReadLargeBlobWithRetries() throws Exception {
+        final int maxRetries = randomIntBetween(2, 10);
+        final AtomicInteger countDown = new AtomicInteger(maxRetries);
+
+        // SDK reads in 2 MB chunks so we use twice that to simulate 2 chunks
+        final byte[] bytes = randomBytes(1 << 22);
+        httpServer.createContext("/download/storage/v1/b/bucket/o/large_blob_retries", exchange -> {
+            Streams.readFully(exchange.getRequestBody());
+            exchange.getResponseHeaders().add("Content-Type", "application/octet-stream");
+            final Tuple<Long, Long> range = getRange(exchange);
+            final int offset = Math.toIntExact(range.v1());
+            final byte[] chunk = Arrays.copyOfRange(bytes, offset, Math.toIntExact(Math.min(range.v2() + 1, bytes.length)));
+            exchange.sendResponseHeaders(RestStatus.OK.getStatus(), chunk.length);
+            if (randomBoolean() && countDown.decrementAndGet() >= 0) {
+                exchange.getResponseBody().write(chunk, 0, chunk.length - 1);
+                exchange.close();
+                return;
+            }
+            exchange.getResponseBody().write(chunk);
+            exchange.close();
+        });
+
+        final BlobContainer blobContainer = createBlobContainer(maxRetries, null);
+        try (InputStream inputStream = blobContainer.readBlob("large_blob_retries")) {
+            assertThat(bytes).isEqualTo(BytesReference.toBytes(Streams.readFully(inputStream)));
+        }
+    }
+
+    @Test
+    public void testWriteBlobWithRetries() throws Exception {
+        final int maxRetries = randomIntBetween(2, 10);
+        final CountDown countDown = new CountDown(maxRetries);
+
+        final byte[] bytes = randomBlobContent();
+        httpServer.createContext("/upload/storage/v1/b/bucket/o", safeHandler(exchange -> {
+            assertThat(exchange.getRequestURI().getQuery()).contains("uploadType=multipart");
+            if (countDown.countDown()) {
+                Optional<Tuple<String, BytesReference>> content = parseMultipartRequestBody(exchange.getRequestBody());
+                assertThat(content.isPresent()).isTrue();
+                assertThat(content.get().v1()).isEqualTo("write_blob_max_retries");
+                if (Objects.deepEquals(bytes, BytesReference.toBytes(content.get().v2()))) {
+                    byte[] response = ("{\"bucket\":\"bucket\",\"name\":\"" + content.get().v1() + "\"}").getBytes(UTF_8);
+                    exchange.getResponseHeaders().add("Content-Type", "application/json");
+                    exchange.sendResponseHeaders(RestStatus.OK.getStatus(), response.length);
+                    exchange.getResponseBody().write(response);
+                } else {
+                    exchange.sendResponseHeaders(HttpStatus.SC_BAD_REQUEST, -1);
+                }
+                return;
+            }
+            if (randomBoolean()) {
+                if (randomBoolean()) {
+                    Streams.readFully(exchange.getRequestBody(), new byte[randomIntBetween(1, Math.max(1, bytes.length - 1))]);
+                } else {
+                    Streams.readFully(exchange.getRequestBody());
+                    exchange.sendResponseHeaders(HttpStatus.SC_INTERNAL_SERVER_ERROR, -1);
+                }
+            }
+        }));
+
+        final BlobContainer blobContainer = createBlobContainer(maxRetries, null);
+        try (InputStream stream = new InputStreamIndexInput(new ByteArrayIndexInput("desc", bytes), bytes.length)) {
+            blobContainer.writeBlob("write_blob_max_retries", stream, bytes.length, false);
+        }
+        assertThat(countDown.isCountedDown()).isTrue();
+    }
+
+    @Test
+    public void testWriteBlobWithReadTimeouts() {
+        final byte[] bytes = randomByteArrayOfLength(randomIntBetween(10, 128));
+        final TimeValue readTimeout = TimeValue.timeValueMillis(randomIntBetween(100, 500));
+        final BlobContainer blobContainer = createBlobContainer(1, readTimeout);
+
+        // HTTP server does not send a response
+        httpServer.createContext("/upload/storage/v1/b/bucket/o", exchange -> {
+            if (randomBoolean()) {
+                if (randomBoolean()) {
+                    Streams.readFully(exchange.getRequestBody(), new byte[randomIntBetween(1, bytes.length - 1)]);
+                } else {
+                    Streams.readFully(exchange.getRequestBody());
+                }
+            }
+        });
+        assertThatThrownBy(() -> {
+            try (InputStream stream = new InputStreamIndexInput(new ByteArrayIndexInput("desc", bytes), bytes.length)) {
+                blobContainer.writeBlob("write_blob_timeout", stream, bytes.length, false);
+            }
+        }).isInstanceOfAny(StorageException.class).hasMessage("Read timed out");
+    }
+
+    @Test
+    public void testWriteLargeBlob() throws IOException {
+        // See {@link BaseWriteChannel#DEFAULT_CHUNK_SIZE}
+        final int defaultChunkSize = 60 * 256 * 1024;
+        final int nbChunks = randomIntBetween(3, 5);
+        final int lastChunkSize = randomIntBetween(1, defaultChunkSize - 1);
+        final int totalChunks = nbChunks + 1;
+        final byte[] data = randomBytes(defaultChunkSize * nbChunks + lastChunkSize);
+        assertThat(data.length).isGreaterThan(GCSBlobStore.LARGE_BLOB_THRESHOLD_BYTE_SIZE);
+
+        final int nbErrors = 2; // we want all requests to fail at least once
+        final AtomicInteger countInits = new AtomicInteger(nbErrors);
+        final AtomicInteger countUploads = new AtomicInteger(nbErrors * totalChunks);
+        final AtomicBoolean allow410Gone = new AtomicBoolean(randomBoolean());
+        final AtomicBoolean allowReadTimeout = new AtomicBoolean(rarely());
+        final int wrongChunk = randomIntBetween(1, totalChunks);
+
+        final AtomicReference<String> sessionUploadId = new AtomicReference<>(UUIDs.randomBase64UUID());
+
+        httpServer.createContext("/upload/storage/v1/b/bucket/o", safeHandler(exchange -> {
+            final BytesReference requestBody = Streams.readFully(exchange.getRequestBody());
+
+            final Map<String, String> params = decodeQueryString(exchange.getRequestURI());
+            assertThat(params.get("uploadType")).isEqualTo("resumable");
+
+            if ("POST".equals(exchange.getRequestMethod())) {
+                assertThat(params.get("name")).isEqualTo("write_large_blob");
+                if (countInits.decrementAndGet() <= 0) {
+                    byte[] response = requestBody.utf8ToString().getBytes(UTF_8);
+                    exchange.getResponseHeaders().add("Content-Type", "application/json");
+                    exchange.getResponseHeaders()
+                        .add(
+                            "Location",
+                            httpServerUrl() + "/upload/storage/v1/b/bucket/o?uploadType=resumable&upload_id=" + sessionUploadId.get()
+                        );
+                    exchange.sendResponseHeaders(RestStatus.OK.getStatus(), response.length);
+                    exchange.getResponseBody().write(response);
+                    return;
+                }
+                if (allowReadTimeout.get()) {
+                    assertThat(wrongChunk).isGreaterThan(0);
+                    return;
+                }
+
+            } else if ("PUT".equals(exchange.getRequestMethod())) {
+                final String uploadId = params.get("upload_id");
+                if (uploadId.equals(sessionUploadId.get()) == false) {
+                    assertThat(wrongChunk).isGreaterThan(0);
+                    exchange.sendResponseHeaders(HttpStatus.SC_GONE, -1);
+                    return;
+                }
+
+                if (countUploads.get() == (wrongChunk * nbErrors)) {
+                    if (allowReadTimeout.compareAndSet(true, false)) {
+                        assertThat(wrongChunk).isGreaterThan(0);
+                        return;
+                    }
+                    if (allow410Gone.compareAndSet(true, false)) {
+                        final String newUploadId = UUIDs.randomBase64UUID(random());
+                        sessionUploadId.set(newUploadId);
+
+                        // we must reset the counters because the whole object upload will be retried
+                        countInits.set(nbErrors);
+                        countUploads.set(nbErrors * totalChunks);
+
+                        exchange.sendResponseHeaders(HttpStatus.SC_GONE, -1);
+                        return;
+                    }
+                }
+
+                final String range = exchange.getRequestHeaders().getFirst("Content-Range");
+                assertThat(Strings.hasLength(range)).isTrue();
+
+                if (countUploads.decrementAndGet() % 2 == 0) {
+                    final int rangeStart = getContentRangeStart(range);
+                    final int rangeEnd = getContentRangeEnd(range);
+                    assertThat(rangeEnd + 1 - rangeStart).isEqualTo(Math.toIntExact(requestBody.length()));
+                    assertThat(new BytesArray(data, rangeStart, rangeEnd - rangeStart + 1)).isEqualTo(requestBody);
+
+                    final Integer limit = getContentRangeLimit(range);
+                    if (limit != null) {
+                        exchange.sendResponseHeaders(RestStatus.OK.getStatus(), -1);
+                        return;
+                    } else {
+                        exchange.getResponseHeaders().add("Range", String.format(Locale.ROOT, "bytes=%d/%d", rangeStart, rangeEnd));
+                        exchange.getResponseHeaders().add("Content-Length", "0");
+                        exchange.sendResponseHeaders(308 /* Resume Incomplete */, -1);
+                        return;
+                    }
+                }
+            }
+
+            if (randomBoolean()) {
+                exchange.sendResponseHeaders(HttpStatus.SC_INTERNAL_SERVER_ERROR, -1);
+            }
+        }));
+
+        final TimeValue readTimeout = allowReadTimeout.get() ? TimeValue.timeValueSeconds(3) : null;
+
+        final BlobContainer blobContainer = createBlobContainer(nbErrors + 1, readTimeout);
+        try (InputStream stream = new InputStreamIndexInput(new ByteArrayIndexInput("desc", data), data.length)) {
+            blobContainer.writeBlob("write_large_blob", stream, data.length, false);
+        }
+
+        assertThat(countInits.get()).isEqualTo(0);
+        assertThat(countUploads.get()).isEqualTo(0);
+        assertThat(allow410Gone.get()).isFalse();
+    }
+
+    static byte[] randomBlobContent() {
+        return randomBlobContent(1);
+    }
+
+    static byte[] randomBlobContent(int minSize) {
+        return randomByteArrayOfLength(randomIntBetween(minSize, frequently() ? 512 : 1 << 20)); // rarely up to 1mb
+    }
+
+    static final Pattern RANGE_PATTERN = Pattern.compile("^bytes=([0-9]+)-([0-9]+)$");
+
+    static Tuple<Long, Long> getRange(HttpExchange exchange) {
+        final String rangeHeader = exchange.getRequestHeaders().getFirst("Range");
+        if (rangeHeader == null) {
+            return new Tuple<>(0L, MAX_RANGE_VAL);
+        }
+
+        final Matcher matcher = RANGE_PATTERN.matcher(rangeHeader);
+        assertThat(matcher.matches()).isTrue();
+        long rangeStart = Long.parseLong(matcher.group(1));
+        long rangeEnd = Long.parseLong(matcher.group(2));
+        assertThat(rangeStart).isLessThanOrEqualTo(rangeEnd);
+        return new Tuple<>(rangeStart, rangeEnd);
+    }
+
+    static int getRangeStart(HttpExchange exchange) {
+        return Math.toIntExact(getRange(exchange).v1());
+    }
+
+    static Optional<Integer> getRangeEnd(HttpExchange exchange) {
+        final long rangeEnd = getRange(exchange).v2();
+        if (rangeEnd == MAX_RANGE_VAL) {
+            return Optional.empty();
+        }
+        return Optional.of(Math.toIntExact(rangeEnd));
+    }
+
+    void sendIncompleteContent(HttpExchange exchange, byte[] bytes) throws IOException {
+        final int rangeStart = getRangeStart(exchange);
+        assertThat(rangeStart).isLessThan(bytes.length);
+        final Optional<Integer> rangeEnd = getRangeEnd(exchange);
+        final int length;
+        if (rangeEnd.isPresent()) {
+            // adapt range end to be compliant to https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.35
+            final int effectiveRangeEnd = Math.min(rangeEnd.get(), bytes.length - 1);
+            length = effectiveRangeEnd - rangeStart + 1;
+        } else {
+            length = bytes.length - rangeStart;
+        }
+        exchange.getResponseHeaders().add("Content-Type", bytesContentType());
+        exchange.sendResponseHeaders(HttpStatus.SC_OK, length);
+        int minSend = Math.min(0, length - 1);
+        final int bytesToSend = randomIntBetween(minSend, length - 1);
+        if (bytesToSend > 0) {
+            exchange.getResponseBody().write(bytes, rangeStart, bytesToSend);
+        }
+        if (randomBoolean()) {
+            exchange.getResponseBody().flush();
+        }
+    }
+
+    private String httpServerUrl() {
+        assertThat(httpServer).isNotNull();
+        InetSocketAddress address = httpServer.getAddress();
+        return "http://" + InetAddresses.toUriString(address.getAddress()) + ":" + address.getPort();
+    }
+
+    String downloadStorageEndpoint(String blob) {
+        return "/download/storage/v1/b/bucket/o/" + blob;
+    }
+
+    String bytesContentType() {
+        return "application/octet-stream";
+    }
+
+    Class<? extends Exception> unresponsiveExceptionType() {
+        return StorageException.class;
+    }
+
+    BlobContainer createBlobContainer(
+        final @Nullable Integer maxRetries,
+        final @Nullable TimeValue readTimeout
+    ) {
+        final Settings.Builder clientSettings = Settings.builder();
+        clientSettings.put(PROJECT_ID_SETTING.getKey(), "project_id");
+        clientSettings.put(CLIENT_ID_SETTING.getKey(), "client_id");
+        clientSettings.put(CLIENT_EMAIL_SETTING.getKey(), "mail@foobar.com");
+        clientSettings.put(PRIVATE_KEY_ID_SETTING.getKey(), "id1234");
+        clientSettings.put(PRIVATE_KEY_SETTING.getKey(), PKCS8_PRIVATE_KEY);
+        clientSettings.put(ENDPOINT_SETTING.getKey(), httpServerUrl());
+        clientSettings.put(TOKEN_URI_SETTING.getKey(), httpServerUrl() + "/token");
+        if (readTimeout != null) {
+            clientSettings.put(READ_TIMEOUT_SETTING.getKey(), readTimeout);
+        }
+
+        final GCSService service = new GCSService() {
+
+            @Override
+            StorageOptions createStorageOptions(
+                final GCSClientSettings clientSettings,
+                final HttpTransportOptions httpTransportOptions
+            ) {
+                StorageOptions options = super.createStorageOptions(clientSettings, httpTransportOptions);
+                RetrySettings.Builder retrySettingsBuilder = RetrySettings.newBuilder()
+                    .setTotalTimeout(options.getRetrySettings().getTotalTimeout())
+                    .setInitialRetryDelay(Duration.ofMillis(10L))
+//                    .setRetryDelayMultiplier(1.0d)
+                    .setMaxRetryDelay(Duration.ofSeconds(1L))
+                    .setInitialRpcTimeout(Duration.ofSeconds(1))
+                    .setRpcTimeoutMultiplier(options.getRetrySettings().getRpcTimeoutMultiplier())
+                    .setMaxRpcTimeout(Duration.ofSeconds(1));
+                if (maxRetries != null) {
+                    retrySettingsBuilder.setMaxAttempts(maxRetries + 1);
+                }
+                return options.toBuilder()
+                    .setHost(options.getHost())
+                    .setCredentials(options.getCredentials())
+                    .setRetrySettings(retrySettingsBuilder.build())
+                    .build();
+            }
+        };
+
+        RepositoryMetadata repositoryMetadata = new RepositoryMetadata("test", "gcs", clientSettings.build());
+
+        httpServer.createContext("/token", new FakeOAuth2HttpHandler());
+        final GCSBlobStore blobStore = new GCSBlobStore(
+            "bucket",
+            service,
+            repositoryMetadata,
+            randomIntBetween(1, 8) * 1024
+        );
+
+        return new GCSBlobContainer(BlobPath.cleanPath(), blobStore);
+    }
+
+    private HttpHandler safeHandler(HttpHandler handler) {
+        final HttpHandler loggingHandler = wrap(handler, logger);
+        return exchange -> {
+            try {
+                loggingHandler.handle(exchange);
+            } finally {
+                exchange.close();
+            }
+        };
+    }
+
+    static HttpHandler wrap(final HttpHandler handler, final Logger logger) {
+        return new ExceptionCatchingHttpHandler(handler, logger);
+    }
+
+    static class ExceptionCatchingHttpHandler implements HttpHandler {
+
+        private final HttpHandler handler;
+        private final Logger logger;
+
+        ExceptionCatchingHttpHandler(HttpHandler handler, Logger logger) {
+            this.handler = handler;
+            this.logger = logger;
+        }
+
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            try {
+                handler.handle(exchange);
+            } catch (Throwable t) {
+                logger.error(
+                    () -> new ParameterizedMessage(
+                        "Exception when handling request {} {} {}",
+                        exchange.getRemoteAddress(),
+                        exchange.getRequestMethod(),
+                        exchange.getRequestURI()
+                    ),
+                    t
+                );
+                throw t;
+            }
+        }
+    }
+}

--- a/plugins/repository-gcs/src/test/java/io/crate/gcs/GCSBlobStoreContainerTests.java
+++ b/plugins/repository-gcs/src/test/java/io/crate/gcs/GCSBlobStoreContainerTests.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package io.crate.gcs;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import org.elasticsearch.cluster.metadata.RepositoryMetadata;
+import org.elasticsearch.common.blobstore.BlobContainer;
+import org.elasticsearch.common.blobstore.BlobPath;
+import org.elasticsearch.common.blobstore.BlobStore;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.IntegTestCase;
+import org.junit.Test;
+
+import com.google.cloud.BatchResult;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageBatch;
+import com.google.cloud.storage.StorageBatchResult;
+import com.google.cloud.storage.StorageException;
+
+public class GCSBlobStoreContainerTests extends IntegTestCase {
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testDeleteBlobsIgnoringIfNotExistsThrowsIOException() throws Exception {
+        final List<String> blobs = Arrays.asList("blobA", "blobB");
+
+        final StorageBatch batch = mock(StorageBatch.class);
+        if (randomBoolean()) {
+            StorageBatchResult<Boolean> result = mock(StorageBatchResult.class);
+            when(batch.delete(any(BlobId.class))).thenReturn(result);
+            doThrow(new StorageException(new IOException("Batch submit throws a storage exception"))).when(batch).submit();
+        } else {
+            StorageBatchResult<Boolean> resultA = mock(StorageBatchResult.class);
+            doReturn(resultA).when(batch).delete(eq(BlobId.of("bucket", "blobA")));
+            doAnswer(invocation -> {
+                StorageException storageException = new StorageException(new IOException("Batched delete throws a storage exception"));
+                ((BatchResult.Callback) invocation.getArguments()[0]).error(storageException);
+                return null;
+            }).when(resultA).notify(any(StorageBatchResult.Callback.class));
+
+            StorageBatchResult<Boolean> resultB = mock(StorageBatchResult.class);
+            doReturn(resultB).when(batch).delete(eq(BlobId.of("bucket", "blobB")));
+            doAnswer(invocation -> {
+                if (randomBoolean()) {
+                    StorageException storageException = new StorageException(new IOException("Batched delete throws a storage exception"));
+                    ((BatchResult.Callback) invocation.getArguments()[0]).error(storageException);
+                } else {
+                    ((BatchResult.Callback) invocation.getArguments()[0]).success(randomBoolean());
+                }
+                return null;
+            }).when(resultB).notify(any(StorageBatchResult.Callback.class));
+
+            doNothing().when(batch).submit();
+        }
+
+        final Storage storage = mock(Storage.class);
+        when(storage.get("bucket")).thenReturn(mock(Bucket.class));
+        when(storage.batch()).thenReturn(batch);
+
+        final GCSService storageService = mock(GCSService.class);
+        when(storageService.client(any(RepositoryMetadata.class))).thenReturn(storage);
+        RepositoryMetadata repositoryMetadata = new RepositoryMetadata("test", "bla", Settings.EMPTY);
+        try (BlobStore store = new GCSBlobStore("bucket", storageService, repositoryMetadata, randomIntBetween(1, 8) * 1024)) {
+            final BlobContainer container = store.blobContainer(new BlobPath());
+            assertThatThrownBy(() -> container.deleteBlobsIgnoringIfNotExists(blobs)).isInstanceOfAny(IOException.class).hasCauseExactlyInstanceOf(StorageException.class);
+        }
+    }
+}

--- a/plugins/repository-gcs/src/test/java/io/crate/gcs/GCSHttpHandler.java
+++ b/plugins/repository-gcs/src/test/java/io/crate/gcs/GCSHttpHandler.java
@@ -391,7 +391,7 @@ public class GCSHttpHandler implements HttpHandler {
         };
     }
 
-    public static List<String> readAllLines(InputStream input) throws IOException {
+    static List<String> readAllLines(InputStream input) throws IOException {
         final List<String> lines = new ArrayList<>();
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8))) {
             String line;
@@ -402,7 +402,7 @@ public class GCSHttpHandler implements HttpHandler {
         return lines;
     }
 
-    private static Map<String, String> decodeQueryString(URI uri) {
+    static Map<String, String> decodeQueryString(URI uri) {
         var result = new HashMap<String, String>();
         for (var entry : new QueryStringDecoder(uri).parameters().entrySet()) {
             result.put(entry.getKey(), entry.getValue().get(0));

--- a/plugins/repository-gcs/src/test/java/io/crate/gcs/GCSSnapshotIntegrationTest.java
+++ b/plugins/repository-gcs/src/test/java/io/crate/gcs/GCSSnapshotIntegrationTest.java
@@ -42,7 +42,7 @@ public class GCSSnapshotIntegrationTest extends IntegTestCase {
     // This is an arbitrary rsa key in pkcs8 format for testing
     // which is not used in the real world. It can be generated with
     // the command `openssl genrsa -out keypair.pem 2048`
-    private static final String PKCS8_PRIVATE_KEY = """
+    static final String PKCS8_PRIVATE_KEY = """
         -----BEGIN PRIVATE KEY-----
         MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC9iMiyCPtIJz8a
         tYrijSfRaCAmGAJQ2SZYrOQ7OSta+fbsvgtmYkKpy0HS1RuLpS5j1pTKqwWtxkJp

--- a/pom.xml
+++ b/pom.xml
@@ -262,10 +262,12 @@
     <versions.jaxb_api>2.3.1</versions.jaxb_api>
     <versions.graalvm>23.0.3</versions.graalvm>
 
-    <versions.google.gax>2.29.0</versions.google.gax>
-    <versions.google.auth>1.17.0</versions.google.auth>
-    <versions.google.oauth2>1.17.0</versions.google.oauth2>
-    <versions.google.cloud>2.22.4</versions.google.cloud>
+    <versions.google.gax>2.43.0</versions.google.gax>
+    <versions.google.auth>1.23.0</versions.google.auth>
+    <versions.google.oauth2>1.23.0</versions.google.oauth2>
+    <versions.google.cloud.storage>1.113.1</versions.google.cloud.storage>
+    <versions.google.cloud.core>2.30.0</versions.google.cloud.core>
+    <versions.google.cloud.core.http>2.23.0</versions.google.cloud.core.http>
 
     <versions.guava>32.0.1-jre</versions.guava>
     <versions.google.gson>1.43.1</versions.google.gson>


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This integrates the retry logic and resiliency improvements for the Google Cloud Storage repository from open-search based on:

https://github.com/opensearch-project/OpenSearch/tree/main/plugins/repository-gcs

The following changes happened:

- Use of the prefix `GCS` instead of `GoogleCloudStorage` for the classes to be able to have a diff for the pr. Can be changed as a follow-up.
- The client caching is removed like in the other repository plugins in CrateDB because the concept does not exist in CrateDB.
- The application name setting was not taken over because it is deprecated.
- The proxy support was not taken over because I could not test it. This could be a follow-up.

 

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
