### PR TITLE
Fix handling of filters on top of a ordered collect

### DIFF
--- a/docs/appendices/release-notes/5.6.3.rst
+++ b/docs/appendices/release-notes/5.6.3.rst
@@ -47,6 +47,10 @@ See the :ref:`version_5.6.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that could cause ``SELECT`` statements to ignore a ``WHERE``
+  clause if it involved views or virtual tables, and unused columns containing a
+  window function.
+
 - Fixed an issue that could cause ``SHOW CREATE TABLE`` on a missing table to
   mention similarly named tables, despite the user not having any permissions on
   those tables.

--- a/server/src/main/java/io/crate/execution/engine/collect/sources/ShardCollectSource.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/sources/ShardCollectSource.java
@@ -259,6 +259,8 @@ public class ShardCollectSource implements CollectSource, IndexEventListener {
         }
         OrderBy orderBy = collectPhase.orderBy();
         if (collectPhase.maxRowGranularity() == RowGranularity.DOC && orderBy != null) {
+            assert !Projections.hasAnyShardProjections(collectPhase.projections())
+                : "Must not have shard projections for ordered collect";
             return createMultiShardScoreDocCollector(
                 collectPhase,
                 requireMoveToStartSupport,

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -28,6 +28,7 @@ import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -2220,5 +2221,42 @@ public class TransportSQLActionTest extends IntegTestCase {
     public void test_subscripts_on_expressions() {
         execute("select [0, 1, 2, 3][2] as val");
         assertThat(response).hasRows("1");
+    }
+
+
+    @Test
+    public void test_filter_on_top_of_order_by_and_collect_works() throws Exception {
+        /**
+         * This is a query that resulted in a Filter/FilterProjection with requiredGranularity==SHARD
+         * That filter was ignored by the ordered-collect logic in ShardCollectSource
+         *
+         * Usually a filter is pushed into the collect, and this case didn't surface, but
+         * here the Filter->Collect could only be merged _after_ column pruning
+         *  (to remove the `row_number()` and the window agg)
+         * and we currently don't run another optimize iteration after column pruning.
+         *
+         * If this ever changes, the test should be adapted to disable the filter->collect merge
+         * with a initial filter->orderBy->Collect plan
+         */
+        execute("CREATE TABLE t1 (ts TIMESTAMP, field1 TEXT, anumber DOUBLE)");
+        execute("INSERT INTO t1 (ts, field1, anumber) VALUES (now(), 'abc', 1.1)");
+        execute("refresh table t1");
+        execute(
+            """
+            CREATE VIEW v1
+            AS
+            SELECT field1, anumber
+            FROM (
+                SELECT
+                    field1,
+                    row_number() OVER (PARTITION BY date_bin('1 day'::interval,ts, 0)) "row_number",
+                    anumber
+                FROM t1
+                ORDER BY field1
+                ) x;
+            """
+        );
+        execute("SELECT * FROM v1 WHERE field1 = 'xyz'");
+        assertThat(response).isEmpty();
     }
 }


### PR DESCRIPTION
Fixes https://github.com/crate/crate/issues/15709

A projection on shard level isn't supported on top of a ordered collect.
The results from the shards would first need to be merged.

The query itself could be optimized by merging the filter into collect,
but that is a separate improvement for a follow up.
