### PR TITLE
VoidReference always has RowGranularity.DOC

### DIFF
--- a/server/src/main/java/io/crate/analyze/relations/AliasedAnalyzedRelation.java
+++ b/server/src/main/java/io/crate/analyze/relations/AliasedAnalyzedRelation.java
@@ -120,7 +120,6 @@ public class AliasedAnalyzedRelation implements AnalyzedRelation, FieldResolver 
         if (field instanceof VoidReference voidReference) {
             return new VoidReference(
                 new ReferenceIdent(alias, voidReference.column()),
-                voidReference.granularity(),
                 voidReference.position());
         }
         ScopedSymbol scopedSymbol = new ScopedSymbol(alias, column, field.valueType());

--- a/server/src/main/java/io/crate/expression/symbol/VoidReference.java
+++ b/server/src/main/java/io/crate/expression/symbol/VoidReference.java
@@ -39,9 +39,8 @@ public class VoidReference extends DynamicReference {
     }
 
     public VoidReference(ReferenceIdent ident,
-                         RowGranularity granularity,
                          int position) {
-        super(ident, granularity, position);
+        super(ident, RowGranularity.DOC, position);
     }
 
     @Override

--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
@@ -526,7 +526,7 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
             case DYNAMIC:
                 if (!forWrite) {
                     if (!errorOnUnknownObjectKey) {
-                        return new VoidReference(new ReferenceIdent(ident(), ident), rowGranularity(), position);
+                        return new VoidReference(new ReferenceIdent(ident(), ident), position);
                     }
                     return null;
                 }

--- a/server/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
+++ b/server/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
@@ -192,7 +192,6 @@ public class SymbolPrinterTest extends CrateDummyClusterServiceUnitTest {
         Reference r = new VoidReference(
             new ReferenceIdent(new RelationName("schema", "table"),
                                new ColumnIdent("column", Arrays.asList("path", "nested"))),
-            RowGranularity.DOC,
             0);
         assertPrint(r, "schema.\"table\".\"column\"['path']['nested']");
     }


### PR DESCRIPTION
When a new VoidReference is constructed, it calls `DocTableInfo#rowGranularity()`
to pass a granularity to the constructor.  This value is always `RowGranularity.DOC`,
so we can remove the constructor parameter entirely.