### PR TITLE
Add predicate pushdown for foreign data wrappers

### DIFF
--- a/server/src/main/java/io/crate/execution/dsl/phases/ForeignCollectPhase.java
+++ b/server/src/main/java/io/crate/execution/dsl/phases/ForeignCollectPhase.java
@@ -39,6 +39,7 @@ public class ForeignCollectPhase extends AbstractProjectionsPhase implements Col
     private final String handlerNode;
     private final RelationName relationName;
     private final List<Symbol> toCollect;
+    private final Symbol query;
 
     private DistributionInfo distributionInfo = DistributionInfo.DEFAULT_BROADCAST;
 
@@ -46,12 +47,14 @@ public class ForeignCollectPhase extends AbstractProjectionsPhase implements Col
                                int phaseId,
                                String handlerNode,
                                RelationName relationName,
-                               List<Symbol> toCollect) {
+                               List<Symbol> toCollect,
+                               Symbol query) {
         super(jobId, phaseId, relationName.fqn(), null);
         this.handlerNode = handlerNode;
         this.relationName = relationName;
         this.toCollect = toCollect;
         this.outputTypes = Symbols.typeView(toCollect);
+        this.query = query;
     }
 
     public ForeignCollectPhase(StreamInput in) throws IOException {
@@ -61,6 +64,7 @@ public class ForeignCollectPhase extends AbstractProjectionsPhase implements Col
         this.toCollect = Symbols.listFromStream(in);
         this.outputTypes = extractOutputTypes(toCollect, projections);
         this.distributionInfo = new DistributionInfo(in);
+        this.query = Symbols.fromStream(in);
     }
 
     @Override
@@ -70,6 +74,7 @@ public class ForeignCollectPhase extends AbstractProjectionsPhase implements Col
         relationName.writeTo(out);
         Symbols.toStream(toCollect, out);
         distributionInfo.writeTo(out);
+        Symbols.toStream(query, out);
     }
 
     @Override
@@ -104,5 +109,9 @@ public class ForeignCollectPhase extends AbstractProjectionsPhase implements Col
 
     public RelationName relationName() {
         return relationName;
+    }
+
+    public Symbol query() {
+        return query;
     }
 }

--- a/server/src/main/java/io/crate/fdw/ForeignDataWrapper.java
+++ b/server/src/main/java/io/crate/fdw/ForeignDataWrapper.java
@@ -47,9 +47,20 @@ public interface ForeignDataWrapper {
         return List.of();
     }
 
+    /**
+     * Indicates if the query can be executed on the foreign server.
+     *
+     * If this returns `false` filtering must be done via dedicated filter operator
+     * because the query parameter to
+     * {@link #getIterator(Role, Server, ForeignTable, TransactionContext, List, Symbol)}
+     * is ignored.
+     **/
+    boolean supportsQueryPushdown(Symbol query);
+
     CompletableFuture<BatchIterator<Row>> getIterator(Role user,
                                                       Server server,
                                                       ForeignTable foreignTable,
                                                       TransactionContext txnCtx,
-                                                      List<Symbol> collect);
+                                                      List<Symbol> collect,
+                                                      Symbol query);
 }

--- a/server/src/main/java/io/crate/fdw/ForeignDataWrappers.java
+++ b/server/src/main/java/io/crate/fdw/ForeignDataWrappers.java
@@ -127,7 +127,8 @@ public class ForeignDataWrappers implements CollectSource {
             server,
             foreignTable,
             txnCtx,
-            collectPhase.toCollect()
+            collectPhase.toCollect(),
+            phase.query()
         );
     }
 }

--- a/server/src/main/java/io/crate/fdw/JdbcBatchIterator.java
+++ b/server/src/main/java/io/crate/fdw/JdbcBatchIterator.java
@@ -21,18 +21,27 @@
 
 package io.crate.fdw;
 
+import java.io.IOException;
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.function.IntSupplier;
+import java.util.function.LongSupplier;
 
+import org.apache.lucene.util.Accountable;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import io.crate.common.collections.Lists;
 import io.crate.common.exceptions.Exceptions;
@@ -40,36 +49,81 @@ import io.crate.data.BatchIterator;
 import io.crate.data.Row;
 import io.crate.data.RowN;
 import io.crate.exceptions.ConversionException;
