### PR TITLE
Amend titles of new FDW doc entries to render verbatim

### DIFF
--- a/docs/sql/statements/create-user-mapping.rst
+++ b/docs/sql/statements/create-user-mapping.rst
@@ -1,9 +1,9 @@
 .. highlight:: psql
 .. _ref-create-user-mapping:
 
-===================
-CREATE USER MAPPING
-===================
+=======================
+``CREATE USER MAPPING``
+=======================
 
 Create a user mapping for a foreign server.
 

--- a/docs/sql/statements/drop-foreign-table.rst
+++ b/docs/sql/statements/drop-foreign-table.rst
@@ -1,9 +1,9 @@
 .. highlight:: psql
 .. _ref-drop-foreign-table:
 
-==================
-DROP FOREIGN TABLE
-==================
+======================
+``DROP FOREIGN TABLE``
+======================
 
 Drops a foreign table.
 

--- a/docs/sql/statements/drop-server.rst
+++ b/docs/sql/statements/drop-server.rst
@@ -1,9 +1,9 @@
 .. highlight:: psql
 .. _ref-drop-server:
 
-===========
-DROP SERVER
-===========
+===============
+``DROP SERVER``
+===============
 
 Drop a foreign server.
 

--- a/docs/sql/statements/drop-user-mapping.rst
+++ b/docs/sql/statements/drop-user-mapping.rst
@@ -1,9 +1,9 @@
 .. highlight:: psql
 .. _ref-drop-user-mapping:
 
-=================
-DROP USER MAPPING
-=================
+=====================
+``DROP USER MAPPING``
+=====================
 
 Drops a user mapping for a foreign server.
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The entries for `CREATE USER MAPPING` , `DROP FOREIGN TABLE` , `DROP SERVER` , and `DROP USER MAPPING` were rending without `code class="docutils literal notranslate"`

## Checklist

 - [X] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [X] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
