### PR TITLE
Update netty to 4.1.108, mockito to 5.11.0 and datasketches to 5.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -255,7 +255,7 @@
     <versions.jts>1.19.0</versions.jts>
     <versions.jna>5.13.0</versions.jna>
     <versions.tdigest>3.3</versions.tdigest>
-    <versions.datasketches>5.0.1</versions.datasketches>
+    <versions.datasketches>5.0.2</versions.datasketches>
     <versions.hdrhistogram>2.1.12</versions.hdrhistogram>
     <versions.caffeine>3.1.8</versions.caffeine>
     <versions.jodatime>2.12.5</versions.jodatime>

--- a/pom.xml
+++ b/pom.xml
@@ -249,7 +249,7 @@
     <versions.antlr>4.13.1</versions.antlr>
     <versions.quickcheck>1.0</versions.quickcheck>
     <versions.hppc>0.8.2</versions.hppc>
-    <versions.netty>4.1.107.Final</versions.netty>
+    <versions.netty>4.1.108.Final</versions.netty>
     <versions.lucene>9.10.0</versions.lucene>
     <versions.spatial4j>0.8</versions.spatial4j>
     <versions.jts>1.19.0</versions.jts>

--- a/pom.xml
+++ b/pom.xml
@@ -281,7 +281,7 @@
     <versions.grpc>1.55.1</versions.grpc>
 
     <versions.hamcrest>2.2</versions.hamcrest>
-    <versions.mockito>5.10.0</versions.mockito>
+    <versions.mockito>5.11.0</versions.mockito>
     <versions.jdbc>42.7.3</versions.jdbc>
     <versions.jsonassert>1.5.1</versions.jsonassert>
 


### PR DESCRIPTION
- https://netty.io/news/2024/03/21/4-1-108-Final.html
- https://github.com/mockito/mockito/releases/tag/v5.11.0
- https://github.com/apache/datasketches-java/releases/tag/5.0.2
