### PR TITLE
Add strpos scalar string function. #15624

### DIFF
--- a/docs/appendices/release-notes/5.7.0.rst
+++ b/docs/appendices/release-notes/5.7.0.rst
@@ -99,6 +99,9 @@ Scalar and Aggregation Functions
   format string to :ref:`to_char <scalar-to_char>` scalar function, which
   behaves exactly the same as uppercase ``YYYY`` to match PostgreSQL behaviour.
 
+- `Dhruv Patel <https://github.com/DHRUV6029>`_ added support for the
+  :ref:`strpos <scalar-strpos>` scalar function.
+
 Performance and Resilience Improvements
 ---------------------------------------
 

--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -797,6 +797,26 @@ Returns: ``text``
     +--------+
     SELECT 1 row in set (... sec)
 
+.. _scalar-strpos:
+
+``strpos(string, substring)``
+-----------------------------
+
+Returns first starting 1-based index of the specified substring within string.
+If substring is not found, returns zero.
+
+Returns: ``integer``
+
+::
+
+    cr> SELECT strpos('crate' , 'ate');
+    +---+
+    | 3 |
+    +---+
+    | 3 |
+    +---+
+    SELECT 1 row in set (... sec)
+
 .. _scalar-reverse:
 
 ``reverse(text)``

--- a/server/src/main/java/io/crate/expression/scalar/ScalarFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/ScalarFunctions.java
@@ -79,6 +79,7 @@ import io.crate.expression.scalar.string.ReverseFunction;
 import io.crate.expression.scalar.string.StringCaseFunction;
 import io.crate.expression.scalar.string.StringLeftRightFunction;
 import io.crate.expression.scalar.string.StringPaddingFunction;
+import io.crate.expression.scalar.string.StringPositionFucntion;
 import io.crate.expression.scalar.string.StringRepeatFunction;
 import io.crate.expression.scalar.string.StringSplitPartFunction;
 import io.crate.expression.scalar.string.TranslateFunction;
@@ -172,6 +173,7 @@ public class ScalarFunctions implements FunctionsProvider {
         TrimFunctions.register(builder);
         AsciiFunction.register(builder);
         EncodeDecodeFunction.register(builder);
+        StringPositionFucntion.register(builder);
         StringRepeatFunction.register(builder);
         StringSplitPartFunction.register(builder);
         ChrFunction.register(builder);

--- a/server/src/main/java/io/crate/expression/scalar/string/StringPositionFucntion.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/StringPositionFucntion.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar.string;
+
+import io.crate.data.Input;
+import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.BoundSignature;
+import io.crate.metadata.functions.Signature;
+import io.crate.types.DataTypes;
+
+public final class StringPositionFucntion extends Scalar<Integer , String> {
+
+    public static void register(Functions.Builder module) {
+        module.add(
+            Signature.scalar(
+                "strpos",
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.INTEGER.getTypeSignature()
+            ),
+            StringPositionFucntion::new
+        );
+    }
+
+    public StringPositionFucntion(Signature signature, BoundSignature boundSignature) {
+        super(signature, boundSignature);
+    }
+
+    @Override
+    public Integer evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<String>[] args) {
+        assert args.length == 2 : "strpos takes exactly two arguments";
+        var text = args[0].value();
+        var pattern = args[1].value();
+        if (text == null || pattern == null) {
+            return null;
+        }
+
+        return text.indexOf(pattern) + 1;
+    }
+}
+

--- a/server/src/test/java/io/crate/expression/scalar/string/StringPositionFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/string/StringPositionFunctionTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar.string;
+
+import org.junit.Test;
+
+import io.crate.expression.scalar.ScalarTestCase;
+
+public class StringPositionFunctionTest extends ScalarTestCase {
+
+    @Test
+    public void find_position_when_substring_found() {
+
+        assertEvaluate("strpos('crate', 'ate')", 3);
+    }
+
+    @Test
+    public void find_position_when_substring_not_found() {
+        assertEvaluate("strpos('crate', 'db')", 0);
+    }
+
+    @Test
+    public void test_multiple_occurrences() {
+        assertEvaluate("strpos('This is crate', 'is')", 3);
+    }
+
+    @Test
+    public void test_when_substring_is_empty() {
+        assertEvaluate("strpos('ThIs IS crate', '')", 1);
+    }
+
+    public void test_when_string_is_empty() {
+        assertEvaluate("strpos('', 'crate')", 0);
+    }
+
+    public void test_when_string_and_substring_is_empty() {
+        assertEvaluate("strpos('', '')", 1);
+    }
+
+    public void test_when_substring_is_null() {
+        assertEvaluateNull("strpos('This is Crate', null)");
+    }
+
+    public void test_when_string_is_null() {
+        assertEvaluateNull("strpos(null, 'crate')");
+    }
+
+    public void test_when_string_and_substring_is_null() {
+        assertEvaluateNull("strpos(null, null)");
+    }
+
+}


### PR DESCRIPTION
Closes #15624

Added strpos(string , substring) scalar string function to find first occurrence index of substring in string (1-based indexing compatible with PostGreSQL) returns 0 if substring is not found in string. 

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
