### PR TITLE
Remove indexSettings from Mappers

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/BuilderFactory.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BuilderFactory.java
@@ -21,13 +21,13 @@
 
 package org.elasticsearch.index.mapper;
 
-import org.elasticsearch.ElasticsearchParseException;
-import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.index.mapper.array.DynamicArrayFieldMapperBuilderFactory;
+import static org.elasticsearch.index.mapper.DocumentParser.getPositionEstimate;
 
 import java.io.IOException;
 
-import static org.elasticsearch.index.mapper.DocumentParser.getPositionEstimate;
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.mapper.array.DynamicArrayFieldMapperBuilderFactory;
 
 /**
  * Used when a document is parsed and a unknown field that contains an array value is encountered
@@ -37,7 +37,7 @@ import static org.elasticsearch.index.mapper.DocumentParser.getPositionEstimate;
 public class BuilderFactory implements DynamicArrayFieldMapperBuilderFactory {
 
     public Mapper create(String name, ObjectMapper parentMapper, ParseContext context) {
-        Mapper.BuilderContext builderContext = new Mapper.BuilderContext(context.indexSettings().getSettings(), context.path());
+        Mapper.BuilderContext builderContext = new Mapper.BuilderContext(context.path());
         try {
             Mapper.Builder innerBuilder = detectInnerMapper(context, name, context.parser());
             if (innerBuilder == null) {
@@ -46,7 +46,7 @@ public class BuilderFactory implements DynamicArrayFieldMapperBuilderFactory {
             innerBuilder.position(getPositionEstimate(context));
             Mapper innerMapper = innerBuilder.build(builderContext);
             if (innerMapper instanceof ObjectMapper objectMapper) {
-                return new ObjectArrayMapper(name, objectMapper, context.indexSettings().getSettings());
+                return new ObjectArrayMapper(name, objectMapper);
             }
             FieldMapper innerFieldMapper = (FieldMapper) innerMapper;
             ArrayFieldType mappedFieldType = new ArrayFieldType(innerFieldMapper.fieldType());

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -37,7 +37,6 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchGenerationException;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.compress.CompressedXContent;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -62,8 +61,7 @@ public class DocumentMapper implements ToXContentFragment {
         private final Mapper.BuilderContext builderContext;
 
         public Builder(RootObjectMapper.Builder builder, MapperService mapperService) {
-            final Settings indexSettings = mapperService.getIndexSettings().getSettings();
-            this.builderContext = new Mapper.BuilderContext(indexSettings, new ContentPath(1));
+            this.builderContext = new Mapper.BuilderContext(new ContentPath(1));
             this.rootObjectMapper = builder.build(builderContext);
 
             DocumentMapper existingMapper = mapperService.documentMapper();

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -401,7 +401,7 @@ final class DocumentParser {
             } else if (dynamic == ObjectMapper.Dynamic.TRUE) {
                 Mapper.Builder builder = new ObjectMapper.Builder(currentFieldName);
                 builder.position(getPositionEstimate(context));
-                Mapper.BuilderContext builderContext = new Mapper.BuilderContext(context.indexSettings().getSettings(), context.path());
+                Mapper.BuilderContext builderContext = new Mapper.BuilderContext(context.path());
                 objectMapper = builder.build(builderContext);
                 context.addDynamicMapper(objectMapper);
                 context.path().add(currentFieldName);
@@ -575,7 +575,7 @@ final class DocumentParser {
         if (dynamic == ObjectMapper.Dynamic.FALSE) {
             return;
         }
-        final Mapper.BuilderContext builderContext = new Mapper.BuilderContext(context.indexSettings().getSettings(), context.path());
+        final Mapper.BuilderContext builderContext = new Mapper.BuilderContext(context.path());
         final Mapper.Builder builder = createBuilderFromDynamicValue(context, token, currentFieldName);
         builder.position(getPositionEstimate(context));
         Mapper mapper = builder.build(builderContext);
@@ -668,8 +668,7 @@ final class DocumentParser {
                     case TRUE:
                         Mapper.Builder builder = new ObjectMapper.Builder(paths[i]);
                         builder.position(getPositionEstimate(context));
-                        Mapper.BuilderContext builderContext = new Mapper.BuilderContext(context.indexSettings().getSettings(),
-                            context.path());
+                        Mapper.BuilderContext builderContext = new Mapper.BuilderContext(context.path());
                         mapper = (ObjectMapper) builder.build(builderContext);
                         context.addDynamicMapper(mapper);
                         break;

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldNamesFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldNamesFieldMapper.java
@@ -32,7 +32,6 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 /**
@@ -90,9 +89,8 @@ public class FieldNamesFieldMapper extends MetadataFieldMapper {
 
         @Override
         public MetadataFieldMapper getDefault(ParserContext context) {
-            final Settings indexSettings = context.mapperService().getIndexSettings().getSettings();
             return parse(NAME, Collections.emptyMap(), context)
-                    .build(new BuilderContext(indexSettings, new ContentPath(1)));
+                    .build(new BuilderContext(new ContentPath(1)));
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
@@ -24,7 +24,6 @@ import java.util.Objects;
 import java.util.function.Function;
 
 import org.elasticsearch.cluster.metadata.ColumnPositionResolver;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.index.analysis.IndexAnalyzers;
 
@@ -33,14 +32,11 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
     public static final int NOT_TO_BE_POSITIONED = 0;
 
     public static class BuilderContext {
-        private final Settings indexSettings;
         private final ContentPath contentPath;
         private final ColumnPositionResolver<Mapper> columnPositionResolver;
 
-        public BuilderContext(Settings indexSettings, ContentPath contentPath) {
-            Objects.requireNonNull(indexSettings, "indexSettings is required");
+        public BuilderContext(ContentPath contentPath) {
             this.contentPath = contentPath;
-            this.indexSettings = indexSettings;
             this.columnPositionResolver = new ColumnPositionResolver<>();
         }
 
@@ -48,9 +44,6 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
             return this.contentPath;
         }
 
-        public Settings indexSettings() {
-            return this.indexSettings;
-        }
 
         public void putPositionInfo(Mapper mapper, int position) {
             if (position < 0) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectArrayMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectArrayMapper.java
@@ -21,14 +21,13 @@
 
 package org.elasticsearch.index.mapper;
 
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.ToXContent;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
+
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
 
 /**
  * Mapper for array(object).
@@ -51,7 +50,7 @@ public class ObjectArrayMapper extends ObjectMapper {
 
         @Override
         public ObjectMapper build(BuilderContext context) {
-            return new ObjectArrayMapper(name, innerBuilder.build(context), context.indexSettings());
+            return new ObjectArrayMapper(name, innerBuilder.build(context));
         }
 
         @Override
@@ -61,27 +60,24 @@ public class ObjectArrayMapper extends ObjectMapper {
                                             boolean isDropped,
                                             String fullPath,
                                             Dynamic dynamic,
-                                            Map<String, Mapper> mappers,
-                                            Settings settings) {
+                                            Map<String, Mapper> mappers) {
             return new ObjectArrayMapper(
                 name,
-                super.createMapper(name, position, columnOID, isDropped, fullPath, dynamic, mappers, settings),
-                settings
+                super.createMapper(name, position, columnOID, isDropped, fullPath, dynamic, mappers)
             );
         }
     }
 
     private ObjectMapper innerMapper;
 
-    ObjectArrayMapper(String name, ObjectMapper innerMapper, Settings settings) {
+    ObjectArrayMapper(String name, ObjectMapper innerMapper) {
         super(name,
               innerMapper.position(),
               innerMapper.columnOID(),
               innerMapper.isDropped(),
               innerMapper.fullPath(),
               innerMapper.dynamic(),
-              Collections.emptyMap(),
-              settings);
+              Collections.emptyMap());
         this.innerMapper = innerMapper;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -37,10 +37,8 @@ import java.util.Map;
 
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.collect.CopyOnWriteHashMap;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.jetbrains.annotations.Nullable;
 
 import io.crate.common.time.IsoLocale;
 
@@ -103,8 +101,7 @@ public class ObjectMapper extends Mapper implements Cloneable {
                 isDropped,
                 context.path().pathAsText(pathName),
                 dynamic,
-                mappers,
-                context.indexSettings()
+                mappers
             );
             if (mapper instanceof RootObjectMapper rootObjectMapper) {
                 context.updateRootObjectMapperWithPositionInfo(rootObjectMapper);
@@ -120,9 +117,8 @@ public class ObjectMapper extends Mapper implements Cloneable {
                                             boolean isDropped,
                                             String fullPath,
                                             Dynamic dynamic,
-                                            Map<String, Mapper> mappers,
-                                            @Nullable Settings settings) {
-            return new ObjectMapper(name, position, columnOID, isDropped, fullPath, dynamic, mappers, settings);
+                                            Map<String, Mapper> mappers) {
+            return new ObjectMapper(name, position, columnOID, isDropped, fullPath, dynamic, mappers);
         }
     }
 
@@ -250,10 +246,8 @@ public class ObjectMapper extends Mapper implements Cloneable {
                  boolean isDropped,
                  String fullPath,
                  Dynamic dynamic,
-                 Map<String, Mapper> mappers,
-                 Settings settings) {
+                 Map<String, Mapper> mappers) {
         super(name, columnOID);
-        assert settings != null;
         this.fullPath = fullPath;
         this.position = position;
         this.isDropped = isDropped;

--- a/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
@@ -19,15 +19,14 @@
 
 package org.elasticsearch.index.mapper;
 
+import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
+
 import java.util.Iterator;
 import java.util.Map;
 
 import org.elasticsearch.cluster.metadata.ColumnPositionResolver;
-import org.elasticsearch.common.settings.Settings;
 
 import io.crate.Constants;
-
-import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
 
 public class RootObjectMapper extends ObjectMapper {
 
@@ -51,14 +50,12 @@ public class RootObjectMapper extends ObjectMapper {
                                             boolean isDropped,
                                             String fullPath,
                                             Dynamic dynamic,
-                                            Map<String, Mapper> mappers,
-                                            Settings settings) {
+                                            Map<String, Mapper> mappers) {
             assert name.equals(Constants.DEFAULT_MAPPING_TYPE) : "Name of root mapper must match `default`: " + name;
             return new RootObjectMapper(
                 name,
                 dynamic,
-                mappers,
-                settings
+                mappers
             );
         }
     }
@@ -83,9 +80,8 @@ public class RootObjectMapper extends ObjectMapper {
 
     RootObjectMapper(String name,
                      Dynamic dynamic,
-                     Map<String, Mapper> mappers,
-                     Settings settings) {
-        super(name, NOT_TO_BE_POSITIONED, COLUMN_OID_UNASSIGNED, false, name, dynamic, mappers, settings);
+                     Map<String, Mapper> mappers) {
+        super(name, NOT_TO_BE_POSITIONED, COLUMN_OID_UNASSIGNED, false, name, dynamic, mappers);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/mapper/BitStringFieldMapperTest.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/BitStringFieldMapperTest.java
@@ -24,7 +24,6 @@ package org.elasticsearch.index.mapper;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.elasticsearch.common.settings.Settings;
 import org.junit.Test;
 
 public class BitStringFieldMapperTest {
@@ -34,7 +33,7 @@ public class BitStringFieldMapperTest {
         BitStringFieldMapper.Builder builder = new BitStringFieldMapper.Builder("x");
         ContentPath contentPath = new ContentPath();
         contentPath.add("o");
-        var context = new Mapper.BuilderContext(Settings.EMPTY, contentPath);
+        var context = new Mapper.BuilderContext(contentPath);
         BitStringFieldMapper mapper = builder.build(context);
         assertThat(mapper.name()).isEqualTo("o.x");
     }
@@ -45,7 +44,7 @@ public class BitStringFieldMapperTest {
         builder.index(false);
         ContentPath contentPath = new ContentPath();
         contentPath.add("o");
-        var context = new Mapper.BuilderContext(Settings.EMPTY, contentPath);
+        var context = new Mapper.BuilderContext(contentPath);
         BitStringFieldMapper mapper = builder.build(context);
         assertThat(mapper.mappedFieldType.isSearchable()).isFalse();
     }
@@ -56,7 +55,7 @@ public class BitStringFieldMapperTest {
         builder.docValues(false);
         ContentPath contentPath = new ContentPath();
         contentPath.add("o");
-        var context = new Mapper.BuilderContext(Settings.EMPTY, contentPath);
+        var context = new Mapper.BuilderContext(contentPath);
         BitStringFieldMapper mapper = builder.build(context);
         assertThat(mapper.mappedFieldType.hasDocValues()).isFalse();
     }
@@ -64,7 +63,7 @@ public class BitStringFieldMapperTest {
     @Test
     public void test_field_mapper_cannot_have_empty_name() {
         ContentPath contentPath = new ContentPath();
-        var context = new Mapper.BuilderContext(Settings.EMPTY, contentPath);
+        var context = new Mapper.BuilderContext(contentPath);
         assertThatThrownBy(() -> new BitStringFieldMapper.Builder("").build(context))
             .isExactlyInstanceOf(IllegalArgumentException.class)
             .hasMessage("name cannot be empty string");


### PR DESCRIPTION
They're not used.

This is motivated by https://github.com/crate/crate/issues/11939 where
the mapping might move from index to a table level, with the implication
that index settings are no longer available in the current form for the
MapperService and everything underneath.
