### PR TITLE
Remove `toIndexName(PartitionName)` from `IndexParts`

### DIFF
--- a/server/src/main/java/io/crate/metadata/IndexParts.java
+++ b/server/src/main/java/io/crate/metadata/IndexParts.java
@@ -24,9 +24,9 @@ package io.crate.metadata;
 import java.util.List;
 
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import io.crate.blob.v2.BlobIndex;
-import org.jetbrains.annotations.VisibleForTesting;
 import io.crate.execution.ddl.tables.AlterTableOperation;
 import io.crate.metadata.blob.BlobSchemaInfo;
 
@@ -125,11 +125,6 @@ public class IndexParts {
 
     public static String toIndexName(RelationName relationName, String partitionIdent) {
         return toIndexName(relationName.schema(), relationName.name(), partitionIdent);
-    }
-
-    public static String toIndexName(PartitionName partitionName) {
-        RelationName relationName = partitionName.relationName();
-        return toIndexName(relationName.schema(), relationName.name(), partitionName.ident());
     }
 
     /**

--- a/server/src/main/java/io/crate/metadata/PartitionName.java
+++ b/server/src/main/java/io/crate/metadata/PartitionName.java
@@ -245,7 +245,7 @@ public class PartitionName {
 
     public String asIndexName() {
         if (indexName == null) {
-            indexName = IndexParts.toIndexName(this);
+            indexName = IndexParts.toIndexName(relationName.schema(), relationName.name(), ident());
         }
         return indexName;
     }

--- a/server/src/main/java/io/crate/planner/statement/DeletePlanner.java
+++ b/server/src/main/java/io/crate/planner/statement/DeletePlanner.java
@@ -31,11 +31,11 @@ import java.util.concurrent.CompletableFuture;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexAction;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.action.support.IndicesOptions;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import io.crate.analyze.AnalyzedDeleteStatement;
 import io.crate.analyze.WhereClause;
 import io.crate.analyze.relations.DocTableRelation;
-import org.jetbrains.annotations.VisibleForTesting;
 import io.crate.common.collections.Lists;
 import io.crate.data.Input;
 import io.crate.data.Row;
@@ -53,7 +53,7 @@ import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitors;
-import io.crate.metadata.IndexParts;
+import io.crate.metadata.PartitionName;
 import io.crate.metadata.Reference;
 import io.crate.metadata.Routing;
 import io.crate.metadata.RoutingProvider;
@@ -107,7 +107,7 @@ public final class DeletePlanner {
             return new DeleteById(tableRel.tableInfo(), detailedQuery.docKeys().get());
         }
         if (table.isPartitioned() && query instanceof Input<?> input && DataTypes.BOOLEAN.sanitizeValue(input.value())) {
-            return new DeleteAllPartitions(Lists.map(table.partitions(), IndexParts::toIndexName));
+            return new DeleteAllPartitions(Lists.map(table.partitions(), PartitionName::asIndexName));
         }
 
         return new Delete(tableRel, detailedQuery);


### PR DESCRIPTION
The method is redundant, `PartitionName.asIndexName()` exists.
