### PR TITLE
Allow non super users to access remote servers

### DIFF
--- a/docs/sql/statements/create-server.rst
+++ b/docs/sql/statements/create-server.rst
@@ -61,7 +61,7 @@ Do not raise an error if the server already exists.
   property to define the connection string::
 
     CREATE SERVER pg FOREIGN DATA WRAPPER jdbc
-    OPTIONS (url 'jdbc:postgresql://example.com:5432')
+    OPTIONS (url 'jdbc:postgresql://example.com:5432/')
 
 See :ref:`administration-fdw` for the foreign data wrapper specific options.
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes https://github.com/crate/crate/issues/15775

As @proddata mentioned, there is no standardized database connection string format and a method to identify `localhost` (maybe string manipulation?) however, since we bundled only Postgres JDBC driver for now so I think we can wrap this up by utilizing `org.postgresql.Driver.parseURL`.
## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
