### PR TITLE
Documentation: Fix single-spot indentation flaw

### DIFF
--- a/docs/config/cluster.rst
+++ b/docs/config/cluster.rst
@@ -261,7 +261,7 @@ about its usage.
 
   The interval a UDC ping is sent.
 
- This field expects a time value either as a ``bigint`` or
+  This field expects a time value either as a ``bigint`` or
   ``double precision`` or alternatively as a string literal with a time suffix
   (``ms``, ``s``, ``m``, ``h``, ``d``, ``w``).
 


### PR DESCRIPTION
## About

At the documentation spot about the [`udc.interval` setting](https://cratedb.com/docs/crate/reference/en/5.6/config/cluster.html#udc-interval), there was one paragraph slightly off. That probably caused this visual flaw that Sphinx renders it as a quotation.

![image](https://github.com/crate/crate/assets/453543/69553ac0-806e-4ceb-843e-f96790b5afd8)
