### PR TITLE
Inline some duplicate setting constants

### DIFF
--- a/server/src/main/java/io/crate/analyze/NumberOfReplicas.java
+++ b/server/src/main/java/io/crate/analyze/NumberOfReplicas.java
@@ -21,25 +21,23 @@
 
 package io.crate.analyze;
 
-import io.crate.common.Booleans;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
 import org.elasticsearch.cluster.metadata.AutoExpandReplicas;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
 
-import java.util.Objects;
-import java.util.regex.Pattern;
+import io.crate.common.Booleans;
 
 public class NumberOfReplicas {
-
-    public static final String NUMBER_OF_REPLICAS = IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
-    public static final String AUTO_EXPAND_REPLICAS = IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS;
 
     private static final Pattern EXPAND_REPLICA_PATTERN = Pattern.compile("\\d+\\-(all|\\d+)");
     private final String esSettingKey;
     private final String esSettingsValue;
 
     public NumberOfReplicas(Integer numReplicas) {
-        this.esSettingKey = NUMBER_OF_REPLICAS;
+        this.esSettingKey = IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
         this.esSettingsValue = numReplicas.toString();
     }
 
@@ -47,7 +45,7 @@ public class NumberOfReplicas {
         assert numReplicas != null : "numReplicas must not be null";
         validateExpandReplicaSetting(numReplicas);
 
-        this.esSettingKey = AUTO_EXPAND_REPLICAS;
+        this.esSettingKey = AutoExpandReplicas.SETTING_KEY;
         this.esSettingsValue = numReplicas;
     }
 
@@ -67,18 +65,18 @@ public class NumberOfReplicas {
 
     public static String fromSettings(Settings settings) {
         String numberOfReplicas;
-        String autoExpandReplicas = settings.get(AUTO_EXPAND_REPLICAS);
+        String autoExpandReplicas = settings.get(AutoExpandReplicas.SETTING_KEY);
         if (autoExpandReplicas != null && !Booleans.isFalse(autoExpandReplicas)) {
             validateExpandReplicaSetting(autoExpandReplicas);
             numberOfReplicas = autoExpandReplicas;
         } else {
-            numberOfReplicas = Objects.requireNonNullElse(settings.get(NUMBER_OF_REPLICAS), "1");
+            numberOfReplicas = Objects.requireNonNullElse(settings.get(IndexMetadata.SETTING_NUMBER_OF_REPLICAS), "1");
         }
         return numberOfReplicas;
     }
 
     public static int fromSettings(Settings settings, int dataNodeCount) {
-        AutoExpandReplicas autoExpandReplicas = IndexMetadata.INDEX_AUTO_EXPAND_REPLICAS_SETTING.get(settings);
+        AutoExpandReplicas autoExpandReplicas = AutoExpandReplicas.SETTING.get(settings);
         if (autoExpandReplicas.isEnabled()) {
             final int min = autoExpandReplicas.getMinReplicas();
             final int max = autoExpandReplicas.getMaxReplicas(dataNodeCount);

--- a/server/src/main/java/io/crate/metadata/settings/NumberOfReplicasSetting.java
+++ b/server/src/main/java/io/crate/metadata/settings/NumberOfReplicasSetting.java
@@ -39,8 +39,7 @@ public class NumberOfReplicasSetting extends Setting<Settings> {
 
     private static final Settings DEFAULT = Settings.builder()
         .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
-        .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS,
-             IndexMetadata.INDEX_AUTO_EXPAND_REPLICAS_SETTING.getDefaultRaw(Settings.EMPTY))
+        .put(AutoExpandReplicas.SETTING_KEY, AutoExpandReplicas.SETTING.getDefaultRaw(Settings.EMPTY))
         .build();
 
     public NumberOfReplicasSetting() {

--- a/server/src/main/java/io/crate/replication/logical/LogicalReplicationSettings.java
+++ b/server/src/main/java/io/crate/replication/logical/LogicalReplicationSettings.java
@@ -23,6 +23,7 @@ package io.crate.replication.logical;
 
 import java.util.Set;
 
+import org.elasticsearch.cluster.metadata.AutoExpandReplicas;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
@@ -106,7 +107,7 @@ public class LogicalReplicationSettings {
      */
     public static final Set<Setting<?>> NON_REPLICATED_SETTINGS = Set.of(
         IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING,
-        IndexMetadata.INDEX_AUTO_EXPAND_REPLICAS_SETTING,
+        AutoExpandReplicas.SETTING,
         IndexMetadata.INDEX_ROUTING_EXCLUDE_GROUP_SETTING,
         IndexMetadata.INDEX_ROUTING_INCLUDE_GROUP_SETTING,
         IndexMetadata.INDEX_ROUTING_REQUIRE_GROUP_SETTING,

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/AutoExpandReplicas.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/AutoExpandReplicas.java
@@ -21,22 +21,23 @@ package org.elasticsearch.cluster.metadata;
 
 import static org.elasticsearch.cluster.metadata.IndexMetadata.isIndexVerifiedBeforeClosed;
 
-import com.carrotsearch.hppc.cursors.ObjectCursor;
-import org.elasticsearch.Version;
-import org.elasticsearch.cluster.node.DiscoveryNode;
-import io.crate.common.Booleans;
-import io.crate.types.DataTypes;
-
-import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
-import org.elasticsearch.cluster.routing.allocation.decider.Decision;
-import org.elasticsearch.common.settings.Setting;
-import org.elasticsearch.common.settings.Setting.Property;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.OptionalInt;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
+import org.elasticsearch.cluster.routing.allocation.decider.Decision;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Setting.Property;
+
+import com.carrotsearch.hppc.cursors.ObjectCursor;
+
+import io.crate.common.Booleans;
+import io.crate.types.DataTypes;
 
 /**
  * This class acts as a functional wrapper around the {@code index.auto_expand_replicas} setting.
@@ -49,8 +50,9 @@ public final class AutoExpandReplicas {
 
     private static final AutoExpandReplicas FALSE_INSTANCE = new AutoExpandReplicas(0, 0, false);
 
+    public static final String SETTING_KEY = "index.auto_expand_replicas";
     public static final Setting<AutoExpandReplicas> SETTING = new Setting<>(
-        IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS,
+        SETTING_KEY,
         "0-1",
         AutoExpandReplicas::parse,
         DataTypes.STRING,
@@ -66,13 +68,13 @@ public final class AutoExpandReplicas {
         }
         final int dash = value.indexOf('-');
         if (-1 == dash) {
-            throw new IllegalArgumentException("failed to parse [" + IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS + "] from value: [" + value + "] at index " + dash);
+            throw new IllegalArgumentException("failed to parse [" + AutoExpandReplicas.SETTING_KEY + "] from value: [" + value + "] at index " + dash);
         }
         final String sMin = value.substring(0, dash);
         try {
             min = Integer.parseInt(sMin);
         } catch (NumberFormatException e) {
-            throw new IllegalArgumentException("failed to parse [" + IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS + "] from value: [" + value + "] at index " + dash, e);
+            throw new IllegalArgumentException("failed to parse [" + AutoExpandReplicas.SETTING_KEY + "] from value: [" + value + "] at index " + dash, e);
         }
         String sMax = value.substring(dash + 1);
         if (sMax.equals(ALL_NODES_VALUE)) {
@@ -81,7 +83,7 @@ public final class AutoExpandReplicas {
             try {
                 max = Integer.parseInt(sMax);
             } catch (NumberFormatException e) {
-                throw new IllegalArgumentException("failed to parse [" + IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS + "] from value: [" + value + "] at index " + dash, e);
+                throw new IllegalArgumentException("failed to parse [" + AutoExpandReplicas.SETTING_KEY + "] from value: [" + value + "] at index " + dash, e);
             }
         }
         return new AutoExpandReplicas(min, max, true);
@@ -93,7 +95,7 @@ public final class AutoExpandReplicas {
 
     private AutoExpandReplicas(int minReplicas, int maxReplicas, boolean enabled) {
         if (minReplicas > maxReplicas) {
-            throw new IllegalArgumentException("[" + IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS + "] minReplicas must be =< maxReplicas but wasn't " + minReplicas + " > " + maxReplicas);
+            throw new IllegalArgumentException("[" + AutoExpandReplicas.SETTING_KEY + "] minReplicas must be =< maxReplicas but wasn't " + minReplicas + " > " + maxReplicas);
         }
         this.minReplicas = minReplicas;
         this.maxReplicas = maxReplicas;

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -172,8 +172,6 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             },
             Property.IndexScope, Property.Final);
 
-    public static final String SETTING_AUTO_EXPAND_REPLICAS = "index.auto_expand_replicas";
-    public static final Setting<AutoExpandReplicas> INDEX_AUTO_EXPAND_REPLICAS_SETTING = AutoExpandReplicas.SETTING;
     public static final String SETTING_READ_ONLY = "index.blocks.read_only";
     public static final Setting<Boolean> INDEX_READ_ONLY_SETTING =
         Setting.boolSetting(SETTING_READ_ONLY, false, Property.Dynamic, Property.IndexScope);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.cluster.metadata;
 
-import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_CREATION_DATE;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_INDEX_UUID;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
@@ -368,8 +367,8 @@ public class MetadataCreateIndexService {
             if (indexSettingsBuilder.get(SETTING_NUMBER_OF_REPLICAS) == null) {
                 indexSettingsBuilder.put(SETTING_NUMBER_OF_REPLICAS, settings.getAsInt(SETTING_NUMBER_OF_REPLICAS, 1));
             }
-            if (settings.get(SETTING_AUTO_EXPAND_REPLICAS) != null && indexSettingsBuilder.get(SETTING_AUTO_EXPAND_REPLICAS) == null) {
-                indexSettingsBuilder.put(SETTING_AUTO_EXPAND_REPLICAS, settings.get(SETTING_AUTO_EXPAND_REPLICAS));
+            if (settings.get(AutoExpandReplicas.SETTING_KEY) != null && indexSettingsBuilder.get(AutoExpandReplicas.SETTING_KEY) == null) {
+                indexSettingsBuilder.put(AutoExpandReplicas.SETTING_KEY, settings.get(AutoExpandReplicas.SETTING_KEY));
             }
 
             setIndexVersionCreatedSetting(indexSettingsBuilder, currentState);

--- a/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.function.Predicate;
 
+import org.elasticsearch.cluster.metadata.AutoExpandReplicas;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.cluster.routing.allocation.ExistingShardsAllocator;
@@ -61,7 +62,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
         IndexMetadata.INDEX_ROUTING_EXCLUDE_GROUP_SETTING,
         IndexMetadata.INDEX_ROUTING_INCLUDE_GROUP_SETTING,
         IndexMetadata.INDEX_ROUTING_REQUIRE_GROUP_SETTING,
-        IndexMetadata.INDEX_AUTO_EXPAND_REPLICAS_SETTING,
+        AutoExpandReplicas.SETTING,
         IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING,
         IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING,
         IndexMetadata.INDEX_ROUTING_PARTITION_SIZE_SETTING,

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -24,7 +24,6 @@ import static io.crate.analyze.SnapshotSettings.SCHEMA_RENAME_REPLACEMENT;
 import static io.crate.analyze.SnapshotSettings.TABLE_RENAME_PATTERN;
 import static io.crate.analyze.SnapshotSettings.TABLE_RENAME_REPLACEMENT;
 import static java.util.Collections.unmodifiableSet;
-import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_CREATION_DATE;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_HISTORY_UUID;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_INDEX_UUID;
@@ -70,6 +69,7 @@ import org.elasticsearch.cluster.RestoreInProgress.ShardRestoreStatus;
 import org.elasticsearch.cluster.SnapshotDeletionsInProgress;
 import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
+import org.elasticsearch.cluster.metadata.AutoExpandReplicas;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
@@ -159,7 +159,7 @@ public class RestoreService implements ClusterStateApplier {
         Set<String> unremovable = new HashSet<>(UNMODIFIABLE_SETTINGS.size() + 4);
         unremovable.addAll(UNMODIFIABLE_SETTINGS);
         unremovable.add(SETTING_NUMBER_OF_REPLICAS);
-        unremovable.add(SETTING_AUTO_EXPAND_REPLICAS);
+        unremovable.add(AutoExpandReplicas.SETTING_KEY);
         unremovable.add(SETTING_VERSION_UPGRADED);
         UNREMOVABLE_SETTINGS = unmodifiableSet(unremovable);
     }

--- a/server/src/test/java/io/crate/analyze/BlobTableAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/BlobTableAnalyzerTest.java
@@ -28,6 +28,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.io.IOException;
 import java.util.function.Function;
 
+import org.elasticsearch.cluster.metadata.AutoExpandReplicas;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.junit.Before;
@@ -100,7 +101,7 @@ public class BlobTableAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(analysis.relationName().name()).isEqualTo("screenshots");
         assertThat(analysis.relationName().schema()).isEqualTo(BlobSchemaInfo.NAME);
         assertThat(settings.getAsInt(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 0)).isEqualTo(10);
-        assertThat(settings.get(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS)).isEqualTo("0-all");
+        assertThat(settings.get(AutoExpandReplicas.SETTING_KEY)).isEqualTo("0-all");
     }
 
     @Test
@@ -127,7 +128,7 @@ public class BlobTableAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
         assertThat(analysis.relationName().name()).isEqualTo("screenshots");
         assertThat(settings.getAsInt(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 0)).isEqualTo(10);
-        assertThat(settings.get(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS)).isEqualTo("0-all");
+        assertThat(settings.get(AutoExpandReplicas.SETTING_KEY)).isEqualTo("0-all");
     }
 
     @Test
@@ -254,7 +255,7 @@ public class BlobTableAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(analysis.relationName().name()).isEqualTo("screenshots");
         assertThat(analysis.relationName().schema()).isEqualTo(BlobSchemaInfo.NAME);
         assertThat(settings.getAsInt(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 0)).isEqualTo(2);
-        assertThat(settings.get(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS)).isEqualTo("0-all");
+        assertThat(settings.get(AutoExpandReplicas.SETTING_KEY)).isEqualTo("0-all");
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/NumberOfReplicasTest.java
+++ b/server/src/test/java/io/crate/analyze/NumberOfReplicasTest.java
@@ -21,9 +21,11 @@
 
 package io.crate.analyze;
 
-import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import org.elasticsearch.cluster.metadata.AutoExpandReplicas;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
@@ -39,7 +41,7 @@ public class NumberOfReplicasTest extends ESTestCase {
     @Test
     public void testNumber() throws Exception {
         String numberOfResplicas = NumberOfReplicas.fromSettings(Settings.builder()
-            .put(NumberOfReplicas.NUMBER_OF_REPLICAS, 4)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 4)
             .build());
         assertThat(numberOfResplicas).isEqualTo("4");
     }
@@ -47,8 +49,8 @@ public class NumberOfReplicasTest extends ESTestCase {
     @Test
     public void testAutoExpandSettingsTakePrecedence() throws Exception {
         String numberOfResplicas = NumberOfReplicas.fromSettings(Settings.builder()
-            .put(NumberOfReplicas.AUTO_EXPAND_REPLICAS, "0-all")
-            .put(NumberOfReplicas.NUMBER_OF_REPLICAS, 1)
+            .put(AutoExpandReplicas.SETTING_KEY, "0-all")
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
             .build());
         assertThat(numberOfResplicas).isEqualTo("0-all");
     }
@@ -57,8 +59,8 @@ public class NumberOfReplicasTest extends ESTestCase {
     public void testInvalidAutoExpandSettings() throws Exception {
         assertThatThrownBy(() ->
             NumberOfReplicas.fromSettings(Settings.builder()
-                .put(NumberOfReplicas.AUTO_EXPAND_REPLICAS, "abc")
-                .put(NumberOfReplicas.NUMBER_OF_REPLICAS, 1)
+                .put(AutoExpandReplicas.SETTING_KEY, "abc")
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
                 .build()))
             .isExactlyInstanceOf(IllegalArgumentException.class)
             .hasMessage("The \"number_of_replicas\" range \"abc\" isn't valid");

--- a/server/src/test/java/io/crate/integrationtests/BlobHttpIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/BlobHttpIntegrationTest.java
@@ -54,6 +54,7 @@ import org.apache.http.message.BasicHeader;
 import org.apache.http.util.EntityUtils;
 import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.cluster.metadata.AutoExpandReplicas;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.http.HttpServerTransport;
@@ -93,7 +94,7 @@ public abstract class BlobHttpIntegrationTest extends BlobIntegrationTestBase {
             .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 2)
             // SETTING_AUTO_EXPAND_REPLICAS is enabled by default
             // but for this test it needs to be disabled so we can have 0 replicas
-            .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "false")
+            .put(AutoExpandReplicas.SETTING_KEY, "false")
             .build();
         blobAdminClient.createBlobTable("test", indexSettings).get();
         blobAdminClient.createBlobTable("test_blobs2", indexSettings).get();

--- a/server/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
@@ -64,6 +64,7 @@ import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
 import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesRequest;
 import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesResponse;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.AutoExpandReplicas;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
@@ -1308,7 +1309,7 @@ public class PartitionedTableIntegrationTest extends IntegTestCase {
         GetIndexTemplatesResponse templatesResponse = client().admin().indices()
             .getTemplates(new GetIndexTemplatesRequest(templateName)).get();
         Settings templateSettings = templatesResponse.getIndexTemplates().get(0).settings();
-        assertThat(templateSettings.get(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS), is("0-all"));
+        assertThat(templateSettings.get(AutoExpandReplicas.SETTING_KEY), is("0-all"));
 
         execute("alter table quotes set (number_of_replicas=0)");
         ensureYellow();
@@ -1317,7 +1318,7 @@ public class PartitionedTableIntegrationTest extends IntegTestCase {
             .getTemplates(new GetIndexTemplatesRequest(templateName)).get();
         templateSettings = templatesResponse.getIndexTemplates().get(0).settings();
         assertThat(templateSettings.getAsInt(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1), is(0));
-        assertThat(templateSettings.getAsBoolean(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, true), is(false));
+        assertThat(templateSettings.getAsBoolean(AutoExpandReplicas.SETTING_KEY, true), is(false));
 
         execute("insert into quotes (id, quote, date) values (?, ?, ?), (?, ?, ?)",
             new Object[]{1, "Don't panic", 1395874800000L,
@@ -1357,7 +1358,7 @@ public class PartitionedTableIntegrationTest extends IntegTestCase {
         templatesResponse = client().admin().indices()
             .getTemplates(new GetIndexTemplatesRequest(templateName)).get();
         templateSettings = templatesResponse.getIndexTemplates().get(0).settings();
-        assertThat(templateSettings.get(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS), is("1-all"));
+        assertThat(templateSettings.get(AutoExpandReplicas.SETTING_KEY), is("1-all"));
 
 
         execute("select number_of_replicas from information_schema.table_partitions");
@@ -1378,7 +1379,7 @@ public class PartitionedTableIntegrationTest extends IntegTestCase {
             .getTemplates(new GetIndexTemplatesRequest(templateName)).get();
         Settings templateSettings = templatesResponse.getIndexTemplates().get(0).settings();
         assertThat(templateSettings.getAsInt(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0), is(1));
-        assertThat(templateSettings.get(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS), is("false"));
+        assertThat(templateSettings.get(AutoExpandReplicas.SETTING_KEY), is("false"));
 
         execute("alter table quotes reset (number_of_replicas)");
         ensureYellow();
@@ -1387,7 +1388,7 @@ public class PartitionedTableIntegrationTest extends IntegTestCase {
             .getTemplates(new GetIndexTemplatesRequest(templateName)).get();
         templateSettings = templatesResponse.getIndexTemplates().get(0).settings();
         assertThat(templateSettings.getAsInt(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0), is(0));
-        assertThat(templateSettings.get(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS), is("0-1"));
+        assertThat(templateSettings.get(AutoExpandReplicas.SETTING_KEY), is("0-1"));
 
     }
 
@@ -1413,7 +1414,7 @@ public class PartitionedTableIntegrationTest extends IntegTestCase {
             .getTemplates(new GetIndexTemplatesRequest(templateName)).get();
         Settings templateSettings = templatesResponse.getIndexTemplates().get(0).settings();
         assertThat(templateSettings.getAsInt(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0), is(0));
-        assertThat(templateSettings.get(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS), is("0-1"));
+        assertThat(templateSettings.get(AutoExpandReplicas.SETTING_KEY), is("0-1"));
         assertBusy(() -> {
             execute("select number_of_replicas from information_schema.table_partitions");
             assertThat(
@@ -1452,7 +1453,7 @@ public class PartitionedTableIntegrationTest extends IntegTestCase {
             .getTemplates(new GetIndexTemplatesRequest(templateName)).get();
         Settings templateSettings = templatesResponse.getIndexTemplates().get(0).settings();
         assertThat(templateSettings.getAsInt(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0), is(0));
-        assertThat(templateSettings.get(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS), is("false"));
+        assertThat(templateSettings.get(AutoExpandReplicas.SETTING_KEY), is("false"));
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/RecoveryTests.java
+++ b/server/src/test/java/io/crate/integrationtests/RecoveryTests.java
@@ -40,6 +40,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.metadata.AutoExpandReplicas;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.bytes.BytesArray;
@@ -172,7 +173,7 @@ public class RecoveryTests extends BlobIntegrationTestBase {
             .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
             // SETTING_AUTO_EXPAND_REPLICAS is enabled by default
             // but for this test it needs to be disabled so we can have 0 replicas
-            .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "false")
+            .put(AutoExpandReplicas.SETTING_KEY, "false")
             .build();
 
         blobAdminClient.createBlobTable("test", indexSettings).get();

--- a/server/src/test/java/org/elasticsearch/action/support/replication/ClusterStateCreationUtils.java
+++ b/server/src/test/java/org/elasticsearch/action/support/replication/ClusterStateCreationUtils.java
@@ -20,7 +20,6 @@
 
 package org.elasticsearch.action.support.replication;
 
-import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_CREATION_DATE;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
@@ -39,6 +38,7 @@ import java.util.stream.Collectors;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.AutoExpandReplicas;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -95,7 +95,7 @@ public class ClusterStateCreationUtils {
         final int primaryTerm = 1 + randomInt(200);
         IndexMetadata indexMetadata = IndexMetadata.builder(index).settings(Settings.builder()
                                                                                 .put(SETTING_VERSION_CREATED, Version.CURRENT)
-                                                                                .put(SETTING_AUTO_EXPAND_REPLICAS, false)
+                                                                                .put(AutoExpandReplicas.SETTING_KEY, false)
                                                                                 .put(SETTING_NUMBER_OF_SHARDS, 1).put(SETTING_NUMBER_OF_REPLICAS, numberOfReplicas)
                                                                                 .put(SETTING_CREATION_DATE, System.currentTimeMillis())).primaryTerm(0, primaryTerm)
             .build();

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationCommandsTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationCommandsTests.java
@@ -45,6 +45,7 @@ import org.elasticsearch.cluster.ClusterInfo;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ESAllocationTestCase;
+import org.elasticsearch.cluster.metadata.AutoExpandReplicas;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -94,7 +95,7 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
             .put(IndexMetadata.builder("test").settings(
                 Settings.builder()
                     .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
-                    .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, false)
+                    .put(AutoExpandReplicas.SETTING_KEY, false)
                     .build()
                 )
                 .numberOfShards(1)
@@ -674,7 +675,7 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
             .put(IndexMetadata.builder(index1).settings(
                 Settings.builder()
                     .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
-                    .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, false)
+                    .put(AutoExpandReplicas.SETTING_KEY, false)
                     .put(IndexMetadata.SETTING_INDEX_UUID, UUIDs.randomBase64UUID())
                     .build()
                 ).numberOfShards(1).numberOfReplicas(1)
@@ -683,7 +684,7 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
             .put(IndexMetadata.builder(index2).settings(
                 Settings.builder()
                     .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
-                    .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, false)
+                    .put(AutoExpandReplicas.SETTING_KEY, false)
                     .put(IndexMetadata.SETTING_INDEX_UUID, UUIDs.randomBase64UUID())
                     .build()
                 ).numberOfShards(1).numberOfReplicas(1)
@@ -692,7 +693,7 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
             .put(IndexMetadata.builder(index3).settings(
                 Settings.builder()
                     .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
-                    .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, false)
+                    .put(AutoExpandReplicas.SETTING_KEY, false)
                     .put(IndexMetadata.SETTING_INDEX_UUID, UUIDs.randomBase64UUID())
                     .build()
                 ).numberOfShards(1).numberOfReplicas(1)

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/NodeVersionAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/NodeVersionAllocationDeciderTests.java
@@ -381,7 +381,7 @@ public class NodeVersionAllocationDeciderTests extends ESAllocationTestCase {
         final IndexMetadata.Builder indexMetadata = IndexMetadata.builder("test")
             .settings(
                 settings(Version.CURRENT)
-                    .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "false")
+                    .put(AutoExpandReplicas.SETTING_KEY, "false")
             )
             .numberOfShards(numberOfShards)
             .numberOfReplicas(randomIntBetween(0, 3));

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/TrackFailedAllocationNodesTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/TrackFailedAllocationNodesTests.java
@@ -30,6 +30,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ESAllocationTestCase;
+import org.elasticsearch.cluster.metadata.AutoExpandReplicas;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
@@ -48,7 +49,7 @@ public class TrackFailedAllocationNodesTests extends ESAllocationTestCase {
             .put(IndexMetadata.builder("idx").settings(
                 Settings.builder()
                     .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
-                    .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, false)
+                    .put(AutoExpandReplicas.SETTING_KEY, false)
                     .build()
                 ).numberOfShards(1).numberOfReplicas(1)
             )

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderTests.java
@@ -43,6 +43,7 @@ import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.DiskUsage;
 import org.elasticsearch.cluster.ESAllocationTestCase;
+import org.elasticsearch.cluster.metadata.AutoExpandReplicas;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -115,7 +116,7 @@ public class DiskThresholdDeciderTests extends ESAllocationTestCase {
                     .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
                     .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
                     .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)
-                    .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "false")))
+                    .put(AutoExpandReplicas.SETTING_KEY, "false")))
             .build();
 
         final RoutingTable initialRoutingTable = RoutingTable.builder()
@@ -299,7 +300,7 @@ public class DiskThresholdDeciderTests extends ESAllocationTestCase {
                 Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
                     .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
                     .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 2)
-                    .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "false")))
+                    .put(AutoExpandReplicas.SETTING_KEY, "false")))
             .build();
 
         RoutingTable initialRoutingTable = RoutingTable.builder()
@@ -509,7 +510,7 @@ public class DiskThresholdDeciderTests extends ESAllocationTestCase {
     public void testDiskThresholdWithShardSizes() {
         Settings diskSettings = Settings.builder()
             .put(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING.getKey(), true)
-            .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "false")
+            .put(AutoExpandReplicas.SETTING_KEY, "false")
             .put(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK_SETTING.getKey(), 0.7)
             .put(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING.getKey(), "71%").build();
 
@@ -543,7 +544,7 @@ public class DiskThresholdDeciderTests extends ESAllocationTestCase {
                 Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
                     .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
                     .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
-                    .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "false")
+                    .put(AutoExpandReplicas.SETTING_KEY, "false")
                     .build()))
             .build();
 
@@ -612,7 +613,7 @@ public class DiskThresholdDeciderTests extends ESAllocationTestCase {
                 Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
                     .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
                     .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
-                    .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "false")))
+                    .put(AutoExpandReplicas.SETTING_KEY, "false")))
             .build();
 
         RoutingTable routingTable = RoutingTable.builder()
@@ -704,12 +705,12 @@ public class DiskThresholdDeciderTests extends ESAllocationTestCase {
                     .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
                     .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 2)
                     .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
-                    .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "false")))
+                    .put(AutoExpandReplicas.SETTING_KEY, "false")))
             .put(IndexMetadata.builder("foo").settings(
                 Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
                     .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
                     .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
-                    .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "false")))
+                    .put(AutoExpandReplicas.SETTING_KEY, "false")))
             .build();
 
         RoutingTable initialRoutingTable = RoutingTable.builder()

--- a/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
@@ -22,7 +22,6 @@
 package org.elasticsearch.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_WAIT_FOR_ACTIVE_SHARDS;
@@ -95,6 +94,7 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterModule;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
+import org.elasticsearch.cluster.metadata.AutoExpandReplicas;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
@@ -603,7 +603,7 @@ public abstract class IntegTestCase extends ESTestCase {
         }
         // always default delayed allocation to 0 to make sure we have tests are not delayed
         builder.put(UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(), 0);
-        builder.put(SETTING_AUTO_EXPAND_REPLICAS, "false");
+        builder.put(AutoExpandReplicas.SETTING_KEY, "false");
         builder.put(SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey(), ActiveShardCount.ONE.toString());
         if (randomBoolean()) {
             builder.put(IndexSettings.INDEX_SOFT_DELETES_RETENTION_OPERATIONS_SETTING.getKey(), between(0, 1000));


### PR DESCRIPTION
Having linked constants makes it harder to get an overview of where a
constant is used.
