### PR TITLE
Run MergeFilterAndCollect rule after column pruning

### DIFF
--- a/docs/appendices/release-notes/5.6.3.rst
+++ b/docs/appendices/release-notes/5.6.3.rst
@@ -47,6 +47,11 @@ See the :ref:`version_5.6.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that could cause ``SELECT`` statements on virtual tables or
+  views and a ``WHERE`` clause to run with an expensive execution plan and not
+  utilize the table's indices due to the ``merge_filter_and_collect`` optimizer
+  rule not being applied.
+
 - Fixed an issue that could cause ``SELECT`` statements to ignore a ``WHERE``
   clause if it involved views or virtual tables, and unused columns containing a
   window function.

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -180,6 +180,7 @@ public class LogicalPlanner {
 
     public static final List<Rule<?>> FETCH_OPTIMIZER_RULES = List.of(
         new RemoveRedundantEval(),
+        new MergeFilterAndCollect(),
         new RewriteToQueryThenFetch()
     );
 


### PR DESCRIPTION
Not sure if this is still applicable for 5.7 despite feature freeze? A bit in the grey area 

---

This is a follow up for the bug fix in
https://github.com/crate/crate/pull/15714 that ensures the case also
gets optimized.

Column pruning can drop entire operators like `WindowAgg`, which can
cause rules like `MergeFilterAndCollect` to match.

This changes the logical plan from:

    Rename[field1, num] AS doc.v1 (rows=0)
      └ Rename[field1, num] AS x (rows=0)
        └ OrderBy[field1 ASC] (rows=0)
          └ Filter[(field1 = 'xyz')] (rows=0)
            └ Collect[doc.t1 | [field1, num] | true] (rows=unknown)

to:

    Rename[field1, num] AS doc.v1 (rows=unknown)
      └ Rename[field1, num] AS x (rows=unknown)
        └ OrderBy[field1 ASC] (rows=unknown)
          └ Collect[doc.t1 | [field1, num] | (field1 = 'xyz')] (rows=unknown)

In a query like:

    SELECT * FROM v1 WHERE field1 = 'xyz'

With a view definition like:

    CREATE VIEW v1
    AS
    SELECT field1, num
    FROM (
        SELECT
            field1,
            row_number() OVER (PARTITION BY date_bin('1 day'::interval,ts, 0)) "row_number",
            num
        FROM t1
        ORDER BY field1
        ) x;
