### PR TITLE
Check for mixed-cluster analyze calls in FetchSampleRequest constructor

### DIFF
--- a/server/src/main/java/io/crate/statistics/ReservoirSampler.java
+++ b/server/src/main/java/io/crate/statistics/ReservoirSampler.java
@@ -128,7 +128,7 @@ public final class ReservoirSampler {
         rateLimiter.setMBPerSec(newReadLimit.getMbFrac()); // mbPerSec is volatile in SimpleRateLimiter, one volatile write
     }
 
-    Samples getSamples(RelationName relationName, List<Reference> columns, int maxSamples) {
+    Samples getSamples(RelationName relationName, List<Reference> columns) {
         TableInfo table;
         try {
             table = schemas.getTableInfo(relationName);
@@ -148,7 +148,6 @@ public final class ReservoirSampler {
         try (SketchRamAccounting rla = new SketchRamAccounting(ramAccounting, rateLimiter)) {
             return getSamples(
                 columns,
-                maxSamples,
                 docTable,
                 rla,
                 random,
@@ -160,13 +159,12 @@ public final class ReservoirSampler {
     }
 
     private Samples getSamples(List<Reference> columns,
-                               int maxSamples,
                                DocTableInfo docTable,
                                SketchRamAccounting ramAccounting,
                                Random random,
                                Metadata metadata) throws IOException {
 
-        Reservoir fetchIdSamples = new Reservoir(maxSamples, random);
+        Reservoir fetchIdSamples = new Reservoir(random);
         long totalNumDocs = 0;
         long totalSizeInBytes = 0;
 

--- a/server/src/main/java/io/crate/statistics/Samples.java
+++ b/server/src/main/java/io/crate/statistics/Samples.java
@@ -69,9 +69,8 @@ class Samples implements Writeable {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        if (out.getVersion().before(Version.V_5_7_0)) {
-            throw new UnsupportedOperationException("Cannot run ANALYZE in a mixed version cluster");
-        }
+        assert out.getVersion().onOrAfter(Version.V_5_7_0)
+            : "ANALYZE in mixed-version cluster should have been caught by FetchSampleRequest constructor";
         out.writeLong(numTotalDocs);
         out.writeLong(numTotalSizeInBytes);
         out.writeVInt(columnSketches.size());

--- a/server/src/main/java/io/crate/statistics/TransportAnalyzeAction.java
+++ b/server/src/main/java/io/crate/statistics/TransportAnalyzeAction.java
@@ -60,21 +60,6 @@ public final class TransportAnalyzeAction {
     private static final String FETCH_SAMPLES = "internal:crate:sql/analyze/fetch_samples";
     private static final String RECEIVE_TABLE_STATS = "internal:crate:sql/analyze/receive_stats";
 
-    /**
-     * This number is from PostgreSQL, they chose this based on the paper
-     * "Random sampling for histogram construction: how much is enough?"
-     *
-     * > Their Corollary 1 to Theorem 5 says that for table size n, histogram size k,
-     * > maximum relative error in bin size f, and error probability gamma, the minimum random sample size is
-     * >    r = 4 * k * ln(2*n/gamma) / f^2
-     * > Taking f = 0.5, gamma = 0.01, n = 10^6 rows, we obtain r = 305.82 * k
-     * > Note that because of the log function, the dependence on n is quite weak;
-     * > even at n = 10^12, a 300*k sample gives <= 0.66 bin size error with probability 0.99.
-     * > So there's no real need to scale for n, which is a good thing because we don't necessarily know it at this point.
-     *
-     * In PostgreSQL `k` is configurable (per column). We don't support changing k, we default it to 100
-     */
-    private static final int NUM_SAMPLES = 30_000;
     private final TransportService transportService;
     private final Schemas schemas;
     private final ClusterService clusterService;
@@ -109,7 +94,7 @@ public final class TransportAnalyzeAction {
 
                     if (previous == null) {
                         newSamples.completeAsync(
-                            () -> reservoirSampler.getSamples(req.relation(), req.columns(), req.maxSamples()),
+                            () -> reservoirSampler.getSamples(req.relation(), req.columns()),
                             executor
                         );
                         return newSamples
@@ -202,7 +187,7 @@ public final class TransportAnalyzeAction {
             transportService.sendRequest(
                 node,
                 FETCH_SAMPLES,
-                new FetchSampleRequest(relationName, columns, NUM_SAMPLES),
+                new FetchSampleRequest(relationName, columns, node.getVersion()),
                 responseHandler
             );
         }


### PR DESCRIPTION
Exceptions thrown when writing to a StreamOutput will in general end 
up closing a node connection, because the NodeActionRequestHandler 
only expects IOExceptions from a writeTo() method.  Instead, we need 
to check for incompatible node versions up-front when deserializing the 
FetchSampleRequest. Errors thrown during deserialization will be reported 
back to the transmitting node in a way that can be handled gracefully.