### PR TITLE
Remove duplicate shard size cache

### DIFF
--- a/server/src/main/java/io/crate/statistics/ReservoirSampler.java
+++ b/server/src/main/java/io/crate/statistics/ReservoirSampler.java
@@ -198,7 +198,7 @@ public final class ReservoirSampler {
                         Engine.Searcher searcher = indexShard.acquireSearcher("update-table-statistics");
                         searchersToRelease.add(new ShardExpressions(searcher, expressions));
                         totalNumDocs += searcher.getIndexReader().numDocs();
-                        totalSizeInBytes += indexShard.storeStats().getSizeInBytes();
+                        totalSizeInBytes += indexShard.estimateSize();
                         // We do the sampling in 2 phases. First we get the docIds;
                         // then we retrieve the column values for the sampled docIds.
                         // we do this in 2 phases because the reservoir sampling might override previously seen

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -1018,6 +1018,15 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         return getEngine().getTranslogStats();
     }
 
+    public long estimateSize() {
+        try {
+            return store.estimateSize();
+        } catch (IOException e) {
+            failShard("Failing shard because of exception during storeStats", e);
+            throw new ElasticsearchException("io exception while building 'store stats'", e);
+        }
+    }
+
     public StoreStats storeStats() {
         try {
             final RecoveryState recoveryState = this.recoveryState;

--- a/server/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/server/src/main/java/org/elasticsearch/index/store/Store.java
@@ -1593,4 +1593,8 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
                 // we also don't specify a codec here and merges should use the engines for this index
                 .setMergePolicy(NoMergePolicy.INSTANCE);
     }
+
+    public long estimateSize() throws IOException {
+        return directory.estimateSize();
+    }
 }

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -1080,6 +1080,7 @@ public class IndexShardTests extends IndexShardTestCase {
                 StoreStats storeStats = indexShard.storeStats();
                 assertThat(storeStats.sizeInBytes())
                            .isGreaterThan(numDoc * 100L); // A doc should be more than 100 bytes.
+                assertThat(storeStats.sizeInBytes()).isEqualTo(indexShard.estimateSize());
 
                 assertThat(docsStats.getTotalSizeInBytes())
                     .as("Estimated total document size is too small compared with the stored size")


### PR DESCRIPTION
The `size` expression for `sys.shards` included a 10 seconds cache but
that's redundant because the `Store` already caches the size
information.

See:

  - https://github.com/crate/crate/blob/b66547cdd356737eb2b0c176ba0c9e3931621974/server/src/main/java/org/elasticsearch/index/store/Store.java#L169-L170
  - https://github.com/crate/crate/blob/b66547cdd356737eb2b0c176ba0c9e3931621974/server/src/main/java/org/elasticsearch/index/store/ByteSizeCachingDirectory.java#L71
  - https://github.com/crate/crate/blob/b66547cdd356737eb2b0c176ba0c9e3931621974/server/src/main/java/org/elasticsearch/index/store/Store.java#L713-L716
