### PR TITLE
Ensure operations unsupported on views/foreign tables raise helpful error

### DIFF
--- a/server/src/test/java/io/crate/fdw/ForeignDataWrapperPlannerTest.java
+++ b/server/src/test/java/io/crate/fdw/ForeignDataWrapperPlannerTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 import org.elasticsearch.common.settings.Settings;
 import org.junit.Test;
 
+import io.crate.exceptions.OperationOnInaccessibleRelationException;
 import io.crate.planner.CreateForeignTablePlan;
 import io.crate.planner.CreateServerPlan;
 import io.crate.planner.CreateUserMappingPlan;
@@ -39,8 +40,7 @@ public class ForeignDataWrapperPlannerTest extends CrateDummyClusterServiceUnitT
 
     @Test
     public void test_creating_foreign_table_with_invalid_name_fails() throws Exception {
-        SQLExecutor e = SQLExecutor.builder(clusterService)
-            .build();
+        SQLExecutor e = SQLExecutor.of(clusterService);
 
         assertThatThrownBy(() -> e.plan("create foreign table sys.nope (x int) server pg"))
             .isExactlyInstanceOf(IllegalArgumentException.class)
@@ -49,7 +49,7 @@ public class ForeignDataWrapperPlannerTest extends CrateDummyClusterServiceUnitT
 
     @Test
     public void test_create_server_fails_if_mandatory_options_are_missing() throws Exception {
-        var e = SQLExecutor.builder(clusterService).build();
+        var e = SQLExecutor.of(clusterService);
         CreateServerPlan plan = e.plan("create server pg foreign data wrapper jdbc");
         assertThatThrownBy(() -> e.execute(plan).getResult())
             .isExactlyInstanceOf(IllegalArgumentException.class)
@@ -58,7 +58,7 @@ public class ForeignDataWrapperPlannerTest extends CrateDummyClusterServiceUnitT
 
     @Test
     public void test_cannot_use_unsupported_options_in_create_server() throws Exception {
-        var e = SQLExecutor.builder(clusterService).build();
+        var e = SQLExecutor.of(clusterService);
         CreateServerPlan plan = e.plan("create server pg foreign data wrapper jdbc options (url '', wrong_option 10)");
         assertThatThrownBy(() -> e.execute(plan).getResult())
             .isExactlyInstanceOf(IllegalArgumentException.class)
@@ -67,7 +67,7 @@ public class ForeignDataWrapperPlannerTest extends CrateDummyClusterServiceUnitT
 
     @Test
     public void test_cannot_create_server_if_fdw_is_missing() throws Exception {
-        var e = SQLExecutor.builder(clusterService).build();
+        var e = SQLExecutor.of(clusterService);
         String stmt = "create server pg foreign data wrapper dummy options (host 'localhost', dbname 'doc', port '5432')";
         CreateServerPlan plan = e.plan(stmt);
         assertThatThrownBy(() -> e.execute(plan).getResult())
@@ -118,5 +118,23 @@ public class ForeignDataWrapperPlannerTest extends CrateDummyClusterServiceUnitT
             ) SERVER pg OPTIONS (schema_name 'doc')
             """.stripIndent().trim()
         );
+    }
+
+    @Test
+    public void test_doc_table_operations_raise_helpful_error_on_foreign_tables() throws Exception {
+        Settings options = Settings.builder()
+            .put("url", "jdbc:postgresql://localhost:5432/")
+            .build();
+        var e = SQLExecutor.of(clusterService)
+            .addServer("pg", "jdbc", "crate", options)
+            .addForeignTable("create foreign table doc.tbl (x int) server pg options (schema_name 'doc')");
+
+        assertThatThrownBy(() -> e.plan("optimize table doc.tbl"))
+            .isExactlyInstanceOf(OperationOnInaccessibleRelationException.class)
+            .hasMessage("The relation \"doc.tbl\" doesn't support or allow OPTIMIZE operations.");
+
+        assertThatThrownBy(() -> e.plan("refresh table doc.tbl"))
+            .isExactlyInstanceOf(OperationOnInaccessibleRelationException.class)
+            .hasMessage("The relation \"doc.tbl\" doesn't support or allow REFRESH operations.");
     }
 }

--- a/server/src/test/java/io/crate/planner/ViewPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/ViewPlannerTest.java
@@ -22,11 +22,13 @@
 package io.crate.planner;
 
 import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 
 import org.junit.Test;
 
+import io.crate.exceptions.OperationOnInaccessibleRelationException;
 import io.crate.metadata.RelationName;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
@@ -57,5 +59,19 @@ public class ViewPlannerTest extends CrateDummyClusterServiceUnitTest {
                       └ Collect[doc.t1 | [id, o['i']] | true]
             """;
         assertThat(logicalPlan).isEqualTo(expectedPlan);
+    }
+
+    @Test
+    public void test_doc_table_operations_raise_helpful_error_on_views() throws Exception {
+        var e = SQLExecutor.of(clusterService)
+            .addView(new RelationName("doc", "v1"), "select * from sys.summits");
+
+        assertThatThrownBy(() -> e.plan("optimize table doc.v1"))
+            .isExactlyInstanceOf(OperationOnInaccessibleRelationException.class)
+            .hasMessage("The relation \"doc.v1\" doesn't support or allow OPTIMIZE operations, as it is read-only.");
+
+        assertThatThrownBy(() -> e.plan("refresh table doc.v1"))
+            .isExactlyInstanceOf(OperationOnInaccessibleRelationException.class)
+            .hasMessage("The relation \"doc.v1\" doesn't support or allow REFRESH operations, as it is read-only.");
     }
 }


### PR DESCRIPTION
`resolveTableInfo` didn't look for foreign tables, so users would get a
relation unknown error instead of a operation-not-supported error.
