### PR TITLE
Fix false detections of equi-joins

### DIFF
--- a/server/src/main/java/io/crate/planner/operators/EquiJoinDetector.java
+++ b/server/src/main/java/io/crate/planner/operators/EquiJoinDetector.java
@@ -82,7 +82,11 @@ public class EquiJoinDetector {
                     }
                     break;
                 case EqOperator.NAME:
+                    if (context.isHashJoinPossible) {
+                        break;
+                    }
                     context.isHashJoinPossible = true;
+                    final var saveInsideEqOperator = context.insideEqOperator;
                     context.insideEqOperator = true;
                     Set<RelationName> usedRelationsFromBothEqOperatorArgs = new HashSet<>();
                     for (Symbol arg : function.arguments()) {
@@ -96,15 +100,13 @@ public class EquiJoinDetector {
                     if (usedRelationsFromBothEqOperatorArgs.size() < 2) {
                         context.isHashJoinPossible = false;
                     }
+                    context.insideEqOperator = saveInsideEqOperator;
                     break;
                 default:
                     if (context.insideEqOperator) {
                         for (Symbol arg : function.arguments()) {
                             arg.accept(this, context);
                         }
-                    } else {
-                        context.isHashJoinPossible = false;
-                        return null;
                     }
                     break;
             }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
~~Fixes https://github.com/crate/crate/issues/15613.~~ Follows https://github.com/crate/crate/pull/15682. Basically this fixes a variant of https://github.com/crate/crate/issues/15613:

```
SELECT * FROM t1 INNER  JOIN t0 ON (t1.c1 = t1.c1 and CASE 'q' WHEN t1.c0 THEN false ELSE (t0.c0 IN (t0.c0)) END);
```


There are two parts to this PR(the current commit is part1 and 2 not yet implemented).

---
**Part 1**

Before fix:
```
cr> explain verbose SELECT * FROM t1 INNER  JOIN t0 ON (t1.c1 = t1.c1) WHERE (CASE 'q' WHEN t1.c0 THEN false ELSE (t0.c0 IN (t0.c0)) END );  
                                                                                                                                                                                              
+-----------------------------+----------------------------------------------------------------------------------------------------+
| STEP                        | QUERY PLAN                                                                                         |
+-----------------------------+----------------------------------------------------------------------------------------------------+
| Initial logical plan        | Join[INNER | ((c1 = c1) AND case(true, (c0 = ANY(_array(c0))), ('q' = c0), false))] (rows=unknown) |
|                             |   ├ Collect[doc.t1 | [c0, c1] | true] (rows=unknown)                                               |
|                             |   └ Collect[doc.t0 | [c0] | true] (rows=unknown)                                                   |
| optimizer_rewrite_join_plan | HashJoin[((c1 = c1) AND case(true, (c0 = ANY(_array(c0))), ('q' = c0), false))] (rows=unknown)     |
|                             |   ├ Collect[doc.t1 | [c0, c1] | true] (rows=unknown)                                               |
|                             |   └ Collect[doc.t0 | [c0] | true] (rows=unknown)                                                   |
| Final logical plan          | HashJoin[((c1 = c1) AND case(true, (c0 = ANY(_array(c0))), ('q' = c0), false))] (rows=unknown)     |
|                             |   ├ Collect[doc.t1 | [c0, c1] | true] (rows=unknown)                                               |
|                             |   └ Collect[doc.t0 | [c0] | true] (rows=unknown)                                                   |
+-----------------------------+----------------------------------------------------------------------------------------------------+
```
After:
```
cr> explain verbose SELECT * FROM t1 INNER  JOIN t0 ON (t1.c1 = t1.c1) WHERE (CASE 'q' WHEN t1.c0 THEN false ELSE (t0.c0 IN (t0.c0)) END );  
                                                                                                                                                                                              
+-------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------+
| STEP                                                        | QUERY PLAN                                                                                                   |
+-------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------+
| Initial logical plan                                        | Join[INNER | ((c1 = c1) AND case(true, (c0 = ANY(_array(c0))), ('q' = c0), false))] (rows=unknown)           |
|                                                             |   ├ Collect[doc.t1 | [c0, c1] | true] (rows=unknown)                                                         |
|                                                             |   └ Collect[doc.t0 | [c0] | true] (rows=unknown)                                                             |
| optimizer_rewrite_join_plan                                 | NestedLoopJoin[INNER | ((c1 = c1) AND case(true, (c0 = ANY(_array(c0))), ('q' = c0), false))] (rows=unknown) |
|                                                             |   ├ Collect[doc.t1 | [c0, c1] | true] (rows=unknown)                                                         |
|                                                             |   └ Collect[doc.t0 | [c0] | true] (rows=unknown)                                                             |
| optimizer_move_constant_join_conditions_beneath_nested_loop | HashJoin[case(true, (c0 = ANY(_array(c0))), ('q' = c0), false)] (rows=unknown)                               |
|                                                             |   ├ Filter[(c1 = c1)] (rows=0)                                                                               |
|                                                             |   │  └ Collect[doc.t1 | [c0, c1] | true] (rows=unknown)                                                      |
|                                                             |   └ Collect[doc.t0 | [c0] | true] (rows=unknown)                                                             |
| optimizer_merge_filter_and_collect                          | HashJoin[case(true, (c0 = ANY(_array(c0))), ('q' = c0), false)] (rows=unknown)                               |
|                                                             |   ├ Collect[doc.t1 | [c0, c1] | (c1 = c1)] (rows=unknown)                                                    |
|                                                             |   └ Collect[doc.t0 | [c0] | true] (rows=unknown)                                                             |
| Final logical plan                                          | HashJoin[case(true, (c0 = ANY(_array(c0))), ('q' = c0), false)] (rows=unknown)                               |
|                                                             |   ├ Collect[doc.t1 | [c0, c1] | (NOT (c1 IS NULL))] (rows=unknown)                                           |
|                                                             |   └ Collect[doc.t0 | [c0] | true] (rows=unknown)                                                             |
+-------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------+
```

=> Basically fixed `EquiJoinDetector.isHashJoinPossible()` to return `false` for the bug scenario but it eventually becomes a hash join. A hash join with such join condition is invalid. `optimizer_move_constant_join_conditions_beneath_nested_loop` should be able to move the constant condition down without rewriting it to a hash join.

---
**Part 2**

This fix causes test failures which seem to be related to `optimizer_move_constant_join_conditions_beneath_nested_loop`, for example:
```
--before:
cr> explain verbose select doc.t1.*, doc.t2.b from doc.t1 join doc.t2 on doc.t1.x = doc.t2.y and doc.t2.b = 'abc';                                                                            
+-------------------------------------------------------------+----------------------------------------------------------------------+
| STEP                                                        | QUERY PLAN                                                           |
+-------------------------------------------------------------+----------------------------------------------------------------------+
| Initial logical plan                                        | Eval[x, b] (rows=unknown)                                            |
|                                                             |   └ Join[INNER | ((x = y) AND (b = 'abc'))] (rows=unknown)           |
|                                                             |     ├ Collect[doc.t1 | [x] | true] (rows=unknown)                    |
|                                                             |     └ Collect[doc.t2 | [b, y] | true] (rows=unknown)                 |
| optimizer_rewrite_join_plan                                 | Eval[x, b] (rows=unknown)                                            |
|                                                             |   └ NestedLoopJoin[INNER | ((x = y) AND (b = 'abc'))] (rows=unknown) |
|                                                             |     ├ Collect[doc.t1 | [x] | true] (rows=unknown)                    |
|                                                             |     └ Collect[doc.t2 | [b, y] | true] (rows=unknown)                 |
| optimizer_move_constant_join_conditions_beneath_nested_loop | Eval[x, b] (rows=unknown)                                            |
|                                                             |   └ HashJoin[(x = y)] (rows=unknown)                                 |
|                                                             |     ├ Collect[doc.t1 | [x] | true] (rows=unknown)                    |
|                                                             |     └ Filter[(b = 'abc')] (rows=0)                                   |
|                                                             |       └ Collect[doc.t2 | [b, y] | true] (rows=unknown)               |
| optimizer_merge_filter_and_collect                          | Eval[x, b] (rows=unknown)                                            |
|                                                             |   └ HashJoin[(x = y)] (rows=unknown)                                 |
|                                                             |     ├ Collect[doc.t1 | [x] | true] (rows=unknown)                    |
|                                                             |     └ Collect[doc.t2 | [b, y] | (b = 'abc')] (rows=unknown)          |
| Final logical plan                                          | Eval[x, b] (rows=unknown)                                            |
|                                                             |   └ HashJoin[(x = y)] (rows=unknown)                                 |
|                                                             |     ├ Collect[doc.t1 | [x] | true] (rows=unknown)                    |
|                                                             |     └ Collect[doc.t2 | [b, y] | (b = 'abc')] (rows=unknown)          |
+-------------------------------------------------------------+----------------------------------------------------------------------+
EXPLAIN 5 rows in set (3.273 sec)


-- after:
cr> explain verbose select doc.t1.*, doc.t2.b from doc.t1 join doc.t2 on doc.t1.x = doc.t2.y and doc.t2.b = 'abc';                                                                            
+-----------------------------+------------------------------------------------------------+
| STEP                        | QUERY PLAN                                                 |
+-----------------------------+------------------------------------------------------------+
| Initial logical plan        | Eval[x, b] (rows=unknown)                                  |
|                             |   └ Join[INNER | ((x = y) AND (b = 'abc'))] (rows=unknown) |
|                             |     ├ Collect[doc.t1 | [x] | true] (rows=unknown)          |
|                             |     └ Collect[doc.t2 | [b, y] | true] (rows=unknown)       |
| optimizer_rewrite_join_plan | Eval[x, b] (rows=unknown)                                  |
|                             |   └ HashJoin[((x = y) AND (b = 'abc'))] (rows=unknown)     |
|                             |     ├ Collect[doc.t1 | [x] | true] (rows=unknown)          |
|                             |     └ Collect[doc.t2 | [b, y] | true] (rows=unknown)       |
| Final logical plan          | Eval[x, b] (rows=unknown)                                  |
|                             |   └ HashJoin[((x = y) AND (b = 'abc'))] (rows=unknown)     |
|                             |     ├ Collect[doc.t1 | [x] | true] (rows=unknown)          |
|                             |     └ Collect[doc.t2 | [b, y] | true] (rows=unknown)       |
+-----------------------------+------------------------------------------------------------+
```

=> Maybe `optimizer_move_constant_join_conditions_beneath_nested_loop` should be allowed to constant-push-down on hash joins.


## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
