### PR TITLE
Merge resolveTableInfo/resolveRelationInfo in Schemas

### DIFF
--- a/server/src/main/java/io/crate/analyze/AlterTableAddColumnAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/AlterTableAddColumnAnalyzer.java
@@ -45,12 +45,12 @@ class AlterTableAddColumnAnalyzer {
         if (!alterTable.table().partitionProperties().isEmpty()) {
             throw new UnsupportedOperationException("Adding a column to a single partition is not supported");
         }
-        DocTableInfo tableInfo = (DocTableInfo) schemas.resolveTableInfo(
+        DocTableInfo tableInfo = schemas.resolveRelationInfo(
             alterTable.table().getName(),
             Operation.ALTER,
             txnCtx.sessionSettings().sessionUser(),
-            txnCtx.sessionSettings().searchPath());
-
+            txnCtx.sessionSettings().searchPath()
+        );
         var analyzer = new TableElementsAnalyzer(tableInfo, txnCtx, nodeCtx, paramTypeHints);
         return analyzer.analyze(alterTable);
     }

--- a/server/src/main/java/io/crate/analyze/CopyAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/CopyAnalyzer.java
@@ -35,8 +35,8 @@ import io.crate.metadata.NodeContext;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.doc.DocTableInfo;
+import io.crate.metadata.settings.CoordinatorSessionSettings;
 import io.crate.metadata.table.Operation;
-import io.crate.metadata.table.TableInfo;
 import io.crate.sql.tree.CopyFrom;
 import io.crate.sql.tree.CopyTo;
 import io.crate.sql.tree.Expression;
