### PR TITLE
Remove join on top of lookup-join when only one side is retrieved 

### DIFF
--- a/server/src/main/java/io/crate/planner/operators/AbstractJoinPlan.java
+++ b/server/src/main/java/io/crate/planner/operators/AbstractJoinPlan.java
@@ -48,15 +48,30 @@ public abstract class AbstractJoinPlan implements LogicalPlan {
     @Nullable
     protected final Symbol joinCondition;
     protected final JoinType joinType;
+    protected final LookUpJoin lookupJoin;
+
+    public enum LookUpJoin {
+        LEFT, RIGHT, NONE;
+
+        public LookUpJoin invert() {
+            return switch (this) {
+                case LEFT -> RIGHT;
+                case RIGHT -> LEFT;
+                case NONE -> NONE;
+            };
+        }
+    }
 
     protected AbstractJoinPlan(LogicalPlan lhs,
                                LogicalPlan rhs,
                                @Nullable Symbol joinCondition,
-                               JoinType joinType) {
+                               JoinType joinType,
+                               LookUpJoin lookupJoin) {
         this.lhs = lhs;
         this.rhs = rhs;
         this.joinCondition = joinCondition;
         this.joinType = joinType;
+        this.lookupJoin = lookupJoin;
     }
 
     public LogicalPlan lhs() {
@@ -65,6 +80,10 @@ public abstract class AbstractJoinPlan implements LogicalPlan {
 
     public LogicalPlan rhs() {
         return rhs;
+    }
+
+    public LookUpJoin lookUpJoin() {
+        return lookupJoin;
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/operators/JoinPlan.java
+++ b/server/src/main/java/io/crate/planner/operators/JoinPlan.java
@@ -53,8 +53,9 @@ public class JoinPlan extends AbstractJoinPlan {
                     @Nullable Symbol joinCondition,
                     boolean isFiltered,
                     boolean rewriteFilterOnOuterJoinToInnerJoinDone,
-                    boolean lookUpJoinRuleApplied) {
-        this(lhs, rhs, joinType, joinCondition, isFiltered, rewriteFilterOnOuterJoinToInnerJoinDone, lookUpJoinRuleApplied, false);
+                    boolean lookUpJoinRuleApplied,
+                    LookUpJoin lookUpJoin) {
+        this(lhs, rhs, joinType, joinCondition, isFiltered, rewriteFilterOnOuterJoinToInnerJoinDone, lookUpJoinRuleApplied, false, lookUpJoin);
     }
 
     @VisibleForTesting
@@ -62,18 +63,19 @@ public class JoinPlan extends AbstractJoinPlan {
                     LogicalPlan rhs,
                     JoinType joinType,
                     @Nullable Symbol joinCondition) {
-        this(lhs, rhs, joinType, joinCondition, false, false, false, false);
+        this(lhs, rhs, joinType, joinCondition, false, false, false, false, LookUpJoin.NONE);
     }
 
     private JoinPlan(LogicalPlan lhs,
-                    LogicalPlan rhs,
-                    JoinType joinType,
-                    @Nullable Symbol joinCondition,
-                    boolean isFiltered,
-                    boolean rewriteFilterOnOuterJoinToInnerJoinDone,
-                    boolean lookUpJoinRuleApplied,
-                    boolean moveConstantJoinConditionRuleApplied) {
-        super(lhs, rhs, joinCondition, joinType);
+                     LogicalPlan rhs,
+                     JoinType joinType,
+                     @Nullable Symbol joinCondition,
+                     boolean isFiltered,
+                     boolean rewriteFilterOnOuterJoinToInnerJoinDone,
+                     boolean lookUpJoinRuleApplied,
+                     boolean moveConstantJoinConditionRuleApplied,
+                     LookUpJoin lookUpJoin) {
+        super(lhs, rhs, joinCondition, joinType, lookUpJoin);
         this.isFiltered = isFiltered;
         this.rewriteFilterOnOuterJoinToInnerJoinDone = rewriteFilterOnOuterJoinToInnerJoinDone;
         this.lookUpJoinRuleApplied = lookUpJoinRuleApplied;
@@ -105,7 +107,9 @@ public class JoinPlan extends AbstractJoinPlan {
             isFiltered,
             rewriteFilterOnOuterJoinToInnerJoinDone,
             lookUpJoinRuleApplied,
-            moveConstantJoinConditionRuleApplied);
+            moveConstantJoinConditionRuleApplied,
+            lookupJoin
+        );
     }
 
     @Override
@@ -153,7 +157,8 @@ public class JoinPlan extends AbstractJoinPlan {
             isFiltered,
             rewriteFilterOnOuterJoinToInnerJoinDone,
             lookUpJoinRuleApplied,
-            moveConstantJoinConditionRuleApplied
+            moveConstantJoinConditionRuleApplied,
+            lookupJoin
         );
     }
 
@@ -182,7 +187,8 @@ public class JoinPlan extends AbstractJoinPlan {
             isFiltered,
             rewriteFilterOnOuterJoinToInnerJoinDone,
             lookUpJoinRuleApplied,
-            moveConstantJoinConditionRuleApplied
+            moveConstantJoinConditionRuleApplied,
+            lookupJoin
         );
     }
 }

