### PR TITLE
Make Input/Scalar AutoCloseable; fix UDF resource leaks

### DIFF
--- a/libs/dex/src/main/java/io/crate/data/Input.java
+++ b/libs/dex/src/main/java/io/crate/data/Input.java
@@ -21,7 +21,12 @@
 
 package io.crate.data;
 
-public interface Input<T> {
+public interface Input<T> extends AutoCloseable {
 
     T value();
+
+
+    @Override
+    default void close() {
+    }
 }

--- a/server/src/main/java/io/crate/analyze/SymbolEvaluator.java
+++ b/server/src/main/java/io/crate/analyze/SymbolEvaluator.java
@@ -66,7 +66,9 @@ public final class SymbolEvaluator extends BaseImplementationSymbolVisitor<Row> 
                                   Row params,
                                   SubQueryResults subQueryValues) {
         SymbolEvaluator symbolEval = new SymbolEvaluator(txnCtx, nodeCtx, subQueryValues);
-        return symbol.accept(symbolEval, params).value();
+        try (Input<?> accept = symbol.accept(symbolEval, params)) {
+            return accept.value();
+        }
     }
 
     @Override
@@ -91,6 +93,10 @@ public final class SymbolEvaluator extends BaseImplementationSymbolVisitor<Row> 
     }
 
     public Function<Symbol, Object> bind(Row params) {
-        return x -> x.accept(this, params).value();
+        return x -> {
+            try (var input = x.accept(this, params)) {
+                return input.value();
+            }
+        };
     }
 }

