### PR TITLE
Raise helpful error on CREATE PUBLICATION with system-/foreign table

### DIFF
--- a/docs/sql/statements/create-foreign-table.rst
+++ b/docs/sql/statements/create-foreign-table.rst
@@ -43,6 +43,10 @@ to view the definition of an existing foreign table.
 
 Creating a foreign table requires ``AL`` permission on schema or cluster level.
 
+A foreign table cannot be used in :ref:`sql-create-publication` for logical
+replication.
+
+
 Clauses
 =======
 

--- a/docs/sql/statements/create-publication.rst
+++ b/docs/sql/statements/create-publication.rst
@@ -46,6 +46,10 @@ If neither ``FOR TABLE`` nor ``FOR ALL TABLES`` is specified, then the publicati
 starts out with an empty set of tables. That is useful if tables are to be
 added later. The creation of a publication does not start any replication.
 
+It is not possible to use system tables or foreign tables in a publication.
+Using them in an explicit ``FOR TABLE`` clause results in an error. With the
+``FOR ALL TABLES`` clause they're excluded.
+
 .. _sql-create-publication-params:
 
 Parameters

--- a/server/src/main/java/io/crate/analyze/Analyzer.java
+++ b/server/src/main/java/io/crate/analyze/Analyzer.java
@@ -695,7 +695,7 @@ public class Analyzer {
         @Override
         public AnalyzedStatement visitCreatePublication(CreatePublication createPublication,
                                                         Analysis context) {
-            return logicalReplicationAnalyzer.analyze(createPublication, context.sessionSettings());
+            return logicalReplicationAnalyzer.analyze(createPublication, context.transactionContext());
         }
 
         @Override

--- a/server/src/main/java/io/crate/metadata/table/Operation.java
+++ b/server/src/main/java/io/crate/metadata/table/Operation.java
@@ -21,19 +21,20 @@
 
 package io.crate.metadata.table;
 
-import io.crate.exceptions.OperationOnInaccessibleRelationException;
-import org.elasticsearch.cluster.metadata.IndexMetadata;
-import io.crate.common.collections.MapBuilder;
-import org.elasticsearch.common.settings.Settings;
-import io.crate.common.collections.Sets;
-import io.crate.metadata.RelationInfo;
+import static io.crate.replication.logical.LogicalReplicationSettings.REPLICATION_SUBSCRIPTION_NAME;
 
 import java.util.EnumSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
-import static io.crate.replication.logical.LogicalReplicationSettings.REPLICATION_SUBSCRIPTION_NAME;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.settings.Settings;
+
+import io.crate.common.collections.MapBuilder;
+import io.crate.common.collections.Sets;
+import io.crate.exceptions.OperationOnInaccessibleRelationException;
+import io.crate.metadata.RelationInfo;
 
 public enum Operation {
     READ("READ"),
@@ -52,7 +53,8 @@ public enum Operation {
     OPTIMIZE("OPTIMIZE"),
     COPY_TO("COPY TO"),
     RESTORE_SNAPSHOT("RESTORE SNAPSHOT"),
-    CREATE_SNAPSHOT("CREATE SNAPSHOT"),;
+    CREATE_SNAPSHOT("CREATE SNAPSHOT"),
+    CREATE_PUBLICATION("CREATE PUBLICATION");
 
     public static final EnumSet<Operation> ALL = EnumSet.allOf(Operation.class);
     public static final EnumSet<Operation> SYS_READ_ONLY = EnumSet.of(READ);
@@ -130,11 +132,8 @@ public enum Operation {
             } else if (relationInfo.supportedOperations().equals(PUBLISHED_IN_LOGICAL_REPLICATION)) {
                 exceptionMessage = "The relation \"%s\" doesn't allow %s operations, because it is included in a " +
                                    "logical replication publication.";
-            } else if (relationInfo.supportedOperations().equals(SYS_READ_ONLY) ||
-                relationInfo.supportedOperations().equals(READ_ONLY)) {
-                exceptionMessage = "The relation \"%s\" doesn't support or allow %s operations, as it is read-only.";
             } else {
-                exceptionMessage = "The relation \"%s\" doesn't support or allow %s operations.";
+                exceptionMessage = "The relation \"%s\" doesn't support or allow %s operations";
             }
             throw new OperationOnInaccessibleRelationException(relationInfo.ident(), String.format(Locale.ENGLISH,
                 exceptionMessage, relationInfo.ident().fqn(), operation));

--- a/server/src/test/java/io/crate/analyze/AlterTableAddColumnAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/AlterTableAddColumnAnalyzerTest.java
@@ -76,7 +76,7 @@ public class AlterTableAddColumnAnalyzerTest extends CrateDummyClusterServiceUni
 
         assertThatThrownBy(() -> e.analyze("alter table sys.shards add column foobar string"))
             .hasMessage("The relation \"sys.shards\" doesn't support or allow ALTER " +
-                "operations, as it is read-only.");
+                "operations");
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/AlterTableDropColumnAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/AlterTableDropColumnAnalyzerTest.java
@@ -225,7 +225,7 @@ public class AlterTableDropColumnAnalyzerTest extends CrateDummyClusterServiceUn
         assertThatThrownBy(() -> e.analyze("ALTER TABLE sys.shards DROP COLUMN foobar"))
             .isExactlyInstanceOf(OperationOnInaccessibleRelationException.class)
             .hasMessage("The relation \"sys.shards\" doesn't support or allow ALTER " +
-                "operations, as it is read-only.");
+                "operations");
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/AlterTableOpenCloseAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/AlterTableOpenCloseAnalyzerTest.java
@@ -46,6 +46,6 @@ public class AlterTableOpenCloseAnalyzerTest extends CrateDummyClusterServiceUni
         assertThatThrownBy(() -> e.analyze("alter table sys.shards close"))
             .isExactlyInstanceOf(OperationOnInaccessibleRelationException.class)
             .hasMessage("The relation \"sys.shards\" doesn't support or allow " +
-                        "ALTER CLOSE operations, as it is read-only.");
+                        "ALTER CLOSE operations");
     }
 }

