### PR TITLE
Allow pushdowns of constant-join-conditions on all join types

### DIFF
--- a/server/src/main/java/io/crate/planner/operators/AbstractJoinPlan.java
+++ b/server/src/main/java/io/crate/planner/operators/AbstractJoinPlan.java
@@ -49,8 +49,7 @@ public abstract class AbstractJoinPlan implements LogicalPlan {
     protected final Symbol joinCondition;
     protected final JoinType joinType;
 
-    protected AbstractJoinPlan(
-                               LogicalPlan lhs,
+    protected AbstractJoinPlan(LogicalPlan lhs,
                                LogicalPlan rhs,
                                @Nullable Symbol joinCondition,
                                JoinType joinType) {

--- a/server/src/main/java/io/crate/planner/operators/JoinPlan.java
+++ b/server/src/main/java/io/crate/planner/operators/JoinPlan.java
@@ -27,6 +27,7 @@ import java.util.SequencedCollection;
 import java.util.Set;
 
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import io.crate.analyze.OrderBy;
 import io.crate.common.collections.Lists;
@@ -44,13 +45,7 @@ public class JoinPlan extends AbstractJoinPlan {
     private final boolean isFiltered;
     private final boolean rewriteFilterOnOuterJoinToInnerJoinDone;
     private final boolean lookUpJoinRuleApplied;
-
-    public JoinPlan(LogicalPlan lhs,
-                    LogicalPlan rhs,
-                    JoinType joinType,
-                    @Nullable Symbol joinCondition) {
-        this(lhs, rhs, joinType, joinCondition, false, false, false);
-    }
+    private final boolean moveConstantJoinConditionRuleApplied;
 
     public JoinPlan(LogicalPlan lhs,
                     LogicalPlan rhs,
@@ -59,10 +54,30 @@ public class JoinPlan extends AbstractJoinPlan {
                     boolean isFiltered,
                     boolean rewriteFilterOnOuterJoinToInnerJoinDone,
                     boolean lookUpJoinRuleApplied) {
+        this(lhs, rhs, joinType, joinCondition, isFiltered, rewriteFilterOnOuterJoinToInnerJoinDone, lookUpJoinRuleApplied, false);
+    }
+
+    @VisibleForTesting
+    public JoinPlan(LogicalPlan lhs,
+                    LogicalPlan rhs,
+                    JoinType joinType,
+                    @Nullable Symbol joinCondition) {
+        this(lhs, rhs, joinType, joinCondition, false, false, false, false);
+    }
+
+    private JoinPlan(LogicalPlan lhs,
+                    LogicalPlan rhs,
+                    JoinType joinType,
+                    @Nullable Symbol joinCondition,
+                    boolean isFiltered,
+                    boolean rewriteFilterOnOuterJoinToInnerJoinDone,
+                    boolean lookUpJoinRuleApplied,
+                    boolean moveConstantJoinConditionRuleApplied) {
         super(lhs, rhs, joinCondition, joinType);
         this.isFiltered = isFiltered;
         this.rewriteFilterOnOuterJoinToInnerJoinDone = rewriteFilterOnOuterJoinToInnerJoinDone;
         this.lookUpJoinRuleApplied = lookUpJoinRuleApplied;
+        this.moveConstantJoinConditionRuleApplied = moveConstantJoinConditionRuleApplied;
     }
 
     public boolean isLookUpJoinRuleApplied() {
@@ -75,6 +90,22 @@ public class JoinPlan extends AbstractJoinPlan {
 
     public boolean isRewriteFilterOnOuterJoinToInnerJoinDone() {
         return rewriteFilterOnOuterJoinToInnerJoinDone;
+    }
+
+    public boolean moveConstantJoinConditionRuleApplied() {
+        return moveConstantJoinConditionRuleApplied;
+    }
+
+    public JoinPlan withMoveConstantJoinConditionRuleApplied(boolean moveConstantJoinConditionRuleApplied) {
+        return new JoinPlan(
+            lhs,
+            rhs,
+            joinType,
+            joinCondition,
+            isFiltered,
+            rewriteFilterOnOuterJoinToInnerJoinDone,
+            lookUpJoinRuleApplied,
+            moveConstantJoinConditionRuleApplied);
     }
 
     @Override
@@ -121,7 +152,8 @@ public class JoinPlan extends AbstractJoinPlan {
             joinCondition,
             isFiltered,
             rewriteFilterOnOuterJoinToInnerJoinDone,
-            lookUpJoinRuleApplied
+            lookUpJoinRuleApplied,
+            moveConstantJoinConditionRuleApplied
         );
     }
 
@@ -149,7 +181,8 @@ public class JoinPlan extends AbstractJoinPlan {
             joinCondition,
             isFiltered,
             rewriteFilterOnOuterJoinToInnerJoinDone,
-            lookUpJoinRuleApplied
+            lookUpJoinRuleApplied,
+            moveConstantJoinConditionRuleApplied
         );
     }
 }

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -98,7 +98,7 @@ import io.crate.planner.optimizer.rule.MergeAggregateRenameAndCollectToCount;
 import io.crate.planner.optimizer.rule.MergeFilterAndCollect;
 import io.crate.planner.optimizer.rule.MergeFilterAndForeignCollect;
 import io.crate.planner.optimizer.rule.MergeFilters;
-import io.crate.planner.optimizer.rule.MoveConstantJoinConditionsBeneathNestedLoop;
+import io.crate.planner.optimizer.rule.MoveConstantJoinConditionsBeneathJoin;
 import io.crate.planner.optimizer.rule.MoveFilterBeneathCorrelatedJoin;
 import io.crate.planner.optimizer.rule.MoveFilterBeneathEval;
 import io.crate.planner.optimizer.rule.MoveFilterBeneathGroupBy;
@@ -166,7 +166,7 @@ public class LogicalPlanner {
         new DeduplicateOrder(),
         new OptimizeCollectWhereClauseAccess(),
         new RewriteGroupByKeysLimitToLimitDistinct(),
-        new MoveConstantJoinConditionsBeneathNestedLoop(),
+        new MoveConstantJoinConditionsBeneathJoin(),
         new EliminateCrossJoin(),
         new EquiJoinToLookupJoin(),
         new RewriteJoinPlan(),

--- a/server/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
@@ -64,7 +64,6 @@ public class NestedLoopJoin extends AbstractJoinPlan {
 
     private final boolean isFiltered;
     private boolean orderByWasPushedDown = false;
-    private final boolean joinConditionOptimised;
     // this can be removed
     private boolean rewriteNestedLoopJoinToHashJoinDone = false;
 
@@ -72,11 +71,9 @@ public class NestedLoopJoin extends AbstractJoinPlan {
                    LogicalPlan rhs,
                    JoinType joinType,
                    @Nullable Symbol joinCondition,
-                   boolean isFiltered,
-                   boolean joinConditionOptimised) {
+                   boolean isFiltered) {
         super(lhs, rhs, joinCondition, joinType);
         this.isFiltered = isFiltered || joinCondition != null;
-        this.joinConditionOptimised = joinConditionOptimised;
     }
 
     public NestedLoopJoin(LogicalPlan lhs,
@@ -85,9 +82,8 @@ public class NestedLoopJoin extends AbstractJoinPlan {
                           @Nullable Symbol joinCondition,
                           boolean isFiltered,
                           boolean orderByWasPushedDown,
-                          boolean joinConditionOptimised,
                           boolean rewriteEquiJoinToHashJoinDone) {
-        this(lhs, rhs, joinType, joinCondition, isFiltered, joinConditionOptimised);
+        this(lhs, rhs, joinType, joinCondition, isFiltered);
         this.orderByWasPushedDown = orderByWasPushedDown;
         this.rewriteNestedLoopJoinToHashJoinDone = rewriteEquiJoinToHashJoinDone;
     }
@@ -95,11 +91,6 @@ public class NestedLoopJoin extends AbstractJoinPlan {
     public boolean isRewriteNestedLoopJoinToHashJoinDone() {
         return rewriteNestedLoopJoinToHashJoinDone;
     }
-
-    public boolean isJoinConditionOptimised() {
-        return joinConditionOptimised;
-    }
-
 
     public boolean isFiltered() {
         return isFiltered;
@@ -222,7 +213,6 @@ public class NestedLoopJoin extends AbstractJoinPlan {
             joinCondition,
             isFiltered,
             orderByWasPushedDown,
-            joinConditionOptimised,
             rewriteNestedLoopJoinToHashJoinDone
         );
     }
@@ -251,7 +241,6 @@ public class NestedLoopJoin extends AbstractJoinPlan {
             joinCondition,
             isFiltered,
             orderByWasPushedDown,
-            joinConditionOptimised,
             rewriteNestedLoopJoinToHashJoinDone
         );
     }
@@ -286,7 +275,6 @@ public class NestedLoopJoin extends AbstractJoinPlan {
                 joinCondition,
                 isFiltered,
                 orderByWasPushedDown,
-                joinConditionOptimised,
                 rewriteNestedLoopJoinToHashJoinDone
             )
         );

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathNestedLoop.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathNestedLoop.java
@@ -107,7 +107,6 @@ public final class MoveOrderBeneathNestedLoop implements Rule<Order> {
                     nestedLoop.joinCondition(),
                     nestedLoop.isFiltered(),
                     true,
-                    false,
                     nestedLoop.isRewriteNestedLoopJoinToHashJoinDone()
                 );
             }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/ReorderNestedLoopJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/ReorderNestedLoopJoin.java
@@ -70,7 +70,6 @@ public class ReorderNestedLoopJoin implements Rule<NestedLoopJoin> {
                         nestedLoop.joinCondition(),
                         nestedLoop.isFiltered(),
                         nestedLoop.orderByWasPushedDown(),
-                        nestedLoop.isJoinConditionOptimised(),
                         nestedLoop.isRewriteNestedLoopJoinToHashJoinDone()
                     ),
                     nestedLoop.outputs());

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteJoinPlan.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteJoinPlan.java
@@ -76,7 +76,6 @@ public class RewriteJoinPlan implements Rule<JoinPlan> {
                 join.joinCondition(),
                 join.isFiltered(),
                 false,
-                false,
                 false
             );
         }

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -235,7 +235,7 @@ public class PgCatalogITest extends IntegTestCase {
             "optimizer_merge_filter_and_collect| true| Indicates if the optimizer rule MergeFilterAndCollect is activated.| NULL| NULL",
             "optimizer_merge_filter_and_foreign_collect| true| Indicates if the optimizer rule MergeFilterAndForeignCollect is activated.| NULL| NULL",
             "optimizer_merge_filters| true| Indicates if the optimizer rule MergeFilters is activated.| NULL| NULL",
-            "optimizer_move_constant_join_conditions_beneath_nested_loop| true| Indicates if the optimizer rule MoveConstantJoinConditionsBeneathNestedLoop is activated.| NULL| NULL",
+            "optimizer_move_constant_join_conditions_beneath_join| true| Indicates if the optimizer rule MoveConstantJoinConditionsBeneathJoin is activated.| NULL| NULL",
             "optimizer_move_filter_beneath_correlated_join| true| Indicates if the optimizer rule MoveFilterBeneathCorrelatedJoin is activated.| NULL| NULL",
             "optimizer_move_filter_beneath_eval| true| Indicates if the optimizer rule MoveFilterBeneathEval is activated.| NULL| NULL",
             "optimizer_move_filter_beneath_group_by| true| Indicates if the optimizer rule MoveFilterBeneathGroupBy is activated.| NULL| NULL",

--- a/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
@@ -414,7 +414,7 @@ public class ShowIntegrationTest extends IntegTestCase {
             "optimizer_merge_filter_and_collect| true| Indicates if the optimizer rule MergeFilterAndCollect is activated.",
             "optimizer_merge_filter_and_foreign_collect| true| Indicates if the optimizer rule MergeFilterAndForeignCollect is activated.",
             "optimizer_merge_filters| true| Indicates if the optimizer rule MergeFilters is activated.",
-            "optimizer_move_constant_join_conditions_beneath_nested_loop| true| Indicates if the optimizer rule MoveConstantJoinConditionsBeneathNestedLoop is activated.",
+            "optimizer_move_constant_join_conditions_beneath_join| true| Indicates if the optimizer rule MoveConstantJoinConditionsBeneathJoin is activated.",
             "optimizer_move_filter_beneath_correlated_join| true| Indicates if the optimizer rule MoveFilterBeneathCorrelatedJoin is activated.",
             "optimizer_move_filter_beneath_eval| true| Indicates if the optimizer rule MoveFilterBeneathEval is activated.",
             "optimizer_move_filter_beneath_group_by| true| Indicates if the optimizer rule MoveFilterBeneathGroupBy is activated.",

--- a/server/src/test/java/io/crate/planner/operators/RelationNamesInLogicalPlanTest.java
+++ b/server/src/test/java/io/crate/planner/operators/RelationNamesInLogicalPlanTest.java
@@ -96,7 +96,6 @@ public class RelationNamesInLogicalPlanTest extends CrateDummyClusterServiceUnit
                                                 t2Rename,
                                                 JoinType.INNER,
                                                 e.asSymbol("x = y"),
-                                                false,
                                                 false);
         assertThat(nestedLoopJoin.getRelationNames(), containsInAnyOrder(t1RenamedRelationName, t2RenamedRelationName));
     }

--- a/server/src/test/java/io/crate/planner/optimizer/costs/PlanStatsTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/costs/PlanStatsTest.java
@@ -250,7 +250,7 @@ public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
         );
 
         var nestedLoopJoin = new NestedLoopJoin(
-            lhs, rhs, JoinType.INNER, Literal.BOOLEAN_TRUE, false, false, false, false);
+            lhs, rhs, JoinType.INNER, Literal.BOOLEAN_TRUE, false, false, false);
 
         var memo = new Memo(nestedLoopJoin);
         PlanStats planStats = new PlanStats(nodeContext, txnCtx, tableStats, memo);
@@ -261,13 +261,13 @@ public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
 
         var joinCondition = e.asSymbol("x = y");
         nestedLoopJoin = new NestedLoopJoin(
-            lhs, rhs, JoinType.INNER, joinCondition, false, false, false, false);
+            lhs, rhs, JoinType.INNER, joinCondition, false, false, false);
         result = planStats.get(nestedLoopJoin);
         assertThat(result.numDocs()).isEqualTo(1L);
         assertThat(result.sizeInBytes()).isEqualTo(32L);
 
         nestedLoopJoin = new NestedLoopJoin(
-            lhs, rhs, JoinType.CROSS, x, false, false, false, false);
+            lhs, rhs, JoinType.CROSS, x, false, false, false);
 
         memo = new Memo(nestedLoopJoin);
         planStats = new PlanStats(nodeContext, txnCtx, tableStats, memo);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
