### PR TITLE
Take to account all new partitions when checking shard limits

### DIFF
--- a/docs/appendices/release-notes/5.6.5.rst
+++ b/docs/appendices/release-notes/5.6.5.rst
@@ -47,4 +47,7 @@ See the :ref:`version_5.6.0` release notes for a full list of changes in the
 Fixes
 =====
 
-None
+- Fixed an issue that allowed ``INSERT INTO`` statements to create more shards
+  than allowed by :ref:`cluster.max_shards_per_node
+  <cluster.max_shards_per_node>` if the statement resulted in the creation of
+  many partitions at once.

--- a/docs/appendices/release-notes/5.7.1.rst
+++ b/docs/appendices/release-notes/5.7.1.rst
@@ -46,4 +46,8 @@ See the :ref:`version_5.7.0` release notes for a full list of changes in the
 Fixes
 =====
 
-None
+- Fixed an issue that allowed ``INSERT INTO`` statements to create more shards
+  than allowed by :ref:`cluster.max_shards_per_node
+  <cluster.max_shards_per_node>` if the statement resulted in the creation of
+  many partitions at once.
+

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitionsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitionsAction.java
@@ -59,6 +59,7 @@ import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -218,7 +219,17 @@ public class TransportCreatePartitionsAction extends TransportMasterNodeAction<C
             // Use only first index to validate that index can be created.
             // All indices share same template/settings so no need to repeat validation for each index.
             Settings commonIndexSettings = createCommonIndexSettings(currentState, template);
-            shardLimitValidator.validateShardLimit(commonIndexSettings, currentState);
+
+            final int numberOfShards = INDEX_NUMBER_OF_SHARDS_SETTING.get(commonIndexSettings);
+            final int numberOfReplicas = IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING.get(commonIndexSettings);
+            // Shard limit check has to take to account all new partitions.
+            final int numShardsToCreate = numberOfShards * (1 + numberOfReplicas) * indicesToCreate.size();
+            shardLimitValidator.checkShardLimit(numShardsToCreate, currentState)
+                .ifPresent(err -> {
+                    final ValidationException e = new ValidationException();
+                    e.addValidationError(err);
+                    throw e;
+                });
             int routingNumShards = IndexMetadata.INDEX_NUMBER_OF_ROUTING_SHARDS_SETTING.get(commonIndexSettings);
             IndexMetadata.Builder tmpImdBuilder = IndexMetadata.builder(firstIndex)
                 .setRoutingNumShards(routingNumShards);

--- a/server/src/test/java/io/crate/integrationtests/ShardLimitsIT.java
+++ b/server/src/test/java/io/crate/integrationtests/ShardLimitsIT.java
@@ -65,6 +65,14 @@ public class ShardLimitsIT extends IntegTestCase {
                 .hasHTTPError(HttpResponseStatus.BAD_REQUEST, 4000)
                 .hasMessageContaining(
                         "this action would add [4] total shards, but this cluster currently has [0]/[2] maximum shards open;");
+
+        // Bulk insert forcing creation of multiple partitions at once.
+        execute("set global \"cluster.max_shards_per_node\" = 4");
+        Asserts.assertSQLError(() -> execute("insert into tbl (x, p) values (1, 1), (2, 2), (3, 3)"))
+            .hasPGError(PGErrorStatus.INTERNAL_ERROR)
+            .hasHTTPError(HttpResponseStatus.BAD_REQUEST, 4000)
+            .hasMessageContaining(
+                "this action would add [12] total shards, but this cluster currently has [0]/[8] maximum shards open");
     }
 
     @Test


### PR DESCRIPTION
Takes a fix from https://github.com/crate/crate/pull/15813 but with a simpler test. 

It's possible to significantly exceed the limit: `values_count/nodes` times.
If initial setup was fine for a single partition, the whole insert passed as we took to account only partition.

This is not a regression caused by https://github.com/crate/crate/pull/13843.
I also checked in 5.2, same problem there. In 5.2 we used  to create "probe" index multiple times via `indicesService.createIndex` but it doesn't affect 
`int currentOpenShards = state.metadata().getTotalOpenIndexShards()` 
(probably because we call `allocationService.reroute` only once after the loop)

This is not a fix for https://github.com/crate/crate/issues/15803 (which is about expanding replicas, or something else but not related to partitioned tables. Maybe even expected and need to expand docs. I will have a dedicated PR for it, out of the scope of this PR).

`insert from select` is also slightly affected but I couldn't significantly exceed the limit.
`BulkShardCreationLimiter` leads to creating new partitions in smaller batches, so creating a batch actually increases
`state.metadata().getTotalOpenIndexShards()` and such `ShardLimitValidator` kinda keeps up with the actual state and cannot significantly exceed the limit. In other words, it doesn't take to account not `total_new_partitions - 1` but "only" `new_partitions_batch_size - 1 `

Anyway, this change also addresses `insert from select` as well, even though it's less visible problem that `insert-from-values`
