### PR TITLE
Ensure that sample docids are iterated in order

### DIFF
--- a/server/src/main/java/io/crate/statistics/Reservoir.java
+++ b/server/src/main/java/io/crate/statistics/Reservoir.java
@@ -21,6 +21,7 @@
 
 package io.crate.statistics;
 
+import java.util.Arrays;
 import java.util.Random;
 
 import com.carrotsearch.hppc.LongArrayList;
@@ -56,6 +57,7 @@ public final class Reservoir {
     }
 
     public LongArrayList samples() {
+        Arrays.sort(samples.buffer, 0, samples.elementsCount);
         return samples;
     }
 }

--- a/server/src/test/java/io/crate/statistics/ReservoirTest.java
+++ b/server/src/test/java/io/crate/statistics/ReservoirTest.java
@@ -25,11 +25,24 @@ package io.crate.statistics;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
 
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.LongField;
+import org.apache.lucene.document.Field.Store;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
 
-public class ReservoirTest {
+import io.crate.common.io.IOUtils;
+
+public class ReservoirTest extends ESTestCase {
 
     @Test
     public void test_sampling() {
@@ -38,7 +51,7 @@ public class ReservoirTest {
         for (int i = 0; i < 100; i++) {
             samples.update(i);
         }
-        assertThat(samples.samples().buffer).containsExactly(83, 50, 13, 18, 38, 0L, 0L, 0L, 0L, 0L);
+        assertThat(samples.samples().buffer).containsExactly(13, 18, 38, 50, 83, 0L, 0L, 0L, 0L, 0L);
     }
 
     @Test
@@ -53,5 +66,43 @@ public class ReservoirTest {
         samples.update(6L);
 
         assertThat(samples.samples()).isEmpty();
+    }
+
+    @Test
+    public void test_sample_ids_are_reported_in_order() throws Exception {
+        int numSearches = random().nextInt(3, 10);
+        List<Directory> dirs = new ArrayList<>();
+        Document doc = new Document();
+        for (int i = 0; i < numSearches; i++) {
+            Directory d = newDirectory();
+            RandomIndexWriter iw = new RandomIndexWriter(random(), d);
+            for (int j = 0; j < 200; j++) {
+                doc.clear();
+                doc.add(new LongField("long", 1, Store.NO));
+                iw.addDocument(doc);
+            }
+            iw.close();
+            dirs.add(d);
+        }
+
+        Reservoir r = new Reservoir(30, random());
+
+        int readerIdx = 0;
+        for (Directory d : dirs) {
+            try (IndexReader ir = DirectoryReader.open(d)) {
+                IndexSearcher searcher = new IndexSearcher(ir);
+                ReservoirSampler.sampleDocIds(r, readerIdx, searcher);
+            }
+            readerIdx++;
+        }
+
+        var sortedSamples = r.samples();
+        long lastId = -1;
+        for (var v : sortedSamples) {
+            assertThat(v.value).isGreaterThan(lastId);
+            lastId = v.value;
+        }
+
+        IOUtils.close(dirs);
     }
 }


### PR DESCRIPTION
Fixes a bug whereby iteration over samples from large datasets would be out-of-order,
messing up the shard/segment/doc collection assumptions.