--- a/server/src/test/java/io/crate/analyze/AlterTableRerouteAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/AlterTableRerouteAnalyzerTest.java
@@ -89,7 +89,7 @@ public class AlterTableRerouteAnalyzerTest extends CrateDummyClusterServiceUnitT
         assertThatThrownBy(() -> analyze("ALTER TABLE sys.cluster REROUTE MOVE SHARD 0 FROM 'n1' TO 'n2'"))
             .isExactlyInstanceOf(OperationOnInaccessibleRelationException.class)
             .hasMessage("The relation \"sys.cluster\" doesn't support or" +
-                        " allow ALTER REROUTE operations, as it is read-only.");
+                        " allow ALTER REROUTE operations");
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/BlobTableAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/BlobTableAnalyzerTest.java
@@ -268,7 +268,7 @@ public class BlobTableAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     public void testAlterBlobTableRenameTable() {
         assertThatThrownBy(() -> e.analyze("alter blob table blobs rename to blobbier"))
             .isExactlyInstanceOf(OperationOnInaccessibleRelationException.class)
-            .hasMessage("The relation \"blob.blobs\" doesn't support or allow ALTER RENAME operations.");
+            .hasMessage("The relation \"blob.blobs\" doesn't support or allow ALTER RENAME operations");
     }
 
     @Test
@@ -282,7 +282,7 @@ public class BlobTableAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     public void testAlterBlobTableOpenClose() {
         assertThatThrownBy(() -> e.analyze("alter blob table blobs close"))
             .isExactlyInstanceOf(OperationOnInaccessibleRelationException.class)
-            .hasMessage("The relation \"blob.blobs\" doesn't support or allow ALTER CLOSE operations.");
+            .hasMessage("The relation \"blob.blobs\" doesn't support or allow ALTER CLOSE operations");
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/CopyAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CopyAnalyzerTest.java
@@ -137,7 +137,7 @@ public class CopyAnalyzerTest extends CrateDummyClusterServiceUnitTest {
             .isExactlyInstanceOf(OperationOnInaccessibleRelationException.class)
             .hasMessage(
                 "The relation \"sys.shards\" doesn't support or allow INSERT " +
-                "operations, as it is read-only.");
+                "operations");
     }
 
     @Test
