### PR TITLE
Fix flaky lookup-join integration test

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/LookupJoinIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/LookupJoinIntegrationTest.java
@@ -36,7 +36,7 @@ public class LookupJoinIntegrationTest extends IntegTestCase {
 
     @Before
     public void setup() throws Exception {
-        execute("create table doc.t1 (id int)");
+        execute("create table doc.t1 (id int) with(number_of_replicas=0)");
         execute("insert into doc.t1 (id) select b from generate_series(1,10000) a(b)");
         execute("create table doc.t2 (id int)");
         execute("insert into doc.t2 (id) select b from generate_series(1,100) a(b)");


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The LookupJoinIntegrationTest appears flaky because of the high inserts which causes pending writes with replicas.
https://jenkins.crate.io/job/CrateDB/job/crate_on_pr/13572/testReport/junit/io.crate.integrationtests/LookupJoinIntegrationTest/test_basic_lookup_join/

Setting it to 0 replicas makes it work.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