+import io.crate.expression.scalar.cast.CastMode;
+import io.crate.expression.symbol.RefReplacer;
+import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.SymbolType;
+import io.crate.expression.symbol.SymbolVisitor;
+import io.crate.expression.symbol.format.Style;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.IndexType;
 import io.crate.metadata.Reference;
+import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RelationName;
+import io.crate.metadata.RowGranularity;
+import io.crate.sql.Identifiers;
+import io.crate.sql.tree.ColumnPolicy;
+import io.crate.types.DataType;
 
 public class JdbcBatchIterator implements BatchIterator<Row> {
 
     private final String url;
     private final Properties properties;
-    private final String sql;
     private final Row row;
     private final Object[] cells;
     private final List<Reference> columns;
+    private final Symbol query;
+    private final RelationName table;
 
     private Connection conn;
     private PreparedStatement statement;
     private ResultSet resultSet;
     private volatile Throwable killed = null;
 
-    public JdbcBatchIterator(String url, Properties properties, List<Reference> columns, RelationName table) {
+    public JdbcBatchIterator(String url,
+                             Properties properties,
+                             List<Reference> columns,
+                             Symbol query,
+                             RelationName table) {
         this.url = url;
         this.properties = properties;
         this.columns = columns;
-        this.sql = String.format(
-            Locale.ENGLISH,
-            "SELECT %s FROM %s",
-            String.join(", ", Lists.mapLazy(columns, ref -> ref.column().quotedOutputName())),
-            table.sqlFqn()
-
-        );
+        this.query = query;
+        this.table = table;
         this.cells = new Object[columns.size()];
         this.row = new RowN(cells);
+    }
+
+    static String generateStatement(RelationName table,
+                                    List<Reference> columns,
+                                    Symbol query,
+                                    String quoteString) {
+        final String qs = quoteString.isBlank() ? "" : quoteString;
+        StringBuilder relationName = new StringBuilder();
+        String schema = table.schema();
+        if (schema != null) {
+            relationName
+                .append(qs)
+                .append(schema)
+                .append(qs)
+                .append('.');
+        }
+        relationName
+            .append(qs)
+            .append(table.name())
+            .append(qs);
+
+        return String.format(
+            Locale.ENGLISH,
+            "SELECT %s FROM %s WHERE %s",
+            String.join(", ", Lists.mapLazy(
+                columns,
+                ref -> new QuotedReference(ref, qs).toString(Style.UNQUALIFIED))),
+            relationName.toString(),
+            RefReplacer.replaceRefs(
+                query,
+                ref -> new QuotedReference(ref, qs)).toString(Style.UNQUALIFIED)
+        );
     }
 
     @Override
@@ -151,6 +205,8 @@ public class JdbcBatchIterator implements BatchIterator<Row> {
             conn = DriverManager.getConnection(url, properties);
         }
         if (statement == null) {
+            DatabaseMetaData metaData = conn.getMetaData();
+            String sql = generateStatement(table, columns, query, metaData.getIdentifierQuoteString());
             statement = conn.prepareStatement(sql);
         }
         resultSet = statement.executeQuery();
@@ -170,6 +226,149 @@ public class JdbcBatchIterator implements BatchIterator<Row> {
     private void raiseIfKilled() {
         if (killed != null) {
             Exceptions.rethrowUnchecked(killed);
+        }
+    }
+
+
+    /**
+     * Reference with custom toString implementation that quotes all identifiers with custom quoteString
+     * Delegates everything else to another reference instance
+     */
+    static class QuotedReference implements Reference {
+
+        private final Reference ref;
+        private final String quoteString;
+
+        private QuotedReference(Reference ref, String quoteString) {
+            this.ref = ref;
+            this.quoteString = quoteString;
+        }
+
+        @Override
+        public String toString(Style style) {
+            ColumnIdent column = ref.column();
+            StringBuilder sb = new StringBuilder();
+            if (style == Style.QUALIFIED) {
+                RelationName tableIdent = ref.ident().tableIdent();
+                String schema = tableIdent.schema();
+                if (schema != null) {
+                    sb.append(quoteString);
+                    sb.append(schema);
+                    sb.append(quoteString);
+                    sb.append('.');
+                }
+                sb.append(quoteString);
+                sb.append(tableIdent.name());
+                sb.append(quoteString);
+            }
+            sb.append(quoteString);
+            sb.append(Identifiers.escape(column.name()));
+            sb.append(quoteString);
+            return sb.toString();
+        }
+
+        public long ramBytesUsed() {
+            return ref.ramBytesUsed();
+        }
+
+        public Collection<Accountable> getChildResources() {
+            return ref.getChildResources();
+        }
+
+        public void writeTo(StreamOutput out) throws IOException {
+            ref.writeTo(out);
+        }
+
+        public ReferenceIdent ident() {
+            return ref.ident();
+        }
+
+        public ColumnIdent column() {
+            return ref.column();
+        }
+
+        public SymbolType symbolType() {
+            return ref.symbolType();
+        }
+
+        public IndexType indexType() {
+            return ref.indexType();
+        }
+
+        public <C, R> R accept(SymbolVisitor<C, R> visitor, C context) {
+            return ref.accept(visitor, context);
+        }
+
+        public ColumnPolicy columnPolicy() {
+            return ref.columnPolicy();
+        }
+
+        public boolean isNullable() {
+            return ref.isNullable();
+        }
+
+        public DataType<?> valueType() {
+            return ref.valueType();
+        }
+
+        public RowGranularity granularity() {
+            return ref.granularity();
+        }
+
+        public Symbol cast(DataType<?> targetType, CastMode... modes) {
+            return ref.cast(targetType, modes);
+        }
+
+        public int position() {
+            return ref.position();
+        }
+
+        public long oid() {
+            return ref.oid();
+        }
+
+        public boolean isDropped() {
+            return ref.isDropped();
+        }
+
+        public boolean hasDocValues() {
+            return ref.hasDocValues();
+        }
+
+        public @Nullable Symbol defaultExpression() {
+            return ref.defaultExpression();
+        }
+
+        public boolean isGenerated() {
+            return ref.isGenerated();
+        }
+
+        public Reference withReferenceIdent(ReferenceIdent referenceIdent) {
+            return ref.withReferenceIdent(referenceIdent);
+        }
+
+        public Reference withOidAndPosition(LongSupplier acquireOid, IntSupplier acquirePosition) {
+            return ref.withOidAndPosition(acquireOid, acquirePosition);
+        }
+
+        public Reference withDropped(boolean dropped) {
+            return ref.withDropped(dropped);
+        }
+
+        public Reference withValueType(DataType<?> type) {
+            return ref.withValueType(type);
+        }
+
+        public String storageIdent() {
+            return ref.storageIdent();
+        }
+
+        public String storageIdentLeafName() {
+            return ref.storageIdentLeafName();
+        }
+
+        public Map<String, Object> toMapping(int position) {
+            return ref.toMapping(position);
         }
     }
 }

--- a/server/src/main/java/io/crate/planner/Planner.java
+++ b/server/src/main/java/io/crate/planner/Planner.java
@@ -192,7 +192,11 @@ public class Planner extends AnalyzedStatementVisitor<PlannerContext, Plan> {
                    SessionSettingRegistry sessionSettingRegistry) {
         this.clusterService = clusterService;
         this.tableStats = tableStats;
-        this.logicalPlanner = new LogicalPlanner(nodeCtx, () -> clusterService.state().nodes().getMinNodeVersion());
+        this.logicalPlanner = new LogicalPlanner(
+            nodeCtx,
+            foreignDataWrappers,
+            () -> clusterService.state().nodes().getMinNodeVersion()
+        );
         this.numberOfShards = numberOfShards;
         this.tableCreator = tableCreator;
         this.roleManager = roleManager;

--- a/server/src/main/java/io/crate/planner/operators/ForeignCollect.java
+++ b/server/src/main/java/io/crate/planner/operators/ForeignCollect.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import org.jetbrains.annotations.Nullable;
 
 import io.crate.analyze.OrderBy;
+import io.crate.analyze.WhereClause;
 import io.crate.common.collections.Lists;
 import io.crate.data.Row;
 import io.crate.execution.dsl.phases.ForeignCollectPhase;
@@ -36,6 +37,7 @@ import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
 import io.crate.execution.engine.pipeline.LimitAndOffset;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
+import io.crate.fdw.ForeignDataWrapper;
 import io.crate.fdw.ForeignTableRelation;
 import io.crate.metadata.RelationName;
 import io.crate.planner.DependencyCarrier;
@@ -44,12 +46,19 @@ import io.crate.planner.PlannerContext;
 
 public class ForeignCollect implements LogicalPlan {
 
+    private final ForeignDataWrapper fdw;
     private final ForeignTableRelation relation;
     private final List<Symbol> toCollect;
+    private final WhereClause where;
 
-    public ForeignCollect(ForeignTableRelation relation, List<Symbol> toCollect) {
+    public ForeignCollect(ForeignDataWrapper fdw,
+                          ForeignTableRelation relation,
+                          List<Symbol> toCollect,
+                          WhereClause where) {
+        this.fdw = fdw;
         this.relation = relation;
         this.toCollect = toCollect;
+        this.where = where;
     }
 
     @Override
@@ -70,7 +79,8 @@ public class ForeignCollect implements LogicalPlan {
             plannerContext.nextExecutionPhaseId(),
             plannerContext.handlerNode(),
             relation.relationName(),
-            Lists.map(toCollect, binder)
+            Lists.map(toCollect, binder),
+            where.map(binder).queryOrFallback()
         );
         return new io.crate.planner.node.dql.Collect(
             phase,
@@ -80,6 +90,18 @@ public class ForeignCollect implements LogicalPlan {
             LimitAndOffset.NO_LIMIT,
             null
         );
+    }
+
+    public ForeignDataWrapper fdw() {
+        return fdw;
+    }
+
+    public ForeignTableRelation relation() {
+        return relation;
+    }
+
+    public WhereClause where() {
+        return where;
     }
 
     @Override
@@ -103,7 +125,7 @@ public class ForeignCollect implements LogicalPlan {
         if (outputsToKeep.containsAll(toCollect)) {
             return this;
         }
-        return new ForeignCollect(relation, List.copyOf(outputsToKeep));
+        return new ForeignCollect(fdw, relation, List.copyOf(outputsToKeep), where);
     }
 
     @Override
@@ -119,5 +141,18 @@ public class ForeignCollect implements LogicalPlan {
     @Override
     public List<RelationName> getRelationNames() {
         return List.of(relation.relationName());
+    }
+
+    @Override
+    public void print(PrintContext printContext) {
+        printContext
+            .text("ForeignCollect[")
+            .text(relation.relationName().toString())
+            .text(" | [")
+            .text(Lists.joinOn(", ", toCollect, Symbol::toString))
+            .text("] | ")
+            .text(where.queryOrFallback().toString())
+            .text("]");
+        printStats(printContext);
     }
 }

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -33,6 +33,8 @@ import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.Metadata;
 
 import io.crate.analyze.AnalyzedInsertStatement;
 import io.crate.analyze.AnalyzedStatement;
@@ -69,7 +71,11 @@ import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.SelectSymbol.ResultType;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
+import io.crate.fdw.ForeignDataWrapper;
+import io.crate.fdw.ForeignDataWrappers;
 import io.crate.fdw.ForeignTableRelation;
+import io.crate.fdw.ServersMetadata;
+import io.crate.fdw.ServersMetadata.Server;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
@@ -89,6 +95,7 @@ import io.crate.planner.optimizer.rule.EliminateCrossJoin;
 import io.crate.planner.optimizer.rule.MergeAggregateAndCollectToCount;
 import io.crate.planner.optimizer.rule.MergeAggregateRenameAndCollectToCount;
 import io.crate.planner.optimizer.rule.MergeFilterAndCollect;
+import io.crate.planner.optimizer.rule.MergeFilterAndForeignCollect;
 import io.crate.planner.optimizer.rule.MergeFilters;
 import io.crate.planner.optimizer.rule.MoveConstantJoinConditionsBeneathNestedLoop;
 import io.crate.planner.optimizer.rule.MoveFilterBeneathCorrelatedJoin;
@@ -129,6 +136,7 @@ public class LogicalPlanner {
     private final Visitor statementVisitor = new Visitor();
     private final Optimizer writeOptimizer;
     private final Optimizer fetchOptimizer;
+    private final ForeignDataWrappers foreignDataWrappers;
 
     // Be careful, the order of the rules matter
     public static final List<Rule<?>> ITERATIVE_OPTIMIZER_RULES = List.of(
@@ -148,6 +156,7 @@ public class LogicalPlanner {
         new MoveLimitBeneathRename(),
         new MoveLimitBeneathEval(),
         new MergeFilterAndCollect(),
+        new MergeFilterAndForeignCollect(),
         new RewriteFilterOnOuterJoinToInnerJoin(),
         new MoveOrderBeneathUnion(),
         new MoveOrderBeneathNestedLoop(),
@@ -178,7 +187,10 @@ public class LogicalPlanner {
     private static final List<Rule<?>> WRITE_OPTIMIZER_RULES =
         List.of(new RewriteInsertFromSubQueryToInsertFromValues());
 
-    public LogicalPlanner(NodeContext nodeCtx, Supplier<Version> minNodeVersionInCluster) {
+    public LogicalPlanner(NodeContext nodeCtx,
+                          ForeignDataWrappers foreignDataWrappers,
+                          Supplier<Version> minNodeVersionInCluster) {
+        this.foreignDataWrappers = foreignDataWrappers;
         this.optimizer = new IterativeOptimizer(
             nodeCtx,
             minNodeVersionInCluster,
@@ -235,7 +247,12 @@ public class LogicalPlanner {
         }
         PlannerContext subSelectPlannerContext = PlannerContext.forSubPlan(plannerContext, fetchSize);
         SubqueryPlanner subqueryPlanner = new SubqueryPlanner(s -> planSubSelect(s, subSelectPlannerContext));
-        var planBuilder = new PlanBuilder(subqueryPlanner, plannerContext.planStats());
+        var planBuilder = new PlanBuilder(
+            subqueryPlanner,
+            foreignDataWrappers,
+            plannerContext.planStats(),
+            plannerContext.clusterState()
+        );
         LogicalPlan plan = relation.accept(planBuilder, relation.outputs());
 
         plan = tryOptimizeForInSubquery(selectSymbol, relation, plan);
@@ -278,7 +295,12 @@ public class LogicalPlanner {
         CoordinatorTxnCtx coordinatorTxnCtx = plannerContext.transactionContext();
         OptimizerTracer tracer = plannerContext.optimizerTracer();
         PlanStats planStats = plannerContext.planStats();
-        var planBuilder = new PlanBuilder(subqueryPlanner, planStats);
+        var planBuilder = new PlanBuilder(
+            subqueryPlanner,
+            foreignDataWrappers,
+            planStats,
+            plannerContext.clusterState()
+        );
         LogicalPlan logicalPlan = relation.accept(planBuilder, relation.outputs());
         LogicalPlan optimizedPlan = optimizer.optimize(logicalPlan, planStats, coordinatorTxnCtx, tracer);
         optimizedPlan = joinOrderOptimizer.optimize(optimizedPlan, planStats, coordinatorTxnCtx, tracer);
@@ -308,11 +330,17 @@ public class LogicalPlanner {
 
         private final SubqueryPlanner subqueryPlanner;
         private final PlanStats planStats;
+        private final ForeignDataWrappers foreignDataWrappers;
+        private final ClusterState clusterState;
 
         private PlanBuilder(SubqueryPlanner subqueryPlanner,
-                            PlanStats planStats) {
+                            ForeignDataWrappers foreignDataWrappers,
+                            PlanStats planStats,
+                            ClusterState clusterState) {
             this.subqueryPlanner = subqueryPlanner;
+            this.foreignDataWrappers = foreignDataWrappers;
             this.planStats = planStats;
+            this.clusterState = clusterState;
         }
 
         @Override
@@ -345,7 +373,16 @@ public class LogicalPlanner {
 
         @Override
         public LogicalPlan visitForeignTable(ForeignTableRelation relation, List<Symbol> outputs) {
-            return new ForeignCollect(relation, outputs);
+            Metadata metadata = clusterState.metadata();
+            ServersMetadata servers = metadata.custom(ServersMetadata.TYPE, ServersMetadata.EMPTY);
+            Server server = servers.get(relation.tableInfo().server());
+            ForeignDataWrapper foreignDataWrapper = foreignDataWrappers.get(server.fdw());
+            return new ForeignCollect(
+                foreignDataWrapper,
+                relation,
+                outputs,
+                WhereClause.MATCH_ALL
+            );
         }
 
         @Override

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MergeFilterAndForeignCollect.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MergeFilterAndForeignCollect.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.rule;
+
+import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.matcher.Patterns.source;
+
+import java.util.function.UnaryOperator;
+
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.operators.Filter;
+import io.crate.planner.operators.ForeignCollect;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
+import io.crate.planner.optimizer.matcher.Capture;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Pattern;
+
+/**
+ * Like {@link MergeFilterAndCollect}, changes `Filter -> ForeignCollect` to
+ * `ForeignCollect` with the filter merged into {@link ForeignCollect#where()}.
+ *
+ * Separate rule to have a separate session setting to disable/enable it.
+ * (And in the future it could be restricted to specific FDW implementations)
+ */
+public class MergeFilterAndForeignCollect implements Rule<Filter> {
+
+    private final Capture<ForeignCollect> collectCapture;
+    private final Pattern<Filter> pattern;
+
+
+    public MergeFilterAndForeignCollect() {
+        this.collectCapture = new Capture<>();
+        this.pattern = typeOf(Filter.class)
+            .with(source(), typeOf(ForeignCollect.class).capturedAs(collectCapture));
+    }
+
+    @Override
+    public Pattern<Filter> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public LogicalPlan apply(Filter filter,
+                             Captures captures,
+                             PlanStats planStats,
+                             TransactionContext txnCtx,
+                             NodeContext nodeCtx,
+                             UnaryOperator<LogicalPlan> resolvePlan) {
+        ForeignCollect collect = captures.get(collectCapture);
+        if (collect.fdw().supportsQueryPushdown(filter.query())) {
+            return new ForeignCollect(
+                collect.fdw(),
+                collect.relation(),
+                collect.outputs(),
+                collect.where().add(filter.query())
+            );
+        }
+        return null;
+    }
+}

--- a/server/src/test/java/io/crate/fdw/JdbcBatchIteratorTest.java
+++ b/server/src/test/java/io/crate/fdw/JdbcBatchIteratorTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.fdw;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.Reference;
+import io.crate.metadata.doc.DocTableInfo;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+
+public class JdbcBatchIteratorTest extends CrateDummyClusterServiceUnitTest {
+
+    @Test
+    public void test_all_column_names_get_quoted() throws Exception {
+        // Foreign SQL databases may use different keywords than CrateDB
+        // → Identifiers.quoteIfNeeded() isn't reliable → quote everything
+
+        var e = SQLExecutor.builder(clusterService)
+            .addTable("create table doc.summits (x int)")
+            .build();
+        DocTableInfo table = e.resolveTableInfo("doc.summits");
+        Symbol query = e.asSymbol("x > 10 and x < 40");
+        List<Reference> columns = List.of(
+            table.getReadReference(new ColumnIdent("x"))
+        );
+        String statement = JdbcBatchIterator.generateStatement(
+            table.ident(),
+            columns,
+            query,
+            "\""
+        );
+        assertThat(statement)
+            .isEqualTo("SELECT \"x\" FROM \"doc\".\"summits\" WHERE ((\"x\" > 10) AND (\"x\" < 40))");
+
+        statement = JdbcBatchIterator.generateStatement(
+            table.ident(),
+            columns,
+            query,
+            " "
+        );
+        assertThat(statement)
+            .as("JDBC metaData.getIdentifierQuoteString space leads to no quotes at all")
+            // See DatabaseMetaData.getIdentifierQuoteString() description:
+            //
+            //      Retrieves the string used to quote SQL identifiers. This method returns a
+            //      space " " if identifier quoting is not supported.
+            //
+            .isEqualTo("SELECT x FROM doc.summits WHERE ((x > 10) AND (x < 40))");
+    }
+}
+

--- a/server/src/test/java/io/crate/fdw/JdbcForeignDataWrapperTest.java
+++ b/server/src/test/java/io/crate/fdw/JdbcForeignDataWrapperTest.java
@@ -30,6 +30,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.junit.Test;
 
 import io.crate.expression.InputFactory;
+import io.crate.expression.symbol.Literal;
 import io.crate.fdw.ServersMetadata.Server;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.CoordinatorTxnCtx;
@@ -70,7 +71,7 @@ public class JdbcForeignDataWrapperTest extends CrateDummyClusterServiceUnitTest
         );
         Map<ColumnIdent, Reference> references = Map.of(nameRef.column(), nameRef);
         ForeignTable foreignTable = new ForeignTable(relationName, references, server.name(), Settings.EMPTY);
-        assertThatThrownBy(() -> fdw.getIterator(arthur, server, foreignTable, txnCtx, List.of(nameRef)))
+        assertThatThrownBy(() -> fdw.getIterator(arthur, server, foreignTable, txnCtx, List.of(nameRef), Literal.BOOLEAN_TRUE))
             .hasMessage("Only a super user can connect to localhost unless `fdw.allow_local` is set to true");
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -22,6 +22,7 @@
 package io.crate.integrationtests;
 
 import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -38,13 +39,13 @@ import io.crate.metadata.Schemas;
 import io.crate.metadata.pgcatalog.OidHash;
 import io.crate.metadata.table.SchemaInfo;
 import io.crate.metadata.view.ViewInfo;
+import io.crate.role.Roles;
 import io.crate.testing.TestingHelpers;
 import io.crate.testing.UseHashJoins;
 import io.crate.testing.UseJdbc;
 import io.crate.testing.UseNewCluster;
 import io.crate.testing.UseRandomizedOptimizerRules;
 import io.crate.testing.UseRandomizedSchema;
-import io.crate.role.Roles;
 
 public class PgCatalogITest extends IntegTestCase {
 
@@ -231,6 +232,7 @@ public class PgCatalogITest extends IntegTestCase {
             "optimizer_merge_aggregate_and_collect_to_count| true| Indicates if the optimizer rule MergeAggregateAndCollectToCount is activated.| NULL| NULL",
             "optimizer_merge_aggregate_rename_and_collect_to_count| true| Indicates if the optimizer rule MergeAggregateRenameAndCollectToCount is activated.| NULL| NULL",
             "optimizer_merge_filter_and_collect| true| Indicates if the optimizer rule MergeFilterAndCollect is activated.| NULL| NULL",
+            "optimizer_merge_filter_and_foreign_collect| true| Indicates if the optimizer rule MergeFilterAndForeignCollect is activated.| NULL| NULL",
             "optimizer_merge_filters| true| Indicates if the optimizer rule MergeFilters is activated.| NULL| NULL",
             "optimizer_move_constant_join_conditions_beneath_nested_loop| true| Indicates if the optimizer rule MoveConstantJoinConditionsBeneathNestedLoop is activated.| NULL| NULL",
             "optimizer_move_filter_beneath_correlated_join| true| Indicates if the optimizer rule MoveFilterBeneathCorrelatedJoin is activated.| NULL| NULL",

--- a/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
@@ -24,6 +24,7 @@ package io.crate.integrationtests;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Locale;
 
@@ -410,6 +411,7 @@ public class ShowIntegrationTest extends IntegTestCase {
             "optimizer_merge_aggregate_and_collect_to_count| true| Indicates if the optimizer rule MergeAggregateAndCollectToCount is activated.",
             "optimizer_merge_aggregate_rename_and_collect_to_count| true| Indicates if the optimizer rule MergeAggregateRenameAndCollectToCount is activated.",
             "optimizer_merge_filter_and_collect| true| Indicates if the optimizer rule MergeFilterAndCollect is activated.",
+            "optimizer_merge_filter_and_foreign_collect| true| Indicates if the optimizer rule MergeFilterAndForeignCollect is activated.",
             "optimizer_merge_filters| true| Indicates if the optimizer rule MergeFilters is activated.",
             "optimizer_move_constant_join_conditions_beneath_nested_loop| true| Indicates if the optimizer rule MoveConstantJoinConditionsBeneathNestedLoop is activated.",
             "optimizer_move_filter_beneath_correlated_join| true| Indicates if the optimizer rule MoveFilterBeneathCorrelatedJoin is activated.",

--- a/server/src/test/java/io/crate/planner/UnionPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/UnionPlannerTest.java
@@ -24,11 +24,13 @@ package io.crate.planner;
 import static io.crate.analyze.TableDefinitions.TEST_DOC_LOCATIONS_TABLE_IDENT;
 import static io.crate.analyze.TableDefinitions.USER_TABLE_IDENT;
 import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.elasticsearch.common.settings.Settings;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -37,6 +39,7 @@ import com.carrotsearch.randomizedtesting.RandomizedTest;
 import io.crate.analyze.TableDefinitions;
 import io.crate.execution.dsl.projection.EvalProjection;
 import io.crate.execution.dsl.projection.LimitAndOffsetProjection;
+import io.crate.fdw.ForeignDataWrappers;
 import io.crate.metadata.RelationName;
 import io.crate.planner.node.dql.Collect;
 import io.crate.planner.operators.LogicalPlan;
@@ -231,6 +234,7 @@ public class UnionPlannerTest extends CrateDummyClusterServiceUnitTest {
         var context = e.getPlannerContext(clusterService.state());
         var logicalPlanner = new LogicalPlanner(
             e.nodeCtx,
+            new ForeignDataWrappers(Settings.EMPTY, clusterService, e.nodeCtx),
             () -> clusterService.state().nodes().getMinNodeVersion()
         );
         var plan = logicalPlanner.plan(e.analyze(stmt), context);

--- a/server/src/test/java/io/crate/planner/operators/CollectTest.java
+++ b/server/src/test/java/io/crate/planner/operators/CollectTest.java
@@ -26,12 +26,14 @@ import static org.mockito.Mockito.mock;
 
 import java.util.Set;
 
+import org.elasticsearch.common.settings.Settings;
 import org.junit.Test;
 
 import io.crate.analyze.QueriedSelectRelation;
 import io.crate.data.Row;
 import io.crate.execution.dsl.phases.RoutedCollectPhase;
 import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
+import io.crate.fdw.ForeignDataWrappers;
 import io.crate.planner.DependencyCarrier;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.PlannerContext;
@@ -50,6 +52,7 @@ public class CollectTest extends CrateDummyClusterServiceUnitTest {
         QueriedSelectRelation analyzedRelation = e.analyze("SELECT 123 AS alias, 456 AS alias2 FROM t ORDER BY alias, 2");
         LogicalPlanner logicalPlanner = new LogicalPlanner(
             e.nodeCtx,
+            new ForeignDataWrappers(Settings.EMPTY, clusterService, e.nodeCtx),
             () -> clusterService.state().nodes().getMinNodeVersion()
         );
         LogicalPlan operator = logicalPlanner.plan(analyzedRelation, plannerCtx);

--- a/server/src/test/java/io/crate/planner/operators/JoinTest.java
+++ b/server/src/test/java/io/crate/planner/operators/JoinTest.java
@@ -28,6 +28,7 @@ import static io.crate.analyze.TableDefinitions.USER_TABLE_IDENT;
 import static io.crate.testing.Asserts.assertList;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.isInputColumn;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
@@ -38,6 +39,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.elasticsearch.common.Randomness;
+import org.elasticsearch.common.settings.Settings;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -46,6 +48,7 @@ import io.crate.data.Row;
 import io.crate.execution.dsl.phases.HashJoinPhase;
 import io.crate.execution.dsl.phases.NestedLoopPhase;
 import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
+import io.crate.fdw.ForeignDataWrappers;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Schemas;
@@ -90,6 +93,7 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
     private LogicalPlan buildLogicalPlan(QueriedSelectRelation mss, PlannerContext plannerCtx) {
         LogicalPlanner logicalPlanner = new LogicalPlanner(
             e.nodeCtx,
+            new ForeignDataWrappers(Settings.EMPTY, clusterService, e.nodeCtx),
             () -> clusterService.state().nodes().getMinNodeVersion()
         );
         SubqueryPlanner subqueryPlanner = new SubqueryPlanner((s) -> logicalPlanner.planSubSelect(s, plannerCtx));
@@ -472,6 +476,7 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
         QueriedSelectRelation mss = e.analyze("select * from t1, t4 order by t1.x");
         LogicalPlanner logicalPlanner = new LogicalPlanner(
             e.nodeCtx,
+            new ForeignDataWrappers(Settings.EMPTY, clusterService, e.nodeCtx),
             () -> clusterService.state().nodes().getMinNodeVersion()
         );
         LogicalPlan operator = logicalPlanner.plan(mss, plannerCtx);
@@ -489,6 +494,7 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
                                               "JOIN t3 t3 on t3.c = t2.b");
         LogicalPlanner logicalPlanner = new LogicalPlanner(
             e.nodeCtx,
+            new ForeignDataWrappers(Settings.EMPTY, clusterService, e.nodeCtx),
             () -> clusterService.state().nodes().getMinNodeVersion()
         );
 


### PR DESCRIPTION
Introduces a new `MergeFilterAndForeignCollect` optimizer rule that
merges a query into a `ForeignCollect` if the foreign data wrapper
supports that particular query.

In this initial version the JDBC fdw implementation will accpet any
query consiting only out of AND, OR, NOT, <, <=, =, >, >=, column and
literal expressions.