### PR TITLE
Align param ordering of `Settings.writeSettingsToStream` with `Writeable.Writer.write`

### DIFF
--- a/server/src/main/java/io/crate/execution/ddl/tables/AlterTableRequest.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/AlterTableRequest.java
@@ -126,7 +126,7 @@ public class AlterTableRequest extends AcknowledgedRequest<AlterTableRequest> {
         out.writeOptionalString(partitionIndexName);
         out.writeBoolean(isPartitioned);
         out.writeBoolean(excludePartitions);
-        writeSettingsToStream(settings, out);
+        writeSettingsToStream(out, settings);
         out.writeOptionalString(mappingDelta);
     }
 }

--- a/server/src/main/java/io/crate/execution/ddl/tables/CreateTableRequest.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/CreateTableRequest.java
@@ -212,7 +212,7 @@ public class CreateTableRequest extends MasterNodeRequest<CreateTableRequest> im
             for (int i = 0; i < pKeyIndices.size(); i++) {
                 out.writeVInt(pKeyIndices.get(i));
             }
-            writeSettingsToStream(settings, out);
+            writeSettingsToStream(out, settings);
             out.writeOptionalString(routingColumn);
             out.writeVInt(tableColumnPolicy.ordinal());
             out.writeCollection(partitionedBy, StreamOutput::writeStringCollection);

--- a/server/src/main/java/io/crate/execution/dsl/phases/FileUriCollectPhase.java
+++ b/server/src/main/java/io/crate/execution/dsl/phases/FileUriCollectPhase.java
@@ -172,7 +172,7 @@ public class FileUriCollectPhase extends AbstractProjectionsPhase implements Col
             parserProperties.writeTo(out);
         }
         if (out.getVersion().onOrAfter(Version.V_4_8_0)) {
-            Settings.writeSettingsToStream(withClauseOptions, out);
+            Settings.writeSettingsToStream(out, withClauseOptions);
         }
     }
 

--- a/server/src/main/java/io/crate/execution/dsl/projection/WriterProjection.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/WriterProjection.java
@@ -223,7 +223,7 @@ public class WriterProjection extends Projection {
         out.writeInt(compressionType != null ? compressionType.ordinal() : -1);
         out.writeInt(outputFormat.ordinal());
         if (out.getVersion().onOrAfter(Version.V_4_8_0)) {
-            Settings.writeSettingsToStream(withClauseOptions, out);
+            Settings.writeSettingsToStream(out, withClauseOptions);
         }
     }
 

--- a/server/src/main/java/io/crate/fdw/CreateForeignTableRequest.java
+++ b/server/src/main/java/io/crate/fdw/CreateForeignTableRequest.java
@@ -67,7 +67,7 @@ public class CreateForeignTableRequest extends AcknowledgedRequest<CreateForeign
         out.writeBoolean(ifNotExists);
         out.writeCollection(columns, Reference::toStream);
         out.writeString(server);
-        Settings.writeSettingsToStream(options, out);
+        Settings.writeSettingsToStream(out, options);
     }
 
     public RelationName tableName() {

--- a/server/src/main/java/io/crate/fdw/CreateServerRequest.java
+++ b/server/src/main/java/io/crate/fdw/CreateServerRequest.java
@@ -62,7 +62,7 @@ public class CreateServerRequest extends AcknowledgedRequest<CreateServerRequest
         out.writeString(fdw);
         out.writeString(owner);
         out.writeBoolean(ifNotExists);
-        Settings.writeSettingsToStream(options, out);
+        Settings.writeSettingsToStream(out, options);
     }
 
     public String name() {

--- a/server/src/main/java/io/crate/fdw/ForeignTable.java
+++ b/server/src/main/java/io/crate/fdw/ForeignTable.java
@@ -81,7 +81,7 @@ public record ForeignTable(RelationName name,
         name.writeTo(out);
         out.writeMap(references, (o, v) -> v.writeTo(o), Reference::toStream);
         out.writeString(server);
-        Settings.writeSettingsToStream(options, out);
+        Settings.writeSettingsToStream(out, options);
     }
 
     public static ForeignTable fromXContent(RelationName name, XContentParser parser) throws IOException {

--- a/server/src/main/java/io/crate/fdw/ServersMetadata.java
+++ b/server/src/main/java/io/crate/fdw/ServersMetadata.java
@@ -83,7 +83,7 @@ public final class ServersMetadata extends AbstractNamedDiffable<Metadata.Custom
             out.writeString(fdw);
             out.writeString(owner);
             out.writeMap(users, StreamOutput::writeString, StreamOutput::writeMap);
-            Settings.writeSettingsToStream(options, out);
+            Settings.writeSettingsToStream(out, options);
         }
 
         @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/server/src/main/java/io/crate/replication/logical/action/CreateSubscriptionRequest.java
+++ b/server/src/main/java/io/crate/replication/logical/action/CreateSubscriptionRequest.java
@@ -86,6 +86,6 @@ public class CreateSubscriptionRequest extends AcknowledgedRequest<CreateSubscri
         out.writeString(name);
         connectionInfo.writeTo(out);
         out.writeStringArray(publications.toArray(new String[0]));
-        Settings.writeSettingsToStream(settings, out);
+        Settings.writeSettingsToStream(out, settings);
     }
 }

