### PR TITLE
Enable push-down of constant join conditions in cross and outer-joins

### DIFF
--- a/docs/appendices/release-notes/5.8.0.rst
+++ b/docs/appendices/release-notes/5.8.0.rst
@@ -116,6 +116,19 @@ Scalar and Aggregation Functions
 Performance and Resilience Improvements
 ---------------------------------------
 
+- Extended push-down of constant join conditions to right, left and cross joins.
+  This optimization applies constant join conditions such as `x > 1` before the
+  join operation to reduce the number of rows to joins. This improves the performance
+  on queries such as::
+
+    select * from t1 left join t2 on t1.id = t2.id and t1.id > 1
+
+  This optimization can be disabled if desired, with the session setting::
+
+    SET optimizer_move_constant_join_conditions_beneath_join = false
+
+  Note that this setting is experimental, and may change in the future.
+
 - Extended the lookup-join optimization to make it applicable to more complex
   queries when they include sub-queries, an inner-equi-join and if there is a
   large imbalance in size between the joined tables. This optimization is

--- a/server/src/main/java/io/crate/planner/operators/JoinPlan.java
+++ b/server/src/main/java/io/crate/planner/operators/JoinPlan.java
@@ -66,7 +66,7 @@ public class JoinPlan extends AbstractJoinPlan {
         this(lhs, rhs, joinType, joinCondition, false, false, false, false, LookUpJoin.NONE);
     }
 
