### PR TITLE
Make testing error handling for plan execution via SQLExecutor easier

### DIFF
--- a/server/src/test/java/io/crate/analyze/PrivilegesAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/PrivilegesAnalyzerTest.java
@@ -33,6 +33,7 @@ import static io.crate.role.Securable.SCHEMA;
 import static io.crate.role.Securable.TABLE;
 import static io.crate.role.Securable.VIEW;
 import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.Before;
@@ -46,9 +47,7 @@ import io.crate.role.Permission;
 import io.crate.role.Policy;
 import io.crate.role.Privilege;
 import io.crate.role.Role;
-import io.crate.role.RoleManager;
 import io.crate.role.Securable;
-import io.crate.role.StubRoleManager;
 import io.crate.role.metadata.RolesHelper;
 import io.crate.sql.parser.SqlParser;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
@@ -59,7 +58,6 @@ public class PrivilegesAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     private static final Role GRANTOR_TEST_USER = RolesHelper.userOf("test");
 
-    private static final RoleManager ROLE_MANAGER = new StubRoleManager();
 
     private SQLExecutor e;
 
@@ -71,7 +69,6 @@ public class PrivilegesAnalyzerTest extends CrateDummyClusterServiceUnitTest {
             .addTable("create table my_schema.locations (id int)")
             .addView(new RelationName("my_schema", "locations_view"),
                      "select * from my_schema.locations limit 2")
-            .setUserManager(ROLE_MANAGER)
             .build();
     }
 

--- a/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
+++ b/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
@@ -45,22 +45,17 @@ import org.elasticsearch.test.ClusterServiceUtils;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Answers;
 
 import io.crate.analyze.FunctionArgumentDefinition;
 import io.crate.analyze.ParamTypeHints;
 import io.crate.analyze.TableDefinitions;
-import io.crate.data.Row;
-import io.crate.data.testing.TestingRowConsumer;
 import io.crate.exceptions.UnauthorizedException;
 import io.crate.execution.engine.collect.sources.SysTableRegistry;
 import io.crate.expression.udf.UserDefinedFunctionMetadata;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.cluster.DDLClusterStateService;
 import io.crate.metadata.settings.CoordinatorSessionSettings;
-import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Plan;
-import io.crate.planner.operators.SubQueryResults;
 import io.crate.protocols.postgres.TransactionState;
 import io.crate.role.Permission;
 import io.crate.role.Policy;
@@ -157,17 +152,6 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
                     "function foo(i) { return i; }")
             )
             .build();
