### PR TITLE
Pin crash <0.31.3

### DIFF
--- a/blackbox/requirements.txt
+++ b/blackbox/requirements.txt
@@ -1,7 +1,7 @@
 # don't pin crate version numbers so the latest will always be pulled when you
 # set up your environment from scratch
 
-crash>=0.25.0
+crash>=0.25.0,<0.31.3
 crate
 asyncpg>=0.27.0
 cr8>=0.19.1


### PR DESCRIPTION
To unblock CI.
https://github.com/crate/crash/pull/432 causes some undesired output:

    VALUES (1, 'one'), (2, 'two'), (3, 'three')
    +------+-------+
    | col1 | col2  |
    +------+-------+
    |    1 | one   |
    |    2 | two   |
    |    3 | three |
    +------+-------+
    VALUES (1, 'ONE'), (2, 'TWO'), (3, 'THREE') 3 rows in set (0.004 sec)
