### PR TITLE
Allow jwt property in ALTER USER statement

### DIFF
--- a/docs/sql/statements/alter-role.rst
+++ b/docs/sql/statements/alter-role.rst
@@ -55,6 +55,17 @@ are supported to alter an existing user account:
     For security reasons it is recommended to authenticate as ``crate`` using a
     client certificate.
 
+:jwt:
+  JWT properties map (``iss`` and ``username``) entered as a string literal.
+  e.g.::
+
+     ALTER USER john WITH (jwt = {"iss" = 'new_issuer', "username" = 'new_username'})
+
+  New JWT properties must not coincide with JWT properties of another user.
+
+  ``NULL`` removes the JWT properties from the user.
+
 .. NOTE::
 
-   Passwords can be set only to existing database users, but not to roles.
+   Passwords and JWT properties can be changed only for existing database
+   users, but not to roles.

--- a/server/src/main/java/io/crate/planner/node/ddl/AlterRolePlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/AlterRolePlan.java
@@ -21,11 +21,15 @@
 
 package io.crate.planner.node.ddl;
 
+import static io.crate.planner.node.ddl.CreateRolePlan.JWT_PROPERTY_KEY;
+import static io.crate.planner.node.ddl.CreateRolePlan.PASSWORD_PROPERTY_KEY;
 import static io.crate.planner.node.ddl.CreateRolePlan.parse;
 
 import java.util.Map;
 
 import io.crate.analyze.AnalyzedAlterRole;
+import io.crate.common.collections.Maps;
+import io.crate.role.JwtProperties;
 import io.crate.role.RoleManager;
 import io.crate.data.Row;
 import io.crate.data.Row1;
@@ -66,8 +70,11 @@ public class AlterRolePlan implements Plan {
             subQueryResults
         );
         SecureHash newPassword = UserActions.generateSecureHash(properties);
+        JwtProperties newJwtProperties = JwtProperties.fromMap(Maps.get(properties, JWT_PROPERTY_KEY));
+        boolean resetPassword = properties.containsKey(PASSWORD_PROPERTY_KEY) && newPassword == null;
+        boolean resetJwtProperties = properties.containsKey(JWT_PROPERTY_KEY) && newJwtProperties == null;
 
-        roleManager.alterRole(alterRole.roleName(), newPassword)
+        roleManager.alterRole(alterRole.roleName(), newPassword, newJwtProperties, resetPassword, resetJwtProperties)
             .whenComplete(new OneRowActionListener<>(consumer, rCount -> new Row1(rCount == null ? -1 : rCount)));
     }
 }

--- a/server/src/main/java/io/crate/planner/node/ddl/CreateRolePlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/CreateRolePlan.java
@@ -85,7 +85,7 @@ public class CreateRolePlan implements Plan {
                                                     "use CREATE USER instead");
         }
 
-        JwtProperties jwtProperties = JwtProperties.fromMap(Maps.getOrDefault(properties, JWT_PROPERTY_KEY, Map.of()));
+        JwtProperties jwtProperties = JwtProperties.fromMap(Maps.get(properties, JWT_PROPERTY_KEY));
 
         roleManager.createRole(createRole.roleName(), createRole.isUser(), newPassword, jwtProperties)
             .whenComplete(new OneRowActionListener<>(consumer, rCount -> new Row1(rCount == null ? -1 : rCount)));

--- a/server/src/main/java/io/crate/role/JwtProperties.java
+++ b/server/src/main/java/io/crate/role/JwtProperties.java
@@ -32,7 +32,6 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import io.crate.common.collections.Maps;
@@ -50,8 +49,8 @@ public record JwtProperties(String iss, String username) implements Writeable, T
     }
 
     @Nullable
