### PR TITLE
Move change entry for hash-join filter push down to 5.6.3

### DIFF
--- a/docs/appendices/release-notes/5.6.3.rst
+++ b/docs/appendices/release-notes/5.6.3.rst
@@ -47,6 +47,9 @@ See the :ref:`version_5.6.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue in filter-push-down for joins which prevented constant join
+  conditions to be pushed-down in hash-joins.
+
 - Fixed an issue that could cause ``SELECT`` statements on virtual tables or
   views and a ``WHERE`` clause to run with an expensive execution plan and not
   utilize the table's indices due to the ``merge_filter_and_collect`` optimizer

--- a/docs/appendices/release-notes/5.7.0.rst
+++ b/docs/appendices/release-notes/5.7.0.rst
@@ -113,9 +113,6 @@ Performance and Resilience Improvements
 - Improved the performance of the :ref:`analyze` statement. CrateDB now uses much
   less memory when collecting column statistics.
 
-- The join optimizer rule that pushes down filters in join conditions for
-  nested loop joins, is expanded to also handle hash joins.
-
 Administration and Operations
 -----------------------------
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
