### PR TITLE
Make lookup-joins work with sub-queries 

### DIFF
--- a/benchmarks/src/main/java/io/crate/analyze/PreExecutionBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/analyze/PreExecutionBenchmark.java
@@ -141,7 +141,8 @@ public class PreExecutionBenchmark {
             null,
             Cursors.EMPTY,
             TransactionState.IDLE,
-            new PlanStats(nodeCtx, CoordinatorTxnCtx.systemTransactionContext(), new TableStats())
+            new PlanStats(nodeCtx, CoordinatorTxnCtx.systemTransactionContext(), new TableStats()),
+            planner::optimize
         );
         return planner.plan(analyzedStatement, plannerContext);
     }

--- a/docs/appendices/release-notes/5.8.0.rst
+++ b/docs/appendices/release-notes/5.8.0.rst
@@ -84,7 +84,14 @@ Scalar and Aggregation Functions
 Performance and Resilience Improvements
 ---------------------------------------
 
-None
+- Extended the lookup-join optimization to make it applicable to more complex
+  queries when they include sub-queries, an inner-equi-join and if there is a
+  large imbalance in size between the joined tables. This optimization can be
+  disabled with the session setting::
+
+     SET optimizer_equi_join_to_lookup_join = false
+
+  Note that this setting is experimental, and may change in the future.
 
 Administration and Operations
 -----------------------------

