### PR TITLE
Add aud (audience) to JWT properties

### DIFF
--- a/docs/admin/auth/methods.rst
+++ b/docs/admin/auth/methods.rst
@@ -123,12 +123,19 @@ CrateDB will validate the token and match it to a user created with ``CREATE
 USER`` with ``JWT`` properties that match those of the provided ``JWT`` token.
 
 Token must contain the following claims:
+
 ``kid`` - `Key ID`_.
+
 ``iss`` - URL of the `JWK endpoint`_.
+
+``aud`` - `aud`_.
+
 ``username`` - user name in a third party app.
 
-``iss`` and  ``username`` values must match the values created by
-``CREATE USER`` statement. See :ref:`create-user-jwt` for details.
+``iss``, ``username`` and ``aud`` values must match the values created by
+``CREATE USER`` statement. If ``aud`` has not been defined on the
+``CREATE USER`` statement, the cluster id is used and must match the token's
+``aud`` value. See :ref:`create-user-jwt` for details.
 
 It's recommended to have ``exp`` (`expiration date`_ as epoch seconds) in the
 header. If it's provided, the token's expiration date will be checked against
@@ -162,3 +169,4 @@ both values are compared and in case of a mismatch the token is rejected.
 .. _Key ID: https://datatracker.ietf.org/doc/html/rfc7517#section-4.5
 .. _expiration date: https://www.rfc-editor.org/rfc/rfc7519#section-4.1.4
 .. _Algorithm parameter: https://datatracker.ietf.org/doc/html/rfc7517#section-4.4
+.. _aud: https://www.rfc-editor.org/rfc/rfc7519#section-4.1.3

--- a/docs/admin/system-information.rst
+++ b/docs/admin/system-information.rst
@@ -2179,6 +2179,9 @@ The ``sys.users`` table contains all existing database users in the cluster.
 +----------------------------+----------------------------------+-------------+
 | ``jwt``                    | JWT authentication properties    | ``OBJECT``  |
 +----------------------------+----------------------------------+-------------+
+| ``jwt[aud]``               | Recipient that the JWT is        | ``TEXT``    |
+|                            | intended for                     |             |
++----------------------------+----------------------------------+-------------+
 | ``jwt[iss]``               | JWK endpoint URL                 | ``TEXT``    |
 +----------------------------+----------------------------------+-------------+
 | ``jwt[username]``          | User name in a third party app   | ``TEXT``    |

--- a/docs/sql/statements/alter-role.rst
+++ b/docs/sql/statements/alter-role.rst
@@ -56,14 +56,19 @@ are supported to alter an existing user account:
     client certificate.
 
 :jwt:
-  JWT properties map (``iss`` and ``username``) entered as a string literal.
+  JWT properties map (``iss``, ``username`` and ``aud``) entered as a string literal.
   e.g.::
 
-     ALTER USER john WITH (jwt = {"iss" = 'new_issuer', "username" = 'john.smith'})
+     ALTER USER john WITH (jwt = {"iss" = 'new_issuer', "username" = 'john.smith', "aud" = 'new_aud'})
 
   New JWT properties must not coincide with JWT properties of another user.
 
   ``NULL`` removes the JWT properties from the user.
+
+.. NOTE::
+
+   ``jwt = {...}`` overrides existing jwt properties. If an optional property
+   is not provided, an existing value will be discarded.
 
 .. NOTE::
 

--- a/docs/sql/statements/create-user.rst
+++ b/docs/sql/statements/create-user.rst
@@ -85,13 +85,15 @@ The following ``user_parameter`` are supported to define a new user account:
 .. _create-user-jwt:
 
 :jwt:
-  JWT properties map ('iss' and 'username') entered as string literal. e.g.::
+  JWT properties map ('iss', 'username' and 'aud') entered as string literal. e.g.::
 
-     CREATE USER john WITH (jwt = {"iss" = 'https://example.com', "username" = 'test@example.com'})
+     CREATE USER john WITH (jwt = {"iss" = 'https://example.com', "username" = 'test@example.com', "aud" = 'test_aud'})
 
-  `iss`_ is a JWK endpoint, containing public keys.
+  `iss`_ is a JWK endpoint, containing public keys. Required field.
 
-  ``username`` is a user name in a third party app.
+  ``username`` is a user name in a third party app. Required field.
+
+  `aud`_ is a recipient that the JWT is intended for. Optional field. If not provided, the cluster id is used (default).
 
   Combination of ``iss`` and ``username`` must be unique.
 
@@ -102,3 +104,4 @@ The following ``user_parameter`` are supported to define a new user account:
 .. vale on
 
 .. _iss: https://www.rfc-editor.org/rfc/rfc7519#section-4.1.1
+.. _aud: https://www.rfc-editor.org/rfc/rfc7519#section-4.1.3

--- a/server/src/main/java/io/crate/auth/Credentials.java
+++ b/server/src/main/java/io/crate/auth/Credentials.java
@@ -138,7 +138,7 @@ public class Credentials implements Closeable {
                 if (role.isUser() && jwtProperties != null) {
                     assert jwtProperties.iss() != null && jwtProperties.username() != null :
                         "If user has jwt properties, 'iss' and 'username' must be not null";
-                    return decodedToken.getIssuer().equals(jwtProperties.iss()) && decodedToken.getClaim("username").asString().equals(jwtProperties.username());
+                    return jwtProperties.match(decodedToken.getIssuer(), decodedToken.getClaim("username").asString());
                 }
                 return false;
             };

--- a/server/src/main/java/io/crate/auth/HostBasedAuthentication.java
+++ b/server/src/main/java/io/crate/auth/HostBasedAuthentication.java
@@ -27,7 +27,6 @@ import io.crate.protocols.postgres.ConnectionProperties;
 import org.apache.http.conn.DnsResolver;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.network.Cidrs;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.settings.Settings;
