### PR TITLE
Factor out DropRoleTask from TransportDropRoleAction

### DIFF
--- a/server/src/main/java/io/crate/role/DropRoleTask.java
+++ b/server/src/main/java/io/crate/role/DropRoleTask.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.role;
+
+import java.util.Collection;
+
+import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.common.Priority;
+
+import io.crate.common.annotations.VisibleForTesting;
+import io.crate.role.metadata.RolesMetadata;
+import io.crate.role.metadata.UsersMetadata;
+import io.crate.role.metadata.UsersPrivilegesMetadata;
+
+public class DropRoleTask extends AckedClusterStateUpdateTask<WriteRoleResponse> {
+
+    private final DropRoleRequest request;
+    private boolean alreadyExists = true;
+
+    DropRoleTask(DropRoleRequest request) {
+        super(Priority.URGENT, request);
+        this.request = request;
+    }
+
+    @Override
+    public ClusterState execute(ClusterState currentState) throws Exception {
+        Metadata currentMetadata = currentState.metadata();
+        Metadata.Builder mdBuilder = Metadata.builder(currentMetadata);
+        alreadyExists = dropRole(
+            mdBuilder,
+            request.roleName()
+        );
+        return ClusterState.builder(currentState).metadata(mdBuilder).build();
+    }
+
+    @Override
+    protected WriteRoleResponse newResponse(boolean acknowledged) {
+        return new WriteRoleResponse(acknowledged, alreadyExists);
+    }
+
+    @VisibleForTesting
+    static boolean dropRole(Metadata.Builder mdBuilder, String roleNameToDrop) {
+        RolesMetadata oldRolesMetadata = (RolesMetadata) mdBuilder.getCustom(RolesMetadata.TYPE);
+        UsersMetadata oldUsersMetadata = (UsersMetadata) mdBuilder.getCustom(UsersMetadata.TYPE);
+        if (oldUsersMetadata == null && oldRolesMetadata == null) {
+            return false;
+        }
+
+        UsersPrivilegesMetadata oldUserPrivilegesMetadata = (UsersPrivilegesMetadata) mdBuilder.getCustom(UsersPrivilegesMetadata.TYPE);
+        RolesMetadata newMetadata = RolesMetadata.of(mdBuilder, oldUsersMetadata, oldUserPrivilegesMetadata, oldRolesMetadata);
+        validateHasChildren(newMetadata.roles().values(), roleNameToDrop);
+        var role = newMetadata.remove(roleNameToDrop);
+        if (role == null && newMetadata.equals(oldRolesMetadata)) {
+            return false;
+        }
+
+        assert !newMetadata.equals(oldRolesMetadata) : "must not be equal to guarantee the cluster change action";
+        mdBuilder.putCustom(RolesMetadata.TYPE, newMetadata);
+
+        return role != null;
+    }
+
+    private static void validateHasChildren(Collection<Role> roles, String roleNameToDrop) {
+        for (Role role : roles) {
+            if (role.grantedRoleNames().contains(roleNameToDrop)) {
+                throw new IllegalArgumentException(
+                    "Cannot drop ROLE: " + roleNameToDrop + " as it is granted on role: " + role.name());
+            }
+        }
+    }
+}

--- a/server/src/test/java/io/crate/role/TransportRoleActionTest.java
+++ b/server/src/test/java/io/crate/role/TransportRoleActionTest.java
@@ -110,12 +110,12 @@ public class TransportRoleActionTest extends ESTestCase {
 
     @Test
     public void testDropUserNoUsersAtAll() throws Exception {
-        assertThat(TransportDropRoleAction.dropRole(Metadata.builder(), "root")).isFalse();
+        assertThat(DropRoleTask.dropRole(Metadata.builder(), "root")).isFalse();
     }
 
     @Test
     public void testDropNonExistingUser() throws Exception {
-        boolean res = TransportDropRoleAction.dropRole(
+        boolean res = DropRoleTask.dropRole(
                 Metadata.builder().putCustom(RolesMetadata.TYPE, new RolesMetadata(SINGLE_USER_ONLY)),
                 "trillian"
         );
@@ -126,7 +126,7 @@ public class TransportRoleActionTest extends ESTestCase {
     public void testDropUser() throws Exception {
         RolesMetadata metadata = new RolesMetadata(DUMMY_USERS);
         Metadata.Builder mdBuilder = Metadata.builder().putCustom(RolesMetadata.TYPE, metadata);
-        boolean res = TransportDropRoleAction.dropRole(mdBuilder, "Arthur");
+        boolean res = DropRoleTask.dropRole(mdBuilder, "Arthur");
         assertThat(roles(mdBuilder)).containsExactlyEntriesOf(Map.of("Ford", DUMMY_USERS.get("Ford")));
         assertThat(res).isTrue();
     }
@@ -143,7 +143,7 @@ public class TransportRoleActionTest extends ESTestCase {
         );
         RolesMetadata metadata = new RolesMetadata(roles);
         Metadata.Builder mdBuilder = Metadata.builder().putCustom(RolesMetadata.TYPE, metadata);
-        assertThatThrownBy(() -> TransportDropRoleAction.dropRole(mdBuilder, "role2"))
+        assertThatThrownBy(() -> DropRoleTask.dropRole(mdBuilder, "role2"))
             .isExactlyInstanceOf(IllegalArgumentException.class)
             .hasMessage("Cannot drop ROLE: role2 as it is granted on role: role3");
     }
@@ -155,7 +155,7 @@ public class TransportRoleActionTest extends ESTestCase {
         Metadata.Builder mdBuilder = Metadata.builder()
             .putCustom(UsersMetadata.TYPE, oldUsersMetadata)
             .putCustom(RolesMetadata.TYPE, oldRolesMetadata);
-        boolean res = TransportDropRoleAction.dropRole(mdBuilder, "Arthur");
+        boolean res = DropRoleTask.dropRole(mdBuilder, "Arthur");
         assertThat(roles(mdBuilder)).containsExactlyEntriesOf(Map.of("Ford", DUMMY_USERS.get("Ford")));
         assertThat(res).isTrue();
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
To be able to test transport actions easier like:
https://github.com/crate/crate/blob/2d08da7c6abbabd84adc7c7ddfe0700da2baffe6/server/src/test/java/io/crate/fdw/ForeignDataWrapperPlannerTest.java#L127-L128

## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
