### PR TITLE
Fix LIKE matching an empty string pattern in WHERE clause

### DIFF
--- a/docs/appendices/release-notes/5.6.4.rst
+++ b/docs/appendices/release-notes/5.6.4.rst
@@ -50,3 +50,9 @@ Fixes
 - Changed :ref:`scalar-has-database-priv` and :ref:`scalar-has-schema-priv`
   functions to be registered under :ref:`postgres-pg_catalog` schema, to be
   compatible with PostgreSQL behaviour.
+
+- Fixed an issue that caused ``LIKE`` operator matching an empty string pattern
+  in ``WHERE`` clause to return invalid results, e.g.::
+
+    SELECT * FROM t WHERE col LIKE ''
+

--- a/server/src/main/java/io/crate/expression/operator/LikeOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/LikeOperator.java
@@ -24,7 +24,9 @@ package io.crate.expression.operator;
 import java.util.List;
 import java.util.regex.Pattern;
 
+import org.apache.lucene.index.Term;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
 import org.jetbrains.annotations.Nullable;
 
 import io.crate.data.Input;
@@ -129,6 +131,9 @@ public class LikeOperator extends Operator<String> {
             Object value = patternLiteral.value();
             assert value instanceof String
                 : "LikeOperator is registered for string types. Value must be a string";
+            if (((String) value).isEmpty()) {
+                return new TermQuery(new Term(ref.storageIdent(), ""));
+            }
             Character escapeChar = escapeFromSymbols.apply(args);
             return caseSensitivity.likeQuery(ref.storageIdent(),
                 (String) value,

--- a/server/src/test/java/io/crate/lucene/LikeQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/LikeQueryBuilderTest.java
@@ -27,6 +27,7 @@ import static io.crate.testing.Asserts.assertThat;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.WildcardQuery;
 import org.junit.Test;
 
@@ -149,5 +150,13 @@ public class LikeQueryBuilderTest extends LuceneQueryBuilderTest {
         Query query = convert("text_no_index ILIKE any(['%abc%'])");
         assertThat(query).hasToString("(text_no_index ILIKE ANY(['%abc%']))");
         assertThat(query).isExactlyInstanceOf(GenericFunctionQuery.class);
+    }
+
+    // tracks a bug https://github.com/crate/crate/issues/15743
+    @Test
+    public void test_like_empty_string_results_in_term_query() {
+        Query query = convert("name like ''");
+        assertThat(query).hasToString("name:");
+        assertThat(query).isExactlyInstanceOf(TermQuery.class);
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes https://github.com/crate/crate/issues/15743

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