--- a/server/src/main/java/io/crate/action/sql/Session.java
+++ b/server/src/main/java/io/crate/action/sql/Session.java
@@ -220,7 +220,8 @@ public class Session implements AutoCloseable {
             params,
             cursors,
             currentTransactionState,
-            new PlanStats(nodeCtx, txnCtx, tableStats)
+            new PlanStats(nodeCtx, txnCtx, tableStats),
+            planner::optimize
         );
         Plan plan;
         try {
@@ -274,7 +275,8 @@ public class Session implements AutoCloseable {
             params,
             cursors,
             currentTransactionState,
-            new PlanStats(nodeCtx, txnCtx, tableStats)
+            new PlanStats(nodeCtx, txnCtx, tableStats),
+            planner::optimize
         );
         Plan plan = planner.plan(stmt, plannerContext);
         plan.execute(executor, plannerContext, consumer, params, SubQueryResults.EMPTY);
@@ -651,7 +653,8 @@ public class Session implements AutoCloseable {
             null,
             cursors,
             currentTransactionState,
-            new PlanStats(nodeCtx, txnCtx, tableStats)
+            new PlanStats(nodeCtx, txnCtx, tableStats),
+            planner::optimize
         );
 
         PreparedStmt firstPreparedStatement = toExec.get(0).portal().preparedStmt();
@@ -739,7 +742,8 @@ public class Session implements AutoCloseable {
             params,
             cursors,
             currentTransactionState,
-            new PlanStats(nodeCtx, txnCtx, tableStats)
+            new PlanStats(nodeCtx, txnCtx, tableStats),
+            planner::optimize
         );
         var analyzedStmt = portal.analyzedStatement();
         String rawStatement = portal.preparedStmt().rawStatement();

--- a/server/src/main/java/io/crate/analyze/relations/AnalyzedRelationVisitor.java
+++ b/server/src/main/java/io/crate/analyze/relations/AnalyzedRelationVisitor.java
@@ -46,6 +46,10 @@ public abstract class AnalyzedRelationVisitor<C, R> {
         return visitAnalyzedRelation(relation, context);
     }
 
+    public R visitPlannedRelation(PlannedRelation relation, C context) {
+        return visitAnalyzedRelation(relation, context);
+    }
+
     public R visitExplain(ExplainAnalyzedStatement explainAnalyzedStatement, C context) {
         return visitAnalyzedRelation(explainAnalyzedStatement, context);
     }

--- a/server/src/main/java/io/crate/analyze/relations/PlannedRelation.java
+++ b/server/src/main/java/io/crate/analyze/relations/PlannedRelation.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.analyze.relations;
+
+import java.util.List;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import io.crate.exceptions.AmbiguousColumnException;
+import io.crate.exceptions.ColumnUnknownException;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.table.Operation;
+import io.crate.planner.operators.LogicalPlan;
+
+public class PlannedRelation implements AnalyzedRelation {
+
+    private final LogicalPlan source;
+
+    public PlannedRelation(LogicalPlan source) {
+        this.source = source;
+    }
+
+    @Override
+    public <C, R> R accept(AnalyzedRelationVisitor<C, R> visitor, C context) {
+        return visitor.visitPlannedRelation(this, context);
+    }
+
+    @Override
+    public @Nullable Symbol getField(
+        ColumnIdent column,
+        Operation operation,
+        boolean errorOnUnknownObjectKey) throws AmbiguousColumnException, ColumnUnknownException, UnsupportedOperationException {
+        throw new UnsupportedOperationException("Not supported on PlannedRelation");
+    }
+
+    @Override
+    public RelationName relationName() {
+        return source.relationNames().getFirst();
+    }
+
+    @Override
+    public @NotNull List<Symbol> outputs() {
+        return source.outputs();
+    }
+
+    @Override
+    public String toString() {
+        return relationName().fqn();
+    }
+}

--- a/server/src/main/java/io/crate/execution/MultiPhaseExecutor.java
+++ b/server/src/main/java/io/crate/execution/MultiPhaseExecutor.java
@@ -49,6 +49,7 @@ public final class MultiPhaseExecutor {
         IdentityHashMap<SelectSymbol, Object> valueBySubQuery = new IdentityHashMap<>();
         for (Map.Entry<LogicalPlan, SelectSymbol> entry : dependencies.entrySet()) {
             LogicalPlan depPlan = entry.getKey();
+            depPlan = plannerContext.optimize().apply(depPlan, plannerContext);
             SelectSymbol selectSymbol = entry.getValue();
 
             CollectingRowConsumer<?, ?> rowConsumer = getConsumer(selectSymbol.getResultType());

--- a/server/src/main/java/io/crate/planner/Planner.java
+++ b/server/src/main/java/io/crate/planner/Planner.java
@@ -141,6 +141,7 @@ import io.crate.planner.node.management.KillPlan;
 import io.crate.planner.node.management.RerouteRetryFailedPlan;
 import io.crate.planner.node.management.ShowCreateTablePlan;
 import io.crate.planner.node.management.VerboseOptimizerTracer;
+import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.LogicalPlanner;
 import io.crate.planner.statement.CopyFromPlan;
 import io.crate.planner.statement.CopyToPlan;
@@ -233,6 +234,10 @@ public class Planner extends AnalyzedStatementVisitor<PlannerContext, Plan> {
      */
     public Plan plan(AnalyzedStatement analyzedStatement, PlannerContext plannerContext) {
         return analyzedStatement.accept(this, plannerContext);
+    }
+
+    public LogicalPlan optimize(LogicalPlan plan, PlannerContext plannerContext) {
+        return logicalPlanner.optimize(plan, plannerContext);
     }
 
     @Override

--- a/server/src/test/java/io/crate/planner/PlannerTest.java
+++ b/server/src/test/java/io/crate/planner/PlannerTest.java
@@ -103,7 +103,8 @@ public class PlannerTest extends CrateDummyClusterServiceUnitTest {
             null,
             Cursors.EMPTY,
             TransactionState.IDLE,
-            e.planStats()
+            e.planStats(),
+            (a,b) -> a
         );
 
         assertThat(plannerContext.nextExecutionPhaseId()).isEqualTo(0);

--- a/server/src/test/java/io/crate/planner/optimizer/rule/EquiJoinToLookupJoinTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/EquiJoinToLookupJoinTest.java
@@ -108,7 +108,8 @@ public class EquiJoinToLookupJoinTest extends CrateDummyClusterServiceUnitTest {
         assertThat(result).hasOperators(
             "Join[INNER | (x = y)]",
             "  ├ MultiPhase",
-            "  │  └ Collect[doc.lhs | [x] | (x = ANY((SELECT y FROM (doc.rhs))))]",
+            "  │  └ Filter[(x = ANY((doc.rhs)))]",
+            "  │    └ Collect[doc.lhs | [x] | true]",
             "  │  └ Collect[doc.rhs | [y] | true]",
             "  └ Collect[doc.rhs | [y] | true]"
         );
@@ -147,7 +148,8 @@ public class EquiJoinToLookupJoinTest extends CrateDummyClusterServiceUnitTest {
             "Join[INNER | (x = y)]",
             "  ├ Collect[doc.lhs | [x] | true]",
             "  └ MultiPhase",
-            "    └ Collect[doc.rhs | [y] | (y = ANY((SELECT x FROM (doc.lhs))))]",
+            "    └ Filter[(y = ANY((doc.lhs)))]",
+            "      └ Collect[doc.rhs | [y] | true]",
             "    └ Collect[doc.lhs | [x] | true]"
         );
     }
@@ -187,7 +189,8 @@ public class EquiJoinToLookupJoinTest extends CrateDummyClusterServiceUnitTest {
             "Join[INNER | (x = y)]",
             "  ├ Collect[doc.lhs | [x] | (x > 0)]",
             "  └ MultiPhase",
-            "    └ Collect[doc.rhs | [y] | (y = ANY((SELECT x FROM (doc.lhs))))]",
+            "    └ Filter[(y = ANY((doc.lhs)))]",
+            "      └ Collect[doc.rhs | [y] | true]",
             "    └ Collect[doc.lhs | [x] | (x > 0)]"
         );
     }
@@ -226,7 +229,8 @@ public class EquiJoinToLookupJoinTest extends CrateDummyClusterServiceUnitTest {
         assertThat(result).hasOperators(
             "Join[INNER | (x = y)]",
             "  ├ MultiPhase",
-            "  │  └ Collect[doc.lhs | [x] | ((x > 0) AND (x = ANY((SELECT y FROM (doc.rhs)))))]",
+            "  │  └ Filter[(x = ANY((doc.rhs)))]",
+            "  │    └ Collect[doc.lhs | [x] | (x > 0)]",
             "  │  └ Collect[doc.rhs | [y] | true]",
             "  └ Collect[doc.rhs | [y] | true]"
         );

--- a/server/src/test/java/io/crate/planner/statement/SetSessionPlanTest.java
+++ b/server/src/test/java/io/crate/planner/statement/SetSessionPlanTest.java
@@ -78,7 +78,8 @@ public class SetSessionPlanTest extends CrateDummyClusterServiceUnitTest {
                 Row.EMPTY,
                 new Cursors(),
                 TransactionState.IDLE,
-                mock(PlanStats.class)
+                mock(PlanStats.class),
+                (a,b) -> a
             ),
             consumer,
             Row.EMPTY,

--- a/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
@@ -252,7 +252,8 @@ public class SQLExecutor {
             null,
             cursors,
             transactionState,
-            planStats
+            planStats,
+            planner::optimize
         );
     }
 
@@ -609,7 +610,8 @@ public class SQLExecutor {
             null,
             cursors,
             transactionState,
-            planStats
+            planStats,
+            planner::optimize
         );
         Plan plan = planner.plan(analyzedStatement, plannerContext);
         if (plan instanceof LogicalPlan logicalPlan) {
@@ -1009,7 +1011,8 @@ public class SQLExecutor {
             null,
             cursors,
             TransactionState.IDLE,
-            new PlanStats(nodeCtx, txnCtx, tableStats)
+            new PlanStats(nodeCtx, txnCtx, tableStats),
+            planner::optimize
         );
         var request = CreateForeignTablePlan.toRequest(
             foreignDataWrappers,

--- a/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
@@ -1774,7 +1774,8 @@ public abstract class IntegTestCase extends ESTestCase {
             null,
             Cursors.EMPTY,
             TransactionState.IDLE,
-            new PlanStats(nodeCtx, coordinatorTxnCtx, tableStats)
+            new PlanStats(nodeCtx, coordinatorTxnCtx, tableStats),
+            planner::optimize
         );
         Plan plan = planner.plan(
             analyzer.analyze(


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This makes lookup-joins work with arbitrary sub-queries. It includes the following changes:

 -  Introduce `PlannedRelation` as place placeholder for `SelectSymbols` for logical plans
 -  Optimize sub-queries of `MultiPhase` with a optimizer pass in the `MultiPhaseExecutor`
 -  Relax the condition for applying this rule, when there is a difference of 5000 rows use the lookup-join query to make it work for more use-cases including https://github.com/crate/crate-issues/issues/2

```
Q: select count(*) from (select t1.id, t1.a, t1.b, max(t.c) from doc.t1 join (select id, c from doc.t2 where c > 1) t on t1.id = t.id group by t1.id, t1.a, t1.b) x;
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |       39.319 ±   24.020 |     31.670 |     33.111 |     33.981 |    243.243 |
|   V2    |        5.719 ±   19.495 |      2.400 |      3.234 |      4.041 |    198.019 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               - 149.21%                           - 164.41%
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 149.21%
The test has statistical significance
```

See also https://github.com/crate/crate-benchmarks/pull/313




## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
