### PR TITLE
Add IF NOT EXISTS to CREATE TABLE AS

### DIFF
--- a/docs/appendices/release-notes/5.8.0.rst
+++ b/docs/appendices/release-notes/5.8.0.rst
@@ -65,7 +65,9 @@ Changes
 SQL Statements
 --------------
 
-None
+- `dshunter107 <https://github.com/dshunter107>`_ added support for the
+  ``IF NOT EXISTS`` clause to :ref:`CREATE TABLE AS <ref-create-table-as>`
+  statement.
 
 SQL Standard and PostgreSQL Compatibility
 -----------------------------------------

--- a/docs/sql/statements/create-table-as.rst
+++ b/docs/sql/statements/create-table-as.rst
@@ -19,7 +19,7 @@ Synopsis
 
 ::
 
-    CREATE TABLE table_ident AS { ( query ) | query }
+    CREATE TABLE [ IF NOT EXISTS ] table_ident AS { ( query ) | query }
 
 
 Description
@@ -35,6 +35,11 @@ the table creation.
 For further details on the default values of the optional parameters,
 see :ref:`sql-create-table`.
 
+``IF NOT EXISTS``
+=================
+
+If the optional ``IF NOT EXISTS`` clause is used, this statement won't do
+anything if the table exists already, and ``0`` rows will be returned.
 
 Parameters
 ==========

--- a/docs/sql/statements/create-table.rst
+++ b/docs/sql/statements/create-table.rst
@@ -254,7 +254,7 @@ Parameters
 =================
 
 If the optional ``IF NOT EXISTS`` clause is used, this statement won't do
-anything if the table exists already.
+anything if the table exists already, and ``0`` rows will be returned.
 
 
 .. _sql-create-table-clustered:

--- a/libs/sql-parser/src/main/antlr/io/crate/sql/parser/antlr/SqlBaseParser.g4
+++ b/libs/sql-parser/src/main/antlr/io/crate/sql/parser/antlr/SqlBaseParser.g4
@@ -587,7 +587,7 @@ createStmt
     : CREATE TABLE (IF NOT EXISTS)? table
         OPEN_ROUND_BRACKET tableElement (COMMA tableElement)* CLOSE_ROUND_BRACKET
          partitionedByOrClusteredInto withProperties?                                #createTable
-    | CREATE TABLE table AS insertSource                                             #createTableAs
+    | CREATE TABLE (IF NOT EXISTS)? table AS insertSource                            #createTableAs
     | CREATE FOREIGN TABLE (IF NOT EXISTS)? tableName=qname
         OPEN_ROUND_BRACKET tableElement (COMMA tableElement)* CLOSE_ROUND_BRACKET
         SERVER server=ident kvOptions?                                               #createForeignTable

--- a/libs/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
@@ -66,6 +66,7 @@ import io.crate.sql.tree.CreateServer;
 import io.crate.sql.tree.CreateSnapshot;
 import io.crate.sql.tree.CreateSubscription;
 import io.crate.sql.tree.CreateTable;
+import io.crate.sql.tree.CreateTableAs;
 import io.crate.sql.tree.CreateUserMapping;
 import io.crate.sql.tree.Declare;
 import io.crate.sql.tree.DecommissionNodeStatement;
@@ -678,6 +679,18 @@ public final class SqlFormatter {
         }
 
         @Override
