### PR TITLE
Apply OpenRewrite assertj recipes

### DIFF
--- a/server/src/test/java/io/crate/execution/dsl/projection/UpdateProjectionTest.java
+++ b/server/src/test/java/io/crate/execution/dsl/projection/UpdateProjectionTest.java
@@ -21,9 +21,9 @@
 
 package io.crate.execution.dsl.projection;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
 
 import java.util.List;
 
@@ -47,9 +47,9 @@ public class UpdateProjectionTest {
         UpdateProjection u2 = new UpdateProjection(
             Literal.of(1), new String[]{"foo"}, new Symbol[]{Literal.of(1)},new Symbol[]{new InputColumn(0, DataTypes.STRING)}, null, null);
 
-        assertThat(u2.equals(u1), is(true));
-        assertThat(u1.equals(u2), is(true));
-        assertThat(u1.hashCode(), is(u2.hashCode()));
+        assertThat(u2.equals(u1)).isTrue();
+        assertThat(u1.equals(u2)).isTrue();
+        assertThat(u1.hashCode()).isEqualTo(u2.hashCode());
 
     }
 

--- a/server/src/test/java/io/crate/execution/engine/collect/collectors/LuceneOrderedDocCollectorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/collectors/LuceneOrderedDocCollectorTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.execution.engine.collect.collectors;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertNull;
@@ -344,8 +345,8 @@ public class LuceneOrderedDocCollectorTest extends RandomizedTest {
 
         Iterator<Row> values = result.iterator();
 
-        assertThat(values.next().get(0), Matchers.is(Float.NaN));
-        assertThat(values.next().get(0), Matchers.is(Float.NaN));
+        assertThat(values.next().get(0)).isEqualTo(Float.NaN);
+        assertThat(values.next().get(0)).isEqualTo(Float.NaN);
     }
 
     @Test
