### PR TITLE
Update checkstyle to 10.15.0

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -209,7 +209,9 @@
             <!--<property name="allowedAbbreviationLength" value="1"/>-->
         <!--</module>-->
         <!--<module name="OverloadMethodsDeclarationOrder"/>-->
-        <module name="VariableDeclarationUsageDistance"/>
+        <module name="VariableDeclarationUsageDistance">
+          <property name="allowedDistance" value="5" />
+        </module>
         <!--<module name="CustomImportOrder">-->
             <!--<property name="sortImportsInGroupAlphabetically" value="true"/>-->
             <!--<property name="separateLineBetweenGroups" value="true"/>-->

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,13 @@
           <includeTestResources>false</includeTestResources>
           <linkXRef>false</linkXRef>
         </configuration>
+         <dependencies>
+            <dependency>
+              <groupId>com.puppycrawl.tools</groupId>
+              <artifactId>checkstyle</artifactId>
+              <version>10.15.0</version>
+            </dependency>
+          </dependencies>
         <executions>
           <execution>
             <id>validate</id>

--- a/server/src/main/java/io/crate/replication/logical/metadata/ConnectionInfo.java
+++ b/server/src/main/java/io/crate/replication/logical/metadata/ConnectionInfo.java
@@ -41,8 +41,8 @@ import org.elasticsearch.transport.RemoteCluster.ConnectionStrategy;
 import org.jetbrains.annotations.Nullable;
 
 import io.crate.replication.logical.exceptions.CreateSubscriptionException;
-import io.crate.types.DataTypes;
 import io.crate.role.Role;
+import io.crate.types.DataTypes;
 
 
 public class ConnectionInfo implements Writeable {
@@ -81,8 +81,6 @@ public class ConnectionInfo implements Writeable {
 
     public static ConnectionInfo fromURL(String url) {
         try {
-            List<String> hosts = new ArrayList<>();
-
             String urlServer = url;
             String urlArgs = "";
 
@@ -142,6 +140,7 @@ public class ConnectionInfo implements Writeable {
 
             Settings settings = settingsBuilder.build();
             String[] addresses = urlServer.substring(0, slash).split(",");
+            List<String> hosts = new ArrayList<>();
             for (String address : addresses) {
                 int portIdx = address.lastIndexOf(':');
                 if (portIdx != -1 && address.lastIndexOf(']') < portIdx) {

--- a/server/src/main/java/org/elasticsearch/index/analysis/AnalysisRegistry.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/AnalysisRegistry.java
@@ -467,7 +467,6 @@ public final class AnalysisRegistry implements Closeable {
                                 Map<String, CharFilterFactory> charFilterFactoryFactories,
                                 Map<String, TokenFilterFactory> tokenFilterFactoryFactories) {
 
-        Index index = indexSettings.getIndex();
         analyzerProviders = new HashMap<>(analyzerProviders);
         Map<String, NamedAnalyzer> analyzers = new HashMap<>();
         Map<String, NamedAnalyzer> normalizers = new HashMap<>();
@@ -495,6 +494,7 @@ public final class AnalysisRegistry implements Closeable {
         }
 
 
+        Index index = indexSettings.getIndex();
         NamedAnalyzer defaultAnalyzer = analyzers.get("default");
         if (defaultAnalyzer == null) {
             throw new IllegalArgumentException("no default analyzer configured");

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -270,7 +270,6 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
     }
 
     private synchronized DocumentMapper internalMerge(DocumentMapper mapper, MergeReason reason) {
-        Map<String, ObjectMapper> fullPathObjectMappers = this.fullPathObjectMappers;
 
         assert mapper != null;
 
@@ -294,6 +293,7 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
 
         this.fieldTypes = new FieldTypeLookup(fieldMappers);
 
+        Map<String, ObjectMapper> fullPathObjectMappers = this.fullPathObjectMappers;
         for (ObjectMapper objectMapper : objectMappers) {
             if (fullPathObjectMappers == this.fullPathObjectMappers) {
                 // first time through the loops

--- a/server/src/main/java/org/elasticsearch/rest/RestStatus.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestStatus.java
@@ -19,15 +19,15 @@
 
 package org.elasticsearch.rest;
 
-import org.elasticsearch.action.ShardOperationFailedException;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
+import static java.util.Collections.unmodifiableMap;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import static java.util.Collections.unmodifiableMap;
+import org.elasticsearch.action.ShardOperationFailedException;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 
 public enum RestStatus {
     /**
@@ -482,6 +482,7 @@ public enum RestStatus {
     INSUFFICIENT_STORAGE(507);
 
     private static final Map<Integer, RestStatus> CODE_TO_STATUS;
+
     static {
         RestStatus[] values = values();
         Map<Integer, RestStatus> codeToStatus = new HashMap<>(values.length);


### PR DESCRIPTION
maven-checkstyle-plugin 3.3.1 defaults to checkstyle 9.3

There are lots of fixes since then - some addressing false positives,
and support for newer features (like pattern matching syntax in switch)

The `VariableDeclarationUsageDistance` evaluation or default changed, it would default to 3. I changed it to 5 because 3 seemed overally restrictive and caused lots of errors. Even 5 required a few adjustments.