### PR TITLE
Fix formatting of 5.7.0 release note

### DIFF
--- a/docs/appendices/release-notes/5.7.0.rst
+++ b/docs/appendices/release-notes/5.7.0.rst
@@ -97,7 +97,7 @@ Performance and Resilience Improvements
 
       SET optimizer_equi_join_to_lookup_join = false
 
-    Note that this setting is experimental, and may change in the future.
+  Note that this setting is experimental, and may change in the future.
 
 - Improved the performance of the :ref:`analyze` statement. CrateDB now uses much
   less memory when collecting column statistics.


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This changes the formatting from:

<img width="967" alt="before" src="https://github.com/crate/crate/assets/338234/8ca5e5fb-7c08-411b-9c81-d5bd7328af29">

to:

<img width="873" alt="after" src="https://github.com/crate/crate/assets/338234/decfa468-c7fb-415d-b779-9f9464b5199e">


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