@@ -56,13 +56,14 @@ class CopyAnalyzer {
     AnalyzedCopyFrom analyzeCopyFrom(CopyFrom<Expression> node,
                                      ParamTypeHints paramTypeHints,
                                      CoordinatorTxnCtx txnCtx) {
-        DocTableInfo tableInfo = (DocTableInfo) schemas.resolveTableInfo(
+        CoordinatorSessionSettings sessionSettings = txnCtx.sessionSettings();
+        DocTableInfo tableInfo = schemas.resolveRelationInfo(
             node.table().getName(),
             Operation.INSERT,
-            txnCtx.sessionSettings().sessionUser(),
-            txnCtx.sessionSettings().searchPath());
-
-        var exprCtx = new ExpressionAnalysisContext(txnCtx.sessionSettings());
+            sessionSettings.sessionUser(),
+            sessionSettings.searchPath()
+        );
+        var exprCtx = new ExpressionAnalysisContext(sessionSettings);
 
         var exprAnalyzerWithoutFields = new ExpressionAnalyzer(
             txnCtx, nodeCtx, paramTypeHints, FieldProvider.UNSUPPORTED, null);
@@ -104,13 +105,14 @@ class CopyAnalyzer {
             throw new UnsupportedOperationException("Using COPY TO without specifying a DIRECTORY is not supported");
         }
 
-        TableInfo tableInfo = schemas.resolveTableInfo(
+        DocTableInfo tableInfo = schemas.resolveRelationInfo(
             node.table().getName(),
             Operation.COPY_TO,
             txnCtx.sessionSettings().sessionUser(),
-            txnCtx.sessionSettings().searchPath());
+            txnCtx.sessionSettings().searchPath()
+        );
         Operation.blockedRaiseException(tableInfo, Operation.READ);
-        DocTableRelation tableRelation = new DocTableRelation((DocTableInfo) tableInfo);
+        DocTableRelation tableRelation = new DocTableRelation(tableInfo);
 
         EvaluatingNormalizer normalizer = new EvaluatingNormalizer(
             nodeCtx,

--- a/server/src/main/java/io/crate/analyze/DropCheckConstraintAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/DropCheckConstraintAnalyzer.java
@@ -42,11 +42,12 @@ class DropCheckConstraintAnalyzer {
     }
 
     public AnalyzedAlterTableDropCheckConstraint analyze(Table<?> table, String name, CoordinatorTxnCtx txnCtx) {
-        DocTableInfo tableInfo = (DocTableInfo) schemas.resolveTableInfo(
+        DocTableInfo tableInfo = schemas.resolveRelationInfo(
             table.getName(),
             Operation.ALTER,
             txnCtx.sessionSettings().sessionUser(),
-            txnCtx.sessionSettings().searchPath());
+            txnCtx.sessionSettings().searchPath()
+        );
         List<CheckConstraint<Symbol>> checkConstraints = tableInfo.checkConstraints();
         for (var checkConstraint : checkConstraints) {
             if (name.equals(checkConstraint.name())) {

--- a/server/src/main/java/io/crate/analyze/DropTableAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/DropTableAnalyzer.java
@@ -76,8 +76,12 @@ class DropTableAnalyzer {
         RelationName tableName;
         boolean maybeCorrupt = false;
         try {
-            //noinspection unchecked
-            tableInfo = (T) schemas.resolveTableInfo(name, Operation.DROP, sessionSettings.sessionUser(), sessionSettings.searchPath());
+            tableInfo = schemas.resolveRelationInfo(
+                name,
+                Operation.DROP,
+                sessionSettings.sessionUser(),
+                sessionSettings.searchPath()
+            );
             tableName = tableInfo.ident();
         } catch (SchemaUnknownException | RelationUnknown e) {
             tableName = RelationName.of(name, sessionSettings.searchPath().currentSchema());

--- a/server/src/main/java/io/crate/analyze/InsertAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/InsertAnalyzer.java
@@ -111,7 +111,7 @@ class InsertAnalyzer {
                 throw new IllegalArgumentException("column \"" + columnName + "\" specified more than once");
             }
         }
-        DocTableInfo tableInfo = (DocTableInfo) schemas.resolveTableInfo(
+        DocTableInfo tableInfo = schemas.resolveRelationInfo(
             insert.table().getName(),
             Operation.INSERT,
             txnCtx.sessionSettings().sessionUser(),

--- a/server/src/main/java/io/crate/analyze/OptimizeTableAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/OptimizeTableAnalyzer.java
@@ -21,6 +21,8 @@
 
 package io.crate.analyze;
 
+import java.util.HashMap;
+
 import io.crate.analyze.expressions.ExpressionAnalysisContext;
 import io.crate.analyze.expressions.ExpressionAnalyzer;
 import io.crate.analyze.relations.FieldProvider;
@@ -33,8 +35,6 @@ import io.crate.metadata.table.TableInfo;
 import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.OptimizeStatement;
 import io.crate.sql.tree.Table;
-
-import java.util.HashMap;
 
 public class OptimizeTableAnalyzer {
 
@@ -58,7 +58,7 @@ public class OptimizeTableAnalyzer {
 
         HashMap<Table<Symbol>, TableInfo> analyzedOptimizeTables = new HashMap<>();
         for (Table<Symbol> table : analyzedStatement.tables()) {
-            TableInfo tableInfo = schemas.resolveTableInfo(
+            TableInfo tableInfo = schemas.resolveRelationInfo(
                 table.getName(),
                 Operation.OPTIMIZE,
                 txnCtx.sessionSettings().sessionUser(),

--- a/server/src/main/java/io/crate/analyze/RefreshTableAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/RefreshTableAnalyzer.java
@@ -21,6 +21,8 @@
 
 package io.crate.analyze;
 
+import java.util.HashMap;
+
 import io.crate.analyze.expressions.ExpressionAnalysisContext;
 import io.crate.analyze.expressions.ExpressionAnalyzer;
 import io.crate.analyze.relations.FieldProvider;
@@ -33,8 +35,6 @@ import io.crate.metadata.table.Operation;
 import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.RefreshStatement;
 import io.crate.sql.tree.Table;
-
-import java.util.HashMap;
 
 class RefreshTableAnalyzer {
 
@@ -56,13 +56,12 @@ class RefreshTableAnalyzer {
         HashMap<Table<Symbol>, DocTableInfo> analyzedTables = new HashMap<>();
         for (var table : refreshStatement.tables()) {
             var analyzedTable = table.map(t -> exprAnalyzerWithFieldsAsString.convert(t, exprCtx));
-
-            // resolve table info and validate whether a table exists
-            var tableInfo = (DocTableInfo) schemas.resolveTableInfo(
+            DocTableInfo tableInfo = schemas.resolveRelationInfo(
                 table.getName(),
                 Operation.REFRESH,
                 txnCtx.sessionSettings().sessionUser(),
-                txnCtx.sessionSettings().searchPath());
+                txnCtx.sessionSettings().searchPath()
+            );
             analyzedTables.put(analyzedTable, tableInfo);
         }
         return new AnalyzedRefreshTable(analyzedTables);

--- a/server/src/main/java/io/crate/analyze/SwapTableAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/SwapTableAnalyzer.java
@@ -32,11 +32,10 @@ import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.SearchPath;
-import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.Operation;
+import io.crate.role.Role;
 import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.SwapTable;
-import io.crate.role.Role;
 
 public final class SwapTableAnalyzer {
 
@@ -69,8 +68,8 @@ public final class SwapTableAnalyzer {
         SearchPath searchPath = txnCtx.sessionSettings().searchPath();
         Role user = txnCtx.sessionSettings().sessionUser();
         return new AnalyzedSwapTable(
-            (DocTableInfo) schemas.resolveTableInfo(swapTable.source(), Operation.ALTER, user, searchPath),
-            (DocTableInfo) schemas.resolveTableInfo(swapTable.target(), Operation.ALTER, user, searchPath),
+            schemas.resolveRelationInfo(swapTable.source(), Operation.ALTER, user, searchPath),
+            schemas.resolveRelationInfo(swapTable.target(), Operation.ALTER, user, searchPath),
             dropSource
         );
     }

--- a/server/src/main/java/io/crate/planner/node/ddl/CreateSnapshotPlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/CreateSnapshotPlan.java
@@ -37,11 +37,11 @@ import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.snapshots.SnapshotInfo;
 import org.elasticsearch.snapshots.SnapshotState;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import io.crate.analyze.AnalyzedCreateSnapshot;
 import io.crate.analyze.SnapshotSettings;
 import io.crate.analyze.SymbolEvaluator;
-import org.jetbrains.annotations.VisibleForTesting;
 import io.crate.common.collections.Lists;
 import io.crate.data.Row;
 import io.crate.data.Row1;
@@ -160,11 +160,12 @@ public class CreateSnapshotPlan implements Plan {
             for (Table<Symbol> table : createSnapshot.tables()) {
                 DocTableInfo docTableInfo;
                 try {
-                    docTableInfo = (DocTableInfo) schemas.resolveTableInfo(
+                    docTableInfo = schemas.resolveRelationInfo(
                         table.getName(),
                         Operation.CREATE_SNAPSHOT,
                         txnCtx.sessionSettings().sessionUser(),
-                        txnCtx.sessionSettings().searchPath());
+                        txnCtx.sessionSettings().searchPath()
+                    );
                 } catch (Exception e) {
                     if (ignoreUnavailable && e instanceof ResourceUnknownException) {
                         LOGGER.info(

--- a/server/src/test/java/io/crate/metadata/SchemasTest.java
+++ b/server/src/test/java/io/crate/metadata/SchemasTest.java
@@ -151,7 +151,7 @@ public class SchemasTest extends CrateDummyClusterServiceUnitTest {
         QualifiedName fqn = QualifiedName.of("crate", "schema", "t");
         var sessionSettings = sqlExecutor.getSessionSettings();
         TableInfo tableInfo = sqlExecutor.schemas()
-            .resolveTableInfo(fqn, Operation.READ, sessionSettings.sessionUser(), sessionSettings.searchPath());
+            .resolveRelationInfo(fqn, Operation.READ, sessionSettings.sessionUser(), sessionSettings.searchPath());
 
         RelationName relation = tableInfo.ident();
         assertThat(relation.schema(), is("schema"));
@@ -172,7 +172,7 @@ public class SchemasTest extends CrateDummyClusterServiceUnitTest {
         var sessionSetttings = sqlExecutor.getSessionSettings();
         expectedException.expect(SchemaUnknownException.class);
         expectedException.expectMessage("Schema 'bogus_schema' unknown");
-        sqlExecutor.schemas().resolveTableInfo(invalidFqn, Operation.READ, sessionSetttings.sessionUser(), sessionSetttings.searchPath());
+        sqlExecutor.schemas().resolveRelationInfo(invalidFqn, Operation.READ, sessionSetttings.sessionUser(), sessionSetttings.searchPath());
     }
 
     @Test
@@ -183,7 +183,7 @@ public class SchemasTest extends CrateDummyClusterServiceUnitTest {
         var sessionSettings = sqlExecutor.getSessionSettings();
         expectedException.expect(RelationUnknown.class);
         expectedException.expectMessage("Relation 'missing_table' unknown");
-        sqlExecutor.schemas().resolveTableInfo(table, Operation.READ, sessionSettings.sessionUser(), sessionSettings.searchPath());
+        sqlExecutor.schemas().resolveRelationInfo(table, Operation.READ, sessionSettings.sessionUser(), sessionSettings.searchPath());
     }
 
     @Test
@@ -192,7 +192,7 @@ public class SchemasTest extends CrateDummyClusterServiceUnitTest {
         QualifiedName tableQn = QualifiedName.of("t");
         var sessionSettings = sqlExecutor.getSessionSettings();
         TableInfo tableInfo = sqlExecutor.schemas()
-            .resolveTableInfo(tableQn, Operation.READ, sessionSettings.sessionUser(), sessionSettings.searchPath());
+            .resolveRelationInfo(tableQn, Operation.READ, sessionSettings.sessionUser(), sessionSettings.searchPath());
 
         RelationName relation = tableInfo.ident();
         assertThat(relation.schema(), is("schema"));

--- a/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
@@ -144,6 +144,7 @@ import io.crate.metadata.FulltextAnalyzerResolver;
 import io.crate.metadata.Functions;
 import io.crate.metadata.IndexParts;
 import io.crate.metadata.NodeContext;
+import io.crate.metadata.RelationInfo;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.RoutingProvider;
 import io.crate.metadata.Schemas;
@@ -679,11 +680,15 @@ public class SQLExecutor {
         return sessionSettings;
     }
 
-    @SuppressWarnings("unchecked")
-    public <T extends TableInfo> T resolveTableInfo(String tableName) {
+    public <T extends RelationInfo> T resolveTableInfo(String tableName) {
         IndexParts indexParts = new IndexParts(tableName);
         QualifiedName qualifiedName = QualifiedName.of(indexParts.getSchema(), indexParts.getTable());
-        return (T) schemas.resolveTableInfo(qualifiedName, Operation.READ, sessionSettings.sessionUser(), sessionSettings.searchPath());
+        return schemas.resolveRelationInfo(
+            qualifiedName,
+            Operation.READ,
+            sessionSettings.sessionUser(),
+            sessionSettings.searchPath()
+        );
     }
 
     public Session createSession() {


### PR DESCRIPTION
Follow up to:

- https://github.com/crate/crate/pull/15689
- https://github.com/crate/crate/pull/15691

We can use a generics and a dirty cast to avoid some `throw new
OperationOnInaccessibleRelationException` duplication.
