### PR TITLE
Use different name for the worker.id property.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
             <include>**/*Tests.java</include>
           </includes>
           <systemPropertyVariables>
-            <worker.id>$${surefire.forkNumber}</worker.id>
+            <worker-id>$${surefire.forkNumber}</worker-id>
           </systemPropertyVariables>
           <properties>
             <configurationParameters>

--- a/server/src/testFixtures/java/org/elasticsearch/test/ESTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/ESTestCase.java
@@ -181,7 +181,7 @@ public abstract class ESTestCase extends CrateLuceneTestCase {
     public static final String TEST_WORKER_VM_ID;
 
     // Set in pom.xml based on surefire.forkNumber
-    public static final String TEST_WORKER_SYS_PROPERTY = "worker.id";
+    public static final String TEST_WORKER_SYS_PROPERTY = "worker-id";
 
     public static final String DEFAULT_TEST_WORKER_ID = "--not-mvn--";
 


### PR DESCRIPTION
Otherwise value gets resolved to “$1”. Probably some reserved var name.