### PR TITLE
Simplify CodecService construction

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/CodecService.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/CodecService.java
@@ -22,11 +22,8 @@ package org.elasticsearch.index.codec;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.logging.log4j.Logger;
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.lucene99.Lucene99Codec;
-import org.elasticsearch.index.mapper.MapperService;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * Since Lucene 4.0 low level index segments are read and written through a
@@ -45,17 +42,12 @@ public class CodecService {
      */
     public static final String LUCENE_DEFAULT_CODEC = "lucene_default";
 
-    public CodecService(@Nullable MapperService mapperService, Logger logger) {
+    public CodecService() {
         final var codecs = new HashMap<String, Codec>();
-        if (mapperService == null) {
-            codecs.put(DEFAULT_CODEC, new Lucene99Codec());
-            codecs.put(BEST_COMPRESSION_CODEC, new Lucene99Codec(Lucene99Codec.Mode.BEST_COMPRESSION));
-        } else {
-            codecs.put(DEFAULT_CODEC,
-                new PerFieldMappingPostingFormatCodec(Lucene99Codec.Mode.BEST_SPEED, mapperService, logger));
-            codecs.put(BEST_COMPRESSION_CODEC,
-                new PerFieldMappingPostingFormatCodec(Lucene99Codec.Mode.BEST_COMPRESSION, mapperService, logger));
-        }
+        codecs.put(DEFAULT_CODEC,
+            new CrateCodec(Lucene99Codec.Mode.BEST_SPEED));
+        codecs.put(BEST_COMPRESSION_CODEC,
+            new CrateCodec(Lucene99Codec.Mode.BEST_COMPRESSION));
         codecs.put(LUCENE_DEFAULT_CODEC, Codec.getDefault());
         for (String codec : Codec.availableCodecs()) {
             codecs.put(codec, Codec.forName(codec));

--- a/server/src/main/java/org/elasticsearch/index/codec/CrateCodec.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/CrateCodec.java
@@ -21,54 +21,34 @@ package org.elasticsearch.index.codec;
 
 import java.io.IOException;
 
-import org.apache.logging.log4j.Logger;
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.DocValuesFormat;
 import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.codecs.KnnVectorsReader;
 import org.apache.lucene.codecs.KnnVectorsWriter;
-import org.apache.lucene.codecs.PostingsFormat;
 import org.apache.lucene.codecs.lucene99.Lucene99Codec;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
 import org.elasticsearch.common.lucene.Lucene;
-import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.mapper.MapperService;
 
 import io.crate.lucene.codec.CustomLucene90DocValuesFormat;
 import io.crate.types.FloatVectorType;
 
 
 /**
- * {@link PerFieldMappingPostingFormatCodec This postings format} is the default
- * {@link PostingsFormat} for Elasticsearch. It utilizes the
- * {@link MapperService} to lookup a {@link PostingsFormat} per field. This
- * allows users to change the low level postings format for individual fields
- * per index in real time via the mapping API. If no specific postings format is
- * configured for a specific field the default postings format is used.
+ * {@link CrateCodec This codec} is the default {@link Codec} for Crate.
+ * It disables compression on docvalues terms dictionaries, and increases
+ * the max supported vector dimension to {@link FloatVectorType#MAX_DIMENSIONS}
  */
 // LUCENE UPGRADE: make sure to move to a new codec depending on the lucene version
-public class PerFieldMappingPostingFormatCodec extends Lucene99Codec {
-    private final Logger logger;
-    private final MapperService mapperService;
+public class CrateCodec extends Lucene99Codec {
 
     static {
-        assert Codec.forName(Lucene.LATEST_CODEC).getClass().isAssignableFrom(PerFieldMappingPostingFormatCodec.class) : "PerFieldMappingPostingFormatCodec must subclass the latest lucene codec: " + Lucene.LATEST_CODEC;
+        assert Codec.forName(Lucene.LATEST_CODEC).getClass().isAssignableFrom(CrateCodec.class) : "CrateCodec must subclass the latest lucene codec: " + Lucene.LATEST_CODEC;
     }
 
-    public PerFieldMappingPostingFormatCodec(Mode compressionMode, MapperService mapperService, Logger logger) {
+    public CrateCodec(Mode compressionMode) {
         super(compressionMode);
-        this.mapperService = mapperService;
-        this.logger = logger;
-    }
-
-    @Override
-    public PostingsFormat getPostingsFormatForField(String field) {
-        final MappedFieldType fieldType = mapperService.fieldType(field);
-        if (fieldType == null) {
-            logger.warn("no index mapper found for field: [{}] returning default postings format", field);
-        }
-        return super.getPostingsFormatForField(field);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -263,7 +263,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         assert shardRouting.initializing();
         this.shardRouting = shardRouting;
         final Settings settings = indexSettings.getSettings();
-        this.codecService = new CodecService(mapperService, logger);
+        this.codecService = new CodecService();
         Objects.requireNonNull(store, "Store must be provided to the index shard");
         this.engineFactoryProviders = engineFactoryProviders;
         this.engineFactory = getEngineFactory();

--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -2922,7 +2922,7 @@ public class InternalEngineTests extends EngineTestCase {
 
     @Test
     public void testSettings() {
-        CodecService codecService = new CodecService(null, logger);
+        CodecService codecService = new CodecService();
         LiveIndexWriterConfig currentIndexWriterConfig = engine.getCurrentIndexWriterConfig();
 
         assertEquals(engine.config().getCodec().getName(), codecService.codec(codecName).getName());
@@ -3270,7 +3270,7 @@ public class InternalEngineTests extends EngineTestCase {
             store,
             newMergePolicy(),
             config.getAnalyzer(),
-            new CodecService(null, logger),
+            new CodecService(),
             config.getEventListener(),
             IndexSearcher.getDefaultQueryCache(),
             IndexSearcher.getDefaultQueryCachingPolicy(),

--- a/server/src/test/java/org/elasticsearch/indices/IndexingMemoryControllerIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndexingMemoryControllerIT.java
@@ -25,7 +25,6 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Optional;
 
-import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.codec.CodecService;
@@ -67,7 +66,7 @@ public class IndexingMemoryControllerIT extends IntegTestCase {
             IndexSettings indexSettings = new IndexSettings(config.getIndexSettings().getIndexMetadata(), settings);
             return new EngineConfig(config.getShardId(), config.getThreadPool(),
                                     indexSettings, config.getStore(), config.getMergePolicy(), config.getAnalyzer(),
-                                    new CodecService(null, LogManager.getLogger(IndexingMemoryControllerIT.class)),
+                                    new CodecService(),
                                     config.getEventListener(), config.getQueryCache(),
                                     config.getQueryCachingPolicy(), config.getTranslogConfig(), config.getFlushMergesAfter(),
                                     config.getExternalRefreshListener(), config.getInternalRefreshListener(),

--- a/server/src/test/java/org/elasticsearch/indices/IndexingMemoryControllerTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndexingMemoryControllerTests.java
@@ -392,7 +392,7 @@ public class IndexingMemoryControllerTests extends IndexShardTestCase {
         internalRefreshListener.add(listener);
         return new EngineConfig(config.getShardId(), config.getThreadPool(),
                                 config.getIndexSettings(), config.getStore(), config.getMergePolicy(), config.getAnalyzer(),
-                                new CodecService(null, logger), config.getEventListener(), config.getQueryCache(),
+                                new CodecService(), config.getEventListener(), config.getQueryCache(),
                                 config.getQueryCachingPolicy(), config.getTranslogConfig(), config.getFlushMergesAfter(),
                                 config.getExternalRefreshListener(), internalRefreshListener,
                                 config.getCircuitBreakerService(), config.getGlobalCheckpointSupplier(), config.retentionLeasesSupplier(),

--- a/server/src/testFixtures/java/org/elasticsearch/index/engine/EngineTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/index/engine/EngineTestCase.java
@@ -170,7 +170,7 @@ public abstract class EngineTestCase extends ESTestCase {
     public void setUp() throws Exception {
         super.setUp();
         primaryTerm.set(randomLongBetween(1, Long.MAX_VALUE));
-        CodecService codecService = new CodecService(null, logger);
+        CodecService codecService = new CodecService();
         String name = Codec.getDefault().getName();
         if (Arrays.asList(codecService.availableCodecs()).contains(name)) {
             // some codecs are read only so we only take the ones that we have in the service and randomly
@@ -214,7 +214,7 @@ public abstract class EngineTestCase extends ESTestCase {
             config.getStore(),
             config.getMergePolicy(),
             config.getAnalyzer(),
-            new CodecService(null, logger),
+            new CodecService(),
             config.getEventListener(),
             config.getQueryCache(),
             config.getQueryCachingPolicy(),
@@ -238,7 +238,7 @@ public abstract class EngineTestCase extends ESTestCase {
             config.getStore(),
             config.getMergePolicy(),
             analyzer,
-            new CodecService(null, logger),
+            new CodecService(),
             config.getEventListener(),
             config.getQueryCache(),
             config.getQueryCachingPolicy(),
@@ -261,7 +261,7 @@ public abstract class EngineTestCase extends ESTestCase {
             config.getStore(),
             mergePolicy,
             config.getAnalyzer(),
-            new CodecService(null, logger),
+            new CodecService(),
             config.getEventListener(),
             config.getQueryCache(),
             config.getQueryCachingPolicy(),
@@ -698,7 +698,7 @@ public abstract class EngineTestCase extends ESTestCase {
             store,
             mergePolicy,
             iwc.getAnalyzer(),
-            new CodecService(null, logger),
+            new CodecService(),
             eventListener,
             IndexSearcher.getDefaultQueryCache(),
             IndexSearcher.getDefaultQueryCachingPolicy(),
@@ -733,7 +733,7 @@ public abstract class EngineTestCase extends ESTestCase {
             store,
             config.getMergePolicy(),
             config.getAnalyzer(),
-            new CodecService(null, logger),
+            new CodecService(),
             config.getEventListener(),
             config.getQueryCache(),
             config.getQueryCachingPolicy(),


### PR DESCRIPTION
PerFieldMappingPostingFormatCodec currently takes a MapperService and 
Logger, which it uses to print a warning message if we ask for terms from a field 
that doesn't exist. However, we always return the default terms format in any 
case, as Crate doesn't allow for per-field configuration here.  The warning is 
not really any use, and the behaviour is always the same whether the field is 
present in mappings or not, so this entire method override can be removed.

Given that it no longer has anything to do with postings formats, and it does
customize some other codec functions, this also renames the codec to
CrateCodec and updates its javadoc.