### PR TITLE
Make fail_fast handling in COPY FROM independent of return summary

### DIFF
--- a/server/src/main/java/io/crate/execution/dsl/projection/SourceIndexWriterReturnSummaryProjection.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/SourceIndexWriterReturnSummaryProjection.java
@@ -25,12 +25,11 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 
-import org.jetbrains.annotations.Nullable;
-
 import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
+import org.jetbrains.annotations.Nullable;
 
 import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Symbol;
@@ -96,10 +95,6 @@ public class SourceIndexWriterReturnSummaryProjection extends SourceIndexWriterP
 
     public InputColumn lineNumber() {
         return lineNumber;
-    }
-
-    public boolean returnSummaryOnFailOnly() {
-        return AbstractIndexWriterProjection.OUTPUTS.equals(outputs());
     }
 
     @Override

--- a/server/src/main/java/io/crate/execution/engine/indexing/IndexWriterProjector.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/IndexWriterProjector.java
@@ -125,9 +125,7 @@ public class IndexWriterProjector implements Projector {
         );
 
         Predicate<UpsertResults> earlyTerminationCondition = results -> failFast && results.containsErrors();
-
         Function<UpsertResults, Throwable> earlyTerminationExceptionGenerator = UpsertResults::resultsToFailure;
-
         shardingUpsertExecutor = new ShardingUpsertExecutor(
             clusterService,
             (ignored1, ignored2) -> {},

--- a/server/src/main/java/io/crate/execution/engine/indexing/UpsertResultContext.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/UpsertResultContext.java
@@ -21,19 +21,20 @@
 
 package io.crate.execution.engine.indexing;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Predicate;
+
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.jetbrains.annotations.Nullable;
+
 import io.crate.data.Input;
 import io.crate.data.Row;
 import io.crate.execution.dsl.projection.SourceIndexWriterReturnSummaryProjection;
 import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.expression.InputFactory;
 import io.crate.metadata.TransactionContext;
-import org.elasticsearch.cluster.node.DiscoveryNode;
-
-import org.jetbrains.annotations.Nullable;
-import java.util.Collections;
-import java.util.List;
-import java.util.function.BiConsumer;
-import java.util.function.Predicate;
 
 public class UpsertResultContext {
 
@@ -91,9 +92,7 @@ public class UpsertResultContext {
             lineNumberInput,
             sourceParsingFailureInput,
             ctxSourceInfo.expressions(),
-            projection.returnSummaryOnFailOnly() ?
-                UpsertResultCollectors.newSummaryOnFailOrRowCountOnSuccessCollector(discoveryNode) :
-                UpsertResultCollectors.newSummaryCollector(discoveryNode)
+            UpsertResultCollectors.newSummaryCollector(discoveryNode)
         );
     }
 

--- a/server/src/main/java/io/crate/execution/engine/indexing/UpsertResults.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/UpsertResults.java
@@ -29,16 +29,18 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import org.jetbrains.annotations.Nullable;
-
 import org.jetbrains.annotations.VisibleForTesting;
+
 import io.crate.data.Row;
 import io.crate.data.RowN;
 import io.crate.exceptions.JobKilledException;
+import io.crate.execution.dml.ShardResponse.Failure;
 
 class UpsertResults {
 
     private final Map<String, Result> resultsByUri = new HashMap<>(1);
     private final Map<String, String> nodeInfo;
+    private Failure failure;
 
     UpsertResults() {
         this.nodeInfo = null;
@@ -48,9 +50,12 @@ class UpsertResults {
         this.nodeInfo = nodeInfo;
     }
 
-    void addResult(long successRowCount) {
+    void addResult(long successRowCount, @Nullable Failure failure) {
         Result result = getResultSafe(null);
         result.successRowCount += successRowCount;
+        if (failure != null) {
+            this.failure = failure;
+        }
     }
 
     void addResultRows(List<Object[]> resultRows) {
@@ -94,7 +99,7 @@ class UpsertResults {
     }
 
     boolean containsErrors() {
-        return resultsByUri.values().stream().anyMatch(result -> result.errorRowCount > 0);
+        return failure != null || resultsByUri.values().stream().anyMatch(result -> result.errorRowCount > 0);
     }
 
     List<Object[]> getResultRowsForNoUri() {
@@ -102,6 +107,7 @@ class UpsertResults {
     }
 
     void merge(UpsertResults other) {
+        this.failure = this.failure == null ? other.failure : this.failure;
         for (Map.Entry<String, Result> entry : other.resultsByUri.entrySet()) {
             Result result = resultsByUri.get(entry.getKey());
             if (result == null) {
@@ -133,6 +139,9 @@ class UpsertResults {
             if (nodeName != null) {
                 sb.append("NODE: ").append(nodeName);
             }
+        }
+        if (results.failure != null) {
+            sb.append(results.failure.message());
         }
         var it = results.resultsByUri.entrySet().iterator();
         while (it.hasNext()) {

--- a/server/src/test/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorFactoryTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorFactoryTest.java
@@ -226,8 +226,14 @@ public class OrderedLuceneBatchIteratorFactoryTest extends ESTestCase {
         rowBatchIterator.kill(new InterruptedException("killed"));
 
         assertThatThrownBy(consumer::getResult)
-            .hasRootCauseInstanceOf(InterruptedException.class)
-            .hasRootCauseMessage("killed");
+            .satisfiesAnyOf(
+                x -> assertThat(x)
+                    .hasRootCauseInstanceOf(InterruptedException.class)
+                    .hasRootCauseMessage("killed"),
+                x -> assertThat(x)
+                    .isExactlyInstanceOf(InterruptedException.class)
+                    .hasMessage("killed")
+            );
     }
 
     private void consumeIteratorAndVerifyResultIsException(BatchIterator<Row> rowBatchIterator, Exception exception)

--- a/server/src/test/java/io/crate/execution/engine/indexing/UpsertResultsTest.java
+++ b/server/src/test/java/io/crate/execution/engine/indexing/UpsertResultsTest.java
@@ -56,7 +56,7 @@ public class UpsertResultsTest {
     public void testContainsAnyErrorMethod() {
         UpsertResults upsertResults = new UpsertResults();
         assertThat(upsertResults.containsErrors(), is(false));
-        upsertResults.addResult(1);
+        upsertResults.addResult(1, null);
         assertThat(upsertResults.containsErrors(), is(false));
         upsertResults.addResult("dummyUri2", "failure test", 1);
         assertThat(upsertResults.containsErrors(), is(true));

--- a/server/src/test/java/io/crate/integrationtests/CopyFromFailFastITest.java
+++ b/server/src/test/java/io/crate/integrationtests/CopyFromFailFastITest.java
@@ -91,7 +91,7 @@ public class CopyFromFailFastITest extends IntegTestCase {
                 "COPY t FROM ? WITH (bulk_size = 1, fail_fast = true)", // fail_fast = true
                 new Object[]{target.toUri() + "*"}))
             .isExactlyInstanceOf(JobKilledException.class)
-            .hasMessageContaining("ERRORS: {Cannot cast value `fail here` to type `integer`");
+            .hasMessageContaining("Job killed. Cannot cast value `fail here` to type `integer`");
     }
 
     @UseRandomizedOptimizerRules(0)


### PR DESCRIPTION
The implementation of `fail_fast` introduced a special cased "summary
collector".

How results are collected, and short-circuit-on-error should remain
independent.
