### PR TITLE
Fix partition name creation in RESTORE SNAPSHOT/COPY FROM

### DIFF
--- a/docs/appendices/release-notes/5.6.5.rst
+++ b/docs/appendices/release-notes/5.6.5.rst
@@ -47,6 +47,10 @@ See the :ref:`version_5.6.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that could prevent a :ref:`sql-restore-snapshot` from
+  restoring a partition if using the ``TABLE PARTITION (...)`` clause to restore
+  an individual partition of a table with more than one partition column.
+
 - Fixed an issue that allowed ``INSERT INTO`` statements to create more shards
   than allowed by :ref:`cluster.max_shards_per_node
   <cluster.max_shards_per_node>` if the statement resulted in the creation of

--- a/docs/appendices/release-notes/5.7.1.rst
+++ b/docs/appendices/release-notes/5.7.1.rst
@@ -46,6 +46,10 @@ See the :ref:`version_5.7.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that could prevent a :ref:`sql-restore-snapshot` from
+  restoring a partition if using the ``TABLE PARTITION (...)`` clause to restore
+  an individual partition of a table with more than one partition column.
+
 - Fixed an issue that allowed ``INSERT INTO`` statements to create more shards
   than allowed by :ref:`cluster.max_shards_per_node
   <cluster.max_shards_per_node>` if the statement resulted in the creation of

--- a/docs/sql/statements/restore-snapshot.rst
+++ b/docs/sql/statements/restore-snapshot.rst
@@ -124,15 +124,16 @@ exclusively.
     [ PARTITION ( partition_column = value [, ...] ) ]
 
 :partition_column:
-  One of the column names used for table partitioning
+  Column name used for table partitioning.
 
 :value:
   The respective column value.
 
 All :ref:`partition columns <gloss-partition-column>` (specified by the
 :ref:`sql-create-table-partitioned-by` clause) must be listed inside the
-parentheses along with their respective values using the ``partition_column =
-value`` syntax (separated by commas).
+parentheses in the order matching the ``PARTITION BY`` definition along with
+their respective values using the ``partition_column = value`` syntax (separated
+by commas).
 
 Because each partition corresponds to a unique set of :ref:`partition column
 <gloss-partition-column>` row values, this clause uniquely identifies a single

--- a/server/src/main/java/io/crate/analyze/PartitionPropertiesAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/PartitionPropertiesAnalyzer.java
@@ -39,8 +39,8 @@ import io.crate.types.DataTypes;
 
 public class PartitionPropertiesAnalyzer {
 
-    public static Map<ColumnIdent, Object> assignmentsToMap(List<Assignment<Object>> assignments) {
-        Map<ColumnIdent, Object> map = new HashMap<>(assignments.size());
+    private static Map<ColumnIdent, Object> assignmentsToMap(List<Assignment<Object>> assignments) {
+        HashMap<ColumnIdent, Object> map = new HashMap<>(assignments.size());
         for (Assignment<Object> assignment : assignments) {
             map.put(
                 ColumnIdent.fromPath(assignment.columnName().toString()),
@@ -51,13 +51,11 @@ public class PartitionPropertiesAnalyzer {
     }
 
     public static PartitionName toPartitionName(RelationName relationName, List<Assignment<Object>> partitionProperties) {
-        // Because only RelationName is available, types of partitioned columns must be guessed
-        Map<ColumnIdent, Object> properties = assignmentsToMap(partitionProperties);
-        String[] values = new String[properties.size()];
 
+        String[] values = new String[partitionProperties.size()];
         int idx = 0;
-        for (Object o : properties.values()) {
-            values[idx++] = DataTypes.STRING.implicitCast(o);
+        for (Assignment<Object> o : partitionProperties) {
+            values[idx++] = DataTypes.STRING.implicitCast(o.expression());
         }
         return new PartitionName(relationName, List.of(values));
     }

--- a/server/src/test/java/io/crate/analyze/PartitionPropertiesAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/PartitionPropertiesAnalyzerTest.java
@@ -21,10 +21,11 @@
 
 package io.crate.analyze;
 
-import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Collections;
+import java.util.List;
 
 import org.junit.Test;
 
@@ -38,23 +39,41 @@ import io.crate.testing.SQLExecutor;
 
 public class PartitionPropertiesAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
-    private PartitionName getPartitionName(DocTableInfo tableInfo) {
-        return PartitionPropertiesAnalyzer.toPartitionName(
-            tableInfo,
-            Collections.singletonList(new Assignment<>(new QualifiedName("name"), "foo"))
+    @Test
+    public void testPartitionNameFromAssignmentsWithoutTable() {
+        PartitionName partitionName = PartitionPropertiesAnalyzer.toPartitionName(
+            new RelationName("dummy", "tbl"),
+            List.of(
+                new Assignment<>(new QualifiedName("p1"), 10),
+                new Assignment<>(new QualifiedName("a"), 20)
+            )
         );
+        assertThat(partitionName.values()).containsExactly("10", "20");
+        assertThat(partitionName.asIndexName()).isEqualTo("dummy..partitioned.tbl.081j2c0368o0");
     }
 
     @Test
-    public void testPartitionNameFromAssignmentWithBytesRef() {
-        DocTableInfo tableInfo = SQLExecutor.partitionedTableInfo(
-            new RelationName("doc", "users"),
-            "create table doc.users (name text primary key) partitioned by (name)",
-            clusterService);
+    public void test_PartitionName_from_assignment_with_table() throws Exception {
+        SQLExecutor e = SQLExecutor.of(clusterService)
+            .addPartitionedTable(
+                "create table doc.users (x int, p1 int) partitioned by (p1)",
+                ".partitioned.users.041j2c0"
+            );
 
-        PartitionName partitionName = getPartitionName(tableInfo);
-        assertThat(partitionName.values()).containsExactly("foo");
-        assertThat(partitionName.asIndexName()).isEqualTo(".partitioned.users.0426crrf");
+        DocTableInfo tableInfo = e.resolveTableInfo("doc.users");
+        PartitionName partitionName = PartitionPropertiesAnalyzer.createPartitionName(
+            List.of(
+                new Assignment<>(new QualifiedName("p1"), 10)
+            ),
+            tableInfo
+        );
+        assertThat(partitionName.values()).containsExactly("10");
+        assertThat(partitionName.asIndexName()).isEqualTo(tableInfo.concreteIndices()[0]);
+
+        assertThatThrownBy(() -> PartitionPropertiesAnalyzer.createPartitionName(
+            List.of(new Assignment<>(new QualifiedName("p1"), 20)),
+            tableInfo
+        )).isExactlyInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
@@ -64,7 +83,10 @@ public class PartitionPropertiesAnalyzerTest extends CrateDummyClusterServiceUni
             "create table doc.users (name text primary key)",
             clusterService);
 
-        assertThatThrownBy(() -> getPartitionName(tableInfo))
+        assertThatThrownBy(() -> PartitionPropertiesAnalyzer.toPartitionName(
+            tableInfo,
+            Collections.singletonList(new Assignment<>(new QualifiedName("name"), "foo"))
+        ))
             .isExactlyInstanceOf(IllegalArgumentException.class)
             .hasMessage("table 'doc.users' is not partitioned");
     }


### PR DESCRIPTION
For snapshots the `PartitionName` is created from values provided in a
`TABLE PARTITION (col = val [, ...])` clause.

The logic involved could flip the order of the columns due to the use of
a `HashMap`, leading to wrong index names.
