### PR TITLE
docs: fix actual max number of replicas for "all"

### DIFF
--- a/docs/sql/statements/create-table.rst
+++ b/docs/sql/statements/create-table.rst
@@ -384,7 +384,7 @@ The number of replicas is defined like this::
 
   The actual maximum number of replicas is max(num_replicas, N-1), where N is
   the number of data nodes in the cluster. If ``max_replicas`` is the string
-  ``all`` then it will always be N.
+  ``all`` then it will always be N-1.
 
 .. SEEALSO::
 


### PR DESCRIPTION
We cannot  have N replicas on N nodes and meet the green cluster requirement 
"replicas cannot be allocated on the same node with their primary"

https://github.com/crate/crate/blob/master/server/src/main/java/org/elasticsearch/cluster/metadata/AutoExpandReplicas.java#L106