### PR TITLE
Make Table/index resolving strict to prevent resolving _all

### DIFF
--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
@@ -411,17 +411,7 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
         if (!isPartitioned) {
             IndexMetadata index = metadata.index(ident.indexNameOrAlias());
             if (index == null) {
-                if (concreteIndices.length > 0) {
-                    index = metadata.index(concreteIndices[0]);
-                    LOGGER.info(
-                        "Found indices={} for relation={} without index template. Orphaned partition?",
-                        concreteIndices,
-                        ident
-                    );
-                }
-                if (index == null) {
-                    throw new RelationUnknown(ident);
-                }
+                throw new RelationUnknown(ident);
             }
             if (concreteIndices.length == 0) {
                 throw new RelationUnknown(ident);

--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfoFactory.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfoFactory.java
@@ -138,17 +138,7 @@ public class DocTableInfoFactory {
         if (indexTemplateMetadata == null) {
             IndexMetadata index = metadata.index(relation.indexNameOrAlias());
             if (index == null) {
-                if (concreteIndices.length > 0) {
-                    index = metadata.index(concreteIndices[0]);
-                    LOGGER.info(
-                        "Found indices={} for relation={} without index template. Orphaned partition?",
-                        concreteIndices,
-                        relation
-                    );
-                }
-                if (index == null) {
-                    throw new RelationUnknown(relation);
-                }
+                throw new RelationUnknown(relation);
             }
             tableParameters = index.getSettings();
             versionCreated = IndexMetadata.SETTING_INDEX_VERSION_CREATED.get(tableParameters);

--- a/server/src/test/java/io/crate/planner/DeletePlannerTest.java
+++ b/server/src/test/java/io/crate/planner/DeletePlannerTest.java
@@ -24,6 +24,7 @@ package io.crate.planner;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.exactlyInstanceOf;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.util.List;
@@ -36,6 +37,7 @@ import org.junit.Test;
 
 import io.crate.analyze.TableDefinitions;
 import io.crate.data.Row;
+import io.crate.exceptions.RelationUnknown;
 import io.crate.exceptions.VersioningValidationException;
 import io.crate.expression.symbol.ParameterSymbol;
 import io.crate.expression.symbol.Symbol;
@@ -112,5 +114,11 @@ public class DeletePlannerTest extends CrateDummyClusterServiceUnitTest {
         Assertions.assertThatThrownBy(() -> e.plan("delete from users where id = 1 and _seq_no = 11"))
             .isExactlyInstanceOf(VersioningValidationException.class)
             .hasMessageContaining(VersioningValidationException.SEQ_NO_AND_PRIMARY_TERM_USAGE_MSG);
+    }
+
+    @Test
+    public void test_cannot_delete_from__all() throws Exception {
+        assertThatThrownBy(() -> e.plan("delete from _all"))
+            .isExactlyInstanceOf(RelationUnknown.class);
     }
 }


### PR DESCRIPTION
Follow up to https://github.com/crate/crate/pull/15931
`delete from _all` could also resolve to all indices, even without
having a `_all` table.

The logic to resolve a table name to indices was lenient to account for
orphaned partitions.
Orphaned partitions could happen in the past because dropping a table
wasn't an atomic operation that dropped both template and indices, but
instead it was two separate operations where dropping the template could
succeed, but dropping the indices fail.

We've fixed that a long time ago and you cannot end up with orphaned
partitions anymore using SQL, so we can make it strict.

See https://github.com/crate/crate/pull/6032