@@ -227,7 +227,7 @@ public class CopyAnalyzerTest extends CrateDummyClusterServiceUnitTest {
             .isExactlyInstanceOf(OperationOnInaccessibleRelationException.class)
             .hasMessage(
                 "The relation \"sys.nodes\" doesn't support or allow COPY TO " +
-                "operations, as it is read-only.");
+                "operations");
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -706,7 +706,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
     public void testAlterSystemTable() {
         assertThatThrownBy(() -> analyze("alter table sys.shards reset (number_of_replicas)"))
             .isExactlyInstanceOf(OperationOnInaccessibleRelationException.class)
-            .hasMessage("The relation \"sys.shards\" doesn't support or allow ALTER operations, as it is read-only.");
+            .hasMessage("The relation \"sys.shards\" doesn't support or allow ALTER operations");
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/DeleteAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/DeleteAnalyzerTest.java
@@ -76,7 +76,7 @@ public class DeleteAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         assertThatThrownBy(() -> e.analyze("delete from sys.nodes where name='Trillian'"))
             .isExactlyInstanceOf(OperationOnInaccessibleRelationException.class)
             .hasMessage("The relation \"sys.nodes\" doesn't support or allow DELETE " +
-                        "operations, as it is read-only.");
+                        "operations");
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/DropTableAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/DropTableAnalyzerTest.java
@@ -67,7 +67,7 @@ public class DropTableAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         assertThatThrownBy(() -> e.analyze("drop table sys.cluster"))
             .isExactlyInstanceOf(OperationOnInaccessibleRelationException.class)
             .hasMessage("The relation \"sys.cluster\" doesn't support or allow DROP " +
-                        "operations, as it is read-only.");
+                        "operations");
     }
 
     @Test
@@ -75,7 +75,7 @@ public class DropTableAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         assertThatThrownBy(() -> e.analyze("drop table information_schema.tables"))
             .isExactlyInstanceOf(OperationOnInaccessibleRelationException.class)
             .hasMessage("The relation \"information_schema.tables\" doesn't support or allow " +
-                        "DROP operations, as it is read-only.");
+                        "DROP operations");
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/OptimizeTableAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/OptimizeTableAnalyzerTest.java
@@ -75,7 +75,7 @@ public class OptimizeTableAnalyzerTest extends CrateDummyClusterServiceUnitTest 
     public void testOptimizeSystemTable() throws Exception {
         expectedException.expect(OperationOnInaccessibleRelationException.class);
         expectedException.expectMessage("The relation \"sys.shards\" doesn't support or allow OPTIMIZE " +
-                                        "operations, as it is read-only.");
+                                        "operations");
         analyze("OPTIMIZE TABLE sys.shards");
     }
 
@@ -182,7 +182,7 @@ public class OptimizeTableAnalyzerTest extends CrateDummyClusterServiceUnitTest 
     public void testOptimizeSysPartitioned() throws Exception {
         expectedException.expect(OperationOnInaccessibleRelationException.class);
         expectedException.expectMessage("The relation \"sys.shards\" doesn't support or allow OPTIMIZE " +
-                                        "operations, as it is read-only.");
+                                        "operations");
         analyze("OPTIMIZE TABLE sys.shards PARTITION (id='n')");
     }
 }

--- a/server/src/test/java/io/crate/analyze/RefreshAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/RefreshAnalyzerTest.java
@@ -57,7 +57,7 @@ public class RefreshAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     public void testRefreshSystemTable() throws Exception {
         expectedException.expect(OperationOnInaccessibleRelationException.class);
         expectedException.expectMessage("The relation \"sys.shards\" doesn't support or allow REFRESH " +
-                                        "operations, as it is read-only.");
+                                        "operations");
         e.analyze("refresh table sys.shards");
     }
 