See the following case:
```
cr> create table v1(a int);                                                                                                                                                                   
CREATE OK, 1 row affected  (1.891 sec)
cr> create table v2(b int);                                                                                                                                                                   
CREATE OK, 1 row affected  (1.935 sec)
cr> explain verbose select * from v1 join v2 on (a = 1 and a = b);                                                                                                                            
+-----------------------------+----------------------------------------------------+
| STEP                        | QUERY PLAN                                         |
+-----------------------------+----------------------------------------------------+
| Initial logical plan        | Join[INNER | ((a = 1) AND (a = b))] (rows=unknown) |
|                             |   ├ Collect[doc.v1 | [a] | true] (rows=unknown)    |
|                             |   └ Collect[doc.v2 | [b] | true] (rows=unknown)    |
| optimizer_rewrite_join_plan | HashJoin[((a = 1) AND (a = b))] (rows=unknown)     |
|                             |   ├ Collect[doc.v1 | [a] | true] (rows=unknown)    |
|                             |   └ Collect[doc.v2 | [b] | true] (rows=unknown)    |
| Final logical plan          | HashJoin[((a = 1) AND (a = b))] (rows=unknown)     |
|                             |   ├ Collect[doc.v1 | [a] | true] (rows=unknown)    |
|                             |   └ Collect[doc.v2 | [b] | true] (rows=unknown)    |
+-----------------------------+----------------------------------------------------+
```

