### PR TITLE
Documentation: Fix broken links after transitioning to the CrateDB Guide

### DIFF
--- a/docs/config/environment.rst
+++ b/docs/config/environment.rst
@@ -119,7 +119,7 @@ General
       Make sure there is enough disk space available for heap dumps.
 
 
-.. _basic installation: https://crate.io/docs/crate/tutorials/en/latest/basic/
-.. _a CrateDB Linux package: https://crate.io/docs/crate/tutorials/en/latest/basic/index.html#linux
-.. _CrateDB on Docker: https://crate.io/docs/crate/tutorials/en/latest/basic/index.html#docker
+.. _basic installation: https://cratedb.com/docs/guide/install/tarball.html
+.. _a CrateDB Linux package: https://cratedb.com/docs/guide/install/
+.. _CrateDB on Docker: https://cratedb.com/docs/guide/install/container/
 .. _environment variables: https://en.wikipedia.org/wiki/Environment_variable

--- a/docs/config/logging.rst
+++ b/docs/config/logging.rst
@@ -166,8 +166,8 @@ garbage collection logging.
   If you have installed `a CrateDB Linux package`_, the default directory is
   ``/var/log/crate`` instead.
 
-.. _basic installation: https://crate.io/docs/crate/tutorials/en/latest/basic/
-.. _a CrateDB Linux package: https://crate.io/docs/crate/tutorials/en/latest/basic/index.html#linux
+.. _basic installation: https://cratedb.com/docs/guide/install/tarball.html
+.. _a CrateDB Linux package: https://cratedb.com/docs/guide/install/
 
 .. _conf-logging-gc-log-size:
 


### PR DESCRIPTION
## About

_Re: [The CrateDB Guide](https://cratedb.com/docs/guide/) supersedes Howtos and Tutorials._

## Details

CrateDB Howtos and Tutorials have been outphased [^1]. Most URLs are covered by employing corresponding redirects on the HTTP level, but on a few edge cases, where HTML anchors are involved, we need to adjust.

[^1]: They are not torn down yet. We will keep the lights on, until all intersphinx references have been updated to point to the new [cratedb-guide](https://github.com/crate/cratedb-guide), in order to not create any widespread havoc without needing to.

## More

Using intersphinx links does not work yet, because the docs setup does not resolve the `guide` reference well. It works well on three different environments, and fails on three others. We don't know why.

```
undefined label: 'guide:install-quick'
```

- GH-15654
