### PR TITLE
Add warning about silent ANALYZER alteration 

### DIFF
--- a/docs/sql/statements/create-analyzer.rst
+++ b/docs/sql/statements/create-analyzer.rst
@@ -55,6 +55,11 @@ searches. It is possible to extend an existing analyzer or define a new
 analyzer chain from scratch. For examples and detailed explanation see
 :ref:`create_custom_analyzer`.
 
+.. CAUTION::
+
+    If ``analyzer_name`` already exists, its definition is updated, but 
+    existing tables will continue to use the old definition.
+
 Parameters
 ==========
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

There is currently no `ALTER ANALYZER` command, but when a `CREATE ANALYZER` statement is issued against an existing custom `ANALYZER` name its definition is updated without a warning, this may be unexpected. This update to the documentation clarifies what happens in this case.

## Checklist

 - [X] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [X] This does not contain breaking changes