### PR TITLE
Fix an issue with Session job IDs

### DIFF
--- a/docs/appendices/release-notes/5.6.5.rst
+++ b/docs/appendices/release-notes/5.6.5.rst
@@ -47,6 +47,10 @@ See the :ref:`version_5.6.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that could result in completed jobs to not be marked with an
+  ``ended`` timestamp and be moved to ``sys.jobs_log``, but stay "forever"
+  (until node restart) in :ref:`sys-jobs` table.
+
 - Fixed an issue that allowed creating tables named ``_all``, which is a
   reversed name that has special effects - like expanding to *all* table names.
   Because of these special semantics, statements like ``DROP TABLE _all`` would

--- a/docs/appendices/release-notes/5.7.1.rst
+++ b/docs/appendices/release-notes/5.7.1.rst
@@ -46,6 +46,10 @@ See the :ref:`version_5.7.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that could result in completed jobs to not be marked with an
+  ``ended`` timestamp and be moved to ``sys.jobs_log``, but stay "forever"
+  (until node restart) in :ref:`sys-jobs` table.
+
 - Fixed an issue that allowed creating tables named ``_all``, which is a
   reversed name that has special effects - like expanding to *all* table names.
   Because of these special semantics, statements like ``DROP TABLE _all`` would

--- a/server/src/main/java/io/crate/action/sql/Session.java
+++ b/server/src/main/java/io/crate/action/sql/Session.java
@@ -422,13 +422,11 @@ public class Session implements AutoCloseable {
     }
 
     @Nullable
-    @SuppressWarnings("unchecked")
     private RelationInfo resolveTableFromSelect(AnalyzedStatement stmt) {
         // See description of {@link DescribeResult#relation()}
         // It is only populated if it is a SELECT on a single table
-        if (stmt instanceof QueriedSelectRelation) {
-            var relation = ((QueriedSelectRelation) stmt);
-            List<AnalyzedRelation> from = relation.from();
+        if (stmt instanceof QueriedSelectRelation qsr) {
+            List<AnalyzedRelation> from = qsr.from();
             if (from.size() == 1 && from.get(0) instanceof AbstractTableRelation) {
                 return ((AbstractTableRelation<? extends TableInfo>) from.get(0)).tableInfo();
             }
@@ -461,8 +459,8 @@ public class Session implements AutoCloseable {
             cursors.close(cursor -> cursor.hold() == Hold.WITHOUT);
             resultReceiver.allFinished();
             return resultReceiver.completionFuture();
-        } else if (analyzedStmt instanceof AnalyzedDeallocate) {
-            String stmtToDeallocate = ((AnalyzedDeallocate) analyzedStmt).preparedStmtName();
+        } else if (analyzedStmt instanceof AnalyzedDeallocate ad) {
+            String stmtToDeallocate = ad.preparedStmtName();
             if (stmtToDeallocate != null) {
                 close((byte) 'S', stmtToDeallocate);
             } else {
@@ -472,8 +470,7 @@ public class Session implements AutoCloseable {
                 preparedStatements.clear();
             }
             resultReceiver.allFinished();
-        } else if (analyzedStmt instanceof AnalyzedDiscard) {
-            AnalyzedDiscard discard = (AnalyzedDiscard) analyzedStmt;
+        } else if (analyzedStmt instanceof AnalyzedDiscard discard) {
             // We don't cache plans, don't have sequences or temporary tables
             // See https://www.postgresql.org/docs/current/sql-discard.html
             if (discard.target() == Target.ALL) {
@@ -620,7 +617,7 @@ public class Session implements AutoCloseable {
     }
 
     private CompletableFuture<?> bulkExec(List<DeferredExecution> toExec) {
-        assert toExec.size() >= 1 : "Must have at least 1 deferred execution for bulk exec";
+        assert !toExec.isEmpty() : "Must have at least 1 deferred execution for bulk exec";
         mostRecentJobID = UUIDs.dirtyUUID();
         final UUID jobId = mostRecentJobID;
         var routingProvider = new RoutingProvider(Randomness.get().nextInt(), planner.getAwarenessAttributes());

--- a/server/src/test/java/io/crate/action/sql/SessionTest.java
+++ b/server/src/test/java/io/crate/action/sql/SessionTest.java
@@ -90,7 +90,7 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
             assertThat(session.getParamType("S_1", 1)).isEqualTo(DataTypes.INTEGER);
 
             DescribeResult describe = session.describe('S', "S_1");
-            assertThat(describe.getParameters()).isEqualTo(new DataType[] { DataTypes.INTEGER, DataTypes.INTEGER });
+            assertThat(describe.getParameters()).isEqualTo(new DataType[]{DataTypes.INTEGER, DataTypes.INTEGER});
 
             assertThat(session.getParamType("S_1", 0)).isEqualTo(DataTypes.INTEGER);
             assertThat(session.getParamType("S_1", 1)).isEqualTo(DataTypes.INTEGER);
@@ -277,6 +277,7 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
             .build()
             .addTable("create table t1 (x int)");
         sqlExecutor.jobsLogsEnabled = true;
+        Session session = sqlExecutor.createSession();
         when(planner.plan(any(AnalyzedStatement.class), any(PlannerContext.class)))
             .thenReturn(
                 new Plan() {
@@ -291,6 +292,8 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
                                               RowConsumer consumer,
                                               Row params,
                                               SubQueryResults subQueryResults) throws Exception {
+                        // Make sure `quickExec()` below completes, and its job is moved to jobs_log
+                        consumer.completionFuture().complete(null);
                     }
 
                     @Override
@@ -298,11 +301,12 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
                                                                      PlannerContext plannerContext,
                                                                      List<Row> bulkParams,
                                                                      SubQueryResults subQueryResults) {
+                        // Do another execution to overwrite `mostRecentJobID`
+                        session.quickExec("SELECT 1", new BaseResultReceiver(), null);
                         return List.of(completedFuture(1L), completedFuture(1L));
                     }
                 }
             );
-        Session session = sqlExecutor.createSession();
 
         session.parse("S_1", "INSERT INTO t1 (x) VALUES (1)", List.of());
         session.bind("P_1", "S_1", List.of(), null);
@@ -312,7 +316,8 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
         session.execute("P_1", 0, new BaseResultReceiver());
 
         session.sync().get(5, TimeUnit.SECONDS);
-        assertThat(sqlExecutor.jobsLogs.metrics().iterator().next().totalCount()).isEqualTo(1L);
+        assertThat(sqlExecutor.jobsLogs.metrics().iterator().next().totalCount()).isEqualTo(2L);
+        assertThat(sqlExecutor.jobsLogs.activeJobs().iterator().hasNext()).isFalse();
     }
 
     @Test
@@ -355,7 +360,7 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
 
             @Override
             public ScheduledFuture<?> answer(InvocationOnMock invocation) throws Throwable {
-                Runnable runnable = (Runnable) invocation.getArgument(0);
+                Runnable runnable = invocation.getArgument(0);
                 runnable.run();
                 return null;
             }


### PR DESCRIPTION
Previously, we were using `mostRecentJobID` in listeners and lamdas
to mark a job as failed/ended, but there is a chance that the client
issues a next statement, before this marking has taken place, and
the `mostRecentJobID` gets overwritten with a brand new UUID, so
the listener/lambda would mark a wrong job, and the first job would
never be marked as failed/ended and stay forever in `sys.jobs` table.
