### PR TITLE
Clarify createPartitionName/toPartitionName diff in PartitionPropertiesAnalyzer

### DIFF
--- a/server/src/main/java/io/crate/exceptions/PartitionUnknownException.java
+++ b/server/src/main/java/io/crate/exceptions/PartitionUnknownException.java
@@ -21,15 +21,15 @@
 
 package io.crate.exceptions;
 
-import io.crate.metadata.PartitionName;
-import io.crate.metadata.RelationName;
-
 import java.util.Collections;
 import java.util.Locale;
 
+import io.crate.metadata.PartitionName;
+import io.crate.metadata.RelationName;
+
 public class PartitionUnknownException extends RuntimeException implements ResourceUnknownException, TableScopeException {
 
-    private RelationName relationName;
+    private final PartitionName partitionName;
 
     public PartitionUnknownException(PartitionName partitionName) {
         super(String.format(Locale.ENGLISH,
@@ -37,11 +37,15 @@ public class PartitionUnknownException extends RuntimeException implements Resou
             partitionName.relationName().fqn(),
             partitionName.ident()));
 
-        this.relationName = partitionName.relationName();
+        this.partitionName = partitionName;
+    }
+
+    public PartitionName partitionName() {
+        return partitionName;
     }
 
     @Override
     public Iterable<RelationName> getTableIdents() {
-        return Collections.singletonList(relationName);
+        return Collections.singletonList(partitionName.relationName());
     }
 }

--- a/server/src/main/java/io/crate/planner/node/ddl/AlterTableOpenClosePlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/AlterTableOpenClosePlan.java
@@ -21,6 +21,8 @@
 
 package io.crate.planner.node.ddl;
 
+import java.util.function.Function;
+
 import io.crate.analyze.AnalyzedAlterTableOpenClose;
 import io.crate.analyze.PartitionPropertiesAnalyzer;
 import io.crate.analyze.SymbolEvaluator;
@@ -36,8 +38,6 @@ import io.crate.planner.Plan;
 import io.crate.planner.PlannerContext;
 import io.crate.planner.operators.SubQueryResults;
 import io.crate.sql.tree.Table;
