### PR TITLE
Fix flaky test_ensure_lucene_ordered_collector_propagates_kill

### DIFF
--- a/server/src/test/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorFactoryTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorFactoryTest.java
@@ -226,8 +226,14 @@ public class OrderedLuceneBatchIteratorFactoryTest extends ESTestCase {
         rowBatchIterator.kill(new InterruptedException("killed"));
 
         assertThatThrownBy(consumer::getResult)
-            .hasRootCauseInstanceOf(InterruptedException.class)
-            .hasRootCauseMessage("killed");
+            .satisfiesAnyOf(
+                x -> assertThat(x)
+                    .hasRootCauseInstanceOf(InterruptedException.class)
+                    .hasRootCauseMessage("killed"),
+                x -> assertThat(x)
+                    .isExactlyInstanceOf(InterruptedException.class)
+                    .hasMessage("killed")
+            );
     }
 
     private void consumeIteratorAndVerifyResultIsException(BatchIterator<Row> rowBatchIterator, Exception exception)


### PR DESCRIPTION
    Expecting a throwable with root cause being an instance of:
      java.lang.InterruptedException
    but current throwable has no cause.
    Throwable that failed the check:
    java.lang.InterruptedException: killed
    	at io.crate.execution.engine.collect.collectors.OrderedLuceneBatchIteratorFactoryTest.test_ensure_lucene_ordered_collector_propagates_kill(OrderedLuceneBatchIteratorFactoryTest.java:226)
    	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
    ...
    	at __randomizedtesting.SeedInfo.seed([384969E2832F58A3:EE7C290235C0A888]:0)
    	at io.crate.execution.engine.collect.collectors.OrderedLuceneBatchIteratorFactoryTest.test_ensure_lucene_ordered_collector_propagates_kill(OrderedLuceneBatchIteratorFactoryTest.java:229)
