### PR TITLE
tests: show actual error message if expected error is different

### DIFF
--- a/server/src/testFixtures/java/io/crate/testing/SQLErrorAssert.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLErrorAssert.java
@@ -28,6 +28,7 @@ import org.elasticsearch.transport.RemoteTransportException;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.ServerErrorMessage;
 
+import io.crate.exceptions.SQLExceptions;
 import io.crate.protocols.postgres.PGErrorStatus;
 import io.crate.rest.action.HttpError;
 import io.netty.handler.codec.http.HttpResponseStatus;
@@ -63,7 +64,8 @@ public final class SQLErrorAssert extends AbstractThrowableAssert<SQLErrorAssert
                 + errorCode
                 + " but "
                 + actual.getClass().getSimpleName()
-                + " has a different code"
+                + " has a different code."
+                + " Actual error message: " + SQLExceptions.messageOf(actual)
             )
             .isEqualTo(errorCode);
         assertThat(httpError.httpResponseStatus()).isEqualTo(httpResponseCode);


### PR DESCRIPTION
I think it's useful as it helped me to debug https://github.com/crate/crate/pull/15650#issuecomment-1978155634.

In the example above ^ assertion failed with 
`[Expected an exception with errorCode 40410 but NullPointerException has a different code]`

and with this change it was

`[Expected an exception... message: Cannot invoke “io.crate.role.metadata.RolesMetadata.contains(io.crate.role.JwtProperties)” because “updatedRolesMetadata” is null]`
