### PR TITLE
MapperService/DocumentMapperParser doesn't need a NamedXContentRegistry

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexUpgradeService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexUpgradeService.java
@@ -33,7 +33,6 @@ import org.apache.lucene.analysis.Analyzer;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.analysis.AnalyzerScope;
 import org.elasticsearch.index.analysis.IndexAnalyzers;
@@ -54,18 +53,15 @@ public class MetadataIndexUpgradeService {
     private static final Logger LOGGER = LogManager.getLogger(MetadataIndexUpgradeService.class);
 
     private final Settings settings;
-    private final NamedXContentRegistry xContentRegistry;
     private final MapperRegistry mapperRegistry;
     private final IndexScopedSettings indexScopedSettings;
     private final BiFunction<IndexMetadata, IndexTemplateMetadata, IndexMetadata> upgraders;
 
     public MetadataIndexUpgradeService(Settings settings,
-                                       NamedXContentRegistry xContentRegistry,
                                        MapperRegistry mapperRegistry,
                                        IndexScopedSettings indexScopedSettings,
                                        Collection<BiFunction<IndexMetadata, IndexTemplateMetadata, IndexMetadata>> indexMetadataUpgraders) {
         this.settings = settings;
-        this.xContentRegistry = xContentRegistry;
         this.mapperRegistry = mapperRegistry;
         this.indexScopedSettings = indexScopedSettings;
         this.upgraders = (indexMetadata, indexTemplateMetadata) -> {
@@ -169,7 +165,6 @@ public class MetadataIndexUpgradeService {
                 try (var mapperService = new MapperService(
                         indexSettings,
                         fakeIndexAnalzyers,
-                        xContentRegistry,
                         mapperRegistry)) {
                     mapperService.merge(indexMetadata, MapperService.MergeReason.MAPPING_RECOVERY);
                 }

--- a/server/src/main/java/org/elasticsearch/index/IndexModule.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexModule.java
@@ -40,7 +40,6 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.index.analysis.AnalysisRegistry;
 import org.elasticsearch.index.cache.query.DisabledQueryCache;
@@ -270,7 +269,6 @@ public final class IndexModule {
     public IndexService newIndexService(
             IndexService.IndexCreationContext indexCreationContext,
             NodeEnvironment environment,
-            NamedXContentRegistry xContentRegistry,
             IndexService.ShardStoreDeleter shardStoreDeleter,
             CircuitBreakerService circuitBreakerService,
             BigArrays bigArrays,
@@ -291,7 +289,6 @@ public final class IndexModule {
             indexSettings,
             indexCreationContext,
             environment,
-            xContentRegistry,
             shardStoreDeleter,
             analysisRegistry,
             engineFactoryProviders,
@@ -339,11 +336,10 @@ public final class IndexModule {
      * creates a new mapper service to do administrative work like mapping updates. This *should not* be used for document parsing.
      * doing so will result in an exception.
      */
-    public MapperService newIndexMapperService(NamedXContentRegistry xContentRegistry, MapperRegistry mapperRegistry) throws IOException {
+    public MapperService newIndexMapperService(MapperRegistry mapperRegistry) throws IOException {
         return new MapperService(
             indexSettings,
             analysisRegistry.build(indexSettings),
-            xContentRegistry,
             mapperRegistry
         );
     }

--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -54,7 +54,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.concurrent.AbstractAsyncTask;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
-import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.env.ShardLock;
 import org.elasticsearch.gateway.MetadataStateFormat;
@@ -114,7 +113,6 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
             IndexSettings indexSettings,
             IndexCreationContext indexCreationContext,
             NodeEnvironment nodeEnv,
-            NamedXContentRegistry xContentRegistry,
             ShardStoreDeleter shardStoreDeleter,
             AnalysisRegistry registry,
             Collection<Function<IndexSettings, Optional<EngineFactory>>> engineFactoryProviders,
@@ -137,7 +135,6 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
             this.mapperService = new MapperService(
                 indexSettings,
                 registry.build(indexSettings),
-                xContentRegistry,
                 mapperRegistry
             );
             this.queryCache = queryCache;

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapperParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapperParser.java
@@ -25,7 +25,6 @@ import java.util.Iterator;
 import java.util.Map;
 
 import org.elasticsearch.common.compress.CompressedXContent;
-import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.indices.mapper.MapperRegistry;
 
@@ -35,17 +34,14 @@ import io.crate.server.xcontent.XContentHelper;
 public class DocumentMapperParser {
 
     final MapperService mapperService;
-    private final NamedXContentRegistry xContentRegistry;
     private final RootObjectMapper.TypeParser rootObjectTypeParser = new RootObjectMapper.TypeParser();
 
     private final Map<String, Mapper.TypeParser> typeParsers;
     private final Map<String, MetadataFieldMapper.TypeParser> rootTypeParsers;
 
     public DocumentMapperParser(MapperService mapperService,
-                                NamedXContentRegistry xContentRegistry,
                                 MapperRegistry mapperRegistry) {
         this.mapperService = mapperService;
-        this.xContentRegistry = xContentRegistry;
         this.typeParsers = mapperRegistry.getMapperParsers();
         this.rootTypeParsers = mapperRegistry.getMetadataMapperParsers();
     }
@@ -158,9 +154,5 @@ public class DocumentMapperParser {
             result = root;
         }
         return result;
-    }
-
-    NamedXContentRegistry getXContentRegistry() {
-        return xContentRegistry;
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -30,6 +30,7 @@ import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexSettings;
@@ -59,7 +60,7 @@ final class DocumentParser {
         final ParseContext.InternalParseContext context;
         final XContentType xContentType = source.getXContentType();
 
-        try (XContentParser parser = XContentHelper.createParser(docMapperParser.getXContentRegistry(),
+        try (XContentParser parser = XContentHelper.createParser(NamedXContentRegistry.EMPTY,
             LoggingDeprecationHandler.INSTANCE, source.source(), xContentType)) {
             context = new ParseContext.InternalParseContext(indexSettings, docMapperParser, docMapper, source, parser);
             validateStart(parser);

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -94,14 +94,12 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
 
     public MapperService(IndexSettings indexSettings,
                          IndexAnalyzers indexAnalyzers,
-                         NamedXContentRegistry xContentRegistry,
                          MapperRegistry mapperRegistry) {
         super(indexSettings);
         this.indexAnalyzers = indexAnalyzers;
         this.fieldTypes = new FieldTypeLookup();
         this.documentParser = new DocumentMapperParser(
             this,
-            xContentRegistry,
             mapperRegistry
         );
         this.indexAnalyzer = new MapperAnalyzerWrapper(indexAnalyzers.getDefaultIndexAnalyzer(), MappedFieldType::indexAnalyzer);

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -70,7 +70,6 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.io.FileSystemUtils;
-import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
@@ -81,7 +80,6 @@ import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.common.util.concurrent.EsThreadPoolExecutor;
-import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.env.ShardLock;
 import org.elasticsearch.env.ShardLockObtainFailedException;
@@ -138,7 +136,6 @@ public class IndicesService extends AbstractLifecycleComponent
     private final ClusterService clusterService;
     private final PluginsService pluginsService;
     private final NodeEnvironment nodeEnv;
-    private final NamedXContentRegistry xContentRegistry;
     private final TimeValue shardsClosedTimeout;
     private final AnalysisRegistry analysisRegistry;
     private final IndexScopedSettings indexScopedSettings;
@@ -177,10 +174,8 @@ public class IndicesService extends AbstractLifecycleComponent
                           ClusterService clusterService,
                           PluginsService pluginsService,
                           NodeEnvironment nodeEnv,
-                          NamedXContentRegistry xContentRegistry,
                           AnalysisRegistry analysisRegistry,
                           MapperRegistry mapperRegistry,
-                          NamedWriteableRegistry namedWriteableRegistry,
                           ThreadPool threadPool,
                           IndexScopedSettings indexScopedSettings,
                           CircuitBreakerService circuitBreakerService,
@@ -194,7 +189,6 @@ public class IndicesService extends AbstractLifecycleComponent
         this.threadPool = threadPool;
         this.pluginsService = pluginsService;
         this.nodeEnv = nodeEnv;
-        this.xContentRegistry = xContentRegistry;
         this.shardsClosedTimeout = settings.getAsTime(INDICES_SHARDS_CLOSED_TIMEOUT, new TimeValue(1, TimeUnit.DAYS));
         this.analysisRegistry = analysisRegistry;
         this.indicesQueryCache = IndicesQueryCache.createCache(settings);
@@ -462,7 +456,6 @@ public class IndicesService extends AbstractLifecycleComponent
         return indexModule.newIndexService(
             indexCreationContext,
             nodeEnv,
-            xContentRegistry,
             this,
             circuitBreakerService,
             bigArrays,
@@ -482,7 +475,7 @@ public class IndicesService extends AbstractLifecycleComponent
         final IndexSettings idxSettings = new IndexSettings(indexMetadata, this.settings, indexScopedSettings);
         final IndexModule indexModule = new IndexModule(idxSettings, analysisRegistry, engineFactoryProviders, directoryFactories);
         pluginsService.onIndexModule(indexModule);
-        return indexModule.newIndexMapperService(xContentRegistry, mapperRegistry);
+        return indexModule.newIndexMapperService(mapperRegistry);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -504,10 +504,8 @@ public class Node implements Closeable {
                 clusterService,
                 pluginsService,
                 nodeEnvironment,
-                xContentRegistry,
                 analysisModule.getAnalysisRegistry(),
                 indicesModule.getMapperRegistry(),
-                namedWriteableRegistry,
                 threadPool,
                 settingsModule.getIndexScopedSettings(),
                 circuitBreakerService,
@@ -592,7 +590,6 @@ public class Node implements Closeable {
                 indexTemplateMetadataUpgraders);
             final MetadataIndexUpgradeService metadataIndexUpgradeService = new MetadataIndexUpgradeService(
                 settings,
-                xContentRegistry,
                 indicesModule.getMapperRegistry(),
                 settingsModule.getIndexScopedSettings(),
                 indexMetadataUpgraders);

--- a/server/src/test/java/io/crate/execution/ddl/tables/DropColumnTaskTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/tables/DropColumnTaskTest.java
@@ -23,17 +23,14 @@ package io.crate.execution.ddl.tables;
 
 import static io.crate.testing.Asserts.assertThat;
 import static java.util.Collections.singletonList;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 import java.util.Map;
 
 import org.elasticsearch.Version;
-import org.elasticsearch.cluster.ClusterModule;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.index.MapperTestUtils;
 import org.junit.Test;
 
@@ -310,7 +307,6 @@ public class DropColumnTaskTest extends CrateDummyClusterServiceUnitTest {
                 new PartitionName(new RelationName("doc", "parted"), singletonList(null)).asIndexName());
         DocTableInfo tbl = e.resolveTableInfo("doc.parted");
         var dropColumnTask = new AlterTableTask<>(e.nodeCtx, imd -> MapperTestUtils.newMapperService(
-            new NamedXContentRegistry(ClusterModule.getNamedXWriteables()),
             createTempDir(),
             Settings.EMPTY,
             "doc.parted"),

--- a/server/src/test/java/io/crate/execution/ddl/tables/RenameColumnTaskTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/tables/RenameColumnTaskTest.java
@@ -22,16 +22,13 @@
 package io.crate.execution.ddl.tables;
 
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 
 import org.elasticsearch.Version;
-import org.elasticsearch.cluster.ClusterModule;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.index.MapperTestUtils;
 import org.junit.Test;
 
@@ -130,7 +127,6 @@ public class RenameColumnTaskTest extends CrateDummyClusterServiceUnitTest {
                 new PartitionName(new RelationName("doc", "tbl"), List.of("3", "4")).asIndexName());
         DocTableInfo tbl = e.resolveTableInfo("doc.tbl");
         var renameColumnTask = new AlterTableTask<>(e.nodeCtx, imd -> MapperTestUtils.newMapperService(
-            new NamedXContentRegistry(ClusterModule.getNamedXWriteables()),
             createTempDir(),
             Settings.EMPTY,
             "doc.tbl"),

--- a/server/src/test/java/io/crate/metadata/doc/mappers/KeywordFieldMapperTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/mappers/KeywordFieldMapperTest.java
@@ -30,7 +30,6 @@ import java.util.List;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.MapperTestUtils;
 import org.elasticsearch.index.mapper.DocumentMapperParser;
@@ -47,7 +46,6 @@ public class KeywordFieldMapperTest extends CrateDummyClusterServiceUnitTest {
 
     private static DocumentMapperParser parser() throws IOException {
         MapperService mapperService = MapperTestUtils.newMapperService(
-            NamedXContentRegistry.EMPTY,
             createTempDir(),
             Settings.EMPTY,
             new IndicesModule(List.of()),

--- a/server/src/test/java/io/crate/metadata/doc/mappers/array/ArrayMapperTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/mappers/array/ArrayMapperTest.java
@@ -42,7 +42,6 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentType;
@@ -78,7 +77,6 @@ public class ArrayMapperTest extends CrateDummyClusterServiceUnitTest {
     public static DocumentMapper mapper(String indexName, String mapping) throws IOException {
         IndicesModule indicesModule = new IndicesModule(List.of());
         MapperService mapperService = MapperTestUtils.newMapperService(
-            NamedXContentRegistry.EMPTY,
             createTempDir(),
             Settings.EMPTY,
             indicesModule,

--- a/server/src/test/java/org/elasticsearch/gateway/GatewayMetaStateTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/GatewayMetaStateTests.java
@@ -208,7 +208,7 @@ public class GatewayMetaStateTests extends ESTestCase {
         private final boolean upgrade;
 
         public MockMetadataIndexUpgradeService(boolean upgrade) {
-            super(Settings.EMPTY, null, null, null, null);
+            super(Settings.EMPTY, null, null, null);
             this.upgrade = upgrade;
         }
 

--- a/server/src/test/java/org/elasticsearch/index/engine/LuceneChangesSnapshotTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/LuceneChangesSnapshotTests.java
@@ -240,7 +240,7 @@ public class LuceneChangesSnapshotTests extends EngineTestCase {
             this.leader = leader;
             this.isDone = isDone;
             this.readLatch = readLatch;
-            this.translogHandler = new TranslogHandler(xContentRegistry(), IndexSettingsModule.newIndexSettings(shardId.getIndexName(),
+            this.translogHandler = new TranslogHandler(IndexSettingsModule.newIndexSettings(shardId.getIndexName(),
                                                                                                                 leader.engineConfig.getIndexSettings().getSettings()));
             this.engine = createEngine(createStore(), createTempDir());
         }

--- a/server/src/test/java/org/elasticsearch/index/engine/ReadOnlyEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/ReadOnlyEngineTests.java
@@ -318,7 +318,7 @@ public class ReadOnlyEngineTests extends EngineTestCase {
                 engine.flushAndClose();
             }
             try (ReadOnlyEngine readOnlyEngine = new ReadOnlyEngine(config, null, null, true, UnaryOperator.identity(), true)) {
-                TranslogHandler translogHandler = new TranslogHandler(xContentRegistry(), config.getIndexSettings());
+                TranslogHandler translogHandler = new TranslogHandler(config.getIndexSettings());
                 readOnlyEngine.recoverFromTranslog(translogHandler, randomNonNegativeLong());
                 int opsRecovered = translogHandler.run(
                     readOnlyEngine,

--- a/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
+++ b/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
@@ -516,7 +516,6 @@ public abstract class AggregationTestCase extends ESTestCase {
             new DummyShardLock(shardPath.getShardId())
         );
         var mapperService = MapperTestUtils.newMapperService(
-            DEFAULT_NAMED_X_CONTENT_REGISTRY,
             createTempDir(),
             indexSettings.getSettings(),
             routing.getIndexName()

--- a/server/src/testFixtures/java/io/crate/testing/IndexEnv.java
+++ b/server/src/testFixtures/java/io/crate/testing/IndexEnv.java
@@ -39,7 +39,6 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.env.ShardLock;
@@ -98,7 +97,6 @@ public final class IndexEnv implements AutoCloseable {
         mapperService = new MapperService(
             idxSettings,
             indexAnalyzers,
-            NamedXContentRegistry.EMPTY,
             mapperRegistry
         );
         IndexMetadata indexMetadata = clusterState.metadata().index(indexName);
@@ -117,7 +115,6 @@ public final class IndexEnv implements AutoCloseable {
         indexService = indexModule.newIndexService(
             IndexCreationContext.CREATE_INDEX,
             nodeEnvironment,
-            NamedXContentRegistry.EMPTY,
             new IndexService.ShardStoreDeleter() {
                 @Override
                 public void deleteShardStore(String reason, ShardLock lock, IndexSettings indexSettings) throws IOException {

--- a/server/src/testFixtures/java/org/elasticsearch/index/MapperTestUtils.java
+++ b/server/src/testFixtures/java/org/elasticsearch/index/MapperTestUtils.java
@@ -21,10 +21,15 @@
 
 package org.elasticsearch.index;
 
+import static org.elasticsearch.test.ESTestCase.createTestAnalysis;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collections;
+
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.analysis.IndexAnalyzers;
 import org.elasticsearch.index.mapper.MapperService;
@@ -32,24 +37,17 @@ import org.elasticsearch.indices.IndicesModule;
 import org.elasticsearch.indices.mapper.MapperRegistry;
 import org.elasticsearch.test.IndexSettingsModule;
 
-import java.io.IOException;
-import java.nio.file.Path;
-import java.util.Collections;
-
-import static org.elasticsearch.test.ESTestCase.createTestAnalysis;
-
 
 public class MapperTestUtils {
 
-    public static MapperService newMapperService(NamedXContentRegistry xContentRegistry,
-                                                 Path tempDir,
+    public static MapperService newMapperService(Path tempDir,
                                                  Settings indexSettings,
                                                  String indexName) throws IOException {
         IndicesModule indicesModule = new IndicesModule(Collections.emptyList());
-        return newMapperService(xContentRegistry, tempDir, indexSettings, indicesModule, indexName);
+        return newMapperService(tempDir, indexSettings, indicesModule, indexName);
     }
 
-    public static MapperService newMapperService(NamedXContentRegistry xContentRegistry, Path tempDir, Settings settings,
+    public static MapperService newMapperService(Path tempDir, Settings settings,
                                                  IndicesModule indicesModule, String indexName) throws IOException {
         Settings.Builder settingsBuilder = Settings.builder()
             .put(Environment.PATH_HOME_SETTING.getKey(), tempDir)
@@ -64,7 +62,6 @@ public class MapperTestUtils {
         return new MapperService(
             indexSettings,
             indexAnalyzers,
-            xContentRegistry,
             mapperRegistry
         );
     }

--- a/server/src/testFixtures/java/org/elasticsearch/index/engine/EngineTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/index/engine/EngineTestCase.java
@@ -86,7 +86,6 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.Bits;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.Version;
-import org.elasticsearch.cluster.ClusterModule;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.routing.AllocationId;
 import org.elasticsearch.common.Randomness;
@@ -96,7 +95,6 @@ import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.lucene.uid.Versions;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.MapperTestUtils;
@@ -428,7 +426,7 @@ public abstract class EngineTestCase extends ESTestCase {
     }
 
     protected TranslogHandler createTranslogHandler(IndexSettings indexSettings) {
-        return new TranslogHandler(xContentRegistry(), indexSettings);
+        return new TranslogHandler(indexSettings);
     }
 
     protected InternalEngine createEngine(Store store, Path translogPath) throws IOException {
@@ -1276,7 +1274,7 @@ public abstract class EngineTestCase extends ESTestCase {
                 .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1))
             .putMapping("{\"properties\": {}}")
             .build();
-        MapperService mapperService = MapperTestUtils.newMapperService(new NamedXContentRegistry(ClusterModule.getNamedXWriteables()),
+        MapperService mapperService = MapperTestUtils.newMapperService(
             createTempDir(), Settings.EMPTY, "test");
         mapperService.merge(indexMetadata, MapperService.MergeReason.MAPPING_UPDATE);
         return mapperService;

--- a/server/src/testFixtures/java/org/elasticsearch/index/engine/TranslogHandler.java
+++ b/server/src/testFixtures/java/org/elasticsearch/index/engine/TranslogHandler.java
@@ -25,7 +25,6 @@ import static java.util.Collections.emptyMap;
 import java.io.IOException;
 
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
-import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.analysis.AnalyzerScope;
@@ -47,12 +46,12 @@ public class TranslogHandler implements Engine.TranslogRecoveryRunner {
 
     private final MapperService mapperService;
 
-    public TranslogHandler(NamedXContentRegistry xContentRegistry, IndexSettings indexSettings) {
+    public TranslogHandler(IndexSettings indexSettings) {
         NamedAnalyzer defaultAnalyzer = new NamedAnalyzer("default", AnalyzerScope.INDEX, new StandardAnalyzer());
         IndexAnalyzers indexAnalyzers =
                 new IndexAnalyzers(indexSettings, defaultAnalyzer, defaultAnalyzer, defaultAnalyzer, emptyMap(), emptyMap(), emptyMap());
         MapperRegistry mapperRegistry = new IndicesModule(emptyList()).getMapperRegistry();
-        mapperService = new MapperService(indexSettings, indexAnalyzers, xContentRegistry, mapperRegistry);
+        mapperService = new MapperService(indexSettings, indexAnalyzers, mapperRegistry);
     }
 
     private DocumentMapper docMapper(String type) {

--- a/server/src/testFixtures/java/org/elasticsearch/index/shard/IndexShardTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/index/shard/IndexShardTestCase.java
@@ -513,7 +513,6 @@ public abstract class IndexShardTestCase extends ESTestCase {
         try {
             var queryCache = DisabledQueryCache.instance();
             MapperService mapperService = MapperTestUtils.newMapperService(
-                xContentRegistry(),
                 createTempDir(),
                 indexSettings.getSettings(),
                 "index"


### PR DESCRIPTION
NamedXContent is a way of parsing custom objects from xcontent that
we use in places like the cluster state persistence layer.  In the MapperService
it allows plugins to register their own mapping types with custom xcontent
representations, but this isn't used anywhere in Crate, so we can just pass
an empty registry when building mapping parsers.