### PR TITLE
Register has_database/schema_privilege functions under pg_catalog

### DIFF
--- a/docs/appendices/release-notes/5.6.4.rst
+++ b/docs/appendices/release-notes/5.6.4.rst
@@ -47,4 +47,6 @@ See the :ref:`version_5.6.0` release notes for a full list of changes in the
 Fixes
 =====
 
-None
+- Changed :ref:`scalar-has-database-priv` and :ref:`scalar-has-schema-priv`
+  functions to be registered under :ref:`postgres-pg_catalog` schema, to be
+  compatible with PostgreSQL behaviour.

--- a/server/src/main/java/io/crate/expression/scalar/HasDatabasePrivilegeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/HasDatabasePrivilegeFunction.java
@@ -30,9 +30,11 @@ import org.jetbrains.annotations.Nullable;
 
 import io.crate.Constants;
 import io.crate.common.FourFunction;
+import io.crate.metadata.FunctionName;
 import io.crate.metadata.Functions;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
+import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
 import io.crate.role.Permission;
 import io.crate.role.Privilege;
 import io.crate.role.Role;
@@ -42,7 +44,7 @@ import io.crate.types.DataTypes;
 
 public class HasDatabasePrivilegeFunction extends HasPrivilegeFunction {
 
-    public static final String NAME = "has_database_privilege";
+    public static final FunctionName NAME = new FunctionName(PgCatalogSchemaInfo.NAME, "has_database_privilege");
 
     private static final FourFunction<Roles, Role, Object, Collection<Permission>, Boolean> CHECK_BY_DB_NAME =
         (roles, user, db, permissions) -> {

--- a/server/src/main/java/io/crate/expression/scalar/HasSchemaPrivilegeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/HasSchemaPrivilegeFunction.java
@@ -29,9 +29,11 @@ import java.util.function.BiFunction;
 import org.jetbrains.annotations.Nullable;
 
 import io.crate.common.FourFunction;
+import io.crate.metadata.FunctionName;
 import io.crate.metadata.Functions;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
+import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
 import io.crate.metadata.pgcatalog.PgCatalogTableDefinitions;
 import io.crate.role.Permission;
 import io.crate.role.Role;
@@ -41,7 +43,7 @@ import io.crate.types.DataTypes;
 
 public class HasSchemaPrivilegeFunction extends HasPrivilegeFunction {
 
-    public static final String NAME = "has_schema_privilege";
+    public static final FunctionName NAME = new FunctionName(PgCatalogSchemaInfo.NAME, "has_schema_privilege");
 
     private static final FourFunction<Roles, Role, Object, Collection<Permission>, Boolean> CHECK_BY_SCHEMA_NAME =
         (roles, user, schema, permissions) -> {

--- a/server/src/test/java/io/crate/expression/scalar/HasDatabasePrivilegeFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/HasDatabasePrivilegeFunctionTest.java
@@ -66,6 +66,12 @@ public class HasDatabasePrivilegeFunctionTest extends ScalarTestCase {
     }
 
     @Test
+    public void test_function_registered_under_pg_catalog() {
+        sqlExpressions = new SqlExpressions(tableSources, null, Role.CRATE_USER);
+        assertEvaluate("pg_catalog.has_database_privilege('crate', 'crate', 'CONNECT')", true);
+    }
+
+    @Test
     public void test_no_user_compile_gets_new_instance() {
         assertCompileAsSuperUser("has_database_privilege(name, 'CONNECT')", isNotSameInstance());
     }

--- a/server/src/test/java/io/crate/expression/scalar/HasSchemaPrivilegeFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/HasSchemaPrivilegeFunctionTest.java
@@ -62,6 +62,12 @@ public class HasSchemaPrivilegeFunctionTest extends ScalarTestCase {
     }
 
     @Test
+    public void test_function_registered_under_pg_catalog() {
+        sqlExpressions = new SqlExpressions(tableSources, null, Role.CRATE_USER);
+        assertEvaluate("pg_catalog.has_schema_privilege('crate', 'sys', 'USAGE')", true);
+    }
+
+    @Test
     public void test_no_user_compile_gets_new_instance() {
         assertCompileAsSuperUser("has_schema_privilege(name, 'USAGE')", isNotSameInstance());
     }


### PR DESCRIPTION
Although those 2 functions were available in the search path, they were not registered under `pg_catalog` schema, as the should, and as a result pg compatible tools which my use full path (e.g.
`pg_catalog.has_shema_privilege()`) would get an `Uknown Function` error.

Fixes: #15749
