### PR TITLE
Remove unnecessary resolveSearchRouting

### DIFF
--- a/server/src/main/java/io/crate/analyze/WhereClause.java
+++ b/server/src/main/java/io/crate/analyze/WhereClause.java
@@ -21,6 +21,14 @@
 
 package io.crate.analyze;
 
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+
+import org.jetbrains.annotations.Nullable;
+
 import io.crate.data.Input;
 import io.crate.exceptions.VersioningValidationException;
 import io.crate.expression.operator.AndOperator;
@@ -28,13 +36,6 @@ import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.doc.DocSysColumns;
-
-import org.jetbrains.annotations.Nullable;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
-import java.util.function.Function;
 
 public class WhereClause {
 
@@ -122,7 +123,6 @@ public class WhereClause {
         return clusteredBy;
     }
 
-    @Nullable
     public Set<String> routingValues() {
         if (clusteredBy.isEmpty() == false) {
             HashSet<String> result = new HashSet<>(clusteredBy.size());
@@ -132,7 +132,7 @@ public class WhereClause {
             }
             return result;
         } else {
-            return null;
+            return Set.of();
         }
     }
 

--- a/server/src/main/java/io/crate/metadata/blob/BlobTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/blob/BlobTableInfo.java
@@ -22,7 +22,6 @@
 package io.crate.metadata.blob;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -122,7 +121,7 @@ public class BlobTableInfo implements TableInfo, ShardedTable, StoredTable {
                               WhereClause whereClause,
                               RoutingProvider.ShardSelection shardSelection,
                               CoordinatorSessionSettings sessionSettings) {
-        return routingProvider.forIndices(state, new String[] { index }, Collections.emptyMap(), false, shardSelection);
+        return routingProvider.forIndices(state, new String[] { index }, Set.of(), false, shardSelection);
     }
 
     @Override

--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
@@ -26,7 +26,6 @@ import static io.crate.expression.reference.doc.lucene.SourceParser.UNKNOWN_COLU
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -46,7 +45,6 @@ import java.util.stream.Stream;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
@@ -357,23 +355,13 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
         } else {
             indices = whereClause.partitions().toArray(new String[0]);
         }
-        Map<String, Set<String>> routingMap = null;
-        if (whereClause.clusteredBy().isEmpty() == false) {
-            Set<String> routing = whereClause.routingValues();
-            if (routing == null) {
-                routing = Collections.emptySet();
-            }
-            routingMap = IndexNameExpressionResolver.resolveSearchRouting(
-                state,
-                routing,
-                indices
-            );
-        }
-
-        if (routingMap == null) {
-            routingMap = Collections.emptyMap();
-        }
-        return routingProvider.forIndices(state, indices, routingMap, isPartitioned, shardSelection);
+        return routingProvider.forIndices(
+            state,
+            indices,
+            whereClause.routingValues(),
+            isPartitioned,
+            shardSelection
+        );
     }
 
     @Override


### PR DESCRIPTION
`resolveSearchRouting` supported resolving expressions to indices, and
then create a map from index to routing-values.

Both aren't needed:

- The DocTableInfo already has access to resolved indices
- The routing values from the where clause - if present - always apply
  to all indices of a table. There's no need to group them by index. We
  don't support queries across indices with different schema/routing as
  ES does.
