### PR TITLE
Improve error messages when query on foreign tables failed

### DIFF
--- a/server/src/main/java/io/crate/fdw/JdbcForeignDataWrapper.java
+++ b/server/src/main/java/io/crate/fdw/JdbcForeignDataWrapper.java
@@ -142,7 +142,7 @@ final class JdbcForeignDataWrapper implements ForeignDataWrapper {
         RelationName remoteName = new RelationName(
             remoteSchema.isEmpty() ? foreignTable.name().schema() : remoteSchema,
             remoteTable.isEmpty() ? foreignTable.name().name() : remoteTable);
-        BatchIterator<Row> it = new JdbcBatchIterator(url, properties, refs, remoteName);
+        BatchIterator<Row> it = new JdbcBatchIterator(url, properties, refs, remoteName, foreignTable.name());
         if (!refs.containsAll(collect)) {
             var sourceRefs = new InputColumns.SourceSymbols(refs);
             List<Symbol> inputColumns = InputColumns.create(collect, sourceRefs);


### PR DESCRIPTION
When a foreign table is used in a complex query the error message becomes harder to understand:
```
cr> select * from t1, t2;                                                                                                             
PSQLException[ERROR: relation "doc.foo" does not exist
  Position: 15]
```