### PR TITLE
Use `languageLevel` 21 for intellij

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -22,7 +22,7 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_22" default="true" project-jdk-name="temurin-22" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" project-jdk-name="temurin-22" project-jdk-type="JavaSDK" />
   <component name="SuppressionsComponent">
     <option name="suppComments" value="[]" />
   </component>


### PR DESCRIPTION
`JDL_22` is not an option from the drop down, only `JDK_X`, (experimental features, which we don't want), and this file is constantly getting changed by Intellij from `JDK_22` to `JDK_X`.

Follows: #15830
