### PR TITLE
Don't pass MapperService to LuceneReferenceResolver

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
@@ -117,7 +117,6 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
         DocTableInfo table = schemas.getTableInfo(relationName);
         this.referenceResolver = new LuceneReferenceResolver(
             indexShard.shardId().getIndexName(),
-            fieldTypeLookup,
             table.partitionedByColumns()
         );
         this.docInputFactory = new DocInputFactory(nodeCtx, referenceResolver);

--- a/server/src/main/java/io/crate/execution/engine/fetch/NodeFetchOperation.java
+++ b/server/src/main/java/io/crate/execution/engine/fetch/NodeFetchOperation.java
@@ -78,10 +78,8 @@ public class NodeFetchOperation {
 
         FetchCollector createCollector(int readerId, RamAccounting ramAccounting) {
             IndexService indexService = fetchTask.indexService(readerId);
-            var mapperService = indexService.mapperService();
             LuceneReferenceResolver resolver = new LuceneReferenceResolver(
                 indexService.index().getName(),
-                mapperService::fieldType,
                 fetchTask.table(readerId).partitionedByColumns()
             );
             ArrayList<LuceneCollectorExpression<?>> exprs = new ArrayList<>(refs.size());

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/LuceneReferenceResolver.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/LuceneReferenceResolver.java
@@ -22,23 +22,20 @@
 package io.crate.expression.reference.doc.lucene;
 
 import static io.crate.metadata.DocReferences.toSourceLookup;
-import static io.crate.types.ArrayType.unnest;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import org.apache.lucene.search.Scorable;
-import org.elasticsearch.index.mapper.MappedFieldType;
 
 import io.crate.common.collections.Maps;
 import io.crate.exceptions.UnhandledServerException;
 import io.crate.exceptions.UnsupportedFeatureException;
 import io.crate.execution.engine.fetch.ReaderContext;
 import io.crate.expression.reference.ReferenceResolver;
-import io.crate.expression.symbol.SymbolType;
-import io.crate.lucene.FieldTypeLookup;
+import io.crate.expression.symbol.DynamicReference;
+import io.crate.expression.symbol.VoidReference;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.Reference;
@@ -53,27 +50,21 @@ import io.crate.types.DoubleType;
 import io.crate.types.FloatType;
 import io.crate.types.FloatVectorType;
 import io.crate.types.GeoPointType;
-import io.crate.types.GeoShapeType;
 import io.crate.types.IntegerType;
 import io.crate.types.IpType;
 import io.crate.types.LongType;
-import io.crate.types.ObjectType;
 import io.crate.types.ShortType;
 import io.crate.types.StringType;
 import io.crate.types.TimestampType;
 
 public class LuceneReferenceResolver implements ReferenceResolver<LuceneCollectorExpression<?>> {
 
-    private static final Set<Integer> NO_FIELD_TYPES_IDS = Set.of(ObjectType.ID, GeoShapeType.ID);
-    private final FieldTypeLookup fieldTypeLookup;
     private final List<Reference> partitionColumns;
     private final String indexName;
 
     public LuceneReferenceResolver(final String indexName,
-                                   final FieldTypeLookup fieldTypeLookup,
                                    final List<Reference> partitionColumns) {
         this.indexName = indexName;
-        this.fieldTypeLookup = fieldTypeLookup;
         this.partitionColumns = partitionColumns;
     }
 
@@ -127,7 +118,7 @@ public class LuceneReferenceResolver implements ReferenceResolver<LuceneCollecto
                     );
                 }
                 return maybeInjectPartitionValue(
-                    typeSpecializedExpression(fieldTypeLookup, ref),
+                    typeSpecializedExpression(ref),
                     indexName,
                     partitionColumns,
                     column
@@ -155,55 +146,32 @@ public class LuceneReferenceResolver implements ReferenceResolver<LuceneCollecto
         return result;
     }
 
-    private static LuceneCollectorExpression<?> typeSpecializedExpression(final FieldTypeLookup fieldTypeLookup,
-                                                                          final Reference ref) {
+    private static LuceneCollectorExpression<?> typeSpecializedExpression(final Reference ref) {
         final String fqn = ref.storageIdent();
-        final MappedFieldType fieldType = fieldTypeLookup.get(fqn);
-        if (fieldType == null) {
-            return NO_FIELD_TYPES_IDS.contains(unnest(ref.valueType()).id()) || isIgnoredDynamicReference(ref)
-                ? DocCollectorExpression.create(toSourceLookup(ref))
-                : new LiteralValueExpression(null);
+        // non-ignored dynamic references should have been resolved to void references by this point
+        if (ref instanceof VoidReference) {
+            return new LiteralValueExpression(null);
         }
-        if (!fieldType.hasDocValues()) {
+        assert ref instanceof DynamicReference == false || ref.columnPolicy() == ColumnPolicy.IGNORED;
+        if (ref.hasDocValues() == false) {
             return DocCollectorExpression.create(toSourceLookup(ref));
         }
-        switch (ref.valueType().id()) {
-            case BitStringType.ID:
-                return new BitStringColumnReference(fqn, ((BitStringType) ref.valueType()).length());
-            case ByteType.ID:
-                return new ByteColumnReference(fqn);
-            case ShortType.ID:
-                return new ShortColumnReference(fqn);
-            case IpType.ID:
-                return new IpColumnReference(fqn);
-            case StringType.ID:
-            case CharacterType.ID:
-                return new BytesRefColumnReference(fqn);
-            case DoubleType.ID:
-                return new DoubleColumnReference(fqn);
-            case BooleanType.ID:
-                return new BooleanColumnReference(fqn);
-            case FloatType.ID:
-                return new FloatColumnReference(fqn);
-            case LongType.ID:
-            case TimestampType.ID_WITH_TZ:
-            case TimestampType.ID_WITHOUT_TZ:
-                return new LongColumnReference(fqn);
-            case IntegerType.ID:
-                return new IntegerColumnReference(fqn);
-            case GeoPointType.ID:
-                return new GeoPointColumnReference(fqn);
-            case ArrayType.ID:
-                return DocCollectorExpression.create(toSourceLookup(ref));
-            case FloatVectorType.ID:
-                return new FloatVectorColumnReference(fqn);
-            default:
-                throw new UnhandledServerException("Unsupported type: " + ref.valueType().getName());
-        }
-    }
-
-    private static boolean isIgnoredDynamicReference(final Reference ref) {
-        return ref.symbolType() == SymbolType.DYNAMIC_REFERENCE && ref.columnPolicy() == ColumnPolicy.IGNORED;
+        return switch (ref.valueType().id()) {
+            case BitStringType.ID -> new BitStringColumnReference(fqn, ((BitStringType) ref.valueType()).length());
+            case ByteType.ID -> new ByteColumnReference(fqn);
+            case ShortType.ID -> new ShortColumnReference(fqn);
+            case IpType.ID -> new IpColumnReference(fqn);
+            case StringType.ID, CharacterType.ID -> new BytesRefColumnReference(fqn);
+            case DoubleType.ID -> new DoubleColumnReference(fqn);
+            case BooleanType.ID -> new BooleanColumnReference(fqn);
+            case FloatType.ID -> new FloatColumnReference(fqn);
+            case LongType.ID, TimestampType.ID_WITH_TZ, TimestampType.ID_WITHOUT_TZ -> new LongColumnReference(fqn);
+            case IntegerType.ID -> new IntegerColumnReference(fqn);
+            case GeoPointType.ID -> new GeoPointColumnReference(fqn);
+            case ArrayType.ID -> DocCollectorExpression.create(toSourceLookup(ref));
+            case FloatVectorType.ID -> new FloatVectorColumnReference(fqn);
+            default -> throw new UnhandledServerException("Unsupported type: " + ref.valueType().getName());
+        };
     }
 
     static class LiteralValueExpression extends LuceneCollectorExpression<Object> {

--- a/server/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
+++ b/server/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
@@ -97,7 +97,6 @@ public class LuceneQueryBuilder {
                            QueryCache queryCache) throws UnsupportedFeatureException {
         var refResolver = new LuceneReferenceResolver(
             indexName,
-            mapperService::fieldType,
             table.partitionedByColumns()
         );
         var normalizer = new EvaluatingNormalizer(nodeCtx, RowGranularity.PARTITION, refResolver, null);
@@ -149,12 +148,10 @@ public class LuceneQueryBuilder {
             this.nodeContext = nodeCtx;
             this.txnCtx = txnCtx;
             this.queryShardContext = queryShardContext;
-            FieldTypeLookup typeLookup = mapperService::fieldType;
             this.docInputFactory = new DocInputFactory(
                 nodeCtx,
                 new LuceneReferenceResolver(
                     indexName,
-                    typeLookup,
                     partitionColumns
                 )
             );

--- a/server/src/main/java/io/crate/statistics/ReservoirSampler.java
+++ b/server/src/main/java/io/crate/statistics/ReservoirSampler.java
@@ -74,7 +74,6 @@ import io.crate.execution.engine.fetch.ReaderContext;
 import io.crate.expression.reference.doc.lucene.CollectorContext;
 import io.crate.expression.reference.doc.lucene.LuceneCollectorExpression;
 import io.crate.expression.reference.doc.lucene.LuceneReferenceResolver;
-import io.crate.lucene.FieldTypeLookup;
 import io.crate.metadata.DocReferences;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
@@ -240,11 +239,8 @@ public final class ReservoirSampler {
         DocTableInfo docTable,
         List<Reference> columns
     ) {
-        var mapperService = indexService.mapperService();
-        FieldTypeLookup fieldTypeLookup = mapperService::fieldType;
         LuceneReferenceResolver referenceResolver = new LuceneReferenceResolver(
             indexService.index().getName(),
-            fieldTypeLookup,
             docTable.partitionedByColumns()
         );
         List<? extends LuceneCollectorExpression<?>> expressions = Lists.map(

--- a/server/src/test/java/io/crate/execution/ddl/tables/AddColumnTaskTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/tables/AddColumnTaskTest.java
@@ -22,7 +22,6 @@
 package io.crate.execution.ddl.tables;
 
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
 

--- a/server/src/test/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIteratorTest.java
@@ -280,7 +280,7 @@ public class DocValuesGroupByOptimizedIteratorTest extends CrateDummyClusterServ
         var collectTask = createCollectTask(shard, collectPhase, Version.CURRENT);
         var nodeCtx = createNodeContext();
         FieldTypeLookup fieldTypeLookup = shard.mapperService()::fieldType;
-        var referenceResolver = new LuceneReferenceResolver(shard.shardId().getIndexName(), fieldTypeLookup, List.of());
+        var referenceResolver = new LuceneReferenceResolver(shard.shardId().getIndexName(), List.of());
 
         var it = DocValuesGroupByOptimizedIterator.tryOptimize(
             functions,

--- a/server/src/test/java/io/crate/execution/engine/collect/GroupByOptimizedIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/GroupByOptimizedIteratorTest.java
@@ -243,7 +243,7 @@ public class GroupByOptimizedIteratorTest extends CrateDummyClusterServiceUnitTe
             new InputFactory(nodeCtx),
             new DocInputFactory(
                 nodeCtx,
-                new LuceneReferenceResolver(shard.shardId().getIndexName(), fieldTypeLookup, List.of())
+                new LuceneReferenceResolver(shard.shardId().getIndexName(), List.of())
             ),
             collectPhase,
             collectTask

--- a/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
+++ b/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
@@ -208,10 +208,8 @@ public abstract class AggregationTestCase extends ESTestCase {
         }
         List<Reference> targetColumns = toReference(actualArgumentTypes);
         var shard = newStartedPrimaryShard(targetColumns, threadPool);
-        var mapperService = shard.mapperService();
         var refResolver = new LuceneReferenceResolver(
             shard.shardId().getIndexName(),
-            mapperService::fieldType,
             List.of()
         );
 

--- a/server/src/testFixtures/java/io/crate/testing/IndexEnv.java
+++ b/server/src/testFixtures/java/io/crate/testing/IndexEnv.java
@@ -109,7 +109,6 @@ public final class IndexEnv implements AutoCloseable {
         nodeEnvironment = new NodeEnvironment(Settings.EMPTY, env);
         luceneReferenceResolver = new LuceneReferenceResolver(
             indexName,
-            mapperService::fieldType,
             table.partitionedByColumns()
         );
         indexService = indexModule.newIndexService(


### PR DESCRIPTION
LuceneReferenceResolver double-checks that a passed in Reference points
to a concrete lucene field by looking at the mappings reported by an IndexShard's
MapperService.  However, references that point to non-ignored non-mapped
fields will already have been resolved as VoidReferences earlier in the call stack,
so we can replace this with an instanceof check and stop passing MapperServices
around.