@@ -369,8 +370,8 @@ public class LuceneOrderedDocCollectorTest extends RandomizedTest {
 
         Iterator<Row> values = result.iterator();
 
-        assertThat(values.next().get(0), Matchers.is(1.0F));
-        assertThat(values.next().get(0), Matchers.is(1.0F));
+        assertThat(values.next().get(0)).isEqualTo(1.0F);
+        assertThat(values.next().get(0)).isEqualTo(1.0F);
     }
 
     private static void addDoc(IndexWriter w, String name, FieldType fieldType, String value) throws IOException {

--- a/server/src/test/java/io/crate/execution/engine/distribution/merge/BatchPagingIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/distribution/merge/BatchPagingIteratorTest.java
@@ -23,7 +23,7 @@ package io.crate.execution.engine.distribution.merge;
 
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -36,7 +36,6 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -146,7 +145,7 @@ public class BatchPagingIteratorTest {
         );
 
         iterator.close();
-        assertThat(pagingIterator.finishedCalled, Matchers.is(true));
+        assertThat(pagingIterator.finishedCalled).isTrue();
     }
 
     private static class TestPagingIterator implements PagingIterator<Integer, Row> {

--- a/server/src/test/java/io/crate/execution/engine/fetch/FetchCollectorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/fetch/FetchCollectorTest.java
@@ -21,9 +21,8 @@
 
 package io.crate.execution.engine.fetch;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.elasticsearch.test.ESTestCase.randomIntBetween;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -41,12 +40,12 @@ public class FetchCollectorTest {
         for (int i = start; i < start + 10; i++) {
             sequential.add(i);
         }
-        assertThat(FetchCollector.isSequential(sequential), is(true));
+        assertThat(FetchCollector.isSequential(sequential)).isTrue();
 
         IntArrayList nonSequential = new IntArrayList();
         nonSequential.add(10);
         nonSequential.add(2);
         nonSequential.add(48);
-        assertThat(FetchCollector.isSequential(nonSequential), is(false));
+        assertThat(FetchCollector.isSequential(nonSequential)).isEqualTo(false);
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/indexing/UpsertResultsTest.java
+++ b/server/src/test/java/io/crate/execution/engine/indexing/UpsertResultsTest.java
@@ -23,7 +23,6 @@ package io.crate.execution.engine.indexing;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Map;
@@ -44,38 +43,36 @@ public class UpsertResultsTest {
         }
 
         Iterable<Row> rows = upsertResults.rowsIterable();
-        assertThat(TestingHelpers.printedTable(rows), is(
-            "NULL| dummyUri| 0| 60| {some failure={count=60, line_numbers=[" +
+        assertThat(TestingHelpers.printedTable(rows)).isEqualTo("NULL| dummyUri| 0| 60| {some failure={count=60, line_numbers=[" +
             "0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, " +
             "19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, " +
-            "36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49]}}\n"
-        ));
+            "36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49]}}\n");
     }
 
     @Test
     public void testContainsAnyErrorMethod() {
         UpsertResults upsertResults = new UpsertResults();
-        assertThat(upsertResults.containsErrors(), is(false));
+        assertThat(upsertResults.containsErrors()).isEqualTo(false);
         upsertResults.addResult(1, null);
-        assertThat(upsertResults.containsErrors(), is(false));
+        assertThat(upsertResults.containsErrors()).isEqualTo(false);
         upsertResults.addResult("dummyUri2", "failure test", 1);
-        assertThat(upsertResults.containsErrors(), is(true));
+        assertThat(upsertResults.containsErrors()).isEqualTo(true);
     }
 
     @Test
     public void testResultToFailureMessageFormat() {
         UpsertResults upsertResults = new UpsertResults();
-        assertThat(UpsertResults.resultsToFailure(upsertResults).getMessage(), is("Job killed. "));
+        assertThat(UpsertResults.resultsToFailure(upsertResults).getMessage()).isEqualTo("Job killed. ");
 
         upsertResults.addResult("file:///t5.json", "failed to parse", 5);
         upsertResults.addResult("file:///t6.json", "failed to parse", 6);
-        assertThat(UpsertResults.resultsToFailure(upsertResults).getMessage(), is("""
+        assertThat(UpsertResults.resultsToFailure(upsertResults).getMessage()).isEqualTo("""
                                                                                       Job killed.\s
                                                                                       [URI: file:///t6.json, ERRORS: {failed to parse={count=1, line_numbers=[6]}}],
-                                                                                      [URI: file:///t5.json, ERRORS: {failed to parse={count=1, line_numbers=[5]}}]"""));
+                                                                                      [URI: file:///t5.json, ERRORS: {failed to parse={count=1, line_numbers=[5]}}]""");
 
         upsertResults = new UpsertResults(Map.of("id", "RMU1uSbNQCijZR6PqtJEKg", "name", "Alplerspitz"));
-        assertThat(UpsertResults.resultsToFailure(upsertResults).getMessage(), is("Job killed. NODE: Alplerspitz"));
+        assertThat(UpsertResults.resultsToFailure(upsertResults).getMessage()).isEqualTo("Job killed. NODE: Alplerspitz");
 
         upsertResults.addResult("file:///t.json",
                                 "mapping set to strict, dynamic introduction of [b] within [default] is not allowed",
@@ -100,7 +97,7 @@ public class UpsertResultsTest {
     public void testResultToFailureSuccessMessages() {
         UpsertResults upsertResults = new UpsertResults();
         upsertResults.addResult("file:///t5.json", null, 5);
-        assertThat(UpsertResults.resultsToFailure(upsertResults).getMessage(), is("Job killed. \n[URI: file:///t5.json, ERRORS: {}]"));
+        assertThat(UpsertResults.resultsToFailure(upsertResults).getMessage()).isEqualTo("Job killed. \n[URI: file:///t5.json, ERRORS: {}]");
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/engine/join/HashInnerJoinBatchIteratorBehaviouralTest.java
+++ b/server/src/test/java/io/crate/execution/engine/join/HashInnerJoinBatchIteratorBehaviouralTest.java
@@ -21,9 +21,9 @@
 
 package io.crate.execution.engine.join;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 
 import java.util.Arrays;
@@ -84,7 +84,7 @@ public class HashInnerJoinBatchIteratorBehaviouralTest {
         // the blocksize is reached. we don't want that as parallel running hash iterators must call loadNextBatch always
         // on the same side synchronously as the upstreams will only send new data after all downstreams responded.
         // to validate this, the right must be repeated 3 times
-        assertThat(rightIterator.getMovetoStartCalls(), is(2));
+        assertThat(rightIterator.getMovetoStartCalls()).isEqualTo(2);
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/engine/join/RamBlockSizeCalculatorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/join/RamBlockSizeCalculatorTest.java
@@ -21,8 +21,7 @@
 
 package io.crate.execution.engine.join;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -43,14 +42,14 @@ public class RamBlockSizeCalculatorTest {
             circuitBreaker,
             5
         );
-        assertThat(blockCalculator100leftRows.applyAsInt(-1), is(20));
+        assertThat(blockCalculator100leftRows.applyAsInt(-1)).isEqualTo(20);
         RamBlockSizeCalculator blockCalculator10LeftRows = new RamBlockSizeCalculator(
             defaultBlockSize,
             circuitBreaker,
             5
         );
-        assertThat(blockCalculator10LeftRows.applyAsInt(-1), is(20));
-        assertThat(blockCalculator10LeftRows.applyAsInt(50), is(2));
+        assertThat(blockCalculator10LeftRows.applyAsInt(-1)).isEqualTo(20);
+        assertThat(blockCalculator10LeftRows.applyAsInt(50)).isEqualTo(2);
     }
 
     @Test
@@ -61,7 +60,7 @@ public class RamBlockSizeCalculatorTest {
             circuitBreaker,
             10
         );
-        assertThat(blockSizeCalculator.applyAsInt(-1), is(RamBlockSizeCalculator.FALLBACK_SIZE));
+        assertThat(blockSizeCalculator.applyAsInt(-1)).isEqualTo(RamBlockSizeCalculator.FALLBACK_SIZE);
 
         when(circuitBreaker.getLimit()).thenReturn(110L);
         when(circuitBreaker.getUsed()).thenReturn(10L);
@@ -70,14 +69,14 @@ public class RamBlockSizeCalculatorTest {
             circuitBreaker,
             10
         );
-        assertThat(blockCalculatorNoNumberOrRowsStats.applyAsInt(-1), is(10));
+        assertThat(blockCalculatorNoNumberOrRowsStats.applyAsInt(-1)).isEqualTo(10);
 
         RamBlockSizeCalculator blockCalculatorNoRowSizeStats = new RamBlockSizeCalculator(
             defaultBlockSize,
             circuitBreaker,
             -1
         );
-        assertThat(blockCalculatorNoRowSizeStats.applyAsInt(-1), is(RamBlockSizeCalculator.FALLBACK_SIZE));
+        assertThat(blockCalculatorNoRowSizeStats.applyAsInt(-1)).isEqualTo(RamBlockSizeCalculator.FALLBACK_SIZE);
     }
 
     @Test
@@ -89,7 +88,7 @@ public class RamBlockSizeCalculatorTest {
             circuitBreaker,
             10
         );
-        assertThat(blockSizeCalculator.applyAsInt(-1), is(10));
+        assertThat(blockSizeCalculator.applyAsInt(-1)).isEqualTo(10);
     }
 
     @Test
@@ -101,7 +100,7 @@ public class RamBlockSizeCalculatorTest {
             circuitBreaker,
             1
         );
-        assertThat(blockSizeCalculator.applyAsInt(-1), is(500_000));
+        assertThat(blockSizeCalculator.applyAsInt(-1)).isEqualTo(500_000);
     }
 
     @Test
@@ -113,6 +112,6 @@ public class RamBlockSizeCalculatorTest {
             circuitBreaker,
             1
         );
-        assertThat(blockSizeCalculator.applyAsInt(-1), is(defaultBlockSize));
+        assertThat(blockSizeCalculator.applyAsInt(-1)).isEqualTo(defaultBlockSize);
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/profile/CollectProfileRequestTest.java
+++ b/server/src/test/java/io/crate/execution/engine/profile/CollectProfileRequestTest.java
@@ -21,8 +21,7 @@
 
 package io.crate.execution.engine.profile;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.UUID;
 
@@ -44,7 +43,7 @@ public class CollectProfileRequestTest {
 
         CollectProfileRequest streamed = new CollectProfileRequest(in);
 
-        assertThat(originalRequest.jobId(), is(streamed.jobId()));
+        assertThat(originalRequest.jobId()).isEqualTo(streamed.jobId());
     }
 
 }

--- a/server/src/test/java/io/crate/execution/engine/profile/NodeCollectProfileResponseTest.java
+++ b/server/src/test/java/io/crate/execution/engine/profile/NodeCollectProfileResponseTest.java
@@ -21,8 +21,7 @@
 
 package io.crate.execution.engine.profile;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -46,6 +45,6 @@ public class NodeCollectProfileResponseTest {
 
         NodeCollectProfileResponse streamed = new NodeCollectProfileResponse(in);
 
-        assertThat(originalResponse.durationByContextIdent(), is(streamed.durationByContextIdent()));
+        assertThat(originalResponse.durationByContextIdent()).isEqualTo(streamed.durationByContextIdent());
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/window/WindowBatchIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/window/WindowBatchIteratorTest.java
@@ -24,9 +24,9 @@ package io.crate.execution.engine.window;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
 import static io.crate.execution.engine.window.WindowFunctionBatchIterator.sortAndComputeWindowFunctions;
 import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.is;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -133,7 +133,7 @@ public class WindowBatchIteratorTest {
             args).get(5, TimeUnit.SECONDS).spliterator(), false)
             .collect(toList());
         var expectedBounds = new Tuple<>(0, 10);
-        IntStream.range(0, 10).forEach(i -> assertThat(result.get(i), is(new Object[] { i, expectedBounds})));
+        IntStream.range(0, 10).forEach(i -> assertThat(result.get(i)).isEqualTo(new Object[]{i, expectedBounds}));
     }
 
     @Test
@@ -360,7 +360,7 @@ public class WindowBatchIteratorTest {
         TestingRowConsumer consumer = new TestingRowConsumer();
         consumer.accept(iterator, null);
         // should've accounted for 10 integers of 48 bytes each (16 for the integer, 32 for the ArrayList element)
-        assertThat(ramAccounting.totalBytes(), is(480L));
+        assertThat(ramAccounting.totalBytes()).isEqualTo(480L);
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/reference/MapLookupByPathExpressionTest.java
+++ b/server/src/test/java/io/crate/expression/reference/MapLookupByPathExpressionTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.expression.reference;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Collections;
@@ -53,6 +54,6 @@ public class MapLookupByPathExpressionTest {
             new MapLookupByPathExpression<>(Function.identity(), Collections.singletonList("correct"), UnaryOperator.identity());
 
         expr.setNextRow(m);
-        assertThat(expr.value(), Matchers.is(10));
+        assertThat(expr.value()).isEqualTo(10);
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -24,7 +24,7 @@ package io.crate.integrationtests;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
 import java.util.List;
@@ -991,9 +991,9 @@ public class InformationSchemaTest extends IntegTestCase {
         Object[] row2 = new Object[]{"my_table", sqlExecutor.getCurrentSchema(), "04134", Map.of("par", 2), "2", 5, "0-1", "1"};
         Object[] row3 = new Object[]{"my_table", sqlExecutor.getCurrentSchema(), "04136", Map.of("par", 3), "3", 5, "0-1", "1"};
 
-        assertArrayEquals(row1, response.rows()[0]);
-        assertArrayEquals(row2, response.rows()[1]);
-        assertArrayEquals(row3, response.rows()[2]);
+        assertThat(response.rows()[0]).containsExactly(row1);
+        assertThat(response.rows()[1]).containsExactly(row2);
+        assertThat(response.rows()[2]).containsExactly(row3);
     }
 
     @Test
@@ -1098,11 +1098,11 @@ public class InformationSchemaTest extends IntegTestCase {
         Object[] row4 = new Object[]{"my_table", sqlExecutor.getCurrentSchema(), "08134136dtng", Map.of("par", 2, "par_str", "foo"), 5, "0-1"};
         Object[] row5 = new Object[]{"my_table", sqlExecutor.getCurrentSchema(), "081341b1edi6c", Map.of("par", 2, "par_str", "asdf"), 4, "0-1"};
 
-        assertArrayEquals(row1, response.rows()[0]);
-        assertArrayEquals(row2, response.rows()[1]);
-        assertArrayEquals(row3, response.rows()[2]);
-        assertArrayEquals(row4, response.rows()[3]);
-        assertArrayEquals(row5, response.rows()[4]);
+        assertThat(response.rows()[0]).containsExactly(row1);
+        assertThat(response.rows()[1]).containsExactly(row2);
+        assertThat(response.rows()[2]).containsExactly(row3);
+        assertThat(response.rows()[3]).containsExactly(row4);
+        assertThat(response.rows()[4]).containsExactly(row5);
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/NodeStatsITest.java
+++ b/server/src/test/java/io/crate/integrationtests/NodeStatsITest.java
@@ -22,7 +22,7 @@
 package io.crate.integrationtests;
 
 import static io.crate.testing.Asserts.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashMap;
 import java.util.List;
@@ -180,9 +180,9 @@ public class NodeStatsITest extends IntegTestCase {
         assertThat(response).hasRowCount(1L);
 
         assertThat((Integer) results.get("available_processors")).isGreaterThan(0);
-        assertEquals(Constants.OS_NAME, results.get("name"));
-        assertEquals(Constants.OS_ARCH, results.get("arch"));
-        assertEquals(Constants.OS_VERSION, results.get("version"));
+        assertThat(results.get("name")).isEqualTo(Constants.OS_NAME);
+        assertThat(results.get("arch")).isEqualTo(Constants.OS_ARCH);
+        assertThat(results.get("version")).isEqualTo(Constants.OS_VERSION);
 
         Map<String, Object> jvmObj = new HashMap<>(4);
         java.lang.Runtime.Version version = Runtime.version();
@@ -190,7 +190,7 @@ public class NodeStatsITest extends IntegTestCase {
         jvmObj.put("vm_name", Constants.JVM_NAME);
         jvmObj.put("vm_vendor", Constants.JVM_VENDOR);
         jvmObj.put("vm_version", version.toString());
-        assertEquals(jvmObj, results.get("jvm"));
+        assertThat(results.get("jvm")).isEqualTo(jvmObj);
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/ObjectColumnTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ObjectColumnTest.java
@@ -27,7 +27,7 @@ import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashMap;
 import java.util.List;
@@ -165,15 +165,12 @@ public class ObjectColumnTest extends IntegTestCase {
         execute("select author, author['job'] from ot " +
                 "where author['name']['first_name']='Douglas' and author['name']['last_name']='Adams'");
         assertThat(response.rowCount()).isEqualTo(1);
-        assertEquals(
-            Map.of(
-                "name", Map.of(
-                    "first_name", "Douglas",
-                    "last_name", "Adams"),
-                "age", 49,
-                "job", "Writer"),
-            response.rows()[0][0]
-        );
+        assertThat(response.rows()[0][0]).isEqualTo(Map.of(
+            "name", Map.of(
+                "first_name", "Douglas",
+                "last_name", "Adams"),
+            "age", 49,
+            "job", "Writer"));
         assertThat(response.rows()[0][1]).isEqualTo("Writer");
     }
 

--- a/server/src/test/java/io/crate/memory/OnHeapMemoryManagerTest.java
+++ b/server/src/test/java/io/crate/memory/OnHeapMemoryManagerTest.java
@@ -21,8 +21,7 @@
 
 package io.crate.memory;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -36,10 +35,10 @@ public class OnHeapMemoryManagerTest {
         var memoryManager = new OnHeapMemoryManager(bytes::addAndGet);
 
         memoryManager.allocate(20);
-        assertThat(bytes.get(), is(20L));
+        assertThat(bytes.get()).isEqualTo(20L);
 
         // Closing the memoryManager doesn't de-account the bytes. That responsibility is delegated to the IntConsumer
         memoryManager.close();
-        assertThat(bytes.get(), is(20L));
+        assertThat(bytes.get()).isEqualTo(20L);
     }
 }

--- a/server/src/test/java/io/crate/metadata/ColumnIdentTest.java
+++ b/server/src/test/java/io/crate/metadata/ColumnIdentTest.java
@@ -25,7 +25,6 @@ import static junit.framework.TestCase.assertTrue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -42,23 +41,22 @@ public class ColumnIdentTest {
     @Test
     public void testSqlFqn() throws Exception {
         ColumnIdent ident = new ColumnIdent("foo", Arrays.asList("x", "y", "z"));
-        assertThat(ident.sqlFqn(), is("foo['x']['y']['z']"));
+        assertThat(ident.sqlFqn()).isEqualTo("foo['x']['y']['z']");
 
         ident = new ColumnIdent("a");
-        assertThat(ident.sqlFqn(), is("a"));
+        assertThat(ident.sqlFqn()).isEqualTo("a");
 
         ident = new ColumnIdent("a", Collections.singletonList(""));
-        assertThat(ident.sqlFqn(), is("a['']"));
+        assertThat(ident.sqlFqn()).isEqualTo("a['']");
 
         ident = new ColumnIdent("a.b", Collections.singletonList("c"));
-        assertThat(ident.sqlFqn(), is("a.b['c']"));
+        assertThat(ident.sqlFqn()).isEqualTo("a.b['c']");
     }
 
     @Test
     public void testShiftRight() throws Exception {
-        assertThat(new ColumnIdent("foo", "bar").shiftRight(), is(new ColumnIdent("bar")));
-        assertThat(new ColumnIdent("foo", Arrays.asList("x", "y", "z")).shiftRight(),
-            is(new ColumnIdent("x", Arrays.asList("y", "z"))));
+        assertThat(new ColumnIdent("foo", "bar").shiftRight()).isEqualTo(new ColumnIdent("bar"));
+        assertThat(new ColumnIdent("foo", Arrays.asList("x", "y", "z")).shiftRight()).isEqualTo(new ColumnIdent("x", Arrays.asList("y", "z")));
         assertThat(new ColumnIdent("foo").shiftRight(), Matchers.nullValue());
     }
 
@@ -69,24 +67,23 @@ public class ColumnIdentTest {
         ColumnIdent rootXY = new ColumnIdent("root", Arrays.asList("x", "y"));
         ColumnIdent rootYX = new ColumnIdent("root", Arrays.asList("y", "x"));
 
-        assertThat(root.isChildOf(root), is(false));
+        assertThat(root.isChildOf(root)).isFalse();
 
-        assertThat(rootX.isChildOf(root), is(true));
-        assertThat(rootXY.isChildOf(root), is(true));
-        assertThat(rootXY.isChildOf(rootX), is(true));
+        assertThat(rootX.isChildOf(root)).isTrue();
+        assertThat(rootXY.isChildOf(root)).isTrue();
+        assertThat(rootXY.isChildOf(rootX)).isTrue();
 
-        assertThat(rootYX.isChildOf(root), is(true));
-        assertThat(rootYX.isChildOf(rootX), is(false));
+        assertThat(rootYX.isChildOf(root)).isTrue();
+        assertThat(rootYX.isChildOf(rootX)).isFalse();
     }
 
     @Test
     public void testPrepend() throws Exception {
         ColumnIdent foo = new ColumnIdent("foo");
-        assertThat(foo.prepend(DocSysColumns.DOC.name()),
-            is(new ColumnIdent(DocSysColumns.DOC.name(), "foo")));
+        assertThat(foo.prepend(DocSysColumns.DOC.name())).isEqualTo(new ColumnIdent(DocSysColumns.DOC.name(), "foo"));
 
         ColumnIdent fooBar = new ColumnIdent("foo", "bar");
-        assertThat(fooBar.prepend("x"), is(new ColumnIdent("x", Arrays.asList("foo", "bar"))));
+        assertThat(fooBar.prepend("x")).isEqualTo(new ColumnIdent("x", Arrays.asList("foo", "bar")));
     }
 
     @Test

--- a/server/src/test/java/io/crate/metadata/sys/SysOperationsLogTableInfoTest.java
+++ b/server/src/test/java/io/crate/metadata/sys/SysOperationsLogTableInfoTest.java
@@ -21,12 +21,11 @@
 
 package io.crate.metadata.sys;
 
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.UUID;
 import java.util.function.LongSupplier;
 
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 import io.crate.expression.reference.sys.operation.OperationContext;
@@ -49,6 +48,6 @@ public class SysOperationsLogTableInfoTest {
         String errorMessage = null;
         expression.setNextRow(new OperationContextLog(new OperationContext(id, jobId, name, started, bytesUsed), errorMessage));
         Object value = (String) expression.value();
-        assertThat(value, Matchers.is(jobId.toString()));
+        assertThat(value).isEqualTo(jobId.toString());
     }
 }

--- a/server/src/test/java/io/crate/metadata/sys/SysSnapshotRestoreTableInfoTest.java
+++ b/server/src/test/java/io/crate/metadata/sys/SysSnapshotRestoreTableInfoTest.java
@@ -21,8 +21,7 @@
 
 package io.crate.metadata.sys;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.UUID;
@@ -60,14 +59,14 @@ public class SysSnapshotRestoreTableInfoTest {
             .snapshotsRestoreInProgress(new RestoreInProgress.Builder().add(entry).build())
             .iterator();
 
-        assertThat(restoreInProgressIt.hasNext(), is(true));
-        assertThat(restoreInProgressIt.next(), is(SysSnapshotRestoreInProgress.of(entry)));
-        assertThat(restoreInProgressIt.hasNext(), is(false));
+        assertThat(restoreInProgressIt.hasNext()).isTrue();
+        assertThat(restoreInProgressIt.next()).isEqualTo(SysSnapshotRestoreInProgress.of(entry));
+        assertThat(restoreInProgressIt.hasNext()).isFalse();
     }
 
     @Test
     public void test_convert_null_restore_in_progress_returns_empty_iterator() {
         var restoreInProgressIt = SysSnapshotRestoreTableInfo.snapshotsRestoreInProgress(null).iterator();
-        assertThat(restoreInProgressIt.hasNext(), is(false));
+        assertThat(restoreInProgressIt.hasNext()).isEqualTo(false);
     }
 }

--- a/server/src/test/java/io/crate/metadata/upgrade/IndexTemplateUpgraderTest.java
+++ b/server/src/test/java/io/crate/metadata/upgrade/IndexTemplateUpgraderTest.java
@@ -27,7 +27,6 @@ import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF
 import static org.elasticsearch.common.settings.AbstractScopedSettings.ARCHIVED_SETTINGS_PREFIX;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.is;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -95,12 +94,12 @@ public class IndexTemplateUpgraderTest {
         assertThat(upgradedTemplate.settings().keySet(), contains(SETTING_NUMBER_OF_SHARDS));
 
         // ensure all other attributes remains the same
-        assertThat(upgradedTemplate.mapping(), is(oldPartitionTemplate.mapping()));
-        assertThat(upgradedTemplate.patterns(), is(oldPartitionTemplate.patterns()));
-        assertThat(upgradedTemplate.aliases(), is(oldPartitionTemplate.aliases()));
+        assertThat(upgradedTemplate.mapping()).isEqualTo(oldPartitionTemplate.mapping());
+        assertThat(upgradedTemplate.patterns()).isEqualTo(oldPartitionTemplate.patterns());
+        assertThat(upgradedTemplate.aliases()).isEqualTo(oldPartitionTemplate.aliases());
 
         // ensure non partitioned table templates are untouched
-        assertThat(upgradedTemplates.get(nonPartitionTemplateName), is(oldNonPartitionTemplate));
+        assertThat(upgradedTemplates.get(nonPartitionTemplateName)).isEqualTo(oldNonPartitionTemplate);
     }
 
     @Test
@@ -116,11 +115,9 @@ public class IndexTemplateUpgraderTest {
         IndexTemplateUpgrader indexTemplateUpgrader = new IndexTemplateUpgrader();
         Map<String, IndexTemplateMetadata> result = indexTemplateUpgrader.apply(Collections.singletonMap(templateName, template));
 
-        assertThat(
-            "Outdated setting `index.recovery.initial_shards` must be removed",
-            result.get(templateName).settings().hasValue("index.recovery.initial_shards"),
-            is(false)
-        );
+        assertThat(result.get(templateName).settings().hasValue("index.recovery.initial_shards"))
+            .as("Outdated setting `index.recovery.initial_shards` must be removed")
+            .isFalse();
     }
 
     @Test
@@ -146,7 +143,7 @@ public class IndexTemplateUpgraderTest {
         IndexTemplateMetadata updatedTemplate = result.get(templateName);
 
         CompressedXContent compressedXContent = updatedTemplate.mapping();
-        assertThat(compressedXContent.string(), is("{\"default\":{\"properties\":{\"name\":{\"position\":1,\"type\":\"keyword\"}}}}"));
+        assertThat(compressedXContent.string()).isEqualTo("{\"default\":{\"properties\":{\"name\":{\"position\":1,\"type\":\"keyword\"}}}}");
     }
 
     @Test
@@ -173,7 +170,7 @@ public class IndexTemplateUpgraderTest {
         IndexTemplateMetadata updatedTemplate = result.get(templateName);
 
         CompressedXContent compressedXContent = updatedTemplate.mapping();
-        assertThat(compressedXContent.string(), is("{\"default\":{\"properties\":{\"name\":{\"position\":1,\"type\":\"keyword\"}}}}"));
+        assertThat(compressedXContent.string()).isEqualTo("{\"default\":{\"properties\":{\"name\":{\"position\":1,\"type\":\"keyword\"}}}}");
     }
 
 

--- a/server/src/test/java/io/crate/operation/collect/files/CSVLineParserTest.java
+++ b/server/src/test/java/io/crate/operation/collect/files/CSVLineParserTest.java
@@ -21,8 +21,7 @@
 
 package io.crate.operation.collect.files;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -79,7 +78,7 @@ public class CSVLineParserTest {
         csvParser.parseHeader(header);
         result = csvParser.parse("GER,Germany\n", 0);
 
-        assertThat(new String(result, StandardCharsets.UTF_8), is("{\"Code\":\"GER\",\"Country\":\"Germany\"}"));
+        assertThat(new String(result, StandardCharsets.UTF_8)).isEqualTo("{\"Code\":\"GER\",\"Country\":\"Germany\"}");
     }
 
     @Test
@@ -88,7 +87,7 @@ public class CSVLineParserTest {
         csvParser.parseHeader(header);
         result = csvParser.parse("GER,Germany\n", 0);
 
-        assertThat(new String(result, StandardCharsets.UTF_8), is("{\"Code\":\"GER\",\"Country\":\"Germany\"}"));
+        assertThat(new String(result, StandardCharsets.UTF_8)).isEqualTo("{\"Code\":\"GER\",\"Country\":\"Germany\"}");
     }
 
     @Test
@@ -97,7 +96,7 @@ public class CSVLineParserTest {
         csvParser.parseHeader(header);
         result = csvParser.parse("", 0);
 
-        assertThat(result, is("{}".getBytes(StandardCharsets.UTF_8)));
+        assertThat(result).isEqualTo("{}".getBytes(StandardCharsets.UTF_8));
     }
 
     @Test
@@ -106,7 +105,7 @@ public class CSVLineParserTest {
         csvParser.parseHeader(header);
         result = csvParser.parse(",", 0);
 
-        assertThat(new String(result, StandardCharsets.UTF_8), is("{\"Code\":\"\",\"Country\":\"\"}"));
+        assertThat(new String(result, StandardCharsets.UTF_8)).isEqualTo("{\"Code\":\"\",\"Country\":\"\"}");
     }
 
     @Test
@@ -118,7 +117,7 @@ public class CSVLineParserTest {
         csvParser.parseHeader(header);
         result = csvParser.parse("GER,Germany\n", 0);
 
-        assertThat(new String(result, StandardCharsets.UTF_8), is("{\"Code\":\"GER\",\"Coun, try\":\"Germany\"}"));
+        assertThat(new String(result, StandardCharsets.UTF_8)).isEqualTo("{\"Code\":\"GER\",\"Coun, try\":\"Germany\"}");
     }
 
     @Test
@@ -130,10 +129,7 @@ public class CSVLineParserTest {
         csvParser.parseHeader(header);
         result = csvParser.parse("GER,,\"\"\n", 0);
 
-        assertThat(
-            new String(result, StandardCharsets.UTF_8),
-            is("{\"Code\":\"GER\",\"Country\":null,\"City\":null}")
-        );
+        assertThat(new String(result, StandardCharsets.UTF_8)).isEqualTo("{\"Code\":\"GER\",\"Country\":null,\"City\":null}");
     }
 
     @Test
@@ -145,10 +141,7 @@ public class CSVLineParserTest {
         csvParser.parseHeader(header);
         result = csvParser.parse("GER|Germany|Berlin\n", 0);
 
-        assertThat(
-            new String(result, StandardCharsets.UTF_8),
-            is("{\"Code\":\"GER\",\"Country\":\"Germany\",\"City\":\"Berlin\"}")
-        );
+        assertThat(new String(result, StandardCharsets.UTF_8)).isEqualTo("{\"Code\":\"GER\",\"Country\":\"Germany\",\"City\":\"Berlin\"}");
     }
 
     @Test
@@ -157,7 +150,7 @@ public class CSVLineParserTest {
         csvParser.parseHeader(header);
         result = csvParser.parse("GER,,Berlin\n", 0);
 
-        assertThat(new String(result, StandardCharsets.UTF_8), is("{\"Code\":\"GER\",\"Country\":\"\",\"City\":\"Berlin\"}"));
+        assertThat(new String(result, StandardCharsets.UTF_8)).isEqualTo("{\"Code\":\"GER\",\"Country\":\"\",\"City\":\"Berlin\"}");
     }
 
     @Test
@@ -166,7 +159,7 @@ public class CSVLineParserTest {
         csvParser.parseHeader(header);
         result = csvParser.parse("GER,Germany\n", 0);
 
-        assertThat(new String(result, StandardCharsets.UTF_8), is("{\"Code\":\"GER\",\"Country\":\"Germany\"}"));
+        assertThat(new String(result, StandardCharsets.UTF_8)).isEqualTo("{\"Code\":\"GER\",\"Country\":\"Germany\"}");
     }
 
     @Test
@@ -175,7 +168,7 @@ public class CSVLineParserTest {
         csvParser.parseHeader(header);
         result = csvParser.parse("GER        ,Germany\n", 0);
 
-        assertThat(new String(result, StandardCharsets.UTF_8), is("{\"Code\":\"GER\",\"Country\":\"Germany\"}"));
+        assertThat(new String(result, StandardCharsets.UTF_8)).isEqualTo("{\"Code\":\"GER\",\"Country\":\"Germany\"}");
     }
 
     @Test
@@ -184,7 +177,7 @@ public class CSVLineParserTest {
         csvParser.parseHeader(header);
         result = csvParser.parse("GER,Germany\n", 0);
 
-        assertThat(new String(result, StandardCharsets.UTF_8), is("{\"Code\":\"GER\",\"Country\":\"Germany\"}"));
+        assertThat(new String(result, StandardCharsets.UTF_8)).isEqualTo("{\"Code\":\"GER\",\"Country\":\"Germany\"}");
     }
 
     @Test
@@ -193,7 +186,7 @@ public class CSVLineParserTest {
         csvParser.parseHeader(header);
         result = csvParser.parse("GER,               Germany\n", 0);
 
-        assertThat(new String(result, StandardCharsets.UTF_8), is("{\"Code\":\"GER\",\"Country\":\"Germany\"}"));
+        assertThat(new String(result, StandardCharsets.UTF_8)).isEqualTo("{\"Code\":\"GER\",\"Country\":\"Germany\"}");
     }
 
     @Test
@@ -206,7 +199,7 @@ public class CSVLineParserTest {
         csvParser.parseHeader(header);
         result = csvParser.parse("GER,Germany\n", 0);
 
-        assertThat(new String(result, StandardCharsets.UTF_8), is("{\"Code\":\"GER\",\"Country\":\"Germany\"}"));
+        assertThat(new String(result, StandardCharsets.UTF_8)).isEqualTo("{\"Code\":\"GER\",\"Country\":\"Germany\"}");
     }
 
     @Test
@@ -218,7 +211,7 @@ public class CSVLineParserTest {
         csvParser.parseHeader(header);
         result = csvParser.parse("GER,Germany,Berlin\n", 0);
 
-        assertThat(new String(result, StandardCharsets.UTF_8), is("{\"Code\":\"GER\",\"Country\":\"Germany\"}"));
+        assertThat(new String(result, StandardCharsets.UTF_8)).isEqualTo("{\"Code\":\"GER\",\"Country\":\"Germany\"}");
     }
 
     @Test
@@ -243,7 +236,7 @@ public class CSVLineParserTest {
             new CopyFromParserProperties(true, false, CsvSchema.DEFAULT_COLUMN_SEPARATOR, 0),
             List.of("Code", "Country"));
         result = csvParser.parseWithoutHeader("GER,Germany,Berlin\n", 0);
-        assertThat(new String(result, StandardCharsets.UTF_8), is("{\"Code\":\"GER\",\"Country\":\"Germany\"}"));
+        assertThat(new String(result, StandardCharsets.UTF_8)).isEqualTo("{\"Code\":\"GER\",\"Country\":\"Germany\"}");
     }
 
     @Test
@@ -254,7 +247,7 @@ public class CSVLineParserTest {
             List.of("City", "Code"));
         csvParser.parseHeader(header);
         result = csvParser.parse("GER,Germany,Berlin\n", 0);
-        assertThat(new String(result, StandardCharsets.UTF_8), is("{\"Code\":\"GER\",\"City\":\"Berlin\"}"));
+        assertThat(new String(result, StandardCharsets.UTF_8)).isEqualTo("{\"Code\":\"GER\",\"City\":\"Berlin\"}");
     }
 
     @Test
@@ -265,6 +258,6 @@ public class CSVLineParserTest {
             List.of());
         csvParser.parseHeader(header);
         result = csvParser.parse("GER,Germany,Berlin\n", 0);
-        assertThat(new String(result, StandardCharsets.UTF_8), is("{\"Code\":\"GER\",\"Country\":\"Germany\",\"City\":\"Berlin\"}"));
+        assertThat(new String(result, StandardCharsets.UTF_8)).isEqualTo("{\"Code\":\"GER\",\"Country\":\"Germany\",\"City\":\"Berlin\"}");
     }
 }

--- a/server/src/test/java/io/crate/planner/IndexBaseBuilderTest.java
+++ b/server/src/test/java/io/crate/planner/IndexBaseBuilderTest.java
@@ -21,8 +21,7 @@
 
 package io.crate.planner;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.TreeMap;
 
@@ -45,10 +44,10 @@ public class IndexBaseBuilderTest {
         builder.allocate("i3", IntArrayList.from(1, 3));
 
         TreeMap<String, Integer> bases = builder.build();
-        assertThat(bases.size(), is(3));
-        assertThat(bases.get("i1"), is(0));
-        assertThat(bases.get("i2"), is(6));
-        assertThat(bases.get("i3"), is(9));
+        assertThat(bases.size()).isEqualTo(3);
+        assertThat(bases.get("i1")).isEqualTo(0);
+        assertThat(bases.get("i2")).isEqualTo(6);
+        assertThat(bases.get("i3")).isEqualTo(9);
     }
 
     @Test
@@ -58,8 +57,8 @@ public class IndexBaseBuilderTest {
         builder.allocate("i1", IntArrayList.from(1, 4));
         builder.allocate("i2", IntArrayList.from(1, 5));
         TreeMap<String, Integer> bases = builder.build();
-        assertThat(bases.size(), is(2));
-        assertThat(bases.get("i1"), is(0));
-        assertThat(bases.get("i2"), is(5));
+        assertThat(bases.size()).isEqualTo(2);
+        assertThat(bases.get("i1")).isEqualTo(0);
+        assertThat(bases.get("i2")).isEqualTo(5);
     }
 }

--- a/server/src/test/java/io/crate/planner/PositionalOrderByTest.java
+++ b/server/src/test/java/io/crate/planner/PositionalOrderByTest.java
@@ -21,12 +21,11 @@
 
 package io.crate.planner;
 
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.List;
 
-import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import io.crate.analyze.OrderBy;
@@ -52,9 +51,9 @@ public class PositionalOrderByTest {
         PositionalOrderBy newOrderBy = positionalOrderBy.tryMapToNewOutputs(oldOutputs, newOutputs);
 
         PositionalOrderBy expected = PositionalOrderBy.of(orderBy, newOutputs);
-        assertThat(newOrderBy.indices(), Matchers.is(expected.indices()));
-        assertThat(newOrderBy.reverseFlags(), Matchers.is(expected.reverseFlags()));
-        assertThat(newOrderBy.nullsFirst(), Matchers.is(expected.nullsFirst()));
+        assertThat(newOrderBy.indices()).isEqualTo(expected.indices());
+        assertThat(newOrderBy.reverseFlags()).isEqualTo(expected.reverseFlags());
+        assertThat(newOrderBy.nullsFirst()).isEqualTo(expected.nullsFirst());
     }
 
     private static Reference ref(String name) {

--- a/server/src/test/java/io/crate/planner/optimizer/OptimizerRuleSessionSettingProviderTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/OptimizerRuleSessionSettingProviderTest.java
@@ -23,9 +23,9 @@ package io.crate.planner.optimizer;
 
 import static io.crate.analyze.SymbolEvaluator.evaluateWithoutParams;
 import static io.crate.testing.TestingHelpers.createNodeContext;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.is;
 
 import java.util.List;
 import java.util.Set;
@@ -56,9 +56,9 @@ public class OptimizerRuleSessionSettingProviderTest {
     public void test_optimizer_rule_session_settings() {
         var sessionSetting = LoadedRules.buildRuleSessionSetting(MergeFilters.class);
 
-        assertThat(sessionSetting.name(), is("optimizer_merge_filters"));
-        assertThat(sessionSetting.description(), is("Indicates if the optimizer rule MergeFilters is activated."));
-        assertThat(sessionSetting.defaultValue(), is("true"));
+        assertThat(sessionSetting.name()).isEqualTo("optimizer_merge_filters");
+        assertThat(sessionSetting.description()).isEqualTo("Indicates if the optimizer rule MergeFilters is activated.");
+        assertThat(sessionSetting.defaultValue()).isEqualTo("true");
 
         SearchPath searchPath = SearchPath.createSearchPathFrom("dummySchema");
         var mergefilterSettings = new CoordinatorSessionSettings(
@@ -71,7 +71,7 @@ public class OptimizerRuleSessionSettingProviderTest {
             0
         );
 
-        assertThat(sessionSetting.getValue(mergefilterSettings), is("false"));
+        assertThat(sessionSetting.getValue(mergefilterSettings)).isEqualTo("false");
 
         var sessionSettings = new CoordinatorSessionSettings(RolesHelper.userOf("user"));
 
@@ -81,6 +81,6 @@ public class OptimizerRuleSessionSettingProviderTest {
 
         // Enable MergeFilters 'SET SESSION optimizer_merge_filters = true'
         sessionSetting.apply(sessionSettings, List.of(Literal.of(true)), eval);
-        assertThat(sessionSettings.excludedOptimizerRules().isEmpty(), is(true));
+        assertThat(sessionSettings.excludedOptimizerRules()).isEmpty();
     }
 }

--- a/server/src/test/java/io/crate/protocols/ErrorMappingTest.java
+++ b/server/src/test/java/io/crate/protocols/ErrorMappingTest.java
@@ -28,6 +28,7 @@ import static io.crate.protocols.postgres.PGErrorStatus.UNDEFINED_FUNCTION;
 import static io.crate.testing.TestingHelpers.createReference;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
@@ -95,12 +96,12 @@ public class ErrorMappingTest {
         var throwable = SQLExceptions.prepareForClientTransmission(AccessControl.DISABLED, t);
 
         var pgError = PGError.fromThrowable(throwable);
-        assertThat(pgError.status(), is(pgErrorStatus));
+        assertThat(pgError.status()).isEqualTo(pgErrorStatus);
         assertThat(pgError.message(), msg);
 
         var httpError = HttpError.fromThrowable(throwable);
-        assertThat(httpError.errorCode(), is(errorCode));
-        assertThat(httpError.httpResponseStatus(), is(httpResponseStatus));
+        assertThat(httpError.errorCode()).isEqualTo(errorCode);
+        assertThat(httpError.httpResponseStatus()).isEqualTo(httpResponseStatus);
         assertThat(httpError.message(), msg);
     }
 }

--- a/server/src/test/java/io/crate/protocols/postgres/DelayableWriteChannelTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/DelayableWriteChannelTest.java
@@ -21,8 +21,7 @@
 
 package io.crate.protocols.postgres;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 
@@ -39,6 +38,6 @@ public class DelayableWriteChannelTest {
         ByteBuf buffer = Unpooled.buffer();
         channel.write(buffer);
         channel.close();
-        assertThat(buffer.refCnt(), is(0));
+        assertThat(buffer.refCnt()).isEqualTo(0);
     }
 }

--- a/server/src/test/java/io/crate/protocols/postgres/types/BitTypeTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/types/BitTypeTest.java
@@ -21,8 +21,7 @@
 
 package io.crate.protocols.postgres.types;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.charset.StandardCharsets;
 
@@ -34,17 +33,11 @@ public class BitTypeTest {
 
     @Test
     public void test_can_decode_text_without_B_prefix() {
-        assertThat(
-            BitType.INSTANCE.decodeUTF8Text("0010".getBytes(StandardCharsets.UTF_8)),
-            is(BitString.ofRawBits("0010"))
-        );
+        assertThat(BitType.INSTANCE.decodeUTF8Text("0010".getBytes(StandardCharsets.UTF_8))).isEqualTo(BitString.ofRawBits("0010"));
     }
 
     @Test
     public void test_can_decode_text_with_B_prefix() {
-        assertThat(
-            BitType.INSTANCE.decodeUTF8Text("B'0010'".getBytes(StandardCharsets.UTF_8)),
-            is(BitString.ofRawBits("0010"))
-        );
+        assertThat(BitType.INSTANCE.decodeUTF8Text("B'0010'".getBytes(StandardCharsets.UTF_8))).isEqualTo(BitString.ofRawBits("0010"));
     }
 }

--- a/server/src/test/java/io/crate/rest/action/SqlHttpHandlerTest.java
+++ b/server/src/test/java/io/crate/rest/action/SqlHttpHandlerTest.java
@@ -23,11 +23,11 @@ package io.crate.rest.action;
 
 import static io.crate.role.metadata.RolesHelper.JWT_TOKEN;
 import static io.crate.role.metadata.RolesHelper.JWT_USER;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -128,7 +128,7 @@ public class SqlHttpHandlerTest {
         verify(mockedRequest, atLeast(1)).headers();
         assertThat(session.sessionSettings().authenticatedUser(), is(dummyUser));
         assertThat(session.sessionSettings().searchPath().currentSchema(), containsString("doc"));
-        assertTrue(session.sessionSettings().hashJoinsEnabled());
+        assertThat(session.sessionSettings().hashJoinsEnabled()).isTrue();
 
         // modify the session settings
         session.sessionSettings().setSearchPath("dummy_path");

--- a/server/src/test/java/io/crate/types/UndefinedTypeTest.java
+++ b/server/src/test/java/io/crate/types/UndefinedTypeTest.java
@@ -22,14 +22,12 @@
 package io.crate.types;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.CoreMatchers.is;
 
 import java.util.BitSet;
 import java.util.Map;
 
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.test.ESTestCase;
-import org.hamcrest.MatcherAssert;
 import org.junit.Test;
 
 import io.crate.sql.tree.BitString;
@@ -45,7 +43,7 @@ public class UndefinedTypeTest extends ESTestCase {
         var in = out.bytes().streamInput();
 
         var valueIn = DataTypes.UNDEFINED.readValueFrom(in);
-        MatcherAssert.assertThat(valueIn, is(valueOut));
+        assertThat(valueIn).isEqualTo(valueOut);
     }
 
     @Test

--- a/server/src/test/java/org/elasticsearch/action/StepListenerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/StepListenerTests.java
@@ -22,7 +22,7 @@ package org.elasticsearch.action;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/FollowersCheckerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/FollowersCheckerTests.java
@@ -18,6 +18,7 @@
  */
 package org.elasticsearch.cluster.coordination;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.elasticsearch.cluster.coordination.FollowersChecker.FOLLOWER_CHECK_ACTION_NAME;
 import static org.elasticsearch.cluster.coordination.FollowersChecker.FOLLOWER_CHECK_INTERVAL_SETTING;
 import static org.elasticsearch.cluster.coordination.FollowersChecker.FOLLOWER_CHECK_RETRY_COUNT_SETTING;
@@ -36,7 +37,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -301,7 +301,7 @@ public class FollowersCheckerTests extends ESTestCase {
         final MockTransport mockTransport = new MockTransport() {
             @Override
             protected void onSendRequest(long requestId, String action, TransportRequest request, DiscoveryNode node) {
-                assertNotEquals(node, localNode);
+                assertThat(localNode).isNotEqualTo(node);
                 deterministicTaskQueue.scheduleNow(new Runnable() {
                     @Override
                     public void run() {

--- a/server/src/test/java/org/elasticsearch/common/unit/ByteSizeValueTest.java
+++ b/server/src/test/java/org/elasticsearch/common/unit/ByteSizeValueTest.java
@@ -1,8 +1,7 @@
 
 package org.elasticsearch.common.unit;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
@@ -10,7 +9,7 @@ public class ByteSizeValueTest {
 
     @Test
     public void test_can_print_negative_byte_values() throws Exception {
-        assertThat(ByteSizeValue.humanReadableBytes(- 283479283), is("-270.3mb"));
+        assertThat(ByteSizeValue.humanReadableBytes(- 283479283)).isEqualTo("-270.3mb");
     }
 }
 

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/ThreadContextTest.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/ThreadContextTest.java
@@ -1,7 +1,6 @@
 package org.elasticsearch.common.util.concurrent;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
@@ -18,7 +17,7 @@ public class ThreadContextTest {
         var in = out.bytes().streamInput();
         in.setVersion(Version.V_4_0_0);
         ThreadContext.bwcReadHeaders(in);
-        assertThat(in.available(), is(0));
+        assertThat(in.available()).isEqualTo(0);
     }
 
     @Test
@@ -28,6 +27,6 @@ public class ThreadContextTest {
 
         var in = out.bytes().streamInput();
         ThreadContext.bwcReadHeaders(in);
-        assertThat(in.available(), is(0));
+        assertThat(in.available()).isEqualTo(0);
     }
 }

--- a/server/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
+++ b/server/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
@@ -20,7 +20,7 @@ package org.elasticsearch.env;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.io.IOException;
 import java.nio.file.Files;

--- a/server/src/test/java/org/elasticsearch/index/IndexSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexSettingsTests.java
@@ -23,10 +23,8 @@ package org.elasticsearch.index;
 
 
 import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -291,17 +289,17 @@ public class IndexSettingsTests extends ESTestCase {
         assertThat(settings.getNumberOfShards()).isEqualTo(numShards);
         assertThat(indexValue.get()).isEqualTo(0);
 
-        assertTrue(settings.updateIndexMetadata(newIndexMeta("index", Settings.builder().
+        assertThat(settings.updateIndexMetadata(newIndexMeta("index", Settings.builder().
             put("index.foo.bar", 42)
             .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, numReplicas + 1)
-            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, numShards).build())));
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, numShards).build()))).isTrue();
 
         assertThat(indexValue.get()).isEqualTo(42);
-        assertSame(nodeSettings, settings.getNodeSettings());
+        assertThat(settings.getNodeSettings()).isSameAs(nodeSettings);
 
-        assertTrue(settings.updateIndexMetadata(newIndexMeta("index", Settings.builder()
+        assertThat(settings.updateIndexMetadata(newIndexMeta("index", Settings.builder()
             .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, numReplicas + 1)
-            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, numShards).build())));
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, numShards).build()))).isTrue();
         assertThat(indexValue.get()).isEqualTo(43);
 
     }
@@ -522,7 +520,7 @@ public class IndexSettingsTests extends ESTestCase {
                 (e, ex) -> {
                     assert false : "should not have been invoked, no invalid settings";
                 });
-        assertSame(settings, Settings.EMPTY);
+        assertThat(Settings.EMPTY).isSameAs(settings);
         settings =
             IndexScopedSettings.DEFAULT_SCOPED_SETTINGS.archiveUnknownOrInvalidSettings(
                 Settings.builder().put("index.refresh_interval", "-200").build(),
@@ -536,7 +534,7 @@ public class IndexSettingsTests extends ESTestCase {
                         "failed to parse setting [index.refresh_interval] with value [-200] as a time value: negative durations are not supported");
                 });
         assertThat(settings.get("archived.index.refresh_interval")).isEqualTo("-200");
-        assertNull(settings.get("index.refresh_interval"));
+        assertThat(settings.get("index.refresh_interval")).isNull();
 
         Settings prevSettings = settings; // no double archive
         settings =
@@ -548,7 +546,7 @@ public class IndexSettingsTests extends ESTestCase {
                 (e, ex) -> {
                     assert false : "should not have been invoked, no invalid settings";
                 });
-        assertSame(prevSettings, settings);
+        assertThat(settings).isSameAs(prevSettings);
 
         settings =
             IndexScopedSettings.DEFAULT_SCOPED_SETTINGS.archiveUnknownOrInvalidSettings(

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -20,11 +20,11 @@ package org.elasticsearch.index.shard;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
 import static org.elasticsearch.cluster.routing.TestShardRouting.newShardRouting;
 import static org.elasticsearch.common.lucene.Lucene.cleanLuceneIndex;
 import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
 import static org.elasticsearch.index.translog.Translog.UNSET_AUTO_GENERATED_TIMESTAMP;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -1954,7 +1954,7 @@ public class IndexShardTests extends IndexShardTestCase {
                         new ActionListener<>() {
                             @Override
                             public void onResponse(Releasable releasable) {
-                                fail();
+                                fail("onResponse must not be called");
                             }
 
                             @Override
@@ -2897,7 +2897,7 @@ public class IndexShardTests extends IndexShardTestCase {
 
         try {
             indexDoc(shard, "1");
-            fail();
+            fail("Index is supposed to be closed");
         } catch (AlreadyClosedException ignored) {
 
         }
@@ -2912,7 +2912,7 @@ public class IndexShardTests extends IndexShardTestCase {
 
         try {
             deleteDoc(shard, "1");
-            fail();
+            fail("Index is supposed to be closed");
         } catch (AlreadyClosedException ignored) {
 
         }

--- a/server/src/test/java/org/elasticsearch/repositories/RepositoryDataTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/RepositoryDataTests.java
@@ -22,7 +22,6 @@ package org.elasticsearch.repositories;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.elasticsearch.repositories.RepositoryData.EMPTY_REPO_GEN;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -338,9 +337,8 @@ public class RepositoryDataTests extends ESTestCase {
 
         RepositoryData newRepoData =
             repositoryData.addSnapshot(newSnapshot, SnapshotState.SUCCESS, Version.CURRENT, shardGenerations, indexLookup, newIdentifiers);
-        assertEquals(newRepoData.indexMetaDataToRemoveAfterRemovingSnapshots(Collections.singleton(newSnapshot)),
-                     newIndices.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey,
-                                                                             e -> Collections.singleton(newIdentifiers.get(e.getValue())))));
+        assertThat(newIndices.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey,
+            e -> Collections.singleton(newIdentifiers.get(e.getValue()))))).isEqualTo(newRepoData.indexMetaDataToRemoveAfterRemovingSnapshots(Collections.singleton(newSnapshot)));
         assertThat(newRepoData.indexMetaDataToRemoveAfterRemovingSnapshots(Collections.singleton(otherSnapshotId))).isEqualTo(removeFromOther);
     }
 

--- a/server/src/test/java/org/elasticsearch/snapshots/InternalSnapshotsInfoServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/InternalSnapshotsInfoServiceTests.java
@@ -26,8 +26,6 @@ import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_VERSION_CREATED;
 import static org.elasticsearch.cluster.routing.allocation.decider.ThrottlingAllocationDecider.CLUSTER_ROUTING_ALLOCATION_NODE_CONCURRENT_RECOVERIES_SETTING;
 import static org.elasticsearch.cluster.routing.allocation.decider.ThrottlingAllocationDecider.CLUSTER_ROUTING_ALLOCATION_NODE_INITIAL_PRIMARIES_RECOVERIES_SETTING;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -174,7 +172,7 @@ public class InternalSnapshotsInfoServiceTests extends ESTestCase {
 
         latch.countDown();
 
-        assertTrue(rerouteLatch.await(30L, TimeUnit.SECONDS));
+        assertThat(rerouteLatch.await(30L, TimeUnit.SECONDS)).isTrue();
         assertThat(snapshotsInfoService.numberOfKnownSnapshotShardSizes()).isEqualTo(numberOfShards);
         assertThat(snapshotsInfoService.numberOfUnknownSnapshotShardSizes()).isEqualTo(0);
         assertThat(snapshotsInfoService.numberOfFailedSnapshotShardSizes()).isEqualTo(0);
@@ -362,12 +360,12 @@ public class InternalSnapshotsInfoServiceTests extends ESTestCase {
             );
             applyClusterState("starting shards for " + indexName, clusterState ->
                     ESAllocationTestCase.startInitializingShardsAndReroute(allocationService, clusterState, indexName));
-            assertTrue(clusterService.state().routingTable().shardsWithState(ShardRoutingState.UNASSIGNED).isEmpty());
+            assertThat(clusterService.state().routingTable().shardsWithState(ShardRoutingState.UNASSIGNED).isEmpty()).isTrue();
 
         } else {
             // simulate deletion of the index
             applyClusterState("delete index " + indexName, clusterState -> deleteIndex(clusterState, indexName));
-            assertFalse(clusterService.state().metadata().hasIndex(indexName));
+            assertThat(clusterService.state().metadata().hasIndex(indexName)).isFalse();
         }
 
         assertThat(snapshotsInfoService.numberOfKnownSnapshotShardSizes()).isEqualTo(0);

--- a/server/src/test/java/org/elasticsearch/transport/InboundHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/InboundHandlerTests.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.transport;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -124,8 +123,8 @@ public class InboundHandlerTests extends ESTestCase {
         handler.inboundMessage(channel, new InboundMessage(null, true));
         if (channel.isServerChannel()) {
             ByteBuf ping = (ByteBuf) embeddedChannel.outboundMessages().poll();
-            assertEquals('E', ping.getByte(0));
-            assertEquals(6, ping.readableBytes());
+            assertThat((char) ping.getByte(0)).isEqualTo('E');
+            assertThat(ping.readableBytes()).isEqualTo(6);
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/transport/OutboundHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/OutboundHandlerTests.java
@@ -21,9 +21,6 @@ package org.elasticsearch.transport;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -155,32 +152,32 @@ public class OutboundHandlerTests extends ESTestCase {
 
         ByteBuf msg = (ByteBuf) embeddedChannel.outboundMessages().poll();
         BytesReference reference = Netty4Utils.toBytesReference(msg);
-        assertEquals(node, nodeRef.get());
-        assertEquals(requestId, requestIdRef.get());
-        assertEquals(action, actionRef.get());
-        assertEquals(request, requestRef.get());
+        assertThat(nodeRef.get()).isEqualTo(node);
+        assertThat(requestIdRef.get()).isEqualTo(requestId);
+        assertThat(actionRef.get()).isEqualTo(action);
+        assertThat(requestRef.get()).isEqualTo(request);
 
         pipeline.handleBytes(channel, new ReleasableBytesReference(reference, () -> {
         }));
         final Tuple<Header, BytesReference> tuple = message.get();
         final Header header = tuple.v1();
         final TestRequest message = new TestRequest(tuple.v2().streamInput());
-        assertEquals(version, header.getVersion());
-        assertEquals(requestId, header.getRequestId());
-        assertTrue(header.isRequest());
-        assertFalse(header.isResponse());
+        assertThat(header.getVersion()).isEqualTo(version);
+        assertThat(header.getRequestId()).isEqualTo(requestId);
+        assertThat(header.isRequest()).isTrue();
+        assertThat(header.isResponse()).isFalse();
         if (isHandshake) {
-            assertTrue(header.isHandshake());
+            assertThat(header.isHandshake()).isTrue();
         } else {
-            assertFalse(header.isHandshake());
+            assertThat(header.isHandshake()).isFalse();
         }
         if (compress) {
-            assertTrue(header.isCompressed());
+            assertThat(header.isCompressed()).isTrue();
         } else {
-            assertFalse(header.isCompressed());
+            assertThat(header.isCompressed()).isFalse();
         }
 
-        assertEquals(value, message.value);
+        assertThat(message.value).isEqualTo(value);
     }
 
     @Test
@@ -208,33 +205,33 @@ public class OutboundHandlerTests extends ESTestCase {
 
         ByteBuf msg = (ByteBuf) embeddedChannel.outboundMessages().poll();
         BytesReference reference = Netty4Utils.toBytesReference(msg);
-        assertEquals(requestId, requestIdRef.get());
-        assertEquals(action, actionRef.get());
-        assertEquals(response, responseRef.get());
+        assertThat(requestIdRef.get()).isEqualTo(requestId);
+        assertThat(actionRef.get()).isEqualTo(action);
+        assertThat(responseRef.get()).isEqualTo(response);
 
         pipeline.handleBytes(channel, new ReleasableBytesReference(reference, () -> {
         }));
         final Tuple<Header, BytesReference> tuple = message.get();
         final Header header = tuple.v1();
         final TestResponse message = new TestResponse(tuple.v2().streamInput());
-        assertEquals(version, header.getVersion());
-        assertEquals(requestId, header.getRequestId());
-        assertFalse(header.isRequest());
-        assertTrue(header.isResponse());
+        assertThat(header.getVersion()).isEqualTo(version);
+        assertThat(header.getRequestId()).isEqualTo(requestId);
+        assertThat(header.isRequest()).isFalse();
+        assertThat(header.isResponse()).isTrue();
         if (isHandshake) {
-            assertTrue(header.isHandshake());
+            assertThat(header.isHandshake()).isTrue();
         } else {
-            assertFalse(header.isHandshake());
+            assertThat(header.isHandshake()).isFalse();
         }
         if (compress) {
-            assertTrue(header.isCompressed());
+            assertThat(header.isCompressed()).isTrue();
         } else {
-            assertFalse(header.isCompressed());
+            assertThat(header.isCompressed()).isFalse();
         }
 
-        assertFalse(header.isError());
+        assertThat(header.isError()).isFalse();
 
-        assertEquals(value, message.value);
+        assertThat(message.value).isEqualTo(value);
     }
 
     @Test
@@ -259,27 +256,27 @@ public class OutboundHandlerTests extends ESTestCase {
 
         ByteBuf msg = (ByteBuf) embeddedChannel.outboundMessages().poll();
         BytesReference reference = Netty4Utils.toBytesReference(msg);
-        assertEquals(requestId, requestIdRef.get());
-        assertEquals(action, actionRef.get());
-        assertEquals(error, responseRef.get());
+        assertThat(requestIdRef.get()).isEqualTo(requestId);
+        assertThat(actionRef.get()).isEqualTo(action);
+        assertThat(responseRef.get()).isEqualTo(error);
 
 
         pipeline.handleBytes(channel, new ReleasableBytesReference(reference, () -> {
         }));
         final Tuple<Header, BytesReference> tuple = message.get();
         final Header header = tuple.v1();
-        assertEquals(version, header.getVersion());
-        assertEquals(requestId, header.getRequestId());
-        assertFalse(header.isRequest());
-        assertTrue(header.isResponse());
-        assertFalse(header.isCompressed());
-        assertFalse(header.isHandshake());
-        assertTrue(header.isError());
+        assertThat(header.getVersion()).isEqualTo(version);
+        assertThat(header.getRequestId()).isEqualTo(requestId);
+        assertThat(header.isRequest()).isFalse();
+        assertThat(header.isResponse()).isTrue();
+        assertThat(header.isCompressed()).isFalse();
+        assertThat(header.isHandshake()).isFalse();
+        assertThat(header.isError()).isTrue();
 
         RemoteTransportException remoteException = tuple.v2().streamInput().readException();
         assertThat(remoteException.getCause()).isInstanceOf(ElasticsearchException.class);
-        assertEquals(remoteException.getCause().getMessage(), "boom");
-        assertEquals(action, remoteException.action());
-        assertEquals(channel.getLocalAddress(), remoteException.address().address());
+        assertThat("boom").isEqualTo(remoteException.getCause().getMessage());
+        assertThat(remoteException.action()).isEqualTo(action);
+        assertThat(remoteException.address().address()).isEqualTo(channel.getLocalAddress());
     }
 }

--- a/server/src/test/java/org/elasticsearch/transport/TransportHandshakerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportHandshakerTests.java
@@ -19,11 +19,8 @@
 
 package org.elasticsearch.transport;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -80,7 +77,7 @@ public class TransportHandshakerTests extends ESTestCase {
 
         verify(requestSender).sendRequest(node, channel, reqId, Version.CURRENT.minimumCompatibilityVersion());
 
-        assertFalse(versionFuture.isDone());
+        assertThat(versionFuture.isDone()).isFalse();
 
         TransportHandshaker.HandshakeRequest handshakeRequest = new TransportHandshaker.HandshakeRequest(Version.CURRENT);
         BytesStreamOutput bytesStreamOutput = new BytesStreamOutput();
@@ -93,8 +90,8 @@ public class TransportHandshakerTests extends ESTestCase {
         TransportResponseHandler<TransportHandshaker.HandshakeResponse> handler = handshaker.removeHandlerForHandshake(reqId);
         handler.handleResponse((TransportHandshaker.HandshakeResponse) responseFuture.get());
 
-        assertTrue(versionFuture.isDone());
-        assertEquals(Version.CURRENT, versionFuture.get());
+        assertThat(versionFuture.isDone()).isTrue();
+        assertThat(versionFuture.get()).isEqualTo(Version.CURRENT);
     }
 
     @Test
@@ -121,16 +118,16 @@ public class TransportHandshakerTests extends ESTestCase {
         StreamInput futureHandshakeStream = futureHandshake.bytes().streamInput();
         // We check that the handshake we serialize for this test equals the actual request.
         // Otherwise, we need to update the test.
-        assertEquals(currentHandshakeBytes.bytes().length(), lengthCheckingHandshake.bytes().length());
-        assertEquals(1031, futureHandshakeStream.available());
+        assertThat(lengthCheckingHandshake.bytes().length()).isEqualTo(currentHandshakeBytes.bytes().length());
+        assertThat(futureHandshakeStream.available()).isEqualTo(1031);
         final FutureActionListener<TransportResponse> responseFuture = new FutureActionListener<>();
         final TestTransportChannel channel = new TestTransportChannel(responseFuture);
         handshaker.handleHandshake(channel, reqId, futureHandshakeStream);
-        assertEquals(0, futureHandshakeStream.available());
+        assertThat(futureHandshakeStream.available()).isEqualTo(0);
 
         TransportHandshaker.HandshakeResponse response = (TransportHandshaker.HandshakeResponse) responseFuture.get();
 
-        assertEquals(Version.CURRENT, response.getResponseVersion());
+        assertThat(response.getResponseVersion()).isEqualTo(Version.CURRENT);
     }
 
     @Test
@@ -141,12 +138,12 @@ public class TransportHandshakerTests extends ESTestCase {
 
         verify(requestSender).sendRequest(node, channel, reqId, Version.CURRENT.minimumCompatibilityVersion());
 
-        assertFalse(versionFuture.isDone());
+        assertThat(versionFuture.isDone()).isFalse();
 
         TransportResponseHandler<TransportHandshaker.HandshakeResponse> handler = handshaker.removeHandlerForHandshake(reqId);
         handler.handleException(new TransportException("failed"));
 
-        assertTrue(versionFuture.isDone());
+        assertThat(versionFuture.isDone()).isTrue();
         assertThatThrownBy(versionFuture::get)
             .cause()
             .isExactlyInstanceOf(IllegalStateException.class)
@@ -162,12 +159,12 @@ public class TransportHandshakerTests extends ESTestCase {
 
         handshaker.sendHandshake(reqId, node, channel, new TimeValue(30, TimeUnit.SECONDS), versionFuture);
 
-        assertTrue(versionFuture.isDone());
+        assertThat(versionFuture.isDone()).isTrue();
         assertThatThrownBy(versionFuture::get)
             .cause()
             .isExactlyInstanceOf(ConnectTransportException.class)
             .hasMessageContaining("failure to send internal:tcp/handshake");
-        assertNull(handshaker.removeHandlerForHandshake(reqId));
+        assertThat(handshaker.removeHandlerForHandshake(reqId)).isNull();
     }
 
     @Test
@@ -183,6 +180,6 @@ public class TransportHandshakerTests extends ESTestCase {
             .isExactlyInstanceOf(ConnectTransportException.class)
             .hasMessageContaining("handshake_timeout");
 
-        assertNull(handshaker.removeHandlerForHandshake(reqId));
+        assertThat(handshaker.removeHandlerForHandshake(reqId)).isNull();
     }
 }


### PR DESCRIPTION
Applies the recipes from https://docs.openrewrite.org/recipes/java/testing/assertj
All executed via maven. For example:

    mvn -U org.openrewrite.maven:rewrite-maven-plugin:run \
      -Drewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-testing-frameworks:RELEASE \
      -Drewrite.activeRecipes=org.openrewrite.java.testing.assertj.JUnitAssertEqualsToAssertThat