### PR TITLE
Replace `resolveRelation` with `resolveRelationInfo`

### DIFF
--- a/server/src/main/java/io/crate/analyze/AlterTableAddColumnAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/AlterTableAddColumnAnalyzer.java
@@ -45,7 +45,7 @@ class AlterTableAddColumnAnalyzer {
         if (!alterTable.table().partitionProperties().isEmpty()) {
             throw new UnsupportedOperationException("Adding a column to a single partition is not supported");
         }
-        DocTableInfo tableInfo = schemas.resolveRelationInfo(
+        DocTableInfo tableInfo = schemas.findRelation(
             alterTable.table().getName(),
             Operation.ALTER,
             txnCtx.sessionSettings().sessionUser(),

--- a/server/src/main/java/io/crate/analyze/AlterTableAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/AlterTableAnalyzer.java
@@ -26,23 +26,23 @@ import java.util.List;
 import io.crate.analyze.expressions.ExpressionAnalysisContext;
 import io.crate.analyze.expressions.ExpressionAnalyzer;
 import io.crate.analyze.relations.FieldProvider;
-import io.crate.exceptions.RelationUnknown;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.NodeContext;
+import io.crate.metadata.RelationInfo;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.blob.BlobSchemaInfo;
 import io.crate.metadata.blob.BlobTableInfo;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.settings.CoordinatorSessionSettings;
-import io.crate.metadata.settings.SessionSettings;
 import io.crate.metadata.table.Operation;
 import io.crate.sql.tree.AlterBlobTable;
 import io.crate.sql.tree.AlterTable;
 import io.crate.sql.tree.AlterTableOpenClose;
 import io.crate.sql.tree.AlterTableRenameTable;
 import io.crate.sql.tree.Expression;
+import io.crate.sql.tree.QualifiedName;
 import io.crate.sql.tree.Table;
 
 class AlterTableAnalyzer {
@@ -92,7 +92,7 @@ class AlterTableAnalyzer {
     }
 
 
-    AnalyzedAlterTableRenameTable analyze(AlterTableRenameTable<Expression> node, SessionSettings sessionSettings) {
+    AnalyzedAlterTableRenameTable analyze(AlterTableRenameTable<Expression> node, CoordinatorSessionSettings sessionSettings) {
         if (!node.table().partitionProperties().isEmpty()) {
             throw new UnsupportedOperationException("Renaming a single partition is not supported");
         }
@@ -104,22 +104,19 @@ class AlterTableAnalyzer {
             throw new IllegalArgumentException("Target table name must not include a schema");
         }
 
-        RelationName sourceName;
-        if (node.blob()) {
-            sourceName = RelationName.fromBlobTable(node.table());
-        } else {
-            sourceName = schemas.resolveRelation(node.table().getName(), sessionSettings.searchPath());
-        }
-
-        boolean isPartitioned = false;
+        QualifiedName qName = node.blob()
+            ? RelationName.fromBlobTable(node.table()).toQualifiedName()
+            : node.table().getName();
+        RelationInfo source = schemas.resolveRelationInfo(
+            qName,
+            Operation.ALTER_TABLE_RENAME,
+            sessionSettings.sessionUser(),
+            sessionSettings.searchPath()
+        );
+        RelationName sourceName = source.ident();
         RelationName targetName = new RelationName(sourceName.schema(), newIdentParts.get(0));
         targetName.ensureValidForRelationCreation();
-        try {
-            DocTableInfo tableInfo = schemas.getTableInfo(sourceName, Operation.ALTER_TABLE_RENAME);
-            isPartitioned = tableInfo.isPartitioned();
-        } catch (RelationUnknown e) {
-            schemas.resolveView(node.table().getName(), sessionSettings.searchPath());
-        }
+        boolean isPartitioned = source instanceof DocTableInfo docTable && docTable.isPartitioned();
         return new AnalyzedAlterTableRenameTable(sourceName, targetName, isPartitioned);
     }
 
@@ -128,17 +125,21 @@ class AlterTableAnalyzer {
                                                CoordinatorTxnCtx txnCtx) {
         var exprAnalyzerWithFieldsAsStrings = new ExpressionAnalyzer(
             txnCtx, nodeCtx, paramTypeHints, FieldProvider.TO_LITERAL_VALIDATE_NAME, null);
-        var exprCtx = new ExpressionAnalysisContext(txnCtx.sessionSettings());
+        CoordinatorSessionSettings sessionSettings = txnCtx.sessionSettings();
+        var exprCtx = new ExpressionAnalysisContext(sessionSettings);
 
         Table<Symbol> table = node.table().map(x -> exprAnalyzerWithFieldsAsStrings.convert(x, exprCtx));
-        RelationName relationName;
-        if (node.blob()) {
-            relationName = RelationName.fromBlobTable(table);
-        } else {
-            relationName = schemas.resolveRelation(table.getName(), txnCtx.sessionSettings().searchPath());
-        }
+        QualifiedName qName = node.blob()
+            ? RelationName.fromBlobTable(node.table()).toQualifiedName()
+            : node.table().getName();
 
-        DocTableInfo tableInfo = schemas.getTableInfo(relationName, node.openTable() ? Operation.ALTER_OPEN : Operation.ALTER_CLOSE);
+        Operation operation = node.openTable() ? Operation.ALTER_OPEN : Operation.ALTER_CLOSE;
+        DocTableInfo tableInfo = schemas.resolveRelationInfo(
+            qName,
+            operation,
+            sessionSettings.sessionUser(),
+            sessionSettings.searchPath()
+        );
         return new AnalyzedAlterTableOpenClose(tableInfo, table, node.openTable());
     }
 }

--- a/server/src/main/java/io/crate/analyze/AlterTableAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/AlterTableAnalyzer.java
@@ -64,7 +64,7 @@ class AlterTableAnalyzer {
         CoordinatorSessionSettings sessionSettings = txnCtx.sessionSettings();
         var exprCtx = new ExpressionAnalysisContext(sessionSettings);
         AlterTable<Symbol> alterTable = node.map(x -> exprAnalyzerWithFieldsAsString.convert(x, exprCtx));
-        DocTableInfo docTableInfo = schemas.resolveRelationInfo(
+        DocTableInfo docTableInfo = schemas.findRelation(
             alterTable.table().getName(),
             Operation.ALTER_BLOCKS,
             sessionSettings.sessionUser(),
@@ -107,7 +107,7 @@ class AlterTableAnalyzer {
         QualifiedName qName = node.blob()
             ? RelationName.fromBlobTable(node.table()).toQualifiedName()
             : node.table().getName();
-        RelationInfo source = schemas.resolveRelationInfo(
+        RelationInfo source = schemas.findRelation(
             qName,
             Operation.ALTER_TABLE_RENAME,
             sessionSettings.sessionUser(),
@@ -134,7 +134,7 @@ class AlterTableAnalyzer {
             : node.table().getName();
 
         Operation operation = node.openTable() ? Operation.ALTER_OPEN : Operation.ALTER_CLOSE;
-        DocTableInfo tableInfo = schemas.resolveRelationInfo(
+        DocTableInfo tableInfo = schemas.findRelation(
             qName,
             operation,
             sessionSettings.sessionUser(),

--- a/server/src/main/java/io/crate/analyze/AlterTableDropColumnAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/AlterTableDropColumnAnalyzer.java
@@ -63,7 +63,7 @@ public class AlterTableDropColumnAnalyzer {
         }
 
         CoordinatorSessionSettings sessionSettings = txnCtx.sessionSettings();
-        DocTableInfo tableInfo = schemas.resolveRelationInfo(
+        DocTableInfo tableInfo = schemas.findRelation(
             alterTable.table().getName(),
             Operation.ALTER,
             sessionSettings.sessionUser(),

--- a/server/src/main/java/io/crate/analyze/AlterTableRenameColumnAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/AlterTableRenameColumnAnalyzer.java
@@ -64,7 +64,7 @@ public class AlterTableRenameColumnAnalyzer {
         }
 
         CoordinatorSessionSettings sessionSettings = txnCtx.sessionSettings();
-        DocTableInfo tableInfo = schemas.resolveRelationInfo(
+        DocTableInfo tableInfo = schemas.findRelation(
             renameColumn.table().getName(),
             Operation.ALTER,
             sessionSettings.sessionUser(),

--- a/server/src/main/java/io/crate/analyze/AlterTableRerouteAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/AlterTableRerouteAnalyzer.java
@@ -72,7 +72,7 @@ public class AlterTableRerouteAnalyzer {
             : table.getName();
 
         CoordinatorSessionSettings sessionSettings = transactionContext.sessionSettings();
-        tableInfo = schemas.resolveRelationInfo(
+        tableInfo = schemas.findRelation(
             qName,
             Operation.ALTER_REROUTE,
             sessionSettings.sessionUser(),

--- a/server/src/main/java/io/crate/analyze/AlterTableRerouteAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/AlterTableRerouteAnalyzer.java
@@ -21,8 +21,6 @@
 
 package io.crate.analyze;
 
-import static io.crate.metadata.RelationName.fromBlobTable;
-
 import java.util.HashMap;
 import java.util.List;
 
@@ -36,6 +34,7 @@ import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Schemas;
+import io.crate.metadata.settings.CoordinatorSessionSettings;
 import io.crate.metadata.table.Operation;
 import io.crate.metadata.table.ShardedTable;
 import io.crate.sql.tree.AlterTableReroute;
@@ -43,9 +42,11 @@ import io.crate.sql.tree.Assignment;
 import io.crate.sql.tree.AstVisitor;
 import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.PromoteReplica;
+import io.crate.sql.tree.QualifiedName;
 import io.crate.sql.tree.RerouteAllocateReplicaShard;
 import io.crate.sql.tree.RerouteCancelShard;
 import io.crate.sql.tree.RerouteMoveShard;
+import io.crate.sql.tree.Table;
 
 public class AlterTableRerouteAnalyzer {
 
@@ -65,20 +66,23 @@ public class AlterTableRerouteAnalyzer {
         // safe to expect a `ShardedTable` since getTableInfo with
         // Operation.ALTER_REROUTE raises a appropriate error for sys tables
         ShardedTable tableInfo;
-        RelationName relationName;
-        if (alterTableReroute.blob()) {
-            relationName = fromBlobTable(alterTableReroute.table());
-        } else {
-            relationName = schemas.resolveRelation(
-                alterTableReroute.table().getName(),
-                transactionContext.sessionSettings().searchPath());
-        }
-        tableInfo = schemas.getTableInfo(relationName, Operation.ALTER_REROUTE);
+        Table<Expression> table = alterTableReroute.table();
+        QualifiedName qName = alterTableReroute.blob()
+            ? RelationName.fromBlobTable(table).toQualifiedName()
+            : table.getName();
+
+        CoordinatorSessionSettings sessionSettings = transactionContext.sessionSettings();
+        tableInfo = schemas.resolveRelationInfo(
+            qName,
+            Operation.ALTER_REROUTE,
+            sessionSettings.sessionUser(),
+            sessionSettings.searchPath()
+        );
         return alterTableReroute.rerouteOption().accept(
             rerouteOptionVisitor,
             new Context(
                 tableInfo,
-                alterTableReroute.table().partitionProperties(),
+                table.partitionProperties(),
                 transactionContext,
                 nodeCtx,
                 paramTypeHints

--- a/server/src/main/java/io/crate/analyze/CopyAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/CopyAnalyzer.java
@@ -57,7 +57,7 @@ class CopyAnalyzer {
                                      ParamTypeHints paramTypeHints,
                                      CoordinatorTxnCtx txnCtx) {
         CoordinatorSessionSettings sessionSettings = txnCtx.sessionSettings();
-        DocTableInfo tableInfo = schemas.resolveRelationInfo(
+        DocTableInfo tableInfo = schemas.findRelation(
             node.table().getName(),
             Operation.INSERT,
             sessionSettings.sessionUser(),
@@ -105,7 +105,7 @@ class CopyAnalyzer {
             throw new UnsupportedOperationException("Using COPY TO without specifying a DIRECTORY is not supported");
         }
 
-        DocTableInfo tableInfo = schemas.resolveRelationInfo(
+        DocTableInfo tableInfo = schemas.findRelation(
             node.table().getName(),
             Operation.COPY_TO,
             txnCtx.sessionSettings().sessionUser(),

--- a/server/src/main/java/io/crate/analyze/DropCheckConstraintAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/DropCheckConstraintAnalyzer.java
@@ -42,7 +42,7 @@ class DropCheckConstraintAnalyzer {
     }
 
     public AnalyzedAlterTableDropCheckConstraint analyze(Table<?> table, String name, CoordinatorTxnCtx txnCtx) {
-        DocTableInfo tableInfo = schemas.resolveRelationInfo(
+        DocTableInfo tableInfo = schemas.findRelation(
             table.getName(),
             Operation.ALTER,
             txnCtx.sessionSettings().sessionUser(),

--- a/server/src/main/java/io/crate/analyze/DropTableAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/DropTableAnalyzer.java
@@ -76,7 +76,7 @@ class DropTableAnalyzer {
         RelationName tableName;
         boolean maybeCorrupt = false;
         try {
-            tableInfo = schemas.resolveRelationInfo(
+            tableInfo = schemas.findRelation(
                 name,
                 Operation.DROP,
                 sessionSettings.sessionUser(),

--- a/server/src/main/java/io/crate/analyze/InsertAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/InsertAnalyzer.java
@@ -111,7 +111,7 @@ class InsertAnalyzer {
                 throw new IllegalArgumentException("column \"" + columnName + "\" specified more than once");
             }
         }
-        DocTableInfo tableInfo = schemas.resolveRelationInfo(
+        DocTableInfo tableInfo = schemas.findRelation(
             insert.table().getName(),
             Operation.INSERT,
             txnCtx.sessionSettings().sessionUser(),

--- a/server/src/main/java/io/crate/analyze/OptimizeTableAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/OptimizeTableAnalyzer.java
@@ -58,7 +58,7 @@ public class OptimizeTableAnalyzer {
 
         HashMap<Table<Symbol>, TableInfo> analyzedOptimizeTables = new HashMap<>();
         for (Table<Symbol> table : analyzedStatement.tables()) {
-            TableInfo tableInfo = schemas.resolveRelationInfo(
+            TableInfo tableInfo = schemas.findRelation(
                 table.getName(),
                 Operation.OPTIMIZE,
                 txnCtx.sessionSettings().sessionUser(),

--- a/server/src/main/java/io/crate/analyze/PrivilegesAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/PrivilegesAnalyzer.java
@@ -239,7 +239,7 @@ class PrivilegesAnalyzer {
                                                             boolean isRevoke) {
         return Lists.map(relations, q -> {
             try {
-                RelationInfo relation = schemas.resolveRelationInfo(q, Operation.READ, sessionUser, searchPath);
+                RelationInfo relation = schemas.findRelation(q, Operation.READ, sessionUser, searchPath);
                 RelationName relationName = relation.ident();
                 if (!isRevoke) {
                     validateSchemaName(relationName.schema());

--- a/server/src/main/java/io/crate/analyze/RefreshTableAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/RefreshTableAnalyzer.java
@@ -56,7 +56,7 @@ class RefreshTableAnalyzer {
         HashMap<Table<Symbol>, DocTableInfo> analyzedTables = new HashMap<>();
         for (var table : refreshStatement.tables()) {
             var analyzedTable = table.map(t -> exprAnalyzerWithFieldsAsString.convert(t, exprCtx));
-            DocTableInfo tableInfo = schemas.resolveRelationInfo(
+            DocTableInfo tableInfo = schemas.findRelation(
                 table.getName(),
                 Operation.REFRESH,
                 txnCtx.sessionSettings().sessionUser(),

--- a/server/src/main/java/io/crate/analyze/ShowStatementAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/ShowStatementAnalyzer.java
@@ -90,7 +90,7 @@ class ShowStatementAnalyzer {
 
     public AnalyzedStatement analyzeShowCreateTable(Table<?> table, Analysis analysis) {
         CoordinatorSessionSettings sessionSettings = analysis.sessionSettings();
-        RelationInfo relation = schemas.resolveRelationInfo(
+        RelationInfo relation = schemas.findRelation(
             table.getName(),
             Operation.SHOW_CREATE,
             sessionSettings.sessionUser(),

--- a/server/src/main/java/io/crate/analyze/SwapTableAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/SwapTableAnalyzer.java
@@ -68,8 +68,8 @@ public final class SwapTableAnalyzer {
         SearchPath searchPath = txnCtx.sessionSettings().searchPath();
         Role user = txnCtx.sessionSettings().sessionUser();
         return new AnalyzedSwapTable(
-            schemas.resolveRelationInfo(swapTable.source(), Operation.ALTER, user, searchPath),
-            schemas.resolveRelationInfo(swapTable.target(), Operation.ALTER, user, searchPath),
+            schemas.findRelation(swapTable.source(), Operation.ALTER, user, searchPath),
+            schemas.findRelation(swapTable.target(), Operation.ALTER, user, searchPath),
             dropSource
         );
     }

--- a/server/src/main/java/io/crate/analyze/ViewAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/ViewAnalyzer.java
@@ -21,6 +21,8 @@
 
 package io.crate.analyze;
 
+import java.util.ArrayList;
+
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.RelationAnalyzer;
 import io.crate.exceptions.RelationUnknown;
@@ -36,8 +38,6 @@ import io.crate.sql.tree.CreateView;
 import io.crate.sql.tree.DropView;
 import io.crate.sql.tree.QualifiedName;
 import io.crate.sql.tree.Query;
-
-import java.util.ArrayList;
 
 public final class ViewAnalyzer {
 
@@ -94,7 +94,7 @@ public final class ViewAnalyzer {
         ArrayList<RelationName> missing = new ArrayList<>();
         for (QualifiedName qualifiedName : dropView.names()) {
             try {
-                views.add(schemas.resolveView(qualifiedName, txnCtx.sessionSettings().searchPath()).name());
+                views.add(schemas.findView(qualifiedName, txnCtx.sessionSettings().searchPath()).name());
             } catch (RelationUnknown e) {
                 if (!dropView.ifExists()) {
                     missing.add(RelationName.of(qualifiedName, txnCtx.sessionSettings().searchPath().currentSchema()));

--- a/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -702,7 +702,7 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
         if (withQuery != null) {
             relation = withQuery;
         } else {
-            RelationInfo relationInfo = schemas.resolveRelationInfo(
+            RelationInfo relationInfo = schemas.findRelation(
                 tableQualifiedName, context.currentOperation(), context.sessionSettings().sessionUser(), searchPath);
             switch (relationInfo) {
                 case DocTableInfo docTable ->

--- a/server/src/main/java/io/crate/metadata/RelationName.java
+++ b/server/src/main/java/io/crate/metadata/RelationName.java
@@ -28,14 +28,13 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
-import org.jetbrains.annotations.Nullable;
-
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.jetbrains.annotations.Nullable;
 
 import io.crate.blob.v2.BlobIndex;
 import io.crate.exceptions.InvalidRelationName;

--- a/server/src/main/java/io/crate/metadata/Schemas.java
+++ b/server/src/main/java/io/crate/metadata/Schemas.java
@@ -163,60 +163,6 @@ public class Schemas extends AbstractLifecycleComponent implements Iterable<Sche
         }
     }
 
-
-    /**
-     * Resolves the provided ident relation (table or view) against the search path.
-     * @param ident
-     * @param searchPath
-     * @throws RelationUnknown in case a valid relation cannot be resolved in the search path.
-     * @return the corresponding RelationName
-     */
-    public RelationName resolveRelation(QualifiedName ident, SearchPath searchPath) {
-        String identSchema = schemaName(ident);
-        String relation = relationName(ident);
-
-        Metadata metadata = clusterService.state().metadata();
-        ViewsMetadata views = metadata.custom(ViewsMetadata.TYPE);
-        ForeignTablesMetadata foreignTables = metadata.custom(ForeignTablesMetadata.TYPE, ForeignTablesMetadata.EMPTY);
-        if (identSchema == null) {
-            for (String pathSchema : searchPath) {
-                RelationName tableOrViewRelation = getRelation(pathSchema, relation, views, foreignTables);
-                if (tableOrViewRelation != null) {
-                    return tableOrViewRelation;
-                }
-            }
-        } else {
-            RelationName tableOrViewRelation = getRelation(identSchema, relation, views, foreignTables);
-            if (tableOrViewRelation != null) {
-                return tableOrViewRelation;
-            }
-        }
-        throw new RelationUnknown(ident.toString());
-    }
-
-    @Nullable
-    private RelationName getRelation(String pathSchema,
-                                     String relation,
-                                     @Nullable ViewsMetadata views,
-                                     ForeignTablesMetadata foreignTables) {
-        SchemaInfo schemaInfo = schemas.get(pathSchema);
-        if (schemaInfo == null) {
-            return null;
-        }
-        TableInfo tableInfo = schemaInfo.getTableInfo(relation);
-        if (tableInfo != null) {
-            return new RelationName(pathSchema, relation);
-        }
-        RelationName relationName = new RelationName(pathSchema, relation);
-        if (views != null && views.contains(relationName)) {
-            return relationName;
-        }
-        if (foreignTables.contains(relationName)) {
-            return relationName;
-        }
-        return null;
-    }
-
     /**
      * <p>
      * Return a relation matching the given qualified name.

--- a/server/src/main/java/io/crate/metadata/Schemas.java
+++ b/server/src/main/java/io/crate/metadata/Schemas.java
@@ -165,7 +165,7 @@ public class Schemas extends AbstractLifecycleComponent implements Iterable<Sche
 
     /**
      * <p>
-     * Return a relation matching the given qualified name.
+     * Finds a relation matching the given qualified name.
      * </p>
      *
      * <p>
@@ -187,17 +187,17 @@ public class Schemas extends AbstractLifecycleComponent implements Iterable<Sche
      * @throws OperationOnInaccessibleRelationException
      **/
     @SuppressWarnings("unchecked")
-    public <T extends RelationInfo> T resolveRelationInfo(QualifiedName qName,
-                                                          Operation operation,
-                                                          Role user,
-                                                          SearchPath searchPath) {
+    public <T extends RelationInfo> T findRelation(QualifiedName qName,
+                                                   Operation operation,
+                                                   Role user,
+                                                   SearchPath searchPath) {
         String schemaName = schemaName(qName);
         String tableName = relationName(qName);
 
         RelationInfo relationInfo = null;
         if (schemaName == null) {
             for (String schema : searchPath) {
-                relationInfo = resolveForeignTable(schema, tableName);
+                relationInfo = getForeignTable(schema, tableName);
                 if (relationInfo != null) {
                     break;
                 }
@@ -226,7 +226,7 @@ public class Schemas extends AbstractLifecycleComponent implements Iterable<Sche
             }
         } else {
             if (relationInfo == null) {
-                relationInfo = resolveForeignTable(schemaName, tableName);
+                relationInfo = getForeignTable(schemaName, tableName);
             }
             if (relationInfo == null) {
                 SchemaInfo schemaInfo = schemas.get(schemaName);
@@ -442,7 +442,7 @@ public class Schemas extends AbstractLifecycleComponent implements Iterable<Sche
 
 
     @Nullable
-    private ForeignTable resolveForeignTable(String schemaName, String tableName) {
+    private ForeignTable getForeignTable(String schemaName, String tableName) {
         Metadata metadata = clusterService.state().metadata();
         ForeignTablesMetadata foreignTables = metadata.custom(ForeignTablesMetadata.TYPE);
         if (foreignTables == null) {
@@ -454,7 +454,7 @@ public class Schemas extends AbstractLifecycleComponent implements Iterable<Sche
     /**
      * @throws RelationUnknown if the view cannot be resolved against the search path.
      */
-    public View resolveView(QualifiedName ident, SearchPath searchPath) {
+    public View findView(QualifiedName ident, SearchPath searchPath) {
         ViewsMetadata views = clusterService.state().metadata().custom(ViewsMetadata.TYPE);
         ViewMetadata metadata = null;
         RelationName name = null;

--- a/server/src/main/java/io/crate/metadata/view/ViewInfo.java
+++ b/server/src/main/java/io/crate/metadata/view/ViewInfo.java
@@ -23,15 +23,15 @@ package io.crate.metadata.view;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
-import org.jetbrains.annotations.Nullable;
-
 import org.elasticsearch.common.settings.Settings;
-
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
+
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationInfo;
@@ -84,7 +84,7 @@ public class ViewInfo implements RelationInfo {
 
     @Override
     public Set<Operation> supportedOperations() {
-        return Operation.READ_ONLY;
+        return EnumSet.of(Operation.READ, Operation.ALTER_TABLE_RENAME);
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/node/ddl/CreateSnapshotPlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/CreateSnapshotPlan.java
@@ -160,7 +160,7 @@ public class CreateSnapshotPlan implements Plan {
             for (Table<Symbol> table : createSnapshot.tables()) {
                 DocTableInfo docTableInfo;
                 try {
-                    docTableInfo = schemas.resolveRelationInfo(
+                    docTableInfo = schemas.findRelation(
                         table.getName(),
                         Operation.CREATE_SNAPSHOT,
                         txnCtx.sessionSettings().sessionUser(),

--- a/server/src/main/java/io/crate/replication/logical/analyze/LogicalReplicationAnalyzer.java
+++ b/server/src/main/java/io/crate/replication/logical/analyze/LogicalReplicationAnalyzer.java
@@ -77,7 +77,7 @@ public class LogicalReplicationAnalyzer {
             createPublication.tables(),
             q -> {
                 CoordinatorSessionSettings sessionSettings = txnCtx.sessionSettings();
-                DocTableInfo tableInfo = schemas.resolveRelationInfo(
+                DocTableInfo tableInfo = schemas.findRelation(
                     q,
                     Operation.CREATE_PUBLICATION,
                     sessionSettings.sessionUser(),

--- a/server/src/test/java/io/crate/metadata/SchemasTest.java
+++ b/server/src/test/java/io/crate/metadata/SchemasTest.java
@@ -198,40 +198,4 @@ public class SchemasTest extends CrateDummyClusterServiceUnitTest {
         assertThat(relation.schema(), is("schema"));
         assertThat(relation.name(), is("t"));
     }
-
-    @Test
-    public void testResolveRelationThrowsRelationUnknownfForInvalidFQN() throws IOException {
-        SQLExecutor sqlExecutor = getSqlExecutorBuilderForTable(new RelationName("schema", "t"), "schema");
-        QualifiedName invalidFqn = QualifiedName.of("bogus_schema", "t");
-
-        expectedException.expect(RelationUnknown.class);
-        expectedException.expectMessage("Relation 'bogus_schema.t' unknown");
-        sqlExecutor.schemas().resolveRelation(invalidFqn, sqlExecutor.getSessionSettings().searchPath());
-    }
-
-    @Test
-    public void testResolveRelationThrowsRelationUnknownIfRelationIsNotInSearchPath() throws IOException {
-        SQLExecutor sqlExecutor = getSqlExecutorBuilderForTable(new RelationName("schema", "t"), "doc", "schema");
-        QualifiedName table = QualifiedName.of("missing_table");
-
-        expectedException.expect(RelationUnknown.class);
-        expectedException.expectMessage("Relation 'missing_table' unknown");
-        sqlExecutor.schemas().resolveRelation(table, sqlExecutor.getSessionSettings().searchPath());
-    }
-
-    @Test
-    public void testResolveRelationForTableAndView() throws IOException {
-        SQLExecutor sqlExecutor = getSqlExecutorBuilderForTable(new RelationName("schema", "t"), "doc", "schema")
-            .addView(new RelationName("schema", "view"), "select 1");
-
-        QualifiedName table = QualifiedName.of("t");
-        RelationName tableRelation = sqlExecutor.schemas().resolveRelation(table, sqlExecutor.getSessionSettings().searchPath());
-        assertThat(tableRelation.schema(), is("schema"));
-        assertThat(tableRelation.name(), is("t"));
-
-        QualifiedName view = QualifiedName.of("view");
-        RelationName viewRelation = sqlExecutor.schemas().resolveRelation(view, sqlExecutor.getSessionSettings().searchPath());
-        assertThat(viewRelation.schema(), is("schema"));
-        assertThat(viewRelation.name(), is("view"));
-    }
 }

--- a/server/src/test/java/io/crate/metadata/SchemasTest.java
+++ b/server/src/test/java/io/crate/metadata/SchemasTest.java
@@ -151,7 +151,7 @@ public class SchemasTest extends CrateDummyClusterServiceUnitTest {
         QualifiedName fqn = QualifiedName.of("crate", "schema", "t");
         var sessionSettings = sqlExecutor.getSessionSettings();
         TableInfo tableInfo = sqlExecutor.schemas()
-            .resolveRelationInfo(fqn, Operation.READ, sessionSettings.sessionUser(), sessionSettings.searchPath());
+            .findRelation(fqn, Operation.READ, sessionSettings.sessionUser(), sessionSettings.searchPath());
 
         RelationName relation = tableInfo.ident();
         assertThat(relation.schema(), is("schema"));
@@ -172,7 +172,7 @@ public class SchemasTest extends CrateDummyClusterServiceUnitTest {
         var sessionSetttings = sqlExecutor.getSessionSettings();
         expectedException.expect(SchemaUnknownException.class);
         expectedException.expectMessage("Schema 'bogus_schema' unknown");
-        sqlExecutor.schemas().resolveRelationInfo(invalidFqn, Operation.READ, sessionSetttings.sessionUser(), sessionSetttings.searchPath());
+        sqlExecutor.schemas().findRelation(invalidFqn, Operation.READ, sessionSetttings.sessionUser(), sessionSetttings.searchPath());
     }
 
     @Test
@@ -183,7 +183,7 @@ public class SchemasTest extends CrateDummyClusterServiceUnitTest {
         var sessionSettings = sqlExecutor.getSessionSettings();
         expectedException.expect(RelationUnknown.class);
         expectedException.expectMessage("Relation 'missing_table' unknown");
-        sqlExecutor.schemas().resolveRelationInfo(table, Operation.READ, sessionSettings.sessionUser(), sessionSettings.searchPath());
+        sqlExecutor.schemas().findRelation(table, Operation.READ, sessionSettings.sessionUser(), sessionSettings.searchPath());
     }
 
     @Test
@@ -192,7 +192,7 @@ public class SchemasTest extends CrateDummyClusterServiceUnitTest {
         QualifiedName tableQn = QualifiedName.of("t");
         var sessionSettings = sqlExecutor.getSessionSettings();
         TableInfo tableInfo = sqlExecutor.schemas()
-            .resolveRelationInfo(tableQn, Operation.READ, sessionSettings.sessionUser(), sessionSettings.searchPath());
+            .findRelation(tableQn, Operation.READ, sessionSettings.sessionUser(), sessionSettings.searchPath());
 
         RelationName relation = tableInfo.ident();
         assertThat(relation.schema(), is("schema"));

--- a/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
@@ -683,7 +683,7 @@ public class SQLExecutor {
     public <T extends RelationInfo> T resolveTableInfo(String tableName) {
         IndexParts indexParts = new IndexParts(tableName);
         QualifiedName qualifiedName = QualifiedName.of(indexParts.getSchema(), indexParts.getTable());
-        return schemas.resolveRelationInfo(
+        return schemas.findRelation(
             qualifiedName,
             Operation.READ,
             sessionSettings.sessionUser(),


### PR DESCRIPTION
Because `resolveRelation`:

- Didn't check the supported operations
- Didn't contain the `getSimilarTables` logic
- Duplicated logic of `resolveRelationInfo`

---

Second commit is then renaming `resolveRelationInfo` to `findRelation`, see commit message for reasoning.
