### PR TITLE
Adjust ExpFunctionTest so that it passes on apple silicon

### DIFF
--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/ExpFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/ExpFunctionTest.java
@@ -31,9 +31,9 @@ public class ExpFunctionTest extends ScalarTestCase {
 
     @Test
     public void test_exp_scalar() {
-        assertNormalize("exp(1)", isLiteral(2.718281828459045));
-        assertNormalize("exp(1::bigint)", isLiteral(2.718281828459045));
-        assertNormalize("exp(1.0)", isLiteral(2.718281828459045));
-        assertNormalize("exp(1.0::real)", isLiteral(2.718281828459045));
+        assertNormalize("exp(1)", isLiteral(2.718281828459045, 1E-15d));
+        assertNormalize("exp(1::bigint)", isLiteral(2.718281828459045, 1E-15d));
+        assertNormalize("exp(1.0)", isLiteral(2.718281828459045, 1E-15d));
+        assertNormalize("exp(1.0::real)", isLiteral(2.718281828459045, 1E-15d));
     }
 }


### PR DESCRIPTION
The result of `java.lang.Math.exp()` is slightly different on various
different platforms.  Here we add a delta to the tests in
`ExpFunctionTest` to ensure that it passes on apple silicon as 
well as intel.