### PR TITLE
Implement httpErrorStatus in exceptions derived from ESException

### DIFF
--- a/server/src/main/java/io/crate/exceptions/InvalidArgumentException.java
+++ b/server/src/main/java/io/crate/exceptions/InvalidArgumentException.java
@@ -21,10 +21,12 @@
 
 package io.crate.exceptions;
 
+import java.io.IOException;
+
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.io.stream.StreamInput;
 
-import java.io.IOException;
+import io.crate.rest.action.HttpErrorStatus;
 
 public class InvalidArgumentException extends ElasticsearchException implements CrateException {
 
@@ -38,5 +40,10 @@ public class InvalidArgumentException extends ElasticsearchException implements 
 
     public InvalidArgumentException(StreamInput in) throws IOException {
         super(in);
+    }
+
+    @Override
+    public HttpErrorStatus httpErrorStatus() {
+        return HttpErrorStatus.FIELD_VALIDATION_FAILED;
     }
 }

--- a/server/src/main/java/io/crate/exceptions/InvalidColumnNameException.java
+++ b/server/src/main/java/io/crate/exceptions/InvalidColumnNameException.java
@@ -21,11 +21,13 @@
 
 package io.crate.exceptions;
 
+import java.io.IOException;
+import java.util.Locale;
+
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.io.stream.StreamInput;
 
-import java.io.IOException;
-import java.util.Locale;
+import io.crate.rest.action.HttpErrorStatus;
 
 public class InvalidColumnNameException extends ElasticsearchException implements ClusterScopeException {
 
@@ -35,5 +37,10 @@ public class InvalidColumnNameException extends ElasticsearchException implement
 
     public InvalidColumnNameException(StreamInput in) throws IOException {
         super(in);
+    }
+
+    @Override
+    public HttpErrorStatus httpErrorStatus() {
+        return HttpErrorStatus.COLUMN_NAME_INVALID;
     }
 }

--- a/server/src/main/java/io/crate/exceptions/JobKilledException.java
+++ b/server/src/main/java/io/crate/exceptions/JobKilledException.java
@@ -21,11 +21,13 @@
 
 package io.crate.exceptions;
 
+import java.io.IOException;
+
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.io.stream.StreamInput;
-
 import org.jetbrains.annotations.Nullable;
-import java.io.IOException;
+
+import io.crate.rest.action.HttpErrorStatus;
 
 public class JobKilledException extends ElasticsearchException implements UnscopedException {
 
@@ -47,4 +49,8 @@ public class JobKilledException extends ElasticsearchException implements Unscop
         super(MESSAGE);
     }
 
+    @Override
+    public HttpErrorStatus httpErrorStatus() {
+        return HttpErrorStatus.QUERY_KILLED_BY_STATEMENT;
+    }
 }

--- a/server/src/main/java/io/crate/exceptions/MissingPrivilegeException.java
+++ b/server/src/main/java/io/crate/exceptions/MissingPrivilegeException.java
@@ -23,6 +23,7 @@ package io.crate.exceptions;
 
 import java.util.Locale;
 
+import io.crate.rest.action.HttpErrorStatus;
 import io.crate.role.Permission;
 
 public class MissingPrivilegeException extends UnauthorizedException {
@@ -37,4 +38,8 @@ public class MissingPrivilegeException extends UnauthorizedException {
         super(String.format(Locale.ENGLISH, "Missing privilege for user '%s'", userName));
     }
 
+    @Override
+    public HttpErrorStatus httpErrorStatus() {
+        return HttpErrorStatus.MISSING_USER_PRIVILEGES;
+    }
 }

--- a/server/src/main/java/io/crate/exceptions/OperationOnInaccessibleRelationException.java
+++ b/server/src/main/java/io/crate/exceptions/OperationOnInaccessibleRelationException.java
@@ -30,6 +30,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import io.crate.metadata.RelationName;
+import io.crate.rest.action.HttpErrorStatus;
 
 public class OperationOnInaccessibleRelationException extends ElasticsearchException implements TableScopeException {
 
@@ -54,5 +55,10 @@ public class OperationOnInaccessibleRelationException extends ElasticsearchExcep
     @Override
     public Collection<RelationName> getTableIdents() {
         return Collections.singletonList(relationName);
+    }
+
+    @Override
+    public HttpErrorStatus httpErrorStatus() {
+        return HttpErrorStatus.RELATION_OPERATION_NOT_SUPPORTED;
     }
 }