--- a/server/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
+++ b/server/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
@@ -128,7 +128,8 @@ public class JoinPlanBuilder {
             validJoinConditions,
             isFiltered,
             false,
-            false);
+            false,
+            AbstractJoinPlan.LookUpJoin.NONE);
 
         joinPlan = Filter.create(joinPlan, validWhereConditions);
         while (it.hasNext()) {
@@ -243,7 +244,9 @@ public class JoinPlanBuilder {
             AndOperator.join(conditions, null),
             isFiltered,
             false,
-            false);
+            false,
+            AbstractJoinPlan.LookUpJoin.NONE
+        );
         return Filter.create(joinPlan, query);
     }
 

--- a/server/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
@@ -72,7 +72,7 @@ public class NestedLoopJoin extends AbstractJoinPlan {
                    JoinType joinType,
                    @Nullable Symbol joinCondition,
                    boolean isFiltered) {
-        super(lhs, rhs, joinCondition, joinType);
+        super(lhs, rhs, joinCondition, joinType, LookUpJoin.NONE);
         this.isFiltered = isFiltered || joinCondition != null;
     }
 
@@ -82,8 +82,10 @@ public class NestedLoopJoin extends AbstractJoinPlan {
                           @Nullable Symbol joinCondition,
                           boolean isFiltered,
                           boolean orderByWasPushedDown,
-                          boolean rewriteEquiJoinToHashJoinDone) {
-        this(lhs, rhs, joinType, joinCondition, isFiltered);
+                          boolean rewriteEquiJoinToHashJoinDone,
+                          LookUpJoin lookUpJoin) {
+        super(lhs, rhs,joinCondition, joinType, lookUpJoin);
+        this.isFiltered = isFiltered || joinCondition != null;
         this.orderByWasPushedDown = orderByWasPushedDown;
         this.rewriteNestedLoopJoinToHashJoinDone = rewriteEquiJoinToHashJoinDone;
     }
@@ -213,7 +215,8 @@ public class NestedLoopJoin extends AbstractJoinPlan {
             joinCondition,
             isFiltered,
             orderByWasPushedDown,
-            rewriteNestedLoopJoinToHashJoinDone
+            rewriteNestedLoopJoinToHashJoinDone,
+            lookupJoin
         );
     }
 
@@ -225,9 +228,20 @@ public class NestedLoopJoin extends AbstractJoinPlan {
             SymbolVisitors.intersection(outputToKeep, lhs.outputs(), lhsToKeep::add);
             SymbolVisitors.intersection(outputToKeep, rhs.outputs(), rhsToKeep::add);
         }
+
         if (joinCondition != null) {
-            SymbolVisitors.intersection(joinCondition, lhs.outputs(), lhsToKeep::add);
-            SymbolVisitors.intersection(joinCondition, rhs.outputs(), rhsToKeep::add);
+            // If there a lookup-join in place, and the outputs belong only to the lookup side,
+            // we can drop the join and return only the lookup-side
+            if (lhsToKeep.isEmpty() && lookupJoin == LookUpJoin.RIGHT) {
+                SymbolVisitors.intersection(joinCondition, rhs.outputs(), rhsToKeep::add);
+                return rhs.pruneOutputsExcept(rhsToKeep);
+            } else if (rhsToKeep.isEmpty() && lookupJoin == LookUpJoin.LEFT) {
+                SymbolVisitors.intersection(joinCondition, lhs.outputs(), lhsToKeep::add);
+                return lhs.pruneOutputsExcept(lhsToKeep);
+            } else {
+                SymbolVisitors.intersection(joinCondition, lhs.outputs(), lhsToKeep::add);
+                SymbolVisitors.intersection(joinCondition, rhs.outputs(), rhsToKeep::add);
+            }
         }
         LogicalPlan newLhs = lhs.pruneOutputsExcept(lhsToKeep);
         LogicalPlan newRhs = rhs.pruneOutputsExcept(rhsToKeep);
@@ -241,7 +255,8 @@ public class NestedLoopJoin extends AbstractJoinPlan {
             joinCondition,
             isFiltered,
             orderByWasPushedDown,
-            rewriteNestedLoopJoinToHashJoinDone
+            rewriteNestedLoopJoinToHashJoinDone,
+            lookupJoin
         );
     }
 
