### PR TITLE
Rename getRelationNames to relationNames in Logical Plan

### DIFF
--- a/server/src/main/java/io/crate/planner/operators/AbstractJoinPlan.java
+++ b/server/src/main/java/io/crate/planner/operators/AbstractJoinPlan.java
@@ -97,8 +97,8 @@ public abstract class AbstractJoinPlan implements LogicalPlan {
     }
 
     @Override
-    public List<RelationName> getRelationNames() {
-        return Lists.concatUnique(lhs.getRelationNames(), rhs.getRelationNames());
+    public List<RelationName> relationNames() {
+        return Lists.concatUnique(lhs.relationNames(), rhs.relationNames());
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/Collect.java
+++ b/server/src/main/java/io/crate/planner/operators/Collect.java
@@ -312,7 +312,7 @@ public class Collect implements LogicalPlan {
     }
 
     @Override
-    public List<RelationName> getRelationNames() {
+    public List<RelationName> relationNames() {
         return List.of(relation.relationName());
     }
 

--- a/server/src/main/java/io/crate/planner/operators/CorrelatedJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/CorrelatedJoin.java
@@ -182,8 +182,8 @@ public class CorrelatedJoin implements LogicalPlan {
     }
 
     @Override
-    public List<RelationName> getRelationNames() {
-        return inputPlan.getRelationNames();
+    public List<RelationName> relationNames() {
+        return inputPlan.relationNames();
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/Count.java
+++ b/server/src/main/java/io/crate/planner/operators/Count.java
@@ -135,7 +135,7 @@ public class Count implements LogicalPlan {
     }
 
     @Override
-    public List<RelationName> getRelationNames() {
+    public List<RelationName> relationNames() {
         return List.of(tableRelation.relationName());
     }
 

--- a/server/src/main/java/io/crate/planner/operators/ForeignCollect.java
+++ b/server/src/main/java/io/crate/planner/operators/ForeignCollect.java
@@ -139,7 +139,7 @@ public class ForeignCollect implements LogicalPlan {
     }
 
     @Override
-    public List<RelationName> getRelationNames() {
+    public List<RelationName> relationNames() {
         return List.of(relation.relationName());
     }
 

--- a/server/src/main/java/io/crate/planner/operators/ForwardingLogicalPlan.java
+++ b/server/src/main/java/io/crate/planner/operators/ForwardingLogicalPlan.java
@@ -58,8 +58,8 @@ public abstract class ForwardingLogicalPlan implements LogicalPlan {
     }
 
     @Override
-    public List<RelationName> getRelationNames() {
-        return source.getRelationNames();
+    public List<RelationName> relationNames() {
+        return source.relationNames();
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/Get.java
+++ b/server/src/main/java/io/crate/planner/operators/Get.java
@@ -197,7 +197,7 @@ public class Get implements LogicalPlan {
     }
 
     @Override
-    public List<RelationName> getRelationNames() {
+    public List<RelationName> relationNames() {
         return List.of(tableRelation.relationName());
     }
 

--- a/server/src/main/java/io/crate/planner/operators/HashJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/HashJoin.java
@@ -83,7 +83,7 @@ public class HashJoin extends AbstractJoinPlan {
             executor, plannerContext, hints, projectionBuilder, NO_LIMIT, 0, null, null, params, subQueryResults);
 
         SubQueryAndParamBinder paramBinder = new SubQueryAndParamBinder(params, subQueryResults);
-        var hashSymbols = createHashSymbols(lhs.getRelationNames(), rhs.getRelationNames(), joinCondition);
+        var hashSymbols = createHashSymbols(lhs.relationNames(), rhs.relationNames(), joinCondition);
 
         var lhsHashSymbols = hashSymbols.lhsHashSymbols();
         var rhsHashSymbols = hashSymbols.rhsHashSymbols();

--- a/server/src/main/java/io/crate/planner/operators/Insert.java
+++ b/server/src/main/java/io/crate/planner/operators/Insert.java
@@ -114,7 +114,7 @@ public class Insert implements LogicalPlan {
     }
 
     @Override
-    public List<RelationName> getRelationNames() {
+    public List<RelationName> relationNames() {
         return List.of();
     }
 

--- a/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
+++ b/server/src/main/java/io/crate/planner/operators/InsertFromValues.java
@@ -822,7 +822,7 @@ public class InsertFromValues implements LogicalPlan {
     }
 
     @Override
-    public List<RelationName> getRelationNames() {
+    public List<RelationName> relationNames() {
         return List.of();
     }
 

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlan.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlan.java
@@ -226,7 +226,7 @@ public interface LogicalPlan extends Plan {
      *
      * @return RelationNames of the sources in order from left to right without duplicates
      */
-    List<RelationName> getRelationNames();
+    List<RelationName> relationNames();
 
     default void print(PrintContext printContext) {
         printContext

--- a/server/src/main/java/io/crate/planner/operators/Rename.java
+++ b/server/src/main/java/io/crate/planner/operators/Rename.java
@@ -215,7 +215,7 @@ public final class Rename extends ForwardingLogicalPlan implements FieldResolver
     }
 
     @Override
-    public List<RelationName> getRelationNames() {
+    public List<RelationName> relationNames() {
         return List.of(name);
     }
 

--- a/server/src/main/java/io/crate/planner/operators/TableFunction.java
+++ b/server/src/main/java/io/crate/planner/operators/TableFunction.java
@@ -119,7 +119,7 @@ public final class TableFunction implements LogicalPlan {
     }
 
     @Override
-    public List<RelationName> getRelationNames() {
+    public List<RelationName> relationNames() {
         return List.of(relation.relationName());
     }
 

--- a/server/src/main/java/io/crate/planner/operators/Union.java
+++ b/server/src/main/java/io/crate/planner/operators/Union.java
@@ -181,8 +181,8 @@ public class Union implements LogicalPlan {
     }
 
     @Override
-    public List<RelationName> getRelationNames() {
-        return Lists.concatUnique(lhs.getRelationNames(), rhs.getRelationNames());
+    public List<RelationName> relationNames() {
+        return Lists.concatUnique(lhs.relationNames(), rhs.relationNames());
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/GroupReference.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/GroupReference.java
@@ -91,7 +91,7 @@ public class GroupReference implements LogicalPlan {
     }
 
     @Override
-    public List<RelationName> getRelationNames() {
+    public List<RelationName> relationNames() {
         return relationNames;
     }
 

--- a/server/src/main/java/io/crate/planner/optimizer/iterative/Memo.java
+++ b/server/src/main/java/io/crate/planner/optimizer/iterative/Memo.java
@@ -200,7 +200,7 @@ public class Memo {
                 .map(child -> new GroupReference(
                     insertRecursive(child),
                     child.outputs(),
-                    child.getRelationNames()))
+                    child.relationNames()))
                 .collect(Collectors.toList()));
     }
 

--- a/server/src/main/java/io/crate/planner/optimizer/rule/EliminateCrossJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/EliminateCrossJoin.java
@@ -66,7 +66,7 @@ public class EliminateCrossJoin implements Rule<JoinPlan> {
                              TransactionContext txnCtx,
                              NodeContext nodeCtx,
                              UnaryOperator<LogicalPlan> resolvePlan) {
-        if (join.getRelationNames().size() >= 3) {
+        if (join.relationNames().size() >= 3) {
             var joinGraph = JoinGraph.create(join, resolvePlan);
             if (joinGraph.hasCrossJoin()) {
                 var newOrder = eliminateCrossJoin(joinGraph);
@@ -166,7 +166,7 @@ public class EliminateCrossJoin implements Rule<JoinPlan> {
             if (criteria.isEmpty()) {
                 var errorMessage = new ArrayList<String>();
                 for (var plan : order) {
-                    for (var relationName : plan.getRelationNames()) {
+                    for (var relationName : plan.relationNames()) {
                         errorMessage.add(relationName.fqn());
                     }
                 }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathJoin.java
@@ -91,8 +91,8 @@ public class MoveConstantJoinConditionsBeneathJoin implements Rule<JoinPlan> {
             // Push constant join condition down to source
             var lhs = resolvePlan.apply(joinPlan.lhs());
             var rhs = resolvePlan.apply(joinPlan.rhs());
-            var queryForLhs = constantConditions.remove(new HashSet<>(lhs.getRelationNames()));
-            var queryForRhs = constantConditions.remove(new HashSet<>(rhs.getRelationNames()));
+            var queryForLhs = constantConditions.remove(new HashSet<>(lhs.relationNames()));
+            var queryForRhs = constantConditions.remove(new HashSet<>(rhs.relationNames()));
             var newLhs = getNewSource(queryForLhs, lhs);
             var newRhs = getNewSource(queryForRhs, rhs);
             joinPlan = new JoinPlan(

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathCorrelatedJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathCorrelatedJoin.java
@@ -69,7 +69,7 @@ public final class MoveFilterBeneathCorrelatedJoin implements Rule<Filter> {
         var splitQuery = QuerySplitter.split(filter.query());
         assert join.sources().size() == 1 : "CorrelatedJoin operator must have 1 children, the input plan";
         var inputPlan = join.sources().get(0);
-        var inputQuery = splitQuery.remove(new HashSet<>(inputPlan.getRelationNames()));
+        var inputQuery = splitQuery.remove(new HashSet<>(inputPlan.relationNames()));
         if (inputQuery == null) {
             return null;
         }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathJoin.java
@@ -133,8 +133,8 @@ public final class MoveFilterBeneathJoin implements Rule<Filter> {
         var lhs = join.lhs();
         var rhs = join.rhs();
 
-        var lhsRelations = new HashSet<>(lhs.getRelationNames());
-        var rhsRelations = new HashSet<>(rhs.getRelationNames());
+        var lhsRelations = new HashSet<>(lhs.relationNames());
+        var rhsRelations = new HashSet<>(rhs.relationNames());
 
         var leftQuery = splitQueries.remove(lhsRelations);
         var rightQuery = splitQueries.remove(rhsRelations);

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathNestedLoop.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathNestedLoop.java
@@ -96,7 +96,7 @@ public final class MoveOrderBeneathNestedLoop implements Rule<Order> {
         }
         if (relationsInOrderBy.size() == 1) {
             var relationInOrderBy = relationsInOrderBy.iterator().next();
-            var topMostLeftRelation = nestedLoop.getRelationNames().get(0);
+            var topMostLeftRelation = nestedLoop.relationNames().get(0);
             if (relationInOrderBy.equals(topMostLeftRelation)) {
                 LogicalPlan lhs = nestedLoop.sources().get(0);
                 LogicalPlan newLhs = order.replaceSources(List.of(lhs));

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoin.java
@@ -132,8 +132,8 @@ public final class RewriteFilterOnOuterJoinToInnerJoin implements Rule<Filter> {
         var sources = Lists.map(join.sources(), resolvePlan);
         LogicalPlan lhs = sources.get(0);
         LogicalPlan rhs = sources.get(1);
-        Set<RelationName> leftName = new HashSet<>(lhs.getRelationNames());
-        Set<RelationName> rightName = new HashSet<>(rhs.getRelationNames());
+        Set<RelationName> leftName = new HashSet<>(lhs.relationNames());
+        Set<RelationName> rightName = new HashSet<>(rhs.relationNames());
 
         Symbol leftQuery = splitQueries.remove(leftName);
         Symbol rightQuery = splitQueries.remove(rightName);

--- a/server/src/test/java/io/crate/planner/operators/JoinTest.java
+++ b/server/src/test/java/io/crate/planner/operators/JoinTest.java
@@ -304,7 +304,7 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
         );
         var hashJoin = plan.sources().get(0);
         assertThat(hashJoin).isExactlyInstanceOf(HashJoin.class);
-        assertThat(((HashJoin) hashJoin).rhs().getRelationNames())
+        assertThat(((HashJoin) hashJoin).rhs().relationNames())
             .as("Smaller table must be on the right-hand-side")
             .containsExactly(TEST_DOC_LOCATIONS_TABLE_IDENT);
 
@@ -333,7 +333,7 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
 
         LogicalPlan hashjoin = plan.sources().get(0).sources().get(0);
         assertThat(hashjoin).isExactlyInstanceOf(HashJoin.class);
-        assertThat(((HashJoin) hashjoin).lhs().getRelationNames())
+        assertThat(((HashJoin) hashjoin).lhs().relationNames())
             .as("Smaller table must be on the left-hand-side")
             .containsExactly(TEST_DOC_LOCATIONS_TABLE_IDENT);
 
@@ -1090,8 +1090,8 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
             "  │    └ Collect[doc.t1 | [a] | true]\n" +
             "  └ Collect[doc.t3 | [c] | true]"
         );
-        assertThat(result.getRelationNames().get(0).toString()).isEqualTo("doc.t2");
-        assertThat(result.getRelationNames().get(1).toString()).isEqualTo("doc.t1");
-        assertThat(result.getRelationNames().get(2).toString()).isEqualTo("doc.t3");
+        assertThat(result.relationNames().get(0).toString()).isEqualTo("doc.t2");
+        assertThat(result.relationNames().get(1).toString()).isEqualTo("doc.t1");
+        assertThat(result.relationNames().get(2).toString()).isEqualTo("doc.t3");
     }
 }

--- a/server/src/test/java/io/crate/planner/operators/RelationNamesInLogicalPlanTest.java
+++ b/server/src/test/java/io/crate/planner/operators/RelationNamesInLogicalPlanTest.java
@@ -87,7 +87,7 @@ public class RelationNamesInLogicalPlanTest extends CrateDummyClusterServiceUnit
     @Test
     public void test_relationnames_are_based_on_sources_in_hashjoin() throws Exception {
         var hashJoin = new HashJoin(t1Rename, t2Rename, e.asSymbol("x = y"));
-        assertThat(hashJoin.getRelationNames(), containsInAnyOrder(t1RenamedRelationName, t2RenamedRelationName));
+        assertThat(hashJoin.relationNames(), containsInAnyOrder(t1RenamedRelationName, t2RenamedRelationName));
     }
 
     @Test
@@ -97,13 +97,13 @@ public class RelationNamesInLogicalPlanTest extends CrateDummyClusterServiceUnit
                                                 JoinType.INNER,
                                                 e.asSymbol("x = y"),
                                                 false);
-        assertThat(nestedLoopJoin.getRelationNames(), containsInAnyOrder(t1RenamedRelationName, t2RenamedRelationName));
+        assertThat(nestedLoopJoin.relationNames(), containsInAnyOrder(t1RenamedRelationName, t2RenamedRelationName));
     }
 
     @Test
     public void test_relationnames_are_based_on_sources_in_union() {
         var union = new Union(t1Rename, t2Rename, List.of());
-        assertThat(union.getRelationNames(), containsInAnyOrder(t1RenamedRelationName, t2RenamedRelationName));
+        assertThat(union.relationNames(), containsInAnyOrder(t1RenamedRelationName, t2RenamedRelationName));
     }
 
     @Test
@@ -111,19 +111,19 @@ public class RelationNamesInLogicalPlanTest extends CrateDummyClusterServiceUnit
         QueriedSelectRelation relation = e.analyze("select * from abs(1)");
         TableFunctionRelation tableFunctionRelation = (TableFunctionRelation) relation.from().get(0);
         var tableFunction = new TableFunction(tableFunctionRelation, List.of(), new WhereClause(null));
-        assertThat(tableFunction.getRelationNames(), containsInAnyOrder(new RelationName(null, "abs")));
+        assertThat(tableFunction.relationNames(), containsInAnyOrder(new RelationName(null, "abs")));
     }
 
     @Test
     public void test_relationnames_are_based_on_sources_in_collect() {
         var collect = new Collect(t1Relation, List.of(), new WhereClause(null));
-        assertThat(collect.getRelationNames(), containsInAnyOrder(t1Relation.relationName()));
+        assertThat(collect.relationNames(), containsInAnyOrder(t1Relation.relationName()));
     }
 
     @Test
     public void test_relationnames_are_based_on_sources_in_get() {
         var get = new Get(t1Relation, new DocKeys(List.of(List.of()), false, false, 1, null), null, List.of(), false);
-        assertThat(get.getRelationNames(), containsInAnyOrder(t1Relation.relationName()));
+        assertThat(get.relationNames(), containsInAnyOrder(t1Relation.relationName()));
     }
 
     @Test
@@ -131,7 +131,7 @@ public class RelationNamesInLogicalPlanTest extends CrateDummyClusterServiceUnit
         QueriedSelectRelation relation = e.analyze("select count(1)");
         Function function = (Function) relation.outputs().get(0);
         var count = new Count(function, t1Relation, new WhereClause(null));
-        assertThat(count.getRelationNames(), containsInAnyOrder(t1Relation.relationName()));
+        assertThat(count.relationNames(), containsInAnyOrder(t1Relation.relationName()));
     }
 
 }

--- a/server/src/test/java/io/crate/planner/optimizer/iterative/MemoTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/iterative/MemoTest.java
@@ -333,7 +333,7 @@ public class MemoTest {
         }
 
         @Override
-        public List<RelationName> getRelationNames() {
+        public List<RelationName> relationNames() {
             return List.of();
         }
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The code style in CrateDB is to use the property name itself if it is immutable and not use a get-prefix.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
