### PR TITLE
Minor fixes around FDW

### DIFF
--- a/server/src/main/java/io/crate/analyze/Analyzer.java
+++ b/server/src/main/java/io/crate/analyze/Analyzer.java
@@ -799,6 +799,10 @@ public class Analyzer {
                 : createUserMapping.userName();
 
             Role user = roleManager.findUser(userName);
+            if (user == null) {
+                throw new IllegalArgumentException("Cannot create a user mapping for an unknown user: '" + userName + "'");
+            }
+
             ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
                 context.transactionContext(),
                 nodeCtx,

--- a/server/src/main/java/io/crate/fdw/AddServerTask.java
+++ b/server/src/main/java/io/crate/fdw/AddServerTask.java
@@ -27,12 +27,12 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.Priority;
 
-final class AddServerTask extends AckedClusterStateUpdateTask<AcknowledgedResponse> {
+public final class AddServerTask extends AckedClusterStateUpdateTask<AcknowledgedResponse> {
 
     private final ForeignDataWrappers foreignDataWrappers;
     private final CreateServerRequest request;
 
-    AddServerTask(ForeignDataWrappers foreignDataWrappers, CreateServerRequest request) {
+    public AddServerTask(ForeignDataWrappers foreignDataWrappers, CreateServerRequest request) {
         super(Priority.NORMAL, request);
         this.foreignDataWrappers = foreignDataWrappers;
         this.request = request;

--- a/server/src/main/java/io/crate/fdw/ForeignDataWrapper.java
+++ b/server/src/main/java/io/crate/fdw/ForeignDataWrapper.java
@@ -43,6 +43,10 @@ public interface ForeignDataWrapper {
         return List.of();
     }
 
+    default List<Setting<?>> optionalUserOptions() {
+        return List.of();
+    }
+
     CompletableFuture<BatchIterator<Row>> getIterator(Role user,
                                                       Server server,
                                                       ForeignTable foreignTable,

--- a/server/src/main/java/io/crate/fdw/JdbcForeignDataWrapper.java
+++ b/server/src/main/java/io/crate/fdw/JdbcForeignDataWrapper.java
@@ -65,6 +65,13 @@ final class JdbcForeignDataWrapper implements ForeignDataWrapper {
         tableName
     );
 
+    private final Setting<String> foreignUser = Setting.simpleString("user");
+    private final Setting<String> foreignPw = Setting.simpleString("password");
+    private final List<Setting<?>> optionalUserOptions = List.of(
+        foreignUser,
+        foreignPw
+    );
+
 
     JdbcForeignDataWrapper(Settings settings, InputFactory inputFactory) {
         this.settings = settings;
@@ -79,6 +86,11 @@ final class JdbcForeignDataWrapper implements ForeignDataWrapper {
     @Override
     public List<Setting<?>> optionalTableOptions() {
         return optionalTableOptions;
+    }
+
+    @Override
+    public List<Setting<?>> optionalUserOptions() {
+        return optionalUserOptions;
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/Planner.java
+++ b/server/src/main/java/io/crate/planner/Planner.java
@@ -650,7 +650,7 @@ public class Planner extends AnalyzedStatementVisitor<PlannerContext, Plan> {
 
     @Override
     public Plan visitCreateUserMapping(AnalyzedCreateUserMapping createUserMapping, PlannerContext context) {
-        return new CreateUserMappingPlan(createUserMapping);
+        return new CreateUserMappingPlan(foreignDataWrappers, createUserMapping);
     }
 
     @Override

--- a/server/src/test/java/io/crate/analyze/CreateUserMappingAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateUserMappingAnalyzerTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.analyze;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import io.crate.execution.engine.collect.sources.SysTableRegistry;
+import io.crate.metadata.cluster.DDLClusterStateService;
+import io.crate.role.Role;
+import io.crate.role.RoleManagerService;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+
+public class CreateUserMappingAnalyzerTest extends CrateDummyClusterServiceUnitTest {
+
+    @Test
+    public void test_cannot_create_user_mapping_for_unknown_user() {
+        var e = SQLExecutor
+            .builder(clusterService)
+            .setUserManager(
+                new RoleManagerService(
+                    null,
+                    null,
+                    null,
+                    null,
+                    mock(SysTableRegistry.class),
+                    () -> List.of(Role.CRATE_USER),
+                    new DDLClusterStateService())
+            )
+            .build();
+        assertThatThrownBy(() -> e.analyze("CREATE USER MAPPING FOR user1 SERVER pg"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Cannot create a user mapping for an unknown user: 'user1'");
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
```
cr> CREATE USER MAPPING FOR user11 SERVER my_postgresql OPTIONS ("option1" 'abc');                                                         
SQLParseException[Cannot create a user mapping for an unknown user: 'user11'] -- NPE fixed

cr> create user user11;                                                                                                                    
CREATE OK, 1 row affected  (0.079 sec)
cr> CREATE USER MAPPING FOR user11 SERVER my_postgresql OPTIONS ("option1" 'abc');                                                         
SQLParseException[Invalid option 'option1' provided, the supported options are: [user, password]] -- reject invalid options

cr> CREATE USER MAPPING FOR user11 SERVER my_postgresql;                                                                                   
CREATE OK, 1 row affected  (0.080 sec)
cr> drop user user11;                                                                                                                      
IllegalStateException[User 'user11' cannot be dropped. The user mapping for a foreign server 'my_postgresql' needs to be dropped first.] -- cannot drop users with user mappings
```

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
