### PR TITLE
Replace broken jobs_log_filter example in docs

### DIFF
--- a/docs/config/cluster.rst
+++ b/docs/config/cluster.rst
@@ -105,7 +105,7 @@ Collecting stats
   common use case is to include only jobs that took a certain amount of time to
   execute::
 
-    cr> SET GLOBAL "stats.jobs_log_filter" = 'ended - started > 100';
+    cr> SET GLOBAL "stats.jobs_log_filter" = $$ended - started > '5 minutes'::interval$$;
 
 .. _stats.jobs_log_persistent_filter:
 


### PR DESCRIPTION
The query:

    SET GLOBAL "stats.jobs_log_filter" = 'ended - started > 100';

Failed with:

    Invalid filter expression: ended - started > 100: Unknown function: ...

Closes https://github.com/crate/crate/issues/15676