@@ -275,7 +290,8 @@ public class NestedLoopJoin extends AbstractJoinPlan {
                 joinCondition,
                 isFiltered,
                 orderByWasPushedDown,
-                rewriteNestedLoopJoinToHashJoinDone
+                rewriteNestedLoopJoinToHashJoinDone,
+                lookupJoin
             )
         );
     }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/EliminateCrossJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/EliminateCrossJoin.java
@@ -39,6 +39,7 @@ import io.crate.expression.operator.EqOperator;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
+import io.crate.planner.operators.AbstractJoinPlan;
 import io.crate.planner.operators.Eval;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.JoinPlan;
@@ -180,7 +181,8 @@ public class EliminateCrossJoin implements Rule<JoinPlan> {
                 AndOperator.join(criteria, null),
                 false,
                 false,
-                false
+                false,
+                AbstractJoinPlan.LookUpJoin.NONE
             );
         }
 

--- a/server/src/main/java/io/crate/planner/optimizer/rule/EquiJoinToLookupJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/EquiJoinToLookupJoin.java
@@ -36,6 +36,7 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.TransactionContext;
+import io.crate.planner.operators.AbstractJoinPlan;
 import io.crate.planner.operators.EquiJoinDetector;
 import io.crate.planner.operators.Eval;
 import io.crate.planner.operators.Filter;
@@ -134,13 +135,16 @@ public class EquiJoinToLookupJoin implements Rule<JoinPlan> {
 
         LogicalPlan newLhs;
         LogicalPlan newRhs;
+        AbstractJoinPlan.LookUpJoin lookUpJoin;
 
         if (rhsIsLarger) {
             newLhs = lhs;
             newRhs = lookupJoin;
+            lookUpJoin = AbstractJoinPlan.LookUpJoin.RIGHT;
         } else {
             newLhs = lookupJoin;
             newRhs = rhs;
+            lookUpJoin = AbstractJoinPlan.LookUpJoin.LEFT;
         }
 
         return new JoinPlan(
@@ -150,7 +154,8 @@ public class EquiJoinToLookupJoin implements Rule<JoinPlan> {
             plan.joinCondition(),
             plan.isFiltered(),
             plan.isRewriteFilterOnOuterJoinToInnerJoinDone(),
-            true
+            plan.moveConstantJoinConditionRuleApplied(),
+            lookUpJoin
         );
     }
 

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathJoin.java
@@ -102,7 +102,8 @@ public class MoveConstantJoinConditionsBeneathJoin implements Rule<JoinPlan> {
                 AndOperator.join(nonConstantConditions),
                 joinPlan.isFiltered(),
                 joinPlan.isRewriteFilterOnOuterJoinToInnerJoinDone(),
-                joinPlan.isLookUpJoinRuleApplied()
+                joinPlan.isLookUpJoinRuleApplied(),
+                joinPlan.lookUpJoin()
             );
         }
         return joinPlan.withMoveConstantJoinConditionRuleApplied(true);

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathNestedLoop.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveOrderBeneathNestedLoop.java
@@ -40,6 +40,7 @@ import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.TransactionContext;
+import io.crate.planner.operators.AbstractJoinPlan;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.operators.NestedLoopJoin;
 import io.crate.planner.operators.Order;
@@ -107,7 +108,8 @@ public final class MoveOrderBeneathNestedLoop implements Rule<Order> {
                     nestedLoop.joinCondition(),
                     nestedLoop.isFiltered(),
                     true,
-                    nestedLoop.isRewriteNestedLoopJoinToHashJoinDone()
+                    nestedLoop.isRewriteNestedLoopJoinToHashJoinDone(),
+                    AbstractJoinPlan.LookUpJoin.NONE
                 );
             }
         }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/ReorderHashJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/ReorderHashJoin.java
@@ -63,7 +63,8 @@ public class ReorderHashJoin implements Rule<HashJoin> {
                 new HashJoin(
                     plan.rhs(),
                     plan.lhs(),
-                    plan.joinCondition()
+                    plan.joinCondition(),
+                    plan.lookUpJoin().invert()
                 ),
                 plan.outputs()
             );

--- a/server/src/main/java/io/crate/planner/optimizer/rule/ReorderNestedLoopJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/ReorderNestedLoopJoin.java
@@ -70,7 +70,8 @@ public class ReorderNestedLoopJoin implements Rule<NestedLoopJoin> {
                         nestedLoop.joinCondition(),
                         nestedLoop.isFiltered(),
                         nestedLoop.orderByWasPushedDown(),
-                        nestedLoop.isRewriteNestedLoopJoinToHashJoinDone()
+                        nestedLoop.isRewriteNestedLoopJoinToHashJoinDone(),
+                        nestedLoop.lookUpJoin().invert()
                     ),
                     nestedLoop.outputs());
             }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnOuterJoinToInnerJoin.java
