### PR TITLE
Make role not found errors more consistent

### DIFF
--- a/server/src/main/java/io/crate/analyze/Analyzer.java
+++ b/server/src/main/java/io/crate/analyze/Analyzer.java
@@ -788,11 +788,7 @@ public class Analyzer {
                 ? context.sessionSettings().userName()
                 : createUserMapping.userName();
 
-            Role user = roleManager.findUser(userName);
-            if (user == null) {
-                throw new IllegalArgumentException("Cannot create a user mapping for an unknown user: '" + userName + "'");
-            }
-
+            Role user = roleManager.getUser(userName);
             ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
                 context.transactionContext(),
                 nodeCtx,

--- a/server/src/main/java/io/crate/exceptions/RoleUnknownException.java
+++ b/server/src/main/java/io/crate/exceptions/RoleUnknownException.java
@@ -31,6 +31,10 @@ public class RoleUnknownException extends RuntimeException implements ResourceUn
         super(getMessage(Collections.singletonList(roleName)));
     }
 
+    public RoleUnknownException(int oid) {
+        super(String.format(Locale.ENGLISH, "Role with OID %d does not exist", oid));
+    }
+
     public RoleUnknownException(List<String> roleNames) {
         super(getMessage(roleNames));
     }

--- a/server/src/main/java/io/crate/expression/scalar/HasPrivilegeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/HasPrivilegeFunction.java
@@ -23,7 +23,6 @@ package io.crate.expression.scalar;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Locale;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
@@ -32,6 +31,7 @@ import org.jetbrains.annotations.Nullable;
 import io.crate.common.FourFunction;
 import io.crate.data.Input;
 import io.crate.exceptions.MissingPrivilegeException;