-    }
-
-    private void executePlan(Plan plan) {
-        TestingRowConsumer consumer = new TestingRowConsumer(true);
-        plan.execute(
-            mock(DependencyCarrier.class, Answers.RETURNS_MOCKS),
-            e.getPlannerContext(clusterService.state()),
-            consumer,
-            Row.EMPTY,
-            SubQueryResults.EMPTY
-        );
     }
 
     private void analyze(String stmt) {
@@ -783,7 +767,7 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
     public void test_fetch_from_cursor_is_allowed_if_user_could_declare_it() throws Exception {
         Plan plan = e.plan("declare c1 no scroll cursor for select 1");
         e.transactionState = TransactionState.IN_TRANSACTION;
-        executePlan(plan);
+        e.execute(plan);
         analyze("fetch from c1");
     }
 
@@ -791,7 +775,7 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
     public void test_close_cursor_is_allowed_if_user_could_declare_it() throws Exception {
         Plan plan = e.plan("declare c1 no scroll cursor for select 1");
         e.transactionState = TransactionState.IN_TRANSACTION;
-        executePlan(plan);
+        e.execute(plan);
         analyze("close c1");
     }
 

--- a/server/src/test/java/io/crate/fdw/ForeignDataWrapperPlannerTest.java
+++ b/server/src/test/java/io/crate/fdw/ForeignDataWrapperPlannerTest.java
@@ -21,23 +21,15 @@
 
 package io.crate.fdw;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
-import java.util.concurrent.TimeUnit;
 
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ClusterServiceUtils;
 import org.junit.Test;
-import org.mockito.Mockito;
 
-import io.crate.data.Row;
-import io.crate.data.testing.TestingRowConsumer;
 import io.crate.planner.CreateForeignTablePlan;
 import io.crate.planner.CreateServerPlan;
 import io.crate.planner.CreateUserMappingPlan;
-import io.crate.planner.DependencyCarrier;
-import io.crate.planner.operators.SubQueryResults;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 
@@ -57,41 +49,18 @@ public class ForeignDataWrapperPlannerTest extends CrateDummyClusterServiceUnitT
     public void test_create_server_fails_if_mandatory_options_are_missing() throws Exception {
         var e = SQLExecutor.builder(clusterService).build();
         CreateServerPlan plan = e.plan("create server pg foreign data wrapper jdbc");
-        var testingRowConsumer = new TestingRowConsumer();
-        plan.execute(
-            Mockito.mock(DependencyCarrier.class),
-            e.getPlannerContext(clusterService.state()),
-            testingRowConsumer,
-            Row.EMPTY,
-            SubQueryResults.EMPTY
-        );
-        assertThat(testingRowConsumer.completionFuture())
-            .failsWithin(0, TimeUnit.SECONDS)
-            .withThrowableThat()
-            .havingRootCause()
-                .isExactlyInstanceOf(IllegalArgumentException.class)
-                .withMessage("Mandatory server option `url` for foreign data wrapper `jdbc` is missing");
-
+        assertThatThrownBy(() -> e.execute(plan).getResult())
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Mandatory server option `url` for foreign data wrapper `jdbc` is missing");
     }
 
     @Test
     public void test_cannot_use_unsupported_options_in_create_server() throws Exception {
         var e = SQLExecutor.builder(clusterService).build();
         CreateServerPlan plan = e.plan("create server pg foreign data wrapper jdbc options (url '', wrong_option 10)");
-        var testingRowConsumer = new TestingRowConsumer();
-        plan.execute(
-            Mockito.mock(DependencyCarrier.class),
-            e.getPlannerContext(clusterService.state()),
-            testingRowConsumer,
-            Row.EMPTY,
-            SubQueryResults.EMPTY
-        );
-        assertThat(testingRowConsumer.completionFuture())
-            .failsWithin(0, TimeUnit.SECONDS)
-            .withThrowableThat()
-            .havingRootCause()
-                .isExactlyInstanceOf(IllegalArgumentException.class)
-                .withMessage("Unsupported server options for foreign data wrapper `jdbc`: wrong_option. Valid options are: url");
+        assertThatThrownBy(() -> e.execute(plan).getResult())
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Unsupported server options for foreign data wrapper `jdbc`: wrong_option. Valid options are: url");
     }
 
     @Test
@@ -99,20 +68,8 @@ public class ForeignDataWrapperPlannerTest extends CrateDummyClusterServiceUnitT
         var e = SQLExecutor.builder(clusterService).build();
         String stmt = "create server pg foreign data wrapper dummy options (host 'localhost', dbname 'doc', port '5432')";
         CreateServerPlan plan = e.plan(stmt);
-
-        var testingRowConsumer = new TestingRowConsumer();
-        plan.execute(
-            Mockito.mock(DependencyCarrier.class),
-            e.getPlannerContext(clusterService.state()),
-            testingRowConsumer,
-            Row.EMPTY,
-            SubQueryResults.EMPTY
-        );
-        assertThat(testingRowConsumer.completionFuture())
-            .failsWithin(0, TimeUnit.SECONDS)
-            .withThrowableThat()
-            .havingRootCause()
-            .withMessageContaining("foreign-data wrapper dummy does not exist");
+        assertThatThrownBy(() -> e.execute(plan).getResult())
+            .hasMessage("foreign-data wrapper dummy does not exist");
     }
 
     @Test
@@ -130,19 +87,8 @@ public class ForeignDataWrapperPlannerTest extends CrateDummyClusterServiceUnitT
 
         String stmt = "create foreign table tbl (x int) server pg options (invalid 42)";
         CreateForeignTablePlan plan = e.plan(stmt);
-        var testingRowConsumer = new TestingRowConsumer();
-        plan.execute(
-            Mockito.mock(DependencyCarrier.class),
-            e.getPlannerContext(clusterService.state()),
-            testingRowConsumer,
-            Row.EMPTY,
-            SubQueryResults.EMPTY
-        );
-        assertThat(testingRowConsumer.completionFuture())
-            .failsWithin(0, TimeUnit.SECONDS)
-            .withThrowableThat()
-            .havingRootCause()
-            .withMessageContaining(
+        assertThatThrownBy(() -> e.execute(plan).getResult())
+            .hasMessageContaining(
                 "Unsupported options for foreign table doc.tbl using fdw `jdbc`: invalid. Valid options are: schema_name, table_name");
     }
 
@@ -161,19 +107,8 @@ public class ForeignDataWrapperPlannerTest extends CrateDummyClusterServiceUnitT
 
         String stmt = "CREATE USER MAPPING FOR crate SERVER pg OPTIONS (\"option1\" 'abc');";
         CreateUserMappingPlan plan = e.plan(stmt);
-        var testingRowConsumer = new TestingRowConsumer();
-        plan.execute(
-            Mockito.mock(DependencyCarrier.class),
-            e.getPlannerContext(clusterService.state()),
-            testingRowConsumer,
-            Row.EMPTY,
-            SubQueryResults.EMPTY
-        );
-        assertThat(testingRowConsumer.completionFuture())
-            .failsWithin(0, TimeUnit.SECONDS)
-            .withThrowableThat()
-            .havingRootCause()
-            .withMessageContaining(
+        assertThatThrownBy(() -> e.execute(plan).getResult())
+            .hasMessageContaining(
                 "Invalid option 'option1' provided, the supported options are: [user, password]");
     }
 }


### PR DESCRIPTION
Moves some boilerplate we've scattered across a few tests into
SQLExecutor by adding an additional `.execute(String|Plan)` method