--- a/server/src/main/java/io/crate/execution/dml/upsert/UpdateToInsert.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/UpdateToInsert.java
@@ -209,7 +209,10 @@ public final class UpdateToInsert {
             int updateIdx = updateColumns.indexOf(ref);
             if (updateIdx >= 0) {
                 Symbol symbol = updateAssignments[updateIdx];
-                Object value = symbol.accept(eval, values).value();
+                Object value;
+                try (Input<?> input = symbol.accept(eval, values)) {
+                    value = input.value();
+                }
                 assert ref.column().isRoot()
                     : "If updateColumns.indexOf(reference-from-table.columns()) is >= 0 it must be a top level reference";
                 insertValues[i] = value;

--- a/server/src/main/java/io/crate/execution/engine/collect/collectors/LuceneBatchIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/collectors/LuceneBatchIterator.java
@@ -21,14 +21,12 @@
 
 package io.crate.execution.engine.collect.collectors;
 
-import io.crate.common.exceptions.Exceptions;
-import io.crate.data.BatchIterator;
-import io.crate.data.Input;
-import io.crate.data.Row;
-import io.crate.execution.engine.fetch.ReaderContext;
-import io.crate.expression.InputRow;
-import io.crate.expression.reference.doc.lucene.CollectorContext;
-import io.crate.expression.reference.doc.lucene.LuceneCollectorExpression;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.DocIdSetIterator;
@@ -38,14 +36,17 @@ import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.Bits;
-
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import java.io.IOException;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
-import java.util.concurrent.CompletionStage;
+
+import io.crate.common.exceptions.Exceptions;
+import io.crate.data.BatchIterator;
+import io.crate.data.Input;
+import io.crate.data.Row;
+import io.crate.execution.engine.fetch.ReaderContext;
+import io.crate.expression.InputRow;
+import io.crate.expression.reference.doc.lucene.CollectorContext;
+import io.crate.expression.reference.doc.lucene.LuceneCollectorExpression;
 
 /**
  * BatchIterator implementation which exposes the data stored in a lucene index.
@@ -62,6 +63,7 @@ public class LuceneBatchIterator implements BatchIterator<Row> {
     private final LuceneCollectorExpression[] expressions;
     private final List<LeafReaderContext> leaves;
     private final InputRow row;
+    private final List<? extends Input<?>> inputs;
     private Weight weight;
     private final Float minScore;
 
@@ -83,6 +85,7 @@ public class LuceneBatchIterator implements BatchIterator<Row> {
         this.doScores = doScores || minScore != null;
         this.minScore = minScore;
         this.collectorContext = collectorContext;
+        this.inputs = inputs;
         this.row = new InputRow(inputs);
         this.expressions = expressions.toArray(new LuceneCollectorExpression[0]);
         leaves = indexSearcher.getTopReaderContext().leaves();
@@ -173,6 +176,9 @@ public class LuceneBatchIterator implements BatchIterator<Row> {
     public void close() {
         clearState();
         killed = BatchIterator.CLOSED;
+        for (var input : inputs) {
+            input.close();
+        }
     }
 
     @Override

--- a/server/src/main/java/io/crate/execution/engine/collect/collectors/LuceneOrderedDocCollector.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/collectors/LuceneOrderedDocCollector.java
@@ -76,6 +76,7 @@ public class LuceneOrderedDocCollector extends OrderedDocCollector {
     private final DummyScorer scorer;
     private final IndexSearcher searcher;
     private final AtomicReference<Throwable> killed = new AtomicReference<>();
+    private final List<? extends Input<?>> inputs;
 
     private int batchSize;
     private boolean batchSizeReduced = false;
@@ -109,6 +110,7 @@ public class LuceneOrderedDocCollector extends OrderedDocCollector {
         this.sort = sort;
         this.scorer = new DummyScorer();
         this.expressions = expressions;
+        this.inputs = inputs;
         this.rowFunction = new ScoreDocRowFunction(
             searcher.getIndexReader(),
             inputs,
@@ -142,6 +144,9 @@ public class LuceneOrderedDocCollector extends OrderedDocCollector {
 
     @Override
     public void close() {
+        for (var input : inputs) {
+            input.close();
+        }
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/FunctionExpression.java
+++ b/server/src/main/java/io/crate/expression/FunctionExpression.java
@@ -21,12 +21,12 @@
 
 package io.crate.expression;
 
+import java.util.Arrays;
+
 import io.crate.data.Input;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.TransactionContext;
 import io.crate.metadata.Scalar;
-
-import java.util.Arrays;
+import io.crate.metadata.TransactionContext;
 
 public final class FunctionExpression<ReturnType, InputType> implements Input<ReturnType> {
 
@@ -55,5 +55,13 @@ public final class FunctionExpression<ReturnType, InputType> implements Input<Re
         return "FuncExpr{" +
                scalar.signature().getName() +
                ", args=" + Arrays.toString(arguments) + '}';
+    }
+
+    @Override
+    public void close() {
+        scalar.close();
+        for (int i = 0; i < arguments.length; i++) {
+            arguments[i].close();
+        }
     }
 }

--- a/server/src/main/java/io/crate/metadata/Scalar.java
+++ b/server/src/main/java/io/crate/metadata/Scalar.java
@@ -63,7 +63,8 @@ import io.crate.role.Roles;
  *
  * @param <ReturnType> the class of the returned value
  */
-public abstract class Scalar<ReturnType, InputType> implements FunctionImplementation, FunctionToQuery {
+public abstract class Scalar<ReturnType, InputType>
+    implements FunctionImplementation, FunctionToQuery, AutoCloseable {
 
     public static final Set<Feature> NO_FEATURES = Set.of();
     public static final Set<Feature> DETERMINISTIC_ONLY = EnumSet.of(Feature.DETERMINISTIC);
@@ -86,6 +87,10 @@ public abstract class Scalar<ReturnType, InputType> implements FunctionImplement
     @Override
     public BoundSignature boundSignature() {
         return boundSignature;
+    }
+
+    @Override
+    public void close() {
     }
 
     /**


### PR DESCRIPTION
Within the `PolyglotScalar` we create a GraalVM polyglot Context that
can allocate native resources, these native resources are not
automatically released - leading to potential leaks.

We didn't notice this with JS as embedded language, but trying to add
Python surfaced this issue as the thread leak detection in the test
suite triggered.

Relevant part from the `Context.close` docs:

    Closes this context and frees up potentially allocated native resources. A context may not
    free all native resources allocated automatically. For this reason it is recommended to close
    contexts after use. If the context is currently being executed on another thread, then an
    {@link IllegalStateException} is thrown. To close concurrently executing contexts see
    {@link #close(boolean)}.

This is a first, but incomplete step towards addressing the problem:

- Makes Input/Scalar closeable
- Updates the PolyglotScalar to properly close the context

What's incomplete is to go through all the `Input` usages and actually
close them after use. (But it would already be an improvement over the status quo, and we could already merge this and iterate on it)