@@ -249,7 +249,8 @@ public final class RewriteFilterOnOuterJoinToInnerJoin implements Rule<Filter> {
             join.joinCondition(),
             join.isFiltered(),
             true,
-            join.isLookUpJoinRuleApplied()
+            join.isLookUpJoinRuleApplied(),
+            join.lookUpJoin()
         );
         assert newJoin.outputs().equals(join.outputs()) : "Outputs after rewrite must be the same as before";
         return splitQueries.isEmpty() ? newJoin : new Filter(newJoin, AndOperator.join(splitQueries.values()));

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteJoinPlan.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteJoinPlan.java
@@ -66,7 +66,8 @@ public class RewriteJoinPlan implements Rule<JoinPlan> {
             return new HashJoin(
                 join.lhs(),
                 join.rhs(),
-                join.joinCondition()
+                join.joinCondition(),
+                join.lookUpJoin()
             );
         } else {
             return new NestedLoopJoin(
@@ -76,7 +77,8 @@ public class RewriteJoinPlan implements Rule<JoinPlan> {
                 join.joinCondition(),
                 join.isFiltered(),
                 false,
-                false
+                false,
+                join.lookUpJoin()
             );
         }
     }

--- a/server/src/test/java/io/crate/planner/optimizer/costs/PlanStatsTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/costs/PlanStatsTest.java
@@ -38,6 +38,7 @@ import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.doc.DocTableInfo;
+import io.crate.planner.operators.AbstractJoinPlan;
 import io.crate.planner.operators.Collect;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.HashJoin;
@@ -250,8 +251,7 @@ public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
             )
         );
 
-        var nestedLoopJoin = new NestedLoopJoin(
-            lhs, rhs, JoinType.INNER, Literal.BOOLEAN_TRUE, false, false, false);
+        var nestedLoopJoin = new NestedLoopJoin(lhs, rhs, JoinType.INNER, Literal.BOOLEAN_TRUE, false, false, false, AbstractJoinPlan.LookUpJoin.NONE);
 
         var memo = new Memo(nestedLoopJoin);
         PlanStats planStats = new PlanStats(nodeContext, txnCtx, tableStats, memo);
@@ -261,14 +261,12 @@ public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
         assertThat(result.sizeInBytes()).isEqualTo(288L);
 
         var joinCondition = e.asSymbol("x = y");
-        nestedLoopJoin = new NestedLoopJoin(
-            lhs, rhs, JoinType.INNER, joinCondition, false, false, false);
+        nestedLoopJoin = new NestedLoopJoin(lhs, rhs, JoinType.INNER, joinCondition, false, false, false, AbstractJoinPlan.LookUpJoin.NONE);
         result = planStats.get(nestedLoopJoin);
         assertThat(result.numDocs()).isEqualTo(1L);
         assertThat(result.sizeInBytes()).isEqualTo(32L);
 
-        nestedLoopJoin = new NestedLoopJoin(
-            lhs, rhs, JoinType.CROSS, x, false, false, false);
+        nestedLoopJoin = new NestedLoopJoin(lhs, rhs, JoinType.CROSS, x, false, false, false, AbstractJoinPlan.LookUpJoin.NONE);
 
         memo = new Memo(nestedLoopJoin);
         planStats = new PlanStats(nodeContext, txnCtx, tableStats, memo);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This is a follow-up for the lookup-join optimization. The Hash/Nestedloop Join operator can be dropped where there is a lookup-join optimization in place and the operators on top of the join reference only the larger table of the join. This happens as part of the column-pruning logic in the Join Operators because the referenced outputs are needed to make this optimization possible.

Assume the following query:

```
explain select count(t1.a) from doc.t1 join doc.t2 on t1.id = t2.id;
```

```
HashAggregate[count(a)] 
 └ HashJoin[(id = id)]
   ├ MultiPhase
   │  └ Collect[doc.t1 | [a, id] | (id = ANY((doc.t2)))]
   │  └ Collect[doc.t2 | [id] | true]
   └ Collect[doc.t2 | [id] | true]
```
becomes:

```
 HashAggregate[count(a)]                               
   └ MultiPhase                                   
     └ Collect[doc.t1 | [a, id] | (id = ANY((doc.t2)))] 
     └ Collect[doc.t2 | [id] | true]            

```

```
Q: select count(t1.a) from doc.t1 join doc.t2 on t1.id = t2.id
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |       45.073 ±   27.470 |     40.679 |     41.745 |     42.544 |    315.736 |
|   V2    |       31.856 ±   26.484 |     27.489 |     28.419 |     29.175 |    292.208 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  34.36%                           -  37.99%
There is a 99.93% probability that the observed difference is not random, and the best estimate of that difference is 34.36%
The test has statistical significance
```


Resolves https://github.com/crate/crate/issues/15003

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