-
-import java.util.function.Function;
 
 public class AlterTableOpenClosePlan implements Plan {
 
@@ -68,10 +68,9 @@ public class AlterTableOpenClosePlan implements Plan {
         DocTableInfo tableInfo = analyzedAlterTable.tableInfo();
         Table<Object> table = analyzedAlterTable.table().map(eval);
 
-        PartitionName partitionName = null;
-        if (tableInfo.isPartitioned()) {
-            partitionName = PartitionPropertiesAnalyzer.createPartitionName(table.partitionProperties(), tableInfo);
-        }
+        PartitionName partitionName = table.partitionProperties().isEmpty()
+            ? null
+            : PartitionPropertiesAnalyzer.toPartitionName(tableInfo, table.partitionProperties());
 
         dependencies.alterTableOperation()
             .executeAlterTableOpenClose(tableInfo.ident(), analyzedAlterTable.isOpenTable(), partitionName)

--- a/server/src/main/java/io/crate/planner/node/ddl/AlterTablePlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/AlterTablePlan.java
@@ -106,7 +106,9 @@ public class AlterTablePlan implements Plan {
         PartitionName partitionName = null;
         TableParameters tableParameters;
         if (tableInfo instanceof DocTableInfo docTableInfo) {
-            partitionName = PartitionPropertiesAnalyzer.createPartitionName(table.partitionProperties(), docTableInfo);
+            partitionName = table.partitionProperties().isEmpty()
+                ? null
+                : PartitionPropertiesAnalyzer.toPartitionName(docTableInfo, table.partitionProperties());
             isPartitioned = docTableInfo.isPartitioned();
             tableParameters = getTableParameterInfo(table, tableInfo, partitionName);
         } else {

--- a/server/src/main/java/io/crate/planner/statement/CopyFromPlan.java
+++ b/server/src/main/java/io/crate/planner/statement/CopyFromPlan.java
@@ -159,16 +159,12 @@ public final class CopyFromPlan implements Plan {
             subQueryResults
         );
 
-        String partitionIdent;
-        if (!copyFrom.table().partitionProperties().isEmpty()) {
-            partitionIdent = PartitionPropertiesAnalyzer
-                .toPartitionName(
-                    copyFrom.tableInfo(),
-                    Lists.map(copyFrom.table().partitionProperties(), x -> x.map(eval)))
-                .ident();
-        } else {
-            partitionIdent = null;
-        }
+        PartitionName partitionName = copyFrom.table().partitionProperties().isEmpty()
+            ? null
+            : PartitionPropertiesAnalyzer.toPartitionNameUnsafe(
+                copyFrom.tableInfo(),
+                Lists.map(copyFrom.table().partitionProperties(), x -> x.map(eval)));
+        String partitionIdent = partitionName == null ? null : partitionName.ident();
         final var properties = copyFrom.properties().map(eval);
         final var nodeFiltersPredicate = discoveryNodePredicate(
             properties.properties().getOrDefault(NodeFilters.NAME, null));

--- a/server/src/main/java/io/crate/planner/statement/CopyToPlan.java
+++ b/server/src/main/java/io/crate/planner/statement/CopyToPlan.java
@@ -35,6 +35,7 @@ import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
 import org.elasticsearch.common.settings.Settings;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import io.crate.analyze.AnalyzedCopyTo;
 import io.crate.analyze.BoundCopyTo;
@@ -42,11 +43,9 @@ import io.crate.analyze.PartitionPropertiesAnalyzer;
 import io.crate.analyze.SymbolEvaluator;
 import io.crate.analyze.WhereClause;
 import io.crate.analyze.relations.DocTableRelation;
-import org.jetbrains.annotations.VisibleForTesting;
 import io.crate.common.collections.Lists;
 import io.crate.data.Row;
 import io.crate.data.RowConsumer;
-import io.crate.exceptions.PartitionUnknownException;
 import io.crate.exceptions.UnsupportedFeatureException;
 import io.crate.execution.dsl.phases.NodeOperationTree;
 import io.crate.execution.dsl.projection.MergeCountProjection;
@@ -280,12 +279,7 @@ public final class CopyToPlan implements Plan {
         if (partitionProperties.isEmpty()) {
             return Collections.emptyList();
         }
-        var partitionName = PartitionPropertiesAnalyzer.toPartitionName(
-            table,
-            partitionProperties);
-        if (!table.partitions().contains(partitionName)) {
-            throw new PartitionUnknownException(partitionName);
-        }
+        var partitionName = PartitionPropertiesAnalyzer.toPartitionName(table, partitionProperties);
         return List.of(partitionName.asIndexName());
     }
 }

--- a/server/src/test/java/io/crate/analyze/CreateAlterPartitionedTableAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateAlterPartitionedTableAnalyzerTest.java
@@ -46,6 +46,7 @@ import org.junit.Test;
 
 import io.crate.data.RowN;
 import io.crate.exceptions.ColumnUnknownException;
+import io.crate.exceptions.PartitionUnknownException;
 import io.crate.metadata.FulltextAnalyzerResolver;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
@@ -378,7 +379,7 @@ public class CreateAlterPartitionedTableAnalyzerTest extends CrateDummyClusterSe
     @Test
     public void testAlterPartitionedTableNonExistentPartition() {
         assertThatThrownBy(() -> analyze("alter table parted partition (date='1970-01-01') set (number_of_replicas='0-all')"))
-            .isExactlyInstanceOf(IllegalArgumentException.class);
+            .isExactlyInstanceOf(PartitionUnknownException.class);
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/PartitionPropertiesAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/PartitionPropertiesAnalyzerTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 
 import org.junit.Test;
 
+import io.crate.exceptions.PartitionUnknownException;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.doc.DocTableInfo;
@@ -61,19 +62,17 @@ public class PartitionPropertiesAnalyzerTest extends CrateDummyClusterServiceUni
             );
 
         DocTableInfo tableInfo = e.resolveTableInfo("doc.users");
-        PartitionName partitionName = PartitionPropertiesAnalyzer.createPartitionName(
-            List.of(
-                new Assignment<>(new QualifiedName("p1"), 10)
-            ),
-            tableInfo
+        PartitionName partitionName = PartitionPropertiesAnalyzer.toPartitionName(
+            tableInfo,
+            List.of(new Assignment<>(new QualifiedName("p1"), 10))
         );
         assertThat(partitionName.values()).containsExactly("10");
         assertThat(partitionName.asIndexName()).isEqualTo(tableInfo.concreteIndices()[0]);
 
-        assertThatThrownBy(() -> PartitionPropertiesAnalyzer.createPartitionName(
-            List.of(new Assignment<>(new QualifiedName("p1"), 20)),
-            tableInfo
-        )).isExactlyInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> PartitionPropertiesAnalyzer.toPartitionName(
+            tableInfo,
+            List.of(new Assignment<>(new QualifiedName("p1"), 20))
+        )).isExactlyInstanceOf(PartitionUnknownException.class);
     }
 
     @Test


### PR DESCRIPTION
The difference between the two methods wasn't clear due to almost
identical signatures, except of the order:

- `createPartitionName(partitionProperties, tableInfo): PartitionName`
- `toPartitionName(tableInfo, partitionProperties): PartitionName`

This changes them to:

- `toPartitionNameUnsafe(tableInfo, partitionProperties)`
- `toPartitionName(tableInfo, partitionProperties)`

Where `unsafe` allows to get a `PartitionName` for a table where the
partition doesn't exist, which is required for import use cases (COPY
FROM, or RESTORE SNAPSHOT)
