### PR TITLE
Changed EXP function to return double types

### DIFF
--- a/docs/appendices/release-notes/5.7.0.rst
+++ b/docs/appendices/release-notes/5.7.0.rst
@@ -48,6 +48,9 @@ Breaking Changes
 - Added ``CURRENT_ROLE`` as a reserved keyword. If you have a column or table
   named ``CURRENT_ROLE``, you must escape it using double quotes.
 
+- Changed :ref:`scalar-exp` to always return ``double`` type for its result,
+  independently of the input type.
+
 Deprecations
 ============
 

--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -2061,7 +2061,7 @@ Returns: ``double precision``
 Returns Euler's number ``e`` raised to the power of the given numeric value.
 The output will be cast to the given input type and thus may loose precision.
 
-Returns: Same as input type.
+Returns: ``double precision``
 
 ::
 

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/ExpFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/ExpFunction.java
@@ -33,19 +33,18 @@ public class ExpFunction {
     public static final String NAME = "exp";
 
     public static void register(Functions.Builder module) {
-        for (var type : DataTypes.NUMERIC_PRIMITIVE_TYPES) {
-            var typeSignature = type.getTypeSignature();
-            module.add(
-                scalar(NAME, typeSignature, typeSignature)
-                    .withFeature(Scalar.Feature.NULLABLE),
-                (declaredSignature, boundSignature) ->
-                    new UnaryScalar<>(
-                        declaredSignature,
-                        boundSignature,
-                        type,
-                        x -> type.sanitizeValue(Math.exp(((Number) x).doubleValue()))
-                    )
-            );
-        }
+        var type = DataTypes.DOUBLE;
+        var signature = type.getTypeSignature();
+        module.add(
+            scalar(NAME, signature, signature)
+                .withFeature(Scalar.Feature.NULLABLE),
+            (declaredSignature, boundSignature) ->
+                new UnaryScalar<>(
+                    declaredSignature,
+                    boundSignature,
+                    type,
+                    x -> type.sanitizeValue(Math.exp(((Number) x).doubleValue()))
+                )
+        );
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/ExpFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/ExpFunctionTest.java
@@ -31,9 +31,9 @@ public class ExpFunctionTest extends ScalarTestCase {
 
     @Test
     public void test_exp_scalar() {
-        assertNormalize("exp(1)", isLiteral(2));
-        assertNormalize("exp(1::bigint)", isLiteral(2L));
-        assertNormalize("exp(1.0)", isLiteral(2.718281828459045d, 1E-15d));
-        assertNormalize("exp(1.0::real)", isLiteral(2.7182817F));
+        assertNormalize("exp(1)", isLiteral(2.718281828459045));
+        assertNormalize("exp(1::bigint)", isLiteral(2.718281828459045));
+        assertNormalize("exp(1.0)", isLiteral(2.718281828459045));
+        assertNormalize("exp(1.0::real)", isLiteral(2.718281828459045));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes https://github.com/crate/crate/issues/15642

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