--- a/server/src/main/java/io/crate/replication/logical/metadata/ConnectionInfo.java
+++ b/server/src/main/java/io/crate/replication/logical/metadata/ConnectionInfo.java
@@ -242,7 +242,7 @@ public class ConnectionInfo implements Writeable {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeStringArray(hosts.toArray(new String[0]));
-        Settings.writeSettingsToStream(settings, out);
+        Settings.writeSettingsToStream(out, settings);
     }
 
     @Override

--- a/server/src/main/java/io/crate/replication/logical/metadata/Subscription.java
+++ b/server/src/main/java/io/crate/replication/logical/metadata/Subscription.java
@@ -141,7 +141,7 @@ public class Subscription implements Writeable {
         out.writeString(owner);
         connectionInfo.writeTo(out);
         out.writeStringArray(publications.toArray(new String[0]));
-        Settings.writeSettingsToStream(settings, out);
+        Settings.writeSettingsToStream(out, settings);
         out.writeVInt(relations.size());
         for (var entry : relations.entrySet()) {
             entry.getKey().writeTo(out);

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/put/PutRepositoryRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/put/PutRepositoryRequest.java
@@ -215,7 +215,7 @@ public class PutRepositoryRequest extends AcknowledgedRequest<PutRepositoryReque
         super.writeTo(out);
         out.writeString(name);
         out.writeString(type);
-        writeSettingsToStream(settings, out);
+        writeSettingsToStream(out, settings);
         out.writeBoolean(verify);
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/settings/ClusterUpdateSettingsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/settings/ClusterUpdateSettingsRequest.java
@@ -147,8 +147,8 @@ public class ClusterUpdateSettingsRequest extends AcknowledgedRequest<ClusterUpd
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        writeSettingsToStream(transientSettings, out);
-        writeSettingsToStream(persistentSettings, out);
+        writeSettingsToStream(out, transientSettings);
+        writeSettingsToStream(out, persistentSettings);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/settings/ClusterUpdateSettingsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/settings/ClusterUpdateSettingsResponse.java
@@ -58,8 +58,8 @@ public class ClusterUpdateSettingsResponse extends AcknowledgedResponse {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        Settings.writeSettingsToStream(transientSettings, out);
-        Settings.writeSettingsToStream(persistentSettings, out);
+        Settings.writeSettingsToStream(out, transientSettings);
+        Settings.writeSettingsToStream(out, persistentSettings);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequest.java
@@ -118,7 +118,7 @@ public class CreateSnapshotRequest extends MasterNodeRequest<CreateSnapshotReque
         if (out.getVersion().after(Version.V_4_5_1)) {
             out.writeStringArray(templates);
         }
-        writeSettingsToStream(settings, out);
+        writeSettingsToStream(out, settings);
         out.writeBoolean(includeGlobalState);
         out.writeBoolean(waitForCompletion);
         out.writeBoolean(partial);

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
@@ -613,8 +613,8 @@ public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotReq
         }
         out.writeBoolean(partial);
         out.writeBoolean(includeAliases);
-        writeSettingsToStream(settings, out);
-        writeSettingsToStream(indexSettings, out);
+        writeSettingsToStream(out, settings);
+        writeSettingsToStream(out, indexSettings);
         out.writeStringArray(ignoreIndexSettings);
         out.writeStringArray(templates);
         if (out.getVersion().onOrAfter(Version.V_4_5_0)) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
@@ -243,7 +243,7 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
         super.writeTo(out);
         out.writeString(cause);
         out.writeString(index);
-        writeSettingsToStream(settings, out);
+        writeSettingsToStream(out, settings);
         if (out.getVersion().onOrAfter(Version.V_5_0_0)) {
             out.writeOptionalString(mapping);
         } else {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/settings/put/UpdateSettingsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/settings/put/UpdateSettingsRequest.java
@@ -166,7 +166,7 @@ public class UpdateSettingsRequest extends AcknowledgedRequest<UpdateSettingsReq
         super.writeTo(out);
         out.writeStringArrayNullable(indices);
         indicesOptions.writeIndicesOptions(out);
-        writeSettingsToStream(settings, out);
+        writeSettingsToStream(out, settings);
         out.writeBoolean(preserveExisting);
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequest.java
@@ -330,7 +330,7 @@ public class PutIndexTemplateRequest extends MasterNodeRequest<PutIndexTemplateR
             out.writeInt(1);
         }
         out.writeBoolean(create);
-        writeSettingsToStream(settings, out);
+        writeSettingsToStream(out, settings);
         if (out.getVersion().onOrAfter(Version.V_5_2_0)) {
             out.writeString(mapping);
         } else {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -686,7 +686,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             out.writeVLong(mappingVersion);
             out.writeVLong(settingsVersion);
             out.writeByte(state.id);
-            Settings.writeSettingsToStream(settings, out);
+            Settings.writeSettingsToStream(out, settings);
             out.writeVLongArray(primaryTerms);
             mappings.writeTo(out);
             aliases.writeTo(out);
@@ -763,7 +763,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         out.writeVLong(settingsVersion);
         out.writeInt(routingNumShards);
         out.writeByte(state.id());
-        writeSettingsToStream(settings, out);
+        writeSettingsToStream(out, settings);
         out.writeVLongArray(primaryTerms);
         if (mapping == null) {
             out.writeVInt(0);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetadata.java
@@ -214,7 +214,7 @@ public class IndexTemplateMetadata extends AbstractDiffable<IndexTemplateMetadat
             out.writeInt(1);
         }
         out.writeStringCollection(patterns);
-        Settings.writeSettingsToStream(settings, out);
+        Settings.writeSettingsToStream(out, settings);
         if (out.getVersion().onOrAfter(Version.V_5_2_0)) {
             mapping.writeTo(out);
         } else {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -509,8 +509,8 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
                 out.writeLong(columnOID);
             }
             coordinationMetadata.writeTo(out);
-            Settings.writeSettingsToStream(transientSettings, out);
-            Settings.writeSettingsToStream(persistentSettings, out);
+            Settings.writeSettingsToStream(out, transientSettings);
+            Settings.writeSettingsToStream(out, persistentSettings);
             indices.writeTo(out);
             templates.writeTo(out);
             customs.writeTo(out);
@@ -571,8 +571,8 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
         out.writeString(clusterUUID);
         out.writeBoolean(clusterUUIDCommitted);
         coordinationMetadata.writeTo(out);
-        writeSettingsToStream(transientSettings, out);
-        writeSettingsToStream(persistentSettings, out);
+        writeSettingsToStream(out, transientSettings);
+        writeSettingsToStream(out, persistentSettings);
         out.writeVInt(indices.size());
         for (IndexMetadata indexMetadata : this) {
             indexMetadata.writeTo(out);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/RepositoryMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/RepositoryMetadata.java
@@ -148,7 +148,7 @@ public class RepositoryMetadata implements Writeable {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(name);
         out.writeString(type);
-        Settings.writeSettingsToStream(settings, out);
+        Settings.writeSettingsToStream(out, settings);
         if (out.getVersion().onOrAfter(REPO_GEN_IN_CS_VERSION)) {
             out.writeLong(generation);
             out.writeLong(pendingGeneration);

--- a/server/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -529,7 +529,7 @@ public final class Settings implements ToXContentFragment {
         return builder.build();
     }
 
-    public static void writeSettingsToStream(Settings settings, StreamOutput out) throws IOException {
+    public static void writeSettingsToStream(StreamOutput out, Settings settings) throws IOException {
         Set<Map.Entry<String, Object>> entries = settings.settings.entrySet();
         out.writeVInt(entries.size());
         for (Map.Entry<String, Object> entry : entries) {

--- a/server/src/test/java/org/elasticsearch/common/settings/SettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/SettingsTests.java
@@ -473,7 +473,7 @@ public class SettingsTests extends ESTestCase {
         builder.putNull("test.key3.bar");
         builder.putList("test.key4.foo", "1", "2");
         assertEquals(3, builder.build().size());
-        Settings.writeSettingsToStream(builder.build(), out);
+        Settings.writeSettingsToStream(out, builder.build());
         StreamInput in = StreamInput.wrap(out.bytes().toBytesRef().bytes);
         Settings settings = Settings.readSettingsFromStream(in);
         assertEquals(3, settings.size());
@@ -577,7 +577,7 @@ public class SettingsTests extends ESTestCase {
         //output.setVersion(randomFrom(Version.CURRENT, Version.V_7_0_0));
         output.setVersion(Version.CURRENT);
         Settings settings = Settings.builder().putList("foo.bar", "0", "1", "2", "3").put("foo.bar.baz", "baz").build();
-        Settings.writeSettingsToStream(settings, output);
+        Settings.writeSettingsToStream(output, settings);
         StreamInput in = StreamInput.wrap(BytesReference.toBytes(output.bytes()));
         Settings build = Settings.readSettingsFromStream(in);
         assertEquals(2, build.size());


### PR DESCRIPTION
such that it can be used as method references, i.e.:: 
`out.writeMap(users, StreamOutput::writeString, Settings::writeSettingsToStream)`
