### PR TITLE
Pending replica writes debug

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/PendingWritesReproductionTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PendingWritesReproductionTest.java
@@ -34,7 +34,7 @@ public class PendingWritesReproductionTest extends IntegTestCase {
     @Repeat(iterations = 100)
     @TestLogging("org.elasticsearch.indices.recovery:TRACE, org.elasticsearch.index.translog:TRACE")
     public void reproduction() throws Exception {
-        execute("create table doc.t1 (id int) with(number_of_replicas=3)");
+        execute("create table doc.t1 (id int) with(number_of_replicas = 3,  \"write.wait_for_active_shards\" = 'ALL')");
         execute("insert into doc.t1 (id) select b from generate_series(1,10000) a(b)");
     }
 

--- a/server/src/test/java/io/crate/integrationtests/PendingWritesReproductionTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PendingWritesReproductionTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.integrationtests;
+
+import org.elasticsearch.test.IntegTestCase;
+import org.elasticsearch.test.junit.annotations.TestLogging;
+import org.junit.Test;
+
+import com.carrotsearch.randomizedtesting.annotations.Repeat;
+
+@IntegTestCase.ClusterScope(numDataNodes = 4, supportsDedicatedMasters = false, numClientNodes = 0)
+public class PendingWritesReproductionTest extends IntegTestCase {
+
+    @Test
+    @Repeat(iterations = 100)
+    @TestLogging("org.elasticsearch.indices.recovery:TRACE, org.elasticsearch.index.translog:TRACE")
+    public void reproduction() throws Exception {
+        execute("create table doc.t1 (id int) with(number_of_replicas=3)");
+        execute("insert into doc.t1 (id) select b from generate_series(1,10000) a(b)");
+    }
+
+}


### PR DESCRIPTION
Relates to https://github.com/crate/crate/pull/15697#pullrequestreview-1934667413


First commit - test failing in 20% cases on CI. 

Locally fails more often but one can increase number of nodes and replicas. 
Would be harder to debug due to the noise though.

https://jenkins.crate.io/job/CrateDB/job/crate_on_pr/13753/#showFailuresLink
In case results gets removed after some time, it's (20 failures / +20) out of 100 iterations

Failure:

pending tasks:
```
 org.opentest4j.AssertionFailedError: [All incoming requests on node [node_s1] should have finished. Expected 0 but got 94652; pending tasks [[]]] 
expected: 0L
 but was: 94652L
```
but also interesting - overaccouting of replicated operations, expect> actual
```
total, if known, should be > recovered. total [1200], recovered [1267]
org.elasticsearch.indices.recovery.RecoveryState$Translog.incrementRecoveredOperations(RecoveryState.java:401)
```