### PR TITLE
Update tqdm to latest version

### DIFF
--- a/blackbox/requirements.txt
+++ b/blackbox/requirements.txt
@@ -5,7 +5,7 @@ crash>=0.25.0
 crate
 asyncpg>=0.27.0
 cr8>=0.19.1
-tqdm==4.24.0
+tqdm>=4.66.4
 pycodestyle==2.4.0
 zc.customdoctests==1.0.1
 minio>=5.0.0


### PR DESCRIPTION
Gets rid of a security vulnerability alert
See https://github.com/tqdm/tqdm/releases/tag/v4.66.3

tqdm is only used for testing, and not called via `python -m tqdm`.
The issue doesn't affect CrateDB