@@ -65,7 +65,7 @@ public class RefreshAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     public void testRefreshBlobTable() throws Exception {
         expectedException.expect(OperationOnInaccessibleRelationException.class);
         expectedException.expectMessage("The relation \"blob.blobs\" doesn't support or allow REFRESH " +
-                                        "operations.");
+                                        "operations");
         e.analyze("refresh table blob.blobs");
     }
 
@@ -92,7 +92,7 @@ public class RefreshAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     public void testRefreshSysPartitioned() throws Exception {
         expectedException.expect(OperationOnInaccessibleRelationException.class);
         expectedException.expectMessage("The relation \"sys.shards\" doesn't support or allow REFRESH" +
-                                        " operations, as it is read-only.");
+                                        " operations");
         e.analyze("refresh table sys.shards partition (id='n')");
     }
 
@@ -100,7 +100,7 @@ public class RefreshAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     public void testRefreshBlobPartitioned() throws Exception {
         expectedException.expect(OperationOnInaccessibleRelationException.class);
         expectedException.expectMessage("The relation \"blob.blobs\" doesn't support or allow REFRESH " +
-                                        "operations.");
+                                        "operations");
         e.analyze("refresh table blob.blobs partition (n='n')");
     }
 

--- a/server/src/test/java/io/crate/analyze/RestoreSnapshotAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/RestoreSnapshotAnalyzerTest.java
@@ -214,7 +214,7 @@ public class RestoreSnapshotAnalyzerTest extends CrateDummyClusterServiceUnitTes
         assertThatThrownBy(() -> analyze(e, "CREATE SNAPSHOT my_repo.my_snapshot TABLE sys.shards"))
             .isExactlyInstanceOf(OperationOnInaccessibleRelationException.class)
             .hasMessage("The relation \"sys.shards\" doesn't support or allow " +
-                        "CREATE SNAPSHOT operations, as it is read-only.");
+                        "CREATE SNAPSHOT operations");
     }
 
     @Test
@@ -228,7 +228,7 @@ public class RestoreSnapshotAnalyzerTest extends CrateDummyClusterServiceUnitTes
     public void testCreateSnapshotFromBlobTable() throws Exception {
         assertThatThrownBy(() -> analyze(e, "CREATE SNAPSHOT my_repo.my_snapshot TABLE blob.my_blobs"))
             .isExactlyInstanceOf(OperationOnInaccessibleRelationException.class)
-            .hasMessage("The relation \"blob.my_blobs\" doesn't support or allow CREATE SNAPSHOT operations.");
+            .hasMessage("The relation \"blob.my_blobs\" doesn't support or allow CREATE SNAPSHOT operations");
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/SwapTableAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SwapTableAnalyzerTest.java
@@ -70,7 +70,7 @@ public class SwapTableAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testSwapTableDoesNotWorkOnSystemTables() {
-        expectedException.expectMessage("The relation \"sys.cluster\" doesn't support or allow ALTER operations, as it is read-only.");
+        expectedException.expectMessage("The relation \"sys.cluster\" doesn't support or allow ALTER operations");
         e.analyze("alter cluster swap table sys.cluster to t2");
     }
 }

--- a/server/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
@@ -168,7 +168,7 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     public void testUpdateSysTables() throws Exception {
         expectedException.expect(OperationOnInaccessibleRelationException.class);
         expectedException.expectMessage("The relation \"sys.nodes\" doesn't support or allow UPDATE " +
-                                        "operations, as it is read-only.");
+                                        "operations");
         analyze("update sys.nodes set fs={\"free\"=0}");
     }
 

--- a/server/src/test/java/io/crate/fdw/ForeignDataWrapperPlannerTest.java
+++ b/server/src/test/java/io/crate/fdw/ForeignDataWrapperPlannerTest.java
@@ -131,10 +131,14 @@ public class ForeignDataWrapperPlannerTest extends CrateDummyClusterServiceUnitT
 
         assertThatThrownBy(() -> e.plan("optimize table doc.tbl"))
             .isExactlyInstanceOf(OperationOnInaccessibleRelationException.class)