--- a/server/src/main/java/io/crate/exceptions/RelationAlreadyExists.java
+++ b/server/src/main/java/io/crate/exceptions/RelationAlreadyExists.java
@@ -21,15 +21,17 @@
 
 package io.crate.exceptions;
 
-import io.crate.metadata.RelationName;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Locale;
+
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.Index;
 
-import java.io.IOException;
-import java.util.Collections;
-import java.util.Locale;
+import io.crate.metadata.RelationName;
+import io.crate.rest.action.HttpErrorStatus;
 
 public final class RelationAlreadyExists extends ElasticsearchException implements ConflictException, TableScopeException {
 
@@ -66,5 +68,10 @@ public final class RelationAlreadyExists extends ElasticsearchException implemen
     @Override
     public Iterable<RelationName> getTableIdents() {
         return Collections.singletonList(relationName);
+    }
+
+    @Override
+    public HttpErrorStatus httpErrorStatus() {
+        return HttpErrorStatus.RELATION_WITH_THE_SAME_NAME_EXISTS_ALREADY;
     }
 }

--- a/server/src/main/java/io/crate/exceptions/RelationUnknown.java
+++ b/server/src/main/java/io/crate/exceptions/RelationUnknown.java
@@ -33,6 +33,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 
 import io.crate.common.collections.Lists;
 import io.crate.metadata.RelationName;
+import io.crate.rest.action.HttpErrorStatus;
 import io.crate.sql.Identifiers;
 
 public class RelationUnknown extends ElasticsearchException implements ResourceUnknownException, TableScopeException {
@@ -90,5 +91,10 @@ public class RelationUnknown extends ElasticsearchException implements ResourceU
     @Override
     public Collection<RelationName> getTableIdents() {
         return Collections.singletonList(relationName);
+    }
+
+    @Override
+    public HttpErrorStatus httpErrorStatus() {
+        return HttpErrorStatus.RELATION_UNKNOWN;
     }
 }

--- a/server/src/main/java/io/crate/exceptions/RoleAlreadyExistsException.java
+++ b/server/src/main/java/io/crate/exceptions/RoleAlreadyExistsException.java
@@ -27,6 +27,8 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
+import io.crate.rest.action.HttpErrorStatus;
+
 
 public class RoleAlreadyExistsException extends ElasticsearchException implements ConflictException, UnscopedException {
 
@@ -41,5 +43,10 @@ public class RoleAlreadyExistsException extends ElasticsearchException implement
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
+    }
+
+    @Override
+    public HttpErrorStatus httpErrorStatus() {
+        return HttpErrorStatus.USER_WITH_SAME_NAME_EXISTS_ALREADY;
     }
 }

--- a/server/src/main/java/io/crate/exceptions/SchemaUnknownException.java
+++ b/server/src/main/java/io/crate/exceptions/SchemaUnknownException.java
@@ -21,15 +21,17 @@
 
 package io.crate.exceptions;
 
-import io.crate.sql.Identifiers;
-import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
-
 import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import io.crate.rest.action.HttpErrorStatus;
+import io.crate.sql.Identifiers;
 
 public class SchemaUnknownException extends ElasticsearchException implements ResourceUnknownException, SchemaScopeException {
 
@@ -78,5 +80,10 @@ public class SchemaUnknownException extends ElasticsearchException implements Re
     @Override
     public String getSchemaName() {
         return schemaName;
+    }
+
+    @Override
+    public HttpErrorStatus httpErrorStatus() {
+        return HttpErrorStatus.SCHEMA_UNKNOWN;
     }
 }

--- a/server/src/main/java/io/crate/exceptions/UnauthorizedException.java
+++ b/server/src/main/java/io/crate/exceptions/UnauthorizedException.java
@@ -26,6 +26,8 @@ import java.io.IOException;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.io.stream.StreamInput;
 