+import io.crate.exceptions.RoleUnknownException;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -49,18 +49,13 @@ public abstract class HasPrivilegeFunction extends Scalar<Boolean, Object> {
 
     private final FourFunction<Roles, Role, Object, Collection<Permission>, Boolean> checkPrivilege;
 
-    protected static final BiFunction<Roles, Object, Role> USER_BY_NAME = (roles, userName) -> {
-        var user = roles.findUser((String) userName);
-        if (user == null) {
-            throw new IllegalArgumentException(String.format(Locale.ENGLISH, "User %s does not exist", userName));
-        }
-        return user;
-    };
+    protected static final BiFunction<Roles, Object, Role> USER_BY_NAME = (roles, userName) -> roles.getUser((String) userName);
 
     protected static final BiFunction<Roles, Object, Role> USER_BY_OID = (roles, userOid) -> {
-        var user = roles.findUser((Integer) userOid);
+        int oid = (int) userOid;
+        var user = roles.findUser(oid);
         if (user == null) {
-            throw new IllegalArgumentException(String.format(Locale.ENGLISH, "User with OID %d does not exist", userOid));
+            throw new RoleUnknownException(oid);
         }
         return user;
     };

--- a/server/src/main/java/io/crate/planner/statement/SetSessionAuthorizationPlan.java
+++ b/server/src/main/java/io/crate/planner/statement/SetSessionAuthorizationPlan.java
@@ -60,10 +60,7 @@ public class SetSessionAuthorizationPlan implements Plan {
         String userName = setSessionAuthorization.user();
         Role user;
         if (userName != null) {
-            user = roles.findUser(userName);
-            if (user == null) {
-                throw new IllegalArgumentException("User '" + userName + "' does not exist.");
-            }
+            user = roles.getUser(userName);
         } else {
             user = sessionSettings.authenticatedUser();
         }

--- a/server/src/main/java/io/crate/role/Roles.java
+++ b/server/src/main/java/io/crate/role/Roles.java
@@ -33,6 +33,7 @@ import java.util.function.Predicate;
 import org.jetbrains.annotations.Nullable;
 
 import io.crate.common.FourFunction;
+import io.crate.exceptions.RoleUnknownException;
 import io.crate.metadata.pgcatalog.OidHash;
 
 public interface Roles {
@@ -60,6 +61,17 @@ public interface Roles {
             return role;
         }
         return null;
+    }
+
+    /**
+     * Like {@link #findUser(String)} but throws {@link RoleUnknownException} if the user is not found.
+     **/
+    default Role getUser(String userName) {
+        Role user = findUser(userName);
+        if (user == null) {
+            throw new RoleUnknownException(userName);
+        }
+        return user;
     }
 
     /**

--- a/server/src/test/java/io/crate/analyze/CreateUserMappingAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateUserMappingAnalyzerTest.java
@@ -25,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.Test;
 
+import io.crate.exceptions.RoleUnknownException;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 
@@ -36,7 +37,7 @@ public class CreateUserMappingAnalyzerTest extends CrateDummyClusterServiceUnitT
             .builder(clusterService)
             .build();
         assertThatThrownBy(() -> e.analyze("CREATE USER MAPPING FOR user1 SERVER pg"))
-            .isExactlyInstanceOf(IllegalArgumentException.class)
-            .hasMessage("Cannot create a user mapping for an unknown user: 'user1'");
+            .isExactlyInstanceOf(RoleUnknownException.class)
+            .hasMessage("Role 'user1' does not exist");
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/HasDatabasePrivilegeFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/HasDatabasePrivilegeFunctionTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 
 import io.crate.Constants;
 import io.crate.exceptions.MissingPrivilegeException;
+import io.crate.exceptions.RoleUnknownException;
 import io.crate.metadata.pgcatalog.OidHash;
 import io.crate.role.Permission;
 import io.crate.role.Policy;
@@ -93,8 +94,8 @@ public class HasDatabasePrivilegeFunctionTest extends ScalarTestCase {
     public void test_throws_error_when_user_is_not_found() {
         assertThatThrownBy(
             () -> assertEvaluate("has_database_privilege('not_existing_user', 'crate', ' CONNECT')", null))
-            .isExactlyInstanceOf(IllegalArgumentException.class)
-            .hasMessage("User not_existing_user does not exist");
+            .isExactlyInstanceOf(RoleUnknownException.class)
+            .hasMessage("Role 'not_existing_user' does not exist");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/HasSchemaPrivilegeFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/HasSchemaPrivilegeFunctionTest.java
@@ -31,6 +31,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import io.crate.exceptions.MissingPrivilegeException;
+import io.crate.exceptions.RoleUnknownException;
 import io.crate.metadata.information.InformationSchemaInfo;
 import io.crate.metadata.pgcatalog.OidHash;
 import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
@@ -89,8 +90,8 @@ public class HasSchemaPrivilegeFunctionTest extends ScalarTestCase {
     public void test_throws_error_when_user_is_not_found() {
         assertThatThrownBy(
             () -> assertEvaluate("has_schema_privilege('not_existing_user', 'pg_catalog', ' USAGE')", null))
-            .isExactlyInstanceOf(IllegalArgumentException.class)
-            .hasMessage("User not_existing_user does not exist");
+            .isExactlyInstanceOf(RoleUnknownException.class)
+            .hasMessage("Role 'not_existing_user' does not exist");
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/BaseRolesIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/BaseRolesIntegrationTest.java
@@ -23,8 +23,6 @@ package io.crate.integrationtests;
 
 import static io.crate.testing.Asserts.assertThat;
 
-import java.util.Objects;
-
 import org.elasticsearch.test.IntegTestCase;
 import org.junit.After;
 import org.junit.Before;
@@ -94,7 +92,7 @@ public abstract class BaseRolesIntegrationTest extends IntegTestCase {
     public SQLResponse executeAs(String stmt, String userName) {
         Sessions sqlOperations = cluster().getInstance(Sessions.class);
         Roles roles = cluster().getInstance(Roles.class);
-        Role user = Objects.requireNonNull(roles.findUser(userName), "User " + userName + " must exist");
+        Role user = roles.getUser(userName);
         try (Session session = sqlOperations.newSession(null, user)) {
             return execute(stmt, null, session);
         }

--- a/server/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
@@ -26,6 +26,7 @@ import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
@@ -1213,7 +1214,7 @@ public class CopyIntegrationTest extends SQLHttpIntegrationTest {
         execute("GRANT ALL TO test_user");
 
         var roles = cluster().getInstance(Roles.class);
-        Role user = roles.findUser("test_user");
+        Role user = roles.getUser("test_user");
         Sessions sqlOperations = cluster().getInstance(Sessions.class);
         try (var session = sqlOperations.newSession(null, user)) {
             assertThatThrownBy(() -> execute("COPY quotes FROM ?", new Object[]{copyFilePath + "test_copy_from.json"}, session))

--- a/server/src/test/java/io/crate/integrationtests/ForeignDataWrapperITest.java
+++ b/server/src/test/java/io/crate/integrationtests/ForeignDataWrapperITest.java
@@ -154,7 +154,7 @@ public class ForeignDataWrapperITest extends IntegTestCase {
         );
 
         var roles = cluster().getInstance(Roles.class);
-        Role trillian = roles.findUser("trillian");
+        Role trillian = roles.getUser("trillian");
         response = sqlExecutor.executeAs("select * from doc.dummy order by x asc", trillian);
         assertThat(response).hasRows(
             "1| 1",
@@ -343,7 +343,7 @@ public class ForeignDataWrapperITest extends IntegTestCase {
         execute("grant al to arthur");
 
         var roles = cluster().getInstance(Roles.class);
-        Role trillian = roles.findUser("trillian");
+        Role trillian = roles.getUser("trillian");
         sqlExecutor.executeAs("""
             CREATE SERVER pg
             FOREIGN DATA WRAPPER jdbc
@@ -366,7 +366,7 @@ public class ForeignDataWrapperITest extends IntegTestCase {
 
         // arthur cannot see the pw because arthur is not being mapped nor is a superuser
         response = sqlExecutor.executeAs("select * from information_schema.user_mapping_options where option_name = 'password'",
-            roles.findUser("arthur"));
+            roles.getUser("arthur"));
         assertThat(response).hasRows("trillian| crate| pg| password| NULL");
 
         // superuser can see the pw

--- a/server/src/test/java/io/crate/integrationtests/LogicalReplicationITest.java
+++ b/server/src/test/java/io/crate/integrationtests/LogicalReplicationITest.java
@@ -22,6 +22,7 @@
 package io.crate.integrationtests;
 
 import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
@@ -30,7 +31,6 @@ import static org.junit.Assert.assertTrue;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -47,9 +47,9 @@ import io.crate.replication.logical.exceptions.CreateSubscriptionException;
 import io.crate.replication.logical.exceptions.PublicationUnknownException;
 import io.crate.replication.logical.metadata.Subscription;
 import io.crate.replication.logical.metadata.SubscriptionsMetadata;
-import io.crate.testing.UseRandomizedSchema;
 import io.crate.role.Role;
 import io.crate.role.Roles;
+import io.crate.testing.UseRandomizedSchema;
 
 
 @UseRandomizedSchema(random = false)
@@ -64,7 +64,7 @@ public class LogicalReplicationITest extends LogicalReplicationITestCase {
         executeOnPublisher("GRANT AL TO " + publicationOwner);
         executeOnPublisher("GRANT DQL, DML, DDL ON TABLE doc.t1 TO " + publicationOwner);
         Roles roles = publisherCluster.getInstance(Roles.class);
-        Role user = Objects.requireNonNull(roles.findUser(publicationOwner), "User " + publicationOwner + " must exist");
+        Role user = roles.getUser(publicationOwner);
 
         executeOnPublisher("DROP USER " + publicationOwner);
         assertThatThrownBy(() -> executeOnPublisherAsUser("CREATE PUBLICATION pub1 FOR TABLE doc.t1", user))
@@ -84,7 +84,7 @@ public class LogicalReplicationITest extends LogicalReplicationITestCase {
         executeOnSubscriber("GRANT AL TO " + subscriptionOwner);
 
         Roles roles = subscriberCluster.getInstance(Roles.class);
-        Role user = Objects.requireNonNull(roles.findUser(subscriptionOwner), "User " + subscriptionOwner + " must exist");
+        Role user = roles.getUser(subscriptionOwner);
 
         executeOnSubscriber("DROP USER " + subscriptionOwner);
         assertThatThrownBy(() -> createSubscriptionAsUser("sub1", "pub1", user))
@@ -103,7 +103,7 @@ public class LogicalReplicationITest extends LogicalReplicationITestCase {
         executeOnPublisher("GRANT DQL, DML, DDL ON TABLE doc.t1 TO " + publicationOwner);
 
         Roles roles = publisherCluster.getInstance(Roles.class);
-        Role user = Objects.requireNonNull(roles.findUser(publicationOwner), "User " + publicationOwner + " must exist");
+        Role user = roles.getUser(publicationOwner);
         executeOnPublisherAsUser("CREATE PUBLICATION pub1 FOR TABLE doc.t1", user);
 
         assertThatThrownBy(() -> executeOnPublisher("DROP USER " + publicationOwner))
@@ -122,7 +122,7 @@ public class LogicalReplicationITest extends LogicalReplicationITestCase {
         executeOnSubscriber("GRANT AL TO " + subscriptionOwner);
 
         Roles roles = subscriberCluster.getInstance(Roles.class);
-        Role user = Objects.requireNonNull(roles.findUser(subscriptionOwner), "User " + subscriptionOwner + " must exist");
+        Role user = roles.getUser(subscriptionOwner);
         createSubscriptionAsUser("sub1", "pub1", user);
 
         assertThatThrownBy(() -> executeOnSubscriber("DROP USER " + subscriptionOwner))
@@ -141,7 +141,7 @@ public class LogicalReplicationITest extends LogicalReplicationITestCase {
         executeOnSubscriber("GRANT AL TO " + subscriptionOwner);
 
         Roles roles = subscriberCluster.getInstance(Roles.class);
-        Role user = Objects.requireNonNull(roles.findUser(subscriptionOwner), "User " + subscriptionOwner + " must exist");
+        Role user = roles.getUser(subscriptionOwner);
         var stmt = String.format(Locale.ENGLISH, "CREATE SUBSCRIPTION sub1 CONNECTION 'crate://localhost:12345/mydb?user=%s&mode=pg_tunnel'" +
                                                  " publication pub1", user.name());
         assertThatThrownBy(() -> subscriberSqlExecutor.executeAs(stmt, user))

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -22,6 +22,7 @@
 package io.crate.integrationtests;
 
 import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -121,7 +122,7 @@ public class PgCatalogITest extends IntegTestCase {
 
         Roles roles = cluster().getInstance(Roles.class);
         Sessions sessions = cluster().getInstance(Sessions.class);
-        try (var session = sessions.newSession("doc", roles.findUser("hoschi"))) {
+        try (var session = sessions.newSession("doc", roles.getUser("hoschi"))) {
             execute("select nspname from pg_catalog.pg_namespace order by nspname", session);
             // shows doc due to table permission, but not vip
             assertThat(response).hasRows(
@@ -133,7 +134,7 @@ public class PgCatalogITest extends IntegTestCase {
 
         execute("create view vip.v1 as select 1");
         execute("grant dql on view vip.v1 to hoschi");
-        try (var session = sessions.newSession("doc", roles.findUser("hoschi"))) {
+        try (var session = sessions.newSession("doc", roles.getUser("hoschi"))) {
             execute("select nspname from pg_catalog.pg_namespace order by nspname", session);
             assertThat(response).hasRows(
                 "doc",

--- a/server/src/test/java/io/crate/planner/statement/SetSessionAuthorizationPlanTest.java
+++ b/server/src/test/java/io/crate/planner/statement/SetSessionAuthorizationPlanTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 
 import org.junit.Test;
 
+import io.crate.exceptions.RoleUnknownException;
 import io.crate.planner.NoopPlan;
 import io.crate.planner.Plan;
 import io.crate.role.Role;
@@ -77,7 +78,7 @@ public class SetSessionAuthorizationPlanTest extends CrateDummyClusterServiceUni
         var e = SQLExecutor.builder(clusterService).build();
         Plan plan = e.plan("SET SESSION AUTHORIZATION 'unknown_user'");
         assertThatThrownBy(() -> e.execute(plan).getResult())
-            .isExactlyInstanceOf(IllegalArgumentException.class)
-            .hasMessage("User 'unknown_user' does not exist.");
+            .isExactlyInstanceOf(RoleUnknownException.class)
+            .hasMessage("Role 'unknown_user' does not exist");
     }
 }

--- a/server/src/test/java/io/crate/replication/logical/action/TransportCreateSubscriptionActionTest.java
+++ b/server/src/test/java/io/crate/replication/logical/action/TransportCreateSubscriptionActionTest.java
@@ -54,14 +54,14 @@ import io.crate.metadata.Schemas;
 import io.crate.replication.logical.LogicalReplicationService;
 import io.crate.replication.logical.metadata.ConnectionInfo;
 import io.crate.replication.logical.metadata.RelationMetadata;
-import io.crate.sql.tree.QualifiedName;
-import io.crate.role.Role;
 import io.crate.role.Roles;
+import io.crate.role.StubRoleManager;
+import io.crate.sql.tree.QualifiedName;
 
 public class TransportCreateSubscriptionActionTest {
 
     private final LogicalReplicationService logicalReplicationService = mock(LogicalReplicationService.class);
-    private final Roles roles = mock(Roles.class);
+    private final Roles roles = new StubRoleManager();
     private final ClusterService clusterService = mock(ClusterService.class);
     private TransportCreateSubscriptionAction transportCreateSubscriptionAction;
 
@@ -94,8 +94,6 @@ public class TransportCreateSubscriptionActionTest {
             mock(ThreadPool.class),
             roles
         );
-
-        when(roles.findUser(anyString())).thenReturn(Role.CRATE_USER);
 
         final DiscoveryNode dataNode = new DiscoveryNode(
             "node",
@@ -139,7 +137,7 @@ public class TransportCreateSubscriptionActionTest {
 
         transportCreateSubscriptionAction.masterOperation(
             new CreateSubscriptionRequest(
-                "dummy",
+                "crate",
                 "dummy",
                 new ConnectionInfo(List.of(), Settings.EMPTY),
                 List.of(),

--- a/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
@@ -1682,7 +1682,7 @@ public abstract class IntegTestCase extends ESTestCase {
     public SQLResponse systemExecute(String stmt, @Nullable String schema, String node) {
         Sessions sqlOperations = cluster().getInstance(Sessions.class, node);
         Roles roles = cluster().getInstance(Roles.class, node);
-        try (Session session = sqlOperations.newSession(schema, roles.findUser("crate"))) {
+        try (Session session = sqlOperations.newSession(schema, roles.getUser("crate"))) {
             response = sqlExecutor.exec(stmt, session);
         }
         return response;


### PR DESCRIPTION
There were a couple of places that raised `IllegalArgumentException`
instead of `RoleUnknownException`.