@@ -96,11 +95,16 @@ public class HostBasedAuthentication implements Authentication {
     private final Roles roles;
     private final DnsResolver dnsResolver;
 
-    @Inject
-    public HostBasedAuthentication(Settings settings, Roles roles, DnsResolver dnsResolver) {
+    private final Supplier<String> clusterId;
+
+    public HostBasedAuthentication(Settings settings,
+                                   Roles roles,
+                                   DnsResolver dnsResolver,
+                                   Supplier<String> clusterId) {
         hbaConf = convertHbaSettingsToHbaConf(settings);
         this.roles = roles;
         this.dnsResolver = dnsResolver;
+        this.clusterId = clusterId;
     }
 
     @VisibleForTesting
@@ -132,7 +136,8 @@ public class HostBasedAuthentication implements Authentication {
             case (JWTAuthenticationMethod.NAME) ->
                 new JWTAuthenticationMethod(
                     roles,
-                    JWTAuthenticationMethod::jwkProvider
+                    JWTAuthenticationMethod::jwkProvider,
+                    clusterId
                 );
             default -> null;
         };

--- a/server/src/main/java/io/crate/auth/JWTAuthenticationMethod.java
+++ b/server/src/main/java/io/crate/auth/JWTAuthenticationMethod.java
@@ -29,6 +29,7 @@ import java.security.PublicKey;
 import java.security.interfaces.RSAPublicKey;
 import java.util.Locale;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -55,10 +56,15 @@ public class JWTAuthenticationMethod implements AuthenticationMethod {
 
     private final Function<String, JwkProvider> urlToJwkProvider;
 
+    private final Supplier<String> clusterId;
 
-    public JWTAuthenticationMethod(Roles roles, Function<String, JwkProvider> urlToJwkProvider) {
+
+    public JWTAuthenticationMethod(Roles roles,
+                                   Function<String, JwkProvider> urlToJwkProvider,
+                                   Supplier<String> clusterId) {
         this.roles = roles;
         this.urlToJwkProvider = urlToJwkProvider;
+        this.clusterId = clusterId;
     }
 
     @Override
@@ -84,7 +90,8 @@ public class JWTAuthenticationMethod implements AuthenticationMethod {
                 // withers below are not needed for payload signature check.
                 // It's an extra step on top of signature verification to double check that user metadata matches token payload.
                 .withIssuer(jwtProperties.iss())
-                .withClaim("username", jwtProperties.username());
+                .withClaim("username", jwtProperties.username())
+                .withAudience(jwtProperties.aud() == null ? clusterId.get() : jwtProperties.aud());
 
             JWTVerifier verifier = verification.build();
             verifier.verify(decodedJWT);

--- a/server/src/main/java/io/crate/role/RoleManagerService.java
+++ b/server/src/main/java/io/crate/role/RoleManagerService.java
@@ -26,6 +26,7 @@ import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
 import org.jetbrains.annotations.Nullable;
@@ -74,13 +75,14 @@ public class RoleManagerService implements RoleManager {
                               TransportPrivilegesAction transportPrivilegesAction,
                               SysTableRegistry sysTableRegistry,
                               Roles roles,
-                              DDLClusterStateService ddlClusterStateService) {
+                              DDLClusterStateService ddlClusterStateService,
+                              ClusterService clusterService) {
         this.transportCreateRoleAction = transportCreateRoleAction;
         this.transportDropRoleAction = transportDropRoleAction;
         this.transportAlterRoleAction = transportAlterRoleAction;
         this.transportPrivilegesAction = transportPrivilegesAction;
         this.roles = roles;
-        var userTable = SysUsersTableInfo.create();
+        var userTable = SysUsersTableInfo.create(() -> clusterService.state().metadata().clusterUUID());
         sysTableRegistry.registerSysTable(
             userTable,
             () -> CompletableFuture.completedFuture(

--- a/server/src/main/java/io/crate/role/TransportAlterRoleAction.java
+++ b/server/src/main/java/io/crate/role/TransportAlterRoleAction.java
@@ -137,7 +137,9 @@ public class TransportAlterRoleAction extends TransportMasterNodeAction<AlterRol
             var newJwtProperties = jwtProperties != null ? jwtProperties : (resetJwtProperties ? null : role.jwtProperties());
 
             if (newMetadata.contains(newJwtProperties)) {
-                throw new RoleAlreadyExistsException("Another role with the same combination of jwt properties already exists");
+                throw new RoleAlreadyExistsException(
+                    "Another role with the same combination of iss/username jwt properties already exists"
+                );
             }
 
             newMetadata.roles().put(roleName, role.with(newSecureHash, newJwtProperties));

--- a/server/src/main/java/io/crate/role/TransportCreateRoleAction.java
+++ b/server/src/main/java/io/crate/role/TransportCreateRoleAction.java
@@ -128,7 +128,9 @@ public class TransportCreateRoleAction extends TransportMasterNodeAction<CreateR
         RolesMetadata newMetadata = RolesMetadata.of(mdBuilder, oldUsersMetadata, oldUserPrivilegesMetadata, oldRolesMetadata);
         boolean exists = true;
         if (newMetadata.contains(jwtProperties)) {
-            throw new RoleAlreadyExistsException("Another role with the same combination of jwt properties already exists");
+            throw new RoleAlreadyExistsException(
+                "Another role with the same combination of iss/username jwt properties already exists"
+            );
         }
         if (newMetadata.contains(roleName) == false) {
             newMetadata.roles().put(roleName, new Role(roleName, isUser, Set.of(), Set.of(), secureHash, jwtProperties));

--- a/server/src/main/java/io/crate/role/metadata/RolesMetadata.java
+++ b/server/src/main/java/io/crate/role/metadata/RolesMetadata.java
@@ -96,12 +96,15 @@ public class RolesMetadata extends AbstractNamedDiffable<Metadata.Custom> implem
     /**
      * Combination of iss/username must be unique throughout all users.
      */
-    public boolean contains(JwtProperties jwtProperties) {
+    public boolean contains(@Nullable JwtProperties jwtProperties) {
+        if (jwtProperties == null) {
+            // Short-circuit for CREATE/ALTER user statements without jwt property specified.
+            return false;
+        }
         for (Role role: roles.values()) {
-            if (role.jwtProperties() != null) {
-                if (role.jwtProperties().equals(jwtProperties)) {
-                    return true;
-                }
+            var jwtProps = role.jwtProperties();
+            if (role.isUser() && jwtProps != null && jwtProps.match(jwtProperties.iss(), jwtProperties.username())) {
+                return true;
             }
         }
         return false;

--- a/server/src/main/java/io/crate/role/metadata/SysUsersTableInfo.java
+++ b/server/src/main/java/io/crate/role/metadata/SysUsersTableInfo.java
@@ -24,6 +24,8 @@ package io.crate.role.metadata;
 import static io.crate.types.DataTypes.BOOLEAN;
 import static io.crate.types.DataTypes.STRING;
 
+import java.util.function.Supplier;
+
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.SystemTable;
@@ -38,7 +40,7 @@ public class SysUsersTableInfo {
 
     private SysUsersTableInfo() {}
 
-    public static SystemTable<Role> create() {
+    public static SystemTable<Role> create(Supplier<String> clusterId) {
         return SystemTable.<Role>builder(IDENT)
             .add("name", STRING, Role::name)
             .add("superuser", BOOLEAN, Role::isSuperUser)
@@ -46,6 +48,7 @@ public class SysUsersTableInfo {
             .startObject("jwt", x -> x.jwtProperties() == null)
                 .add("iss", STRING, x -> x.jwtProperties().iss())
                 .add("username", STRING, x -> x.jwtProperties().username())
+                .add("aud", STRING, x -> x.jwtProperties().aud() == null ? clusterId.get() : x.jwtProperties().aud())
             .endObject()
             .startObjectArray("granted_roles", r -> r.grantedRoles().stream().sorted().toList())
                 .add("role", STRING, GrantedRole::roleName)

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -544,7 +544,12 @@ public class Node implements Closeable {
             modules.add(actionModule);
 
             var authentication = AuthSettings.AUTH_HOST_BASED_ENABLED_SETTING.get(settings)
-                ? new HostBasedAuthentication(settings, roles, SystemDefaultDnsResolver.INSTANCE)
+                ? new HostBasedAuthentication(
+                    settings,
+                    roles,
+                    SystemDefaultDnsResolver.INSTANCE,
+                    () -> clusterService.state().metadata().clusterUUID()
+                )
                 : new AlwaysOKAuthentication(roles);
 
             final SslContextProvider sslContextProvider = new SslContextProvider(settings);

--- a/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
+++ b/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
@@ -130,7 +130,9 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
             null,
             mock(SysTableRegistry.class),
             roles,
-            new DDLClusterStateService());
+            new DDLClusterStateService(),
+            this.clusterService
+        );
 
         e = SQLExecutor.builder(clusterService)
             .addBlobTable("create blob table blobs")

--- a/server/src/test/java/io/crate/auth/HostBasedAuthenticationTest.java
+++ b/server/src/test/java/io/crate/auth/HostBasedAuthenticationTest.java
@@ -143,7 +143,12 @@ public class HostBasedAuthenticationTest extends ESTestCase {
 
     @Test
     public void testMissingUserOrAddress() {
-        HostBasedAuthentication authService = new HostBasedAuthentication(Settings.EMPTY, null, SystemDefaultDnsResolver.INSTANCE);
+        HostBasedAuthentication authService = new HostBasedAuthentication(
+            Settings.EMPTY,
+            null,
+            SystemDefaultDnsResolver.INSTANCE,
+            () -> "dummy"
+        );
         AuthenticationMethod method;
         method = authService.resolveAuthenticationType(null, new ConnectionProperties(LOCALHOST, Protocol.POSTGRES, null));
         assertNull(method);
@@ -153,7 +158,12 @@ public class HostBasedAuthenticationTest extends ESTestCase {
 
     @Test
     public void testEmptyHbaConf() {
-        HostBasedAuthentication authService = new HostBasedAuthentication(Settings.EMPTY, null, SystemDefaultDnsResolver.INSTANCE);
+        HostBasedAuthentication authService = new HostBasedAuthentication(
+            Settings.EMPTY,
+            null,
+            SystemDefaultDnsResolver.INSTANCE,
+            () -> "dummy"
+        );
         AuthenticationMethod method =
             authService.resolveAuthenticationType("crate", new ConnectionProperties(LOCALHOST, Protocol.POSTGRES, null));
         assertNull(method);
@@ -161,7 +171,12 @@ public class HostBasedAuthenticationTest extends ESTestCase {
 
     @Test
     public void testResolveAuthMethod() {
-        HostBasedAuthentication authService = new HostBasedAuthentication(HBA_1, null, SystemDefaultDnsResolver.INSTANCE);
+        HostBasedAuthentication authService = new HostBasedAuthentication(
+            HBA_1,
+            null,
+            SystemDefaultDnsResolver.INSTANCE,
+            () -> "dummy"
+        );
         AuthenticationMethod method =
             authService.resolveAuthenticationType("crate", new ConnectionProperties(LOCALHOST, Protocol.POSTGRES, null));
         assertThat(method, instanceOf(TrustAuthenticationMethod.class));
@@ -169,7 +184,12 @@ public class HostBasedAuthenticationTest extends ESTestCase {
 
     @Test
     public void test_resolve_jwt_method() {
-        HostBasedAuthentication authService = new HostBasedAuthentication(HBA_6, null, SystemDefaultDnsResolver.INSTANCE);
+        HostBasedAuthentication authService = new HostBasedAuthentication(
+            HBA_6,
+            null,
+            SystemDefaultDnsResolver.INSTANCE,
+            () -> "dummy"
+        );
         AuthenticationMethod method =
             authService.resolveAuthenticationType("jwt_user", new ConnectionProperties(LOCALHOST, Protocol.HTTP, null));
         assertThat(method, instanceOf(JWTAuthenticationMethod.class));
@@ -183,7 +203,12 @@ public class HostBasedAuthenticationTest extends ESTestCase {
             .put("auth.host_based.config.1.method", "jwt")
             .build();
         assertThatThrownBy(
-            () -> new HostBasedAuthentication(noProtocolSettings, null, SystemDefaultDnsResolver.INSTANCE)
+            () -> new HostBasedAuthentication(
+                noProtocolSettings,
+                null,
+                SystemDefaultDnsResolver.INSTANCE,
+                () -> "dummy"
+            )
         ).isExactlyInstanceOf(IllegalArgumentException.class)
         .hasMessage("protocol must be set to http when using jwt auth method");
 
@@ -194,14 +219,24 @@ public class HostBasedAuthenticationTest extends ESTestCase {
             .put("auth.host_based.config.1.protocol", "pg")
             .build();
         assertThatThrownBy(
-            () -> new HostBasedAuthentication(unsupportedProtocolSettings, null, SystemDefaultDnsResolver.INSTANCE)
+            () -> new HostBasedAuthentication(
+                unsupportedProtocolSettings,
+                null,
+                SystemDefaultDnsResolver.INSTANCE,
+                () -> "dummy"
+            )
         ).isExactlyInstanceOf(IllegalArgumentException.class)
         .hasMessage("protocol must be set to http when using jwt auth method");
     }
 
     @Test
     public void testFilterEntriesSimple() {
-        HostBasedAuthentication authService = new HostBasedAuthentication(HBA_1, null, SystemDefaultDnsResolver.INSTANCE);
+        HostBasedAuthentication authService = new HostBasedAuthentication(
+            HBA_1,
+            null,
+            SystemDefaultDnsResolver.INSTANCE,
+            () -> "dummy"
+        );
         Optional entry;
 
         entry = authService.getEntry("crate", new ConnectionProperties(LOCALHOST, Protocol.POSTGRES, null));
@@ -218,7 +253,12 @@ public class HostBasedAuthenticationTest extends ESTestCase {
     @Test
     public void testFilterEntriesCIDR() {
         Settings settings = Settings.builder().put(HBA_2).put(HBA_3).build();
-        HostBasedAuthentication authService = new HostBasedAuthentication(settings, null, SystemDefaultDnsResolver.INSTANCE);
+        HostBasedAuthentication authService = new HostBasedAuthentication(
+            settings,
+            null,
+            SystemDefaultDnsResolver.INSTANCE,
+            () -> "dummy"
+        );
 
         Optional<Map.Entry<String, Map<String, String>>> entry;
 
@@ -239,7 +279,12 @@ public class HostBasedAuthenticationTest extends ESTestCase {
 
     @Test
     public void testLocalhostMatchesBothIpv4AndIpv6() {
-        HostBasedAuthentication authService = new HostBasedAuthentication(HBA_4, null, SystemDefaultDnsResolver.INSTANCE);
+        HostBasedAuthentication authService = new HostBasedAuthentication(
+            HBA_4,
+            null,
+            SystemDefaultDnsResolver.INSTANCE,
+            () -> "dummy"
+        );
 
         Optional<Map.Entry<String, Map<String, String>>> entry;
         entry = authService.getEntry("crate",
@@ -252,7 +297,12 @@ public class HostBasedAuthenticationTest extends ESTestCase {
 
     @Test
     public void test_filter_entries_hostname() {
-        HostBasedAuthentication authService = new HostBasedAuthentication(HBA_5, null, IN_MEMORY_RESOLVER);
+        HostBasedAuthentication authService = new HostBasedAuthentication(
+            HBA_5,
+            null,
+            IN_MEMORY_RESOLVER,
+            () -> "dummy"
+        );
 
         Optional entry = authService.getEntry("crate",
             new ConnectionProperties(InetAddresses.forString(TEST_DNS_IP), Protocol.POSTGRES, null));
@@ -328,7 +378,12 @@ public class HostBasedAuthenticationTest extends ESTestCase {
                 "3", new String[]{}, new String[]{}) // ignored because empty
             .build();
 
-        HostBasedAuthentication authService = new HostBasedAuthentication(settings, null, SystemDefaultDnsResolver.INSTANCE);
+        HostBasedAuthentication authService = new HostBasedAuthentication(
+            settings,
+            null,
+            SystemDefaultDnsResolver.INSTANCE,
+            () -> "dummy"
+        );
         Settings confirmSettings = Settings.builder().put(HBA_1).put(HBA_2).build();
         assertThat(authService.hbaConf(), is(authService.convertHbaSettingsToHbaConf(confirmSettings)));
     }
@@ -341,7 +396,12 @@ public class HostBasedAuthenticationTest extends ESTestCase {
         sslConfig = Settings.builder().put(HBA_1)
             .put("auth.host_based.config.1." + HostBasedAuthentication.SSL.KEY, HostBasedAuthentication.SSL.OPTIONAL.VALUE)
             .build();
-        authService = new HostBasedAuthentication(sslConfig, null, SystemDefaultDnsResolver.INSTANCE);
+        authService = new HostBasedAuthentication(
+            sslConfig,
+            null,
+            SystemDefaultDnsResolver.INSTANCE,
+            () -> "dummy"
+        );
         assertThat(
             authService.getEntry("crate", new ConnectionProperties(LOCALHOST, Protocol.POSTGRES, null)),
             not(Optional.empty()));
@@ -352,7 +412,12 @@ public class HostBasedAuthenticationTest extends ESTestCase {
         sslConfig = Settings.builder().put(HBA_1)
             .put("auth.host_based.config.1." + HostBasedAuthentication.SSL.KEY, HostBasedAuthentication.SSL.REQUIRED.VALUE)
             .build();
-        authService = new HostBasedAuthentication(sslConfig, null, SystemDefaultDnsResolver.INSTANCE);
+        authService = new HostBasedAuthentication(
+            sslConfig,
+            null,
+            SystemDefaultDnsResolver.INSTANCE,
+            () -> "dummy"
+        );
         assertThat(
             authService.getEntry("crate", new ConnectionProperties(LOCALHOST, Protocol.POSTGRES, null)),
             is(Optional.empty()));
@@ -363,7 +428,12 @@ public class HostBasedAuthenticationTest extends ESTestCase {
         sslConfig = Settings.builder().put(HBA_1)
             .put("auth.host_based.config.1." + HostBasedAuthentication.SSL.KEY, HostBasedAuthentication.SSL.NEVER.VALUE)
             .build();
-        authService = new HostBasedAuthentication(sslConfig, null, SystemDefaultDnsResolver.INSTANCE);
+        authService = new HostBasedAuthentication(
+            sslConfig,
+            null,
+            SystemDefaultDnsResolver.INSTANCE,
+            () -> "dummy"
+        );
         assertThat(
             authService.getEntry("crate", new ConnectionProperties(LOCALHOST, Protocol.POSTGRES, null)),
             not(Optional.empty()));
@@ -391,21 +461,36 @@ public class HostBasedAuthenticationTest extends ESTestCase {
         sslConfig = Settings.builder().put(baseConfig)
             .put("auth.host_based.config.1." + HostBasedAuthentication.SSL.KEY, HostBasedAuthentication.SSL.OPTIONAL.VALUE)
             .build();
-        authService = new HostBasedAuthentication(sslConfig, null, SystemDefaultDnsResolver.INSTANCE);
+        authService = new HostBasedAuthentication(
+            sslConfig,
+            null,
+            SystemDefaultDnsResolver.INSTANCE,
+            () -> "dummy"
+        );
         assertThat(authService.getEntry("crate", noSslConnProperties), not(Optional.empty()));
         assertThat(authService.getEntry("crate", sslConnProperties), not(Optional.empty()));
 
         sslConfig = Settings.builder().put(baseConfig)
             .put("auth.host_based.config.1." + HostBasedAuthentication.SSL.KEY, HostBasedAuthentication.SSL.REQUIRED.VALUE)
             .build();
-        authService = new HostBasedAuthentication(sslConfig, null, SystemDefaultDnsResolver.INSTANCE);
+        authService = new HostBasedAuthentication(
+            sslConfig,
+            null,
+            SystemDefaultDnsResolver.INSTANCE,
+            () -> "dummy"
+        );
         assertThat(authService.getEntry("crate", noSslConnProperties), is(Optional.empty()));
         assertThat(authService.getEntry("crate", sslConnProperties), not(Optional.empty()));
 
         sslConfig = Settings.builder().put(baseConfig)
             .put("auth.host_based.config.1." + HostBasedAuthentication.SSL.KEY, HostBasedAuthentication.SSL.NEVER.VALUE)
             .build();
-        authService = new HostBasedAuthentication(sslConfig, null, SystemDefaultDnsResolver.INSTANCE);
+        authService = new HostBasedAuthentication(
+            sslConfig,
+            null,
+            SystemDefaultDnsResolver.INSTANCE,
+            () -> "dummy"
+        );
         assertThat(authService.getEntry("crate", noSslConnProperties), not(Optional.empty()));
         assertThat(authService.getEntry("crate", sslConnProperties), is(Optional.empty()));
     }
@@ -422,7 +507,12 @@ public class HostBasedAuthenticationTest extends ESTestCase {
 
         // add in reverse order to test natural order of keys in config
         Settings settings = Settings.builder().put(second).put(first).build();
-        HostBasedAuthentication hba = new HostBasedAuthentication(settings, null, SystemDefaultDnsResolver.INSTANCE);
+        HostBasedAuthentication hba = new HostBasedAuthentication(
+            settings,
+            null,
+            SystemDefaultDnsResolver.INSTANCE,
+            () -> "dummy"
+        );
 
         AuthenticationMethod authMethod = hba.resolveAuthenticationType("crate",
             new ConnectionProperties(InetAddresses.forString("1.2.3.4"), Protocol.POSTGRES, null));
@@ -454,7 +544,12 @@ public class HostBasedAuthenticationTest extends ESTestCase {
         // 'on' becomes 'true' -
         assertThat(finalSettings.get("auth.host_based.config.0.ssl"), is("true"));
 
-        HostBasedAuthentication hba = new HostBasedAuthentication(finalSettings, null, SystemDefaultDnsResolver.INSTANCE);
+        HostBasedAuthentication hba = new HostBasedAuthentication(
+            finalSettings,
+            null,
+            SystemDefaultDnsResolver.INSTANCE,
+            () -> "dummy"
+        );
         AuthenticationMethod authMethod = hba.resolveAuthenticationType("crate",
             new ConnectionProperties(InetAddresses.forString("1.2.3.4"), Protocol.TRANSPORT, mock(SSLSession.class)));
         assertThat(authMethod, instanceOf(ClientCertAuth.class));

--- a/server/src/test/java/io/crate/auth/HttpAuthUpstreamHandlerTest.java
+++ b/server/src/test/java/io/crate/auth/HttpAuthUpstreamHandlerTest.java
@@ -70,7 +70,12 @@ public class HttpAuthUpstreamHandlerTest extends ESTestCase {
         .build();
 
     // Roles always returns null, so there are no users (even no default crate superuser)
-    private final Authentication authService = new HostBasedAuthentication(hbaEnabled, List::of, SystemDefaultDnsResolver.INSTANCE);
+    private final Authentication authService = new HostBasedAuthentication(
+        hbaEnabled,
+        List::of,
+        SystemDefaultDnsResolver.INSTANCE,
+        () -> "dummy"
+    );
     private final HttpAuthUpstreamHandler handlerWithHBA = new HttpAuthUpstreamHandler(Settings.EMPTY, authService, new StubRoleManager());
 
     private static void assertUnauthorized(DefaultFullHttpResponse resp, String expectedBody) {

--- a/server/src/test/java/io/crate/auth/JwtAuthenticationIntegrationTest.java
+++ b/server/src/test/java/io/crate/auth/JwtAuthenticationIntegrationTest.java
@@ -155,6 +155,7 @@ public class JwtAuthenticationIntegrationTest extends IntegTestCase {
         String jwt = JWT.create()
             .withHeader(Map.of("typ", "JWT", "alg", "RS256", "kid", KID))
             .withIssuer(iss)
+            .withAudience(clusterService().state().metadata().clusterUUID())
             .withClaim("username", appUsername)
             .sign(Algorithm.RSA256(null, privateKey));
 
@@ -191,6 +192,7 @@ public class JwtAuthenticationIntegrationTest extends IntegTestCase {
         String jwt = JWT.create()
             .withHeader(Map.of("typ", "JWT", "alg", "RS256", "kid", KID))
             .withIssuer(iss)
+            .withAudience(clusterService().state().metadata().clusterUUID())
             .withClaim("username", appUsername)
             .sign(Algorithm.RSA256(null, privateKey));
 

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -569,7 +569,7 @@ public class InformationSchemaTest extends IntegTestCase {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertThat(response.rowCount()).isEqualTo(1015);
+        assertThat(response.rowCount()).isEqualTo(1016);
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/RoleManagementIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/RoleManagementIntegrationTest.java
@@ -102,6 +102,7 @@ public class RoleManagementIntegrationTest extends BaseRolesIntegrationTest {
             "granted_roles['grantor']| text_array",
             "granted_roles['role']| text_array",
             "jwt| object",
+            "jwt['aud']| text",
             "jwt['iss']| text",
             "jwt['username']| text",
             "name| text",
@@ -283,30 +284,26 @@ public class RoleManagementIntegrationTest extends BaseRolesIntegrationTest {
     }
 
     @Test
-    public void test_create_user_jwt_properties_must_be_unique() {
-        execute("CREATE USER user1 WITH (jwt = {\"iss\" = 'dummy.org/keys', \"username\" = 'app_user'})");
+    public void test_create_user_jwt_iss_and_username_must_be_unique() {
+        // 'aud' field is intentionally different in 2 CREATE statements as it's not taken to account on JWT uniqueness check.
+        execute("CREATE USER user1 WITH (jwt = {\"iss\" = 'dummy.org/keys', \"username\" = 'app_user', \"aud\" = 'aud1'})");
         execute("SELECT name, jwt from sys.users WHERE name = 'user1'");
-        assertThat(response).hasRows("user1| {iss=dummy.org/keys, username=app_user}");
-        Asserts.assertSQLError(() -> execute("CREATE USER user2 WITH (jwt = {\"iss\" = 'dummy.org/keys', \"username\" = 'app_user'})"))
+        assertThat(response).hasRows("user1| {aud=aud1, iss=dummy.org/keys, username=app_user}");
+        Asserts.assertSQLError(() -> execute("CREATE USER user2 WITH (jwt = {\"iss\" = 'dummy.org/keys', \"username\" = 'app_user',  \"aud\" = 'aud2'})"))
             .hasPGError(INTERNAL_ERROR)
             .hasHTTPError(CONFLICT, 4099)
-            .hasMessageContaining("Another role with the same combination of jwt properties already exists");
+            .hasMessageContaining("Another role with the same combination of iss/username jwt properties already exists");
     }
 
     @Test
-    public void test_alter_user_jwt_properties() {
+    public void test_alter_user_jwt_iss_and_username_must_be_unique() {
         execute("CREATE USER user1 WITH (password = 'pwd', jwt = {\"iss\" = 'issuer1', \"username\" = 'user1'})");
         execute("CREATE USER user2 WITH (password = 'pwd', jwt = {\"iss\" = 'issuer2', \"username\" = 'user2'})");
-
-        // Regular alter - update all properties
-        execute("ALTER USER user1 set (jwt = {\"iss\" = 'issuer11', \"username\" = 'user11'})");
-        execute("SELECT name, jwt from sys.users WHERE name = 'user1'");
-        assertThat(response).hasRows("user1| {iss=issuer11, username=user11}");
 
         // Updating JWT properties clashes with JWT properties of an existing user.
         Asserts.assertSQLError(() -> execute("ALTER USER user1 set (jwt = {\"iss\" = 'issuer2', \"username\" = 'user2'})"))
             .hasPGError(INTERNAL_ERROR)
             .hasHTTPError(CONFLICT, 4099)
-            .hasMessageContaining("Another role with the same combination of jwt properties already exists");
+            .hasMessageContaining("Another role with the same combination of iss/username jwt properties already exists");
     }
 }

--- a/server/src/test/java/io/crate/planner/node/ddl/CreateRolePlanTest.java
+++ b/server/src/test/java/io/crate/planner/node/ddl/CreateRolePlanTest.java
@@ -70,7 +70,7 @@ public class CreateRolePlanTest {
         final Map<String, Object> invalidJwtProperties = Maps.getOrDefault(parsedProperties, "jwt", Map.of());
         assertThatThrownBy(() -> JwtProperties.fromMap(invalidJwtProperties))
             .isExactlyInstanceOf(IllegalArgumentException.class)
-            .hasMessage("Only 'iss' and 'username' JWT properties are allowed");
+            .hasMessage("Only 'iss', 'username' and 'aud' JWT properties are allowed");
     }
 
 }

--- a/server/src/test/java/io/crate/role/CreateRoleRequestTest.java
+++ b/server/src/test/java/io/crate/role/CreateRoleRequestTest.java
@@ -37,7 +37,7 @@ public class CreateRoleRequestTest extends ESTestCase {
             new CreateRoleRequest("testUser",
                 false,
                 SecureHash.of(new SecureString("passwd".toCharArray())),
-                new JwtProperties("https:dummy.org", "test")
+                new JwtProperties("https:dummy.org", "test", "test_aud")
             );
 
         BytesStreamOutput out = new BytesStreamOutput();
@@ -46,8 +46,11 @@ public class CreateRoleRequestTest extends ESTestCase {
         assertThat(crr2.roleName()).isEqualTo(crr1.roleName());
         assertThat(crr2.secureHash()).isEqualTo(crr1.secureHash());
         assertThat(crr2.isUser()).isFalse();
-        assertThat(crr2.jwtProperties().iss()).isEqualTo("https:dummy.org");
-        assertThat(crr2.jwtProperties().username()).isEqualTo("test");
+        var jwtProps = crr2.jwtProperties();
+        assertThat(jwtProps).isNotNull();
+        assertThat(jwtProps.iss()).isEqualTo("https:dummy.org");
+        assertThat(jwtProps.username()).isEqualTo("test");
+        assertThat(jwtProps.aud()).isEqualTo("test_aud");
 
         out = new BytesStreamOutput();
         out.setVersion(Version.V_5_5_0);

--- a/server/src/test/java/io/crate/role/TransportRoleActionTest.java
+++ b/server/src/test/java/io/crate/role/TransportRoleActionTest.java
@@ -65,29 +65,33 @@ public class TransportRoleActionTest extends CrateDummyClusterServiceUnitTest {
             "root",
             true,
             null,
-            new JwtProperties("https:dummy.org", "test"));
+            new JwtProperties("https:dummy.org", "test", "test_aud"));
         RolesMetadata metadata = (RolesMetadata) mdBuilder.getCustom(RolesMetadata.TYPE);
         assertThat(metadata.roleNames()).containsExactly("root");
-        assertThat(metadata.roles().get("root").jwtProperties().iss()).isEqualTo("https:dummy.org");
-        assertThat(metadata.roles().get("root").jwtProperties().username()).isEqualTo("test");
+        var jwtProps = metadata.roles().get("root").jwtProperties();
+        assertThat(jwtProps).isNotNull();
+        assertThat(jwtProps.iss()).isEqualTo("https:dummy.org");
+        assertThat(jwtProps.username()).isEqualTo("test");
+        assertThat(jwtProps.aud()).isEqualTo("test_aud");
     }
 
     @Test
     public void test_create_user_with_matching_jwt_props_exists() throws Exception {
+        // Users have different "aud" property values - still clashing as only iss/username matters.
         Metadata.Builder mdBuilder = new Metadata.Builder();
         TransportCreateRoleAction.putRole(mdBuilder,
             "user1",
             true,
             null,
-            new JwtProperties("https:dummy.org", "test"));
+            new JwtProperties("https:dummy.org", "test", "aud1"));
 
         assertThatThrownBy(() -> TransportCreateRoleAction.putRole(mdBuilder,
                 "user2",
                 true,
                 null,
-                new JwtProperties("https:dummy.org", "test")))
+                new JwtProperties("https:dummy.org", "test", "aud2")))
             .isExactlyInstanceOf(RoleAlreadyExistsException.class)
-            .hasMessage("Another role with the same combination of jwt properties already exists");
+            .hasMessage("Another role with the same combination of iss/username jwt properties already exists");
     }
 
     @Test
@@ -97,13 +101,13 @@ public class TransportRoleActionTest extends CrateDummyClusterServiceUnitTest {
             "user1",
             true,
             null,
-            new JwtProperties("https:dummy.org", "test"));
+            new JwtProperties("https:dummy.org", "test", null));
 
         boolean exists = TransportCreateRoleAction.putRole(mdBuilder,
             "user1",
             true,
             null,
-            new JwtProperties("https:dummy.org", "test2"));
+            new JwtProperties("https:dummy.org", "test2", null));
         assertThat(exists).isTrue();
     }
 
@@ -284,7 +288,7 @@ public class TransportRoleActionTest extends CrateDummyClusterServiceUnitTest {
             mdBuilder,
             "DummyRole",
             null,
-            new JwtProperties("iss", "username"),
+            new JwtProperties("iss", "username", null),
             false,
             false))
             .isExactlyInstanceOf(UnsupportedFeatureException.class)
@@ -311,7 +315,7 @@ public class TransportRoleActionTest extends CrateDummyClusterServiceUnitTest {
             Set.of(),
             new HashSet<>(),
             oldPassword,
-            new JwtProperties("https:dummy.org", "test"))
+            new JwtProperties("https:dummy.org", "test", null))
         );
         var oldRolesMetadata = new RolesMetadata(roleWithJwtAndPassword);
         Metadata.Builder mdBuilder = Metadata.builder()
@@ -320,7 +324,7 @@ public class TransportRoleActionTest extends CrateDummyClusterServiceUnitTest {
             mdBuilder,
             "John",
             null,
-            new JwtProperties("new_issuer", "new_username"),
+            new JwtProperties("new_issuer", "new_username", null),
             false, // No reset, keep pwd
             false
         );
@@ -331,7 +335,7 @@ public class TransportRoleActionTest extends CrateDummyClusterServiceUnitTest {
                     Set.of(),
                     new HashSet<>(),
                     oldPassword,
-                    new JwtProperties("new_issuer", "new_username")
+                    new JwtProperties("new_issuer", "new_username", null)
                 )
             )
         );
@@ -346,7 +350,7 @@ public class TransportRoleActionTest extends CrateDummyClusterServiceUnitTest {
             Set.of(),
             new HashSet<>(),
             oldPassword,
-            new JwtProperties("https:dummy.org", "test"))
+            new JwtProperties("https:dummy.org", "test", null))
         );
         var oldRolesMetadata = new RolesMetadata(roleWithJwtAndPassword);
         Metadata.Builder mdBuilder = Metadata.builder()
@@ -375,19 +379,20 @@ public class TransportRoleActionTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void test_alter_user_throws_error_on_jwt_properties_clash() throws Exception {
         Map<String, Role> roleWithJwtAndPassword = new HashMap<>();
+        // Users have different "aud" property values - still clashing as only iss/username matters.
         roleWithJwtAndPassword.put("another_user_causing_clash", userOf(
             "another_user_causing_clash",
             Set.of(),
             new HashSet<>(),
             null,
-            new JwtProperties("https:dummy.org", "test"))
+            new JwtProperties("https:dummy.org", "test", "aud1"))
         );
         roleWithJwtAndPassword.put("John", userOf(
             "John",
             Set.of(),
             new HashSet<>(),
             null,
-            new JwtProperties("john's valid iss", "john's valid username"))
+            new JwtProperties("john's valid iss", "john's valid username", "aud2"))
         );
         var oldRolesMetadata = new RolesMetadata(roleWithJwtAndPassword);
         Metadata.Builder mdBuilder = Metadata.builder()
@@ -396,11 +401,11 @@ public class TransportRoleActionTest extends CrateDummyClusterServiceUnitTest {
             mdBuilder,
             "John",
             null,
-            new JwtProperties("https:dummy.org", "test"),
+            new JwtProperties("https:dummy.org", "test", null),
             false,
             false))
             .isExactlyInstanceOf(RoleAlreadyExistsException.class)
-            .hasMessage("Another role with the same combination of jwt properties already exists");
+            .hasMessage("Another role with the same combination of iss/username jwt properties already exists");
     }
 
 

--- a/server/src/test/java/io/crate/role/metadata/RolesHelper.java
+++ b/server/src/test/java/io/crate/role/metadata/RolesHelper.java
@@ -59,18 +59,20 @@ public final class RolesHelper {
      * Payload:
      * {
      *   "iss": "https://console.cratedb-dev.cloud/api/v2/meta/jwk/",
-     *   "username": "cloud_user"
+     *   "username": "cloud_user",
+     *   "aud": "test_cluster_id"
      * }
      */
     public static final String JWT_TOKEN = """
         eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IjEifQ.eyJpc3MiOiJod\
         HRwczovL2NvbnNvbGUuY3JhdGVkYi1kZXYuY2xvdWQvYXBpL3YyL21ldGEvandrL\
-        yIsInVzZXJuYW1lIjoiY2xvdWRfdXNlciJ9.sbawfydZA66n6T8hCvioLYpBrqov\
-        p0BuMCIhStrqGKpDiw2JLeB6e3Tb3a9T9nuMF0S7HHMXHKXrypPCuBxeJsR4jck9m\
-        DeVyPZ1i4daNK-wezF0n-OLPJAV_lOvgv_exi2mpi2Ws7tfS3Ht3ZY8aQIOtnZjwW\
-        1O2GAljToLfRopUzJ8f6MZtZw2UKfkHvWZUalCcA5WWTqqzBx8hELswJ_VkUyYWYq\
-        wFgjaHsn2xF8nrS7_qF8OhD59_gCEUOzqIN0z2ctjSxRbFQ6VUewqQwMYVJTP7Lyl\
-        c89wlemQGx6JVk7wqejbLeCJqiHJXZFUe69A5MsWK8SZXDTfQoGWow\
+        yIsInVzZXJuYW1lIjoiY2xvdWRfdXNlciIsImF1ZCI6InRlc3RfY2x1c3Rlcl9pZ\
+        CJ9.OYV2uPx7qr1bghV5Uwh3ZKH50ARVL3oeTBXZhpPNmEuzbxBjgWF8I-HULRrl\
+        5LbWIi4SPE5D98HF94cjL61ArkxcPC2IKZY2JVhVpO59C8sDDN1lO8GDbUr003sT\
+        PxBpQIrSrMd1YPU2C094lP7vfkqLJtwDhmHQgl4YF_5wiUXvMICOh_kT8KiWfaHP\
+        n9gPdnRo3UgwPZHOnUK1NMSfyl_6qT5Z46A0flpdzbBN1zjsvnr1aig_Nn6GvNeu\
+        hUuhLlDHh6Cq3TiPyKWhh5lAAjUUFEqZzj3IPdsSYE9LcKzt_laAsmZT9XIvJv4c\
+        Va_M2PLiMJlYwHUDU74Vta0Isw\
         """;
 
     public static Role JWT_USER = userOf(
@@ -78,7 +80,7 @@ public final class RolesHelper {
         Set.of(),
         new HashSet<>(),
         getSecureHash("johns-pwd"),
-        new JwtProperties("https://console.cratedb-dev.cloud/api/v2/meta/jwk/", "cloud_user")
+        new JwtProperties("https://console.cratedb-dev.cloud/api/v2/meta/jwk/", "cloud_user", "test_cluster_id")
     );
 
 

--- a/server/src/test/java/io/crate/role/metadata/RolesMetadataTest.java
+++ b/server/src/test/java/io/crate/role/metadata/RolesMetadataTest.java
@@ -78,7 +78,7 @@ public class RolesMetadataTest extends ESTestCase {
             Set.of(),
             new HashSet<>(),
             getSecureHash("johns-pwd"),
-            new JwtProperties("https:dummy.org", "test"))
+            new JwtProperties("https:dummy.org", "test", null))
         );
         DummyUsersAndRolesWithParentRoles.put("role1", roleOf("role1"));
         DummyUsersAndRolesWithParentRoles.put("role2", roleOf("role2"));
@@ -242,6 +242,23 @@ public class RolesMetadataTest extends ESTestCase {
         assertThatThrownBy(() -> JwtProperties.fromXContent(finalParser1))
             .isExactlyInstanceOf(ElasticsearchParseException.class)
             .hasMessage("failed to parse jwt, 'username' value is not a string [VALUE_NUMBER]");
+
+        xContentBuilder = JsonXContent.builder();
+        xContentBuilder.startObject();
+        xContentBuilder.field("iss", "dummy");
+        xContentBuilder.field("username", "dummy");
+        xContentBuilder.field("aud", 5);
+        xContentBuilder.endObject();
+
+        parser = JsonXContent.JSON_XCONTENT.createParser(
+            xContentRegistry(),
+            DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+            Strings.toString(xContentBuilder));
+
+        XContentParser finalParser2 = parser;
+        assertThatThrownBy(() -> JwtProperties.fromXContent(finalParser2))
+            .isExactlyInstanceOf(ElasticsearchParseException.class)
+            .hasMessage("failed to parse jwt, 'aud' value is not a string [VALUE_NUMBER]");
 
         xContentBuilder = JsonXContent.builder();
         xContentBuilder.startObject();


### PR DESCRIPTION
Follow up to https://github.com/crate/crate/pull/15650

Summary:
1. CREATE/ALTER user support aud property.
2. jwt authentication compares token.aud with user's aud if exists or cluster id.
3. Uniqueness check is done based on iss/username, see changes in `RolesMetadata.contains`
4. `JWT_TOKEN` constant is regenerated with "aud" as it's used in happy path scenarios or non-happy path scenarios where `aud` shouldn't  be a problem