### PR TITLE
Remove deprecated index.warmer.enabled setting

### DIFF
--- a/docs/appendices/release-notes/5.8.0.rst
+++ b/docs/appendices/release-notes/5.8.0.rst
@@ -44,6 +44,11 @@ Version 5.8.0 - Unreleased
 Breaking Changes
 ================
 
+- Removed the ``index.warmer.enabled`` setting and its corresponding column
+  within the ``settings`` column of ``information_schema.tables`` and
+  ``information_schema.table_partitions``. The setting had been deprecated in
+  CrateDB 4.2.0.
+
 - Removed ``network`` column from :ref:`sys.nodes <sys-nodes>` table. The column
   was deprecated since `version_2.3.0_` and all of the sub-columns where
   returning 0.

--- a/server/src/main/java/io/crate/analyze/TableParameters.java
+++ b/server/src/main/java/io/crate/analyze/TableParameters.java
@@ -96,7 +96,6 @@ public class TableParameters {
             IndexSettings.INDEX_TRANSLOG_DURABILITY_SETTING,
             ShardsLimitAllocationDecider.INDEX_TOTAL_SHARDS_PER_NODE_SETTING,
             MapperService.INDEX_MAPPING_TOTAL_FIELDS_LIMIT_SETTING,
-            IndexSettings.INDEX_WARMER_ENABLED_SETTING,
             UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING,
             IndexMetadata.SETTING_WAIT_FOR_ACTIVE_SHARDS,
             MaxRetryAllocationDecider.SETTING_ALLOCATION_MAX_RETRY,
@@ -129,7 +128,6 @@ public class TableParameters {
      */
     static final Set<Setting<?>> SETTINGS_NOT_INCLUDED_IN_DEFAULT = Set.of(
         IndexMetadata.INDEX_NUMBER_OF_ROUTING_SHARDS_SETTING,
-        IndexSettings.INDEX_WARMER_ENABLED_SETTING,
         IndexService.GLOBAL_CHECKPOINT_SYNC_INTERVAL_SETTING,
         MergeSchedulerConfig.MAX_THREAD_COUNT_SETTING,
         IndexSettings.INDEX_SOFT_DELETES_SETTING,

--- a/server/src/main/java/io/crate/metadata/information/InformationPartitionsTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/information/InformationPartitionsTableInfo.java
@@ -103,10 +103,6 @@ public class InformationPartitionsTableInfo {
                     .endObject()
                 .endObject()
 
-                .startObject("warmer")
-                    .add("enabled", BOOLEAN, fromSetting(IndexSettings.INDEX_WARMER_ENABLED_SETTING))
-                .endObject()
-
                 .startObject("unassigned")
                     .startObject("node_left")
                         .add("delayed_timeout", LONG, fromTimeValue(UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING))

--- a/server/src/main/java/io/crate/metadata/information/InformationTablesTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/information/InformationTablesTableInfo.java
@@ -200,10 +200,6 @@ public class InformationTablesTableInfo {
                     .endObject()
                 .endObject()
 
-                .startObject("warmer")
-                    .add("enabled", BOOLEAN, fromSetting(IndexSettings.INDEX_WARMER_ENABLED_SETTING))
-                .endObject()
-
                 .startObject("unassigned")
                     .startObject("node_left")
                         .add("delayed_timeout", LONG, fromTimeValue(UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING))

--- a/server/src/main/java/io/crate/replication/logical/LogicalReplicationSettings.java
+++ b/server/src/main/java/io/crate/replication/logical/LogicalReplicationSettings.java
@@ -122,7 +122,6 @@ public class LogicalReplicationSettings {
         ShardsLimitAllocationDecider.INDEX_TOTAL_SHARDS_PER_NODE_SETTING,
         MaxRetryAllocationDecider.SETTING_ALLOCATION_MAX_RETRY,
         UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING,
-        IndexSettings.INDEX_WARMER_ENABLED_SETTING,
         IndexSettings.INDEX_REFRESH_INTERVAL_SETTING,
         IndexSettings.INDEX_SEARCH_IDLE_AFTER,
         IndexSettings.INDEX_SOFT_DELETES_RETENTION_OPERATIONS_SETTING,

--- a/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -85,7 +85,6 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
         MergePolicyConfig.INDEX_MERGE_POLICY_SEGMENTS_PER_TIER_SETTING,
         MergePolicyConfig.INDEX_MERGE_POLICY_RECLAIM_DELETES_WEIGHT_SETTING,
         IndexSettings.INDEX_TRANSLOG_DURABILITY_SETTING,
-        IndexSettings.INDEX_WARMER_ENABLED_SETTING,
         IndexSettings.INDEX_REFRESH_INTERVAL_SETTING,
         IndexSettings.MAX_NGRAM_DIFF_SETTING,
         IndexSettings.MAX_SHINGLE_DIFF_SETTING,

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -65,9 +65,6 @@ public final class IndexSettings {
                       Property.IndexScope,
                       Property.ReplicatedIndexScope);
 
-    public static final Setting<Boolean> INDEX_WARMER_ENABLED_SETTING =
-        Setting.boolSetting("index.warmer.enabled", true, Property.Dynamic, Property.IndexScope, Property.Deprecated);
-
     public static final Setting<String> INDEX_CHECK_ON_STARTUP = new Setting<>("index.shard.check_on_startup", "false", (s) -> {
         switch (s) {
             case "false":
@@ -275,7 +272,6 @@ public final class IndexSettings {
         this.retentionLeaseMillis = retentionLease.millis();
     }
 
-    private volatile boolean warmerEnabled;
     private volatile int maxNgramDiff;
     private volatile int maxShingleDiff;
     private volatile TimeValue searchIdleAfter;
@@ -324,7 +320,6 @@ public final class IndexSettings {
         softDeleteEnabled = scopedSettings.get(INDEX_SOFT_DELETES_SETTING);
         softDeleteRetentionOperations = scopedSettings.get(INDEX_SOFT_DELETES_RETENTION_OPERATIONS_SETTING);
         retentionLeaseMillis = scopedSettings.get(INDEX_SOFT_DELETES_RETENTION_LEASE_PERIOD_SETTING).millis();
-        warmerEnabled = scopedSettings.get(INDEX_WARMER_ENABLED_SETTING);
         maxNgramDiff = scopedSettings.get(MAX_NGRAM_DIFF_SETTING);
         maxShingleDiff = scopedSettings.get(MAX_SHINGLE_DIFF_SETTING);
         maxRefreshListeners = scopedSettings.get(MAX_REFRESH_LISTENERS_PER_SHARD);
@@ -348,7 +343,6 @@ public final class IndexSettings {
         scopedSettings.addSettingsUpdateConsumer(INDEX_TRANSLOG_SYNC_INTERVAL_SETTING, this::setTranslogSyncInterval);
         scopedSettings.addSettingsUpdateConsumer(MAX_NGRAM_DIFF_SETTING, this::setMaxNgramDiff);
         scopedSettings.addSettingsUpdateConsumer(MAX_SHINGLE_DIFF_SETTING, this::setMaxShingleDiff);
-        scopedSettings.addSettingsUpdateConsumer(INDEX_WARMER_ENABLED_SETTING, this::setEnableWarmer);
         scopedSettings.addSettingsUpdateConsumer(INDEX_GC_DELETES_SETTING, this::setGCDeletes);
         scopedSettings.addSettingsUpdateConsumer(INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING, this::setTranslogFlushThresholdSize);
         scopedSettings.addSettingsUpdateConsumer(
@@ -539,17 +533,6 @@ public final class IndexSettings {
 
     private void setTranslogDurability(Translog.Durability durability) {
         this.durability = durability;
-    }
-
-    /**
-     * Returns true if index warmers are enabled, otherwise <code>false</code>
-     */
-    public boolean isWarmerEnabled() {
-        return warmerEnabled;
-    }
-
-    private void setEnableWarmer(boolean enableWarmer) {
-        this.warmerEnabled = enableWarmer;
     }
 
     /**

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -569,7 +569,7 @@ public class InformationSchemaTest extends IntegTestCase {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertThat(response.rowCount()).isEqualTo(1002L);
+        assertThat(response.rowCount()).isEqualTo(998L);
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
@@ -648,7 +648,7 @@ public class PrivilegesIntegrationTest extends BaseRolesIntegrationTest {
         //make sure a new user has default accesses to pg tables with information and pg catalog schema related entries
         try (Session testUserSession = testUserSession()) {
             execute("select * from pg_catalog.pg_attribute order by attname", null, testUserSession);
-            assertThat(response).hasRowCount(564L);
+            assertThat(response).hasRowCount(560L);
 
             //create a table with an attribute that a new user is not privileged to access
             executeAsSuperuser("create table test_schema.my_table (my_col int)");

--- a/server/src/test/java/io/crate/integrationtests/TableSettingsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TableSettingsTest.java
@@ -57,7 +57,6 @@ public class TableSettingsTest extends IntegTestCase {
                 "\"routing.allocation.exclude.foo\" = 'bar' ," +
                 "\"translog.sync_interval\" = '3600ms', " +
                 "\"translog.flush_threshold_size\" = '1000000b', " +
-                "\"warmer.enabled\" = false, " +
                 "\"store.type\" = 'niofs', " +
                 "\"translog.sync_interval\" = '20s'," +
                 "\"refresh_interval\" = '1000ms'," +
@@ -82,7 +81,6 @@ public class TableSettingsTest extends IntegTestCase {
             assertTrue(((Map<String, Object>) row[0]).containsKey("mapping"));
             assertTrue(((Map<String, Object>) row[0]).containsKey("routing"));
             assertTrue(((Map<String, Object>) row[0]).containsKey("translog"));
-            assertTrue(((Map<String, Object>) row[0]).containsKey("warmer"));
             assertTrue(((Map<String, Object>) row[0]).containsKey("refresh_interval"));
             assertTrue(((Map<String, Object>) row[0]).containsKey("unassigned"));
             assertTrue(((Map<String, Object>) row[0]).containsKey("write"));
@@ -104,7 +102,7 @@ public class TableSettingsTest extends IntegTestCase {
                 "where settings IS NULL");
         assertEquals(66L, response.rowCount());
         execute("select * from information_schema.tables " +
-                "where table_name = 'settings_table' and settings['warmer']['enabled'] IS NULL");
+                "where table_name = 'settings_table' and settings['blocks']['read'] IS NULL");
         assertEquals(0, response.rowCount());
     }
 


### PR DESCRIPTION
Relates to https://github.com/crate/crate/issues/11939, which may
require splitting indexSettings into table and indexSettings.

Having fewer settings makes that easier.
