### PR TITLE
Do not move where-clause parts to join condition if it's CASE expr

### DIFF
--- a/docs/appendices/release-notes/5.6.3.rst
+++ b/docs/appendices/release-notes/5.6.3.rst
@@ -100,5 +100,8 @@ Fixes
   is set to ``on`` which caused the clients to treat all query strings as non
   standard conforming.
 
+- Fixed an issue that caused a ``JOIN`` query to return invalid results when
+  the ``WHERE`` clause contains a ``CASE`` expression.
+
 - Fixed ``NullPointerException`` thrown when joining tables with ``USING``
   clause which contains columns not existing in either or both tables.

--- a/server/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
+++ b/server/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
@@ -42,6 +42,7 @@ import io.crate.analyze.relations.JoinPair;
 import io.crate.analyze.relations.QuerySplitter;
 import io.crate.common.collections.Lists;
 import io.crate.expression.operator.AndOperator;
+import io.crate.expression.scalar.conditional.CaseFunction;
 import io.crate.expression.symbol.FieldsVisitor;
 import io.crate.expression.symbol.RefVisitor;
 import io.crate.expression.symbol.SelectSymbol;
@@ -283,9 +284,12 @@ public class JoinPlanBuilder {
         while (queryIterator.hasNext()) {
             Map.Entry<Set<RelationName>, Symbol> queryEntry = queryIterator.next();
             Set<RelationName> relations = queryEntry.getKey();
+            Symbol implicitJoinCondition = queryEntry.getValue();
+            if (implicitJoinCondition instanceof io.crate.expression.symbol.Function func && CaseFunction.NAME.equals(func.name())) {
+                continue;
+            }
 
             if (relations.size() == 2) { // If more than 2 relations are involved it cannot be converted to a JoinPair
-                Symbol implicitJoinCondition = queryEntry.getValue();
                 JoinPair newJoinPair = null;
                 int existingJoinPairIdx = -1;
                 for (int i = 0; i < explicitJoinPairs.size(); i++) {

--- a/server/src/test/java/io/crate/planner/operators/JoinPlanBuilderTest.java
+++ b/server/src/test/java/io/crate/planner/operators/JoinPlanBuilderTest.java
@@ -37,7 +37,6 @@ import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.JoinPair;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.RelationName;
-import io.crate.planner.operators.JoinPlanBuilder;
 import io.crate.sql.tree.JoinType;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SqlExpressions;
@@ -178,5 +177,15 @@ public class JoinPlanBuilderTest extends CrateDummyClusterServiceUnitTest {
             assertThat(newPairAtPos.left()).isEqualTo(oldPairAtPos.left());
             assertThat(newPairAtPos.right()).isEqualTo(oldPairAtPos.right());
         }
+    }
+
+    @Test
+    public void test_convertImplicitJoinConditionsToJoinPairs_to_reject_case_expressions() {
+        List<JoinPair> joinPairs = List.of();
+        Map<Set<RelationName>, Symbol> remainingQueries = new HashMap<>();
+        remainingQueries.put(Set.of(T3.T1), asSymbol("case when t1.a > 5 then true else false end"));
+        List<JoinPair> newJoinPairs =
+            JoinPlanBuilder.convertImplicitJoinConditionsToJoinPairs(joinPairs, remainingQueries);
+        assertThat(newJoinPairs).isEmpty();
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes https://github.com/crate/crate/issues/15613.

On current master below is the explain output:
```
cr> explain verbose SELECT * FROM t1 INNER  JOIN t0 ON (t1.c1 = t1.c1) WHERE (CASE 'q' WHEN t1.c0 THEN false ELSE (t0.c0 IN (t0.c0)) END );  
                                                                                                                                                                                              
+-----------------------------+----------------------------------------------------------------------------------------------------+
| STEP                        | QUERY PLAN                                                                                         |
+-----------------------------+----------------------------------------------------------------------------------------------------+
| Initial logical plan        | Join[INNER | ((c1 = c1) AND case(true, (c0 = ANY(_array(c0))), ('q' = c0), false))] (rows=unknown) |
|                             |   ├ Collect[doc.t1 | [c0, c1] | true] (rows=unknown)                                               |
|                             |   └ Collect[doc.t0 | [c0] | true] (rows=unknown)                                                   |
| optimizer_rewrite_join_plan | HashJoin[((c1 = c1) AND case(true, (c0 = ANY(_array(c0))), ('q' = c0), false))] (rows=unknown)     |
|                             |   ├ Collect[doc.t1 | [c0, c1] | true] (rows=unknown)                                               |
|                             |   └ Collect[doc.t0 | [c0] | true] (rows=unknown)                                                   |
| Final logical plan          | HashJoin[((c1 = c1) AND case(true, (c0 = ANY(_array(c0))), ('q' = c0), false))] (rows=unknown)     |
|                             |   ├ Collect[doc.t1 | [c0, c1] | true] (rows=unknown)                                               |
|                             |   └ Collect[doc.t0 | [c0] | true] (rows=unknown)                                                   |
+-----------------------------+----------------------------------------------------------------------------------------------------+
```
I think there are two issues involved which are 1) the `case` expr moving to join condition and 2) rewriting such inner join to a hash join. 1) is handled by this PR and 2) is handled by https://github.com/crate/crate/pull/15677.

