### PR TITLE
Make RoleAlreadyExistsException streamable

### DIFF
--- a/server/src/main/java/io/crate/exceptions/RoleAlreadyExistsException.java
+++ b/server/src/main/java/io/crate/exceptions/RoleAlreadyExistsException.java
@@ -21,27 +21,25 @@
 
 package io.crate.exceptions;
 
-import java.util.Locale;
+import java.io.IOException;
 
-import org.jetbrains.annotations.Nullable;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 
-import io.crate.role.JwtProperties;
 
-public class RoleAlreadyExistsException extends RuntimeException implements ConflictException, UnscopedException {
+public class RoleAlreadyExistsException extends ElasticsearchException implements ConflictException, UnscopedException {
 
-    private RoleAlreadyExistsException(String message) {
+    public RoleAlreadyExistsException(String message) {
         super(message);
     }
 
-    public static RoleAlreadyExistsException of(String roleName, @Nullable JwtProperties jwtProperties) {
-        if (jwtProperties == null) {
-            return new RoleAlreadyExistsException(String.format(Locale.ENGLISH, "Role '%s' already exists", roleName));
-        } else {
-            return new RoleAlreadyExistsException(String.format(
-                Locale.ENGLISH,
-                "Role '%s' or another role with the same combination of jwt properties already exists",
-                roleName
-            ));
-        }
+    public RoleAlreadyExistsException(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
     }
 }

--- a/server/src/main/java/io/crate/role/RoleManagerService.java
+++ b/server/src/main/java/io/crate/role/RoleManagerService.java
@@ -116,7 +116,7 @@ public class RoleManagerService implements RoleManager {
                                               @Nullable JwtProperties jwtProperties) {
         return transportCreateRoleAction.execute(new CreateRoleRequest(roleName, isUser, hashedPw, jwtProperties), r -> {
             if (r.doesUserExist()) {
-                throw RoleAlreadyExistsException.of(roleName, jwtProperties);
+                throw new RoleAlreadyExistsException(String.format(Locale.ENGLISH, "Role '%s' already exists", roleName));
             }
             return 1L;
         });

--- a/server/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/server/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -1000,7 +1000,12 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
             UserMappingAlreadyExists.class,
             UserMappingAlreadyExists::new,
             179,
-            Version.V_5_7_0) ;
+            Version.V_5_7_0),
+        ROLE_ALREADY_EXISTS(
+            io.crate.exceptions.RoleAlreadyExistsException.class,
+            io.crate.exceptions.RoleAlreadyExistsException::new,
+            180,
+            Version.V_5_7_0);
 
         final Class<? extends ElasticsearchException> exceptionClass;
         final CheckedFunction<StreamInput, ? extends ElasticsearchException, IOException> constructor;

--- a/server/src/test/java/io/crate/integrationtests/RoleManagementIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/RoleManagementIntegrationTest.java
@@ -290,6 +290,6 @@ public class RoleManagementIntegrationTest extends BaseRolesIntegrationTest {
         Asserts.assertSQLError(() -> execute("CREATE USER user2 WITH (jwt = {\"iss\" = 'dummy.org/keys', \"username\" = 'app_user'})"))
             .hasPGError(INTERNAL_ERROR)
             .hasHTTPError(CONFLICT, 4099)
-            .hasMessageContaining("Role 'user2' or another role with the same combination of jwt properties already exists");
+            .hasMessageContaining("Another role with the same combination of jwt properties already exists");
     }
 }

--- a/server/src/test/java/io/crate/role/TransportRoleActionTest.java
+++ b/server/src/test/java/io/crate/role/TransportRoleActionTest.java
@@ -41,6 +41,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ClusterServiceUtils;
 import org.junit.Test;
 
+import io.crate.exceptions.RoleAlreadyExistsException;
 import io.crate.fdw.AddServerTask;
 import io.crate.fdw.CreateServerRequest;
 import io.crate.role.metadata.RolesHelper;
@@ -75,12 +76,13 @@ public class TransportRoleActionTest extends CrateDummyClusterServiceUnitTest {
             null,
             new JwtProperties("https:dummy.org", "test"));
 
-        boolean exists = TransportCreateRoleAction.putRole(mdBuilder,
-            "user2",
-            true,
-            null,
-            new JwtProperties("https:dummy.org", "test"));
-        assertThat(exists).isTrue();
+        assertThatThrownBy(() -> TransportCreateRoleAction.putRole(mdBuilder,
+                "user2",
+                true,
+                null,
+                new JwtProperties("https:dummy.org", "test")))
+            .isExactlyInstanceOf(RoleAlreadyExistsException.class)
+            .hasMessage("Another role with the same combination of jwt properties already exists");
     }
 
     @Test


### PR DESCRIPTION
Similar to https://github.com/crate/crate/commit/d365827bfc904b9e0feb030fc86d16a44ea9e573 and https://github.com/crate/crate/commit/23c610017e13e13065cd94cbc00064f514f60949

Helps to avoid confusing messages where we don't know whether its username clash or jwt clash.

For `CREATE USER` maybe not visible but for `ALTER USER` would be even more useful as `exists` flag in `WriteRoleResponse` is used as a happy path scenario (not exists would be `RoleUnknownException`). 

Instead of adding a new flag to the `WriteRoleResponse` we can make exception streamable and make a very precise error message.