### PR TITLE
Match test name for JoinConditionSymbolsExtractor

### DIFF
--- a/server/src/test/java/io/crate/planner/operators/JoinConditionSymbolsExtractorTest.java
+++ b/server/src/test/java/io/crate/planner/operators/JoinConditionSymbolsExtractorTest.java
@@ -40,7 +40,7 @@ import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SqlExpressions;
 import io.crate.testing.T3;
 
-public class HashJoinConditionSymbolsExtractorTest extends CrateDummyClusterServiceUnitTest {
+public class JoinConditionSymbolsExtractorTest extends CrateDummyClusterServiceUnitTest {
 
     private SqlExpressions sqlExpressions;
     private AnalyzedRelation tr1;


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`HashJoinConditionSymbolsExtractor` was renamed to `JoinConditionSymbolsExtractor` but the test was not.


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
