### PR TITLE
Fix order of columns of smaller side of the lookup-join

### DIFF
--- a/server/src/main/java/io/crate/planner/optimizer/rule/EquiJoinToLookupJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/EquiJoinToLookupJoin.java
@@ -37,6 +37,7 @@ import io.crate.metadata.NodeContext;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.TransactionContext;
 import io.crate.planner.operators.EquiJoinDetector;
+import io.crate.planner.operators.Eval;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.JoinConditionSymbolsExtractor;
 import io.crate.planner.operators.JoinPlan;
@@ -181,7 +182,8 @@ public class EquiJoinToLookupJoin implements Rule<JoinPlan> {
         );
         var largerSideWithLookup = new Filter(largerSide, anyEqFunction);
         var smallerSidePruned = smallerSide.pruneOutputsExcept(List.of(smallerRelationColumn));
-        var smallerSideIdLookup = new RootRelationBoundary(smallerSidePruned);
+        var eval = Eval.create(smallerSidePruned, List.of(smallerRelationColumn));
+        var smallerSideIdLookup = new RootRelationBoundary(eval);
         Map<LogicalPlan, SelectSymbol> subQueries = Map.of(smallerSideIdLookup, lookUpQuery);
         return MultiPhase.createIfNeeded(subQueries, largerSideWithLookup);
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Follow-up https://github.com/crate/crate/pull/15877

```
cr> explain select count(*) from articles inner join colors on articles.id = colors.id where colors.name like 'T%';
+-------------------------------------------------------------------------------+
| QUERY PLAN                                                                    |
+-------------------------------------------------------------------------------+
| HashAggregate[count(*)] (rows=1)                                              |
|   └ HashJoin[(id = id)] (rows=1)                                              |
|     ├ MultiPhase (rows=33300)                                                 |
|     │  └ Collect[doc.articles | [id] | (id = ANY((doc.colors)))] (rows=33300) |
|     │  └ Eval[id] (rows=33300)                                                |
|     │    └ Filter[(name LIKE 'T%')] (rows=33300)                              |
|     │      └ Collect[doc.colors | [name, id] | true] (rows=100000)            |
|     └ Collect[doc.colors | [id] | (name LIKE 'T%')] (rows=33300)              |
+-------------------------------------------------------------------------------+
```


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
