### PR TITLE
Fix ALTER USER to actually update jwt properties

### DIFF
--- a/server/src/main/java/io/crate/role/TransportAlterRoleAction.java
+++ b/server/src/main/java/io/crate/role/TransportAlterRoleAction.java
@@ -96,10 +96,6 @@ public class TransportAlterRoleAction extends TransportMasterNodeAction<AlterRol
                                 request.resetPassword(),
                                 request.resetJwtProperties()
                         );
-                        RolesMetadata updatedRolesMetadata = (RolesMetadata) mdBuilder.getCustom(RolesMetadata.TYPE);
-                        if (updatedRolesMetadata != null && updatedRolesMetadata.contains(request.jwtProperties())) {
-                            throw new RoleAlreadyExistsException("Another role with the same combination of jwt properties already exists");
-                        }
                         return ClusterState.builder(currentState).metadata(mdBuilder).build();
                     }
 
@@ -139,6 +135,10 @@ public class TransportAlterRoleAction extends TransportMasterNodeAction<AlterRol
 
             var newSecureHash = secureHash != null ? secureHash : (resetPassword ? null : role.password());
             var newJwtProperties = jwtProperties != null ? jwtProperties : (resetJwtProperties ? null : role.jwtProperties());
+
+            if (newMetadata.contains(newJwtProperties)) {
+                throw new RoleAlreadyExistsException("Another role with the same combination of jwt properties already exists");
+            }
 
             newMetadata.roles().put(roleName, role.with(newSecureHash, newJwtProperties));
             exists = true;

--- a/server/src/test/java/io/crate/integrationtests/RoleManagementIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/RoleManagementIntegrationTest.java
@@ -297,6 +297,12 @@ public class RoleManagementIntegrationTest extends BaseRolesIntegrationTest {
     public void test_alter_user_jwt_properties() {
         execute("CREATE USER user1 WITH (password = 'pwd', jwt = {\"iss\" = 'issuer1', \"username\" = 'user1'})");
         execute("CREATE USER user2 WITH (password = 'pwd', jwt = {\"iss\" = 'issuer2', \"username\" = 'user2'})");
+
+        // Regular alter - update all properties
+        execute("ALTER USER user1 set (jwt = {\"iss\" = 'issuer11', \"username\" = 'user11'})");
+        execute("SELECT name, jwt from sys.users WHERE name = 'user1'");
+        assertThat(response).hasRows("user1| {iss=issuer11, username=user11}");
+
         // Updating JWT properties clashes with JWT properties of an existing user.
         Asserts.assertSQLError(() -> execute("ALTER USER user1 set (jwt = {\"iss\" = 'issuer2', \"username\" = 'user2'})"))
             .hasPGError(INTERNAL_ERROR)


### PR DESCRIPTION
Follow up to https://github.com/crate/crate/pull/15650

Bug: `checking contains(request.jwtProps)` after updating metadata is wrong as successfully updated values would clash with itself/request values. Instead, it should be done before updating metadata, similar to `CREATE ROLE`.


Tests in `TransportRoleActionTest` don't catch it since updating metadata in `alterRole` works fine - error was in throwing error later in `execute`.

Itest was testing only non-happy path where we actually had an actual clash  + "fake-clash" so this issue got invisible.