+        public Void visitCreateTableAs(CreateTableAs<?> node, Integer indent) {
+            builder.append("CREATE TABLE ");
+            if (node.ifNotExists()) {
+                builder.append("IF NOT EXISTS ");
+            }
+            node.name().accept(this, indent);
+            builder.append(" AS ");
+            node.query().accept(this, indent);
+            return null;
+        }
+
+        @Override
         public Void visitCreateForeignTable(CreateForeignTable createTable, Integer indent) {
             builder.append("CREATE FOREIGN TABLE ");
             if (createTable.ifNotExists()) {
@@ -749,7 +762,6 @@ public final class SqlFormatter {
                     builder.append(optionName);
                     builder.append(" ");
                     value.accept(this, indent);
-
                     if (it.hasNext()) {
                         builder.append(", ");
                     }

--- a/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -517,8 +517,8 @@ class AstBuilder extends SqlBaseParserBaseVisitor<Node> {
     public Node visitCreateTableAs(SqlBaseParser.CreateTableAsContext context) {
         return new CreateTableAs<>(
             (Table<?>) visit(context.table()),
-            (Query) visit(context.insertSource().query())
-        );
+            (Query) visit(context.insertSource().query()),
+            context.EXISTS() != null);
     }
 
     @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/CreateTableAs.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/CreateTableAs.java
@@ -27,10 +27,12 @@ public final class CreateTableAs<T> extends Statement {
 
     private final Table<T> name;
     private final Query query;
+    private final boolean ifNotExists;
 
-    public CreateTableAs(Table<T> name, Query query) {
+    public CreateTableAs(Table<T> name, Query query, boolean ifNotExists) {
         this.name = name;
         this.query = query;
+        this.ifNotExists = ifNotExists;
     }
 
     public Table<T> name() {
@@ -56,12 +58,17 @@ public final class CreateTableAs<T> extends Statement {
         }
         CreateTableAs<?> that = (CreateTableAs<?>) o;
         return name.equals(that.name) &&
-               query.equals(that.query);
+            query.equals(that.query) &&
+            ifNotExists == that.ifNotExists;
+    }
+
+    public boolean ifNotExists() {
+        return ifNotExists;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, query);
+        return Objects.hash(name, query, ifNotExists);
     }
 
     @Override

--- a/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -55,6 +55,7 @@ import io.crate.sql.tree.CreateRole;
 import io.crate.sql.tree.CreateServer;
 import io.crate.sql.tree.CreateSubscription;
 import io.crate.sql.tree.CreateTable;
+import io.crate.sql.tree.CreateTableAs;
 import io.crate.sql.tree.CreateUserMapping;
 import io.crate.sql.tree.DeallocateStatement;
 import io.crate.sql.tree.Declare;
@@ -763,6 +764,12 @@ public class TestStatementBuilder {
         printStatement("create table test (col1 int, col2 timestamp without time zone not null)");
 
         printStatement("create table test (col1 string storage with (columnstore = false))");
+    }
+
+    @Test
+    public void testCreateTableAs() {
+        printStatement("create table test as select * from created");
+        printStatement("create table if not exists test  as Select * FROM created");
     }
 
     @Test
@@ -2199,6 +2206,7 @@ public class TestStatementBuilder {
         // TODO: support formatting all statement types
         if (statement instanceof Query ||
             statement instanceof CreateTable ||
+            statement instanceof CreateTableAs ||
             statement instanceof CreateForeignTable ||
             statement instanceof CopyFrom ||
             statement instanceof SwapTable ||

--- a/server/src/main/java/io/crate/analyze/CreateTableAsAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/CreateTableAsAnalyzer.java
@@ -79,7 +79,7 @@ public final class CreateTableAsAnalyzer {
             Optional.empty(),
             Optional.empty(),
             GenericProperties.empty(),
-            false);
+            createTableAs.ifNotExists());
 
         // This is only a preliminary analysis to to have the source available for privilege checks.
         // It will be analyzed again with the target columns from the target table once

--- a/server/src/main/java/io/crate/execution/ddl/tables/TableCreator.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TableCreator.java
@@ -126,22 +126,21 @@ public class TableCreator {
                 // this is a generic mapping parse exception,
                 // the cause has usually a better more detailed error message
                 throw Exceptions.toRuntimeException(cause);
-            } else if (createTable.ifNotExists() && isTableExistsError(t, templateName)) {
-                return 0L;
             } else {
                 throw Exceptions.toRuntimeException(t);
             }
         });
     }
 
-    private static boolean isTableExistsError(Throwable e, @Nullable String templateName) {
-        return e instanceof ResourceAlreadyExistsException
-            || e instanceof RelationAlreadyExists
-            || (templateName != null && isTemplateAlreadyExistsException(e));
+    public static boolean isTableExistsError(Throwable t, @Nullable String templateName) {
+        t = SQLExceptions.unwrap(t);
+        return t instanceof ResourceAlreadyExistsException
+            || t instanceof RelationAlreadyExists
+            || (templateName != null && isTemplateAlreadyExistsException(t));
     }
 
-    private static boolean isTemplateAlreadyExistsException(Throwable e) {
-        return e instanceof IllegalArgumentException
-            && e.getMessage() != null && e.getMessage().endsWith("already exists");
+    private static boolean isTemplateAlreadyExistsException(Throwable t) {
+        return t instanceof IllegalArgumentException
+            && t.getMessage() != null && t.getMessage().endsWith("already exists");
     }
 }

--- a/server/src/main/java/io/crate/planner/consumer/CreateTableAsPlan.java
+++ b/server/src/main/java/io/crate/planner/consumer/CreateTableAsPlan.java
@@ -27,8 +27,10 @@ import io.crate.analyze.AnalyzedCreateTable;
 import io.crate.analyze.AnalyzedCreateTableAs;
 import io.crate.analyze.BoundCreateTable;
 import io.crate.analyze.NumberOfShards;
+import io.crate.data.InMemoryBatchIterator;
 import io.crate.data.Row;
 import io.crate.data.RowConsumer;
+import io.crate.data.SentinelRow;
 import io.crate.execution.ddl.tables.TableCreator;
 import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Plan;
@@ -98,10 +100,14 @@ public final class CreateTableAsPlan implements Plan {
                         params,
                         subQueryResults
                     );
+                } else if (boundCreateTable.ifNotExists() && TableCreator.isTableExistsError(err, boundCreateTable.templateName())) {
+                    consumer.accept(InMemoryBatchIterator.empty(SentinelRow.SENTINEL), null);
                 } else {
                     consumer.accept(null, err);
                 }
             });
     }
