### PR TITLE
Amend year of 5.6.3 release from 2023 to 2024

### DIFF
--- a/docs/appendices/release-notes/5.6.3.rst
+++ b/docs/appendices/release-notes/5.6.3.rst
@@ -5,7 +5,7 @@ Version 5.6.3
 =============
 
 
-Released on 2023-03-22.
+Released on 2024-03-22.
 
 .. NOTE::
     If you are upgrading a cluster, you must be running CrateDB 4.0.2 or higher


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The release notes for version 5.6.3 mentioned 2023 instead of 2024

## Checklist

 - [X] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [X] This does not contain breaking changes