-            .hasMessage("The relation \"doc.tbl\" doesn't support or allow OPTIMIZE operations.");
+            .hasMessage("The relation \"doc.tbl\" doesn't support or allow OPTIMIZE operations");
 
         assertThatThrownBy(() -> e.plan("refresh table doc.tbl"))
             .isExactlyInstanceOf(OperationOnInaccessibleRelationException.class)
-            .hasMessage("The relation \"doc.tbl\" doesn't support or allow REFRESH operations.");
+            .hasMessage("The relation \"doc.tbl\" doesn't support or allow REFRESH operations");
+
+        assertThatThrownBy(() -> e.plan("create publication pub1 for table doc.tbl"))
+            .isExactlyInstanceOf(OperationOnInaccessibleRelationException.class)
+            .hasMessage("The relation \"doc.tbl\" doesn't support or allow CREATE PUBLICATION operations");
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
@@ -46,7 +46,7 @@ public class ShowIntegrationTest extends IntegTestCase {
         Asserts.assertSQLError(() -> execute("show create table sys.shards"))
             .hasPGError(INTERNAL_ERROR)
             .hasHTTPError(BAD_REQUEST, 4007)
-            .hasMessageContaining("The relation \"sys.shards\" doesn't support or allow SHOW CREATE operations, as it is read-only.");
+            .hasMessageContaining("The relation \"sys.shards\" doesn't support or allow SHOW CREATE operations");
     }
 
     @Test