+
+
 }
 

--- a/server/src/test/java/io/crate/analyze/CreateTableAsAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateTableAsAnalyzerTest.java
@@ -41,7 +41,6 @@ public class CreateTableAsAnalyzerTest extends CrateDummyClusterServiceUnitTest 
 
     @Test
     public void testSimpleCompareAgainstAnalyzedCreateTable() throws IOException {
-
         SQLExecutor e = SQLExecutor.of(clusterService)
             .addTable(
                 "create table tbl (" +
@@ -84,10 +83,47 @@ public class CreateTableAsAnalyzerTest extends CrateDummyClusterServiceUnitTest 
             SubQueryResults.EMPTY
         );
 
+        assertThat(actual.ifNotExists()).isFalse();
         assertThat(expected.tableName()).isEqualTo(actual.tableName());
         assertThat(expected.columns().keySet()).containsExactlyElementsOf(actual.columns().keySet());
         List<DataType<?>> expectedTypes = Lists.map(expected.columns().values(), Symbol::valueType);
         List<DataType<?>> actualTypes = Lists.map(actual.columns().values(), Symbol::valueType);
         assertThat(expectedTypes).containsExactlyElementsOf(actualTypes);
+    }
+
+    @Test
+    public void testAnalyzedCreateTableAsWithNotExists() throws IOException {
+
+        SQLExecutor e = SQLExecutor.of(clusterService)
+            .addTable("create table tbl (a int)");
+
+        var expected = ((AnalyzedCreateTable) e.analyze("create table cpy (a int)"))
+            .bind(
+                new NumberOfShards(clusterService),
+                e.fulltextAnalyzerResolver(),
+                e.nodeCtx,
+                CoordinatorTxnCtx.systemTransactionContext(),
+                Row.EMPTY,
+                SubQueryResults.EMPTY
+        );
+
+        AnalyzedCreateTableAs analyzedCreateTableAs = e.analyze(
+            "create table if not exists cpy as select * from  tbl"
+        );
+        var actual = analyzedCreateTableAs.analyzedCreateTable().bind(
+            new NumberOfShards(clusterService),
+            e.fulltextAnalyzerResolver(),
+            e.nodeCtx,
+            CoordinatorTxnCtx.systemTransactionContext(),
+            Row.EMPTY,
+            SubQueryResults.EMPTY
+        );
+
+        assertThat(actual.ifNotExists()).isTrue();
+        assertThat(actual.tableName()).isEqualTo(expected.tableName());
+        assertThat(actual.columns().keySet()).containsExactlyElementsOf(expected.columns().keySet());
+        List<DataType<?>> expectedTypes = Lists.map(expected.columns().values(), Symbol::valueType);
+        List<DataType<?>> actualTypes = Lists.map(actual.columns().values(), Symbol::valueType);
+        assertThat(actualTypes).containsExactlyElementsOf(expectedTypes);
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/CreateTableAsIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CreateTableAsIntegrationTest.java
@@ -126,4 +126,15 @@ public class CreateTableAsIntegrationTest extends IntegTestCase {
             .isExactlyInstanceOf(RelationAlreadyExists.class)
             .hasMessage("Relation 'doc.cpy' already exists.");
     }
+
+    @Test
+    public void testCreateTableIfNotExists() {
+        execute("create table tbl (a int, b string)");
+        execute("insert into tbl(a, b) select g, g || 'foo' from generate_series(1, 10, 1) as g");
+        execute("refresh table tbl");
+        execute("create table if not exists cpy as select * from tbl");
+        assertThat(response).hasRowCount(10);
+        execute("create table if not exists cpy as select * from tbl");
+        assertThat(response).hasRowCount(0);
+    }
 }


### PR DESCRIPTION
Similarly to `CREATE TABLE IF NOT EXISTS <table definition>`,
the `IF NOT EXISTS` clause will just return `0 rows` for a
`CREATE TABLE t IF NOT EXISTS AS SELECT ...` statement if table
`t` already exists, and don't perform any insert of rows.

Instead of returning 0 rows or exception from the TableCreator,
handle all cases: error, error and IF NOT EXISTS, no error -> proceed
in the plan methods instead.

Closes: #14834
