### PR TITLE
Fix flaky test_write_to_subscribed_empty_partitioned_table_is_forbidden

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/LogicalReplicationITest.java
+++ b/server/src/test/java/io/crate/integrationtests/LogicalReplicationITest.java
@@ -437,21 +437,13 @@ public class LogicalReplicationITest extends LogicalReplicationITestCase {
         createPublication("pub1", false, List.of("doc.t1"));
         executeOnSubscriber("CREATE SUBSCRIPTION sub1" +
             " CONNECTION '" + publisherConnectionUrl() + "' PUBLICATION pub1");
-        // Wait until empty partitioned table (template only) is replicated
-        assertBusy(() -> {
-            var r = executeOnSubscriber("SELECT column_name FROM information_schema.columns" +
-                " WHERE table_name = 't1'" +
-                " ORDER BY ordinal_position");
-            assertThat(r).hasRows(
-                "id",
-                "p"
-            );
-        });
 
-        assertThatThrownBy(() -> executeOnSubscriber("INSERT INTO doc.t1 (id) VALUES(3)"))
-            .isExactlyInstanceOf(OperationOnInaccessibleRelationException.class)
-            .hasMessageContaining(
-                    "The relation \"doc.t1\" doesn't allow INSERT operations, because it is included in a logical replication subscription.");
+        assertBusy(() -> {
+            assertThatThrownBy(() -> executeOnSubscriber("INSERT INTO doc.t1 (id) VALUES(3)"))
+                .isExactlyInstanceOf(OperationOnInaccessibleRelationException.class)
+                .hasMessageContaining(
+                        "The relation \"doc.t1\" doesn't allow INSERT operations, because it is included in a logical replication subscription.");
+        });
     }
 
     @Test


### PR DESCRIPTION
Test could fail with:

    Expecting actual throwable to be exactly an instance of:
      io.crate.exceptions.OperationOnInaccessibleRelationException
    but was:
      io.crate.exceptions.RelationUnknown: Relation 'doc.t1' unknown
    	at io.crate.exceptions.RelationUnknown.of(RelationUnknown.java:46)
    	at io.crate.metadata.Schemas.findRelation(Schemas.java:240)
    	at io.crate.analyze.InsertAnalyzer.analyze(InsertAnalyzer.java:114)
    	...(57 remaining lines not displayed - this can be changed with Assertions.setMaxStackTraceElementsDisplayed)
    	at __randomizedtesting.SeedInfo.seed([761FC951AF2401FB:D615A79D71EDAB21]:0)
    	at io.crate.integrationtests.LogicalReplicationITest.test_write_to_subscribed_empty_partitioned_table_is_forbidden(LogicalReplicationITest.java:452)

I wasn't able to reproduce it, but my assumption is that the information
schema check can pass on one node, while another node hit with the next
query still hasn't processed the cluster state update.