+import io.crate.rest.action.HttpErrorStatus;
+
 public class UnauthorizedException extends ElasticsearchException implements UnscopedException {
 
     public UnauthorizedException(String message) {
@@ -34,5 +36,10 @@ public class UnauthorizedException extends ElasticsearchException implements Uns
 
     public UnauthorizedException(StreamInput in) throws IOException {
         super(in);
+    }
+
+    @Override
+    public HttpErrorStatus httpErrorStatus() {
+        return HttpErrorStatus.USER_NOT_AUTHORIZED_TO_PERFORM_STATEMENT;
     }
 }

--- a/server/src/main/java/io/crate/exceptions/UnsupportedFeatureException.java
+++ b/server/src/main/java/io/crate/exceptions/UnsupportedFeatureException.java
@@ -21,10 +21,12 @@
 
 package io.crate.exceptions;
 
+import java.io.IOException;
+
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.io.stream.StreamInput;
 
-import java.io.IOException;
+import io.crate.rest.action.HttpErrorStatus;
 
 public class UnsupportedFeatureException extends ElasticsearchException implements ClusterScopeException {
 
@@ -38,5 +40,10 @@ public class UnsupportedFeatureException extends ElasticsearchException implemen
 
     public UnsupportedFeatureException(StreamInput in) throws IOException {
         super(in);
+    }
+
+    @Override
+    public HttpErrorStatus httpErrorStatus() {
+        return HttpErrorStatus.POSSIBLE_FEATURE_NOT_SUPPROTED_YET;
     }
 }

--- a/server/src/main/java/io/crate/exceptions/UserDefinedFunctionAlreadyExistsException.java
+++ b/server/src/main/java/io/crate/exceptions/UserDefinedFunctionAlreadyExistsException.java
@@ -21,13 +21,15 @@
 
 package io.crate.exceptions;
 
-import io.crate.expression.udf.UserDefinedFunctionMetadata;
+import java.io.IOException;
+import java.util.Locale;
+
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
-import java.io.IOException;
-import java.util.Locale;
+import io.crate.expression.udf.UserDefinedFunctionMetadata;
+import io.crate.rest.action.HttpErrorStatus;
 
 public class UserDefinedFunctionAlreadyExistsException extends ElasticsearchException implements ConflictException, SchemaScopeException {
 
@@ -55,5 +57,10 @@ public class UserDefinedFunctionAlreadyExistsException extends ElasticsearchExce
     @Override
     public String getSchemaName() {
         return schema;
+    }
+
+    @Override
+    public HttpErrorStatus httpErrorStatus() {
+        return HttpErrorStatus.USER_DEFINED_FUNCTION_WITH_SAME_SIGNATURE_EXISTS_ALREADY;
     }
 }

--- a/server/src/main/java/io/crate/exceptions/UserDefinedFunctionUnknownException.java
+++ b/server/src/main/java/io/crate/exceptions/UserDefinedFunctionUnknownException.java
@@ -21,15 +21,17 @@
 
 package io.crate.exceptions;
 
-import io.crate.types.DataType;
-import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
-
 import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import io.crate.rest.action.HttpErrorStatus;
+import io.crate.types.DataType;
 
 public class UserDefinedFunctionUnknownException extends ElasticsearchException implements ResourceUnknownException, SchemaScopeException {
 
@@ -56,5 +58,10 @@ public class UserDefinedFunctionUnknownException extends ElasticsearchException 
     @Override
     public String getSchemaName() {
         return schema;
+    }
+
+    @Override
+    public HttpErrorStatus httpErrorStatus() {
+        return HttpErrorStatus.USER_DEFINED_FUNCTION_UNKNOWN;
     }
 }

--- a/server/src/main/java/io/crate/exceptions/VersioningValidationException.java
+++ b/server/src/main/java/io/crate/exceptions/VersioningValidationException.java
@@ -21,10 +21,12 @@
 
 package io.crate.exceptions;
 
+import java.io.IOException;
+
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.io.stream.StreamInput;
 
-import java.io.IOException;
+import io.crate.rest.action.HttpErrorStatus;
 
 public class VersioningValidationException extends ElasticsearchException implements UnscopedException {
 
@@ -57,5 +59,10 @@ public class VersioningValidationException extends ElasticsearchException implem
 
     public VersioningValidationException(StreamInput in) throws IOException {
         super(in);
+    }
+
+    @Override
+    public HttpErrorStatus httpErrorStatus() {
+        return HttpErrorStatus.STATEMENT_INVALID_OR_UNSUPPORTED_SYNTAX;
     }
 }

--- a/server/src/main/java/io/crate/rest/action/HttpError.java
+++ b/server/src/main/java/io/crate/rest/action/HttpError.java
@@ -28,10 +28,7 @@ import java.io.IOException;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
-import org.elasticsearch.index.mapper.MapperParsingException;
-import org.elasticsearch.repositories.RepositoryMissingException;
 import org.elasticsearch.snapshots.InvalidSnapshotNameException;
-import org.elasticsearch.snapshots.SnapshotMissingException;
 import org.jetbrains.annotations.Nullable;
 
 import io.crate.common.exceptions.Exceptions;
@@ -42,33 +39,19 @@ import io.crate.exceptions.AnalyzerUnknownException;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.exceptions.ColumnValidationException;
 import io.crate.exceptions.DuplicateKeyException;
-import io.crate.exceptions.InvalidArgumentException;
-import io.crate.exceptions.InvalidColumnNameException;
 import io.crate.exceptions.InvalidRelationName;
 import io.crate.exceptions.InvalidSchemaNameException;
-import io.crate.exceptions.JobKilledException;
-import io.crate.exceptions.MissingPrivilegeException;
-import io.crate.exceptions.OperationOnInaccessibleRelationException;
 import io.crate.exceptions.PartitionAlreadyExistsException;
 import io.crate.exceptions.PartitionUnknownException;
 import io.crate.exceptions.ReadOnlyException;
-import io.crate.exceptions.RelationAlreadyExists;
-import io.crate.exceptions.RelationUnknown;
 import io.crate.exceptions.RelationValidationException;
 import io.crate.exceptions.RelationsUnknown;
 import io.crate.exceptions.RepositoryAlreadyExistsException;
-import io.crate.exceptions.RoleAlreadyExistsException;
 import io.crate.exceptions.RoleUnknownException;
 import io.crate.exceptions.SQLExceptions;
 import io.crate.exceptions.SQLParseException;
-import io.crate.exceptions.SchemaUnknownException;
-import io.crate.exceptions.UnauthorizedException;
 import io.crate.exceptions.UnavailableShardsException;
-import io.crate.exceptions.UnsupportedFeatureException;
 import io.crate.exceptions.UnsupportedFunctionException;
-import io.crate.exceptions.UserDefinedFunctionAlreadyExistsException;
-import io.crate.exceptions.UserDefinedFunctionUnknownException;
-import io.crate.exceptions.VersioningValidationException;
 import io.netty.handler.codec.http.HttpResponseStatus;
 
 public class HttpError {
@@ -131,11 +114,7 @@ public class HttpError {
 
     public static HttpError fromThrowable(Throwable throwable) {
         var httpErrorStatus = HttpErrorStatus.UNHANDLED_SERVER_ERROR;
-        if (throwable instanceof MapperParsingException) {
-            httpErrorStatus = HttpErrorStatus.FIELD_VALIDATION_FAILED;
-        } else if (throwable instanceof MissingPrivilegeException) {
-            httpErrorStatus = HttpErrorStatus.MISSING_USER_PRIVILEGES;
-        } else if (throwable instanceof AmbiguousColumnAliasException) {
+        if (throwable instanceof AmbiguousColumnAliasException) {
             httpErrorStatus = HttpErrorStatus.COLUMN_ALIAS_IS_AMBIGUOUS;
         } else if (throwable instanceof AmbiguousColumnException) {
             httpErrorStatus = HttpErrorStatus.COLUMN_ALIAS_IS_AMBIGUOUS;
@@ -143,65 +122,36 @@ public class HttpError {
             httpErrorStatus = HttpErrorStatus.STATEMENT_INVALID_ANALYZER_DEFINITION;
         } else if (throwable instanceof ColumnValidationException) {
             httpErrorStatus = HttpErrorStatus.FIELD_VALIDATION_FAILED;
-        } else if (throwable instanceof InvalidArgumentException) {
-            httpErrorStatus = HttpErrorStatus.FIELD_VALIDATION_FAILED;
-        } else if (throwable instanceof InvalidColumnNameException) {
-            httpErrorStatus = HttpErrorStatus.COLUMN_NAME_INVALID;
         } else if (throwable instanceof InvalidRelationName) {
             httpErrorStatus = HttpErrorStatus.RELATION_INVALID_NAME;
         } else if (throwable instanceof InvalidSchemaNameException) {
             httpErrorStatus = HttpErrorStatus.RELATION_INVALID_NAME;
-        } else if (throwable instanceof OperationOnInaccessibleRelationException) {
-            httpErrorStatus = HttpErrorStatus.RELATION_OPERATION_NOT_SUPPORTED;
         } else if (throwable instanceof RelationValidationException) {
             httpErrorStatus = HttpErrorStatus.FIELD_VALIDATION_FAILED;
         } else if (throwable instanceof SQLParseException) {
             httpErrorStatus = HttpErrorStatus.STATEMENT_INVALID_OR_UNSUPPORTED_SYNTAX;
-        } else if (throwable instanceof UnsupportedFeatureException ||
-                    throwable instanceof UnsupportedFunctionException) {
+        } else if (throwable instanceof UnsupportedFunctionException) {
             httpErrorStatus = HttpErrorStatus.POSSIBLE_FEATURE_NOT_SUPPROTED_YET;
-        } else if (throwable instanceof VersioningValidationException) {
-            httpErrorStatus = HttpErrorStatus.STATEMENT_INVALID_OR_UNSUPPORTED_SYNTAX;
         } else if (throwable instanceof AnalyzerUnknownException) {
             httpErrorStatus = HttpErrorStatus.STATEMENT_INVALID_ANALYZER_DEFINITION;
         } else if (throwable instanceof ColumnUnknownException) {
             httpErrorStatus = HttpErrorStatus.COLUMN_UNKNOWN;
         } else if (throwable instanceof PartitionUnknownException) {
             httpErrorStatus = HttpErrorStatus.PARTITION_UNKNOWN;
-        } else if (throwable instanceof RelationUnknown) {
-            httpErrorStatus = HttpErrorStatus.RELATION_UNKNOWN;
         } else if (throwable instanceof RelationsUnknown) {
             httpErrorStatus = HttpErrorStatus.RELATION_UNKNOWN;
-        } else if (throwable instanceof RepositoryMissingException) {
-            httpErrorStatus = HttpErrorStatus.REPOSITORY_UNKNOWN;
-        } else if (throwable instanceof SchemaUnknownException) {
-            httpErrorStatus = HttpErrorStatus.SCHEMA_UNKNOWN;
-        } else if (throwable instanceof UserDefinedFunctionUnknownException) {
-            httpErrorStatus = HttpErrorStatus.USER_DEFINED_FUNCTION_UNKNOWN;
         } else if (throwable instanceof RoleUnknownException) {
             httpErrorStatus = HttpErrorStatus.USER_UNKNOWN;
-        } else if (throwable instanceof SnapshotMissingException) {
-            httpErrorStatus = HttpErrorStatus.SNAPSHOT_UNKNOWN;
-        } else if (throwable instanceof UnauthorizedException) {
-            httpErrorStatus = HttpErrorStatus.USER_NOT_AUTHORIZED_TO_PERFORM_STATEMENT;
         } else if (throwable instanceof ReadOnlyException) {
             httpErrorStatus = HttpErrorStatus.ONLY_READ_OPERATION_ALLOWED_ON_THIS_NODE;
         } else if (throwable instanceof DuplicateKeyException) {
             httpErrorStatus = HttpErrorStatus.DOCUMENT_WITH_THE_SAME_PRIMARY_KEY_EXISTS_ALREADY;
         } else if (throwable instanceof PartitionAlreadyExistsException) {
             httpErrorStatus = HttpErrorStatus.PARTITION_FOR_THE_SAME_VALUE_EXISTS_ALREADY;
-        } else if (throwable instanceof RelationAlreadyExists) {
-            httpErrorStatus = HttpErrorStatus.RELATION_WITH_THE_SAME_NAME_EXISTS_ALREADY;
         } else if (throwable instanceof RepositoryAlreadyExistsException) {
             httpErrorStatus = HttpErrorStatus.REPOSITORY_WITH_SAME_NAME_EXISTS_ALREADY;
         } else if (throwable instanceof InvalidSnapshotNameException) {
             httpErrorStatus = HttpErrorStatus.SNAPSHOT_WITH_SAME_NAME_EXISTS_ALREADY;
-        } else if (throwable instanceof RoleAlreadyExistsException) {
-            httpErrorStatus = HttpErrorStatus.USER_WITH_SAME_NAME_EXISTS_ALREADY;
-        } else if (throwable instanceof UserDefinedFunctionAlreadyExistsException) {
-            httpErrorStatus = HttpErrorStatus.USER_DEFINED_FUNCTION_WITH_SAME_SIGNATURE_EXISTS_ALREADY;
-        } else if (throwable instanceof JobKilledException) {
-            httpErrorStatus = HttpErrorStatus.QUERY_KILLED_BY_STATEMENT;
         } else if (throwable instanceof UnavailableShardsException) {
             httpErrorStatus = HttpErrorStatus.ONE_OR_MORE_SHARDS_NOT_AVAILABLE;
         } else if (throwable instanceof ElasticsearchException ex) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperParsingException.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperParsingException.java
@@ -19,10 +19,12 @@
 
 package org.elasticsearch.index.mapper;
 
+import java.io.IOException;
+
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.rest.RestStatus;
 
-import java.io.IOException;
+import io.crate.rest.action.HttpErrorStatus;
 
 public class MapperParsingException extends MapperException {
 
@@ -45,5 +47,10 @@ public class MapperParsingException extends MapperException {
     @Override
     public RestStatus status() {
         return RestStatus.BAD_REQUEST;
+    }
+
+    @Override
+    public HttpErrorStatus httpErrorStatus() {
+        return HttpErrorStatus.FIELD_VALIDATION_FAILED;
     }
 }

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoryMissingException.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoryMissingException.java
@@ -26,6 +26,7 @@ import org.elasticsearch.rest.RestStatus;
 
 import io.crate.exceptions.ClusterScopeException;
 import io.crate.exceptions.ResourceUnknownException;
+import io.crate.rest.action.HttpErrorStatus;
 
 /**
  * Repository missing exception
@@ -43,5 +44,10 @@ public class RepositoryMissingException extends RepositoryException implements R
 
     public RepositoryMissingException(StreamInput in) throws IOException {
         super(in);
+    }
+
+    @Override
+    public HttpErrorStatus httpErrorStatus() {
+        return HttpErrorStatus.REPOSITORY_UNKNOWN;
     }
 }

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotMissingException.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotMissingException.java
@@ -26,6 +26,7 @@ import org.elasticsearch.rest.RestStatus;
 
 import io.crate.exceptions.ClusterScopeException;
 import io.crate.exceptions.ResourceUnknownException;
+import io.crate.rest.action.HttpErrorStatus;
 
 /**
  * Thrown if requested snapshot doesn't exist
@@ -51,5 +52,10 @@ public class SnapshotMissingException extends SnapshotException implements Resou
     @Override
     public RestStatus status() {
         return RestStatus.NOT_FOUND;
+    }
+
+    @Override
+    public HttpErrorStatus httpErrorStatus() {
+        return HttpErrorStatus.SNAPSHOT_UNKNOWN;
     }
 }


### PR DESCRIPTION
https://github.com/crate/crate/commit/23c610017e13e13065cd94cbc00064f514f60949
added a `httpErrorStatus` to `ElasticsearchException` which we can use
in more places to reduce the large if/else block in `HttpError`
