### PR TITLE
 Add Lookup-Join optimization for Equi-Inner-Joins

### DIFF
--- a/docs/appendices/release-notes/5.7.0.rst
+++ b/docs/appendices/release-notes/5.7.0.rst
@@ -94,7 +94,13 @@ Scalar and Aggregation Functions
 Performance and Resilience Improvements
 ---------------------------------------
 
-None
+- Improved the performance for hash-joins when there is a large
+  imbalance between the size of the tables with a lookup-join optimization.
+  This optimization can be disabled if desired, with the session setting::
+
+      SET optimizer_equi_join_to_lookup_join = false
+
+    Note that this setting is experimental, and may change in the future.
 
 Administration and Operations
 -----------------------------

--- a/server/src/main/java/io/crate/planner/operators/EquiJoinDetector.java
+++ b/server/src/main/java/io/crate/planner/operators/EquiJoinDetector.java
@@ -57,7 +57,7 @@ public class EquiJoinDetector {
         return isEquiJoin(joinCondition);
     }
 
-    private static boolean isEquiJoin(Symbol joinCondition) {
+    public static boolean isEquiJoin(Symbol joinCondition) {
         assert joinCondition != null : "join condition must not be null on inner joins";
         Context context = new Context();
         joinCondition.accept(VISITOR, context);

--- a/server/src/main/java/io/crate/planner/operators/HashJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/HashJoin.java
@@ -286,7 +286,7 @@ public class HashJoin extends AbstractJoinPlan {
         var lhsHashSymbols = new ArrayList<Symbol>();
         var rhsHashSymbols = new ArrayList<Symbol>();
         for (var condition : QuerySplitter.split(symbol).entrySet()) {
-            for (var entry : HashJoinConditionSymbolsExtractor.extract(condition.getValue()).entrySet()) {
+            for (var entry : JoinConditionSymbolsExtractor.extract(condition.getValue()).entrySet()) {
                 var relationName = entry.getKey();
                 var symbols = entry.getValue();
                 if (symbols != null) {

--- a/server/src/main/java/io/crate/planner/operators/JoinConditionSymbolsExtractor.java
+++ b/server/src/main/java/io/crate/planner/operators/JoinConditionSymbolsExtractor.java
@@ -58,13 +58,13 @@ import io.crate.metadata.RelationName;
  * It is expected that each expression argument of a EQ operator only contains symbols of one relation.
  * This can be ensured by using the {@link EquiJoinDetector} upfront.
  */
-public final class HashJoinConditionSymbolsExtractor {
+public final class JoinConditionSymbolsExtractor {
 
     private static final SymbolExtractor SYMBOL_EXTRACTOR = new SymbolExtractor();
     private static final RelationExtractor RELATION_EXTRACTOR = new RelationExtractor();
 
     /**
-     * Extracts all symbols per relations from any EQ join conditions. See {@link HashJoinConditionSymbolsExtractor}
+     * Extracts all symbols per relations from any EQ join conditions. See {@link JoinConditionSymbolsExtractor}
      * class documentation for details.
      */
     public static Map<RelationName, List<Symbol>> extract(Symbol symbol) {
@@ -146,6 +146,6 @@ public final class HashJoinConditionSymbolsExtractor {
         }
     }
 
-    private HashJoinConditionSymbolsExtractor() {
+    private JoinConditionSymbolsExtractor() {
     }
 }

--- a/server/src/main/java/io/crate/planner/operators/JoinPlan.java
+++ b/server/src/main/java/io/crate/planner/operators/JoinPlan.java
@@ -43,12 +43,13 @@ public class JoinPlan extends AbstractJoinPlan {
 
     private final boolean isFiltered;
     private final boolean rewriteFilterOnOuterJoinToInnerJoinDone;
+    private final boolean lookUpJoinRuleApplied;
 
     public JoinPlan(LogicalPlan lhs,
                     LogicalPlan rhs,
                     JoinType joinType,
                     @Nullable Symbol joinCondition) {
-        this(lhs, rhs, joinType, joinCondition, false, false);
+        this(lhs, rhs, joinType, joinCondition, false, false, false);
     }
 
     public JoinPlan(LogicalPlan lhs,
@@ -56,10 +57,16 @@ public class JoinPlan extends AbstractJoinPlan {
                     JoinType joinType,
                     @Nullable Symbol joinCondition,
                     boolean isFiltered,
-                    boolean rewriteFilterOnOuterJoinToInnerJoinDone) {
+                    boolean rewriteFilterOnOuterJoinToInnerJoinDone,
+                    boolean lookUpJoinRuleApplied) {
         super(lhs, rhs, joinCondition, joinType);
         this.isFiltered = isFiltered;
         this.rewriteFilterOnOuterJoinToInnerJoinDone = rewriteFilterOnOuterJoinToInnerJoinDone;
+        this.lookUpJoinRuleApplied = lookUpJoinRuleApplied;
+    }
+
+    public boolean isLookUpJoinRuleApplied() {
+        return lookUpJoinRuleApplied;
     }
 
     public boolean isFiltered() {
@@ -113,7 +120,8 @@ public class JoinPlan extends AbstractJoinPlan {
             joinType,
             joinCondition,
             isFiltered,
-            rewriteFilterOnOuterJoinToInnerJoinDone
+            rewriteFilterOnOuterJoinToInnerJoinDone,
+            lookUpJoinRuleApplied
         );
     }
 
@@ -140,7 +148,8 @@ public class JoinPlan extends AbstractJoinPlan {
             joinType,
             joinCondition,
             isFiltered,
-            rewriteFilterOnOuterJoinToInnerJoinDone
+            rewriteFilterOnOuterJoinToInnerJoinDone,
+            lookUpJoinRuleApplied
         );
     }
 }

--- a/server/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
+++ b/server/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
@@ -127,6 +127,7 @@ public class JoinPlanBuilder {
             joinType,
             validJoinConditions,
             isFiltered,
+            false,
             false);
 
         joinPlan = Filter.create(joinPlan, validWhereConditions);
@@ -241,6 +242,7 @@ public class JoinPlanBuilder {
             type,
             AndOperator.join(conditions, null),
             isFiltered,
+            false,
             false);
         return Filter.create(joinPlan, query);
     }

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -92,6 +92,7 @@ import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.iterative.IterativeOptimizer;
 import io.crate.planner.optimizer.rule.DeduplicateOrder;
 import io.crate.planner.optimizer.rule.EliminateCrossJoin;
+import io.crate.planner.optimizer.rule.EquiJoinToLookupJoin;
 import io.crate.planner.optimizer.rule.MergeAggregateAndCollectToCount;
 import io.crate.planner.optimizer.rule.MergeAggregateRenameAndCollectToCount;
 import io.crate.planner.optimizer.rule.MergeFilterAndCollect;
@@ -167,6 +168,7 @@ public class LogicalPlanner {
         new RewriteGroupByKeysLimitToLimitDistinct(),
         new MoveConstantJoinConditionsBeneathNestedLoop(),
         new EliminateCrossJoin(),
+        new EquiJoinToLookupJoin(),
         new RewriteJoinPlan(),
         new RewriteNestedLoopJoinToHashJoin()
     );

--- a/server/src/main/java/io/crate/planner/optimizer/rule/EliminateCrossJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/EliminateCrossJoin.java
@@ -179,6 +179,7 @@ public class EliminateCrossJoin implements Rule<JoinPlan> {
                 JoinType.INNER,
                 AndOperator.join(criteria, null),
                 false,
+                false,
                 false
             );
         }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/EquiJoinToLookupJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/EquiJoinToLookupJoin.java
@@ -1,0 +1,212 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.rule;
+
+import static io.crate.common.collections.Iterables.getOnlyElement;
+import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.UnaryOperator;
+
+import io.crate.analyze.QueriedSelectRelation;
+import io.crate.analyze.WhereClause;
+import io.crate.expression.operator.any.AnyEqOperator;
+import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.Literal;
+import io.crate.expression.symbol.SelectSymbol;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.operators.Collect;
+import io.crate.planner.operators.EquiJoinDetector;
+import io.crate.planner.operators.JoinConditionSymbolsExtractor;
+import io.crate.planner.operators.JoinPlan;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.operators.MultiPhase;
+import io.crate.planner.operators.RootRelationBoundary;
+import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.costs.PlanStats;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Pattern;
+import io.crate.sql.tree.JoinType;
+import io.crate.types.ArrayType;
+import io.crate.types.DataTypes;
+
+/**
+ * This rule optimizes equi-inner-joins with a lookup-join if there is
+ * a large imbalance between the two relations joined.
+ */
+public class EquiJoinToLookupJoin implements Rule<JoinPlan> {
+
+    private final Pattern<JoinPlan> pattern = typeOf(JoinPlan.class).with(j ->
+        j.isLookUpJoinRuleApplied() == false &&
+            // only inner-equi-joins
+            j.joinType() == JoinType.INNER &&
+            j.joinCondition() != null &&
+            EquiJoinDetector.isEquiJoin(j.joinCondition())
+    );
+
+    @Override
+    public Pattern<JoinPlan> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public LogicalPlan apply(JoinPlan plan,
+                             Captures captures,
+                             PlanStats planStats,
+                             TransactionContext txnCtx,
+                             NodeContext nodeCtx,
+                             UnaryOperator<LogicalPlan> resolvePlan) {
+
+        LogicalPlan lhs = resolvePlan.apply(plan.lhs());
+        LogicalPlan rhs = resolvePlan.apply(plan.rhs());
+
+        if (lhs instanceof Collect == false || rhs instanceof Collect == false) {
+            return null;
+        }
+
+        long lhsNumDocs = planStats.get(lhs).numDocs();
+        long rhsNumDocs = planStats.get(rhs).numDocs();
+
+        if (applyOptimization(lhsNumDocs, rhsNumDocs) == false) {
+            return null;
+        }
+
+        Collect smallerSide;
+        Collect largerSide;
+
+        boolean rhsIsLarger = rhsNumDocs > lhsNumDocs;
+
+        if (rhsIsLarger) {
+            smallerSide = (Collect) lhs;
+            largerSide = (Collect) rhs;
+        } else {
+            smallerSide = (Collect) rhs;
+            largerSide = (Collect) lhs;
+        }
+
+        Map<RelationName, List<Symbol>> equiJoinCondition = JoinConditionSymbolsExtractor.extract(plan.joinCondition());
+        Symbol smallerRelationColumn = getOnlyElement(equiJoinCondition.get(smallerSide.relation().relationName()));
+        Symbol largerRelationColumn = getOnlyElement(equiJoinCondition.get(largerSide.relation().relationName()));
+
+        LogicalPlan lookupJoin = createLookup(
+            smallerSide,
+            smallerRelationColumn,
+            largerSide,
+            largerRelationColumn,
+            nodeCtx,
+            txnCtx
+        );
+
+        LogicalPlan newLhs;
+        LogicalPlan newRhs;
+
+        if (rhsIsLarger) {
+            newLhs = lhs;
+            newRhs = lookupJoin;
+        } else {
+            newLhs = lookupJoin;
+            newRhs = rhs;
+        }
+
+        return new JoinPlan(
+            newLhs,
+            newRhs,
+            plan.joinType(),
+            plan.joinCondition(),
+            plan.isFiltered(),
+            plan.isRewriteFilterOnOuterJoinToInnerJoinDone(),
+            true
+        );
+    }
+
+    private static LogicalPlan createLookup(Collect smallerRelation,
+                                            Symbol smallerRelationColumn,
+                                            Collect largerRelation,
+                                            Symbol largerRelationColumn,
+                                            NodeContext nodeCtx,
+                                            TransactionContext txnCtx) {
+
+        var lookUpQuery = new SelectSymbol(
+            new QueriedSelectRelation(
+                false,
+                List.of(smallerRelation.relation()),
+                List.of(),
+                List.of(smallerRelationColumn),
+                Literal.BOOLEAN_TRUE,
+                List.of(),
+                null,
+                null,
+                null,
+                null
+            ),
+            new ArrayType<>(smallerRelationColumn.valueType()),
+            SelectSymbol.ResultType.SINGLE_COLUMN_MULTIPLE_VALUES,
+            true
+        );
+
+        var anyEqImplementation = nodeCtx.functions().get(
+            null,
+            AnyEqOperator.NAME,
+            List.of(largerRelationColumn, lookUpQuery),
+            txnCtx.sessionSettings().searchPath()
+        );
+
+        var anyEqFunction = new Function(
+            anyEqImplementation.signature(),
+            List.of(largerRelationColumn, lookUpQuery),
+            DataTypes.BOOLEAN
+        );
+        WhereClause whereClause = largerRelation.where().add(anyEqFunction);
+        LogicalPlan largerSideWithLookup = new Collect(largerRelation.relation(), largerRelation.outputs(), whereClause);
+        LogicalPlan smallerSideIdLookup = new Collect(smallerRelation.relation(), List.of(smallerRelationColumn), smallerRelation.where());
+        smallerSideIdLookup = new RootRelationBoundary(smallerSideIdLookup);
+
+        return MultiPhase.createIfNeeded(Map.of(smallerSideIdLookup, lookUpQuery), largerSideWithLookup);
+    }
+
+    private static boolean applyOptimization(long lhsNumDocs, long rhsNumDocs) {
+        if ((lhsNumDocs == -1L || rhsNumDocs == -1L) ||
+            (lhsNumDocs == 0 || rhsNumDocs == 0) ||
+            lhsNumDocs == rhsNumDocs) {
+            return false;
+        }
+        long smaller, larger;
+        if (lhsNumDocs > rhsNumDocs) {
+            larger = lhsNumDocs;
+            smaller = rhsNumDocs;
+
+        } else {
+            larger = rhsNumDocs;
+            smaller = lhsNumDocs;
+        }
+        // Benchmarks revealed that the imbalance should be at least factor 10 with the larger table at least 10.000 rows
+        // See https://github.com/crate/crate/pull/15664 for details
+        if (larger < 10_000) {
+            return false;
+        }
+        return larger / smaller >= 10;
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoin.java
@@ -248,7 +248,8 @@ public final class RewriteFilterOnOuterJoinToInnerJoin implements Rule<Filter> {
             newJoinIsInnerJoin ? JoinType.INNER : join.joinType(),
             join.joinCondition(),
             join.isFiltered(),
-            true
+            true,
+            join.isLookUpJoinRuleApplied()
         );
         assert newJoin.outputs().equals(join.outputs()) : "Outputs after rewrite must be the same as before";
         return splitQueries.isEmpty() ? newJoin : new Filter(newJoin, AndOperator.join(splitQueries.values()));

--- a/server/src/test/java/io/crate/integrationtests/LookupJoinIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/LookupJoinIntegrationTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.integrationtests;
+
+
+
+import static io.crate.testing.Asserts.assertThat;
+
+import org.elasticsearch.test.IntegTestCase;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.crate.testing.UseHashJoins;
+import io.crate.testing.UseRandomizedOptimizerRules;
+
+public class LookupJoinIntegrationTest extends IntegTestCase {
+
+    @Before
+    public void setup() throws Exception {
+        execute("create table doc.t1 (id int)");
+        execute("insert into doc.t1 (id) select b from generate_series(1,10000) a(b)");
+        execute("create table doc.t2 (id int)");
+        execute("insert into doc.t2 (id) select b from generate_series(1,100) a(b)");
+        execute("refresh table doc.t1");
+        execute("refresh table doc.t2");
+        execute("analyze");
+        waitNoPendingTasksOnAll();
+    }
+
+    @UseRandomizedOptimizerRules(0)
+    @UseHashJoins(1)
+    @Test
+    public void test_basic_lookup_join() throws Exception {
+        var query = "select count(*) from doc.t1 join doc.t2 on t1.id = t2.id";
+        execute("explain (costs false)" + query);
+        assertThat(response).hasLines(
+            "HashAggregate[count(*)]",
+            "  └ HashJoin[(id = id)]",
+            "    ├ MultiPhase",
+            "    │  └ Collect[doc.t1 | [id] | (id = ANY((SELECT id FROM (doc.t2))))]",
+            "    │  └ Collect[doc.t2 | [id] | true]",
+            "    └ Collect[doc.t2 | [id] | true]"
+        );
+        execute(query);
+        assertThat(response).hasRows("100");
+    }
+}

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -229,6 +229,7 @@ public class PgCatalogITest extends IntegTestCase {
             "memory.operation_limit| 0| Memory limit in bytes for an individual operation. 0 by-passes the operation limit, relying entirely on the global circuit breaker limits| NULL| NULL",
             "optimizer_deduplicate_order| true| Indicates if the optimizer rule DeduplicateOrder is activated.| NULL| NULL",
             "optimizer_eliminate_cross_join| true| Indicates if the optimizer rule EliminateCrossJoin is activated.| NULL| NULL",
+            "optimizer_equi_join_to_lookup_join| true| Indicates if the optimizer rule EquiJoinToLookupJoin is activated.| NULL| NULL",
             "optimizer_merge_aggregate_and_collect_to_count| true| Indicates if the optimizer rule MergeAggregateAndCollectToCount is activated.| NULL| NULL",
             "optimizer_merge_aggregate_rename_and_collect_to_count| true| Indicates if the optimizer rule MergeAggregateRenameAndCollectToCount is activated.| NULL| NULL",
             "optimizer_merge_filter_and_collect| true| Indicates if the optimizer rule MergeFilterAndCollect is activated.| NULL| NULL",

--- a/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
@@ -408,6 +408,7 @@ public class ShowIntegrationTest extends IntegTestCase {
             "memory.operation_limit| 0| Memory limit in bytes for an individual operation. 0 by-passes the operation limit, relying entirely on the global circuit breaker limits",
             "optimizer_deduplicate_order| true| Indicates if the optimizer rule DeduplicateOrder is activated.",
             "optimizer_eliminate_cross_join| true| Indicates if the optimizer rule EliminateCrossJoin is activated.",
+            "optimizer_equi_join_to_lookup_join| true| Indicates if the optimizer rule EquiJoinToLookupJoin is activated.",
             "optimizer_merge_aggregate_and_collect_to_count| true| Indicates if the optimizer rule MergeAggregateAndCollectToCount is activated.",
             "optimizer_merge_aggregate_rename_and_collect_to_count| true| Indicates if the optimizer rule MergeAggregateRenameAndCollectToCount is activated.",
             "optimizer_merge_filter_and_collect| true| Indicates if the optimizer rule MergeFilterAndCollect is activated.",

--- a/server/src/test/java/io/crate/planner/operators/HashJoinConditionSymbolsExtractorTest.java
+++ b/server/src/test/java/io/crate/planner/operators/HashJoinConditionSymbolsExtractorTest.java
@@ -57,7 +57,7 @@ public class HashJoinConditionSymbolsExtractorTest extends CrateDummyClusterServ
     @Test
     public void testExtractFromTopEqCondition() {
         Symbol joinCondition = sqlExpressions.asSymbol("t1.x = t2.y");
-        Map<RelationName, List<Symbol>> symbolsPerRelation = HashJoinConditionSymbolsExtractor.extract(joinCondition);
+        Map<RelationName, List<Symbol>> symbolsPerRelation = JoinConditionSymbolsExtractor.extract(joinCondition);
         assertThat(symbolsPerRelation.get(tr1.relationName())).satisfiesExactly(isReference("x"));
         assertThat(symbolsPerRelation.get(tr2.relationName())).satisfiesExactly(isReference("y"));
     }
@@ -65,7 +65,7 @@ public class HashJoinConditionSymbolsExtractorTest extends CrateDummyClusterServ
     @Test
     public void testExtractFromNestedEqCondition() {
         Symbol joinCondition = sqlExpressions.asSymbol("t1.x > t2.y and t1.a = t2.b and not(t1.i = t2.i)");
-        Map<RelationName, List<Symbol>> symbolsPerRelation = HashJoinConditionSymbolsExtractor.extract(joinCondition);
+        Map<RelationName, List<Symbol>> symbolsPerRelation = JoinConditionSymbolsExtractor.extract(joinCondition);
         assertThat(symbolsPerRelation.get(tr1.relationName())).satisfiesExactly(isReference("a"));
         assertThat(symbolsPerRelation.get(tr2.relationName())).satisfiesExactly(isReference("b"));
     }
@@ -74,7 +74,7 @@ public class HashJoinConditionSymbolsExtractorTest extends CrateDummyClusterServ
     public void testExtractSymbolsWithDuplicates() {
         Symbol joinCondition = sqlExpressions.asSymbol(
             "t1.a = t2.b and t1.i + 1::int = t2.i and t2.y = t1.i + 1::int");
-        Map<RelationName, List<Symbol>> symbolsPerRelation = HashJoinConditionSymbolsExtractor.extract(joinCondition);
+        Map<RelationName, List<Symbol>> symbolsPerRelation = JoinConditionSymbolsExtractor.extract(joinCondition);
         assertThat(symbolsPerRelation.get(tr1.relationName())).satisfiesExactlyInAnyOrder(
             isReference("a"),
             isFunction(ArithmeticFunctions.Names.ADD, isReference("i"), isLiteral(1)));
@@ -86,7 +86,7 @@ public class HashJoinConditionSymbolsExtractorTest extends CrateDummyClusterServ
     public void testExtractRelationsOfFunctionsWithLiterals() {
         Symbol joinCondition = sqlExpressions.asSymbol(
             "t1.a = t2.b and t1.i + 1::int = t2.i and t2.y = 1::int + t1.i");
-        Map<RelationName, List<Symbol>> symbolsPerRelation = HashJoinConditionSymbolsExtractor.extract(joinCondition);
+        Map<RelationName, List<Symbol>> symbolsPerRelation = JoinConditionSymbolsExtractor.extract(joinCondition);
         assertThat(symbolsPerRelation.get(tr1.relationName())).satisfiesExactlyInAnyOrder(
             isReference("a"),
             isFunction(ArithmeticFunctions.Names.ADD, isReference("i"), isLiteral(1)),
@@ -99,7 +99,7 @@ public class HashJoinConditionSymbolsExtractorTest extends CrateDummyClusterServ
     public void test_extract_symbols_per_relation_maintains_visit_order() {
         Symbol joinCondition = sqlExpressions.asSymbol("t1.i = t3.z AND t3.c = t2.b");
         Map<RelationName, List<Symbol>> symbolsPerRelation =
-            HashJoinConditionSymbolsExtractor.extract(joinCondition);
+            JoinConditionSymbolsExtractor.extract(joinCondition);
         assertThat(symbolsPerRelation.keySet()).containsExactly(
                 RelationName.fromIndexName("t1"),
                 RelationName.fromIndexName("t3"),
@@ -112,7 +112,7 @@ public class HashJoinConditionSymbolsExtractorTest extends CrateDummyClusterServ
     public void test_extract_symbols_per_relation_maintains_visit_order_when_removing_an_entry_from_result() {
         Symbol joinCondition = sqlExpressions.asSymbol("t1.i = t3.z AND t3.c = t2.b");
         Map<RelationName, List<Symbol>> symbolsPerRelation =
-            HashJoinConditionSymbolsExtractor.extract(joinCondition);
+            JoinConditionSymbolsExtractor.extract(joinCondition);
         symbolsPerRelation.remove(RelationName.fromIndexName("t3"));
         assertThat(symbolsPerRelation.keySet()).containsExactly(
                 RelationName.fromIndexName("t1"),

--- a/server/src/test/java/io/crate/planner/operators/JoinTest.java
+++ b/server/src/test/java/io/crate/planner/operators/JoinTest.java
@@ -127,7 +127,7 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
 
         Map<RelationName, Stats> rowCountByTable = new HashMap<>();
         rowCountByTable.put(USER_TABLE_IDENT, new Stats(10, 0, Map.of()));
-        rowCountByTable.put(TEST_DOC_LOCATIONS_TABLE_IDENT, new Stats(10_000, 0, Map.of()));
+        rowCountByTable.put(TEST_DOC_LOCATIONS_TABLE_IDENT, new Stats(5_000, 0, Map.of()));
         e.updateTableStats(rowCountByTable);
 
         var plannerCtx = e.getPlannerContext(clusterService.state());
@@ -136,7 +136,7 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
         assertThat(tableName(nl.left())).isEqualTo("locations");
         assertThat(tableName(nl.right())).isEqualTo("users");
 
-        rowCountByTable.put(USER_TABLE_IDENT, new Stats(10_000, 0, Map.of()));
+        rowCountByTable.put(USER_TABLE_IDENT, new Stats(5_000, 0, Map.of()));
         rowCountByTable.put(TEST_DOC_LOCATIONS_TABLE_IDENT, new Stats(10, 0, Map.of()));
         e.updateTableStats(rowCountByTable);
 
@@ -249,7 +249,7 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
 
         Map<RelationName, Stats> rowCountByTable = new HashMap<>();
         rowCountByTable.put(USER_TABLE_IDENT, new Stats(10, 0, Map.of()));
-        rowCountByTable.put(TEST_DOC_LOCATIONS_TABLE_IDENT, new Stats(10_0000, 0, Map.of()));
+        rowCountByTable.put(TEST_DOC_LOCATIONS_TABLE_IDENT, new Stats(5_000, 0, Map.of()));
         e.updateTableStats(rowCountByTable);
 
         PlannerContext context = e.getPlannerContext(clusterService.state());
@@ -264,7 +264,7 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
     public void testNestedLoop_TablesAreNotSwitchedAfterOrderByPushDown() {
         Map<RelationName, Stats> rowCountByTable = new HashMap<>();
         rowCountByTable.put(USER_TABLE_IDENT, new Stats(10, 0, Map.of()));
-        rowCountByTable.put(TEST_DOC_LOCATIONS_TABLE_IDENT, new Stats(10_0000, 0, Map.of()));
+        rowCountByTable.put(TEST_DOC_LOCATIONS_TABLE_IDENT, new Stats(1000, 0, Map.of()));
         e.updateTableStats(rowCountByTable);
 
         QueriedSelectRelation mss = e.analyze("select users.id from users, locations " +

--- a/server/src/test/java/io/crate/planner/optimizer/rule/EquiJoinToLookupJoinTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/EquiJoinToLookupJoinTest.java
@@ -1,0 +1,297 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.rule;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.UnaryOperator;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.crate.analyze.WhereClause;
+import io.crate.analyze.relations.DocTableRelation;
+import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.Reference;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.doc.DocTableInfo;
+import io.crate.planner.operators.Collect;
+import io.crate.planner.operators.Filter;
+import io.crate.planner.operators.JoinPlan;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Match;
+import io.crate.sql.tree.JoinType;
+import io.crate.statistics.Stats;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+
+import static io.crate.testing.Asserts.assertThat;
+
+public class EquiJoinToLookupJoinTest extends CrateDummyClusterServiceUnitTest {
+
+    private SQLExecutor e;
+    private Reference x;
+    private Reference y;
+    private Collect lhs;
+    private Collect rhs;
+    private DocTableInfo lhsDocTableInfo;
+    private DocTableInfo rhsDocTableInfo;
+
+    @Before
+    public void prepare() throws Exception {
+        e = SQLExecutor.builder(clusterService)
+            .build()
+            .addTable("create table doc.lhs (x int)")
+            .addTable("create table doc.rhs (y int)");
+
+        lhsDocTableInfo = e.resolveTableInfo("lhs");
+        rhsDocTableInfo = e.resolveTableInfo("rhs");
+
+        x = (Reference) e.asSymbol("x");
+        y = (Reference) e.asSymbol("y");
+
+        lhs = new Collect(new DocTableRelation(lhsDocTableInfo), List.of(x), WhereClause.MATCH_ALL);
+        rhs = new Collect(new DocTableRelation(rhsDocTableInfo), List.of(y), WhereClause.MATCH_ALL);
+    }
+
+    @Test
+    public void test_lookup_join_lhs_is_larger() throws Exception {
+        var joinCondition = e.asSymbol("lhs.x = rhs.y");
+        var join = new JoinPlan(lhs, rhs, JoinType.INNER, joinCondition);
+
+        assertThat(join).hasOperators(
+            "Join[INNER | (x = y)]",
+            "  ├ Collect[doc.lhs | [x] | true]",
+            "  └ Collect[doc.rhs | [y] | true]"
+        );
+
+        Map<RelationName, Stats> rowCountByTable = new HashMap<>();
+        rowCountByTable.put(lhsDocTableInfo.ident(), new Stats(10000, 0, Map.of()));
+        rowCountByTable.put(rhsDocTableInfo.ident(), new Stats(10, 0, Map.of()));
+        e.updateTableStats(rowCountByTable);
+
+        var rule = new EquiJoinToLookupJoin();
+        Match<JoinPlan> match = rule.pattern().accept(join, Captures.empty());
+
+        Assertions.assertThat(match.isPresent()).isTrue();
+        assertThat(match.value()).isEqualTo(join);
+
+        var result = rule.apply(match.value(),
+            match.captures(),
+            e.planStats(),
+            CoordinatorTxnCtx.systemTransactionContext(),
+            e.nodeCtx,
+            UnaryOperator.identity());
+
+        assertThat(result).hasOperators(
+            "Join[INNER | (x = y)]",
+            "  ├ MultiPhase",
+            "  │  └ Collect[doc.lhs | [x] | (x = ANY((SELECT y FROM (doc.rhs))))]",
+            "  │  └ Collect[doc.rhs | [y] | true]",
+            "  └ Collect[doc.rhs | [y] | true]"
+        );
+    }
+
+    @Test
+    public void test_lookup_join_rhs_is_larger() throws Exception {
+        var joinCondition = e.asSymbol("lhs.x = rhs.y");
+        var join = new JoinPlan(lhs, rhs, JoinType.INNER, joinCondition);
+
+        assertThat(join).hasOperators(
+            "Join[INNER | (x = y)]",
+            "  ├ Collect[doc.lhs | [x] | true]",
+            "  └ Collect[doc.rhs | [y] | true]"
+        );
+
+        Map<RelationName, Stats> rowCountByTable = new HashMap<>();
+        rowCountByTable.put(lhsDocTableInfo.ident(), new Stats(10, 0, Map.of()));
+        rowCountByTable.put(rhsDocTableInfo.ident(), new Stats(10000, 0, Map.of()));
+        e.updateTableStats(rowCountByTable);
+
+        var rule = new EquiJoinToLookupJoin();
+        Match<JoinPlan> match = rule.pattern().accept(join, Captures.empty());
+
+        Assertions.assertThat(match.isPresent()).isTrue();
+        assertThat(match.value()).isEqualTo(join);
+
+        var result = rule.apply(match.value(),
+            match.captures(),
+            e.planStats(),
+            CoordinatorTxnCtx.systemTransactionContext(),
+            e.nodeCtx,
+            UnaryOperator.identity());
+
+        assertThat(result).hasOperators(
+            "Join[INNER | (x = y)]",
+            "  ├ Collect[doc.lhs | [x] | true]",
+            "  └ MultiPhase",
+            "    └ Collect[doc.rhs | [y] | (y = ANY((SELECT x FROM (doc.lhs))))]",
+            "    └ Collect[doc.lhs | [x] | true]"
+        );
+    }
+
+    @Test
+    public void test_filter_on_smaller_side() throws Exception {
+        var joinCondition = e.asSymbol("lhs.x = rhs.y");
+        var whereClause = lhs.where().add(e.asSymbol("lhs.x > 0"));
+        var newLhsCollect = new Collect(lhs.relation(), lhs.outputs(), whereClause);
+        var join = new JoinPlan(newLhsCollect, rhs, JoinType.INNER, joinCondition);
+
+        assertThat(join).hasOperators(
+            "Join[INNER | (x = y)]",
+            "  ├ Collect[doc.lhs | [x] | (x > 0)]",
+            "  └ Collect[doc.rhs | [y] | true]"
+        );
+
+        Map<RelationName, Stats> rowCountByTable = new HashMap<>();
+        rowCountByTable.put(lhsDocTableInfo.ident(), new Stats(10, 0, Map.of()));
+        rowCountByTable.put(rhsDocTableInfo.ident(), new Stats(10000, 0, Map.of()));
+        e.updateTableStats(rowCountByTable);
+
+        var rule = new EquiJoinToLookupJoin();
+        Match<JoinPlan> match = rule.pattern().accept(join, Captures.empty());
+
+        Assertions.assertThat(match.isPresent()).isTrue();
+        assertThat(match.value()).isEqualTo(join);
+
+        var result = rule.apply(match.value(),
+            match.captures(),
+            e.planStats(),
+            CoordinatorTxnCtx.systemTransactionContext(),
+            e.nodeCtx,
+            UnaryOperator.identity());
+
+        assertThat(result).hasOperators(
+            "Join[INNER | (x = y)]",
+            "  ├ Collect[doc.lhs | [x] | (x > 0)]",
+            "  └ MultiPhase",
+            "    └ Collect[doc.rhs | [y] | (y = ANY((SELECT x FROM (doc.lhs))))]",
+            "    └ Collect[doc.lhs | [x] | (x > 0)]"
+        );
+    }
+
+    @Test
+    public void test_filter_on_larger_side() throws Exception {
+        var joinCondition = e.asSymbol("lhs.x = rhs.y");
+        var whereClause = lhs.where().add(e.asSymbol("lhs.x > 0"));
+        var newLhsCollect = new Collect(lhs.relation(), lhs.outputs(), whereClause);
+        var join = new JoinPlan(newLhsCollect, rhs, JoinType.INNER, joinCondition);
+
+        assertThat(join).hasOperators(
+            "Join[INNER | (x = y)]",
+            "  ├ Collect[doc.lhs | [x] | (x > 0)]",
+            "  └ Collect[doc.rhs | [y] | true]"
+        );
+
+        Map<RelationName, Stats> rowCountByTable = new HashMap<>();
+        rowCountByTable.put(lhsDocTableInfo.ident(), new Stats(100000, 0, Map.of()));
+        rowCountByTable.put(rhsDocTableInfo.ident(), new Stats(10, 0, Map.of()));
+        e.updateTableStats(rowCountByTable);
+
+        var rule = new EquiJoinToLookupJoin();
+        Match<JoinPlan> match = rule.pattern().accept(join, Captures.empty());
+
+        Assertions.assertThat(match.isPresent()).isTrue();
+        assertThat(match.value()).isEqualTo(join);
+
+        var result = rule.apply(match.value(),
+            match.captures(),
+            e.planStats(),
+            CoordinatorTxnCtx.systemTransactionContext(),
+            e.nodeCtx,
+            UnaryOperator.identity());
+
+        assertThat(result).hasOperators(
+            "Join[INNER | (x = y)]",
+            "  ├ MultiPhase",
+            "  │  └ Collect[doc.lhs | [x] | ((x > 0) AND (x = ANY((SELECT y FROM (doc.rhs)))))]",
+            "  │  └ Collect[doc.rhs | [y] | true]",
+            "  └ Collect[doc.rhs | [y] | true]"
+        );
+    }
+
+    @Test
+    public void test_skip_non_equi_joins() throws Exception {
+        var joinCondition = e.asSymbol("lhs.x = rhs.y and lhs.x = 2");
+        var join = new JoinPlan(lhs, rhs, JoinType.INNER, joinCondition);
+
+        Map<RelationName, Stats> rowCountByTable = new HashMap<>();
+        rowCountByTable.put(lhsDocTableInfo.ident(), new Stats(10, 0, Map.of()));
+        rowCountByTable.put(rhsDocTableInfo.ident(), new Stats(10000, 0, Map.of()));
+        e.updateTableStats(rowCountByTable);
+
+        var rule = new EquiJoinToLookupJoin();
+        Match<JoinPlan> match = rule.pattern().accept(join, Captures.empty());
+
+        Assertions.assertThat(match.isPresent()).isFalse();
+    }
+
+    @Test
+    public void test_skip_no_stats() throws Exception {
+        var joinCondition = e.asSymbol("lhs.x = rhs.y");
+        var join = new JoinPlan(lhs, rhs, JoinType.INNER, joinCondition);
+
+        Map<RelationName, Stats> rowCountByTable = new HashMap<>();
+        rowCountByTable.put(lhsDocTableInfo.ident(), Stats.EMPTY);
+        rowCountByTable.put(rhsDocTableInfo.ident(), Stats.EMPTY);
+        e.updateTableStats(rowCountByTable);
+
+        var rule = new EquiJoinToLookupJoin();
+        Match<JoinPlan> match = rule.pattern().accept(join, Captures.empty());
+
+        Assertions.assertThat(match.isPresent()).isTrue();
+        assertThat(match.value()).isEqualTo(join);
+
+        var result = rule.apply(match.value(),
+            match.captures(),
+            e.planStats(),
+            CoordinatorTxnCtx.systemTransactionContext(),
+            e.nodeCtx,
+            UnaryOperator.identity());
+
+        assertThat(result).isNull();
+    }
+
+    public void test_skip_if_source_is_not_a_collect() throws Exception {
+        var joinCondition = e.asSymbol("lhs.x = rhs.y");
+        var lhsFilter = new Filter(lhs, e.asSymbol("lhs.x > 1"));
+        var join = new JoinPlan(lhsFilter, rhs, JoinType.INNER, joinCondition);
+
+        var rule = new EquiJoinToLookupJoin();
+        Match<JoinPlan> match = rule.pattern().accept(join, Captures.empty());
+
+        Assertions.assertThat(match.isPresent()).isTrue();
+        assertThat(match.value()).isEqualTo(join);
+
+        var result = rule.apply(match.value(),
+            match.captures(),
+            e.planStats(),
+            CoordinatorTxnCtx.systemTransactionContext(),
+            e.nodeCtx,
+            UnaryOperator.identity());
+
+        assertThat(result).isNull();
+    }
+
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This adds an optimizer rule to optimize joins with a lookup-join under the following conditions:

- The join is an equi-inner join
- The lhs/rhs are Collect operators
- There is a large imbalance in size between the two joined relations

Assume the following query:

```
select t1.id from doc.t1 inner join doc.t2 on t1.id = t2.id
```

This generates the following query plan:

```
Eval[t1.id]
  └ HashJoin[(id = id)]
    ├ Collect[doc.t1 | [id] | true]
    └ Collect[doc.t2 | [id] | true]
```

If there is a large imbalance in size between the two tables then we can optimize the plan with a lookup-join. A lookup-join pre-filters the larger table with the smaller table based on the join condition to reduce the number of join operations. So if `t1` is much larger than `t2`, we can apply the following optimization:

```
Eval[doc.t1.id]
  └ HashJoin[(id = id)]
    ├ LookupJoin[doc.t1.id]
    │  └ MultiPhase
    │    └ Collect[doc.t1 | [id] | (id = ANY((SELECT id FROM (doc.t2))))] 
    │    └ Collect[doc.t2 | [id] | true] 
    └ Collect[doc.t2 | [id] | true]
```


## Benchmarks

### 1. Ids-only benchmark

Scenario:

We are joining two tables, retrieving only the id column from the larger table. The size of the larger table is constant at 100.000 while the size of the smaller table is increased from 10 to 100.000 to find out what size difference works best for a lockup-join.

Query:
```
select t1.id from t1 inner join t2 on t1.id = t2.id;
```

Setup:
```
create table t1 (id int);
create table t2 (id int)",
insert into t1 (id) select b from generate_series(1,size_small_table) a(b);
insert into t2 (id) select b from generate_series(1,100000) a(b);
```

Logical Plan:
```
Eval[doc.t1.id]
  └ HashJoin[(id = id)]
    ├ LookupJoin[doc.t1.id]
    │  └ MultiPhase
    │    └ Collect[doc.t1 | [id] | (id = ANY((SELECT id FROM (doc.t2))))] 
    │    └ Collect[doc.t2 | [id] | true] 
    └ Collect[doc.t2 | [id] | true]
```

Result with 1000 iterations: 

| Table sizes | Hash-Join (ms mean) | Hash-Join-with-Lookup Join (ms mean)| 
| ------------- | ------------- | ------------- | 
| 10 / 100.000  | 14.933  | 3.725  | 
| 100 / 100.000  | 13.084  | 4.187  | 
| 1000 / 100.000  | 13.221  | 4.648  | 
| 10000 / 100.000  | 17.498  | 11.181  | 
| 50000 / 100.000  | 24.790  | 48.017  | 
| 100000 / 100.000  | 33.782  | 88.622  | 

Outcome:

The query runs faster with the lookup-join optimization until a ratio 10.000 vs 100.000 is reached, then the hash-join version is faster.

### 2. Multiple-columns benchmark

Scenario:

We are joining two tables, and retrieving multiple columns from both tables. The size of the larger table is constant at 100.000 while the size of the smaller table is increased from 10 to 100.000. 

Query:
```
select * from t1 inner join t2 on t1.id = t2.id;
```

Setup:

```
create table t1 (id int primary key,a text,b text);
insert into t1 (id,a,b) select b,(b%300)::TEXT,(b%450)::TEXT from generate_series(1,100000) a(b)
create table t2 (ts timestamp,id int,c double);
insert into t2(ts,id,c) select now(),b%7000,b%6300 from generate_series(1,size_small_table) a(b);
```

Logical Plan:
```
 HashJoin[(id = id)]                                                           
   ├ LookupJoin[doc.t1]                                                        
   │  └ MultiPhase                                                             
   │    └ Collect[doc.t1 | [id, a, b] | (id = ANY((SELECT id FROM (doc.t2))))] 
   │    └ Collect[doc.t2 | [id] | true]                                        
   └ Collect[doc.t2 | [ts, id, c] | true]                                      

```

Result with 1000 iterations: 

| Table sizes | Hash-Join (ms mean) | Hash-Join-with-Lookup Join (ms mean) | 
| ------------- | ------------- | ------------- | 
| 10 / 100.000  | 38.981  | 3.522  |
| 100 / 100.000  | 36.042  | 3.775  | 
| 1000 / 100.000  | 38.741  | 5.195  | 
| 10000 / 100.000  | 40.069  | 14.331  | 
| 50000 / 100.000  | 56.507  | 48.84  | 
| 100000 / 100.000  | 75.627  | 86.957  | 

Outcome:
The query runs faster with the lookup-join optimization with the ratio 10.000 vs 100.000 then the hash-join is faster. The performance improvement of the lookup-join is more significant than on the previous benchmark, because more data is transferred through the hash-join operation. 

Conclusion:
The benchmarks indicate that we get a significant performance improvement when the imbalance of the tables is at `factor of 10` or more.

### 3. Table-size benchmark

Scenario:

We want to find the minimum size of the tables for the imbalance with a `factor of 10`. We first try the small table with size 10 and the larger with size 100, then 100 and the larger 1000 and so on.

#### Ids-only benchmark

| Table sizes | Hash-Join (ms mean) | Hash-Join-with-Lookup Join (ms mean)| 
| ------------- | ------------- | ------------- | 
| 10/100  | 2.386  | 3.127  | 
| 100/1000 | 2.542  | 3.50  |  
| 1000/10000  | 4.313  | 4.428   |
| 10000/100000  | 17.039  | 10.928  | 
| 100000/100000  | 33.782  | 88.622  | 

#### Multiple-columns benchmark

| Table sizes | Hash-Join (ms mean) | Hash-Join-with-Lookup Join (ms mean) |
| ------------- | ------------- | ------------- |
| 10/100  | 2.502  | 3.234  | 
| 100/1000 | 2.926  | 3.633  |
| 1000/10000  | 6.224  | 5.032   |
| 10000/100000  | 38.976  | 10.509  |
| 100000/100000  |  75.627   | 86.957  |

Outcome:

The benchmarks indicate that the larger table should have a minimum size of 10.000 and the smaller table should be at least 10 times smaller.  


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