@@ -55,7 +55,7 @@ public class ShowIntegrationTest extends IntegTestCase {
         Asserts.assertSQLError(() -> execute("show create table blob.table_blob"))
             .hasPGError(INTERNAL_ERROR)
             .hasHTTPError(BAD_REQUEST, 4007)
-            .hasMessageContaining("The relation \"blob.table_blob\" doesn't support or allow SHOW CREATE operations.");
+            .hasMessageContaining("The relation \"blob.table_blob\" doesn't support or allow SHOW CREATE operations");
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/TableBlocksIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TableBlocksIntegrationTest.java
@@ -70,7 +70,7 @@ public class TableBlocksIntegrationTest extends IntegTestCase {
             .hasHTTPError(BAD_REQUEST, 4007)
             .hasMessageContaining(String.format(
                 Locale.ENGLISH,
-                "The relation \"%s.t1\" doesn't support or allow INSERT operations.",
+                "The relation \"%s.t1\" doesn't support or allow INSERT operations",
                 sqlExecutor.getCurrentSchema()));
     }
 
@@ -84,7 +84,7 @@ public class TableBlocksIntegrationTest extends IntegTestCase {
             .hasHTTPError(BAD_REQUEST, 4007)
             .hasMessageContaining(String.format(
                 Locale.ENGLISH,
-                "The relation \"%s.t1\" doesn't support or allow UPDATE operations.",
+                "The relation \"%s.t1\" doesn't support or allow UPDATE operations",
                 sqlExecutor.getCurrentSchema()));
     }
 
@@ -98,7 +98,7 @@ public class TableBlocksIntegrationTest extends IntegTestCase {
             .hasHTTPError(BAD_REQUEST, 4007)
             .hasMessageContaining(String.format(
                 Locale.ENGLISH,
-                "The relation \"%s.t1\" doesn't support or allow DELETE operations.",
+                "The relation \"%s.t1\" doesn't support or allow DELETE operations",
                 sqlExecutor.getCurrentSchema()
             ));
     }
@@ -113,7 +113,7 @@ public class TableBlocksIntegrationTest extends IntegTestCase {
             .hasHTTPError(BAD_REQUEST, 4007)
             .hasMessageContaining(String.format(
                 Locale.ENGLISH,
-                "The relation \"%s.t1\" doesn't support or allow DROP operations.",
+                "The relation \"%s.t1\" doesn't support or allow DROP operations",
                 sqlExecutor.getCurrentSchema()));
     }
 
@@ -127,7 +127,7 @@ public class TableBlocksIntegrationTest extends IntegTestCase {
             .hasHTTPError(BAD_REQUEST, 4007)
             .hasMessageContaining(String.format(
                 Locale.ENGLISH,
-                "The relation \"%s.t1\" doesn't support or allow ALTER operations.",
+                "The relation \"%s.t1\" doesn't support or allow ALTER operations",
                 sqlExecutor.getCurrentSchema()));
     }
 
@@ -141,7 +141,7 @@ public class TableBlocksIntegrationTest extends IntegTestCase {
             .hasHTTPError(BAD_REQUEST, 4007)
             .hasMessageContaining(String.format(
                 Locale.ENGLISH,
-                "The relation \"%s.t1\" doesn't support or allow ALTER operations.",
+                "The relation \"%s.t1\" doesn't support or allow ALTER operations",
                 sqlExecutor.getCurrentSchema())
             );
     }
@@ -170,7 +170,7 @@ public class TableBlocksIntegrationTest extends IntegTestCase {
             .hasHTTPError(BAD_REQUEST, 4007)
             .hasMessageContaining(String.format(
                 Locale.ENGLISH,
-                "The relation \"%s.t1\" doesn't support or allow READ operations.",
+                "The relation \"%s.t1\" doesn't support or allow READ operations",
                 sqlExecutor.getCurrentSchema())
             );
     }
@@ -187,7 +187,7 @@ public class TableBlocksIntegrationTest extends IntegTestCase {
             .hasHTTPError(BAD_REQUEST, 4007)
             .hasMessageContaining(String.format(
                 Locale.ENGLISH,
-                "The relation \"%s.t1\" doesn't support or allow READ operations.",
+                "The relation \"%s.t1\" doesn't support or allow READ operations",
                 sqlExecutor.getCurrentSchema())
             );
     }
@@ -203,7 +203,7 @@ public class TableBlocksIntegrationTest extends IntegTestCase {
             .hasHTTPError(BAD_REQUEST, 4007)
             .hasMessageContaining(String.format(
                 Locale.ENGLISH,
-                "The relation \"%s.t1\" doesn't support or allow READ operations.",
+                "The relation \"%s.t1\" doesn't support or allow READ operations",
                 sqlExecutor.getCurrentSchema())
             );
     }
@@ -217,7 +217,7 @@ public class TableBlocksIntegrationTest extends IntegTestCase {
             .hasHTTPError(BAD_REQUEST, 4007)
             .hasMessageContaining(String.format(
                 Locale.ENGLISH,
-                "The relation \"%s.t1\" doesn't support or allow COPY TO operations.",
+                "The relation \"%s.t1\" doesn't support or allow COPY TO operations",
                 sqlExecutor.getCurrentSchema()));
     }
 
@@ -231,7 +231,7 @@ public class TableBlocksIntegrationTest extends IntegTestCase {
             .hasHTTPError(BAD_REQUEST, 4007)
             .hasMessageContaining(String.format(
                 Locale.ENGLISH,
-                "The relation \"%s.t1\" doesn't support or allow INSERT operations.",
+                "The relation \"%s.t1\" doesn't support or allow INSERT operations",
                 sqlExecutor.getCurrentSchema()));
     }
 
@@ -247,7 +247,7 @@ public class TableBlocksIntegrationTest extends IntegTestCase {
             .hasHTTPError(BAD_REQUEST, 4007)
             .hasMessageContaining(String.format(
                 Locale.ENGLISH,
-                "The relation \"%s.t1\" doesn't support or allow CREATE SNAPSHOT operations.",
+                "The relation \"%s.t1\" doesn't support or allow CREATE SNAPSHOT operations",
                 sqlExecutor.getCurrentSchema()));
     }
 
@@ -263,7 +263,7 @@ public class TableBlocksIntegrationTest extends IntegTestCase {
             .hasHTTPError(BAD_REQUEST, 4007)
             .hasMessageContaining(String.format(
                 Locale.ENGLISH,
-                "The relation \"%s.t1\" doesn't support or allow READ operations.",
+                "The relation \"%s.t1\" doesn't support or allow READ operations",
                 sqlExecutor.getCurrentSchema()));
     }
 
@@ -287,7 +287,7 @@ public class TableBlocksIntegrationTest extends IntegTestCase {
             .hasHTTPError(BAD_REQUEST, 4007)
             .hasMessageContaining(String.format(
                 Locale.ENGLISH,
-                "The relation \"%s.t1\" doesn't support or allow INSERT operations, as it is read-only.",
+                "The relation \"%s.t1\" doesn't support or allow INSERT operations",
                 sqlExecutor.getCurrentSchema()));
     }
 }