We can allow the optimizer rule to push down the constant join condition:
```
cr> explain verbose select * from v1 join v2 on (a = 1 and a = b);                                                                                                                            
+------------------------------------------------------+----------------------------------------------------+
| STEP                                                 | QUERY PLAN                                         |
+------------------------------------------------------+----------------------------------------------------+
| Initial logical plan                                 | Join[INNER | ((a = 1) AND (a = b))] (rows=unknown) |
|                                                      |   ├ Collect[doc.v1 | [a] | true] (rows=unknown)    |
|                                                      |   └ Collect[doc.v2 | [b] | true] (rows=unknown)    |
| optimizer_rewrite_join_plan                          | HashJoin[((a = 1) AND (a = b))] (rows=unknown)     |
|                                                      |   ├ Collect[doc.v1 | [a] | true] (rows=unknown)    |
|                                                      |   └ Collect[doc.v2 | [b] | true] (rows=unknown)    |
| optimizer_move_constant_join_conditions_beneath_join | HashJoin[(a = b)] (rows=unknown)                   |
|                                                      |   ├ Filter[(a = 1)] (rows=0)                       |
|                                                      |   │  └ Collect[doc.v1 | [a] | true] (rows=unknown) |
|                                                      |   └ Collect[doc.v2 | [b] | true] (rows=unknown)    |
| optimizer_merge_filter_and_collect                   | HashJoin[(a = b)] (rows=unknown)                   |
|                                                      |   ├ Collect[doc.v1 | [a] | (a = 1)] (rows=unknown) |
|                                                      |   └ Collect[doc.v2 | [b] | true] (rows=unknown)    |
| Final logical plan                                   | HashJoin[(a = b)] (rows=unknown)                   |
|                                                      |   ├ Collect[doc.v1 | [a] | (a = 1)] (rows=unknown) |
|                                                      |   └ Collect[doc.v2 | [b] | true] (rows=unknown)    |
+------------------------------------------------------+----------------------------------------------------+
EXPLAIN 5 rows in set (0.003 sec)
```

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
