### PR TITLE
Correct DocTableInfo.versionCreated() annotation

### DIFF
--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
@@ -472,7 +472,7 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
         return columnPolicy;
     }
 
-    @Nullable
+    @NotNull
     @Override
     public Version versionCreated() {
         return versionCreated;


### PR DESCRIPTION
This was marked as `@Nullable` when it should have been `@NotNull`