When 2) is fixed, fixing 1) becomes unnecessary but as the name suggests `convertImplicitJoinConditionsToJoinPairs`, `case` should not go thought implicit to explicit join condition conversion.

With proper implementation of 1), I expect to see the following explain output:
```
cr> explain verbose SELECT * FROM t1 INNER  JOIN t0 ON (t1.c1 = t1.c1) WHERE (CASE 'q' WHEN t1.c0 THEN false ELSE (t0.c0 IN (t0.c0)) END );  
                                                                                                                                                                                              
+-------------------------------------------------------------+------------------------------------------------------------------------+
| STEP                                                        | QUERY PLAN                                                             |
+-------------------------------------------------------------+------------------------------------------------------------------------+
| Initial logical plan                                        | Filter[case(true, (c0 = ANY(_array(c0))), ('q' = c0), false)] (rows=0) |
|                                                             |   └ Join[INNER | (c1 = c1)] (rows=unknown)                             |
|                                                             |     ├ Collect[doc.t1 | [c0, c1] | true] (rows=unknown)                 |
|                                                             |     └ Collect[doc.t0 | [c0] | true] (rows=unknown)                     |
| optimizer_rewrite_join_plan                                 | Filter[case(true, (c0 = ANY(_array(c0))), ('q' = c0), false)] (rows=0) |
|                                                             |   └ NestedLoopJoin[INNER | (c1 = c1)] (rows=unknown)                   |
|                                                             |     ├ Collect[doc.t1 | [c0, c1] | true] (rows=unknown)                 |
|                                                             |     └ Collect[doc.t0 | [c0] | true] (rows=unknown)                     |
| optimizer_move_constant_join_conditions_beneath_nested_loop | Filter[case(true, (c0 = ANY(_array(c0))), ('q' = c0), false)] (rows=0) |
|                                                             |   └ NestedLoopJoin[INNER | (c1 = c1)] (rows=unknown)                   |
|                                                             |     ├ Collect[doc.t1 | [c0, c1] | true] (rows=unknown)                 |
|                                                             |     └ Collect[doc.t0 | [c0] | true] (rows=unknown)                     |
| Final logical plan                                          | Filter[case(true, (c0 = ANY(_array(c0))), ('q' = c0), false)] (rows=0) |
|                                                             |   └ NestedLoopJoin[INNER | (c1 = c1)] (rows=unknown)                   |
|                                                             |     ├ Collect[doc.t1 | [c0, c1] | true] (rows=unknown)                 |
|                                                             |     └ Collect[doc.t0 | [c0] | true] (rows=unknown)                     |
+-------------------------------------------------------------+------------------------------------------------------------------------+
```

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
