### PR TITLE
Return empty statistics as default value for logical plans

### DIFF
--- a/server/src/main/java/io/crate/planner/optimizer/costs/PlanStats.java
+++ b/server/src/main/java/io/crate/planner/optimizer/costs/PlanStats.java
@@ -281,7 +281,7 @@ public class PlanStats {
             if (sources.size() == 1) {
                 return sources.get(0).accept(this, context);
             }
-            throw new UnsupportedOperationException("Plan stats not available for " + logicalPlan.getClass().getSimpleName());
+            return Stats.EMPTY;
         }
     }
 }

--- a/server/src/main/java/io/crate/statistics/Stats.java
+++ b/server/src/main/java/io/crate/statistics/Stats.java
@@ -87,6 +87,10 @@ public class Stats implements Writeable {
         }
     }
 
+    public boolean isEmpty() {
+        return numDocs == -1 && sizeInBytes == -1 && statsByColumn.isEmpty();
+    }
+
     public Stats withNumDocs(long numDocs) {
         long sizePerRow = averageSizePerRowInBytes();
         if (sizePerRow < 1) {

--- a/server/src/test/java/io/crate/planner/optimizer/costs/PlanStatsTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/costs/PlanStatsTest.java
@@ -22,7 +22,6 @@
 package io.crate.planner.optimizer.costs;
 
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.Map;
@@ -47,6 +46,7 @@ import io.crate.planner.operators.NestedLoopJoin;
 import io.crate.planner.operators.Union;
 import io.crate.planner.optimizer.iterative.GroupReference;
 import io.crate.planner.optimizer.iterative.Memo;
+import io.crate.planner.optimizer.iterative.MemoTest;
 import io.crate.role.Role;
 import io.crate.sql.tree.JoinType;
 import io.crate.statistics.ColumnStats;
@@ -306,5 +306,12 @@ public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
         PlanStats planStats = new PlanStats(nodeContext, txnCtx, tableStats, null);
         Stats stats = planStats.get(filter);
         assertThat(stats.numDocs()).isEqualTo(2);
+    }
+
+    @Test
+    public void test_unsupported_plan_return_empty_stats() throws Exception {
+        MemoTest.TestPlan unsupportedPlan = new MemoTest.TestPlan(1, List.of());
+        PlanStats planStats = new PlanStats(nodeContext, txnCtx, new TableStats(), null);
+        assertThat(planStats.get(unsupportedPlan).isEmpty()).isTrue();
     }
 }

--- a/server/src/test/java/io/crate/planner/optimizer/iterative/MemoTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/iterative/MemoTest.java
@@ -275,7 +275,7 @@ public class MemoTest {
         return plan(ids.getAsInt(), children);
     }
 
-    static class TestPlan implements LogicalPlan {
+    public static class TestPlan implements LogicalPlan {
         private final List<LogicalPlan> sources;
         private final int id;
 


### PR DESCRIPTION
I ran into the following error while logging the optimizer running an insert-from-values:

```
io.crate.exceptions.UnsupportedFeatureException: Plan stats not available for InsertFromValues
	at __randomizedtesting.SeedInfo.seed([D30AA7E7DB444068:815898070CC79766]:0)
	at io.crate.exceptions.SQLExceptions.esToCrateException(SQLExceptions.java:213)
	at io.crate.exceptions.SQLExceptions.prepareForClientTransmission(SQLExceptions.java:200)
	at io.crate.testing.SQLTransportExecutor.lambda$execute$3(SQLTransportExecutor.java:293)
	at java.base/java.util.concurrent.CompletableFuture.uniExceptionally(CompletableFuture.java:990)
	at java.base/java.util.concurrent.CompletableFuture.uniExceptionallyStage(CompletableFuture.java:1008)
	at java.base/java.util.concurrent.CompletableFuture.exceptionally(CompletableFuture.java:2396)
	at io.crate.testing.SQLTransportExecutor.execute(SQLTransportExecutor.java:292)
	at io.crate.testing.SQLTransportExecutor.executeTransportOrJdbc(SQLTransportExecutor.java:230)
	at io.crate.testing.SQLTransportExecutor.exec(SQLTransportExecutor.java:139)
	at org.elasticsearch.test.IntegTestCase.execute(IntegTestCase.java:1700)
	at org.elasticsearch.test.IntegTestCase.execute(IntegTestCase.java:1838)
	at io.crate.integrationtests.JoinIntegrationTest.test_alias_in_left_join_condition(JoinIntegrationTest.java:1319)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at com.carrotsearch.randomizedtesting.RandomizedRunner.invoke(RandomizedRunner.java:1758)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$8.evaluate(RandomizedRunner.java:946)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$9.evaluate(RandomizedRunner.java:982)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$10.evaluate(RandomizedRunner.java:996)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: java.lang.UnsupportedOperationException: Plan stats not available for InsertFromValues

```

Currently, PlanStats throws an Exception when there is no support for statistics for a logical plan. This causes problems when printing plans while using `explain verbose` or logging the progress of the optimizer. 

This changes it to return empty statistics as default value for logical plans to not run into unexpected exceptions.



## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