-    public static JwtProperties fromMap(@NotNull Map<String, Object> jwtPropertiesMap) {
-        if (jwtPropertiesMap.isEmpty() == false) {
+    public static JwtProperties fromMap(@Nullable Map<String, Object> jwtPropertiesMap) {
+        if (jwtPropertiesMap != null && jwtPropertiesMap.isEmpty() == false) {
             String iss = Maps.get(jwtPropertiesMap, "iss");
             ensureNotNull("iss", iss);
             String username = Maps.get(jwtPropertiesMap, "username");

--- a/server/src/main/java/io/crate/role/Role.java
+++ b/server/src/main/java/io/crate/role/Role.java
@@ -165,10 +165,16 @@ public class Role implements Writeable, ToXContent {
         return new Role(name, new RolePrivileges(privileges), grantedRoles, properties, false);
     }
 
-    public Role with(SecureHash password) {
-        return new Role(name, privileges, grantedRoles, new Properties(properties.login, password, properties.jwtProperties), false);
+    public Role with(@Nullable SecureHash password,
+                     @Nullable JwtProperties jwtProperties) {
+        return new Role(
+            name,
+            privileges,
+            grantedRoles,
+            new Properties(properties.login, password, jwtProperties),
+            false
+        );
     }
-
 
     public String name() {
         return name;

--- a/server/src/main/java/io/crate/role/RoleManager.java
+++ b/server/src/main/java/io/crate/role/RoleManager.java
@@ -64,9 +64,16 @@ public interface RoleManager extends Roles {
      *
      * @param roleName of the existing role to modify
      * @param newHashedPw new password; if null the password is removed from the role
+     * @param newJwtProperties new jwt properties. if null properties are removed from the role
+     * @param resetPassword hints how to treat NULL password: as not provided and supposed to be kept or explicitly set to NULL.
+     * @param resetJwtProperties hints how to treat NULL jwt: as not provided and supposed to be kept or explicitly set to NULL.
      * @return 1 if the role has been updated, otherwise a failed future.
      */
-    CompletableFuture<Long> alterRole(String roleName, @Nullable SecureHash newHashedPw);
+    CompletableFuture<Long> alterRole(String roleName,
+                                      @Nullable SecureHash newHashedPw,
+                                      @Nullable JwtProperties newJwtProperties,
+                                      boolean resetPassword,
+                                      boolean resetJwtProperties);
 
     /**
      * Apply given list of {@link Privilege}s or {@link Role} for each given role

--- a/server/src/main/java/io/crate/role/RoleManagerService.java
+++ b/server/src/main/java/io/crate/role/RoleManagerService.java
@@ -137,13 +137,20 @@ public class RoleManagerService implements RoleManager {
     }
 
     @Override
-    public CompletableFuture<Long> alterRole(String roleName, @Nullable SecureHash newHashedPw) {
-        return transportAlterRoleAction.execute(new AlterRoleRequest(roleName, newHashedPw), r -> {
-            if (r.doesUserExist() == false) {
-                throw new RoleUnknownException(roleName);
+    public CompletableFuture<Long> alterRole(String roleName,
+                                             @Nullable SecureHash newHashedPw,
+                                             @Nullable JwtProperties newJwtProperties,
+                                             boolean resetPassword,
+                                             boolean resetJwtProperties) {
+        return transportAlterRoleAction.execute(
+            new AlterRoleRequest(roleName, newHashedPw, newJwtProperties, resetPassword, resetJwtProperties),
+            r -> {
+                if (r.doesUserExist() == false) {
+                    throw new RoleUnknownException(roleName);
+                }
+                return 1L;
             }
-            return 1L;
-        });
+        );
     }
 
     public CompletableFuture<Long> applyPrivileges(Collection<String> roleNames,

--- a/server/src/main/java/io/crate/role/TransportCreateRoleAction.java
+++ b/server/src/main/java/io/crate/role/TransportCreateRoleAction.java
@@ -88,7 +88,13 @@ public class TransportCreateRoleAction extends TransportMasterNodeAction<CreateR
                     public ClusterState execute(ClusterState currentState) throws Exception {
                         Metadata currentMetadata = currentState.metadata();
                         Metadata.Builder mdBuilder = Metadata.builder(currentMetadata);
-                        alreadyExists = putRole(mdBuilder, request.roleName(), request.isUser(), request.secureHash(), request.jwtProperties());
+                        alreadyExists = putRole(
+                            mdBuilder,
+                            request.roleName(),
+                            request.isUser(),
+                            request.secureHash(),
+                            request.jwtProperties()
+                        );
                         return ClusterState.builder(currentState).metadata(mdBuilder).build();
                     }
 

--- a/server/src/test/java/io/crate/integrationtests/RoleManagementIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/RoleManagementIntegrationTest.java
@@ -292,4 +292,15 @@ public class RoleManagementIntegrationTest extends BaseRolesIntegrationTest {
             .hasHTTPError(CONFLICT, 4099)
             .hasMessageContaining("Another role with the same combination of jwt properties already exists");
     }
+
+    @Test
+    public void test_alter_user_jwt_properties() {
+        execute("CREATE USER user1 WITH (password = 'pwd', jwt = {\"iss\" = 'issuer1', \"username\" = 'user1'})");
+        execute("CREATE USER user2 WITH (password = 'pwd', jwt = {\"iss\" = 'issuer2', \"username\" = 'user2'})");
+        // Updating JWT properties clashes with JWT properties of an existing user.
+        Asserts.assertSQLError(() -> execute("ALTER USER user1 set (jwt = {\"iss\" = 'issuer2', \"username\" = 'user2'})"))
+            .hasPGError(INTERNAL_ERROR)
+            .hasHTTPError(CONFLICT, 4099)
+            .hasMessageContaining("Another role with the same combination of jwt properties already exists");
+    }
 }

--- a/server/src/test/java/io/crate/role/TransportRoleActionTest.java
+++ b/server/src/test/java/io/crate/role/TransportRoleActionTest.java
@@ -28,12 +28,16 @@ import static io.crate.role.metadata.RolesHelper.DUMMY_USERS_WITHOUT_PASSWORD;
 import static io.crate.role.metadata.RolesHelper.OLD_DUMMY_USERS_PRIVILEGES;
 import static io.crate.role.metadata.RolesHelper.SINGLE_USER_ONLY;
 import static io.crate.role.metadata.RolesHelper.getSecureHash;
+import static io.crate.role.metadata.RolesHelper.userOf;
 import static io.crate.role.metadata.RolesHelper.usersMetadataOf;
 import static io.crate.testing.Asserts.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.Metadata;
@@ -42,6 +46,7 @@ import org.elasticsearch.test.ClusterServiceUtils;
 import org.junit.Test;
 
 import io.crate.exceptions.RoleAlreadyExistsException;
+import io.crate.exceptions.UnsupportedFeatureException;
 import io.crate.fdw.AddServerTask;
 import io.crate.fdw.CreateServerRequest;
 import io.crate.role.metadata.RolesHelper;
@@ -143,14 +148,20 @@ public class TransportRoleActionTest extends CrateDummyClusterServiceUnitTest {
             .putCustom(UsersPrivilegesMetadata.TYPE, oldUsersPrivilegesMetadata)
             .putCustom(RolesMetadata.TYPE, oldRolesMetadata);
         var newPasswd = getSecureHash("arthurs-new-passwd");
-        boolean res = TransportAlterRoleAction.alterRole(mdBuilder, "Arthur", newPasswd);
+        boolean res = TransportAlterRoleAction.alterRole(mdBuilder,
+            "Arthur",
+            newPasswd,
+            null,
+            false,
+            false
+        );
         assertThat(res).isTrue();
 
         var newFordUser = DUMMY_USERS_WITHOUT_PASSWORD.get("Ford")
                 .with(OLD_DUMMY_USERS_PRIVILEGES.get("Ford"));
         var newArthurUser = DUMMY_USERS_WITHOUT_PASSWORD.get("Arthur")
                 .with(OLD_DUMMY_USERS_PRIVILEGES.get("Arthur"))
-                .with(newPasswd);
+                .with(newPasswd, null);
         assertThat(roles(mdBuilder)).containsExactlyInAnyOrderEntriesOf(
             Map.of("Arthur", newArthurUser,
                 "Ford", newFordUser));
@@ -234,6 +245,133 @@ public class TransportRoleActionTest extends CrateDummyClusterServiceUnitTest {
             .isExactlyInstanceOf(IllegalStateException.class)
             .hasMessage("User 'role1' cannot be dropped. The user mappings for foreign servers '[pg]' needs to be dropped first.");
     }
+
+    @Test
+    public void test_alter_user_cannot_set_password_to_role() throws Exception {
+        var oldRolesMetadata = new RolesMetadata(DUMMY_USERS_AND_ROLES_WITHOUT_PASSWORD);
+        Metadata.Builder mdBuilder = Metadata.builder()
+            .putCustom(RolesMetadata.TYPE, oldRolesMetadata);
+        // Set new password
+        assertThatThrownBy(() -> TransportAlterRoleAction.alterRole(
+            mdBuilder,
+            "DummyRole",
+            getSecureHash("new-passwd"),
+            null,
+            false,
+            false))
+            .isExactlyInstanceOf(UnsupportedFeatureException.class)
+            .hasMessage("Setting a password to a ROLE is not allowed");
+
+        // Set NULL - reset
+        assertThatThrownBy(() -> TransportAlterRoleAction.alterRole(
+            mdBuilder,
+            "DummyRole",
+            null,
+            null,
+            true,
+            false))
+            .isExactlyInstanceOf(UnsupportedFeatureException.class)
+            .hasMessage("Setting a password to a ROLE is not allowed");
+    }
+
+    @Test
+    public void test_alter_user_cannot_set_jwt_to_role() throws Exception {
+        var oldRolesMetadata = new RolesMetadata(DUMMY_USERS_AND_ROLES_WITHOUT_PASSWORD);
+        Metadata.Builder mdBuilder = Metadata.builder()
+            .putCustom(RolesMetadata.TYPE, oldRolesMetadata);
+        // Set new jwt
+        assertThatThrownBy(() -> TransportAlterRoleAction.alterRole(
+            mdBuilder,
+            "DummyRole",
+            null,
+            new JwtProperties("iss", "username"),
+            false,
+            false))
+            .isExactlyInstanceOf(UnsupportedFeatureException.class)
+            .hasMessage("Setting JWT properties to a ROLE is not allowed");
+
+        // Set NULL - reset
+        assertThatThrownBy(() -> TransportAlterRoleAction.alterRole(
+            mdBuilder,
+            "DummyRole",
+            null,
+            null,
+            false,
+            true))
+            .isExactlyInstanceOf(UnsupportedFeatureException.class)
+            .hasMessage("Setting JWT properties to a ROLE is not allowed");
+    }
+
+    @Test
+    public void test_alter_user_change_jwt_and_keep_password() throws Exception {
+        Map<String, Role> roleWithJwtAndPassword = new HashMap<>();
+        var oldPassword = getSecureHash("johns-pwd"); // Has randomness, keep it for assertions.
+        roleWithJwtAndPassword.put("John", userOf(
+            "John",
+            Set.of(),
+            new HashSet<>(),
+            oldPassword,
+            new JwtProperties("https:dummy.org", "test"))
+        );
+        var oldRolesMetadata = new RolesMetadata(roleWithJwtAndPassword);
+        Metadata.Builder mdBuilder = Metadata.builder()
+            .putCustom(RolesMetadata.TYPE, oldRolesMetadata);
+        boolean exists = TransportAlterRoleAction.alterRole(
+            mdBuilder,
+            "John",
+            null,
+            new JwtProperties("new_issuer", "new_username"),
+            false, // No reset, keep pwd
+            false
+        );
+        assertThat(exists).isTrue();
+        assertThat(roles(mdBuilder)).containsExactlyInAnyOrderEntriesOf(
+            Map.of("John", userOf(
+                    "John",
+                    Set.of(),
+                    new HashSet<>(),
+                    oldPassword,
+                    new JwtProperties("new_issuer", "new_username")
+                )
+            )
+        );
+    }
+
+    @Test
+    public void test_alter_user_reset_jwt_and_password() throws Exception {
+        Map<String, Role> roleWithJwtAndPassword = new HashMap<>();
+        var oldPassword = getSecureHash("johns-pwd"); // Has randomness, keep it for assertions.
+        roleWithJwtAndPassword.put("John", userOf(
+            "John",
+            Set.of(),
+            new HashSet<>(),
+            oldPassword,
+            new JwtProperties("https:dummy.org", "test"))
+        );
+        var oldRolesMetadata = new RolesMetadata(roleWithJwtAndPassword);
+        Metadata.Builder mdBuilder = Metadata.builder()
+            .putCustom(RolesMetadata.TYPE, oldRolesMetadata);
+        boolean exists = TransportAlterRoleAction.alterRole(
+            mdBuilder,
+            "John",
+            null,
+            null,
+            true,
+            true
+        );
+        assertThat(exists).isTrue();
+        assertThat(roles(mdBuilder)).containsExactlyInAnyOrderEntriesOf(
+            Map.of("John", userOf(
+                    "John",
+                    Set.of(),
+                    new HashSet<>(),
+                    null,
+                    null
+                )
+            )
+        );
+    }
+
 
     private static Map<String, Role> roles(Metadata.Builder mdBuilder) {
         return ((RolesMetadata) mdBuilder.build().custom(RolesMetadata.TYPE)).roles();

--- a/server/src/testFixtures/java/io/crate/role/StubRoleManager.java
+++ b/server/src/testFixtures/java/io/crate/role/StubRoleManager.java
@@ -57,7 +57,11 @@ public class StubRoleManager implements RoleManager {
     }
 
     @Override
-    public CompletableFuture<Long> alterRole(String roleName, @Nullable SecureHash newHashedPw) {
+    public CompletableFuture<Long> alterRole(String roleName,
+                                             @Nullable SecureHash newHashedPw,
+                                             @Nullable JwtProperties newJwtProperties,
+                                             boolean resetPassword,
+                                             boolean resetJwtProperties) {
         return CompletableFuture.failedFuture(new UnsupportedFeatureException("alterRole is not implemented in StubRoleManager"));
     }
 


### PR DESCRIPTION
Adding missing support for altering jwt properties.

1. We don't have RESET (like in CREATE TABLE) in ALTER USER, hence need for extra flags to differentiate NULL treatment - skip it or set it. Before it was not a problem since password was the only parameter.

2. No support for partial update of JWT properties, ie both iss/username must be specified in ALTER USER. No concrete blockers - it's a MUST on CREATE USER to have both specified so I thought could be aligned. But also not a big deal to allow partial update. wdyt?