### PR TITLE
Revert "Update GraalVM to 24.0.0; switch to polyglot package"

### DIFF
--- a/extensions/lang-js/pom.xml
+++ b/extensions/lang-js/pom.xml
@@ -24,15 +24,9 @@
       <version>${versions.annotations}</version>
     </dependency>
     <dependency>
-      <groupId>org.graalvm.polyglot</groupId>
-      <artifactId>polyglot</artifactId>
+      <groupId>org.graalvm.js</groupId>
+      <artifactId>js</artifactId>
       <version>${versions.graalvm}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.graalvm.polyglot</groupId>
-      <artifactId>js-community</artifactId>
-      <version>${versions.graalvm}</version>
-      <type>pom</type>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -262,7 +262,7 @@
     <versions.aws>1.12.353</versions.aws>
     <versions.commonsmath>3.6.1</versions.commonsmath>
     <versions.jaxb_api>2.3.1</versions.jaxb_api>
-    <versions.graalvm>24.0.0</versions.graalvm>
+    <versions.graalvm>23.0.3</versions.graalvm>
     <versions.jwt>4.4.0</versions.jwt>
     <versions.jwks-rsa>0.22.1</versions.jwks-rsa>
 


### PR DESCRIPTION
This reverts commit 8ace5130edb1a551dc39b5ec9ef41b4f3a235e29.

Seeing errors in CI:

    Error injecting constructor, java.lang.InternalError: java.lang.UnsatisfiedLinkError: Expecting an absolute path of the library: ?/.cache/org.graalvm.polyglot/engine/libtruffleattach/ad91dae1c5adc8f7ce79f78620596dbbdf2c86b43891cd5aff1d62d28f41429a/bin/libtruffleattach.so
      at io.crate.operation.language.JavaScriptLanguage.<init>(Unknown Source)
      while locating io.crate.operation.language.JavaScriptLanguage
    Caused by: java.lang.InternalError: java.lang.UnsatisfiedLinkError: Expecting an absolute path of the library: ?/.cache/org.graalvm.polyglot/engine/libtruffleattach/ad91dae1c5adc8f7ce79f78620596dbbdf2c86b43891cd5aff1d62d28f41429a/bin/libtruffleattach.so

Couldn't reproduce it locally yet, seems to be related to tests running
in docker containers.

Doing this as a quickfix to get CI green until the root cause is
identified and resolved
