### PR TITLE
Revert "Use `languageLevel` 21 for intellij"

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -22,7 +22,7 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" project-jdk-name="temurin-22" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_22" default="true" project-jdk-name="temurin-22" project-jdk-type="JavaSDK" />
   <component name="SuppressionsComponent">
     <option name="suppComments" value="[]" />
   </component>


### PR DESCRIPTION
This reverts commit 28efccf99ee5773e09fd5366fc70c1c58d692b33.

Works with new Intellij 2024.