-    private JoinPlan(LogicalPlan lhs,
+    public JoinPlan(LogicalPlan lhs,
                      LogicalPlan rhs,
                      JoinType joinType,
                      @Nullable Symbol joinCondition,

--- a/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -1336,14 +1336,14 @@ public class JoinIntegrationTest extends IntegTestCase {
         execute("EXPLAIN (COSTS FALSE)" + stmt);
         assertThat(response).hasLines(
                 "Eval[id, reference]",
-                "  └ NestedLoopJoin[LEFT | ((cluster_id = id) AND (kind = 'bar'))]",
+                "  └ NestedLoopJoin[LEFT | (cluster_id = id)]",
                 "    ├ HashJoin[(cluster_id = id)]",
                 "    │  ├ HashJoin[(subscription_id = id)]",
                 "    │  │  ├ Collect[doc.t3 | [id, reference] | (reference = 'bazinga')]",
                 "    │  │  └ Collect[doc.t1 | [subscription_id, id] | true]",
                 "    │  └ Collect[doc.t2 | [cluster_id] | (kind = 'bar')]",
-                "    └ Rename[cluster_id, kind] AS temp",
-                "      └ Collect[doc.t2 | [cluster_id, kind] | true]"
+                "    └ Rename[cluster_id] AS temp",
+                "      └ Collect[doc.t2 | [cluster_id] | (kind = 'bar')]"
         );
 
         execute(stmt);

--- a/server/src/test/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathJoinTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathJoinTest.java
@@ -21,7 +21,7 @@
 
 package io.crate.planner.optimizer.rule;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static io.crate.testing.Asserts.assertThat;
 
 import java.util.Collections;
 import java.util.Map;
@@ -36,8 +36,8 @@ import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.RelationName;
 import io.crate.planner.operators.Collect;
-import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.JoinPlan;
+import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.optimizer.costs.PlanStats;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Match;
@@ -52,26 +52,22 @@ public class MoveConstantJoinConditionsBeneathJoinTest extends CrateDummyCluster
     private SqlExpressions sqlExpressions;
     private Map<RelationName, AnalyzedRelation> sources;
     private PlanStats planStats;
+    private Collect c1;
+    private Collect c2;
 
     @Before
     public void prepare() throws Exception {
         sources = T3.sources(clusterService);
         sqlExpressions = new SqlExpressions(sources);
         planStats = new PlanStats(sqlExpressions.nodeCtx, CoordinatorTxnCtx.systemTransactionContext(), new TableStats());
+        c1 = new Collect((AbstractTableRelation<?>) sources.get(T3.T1), Collections.emptyList(), WhereClause.MATCH_ALL);
+        c2 = new Collect((AbstractTableRelation<?>) sources.get(T3.T2), Collections.emptyList(), WhereClause.MATCH_ALL);
     }
 
     @Test
-    public void test_move_constant_join_condition_beneath_join_plan() {
-        var t1 = (AbstractTableRelation<?>) sources.get(T3.T1);
-        var t2 = (AbstractTableRelation<?>) sources.get(T3.T2);
-
-        Collect c1 = new Collect(t1, Collections.emptyList(), WhereClause.MATCH_ALL);
-        Collect c2 = new Collect(t2, Collections.emptyList(), WhereClause.MATCH_ALL);
-
+    public void test_extract_constant_join_condition_into_filter_on_inner_join() {
         // This condition has a non-constant part `doc.t1.x = doc.t2.y` and a constant part `doc.t2.b = 'abc'`
         var joinCondition = sqlExpressions.asSymbol("doc.t1.x = doc.t2.y and doc.t2.b = 'abc'");
-        var nonConstantPart = sqlExpressions.asSymbol("doc.t1.x = doc.t2.y");
-        var constantPart = sqlExpressions.asSymbol("doc.t2.b = 'abc'");
 
         JoinPlan jp = new JoinPlan(c1, c2, JoinType.INNER, joinCondition);
         var rule = new MoveConstantJoinConditionsBeneathJoin();
@@ -80,7 +76,7 @@ public class MoveConstantJoinConditionsBeneathJoinTest extends CrateDummyCluster
         assertThat(match.isPresent()).isTrue();
         assertThat(match.value()).isEqualTo(jp);
 
-        JoinPlan result = (JoinPlan) rule.apply(
+        LogicalPlan result = rule.apply(
             match.value(),
             match.captures(),
             planStats,
@@ -88,10 +84,172 @@ public class MoveConstantJoinConditionsBeneathJoinTest extends CrateDummyCluster
             sqlExpressions.nodeCtx,
             UnaryOperator.identity());
 
-        assertThat(result.joinCondition()).isEqualTo(nonConstantPart);
-        assertThat(result.lhs()).isEqualTo(c1);
-        Filter filter = (Filter) result.rhs();
-        assertThat(filter.source()).isEqualTo(c2);
-        assertThat(filter.query()).isEqualTo(constantPart);
+        assertThat(result).hasOperators(
+            "Join[INNER | (x = y)]",
+            "  ├ Collect[doc.t1 | [] | true]",
+            "  └ Filter[(b = 'abc')]",
+            "    └ Collect[doc.t2 | [] | true]"
+        );
+    }
+
+    @Test
+    public void test_extract_constant_join_condition_into_filter_on_cross_join() {
+        var joinCondition = sqlExpressions.asSymbol("doc.t1.x = doc.t2.y and doc.t2.b = 'abc'");
+
+        JoinPlan jp = new JoinPlan(c1, c2, JoinType.CROSS, joinCondition);
+        var rule = new MoveConstantJoinConditionsBeneathJoin();
+        Match<JoinPlan> match = rule.pattern().accept(jp, Captures.empty());
+
+        assertThat(match.isPresent()).isTrue();
+        assertThat(match.value()).isEqualTo(jp);
+
+        LogicalPlan result = rule.apply(
+            match.value(),
+            match.captures(),
+            planStats,
+            CoordinatorTxnCtx.systemTransactionContext(),
+            sqlExpressions.nodeCtx,
+            UnaryOperator.identity());
+
+        assertThat(result).hasOperators(
+            "Join[CROSS | (x = y)]",
+            "  ├ Collect[doc.t1 | [] | true]",
+            "  └ Filter[(b = 'abc')]",
+            "    └ Collect[doc.t2 | [] | true]"
+        );
+    }
+
+    @Test
+    public void test_filter_on_lhs_on_right_join() {
+        var joinCondition = sqlExpressions.asSymbol("doc.t1.x = doc.t2.y and doc.t1.x > 1");
+
+        JoinPlan jp = new JoinPlan(c1, c2, JoinType.RIGHT, joinCondition);
+        var rule = new MoveConstantJoinConditionsBeneathJoin();
+        Match<JoinPlan> match = rule.pattern().accept(jp, Captures.empty());
+
+        assertThat(match.isPresent()).isTrue();
+        assertThat(match.value()).isEqualTo(jp);
+
+        LogicalPlan result = rule.apply(
+            match.value(),
+            match.captures(),
+            planStats,
+            CoordinatorTxnCtx.systemTransactionContext(),
+            sqlExpressions.nodeCtx,
+            UnaryOperator.identity());
+
+        assertThat(result).hasOperators(
+            "Join[RIGHT | (x = y)]",
+            "  ├ Filter[(x > 1)]",
+            "  │  └ Collect[doc.t1 | [] | true]",
+            "  └ Collect[doc.t2 | [] | true]"
+        );
+    }
+
+    @Test
+    public void test_filter_on_rhs_on_right_join() {
+        var joinCondition = sqlExpressions.asSymbol("doc.t1.x = doc.t2.y and doc.t2.y > 1");
+
+        JoinPlan jp = new JoinPlan(c1, c2, JoinType.RIGHT, joinCondition);
+        var rule = new MoveConstantJoinConditionsBeneathJoin();
+        Match<JoinPlan> match = rule.pattern().accept(jp, Captures.empty());
+
+        assertThat(match.isPresent()).isTrue();
+        assertThat(match.value()).isEqualTo(jp);
+
+        LogicalPlan result = rule.apply(
+            match.value(),
+            match.captures(),
+            planStats,
+            CoordinatorTxnCtx.systemTransactionContext(),
+            sqlExpressions.nodeCtx,
+            UnaryOperator.identity());
+
+        assertThat(result).hasOperators(
+            "Join[RIGHT | ((x = y) AND (y > 1))]",
+            "  ├ Collect[doc.t1 | [] | true]",
+            "  └ Collect[doc.t2 | [] | true]"
+        );
+    }
+
+    @Test
+    public void test_filter_on_rhs_on_left_join() {
+        var joinCondition = sqlExpressions.asSymbol("doc.t1.x = doc.t2.y and doc.t2.y > 1");
+
+        JoinPlan jp = new JoinPlan(c1, c2, JoinType.LEFT, joinCondition);
+        var rule = new MoveConstantJoinConditionsBeneathJoin();
+        Match<JoinPlan> match = rule.pattern().accept(jp, Captures.empty());
+
+        assertThat(match.isPresent()).isTrue();
+        assertThat(match.value()).isEqualTo(jp);
+
+        LogicalPlan result = rule.apply(
+            match.value(),
+            match.captures(),
+            planStats,
+            CoordinatorTxnCtx.systemTransactionContext(),
+            sqlExpressions.nodeCtx,
+            UnaryOperator.identity());
+
+        assertThat(result).hasOperators(
+            "Join[LEFT | (x = y)]",
+            "  ├ Collect[doc.t1 | [] | true]",
+            "  └ Filter[(y > 1)]",
+            "    └ Collect[doc.t2 | [] | true]"
+        );
+    }
+
+    @Test
+    public void test_filter_on_lhs_on_left_join() {
+        var joinCondition = sqlExpressions.asSymbol("doc.t1.x = doc.t2.y and doc.t1.x > 1");
+
+        JoinPlan jp = new JoinPlan(c1, c2, JoinType.LEFT, joinCondition);
+        var rule = new MoveConstantJoinConditionsBeneathJoin();
+        Match<JoinPlan> match = rule.pattern().accept(jp, Captures.empty());
+
+        assertThat(match.isPresent()).isTrue();
+        assertThat(match.value()).isEqualTo(jp);
+
+        LogicalPlan result = rule.apply(
+            match.value(),
+            match.captures(),
+            planStats,
+            CoordinatorTxnCtx.systemTransactionContext(),
+            sqlExpressions.nodeCtx,
+            UnaryOperator.identity());
+
+        assertThat(result).hasOperators(
+            "Join[LEFT | ((x = y) AND (x > 1))]",
+            "  ├ Collect[doc.t1 | [] | true]",
+            "  └ Collect[doc.t2 | [] | true]"
+        );
+    }
+
+    @Test
+    public void test_filter_on_lhs_on_left_join_with_remaining_filter() {
+        var joinCondition = sqlExpressions.asSymbol("doc.t1.x = doc.t2.y and doc.t1.x = 1 and t2.y > 5");
+
+        JoinPlan jp = new JoinPlan(c1, c2, JoinType.LEFT, joinCondition);
+        var rule = new MoveConstantJoinConditionsBeneathJoin();
+        Match<JoinPlan> match = rule.pattern().accept(jp, Captures.empty());
+
+        assertThat(match.isPresent()).isTrue();
+        assertThat(match.value()).isEqualTo(jp);
+
+        LogicalPlan result = rule.apply(
+            match.value(),
+            match.captures(),
+            planStats,
+            CoordinatorTxnCtx.systemTransactionContext(),
+            sqlExpressions.nodeCtx,
+            UnaryOperator.identity());
+
+        assertThat(result).hasOperators(
+            "Join[LEFT | ((x = y) AND (x = 1))]",
+            "  ├ Collect[doc.t1 | [] | true]",
+            "  └ Filter[(y > 5)]",
+            "    └ Collect[doc.t2 | [] | true]"
+        );
+
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This extends `optimizer_move_constant_join_conditions_beneath_join` to also provide filter-push-down for cross and outer joins.

```
Q: select count(*) from doc.t1 right join doc.t2 on t1.id = t2.id and t1.id < 1000
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |     6180.172 ±  107.879 |   6037.348 |   6157.541 |   6255.526 |   6353.298 |
|   V2    |       77.206 ±   55.086 |     56.349 |     59.384 |     62.273 |    233.831 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               - 195.06%                           - 196.18%
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 195.06%
The test has statistical significance
```

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
