### PR TITLE
Add retries for logical replication itests

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/LogicalReplicationITest.java
+++ b/server/src/test/java/io/crate/integrationtests/LogicalReplicationITest.java
@@ -37,6 +37,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.junit.Rule;
 import org.junit.Test;
 
 import io.crate.exceptions.OperationOnInaccessibleRelationException;
@@ -49,11 +50,15 @@ import io.crate.replication.logical.metadata.Subscription;
 import io.crate.replication.logical.metadata.SubscriptionsMetadata;
 import io.crate.role.Role;
 import io.crate.role.Roles;
+import io.crate.testing.RetryRule;
 import io.crate.testing.UseRandomizedSchema;
 
 
 @UseRandomizedSchema(random = false)
 public class LogicalReplicationITest extends LogicalReplicationITestCase {
+
+    @Rule
+    public RetryRule retryRule = new RetryRule(3);
 
     @Test
     public void test_create_publication_checks_owner_was_not_deleted_before_creation() {

--- a/server/src/test/java/io/crate/integrationtests/MetadataTrackerITest.java
+++ b/server/src/test/java/io/crate/integrationtests/MetadataTrackerITest.java
@@ -22,21 +22,27 @@
 package io.crate.integrationtests;
 
 import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import org.junit.Rule;
 import org.junit.Test;
 
 import io.crate.exceptions.OperationOnInaccessibleRelationException;
 import io.crate.replication.logical.LogicalReplicationService;
 import io.crate.replication.logical.MetadataTracker;
+import io.crate.testing.RetryRule;
 import io.crate.testing.UseRandomizedSchema;
 
 @UseRandomizedSchema(random = false)
 public class MetadataTrackerITest extends LogicalReplicationITestCase {
+
+    @Rule
+    public RetryRule retryRule = new RetryRule(3);
 
     @Test
     public void test_schema_changes_of_subscribed_table_is_replicated() throws Exception {

--- a/server/src/testFixtures/java/io/crate/testing/RetryRule.java
+++ b/server/src/testFixtures/java/io/crate/testing/RetryRule.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.testing;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+public class RetryRule implements TestRule {
+
+    private final int retryCount;
+
+    public RetryRule(int retryCount) {
+        this.retryCount = retryCount;
+    }
+
+    @Override
+    public Statement apply(Statement statement, Description description) {
+        return new Statement() {
+
+            Throwable err;
+
+            @Override
+            public void evaluate() throws Throwable {
+                for (int i = 0; i < retryCount; i++) {
+                    try {
+                        statement.evaluate();
+                        return;
+                    } catch (Throwable t) {
+                        if (err == null) {
+                            err = t;
+                        } else {
+                            err.addSuppressed(t);
+                        }
+                    }
+                }
+                throw err;
+            }
+        };
+    }
+}


### PR DESCRIPTION
Some of the logical replication test cases are flaky, for example:

`test_subscription_state_order` fails with:

    org.opentest4j.AssertionFailedError:

    Expecting actual:
      [INITIALIZING, RESTORING]
    to contain exactly (and in same order):
      [INITIALIZING, RESTORING, MONITORING]
    but could not find the following elements:
      [MONITORING]
    	at __randomizedtesting.SeedInfo.seed([4AC3CDF8823AA15F:B53F7963FF6FCC96]:0)
    	at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)
    	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502)
    	at io.crate.integrationtests.LogicalReplicationITest.lambda$test_subscription_state_order$15(LogicalReplicationITest.java:483)
    	at org.elasticsearch.test.ESTestCase.assertBusy(ESTestCase.java:719)
    	at io.crate.integrationtests.LogicalReplicationITest.test_subscription_state_order(LogicalReplicationITest.java:480)

`test_schema_changes_of_multiple_tables_are_replicated` fails with:

    org.opentest4j.AssertionFailedError:
    Expecting actual:
      ["id"]
    to contain exactly (and in same order):
      ["id", "name"]
    but could not find the following elements:
      ["name"]
    	at __randomizedtesting.SeedInfo.seed([877EA034680DA549:FAB33D3BD7C923A6]:0)
    	at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)
    	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502)
    	at io.crate.testing.SQLResponseAssert.hasRows(SQLResponseAssert.java:65)
    	at io.crate.integrationtests.MetadataTrackerITest.lambda$test_schema_changes_of_multiple_tables_are_replicated$5(MetadataTrackerITest.java:122)
    	at org.elasticsearch.test.ESTestCase.assertBusy(ESTestCase.java:719)
    	at io.crate.integrationtests.MetadataTrackerITest.test_schema_changes_of_multiple_tables_are_replicated(MetadataTrackerITest.java:117)

Currently we effectively ignore them. Our normal policy is to fix flaky
tests, but in this case it turned out that it would require a lot of
effort, which we currently do not want to invest.

This introduces a retry rule and uses it for the logical replication
test cases. This should avoid CI failures due to the known flaky cases,
but still notify us if tests break completely.

An alternative would be to use
https://maven.apache.org/surefire/maven-surefire-plugin/examples/rerun-failing-tests.html,
but that would affect all tests, and likely encourage more
tolerance towards flakyness, which is not desired.
