### PR TITLE
Document interval type id in http interface docs

### DIFF
--- a/docs/interfaces/http.rst
+++ b/docs/interfaces/http.rst
@@ -282,6 +282,8 @@ IDs of all currently available data types:
      - :ref:`TIMESTAMP WITHOUT TIME ZONE <type-timestamp-without-tz>`
    * - 16
      - Unchecked object
+   * - 17
+     - :ref:`INTERVAL <type-interval>`
    * - 19
      - :ref:`REGPROC <type-regproc>`
    * - 20


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
As title says.

Id is `17` as per https://github.com/crate/crate/blob/b11dcd528de4ebb3bbc6c476cf68d3bab463f276/server/src/main/java/io/crate/types/IntervalType.java#L39

I also went ahead and checked all types from https://github.com/crate/crate/tree/master/server/src/main/java/io/crate/types and seems that we are not missing anything now.

## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
