### PR TITLE
Remove `Schemas.getTableInfo(RelationName, Operation)` overload

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/collect/count/InternalCountOperation.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/count/InternalCountOperation.java
@@ -46,11 +46,11 @@ import org.elasticsearch.index.shard.IllegalIndexShardStateException;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import com.carrotsearch.hppc.IntIndexedContainer;
 import com.carrotsearch.hppc.cursors.IntCursor;
 
-import org.jetbrains.annotations.VisibleForTesting;
 import io.crate.common.concurrent.CompletableFutures;
 import io.crate.exceptions.JobKilledException;
 import io.crate.execution.support.ThreadPools;
@@ -61,7 +61,6 @@ import io.crate.metadata.RelationName;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocTableInfo;
-import io.crate.metadata.table.Operation;
 
 @Singleton
 public class InternalCountOperation implements CountOperation {
@@ -150,7 +149,7 @@ public class InternalCountOperation implements CountOperation {
         try (Engine.Searcher searcher = indexShard.acquireSearcher("count-operation")) {
             String indexName = indexShard.shardId().getIndexName();
             var relationName = RelationName.fromIndexName(indexName);
-            DocTableInfo table = schemas.getTableInfo(relationName, Operation.READ);
+            DocTableInfo table = schemas.getTableInfo(relationName);
             LuceneQueryBuilder.Context queryCtx = queryBuilder.convert(
                 filter,
                 txnCtx,

--- a/server/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
+++ b/server/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
@@ -137,7 +137,6 @@ import io.crate.metadata.RowGranularity;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.sys.SysNodeChecksTableInfo;
-import io.crate.metadata.table.Operation;
 import io.crate.planner.operators.SubQueryResults;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -521,7 +520,7 @@ public class ProjectionToProjectorVisitor
         BiConsumer<String, IndexItem> constraintsChecker = (indexName, indexItem) -> checkConstraints(
             indexItem,
             indexName,
-            schemas.getTableInfo(projection.tableIdent(), Operation.INSERT),
+            schemas.getTableInfo(projection.tableIdent()),
             context.txnCtx,
             nodeCtx,
             validatorsCache,

--- a/server/src/main/java/io/crate/execution/jobs/JobSetup.java
+++ b/server/src/main/java/io/crate/execution/jobs/JobSetup.java
@@ -67,8 +67,8 @@ import com.carrotsearch.hppc.procedures.ObjectProcedure;
 
 import io.crate.Streamer;
 import io.crate.breaker.ConcurrentRamAccounting;
-import io.crate.breaker.TypedRowAccounting;
 import io.crate.breaker.TypedCellsAccounting;
+import io.crate.breaker.TypedRowAccounting;
 import io.crate.data.Paging;
 import io.crate.data.Row;
 import io.crate.data.RowConsumer;
@@ -120,7 +120,6 @@ import io.crate.metadata.Routing;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.settings.SessionSettings;
-import io.crate.metadata.table.Operation;
 import io.crate.planner.distribution.DistributionType;
 import io.crate.planner.node.StreamerVisitor;
 import io.crate.planner.operators.PKAndVersion;
@@ -833,7 +832,7 @@ public class JobSetup {
                 localNodeId,
                 context.sharedShardContexts,
                 clusterService.state().metadata(),
-                relationName -> schemas.getTableInfo(relationName, Operation.READ),
+                relationName -> schemas.getTableInfo(relationName),
                 routings));
             return null;
         }

--- a/server/src/main/java/io/crate/planner/node/ddl/RestoreSnapshotPlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/RestoreSnapshotPlan.java
@@ -47,12 +47,12 @@ import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.ElasticsearchClient;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.snapshots.SnapshotInfo;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import io.crate.analyze.AnalyzedRestoreSnapshot;
 import io.crate.analyze.BoundRestoreSnapshot;
 import io.crate.analyze.SnapshotSettings;
 import io.crate.analyze.SymbolEvaluator;
-import org.jetbrains.annotations.VisibleForTesting;
 import io.crate.common.collections.Lists;
 import io.crate.data.Row;
 import io.crate.data.Row1;
@@ -218,7 +218,8 @@ public class RestoreSnapshotPlan implements Plan {
                 txnCtx.sessionSettings().searchPath().currentSchema());
 
             try {
-                DocTableInfo docTableInfo = schemas.getTableInfo(relationName, Operation.RESTORE_SNAPSHOT);
+                DocTableInfo docTableInfo = schemas.getTableInfo(relationName);
+                Operation.blockedRaiseException(docTableInfo, Operation.RESTORE_SNAPSHOT);
                 // Table existence check is done later after resolving indices and applying all table name/schema renaming options.
                 PartitionName partitionName = null;
                 if (table.partitionProperties().isEmpty() == false) {

--- a/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
+++ b/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
@@ -106,7 +106,6 @@ import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocTableInfo;
-import io.crate.metadata.table.Operation;
 import io.crate.metadata.tablefunctions.TableFunctionImplementation;
 import io.crate.planner.DependencyCarrier;
 import io.crate.planner.ExecutionPlan;
@@ -138,7 +137,7 @@ public class InsertFromValues implements LogicalPlan {
                         SubQueryResults subQueryResults) {
         DocTableInfo tableInfo = dependencies
             .schemas()
-            .getTableInfo(writerProjection.tableIdent(), Operation.INSERT);
+            .getTableInfo(writerProjection.tableIdent());
 
         // For instance, the target table of the insert from values
         // statement is the table with the following schema:
@@ -314,7 +313,7 @@ public class InsertFromValues implements LogicalPlan {
                                                      SubQueryResults subQueryResults) {
         final DocTableInfo tableInfo = dependencies
             .schemas()
-            .getTableInfo(writerProjection.tableIdent(), Operation.INSERT);
+            .getTableInfo(writerProjection.tableIdent());
 
         String[] updateColumnNames;
         Assignments assignments;

--- a/server/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
+++ b/server/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
@@ -26,7 +26,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
@@ -86,7 +85,6 @@ import io.crate.metadata.SearchPath;
 import io.crate.metadata.SimpleReference;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.settings.SessionSettings;
-import io.crate.metadata.table.Operation;
 import io.crate.netty.NettyBootstrap;
 import io.crate.sql.tree.ColumnPolicy;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
@@ -173,7 +171,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
         Schemas schemas = mock(Schemas.class);
         when(tableInfo.columns()).thenReturn(Collections.<Reference>emptyList());
         when(tableInfo.versionCreated()).thenReturn(Version.CURRENT);
-        when(schemas.getTableInfo(any(RelationName.class), eq(Operation.INSERT))).thenReturn(tableInfo);
+        when(schemas.getTableInfo(any(RelationName.class))).thenReturn(tableInfo);
 
         var dynamicLongColRef = new SimpleReference(
                 new ReferenceIdent(TABLE_IDENT,"dynamic_long_col"),

--- a/server/src/test/java/io/crate/metadata/SchemasTest.java
+++ b/server/src/test/java/io/crate/metadata/SchemasTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.metadata;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_VERSION_CREATED;
@@ -29,7 +30,6 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -48,11 +48,14 @@ import io.crate.exceptions.SchemaUnknownException;
 import io.crate.expression.udf.UserDefinedFunctionMetadata;
 import io.crate.expression.udf.UserDefinedFunctionsMetadata;
 import io.crate.metadata.doc.DocSchemaInfoFactory;
+import io.crate.metadata.sys.SysSchemaInfo;
 import io.crate.metadata.table.Operation;
 import io.crate.metadata.table.SchemaInfo;
 import io.crate.metadata.table.TableInfo;
 import io.crate.metadata.view.ViewsMetadata;
 import io.crate.metadata.view.ViewsMetadataTest;
+import io.crate.role.Role;
+import io.crate.role.Roles;
 import io.crate.sql.tree.QualifiedName;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
@@ -62,20 +65,16 @@ public class SchemasTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testSystemSchemaIsNotWritable() throws Exception {
-        expectedException.expect(OperationOnInaccessibleRelationException.class);
-        expectedException.expectMessage("The relation \"foo.bar\" doesn't support or allow INSERT " +
-                                        "operations");
-
-        RelationName relationName = new RelationName("foo", "bar");
-        SchemaInfo schemaInfo = mock(SchemaInfo.class);
-        TableInfo tableInfo = mock(TableInfo.class);
-        when(tableInfo.ident()).thenReturn(relationName);
-        when(tableInfo.supportedOperations()).thenReturn(Operation.SYS_READ_ONLY);
-        when(schemaInfo.getTableInfo(relationName.name())).thenReturn(tableInfo);
-        when(schemaInfo.name()).thenReturn(relationName.schema());
-
-        Schemas schemas = getReferenceInfos(schemaInfo);
-        schemas.getTableInfo(relationName, Operation.INSERT);
+        Roles roles = () -> List.of(Role.CRATE_USER);
+        var sysSchemaInfo = new SysSchemaInfo(clusterService, roles);
+        Map<String, SchemaInfo> builtInSchemas = Map.of("sys", sysSchemaInfo);
+        DocSchemaInfoFactory docSchemaInfoFactory = mock(DocSchemaInfoFactory.class);
+        try (Schemas schemas = new Schemas(builtInSchemas, clusterService, docSchemaInfoFactory, roles)) {
+            QualifiedName qname = QualifiedName.of("sys", "summits");
+            assertThatThrownBy(() -> schemas.findRelation(qname, Operation.INSERT, Role.CRATE_USER, SearchPath.pathWithPGCatalogAndDoc()))
+                .isExactlyInstanceOf(OperationOnInaccessibleRelationException.class)
+                .hasMessage("The relation \"sys.summits\" doesn't support or allow INSERT operations");
+        }
     }
 
     @Test


### PR DESCRIPTION
We had:

- `schemas.getTableInfo(RelationName)`
- `schemas.getTableInfo(RelationName, Operation)`

This removes the second overload as in most cases an additional
operation checks is redundant, and if needed easily done by calling
`Operation.blockedRaiseException` on the result.

An alternative would be to remove the first overload, and always
enforce an operation check.

---

This additionally also integrates foreign table handling, and re-raises
`ClassCastException` due to upcasts with a
`OperationOnInaccessibleRelationException`. This is currently not
needed, but based on the method signature it's kinda expected that it
can return foreign tables too.