--- a/server/src/test/java/io/crate/metadata/SchemasTest.java
+++ b/server/src/test/java/io/crate/metadata/SchemasTest.java
@@ -64,7 +64,7 @@ public class SchemasTest extends CrateDummyClusterServiceUnitTest {
     public void testSystemSchemaIsNotWritable() throws Exception {
         expectedException.expect(OperationOnInaccessibleRelationException.class);
         expectedException.expectMessage("The relation \"foo.bar\" doesn't support or allow INSERT " +
-                                        "operations, as it is read-only.");
+                                        "operations");
 
         RelationName relationName = new RelationName("foo", "bar");
         SchemaInfo schemaInfo = mock(SchemaInfo.class);

--- a/server/src/test/java/io/crate/planner/ViewPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/ViewPlannerTest.java
@@ -68,10 +68,10 @@ public class ViewPlannerTest extends CrateDummyClusterServiceUnitTest {
 
         assertThatThrownBy(() -> e.plan("optimize table doc.v1"))
             .isExactlyInstanceOf(OperationOnInaccessibleRelationException.class)
-            .hasMessage("The relation \"doc.v1\" doesn't support or allow OPTIMIZE operations, as it is read-only.");
+            .hasMessage("The relation \"doc.v1\" doesn't support or allow OPTIMIZE operations");
 
         assertThatThrownBy(() -> e.plan("refresh table doc.v1"))
             .isExactlyInstanceOf(OperationOnInaccessibleRelationException.class)
-            .hasMessage("The relation \"doc.v1\" doesn't support or allow REFRESH operations, as it is read-only.");
+            .hasMessage("The relation \"doc.v1\" doesn't support or allow REFRESH operations");
     }
 }

--- a/server/src/test/java/io/crate/replication/logical/analyze/LogicalReplicationAnalyzerTest.java
+++ b/server/src/test/java/io/crate/replication/logical/analyze/LogicalReplicationAnalyzerTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.replication.logical.analyze;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertThrows;
@@ -34,6 +35,7 @@ import org.junit.Test;
 
 import io.crate.analyze.ParamTypeHints;
 import io.crate.exceptions.InvalidArgumentException;
+import io.crate.exceptions.OperationOnInaccessibleRelationException;
 import io.crate.exceptions.RelationUnknown;
 import io.crate.exceptions.UnauthorizedException;
 import io.crate.metadata.RelationName;
@@ -249,5 +251,13 @@ public class LogicalReplicationAnalyzerTest extends CrateDummyClusterServiceUnit
             SubscriptionUnknownException.class,
             () -> e.analyze("ALTER SUBSCRIPTION sub1 DISABLE")
         );
+    }
+
+    @Test
+    public void test_cannot_create_publication_for_system_table() throws Exception {
+        SQLExecutor e = SQLExecutor.of(clusterService);
+        assertThatThrownBy(() -> e.plan("create publication pub1 for table sys.summits"))
+            .isExactlyInstanceOf(OperationOnInaccessibleRelationException.class)
+            .hasMessage("The relation \"sys.summits\" doesn't support or allow CREATE PUBLICATION operations");
     }
 }


### PR DESCRIPTION
CREATE PUBLICATION with a system or foreign table resulted in a relation
unknown error instead of stating that the table doesn't support the
operation.

I also removed the "as it is read-only" suffix in the generic message,
because it doesn't make sense in the CREATE PUBLICATION context.