### PR TITLE
Make RoleUnknownException streamable and map to pg code 42704

### DIFF
--- a/server/src/main/java/io/crate/exceptions/RoleUnknownException.java
+++ b/server/src/main/java/io/crate/exceptions/RoleUnknownException.java
@@ -21,11 +21,18 @@
 
 package io.crate.exceptions;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
-public class RoleUnknownException extends RuntimeException implements ResourceUnknownException, UnscopedException {
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.io.stream.StreamInput;
+
+import io.crate.protocols.postgres.PGErrorStatus;
+import io.crate.rest.action.HttpErrorStatus;
+
+public class RoleUnknownException extends ElasticsearchException implements ResourceUnknownException, UnscopedException {
 
     public RoleUnknownException(String roleName) {
         super(getMessage(Collections.singletonList(roleName)));
@@ -39,6 +46,10 @@ public class RoleUnknownException extends RuntimeException implements ResourceUn
         super(getMessage(roleNames));
     }
 
+    public RoleUnknownException(StreamInput in) throws IOException {
+        super(in);
+    }
+
     private static String getMessage(List<String> roleNames) {
         //noinspection PointlessBooleanExpression
         assert roleNames.isEmpty() == false : "At least one username must be provided";
@@ -46,5 +57,15 @@ public class RoleUnknownException extends RuntimeException implements ResourceUn
             return String.format(Locale.ENGLISH, "Role '%s' does not exist", roleNames.get(0));
         }
         return String.format(Locale.ENGLISH, "Roles '%s' do not exist", String.join(", ", roleNames));
+    }
+
+    @Override
+    public HttpErrorStatus httpErrorStatus() {
+        return HttpErrorStatus.USER_UNKNOWN;
+    }
+
+    @Override
+    public PGErrorStatus pgErrorStatus() {
+        return PGErrorStatus.UNDEFINED_OBJECT;
     }
 }

--- a/server/src/main/java/io/crate/rest/action/HttpError.java
+++ b/server/src/main/java/io/crate/rest/action/HttpError.java
@@ -47,7 +47,6 @@ import io.crate.exceptions.ReadOnlyException;
 import io.crate.exceptions.RelationValidationException;
 import io.crate.exceptions.RelationsUnknown;
 import io.crate.exceptions.RepositoryAlreadyExistsException;
-import io.crate.exceptions.RoleUnknownException;
 import io.crate.exceptions.SQLExceptions;
 import io.crate.exceptions.SQLParseException;
 import io.crate.exceptions.UnavailableShardsException;
@@ -140,8 +139,6 @@ public class HttpError {
             httpErrorStatus = HttpErrorStatus.PARTITION_UNKNOWN;
         } else if (throwable instanceof RelationsUnknown) {
             httpErrorStatus = HttpErrorStatus.RELATION_UNKNOWN;
-        } else if (throwable instanceof RoleUnknownException) {
-            httpErrorStatus = HttpErrorStatus.USER_UNKNOWN;
         } else if (throwable instanceof ReadOnlyException) {
             httpErrorStatus = HttpErrorStatus.ONLY_READ_OPERATION_ALLOWED_ON_THIS_NODE;
         } else if (throwable instanceof DuplicateKeyException) {

--- a/server/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/server/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -53,6 +53,7 @@ import org.elasticsearch.transport.TcpTransport;
 import io.crate.common.CheckedFunction;
 import io.crate.common.exceptions.Exceptions;
 import io.crate.exceptions.ArrayViaDocValuesUnsupportedException;
+import io.crate.exceptions.RoleUnknownException;
 import io.crate.exceptions.SQLExceptions;
 import io.crate.fdw.ServerAlreadyExistsException;
 import io.crate.fdw.UserMappingAlreadyExists;
@@ -1005,7 +1006,13 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
             io.crate.exceptions.RoleAlreadyExistsException.class,
             io.crate.exceptions.RoleAlreadyExistsException::new,
             180,
-            Version.V_5_7_0);
+            Version.V_5_7_0),
+        ROLE_UNKNOWN(
+            RoleUnknownException.class,
+            RoleUnknownException::new,
+            181,
+            Version.V_5_7_0
+        );
 
         final Class<? extends ElasticsearchException> exceptionClass;
         final CheckedFunction<StreamInput, ? extends ElasticsearchException, IOException> constructor;


### PR DESCRIPTION
See https://www.postgresql.org/docs/current/errcodes-appendix.html
Or run `has_database_privilege('foo', 'pg', 'CONNECT')` against
PostgreSQL:

    ERROR:  42704: role "foo" does not exist
    LOCATION:  get_role_oid, acl.c:5254
