### PR TITLE
Add pg_catalog.has_table_privilege function

### DIFF
--- a/docs/appendices/release-notes/5.8.0.rst
+++ b/docs/appendices/release-notes/5.8.0.rst
@@ -90,6 +90,8 @@ Scalar and Aggregation Functions
 
 - Added a :ref:`vector_similarity <scalar_vector_similarity>` scalar.
 
+- Added a :ref:`has_table_privilege <scalar-has-table-priv>` scalar.
+
 Performance and Resilience Improvements
 ---------------------------------------
 

--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -3962,6 +3962,39 @@ Example::
     +----------+
     SELECT 1 row in set (... sec)
 
+
+.. _scalar-has-table-priv:
+
+``has_table_privilege([user,] table, privilege text)``
+------------------------------------------------------
+
+Returns ``boolean`` or ``NULL`` if at least one argument is ``NULL``.
+
+First argument is ``TEXT`` user name or ``INTEGER`` user OID. If user is not
+specified current user is used as an argument.
+
+Second argument is ``TEXT`` table name or ``INTEGER`` table OID.
+
+Third argument is privilege(s) to check. Multiple privileges can be provided as
+a comma separated list, in which case the result will be ``true`` if any of the
+listed privileges is held. Allowed privilege types are ``SELECT`` which
+corresponds to CrateDB's ``DQL`` and ``INSERT``, ``UPDATE``, ``DELETE`` which
+all correspond to CrateDB's ``DML``. Privilege string is case insensitive and
+extra whitespace is allowed between privilege names. Duplicate entries in
+privilege string are allowed.
+
+Example::
+
+    cr> select has_table_privilege('sys.summits', ' Select  ')
+    ... as has_priv;
+    +----------+
+    | has_priv |
+    +----------+
+    | TRUE     |
+    +----------+
+    SELECT 1 row in set (... sec)
+    
+    
 .. _scalar-pg_backend_pid:
 
 ``pg_backend_pid()``

--- a/server/src/main/java/io/crate/expression/scalar/HasTablePrivilegeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/HasTablePrivilegeFunction.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.  You may
  * obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
@@ -29,50 +29,38 @@ import java.util.Locale;
 
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.Functions;
+import io.crate.metadata.RelationName;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.functions.Signature;
 import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
-import io.crate.metadata.pgcatalog.PgCatalogTableDefinitions;
 import io.crate.role.Permission;
 import io.crate.role.Role;
 import io.crate.role.Roles;
 import io.crate.role.Securable;
 import io.crate.types.DataTypes;
 
-public class HasSchemaPrivilegeFunction {
+public class HasTablePrivilegeFunction {
 
-    public static final FunctionName NAME = new FunctionName(PgCatalogSchemaInfo.NAME, "has_schema_privilege");
+    public static final FunctionName NAME = new FunctionName(PgCatalogSchemaInfo.NAME, "has_table_privilege");
 
-    public static boolean checkBySchemaName(Roles roles, Role user, Object schema, Collection<Permission> permissions, Schemas schemas) {
-        String schemaName = (String) schema;
-        boolean result = false;
-        for (Permission permission : permissions) {
-            // USAGE is allowed for public schemas
-            if (permission == Permission.DQL && PgCatalogTableDefinitions.isPgCatalogOrInformationSchema(schemaName)) {
-                return true;
-            }
-            // Last argument is null as it's not used for Privilege.Securable.SCHEMA
-            result |= roles.hasPrivilege(user, permission, Securable.SCHEMA, schemaName);
-        }
-        return result;
+    public static boolean checkByTableName(Roles roles, Role user, Object table, Collection<Permission> permissions, Schemas schemas) {
+        String tableFqn = RelationName.fqnFromIndexName((String) table);
+        return checkPrivileges(roles, user, tableFqn, permissions);
     }
 
-    public static boolean checkBySchemaOid(Roles roles, Role user, Object schema, Collection<Permission> permissions, Schemas schemas) {
-        Integer schemaOid = (Integer) schema;
-        boolean result = false;
-        for (Permission permission : permissions) {
-            // USAGE is allowed for public schemas
-            if (permission == Permission.DQL && PgCatalogTableDefinitions.isPgCatalogOrInformationSchema(schemaOid)) {
-                return true;
-            }
-            result |= roles.hasSchemaPrivilege(user, permission, schemaOid); // Returns true if has any privilege out of 2 possible
+    public static boolean checkByTableOid(Roles roles, Role user, Object table, Collection<Permission> permissions, Schemas schemas) {
+        int tableOid = (int) table;
+        RelationName relationName = schemas.getRelation(tableOid);
+        if (relationName == null) {
+            throw new IllegalArgumentException("Cannot find corresponding relation by the given oid");
         }
-        return result;
+        String tableFqn = relationName.fqn();
+        return checkPrivileges(roles, user, tableFqn, permissions);
     }
 
     /**
      * @param permissionNames is a comma separated list.
-     * Valid permissionNames are 'CREATE' and 'USAGE' which map to DDL and DQL respectively.
+     * Valid permissionNames are 'SELECT' and 'INSERT', 'UPDATE', and 'DELETE' which map to DQL and DML respectively.
      * Extra whitespaces between privilege names and repetition of a valid argument are allowed.
      *
      * @see HasPrivilegeFunction.ParsePermissions#parse(String)
@@ -82,9 +70,9 @@ public class HasSchemaPrivilegeFunction {
         String[] permissions = permissionNames.toLowerCase(Locale.ENGLISH).split(",");
         for (String p : permissions) {
             p = p.trim();
-            if (p.equals("create")) {
-                toCheck.add(Permission.DDL);
-            } else if (p.equals("usage")) {
+            if (p.equals("insert") || p.equals("update") || p.equals("delete")) {
+                toCheck.add(Permission.DML);
+            } else if (p.equals("select")) {
                 toCheck.add(Permission.DQL);
             } else {
                 // Same error as PG
@@ -94,12 +82,26 @@ public class HasSchemaPrivilegeFunction {
         return toCheck;
     }
 
+    private static boolean checkPrivileges(Roles roles, Role user, String table, Collection<Permission> permissions) {
+        for (Permission permission : permissions) {
+            if (roles.hasPrivilege(user, permission, Securable.TABLE, table)) {
+                return true;
+            }
+        }
+        for (Permission permission : permissions) {
+            if (roles.hasPrivilege(user, permission, Securable.VIEW, table)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public static void register(Functions.Builder module) {
         // Signature without user, takes user from session.
         module.add(
             Signature.scalar(
                 NAME,
-                DataTypes.STRING.getTypeSignature(), // Schema
+                DataTypes.STRING.getTypeSignature(), // Table
                 DataTypes.STRING.getTypeSignature(), // Privilege
                 DataTypes.BOOLEAN.getTypeSignature()
             ).withFeatures(DETERMINISTIC_ONLY),
@@ -107,8 +109,8 @@ public class HasSchemaPrivilegeFunction {
                 signature,
                 boundSignature,
                 HasPrivilegeFunction::userByName,
-                HasSchemaPrivilegeFunction::checkBySchemaName,
-                HasSchemaPrivilegeFunction::parsePermissions
+                HasTablePrivilegeFunction::checkByTableName,
+                HasTablePrivilegeFunction::parsePermissions
             )
         );
 
@@ -116,7 +118,7 @@ public class HasSchemaPrivilegeFunction {
         module.add(
             Signature.scalar(
                 NAME,
-                DataTypes.INTEGER.getTypeSignature(), // Schema
+                DataTypes.INTEGER.getTypeSignature(), // Table
                 DataTypes.STRING.getTypeSignature(),  // Privilege
                 DataTypes.BOOLEAN.getTypeSignature()
             ).withFeatures(DETERMINISTIC_ONLY),
@@ -124,8 +126,8 @@ public class HasSchemaPrivilegeFunction {
                 signature,
                 boundSignature,
                 HasPrivilegeFunction::userByName,
-                HasSchemaPrivilegeFunction::checkBySchemaOid,
-                HasSchemaPrivilegeFunction::parsePermissions
+                HasTablePrivilegeFunction::checkByTableOid,
+                HasTablePrivilegeFunction::parsePermissions
             )
         );
 
@@ -133,7 +135,7 @@ public class HasSchemaPrivilegeFunction {
             Signature.scalar(
                 NAME,
                 DataTypes.STRING.getTypeSignature(), // User
-                DataTypes.STRING.getTypeSignature(), // Schema
+                DataTypes.STRING.getTypeSignature(), // Table
                 DataTypes.STRING.getTypeSignature(), // Privilege
                 DataTypes.BOOLEAN.getTypeSignature()
             ).withFeatures(DETERMINISTIC_ONLY),
@@ -141,8 +143,8 @@ public class HasSchemaPrivilegeFunction {
                 signature,
                 boundSignature,
                 HasPrivilegeFunction::userByName,
-                HasSchemaPrivilegeFunction::checkBySchemaName,
-                HasSchemaPrivilegeFunction::parsePermissions
+                HasTablePrivilegeFunction::checkByTableName,
+                HasTablePrivilegeFunction::parsePermissions
             )
         );
 
@@ -150,7 +152,7 @@ public class HasSchemaPrivilegeFunction {
             Signature.scalar(
                 NAME,
                 DataTypes.STRING.getTypeSignature(),  // User
-                DataTypes.INTEGER.getTypeSignature(), // Schema
+                DataTypes.INTEGER.getTypeSignature(), // Table
                 DataTypes.STRING.getTypeSignature(),  // Privilege
                 DataTypes.BOOLEAN.getTypeSignature()
             ).withFeatures(DETERMINISTIC_ONLY),
@@ -158,8 +160,8 @@ public class HasSchemaPrivilegeFunction {
                 signature,
                 boundSignature,
                 HasPrivilegeFunction::userByName,
-                HasSchemaPrivilegeFunction::checkBySchemaOid,
-                HasSchemaPrivilegeFunction::parsePermissions
+                HasTablePrivilegeFunction::checkByTableOid,
+                HasTablePrivilegeFunction::parsePermissions
             )
         );
 
@@ -167,7 +169,7 @@ public class HasSchemaPrivilegeFunction {
             Signature.scalar(
                 NAME,
                 DataTypes.INTEGER.getTypeSignature(), // User
-                DataTypes.STRING.getTypeSignature(),  // Schema
+                DataTypes.STRING.getTypeSignature(),  // Table
                 DataTypes.STRING.getTypeSignature(),  // Privilege
                 DataTypes.BOOLEAN.getTypeSignature()
             ).withFeatures(DETERMINISTIC_ONLY),
@@ -175,8 +177,8 @@ public class HasSchemaPrivilegeFunction {
                 signature,
                 boundSignature,
                 HasPrivilegeFunction::userByOid,
-                HasSchemaPrivilegeFunction::checkBySchemaName,
-                HasSchemaPrivilegeFunction::parsePermissions
+                HasTablePrivilegeFunction::checkByTableName,
+                HasTablePrivilegeFunction::parsePermissions
             )
         );
 
@@ -184,7 +186,7 @@ public class HasSchemaPrivilegeFunction {
             Signature.scalar(
                 NAME,
                 DataTypes.INTEGER.getTypeSignature(), // User
-                DataTypes.INTEGER.getTypeSignature(), // Schema
+                DataTypes.INTEGER.getTypeSignature(), // Table
                 DataTypes.STRING.getTypeSignature(),  // Privilege
                 DataTypes.BOOLEAN.getTypeSignature()
             ).withFeatures(DETERMINISTIC_ONLY),
@@ -192,12 +194,12 @@ public class HasSchemaPrivilegeFunction {
                 signature,
                 boundSignature,
                 HasPrivilegeFunction::userByOid,
-                HasSchemaPrivilegeFunction::checkBySchemaOid,
-                HasSchemaPrivilegeFunction::parsePermissions
+                HasTablePrivilegeFunction::checkByTableOid,
+                HasTablePrivilegeFunction::parsePermissions
             )
         );
     }
 
-    private HasSchemaPrivilegeFunction() {
+    private HasTablePrivilegeFunction() {
     }
 }

--- a/server/src/main/java/io/crate/expression/scalar/ScalarFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/ScalarFunctions.java
@@ -244,6 +244,7 @@ public class ScalarFunctions implements FunctionsProvider {
 
         HasSchemaPrivilegeFunction.register(builder);
         HasDatabasePrivilegeFunction.register(builder);
+        HasTablePrivilegeFunction.register(builder);
         ParseURIFunction.register(builder);
         ParseURLFunction.register(builder);
 

--- a/server/src/test/java/io/crate/expression/scalar/HasDatabasePrivilegeFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/HasDatabasePrivilegeFunctionTest.java
@@ -63,7 +63,7 @@ public class HasDatabasePrivilegeFunctionTest extends ScalarTestCase {
     public void prepare() {
         sqlExpressions = new SqlExpressions(
             tableSources, null, randomFrom(Role.CRATE_USER, TEST_USER_WITH_AL_ON_CLUSTER, TEST_USER_WITH_DQL_ON_SYS),
-            List.of(Role.CRATE_USER, TEST_USER, TEST_USER_WITH_CREATE));
+            List.of(Role.CRATE_USER, TEST_USER, TEST_USER_WITH_CREATE), null);
     }
 
     @Test
@@ -112,7 +112,7 @@ public class HasDatabasePrivilegeFunctionTest extends ScalarTestCase {
 
     @Test
     public void test_throws_error_when_user_is_not_super_user_checking_for_other_user() {
-        sqlExpressions = new SqlExpressions(tableSources, null, TEST_USER, List.of(TEST_USER_WITH_AL_ON_CLUSTER));
+        sqlExpressions = new SqlExpressions(tableSources, null, TEST_USER, List.of(TEST_USER_WITH_AL_ON_CLUSTER), null);
         assertThatThrownBy(
             () -> assertEvaluate("has_database_privilege('testUserWithClusterAL', 'crate', 'CREATE')", null))
             .isExactlyInstanceOf(MissingPrivilegeException.class)
@@ -121,7 +121,7 @@ public class HasDatabasePrivilegeFunctionTest extends ScalarTestCase {
 
     @Test
     public void test_throws_error_when_user_is_not_super_user_checking_for_other_user_for_compiled() {
-        sqlExpressions = new SqlExpressions(tableSources, null, TEST_USER, List.of(TEST_USER_WITH_AL_ON_CLUSTER));
+        sqlExpressions = new SqlExpressions(tableSources, null, TEST_USER, List.of(TEST_USER_WITH_AL_ON_CLUSTER), null);
         assertThatThrownBy(
             () -> assertCompile("has_database_privilege('testUserWithClusterAL', name, 'CREATE')",
                                 TEST_USER, () -> List.of(TEST_USER, TEST_USER_WITH_AL_ON_CLUSTER),

--- a/server/src/test/java/io/crate/expression/scalar/HasSchemaPrivilegeFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/HasSchemaPrivilegeFunctionTest.java
@@ -59,7 +59,7 @@ public class HasSchemaPrivilegeFunctionTest extends ScalarTestCase {
     @Before
     public void prepare() {
         sqlExpressions = new SqlExpressions(
-            tableSources, null, randomFrom(TEST_USER_WITH_AL_ON_CLUSTER, TEST_USER_WITH_DQL_ON_SYS, Role.CRATE_USER), List.of(TEST_USER));
+            tableSources, null, randomFrom(TEST_USER_WITH_AL_ON_CLUSTER, TEST_USER_WITH_DQL_ON_SYS, Role.CRATE_USER), List.of(TEST_USER), null);
     }
 
     @Test
@@ -108,7 +108,7 @@ public class HasSchemaPrivilegeFunctionTest extends ScalarTestCase {
 
     @Test
     public void test_throws_error_when_user_without_related_privileges_is_checking_for_other_user() {
-        sqlExpressions = new SqlExpressions(tableSources, null, TEST_USER, List.of(TEST_USER_WITH_AL_ON_CLUSTER));
+        sqlExpressions = new SqlExpressions(tableSources, null, TEST_USER, List.of(TEST_USER_WITH_AL_ON_CLUSTER), null);
         assertThatThrownBy(
             () -> assertEvaluate("has_schema_privilege('testUserWithClusterAL', 'pg_catalog', ' USAGE, CREATE, SELECT')", null))
             .isExactlyInstanceOf(MissingPrivilegeException.class)
@@ -117,7 +117,7 @@ public class HasSchemaPrivilegeFunctionTest extends ScalarTestCase {
 
     @Test
     public void test_throws_error_when_user_without_related_privileges_is_checking_for_other_user_for_compiled() {
-        sqlExpressions = new SqlExpressions(tableSources, null, TEST_USER, List.of(TEST_USER_WITH_AL_ON_CLUSTER));
+        sqlExpressions = new SqlExpressions(tableSources, null, TEST_USER, List.of(TEST_USER_WITH_AL_ON_CLUSTER), null);
         assertThatThrownBy(
             () -> assertCompile("has_schema_privilege('testUserWithClusterAL', name, 'USAGE')",
                                 TEST_USER, () -> List.of(TEST_USER, TEST_USER_WITH_AL_ON_CLUSTER),

--- a/server/src/test/java/io/crate/expression/scalar/HasTablePrivilegeFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/HasTablePrivilegeFunctionTest.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Test;
+
+import io.crate.metadata.RelationName;
+import io.crate.metadata.Schemas;
+import io.crate.metadata.pgcatalog.OidHash;
+import io.crate.role.Permission;
+import io.crate.role.Policy;
+import io.crate.role.Privilege;
+import io.crate.role.Role;
+import io.crate.role.Securable;
+import io.crate.role.metadata.RolesHelper;
+import io.crate.testing.SqlExpressions;
+
+public class HasTablePrivilegeFunctionTest extends ScalarTestCase {
+
+    private static final Role TEST_USER_WITH_SYS_SUMMITS_TABLE_DQL =
+        RolesHelper.userOf("testUserWithSysSummitsDQL", Set.of(
+                new Privilege(Policy.GRANT, Permission.DQL, Securable.TABLE, "sys.summits", Role.CRATE_USER.name())),
+            null);
+
+    private static final Role TEST_USER_WITH_SYS_HEALTH_TABLE_DQL =
+        RolesHelper.userOf("testUserWithSysHealthDQL", Set.of(
+                new Privilege(Policy.GRANT, Permission.DQL, Securable.TABLE, "sys.health", Role.CRATE_USER.name())),
+            null);
+
+    private static final Role TEST_USER_WITH_SYS_HEALTH_TABLE_DML =
+        RolesHelper.userOf("testUserWithSysHealthDML", Set.of(
+                new Privilege(Policy.GRANT, Permission.DML, Securable.TABLE, "sys.health", Role.CRATE_USER.name())),
+            null);
+
+    private static final Role TEST_USER_WITH_DOC_USERS_TABLE_DQL =
+        RolesHelper.userOf("testUserWithUsersTableDQL", Set.of(
+                new Privilege(Policy.GRANT, Permission.DQL, Securable.TABLE, "doc.users", Role.CRATE_USER.name())),
+            null);
+
+    @Test
+    public void test_user_with_sys_health_table_dql_do_not_have_privilege_on_sys_summits_table() {
+        sqlExpressions = new SqlExpressions(tableSources, null, TEST_USER_WITH_SYS_HEALTH_TABLE_DQL, List.of(), null);
+        assertEvaluate("has_table_privilege('testUserWithSysHealthDQL', 'sys.summits', 'SELECT')", false);
+    }
+
+    @Test
+    public void test_user_with_sys_summits_table_dql_have_privilege_on_sys_summits_table() {
+        sqlExpressions = new SqlExpressions(tableSources, null, TEST_USER_WITH_SYS_SUMMITS_TABLE_DQL, List.of(), null);
+        assertEvaluate("has_table_privilege('testUserWithSysSummitsDQL', 'sys.summits', 'SELECT')", true);
+    }
+
+    @Test
+    public void test_has_table_privilege_function_without_user_parameter() {
+        sqlExpressions = new SqlExpressions(tableSources, null, TEST_USER_WITH_SYS_SUMMITS_TABLE_DQL, List.of(), null);
+        assertEvaluate("has_table_privilege('sys.summits', 'SELECT')", true);
+
+        sqlExpressions = new SqlExpressions(tableSources, null, TEST_USER_WITH_SYS_HEALTH_TABLE_DQL, List.of(), null);
+        assertEvaluate("has_table_privilege('sys.summits', 'SELECT')", false);
+    }
+
+    @Test
+    public void test_has_table_privilege_function_with_table_as_oid() {
+        final RelationName usersTable = new RelationName("doc", "users");
+        final int usersTableOid = OidHash.relationOid(OidHash.Type.TABLE, usersTable);
+
+        Schemas schemas = mock(Schemas.class);
+        when(schemas.getRelation(usersTableOid)).thenReturn(usersTable);
+
+        sqlExpressions = new SqlExpressions(tableSources, null, TEST_USER_WITH_DOC_USERS_TABLE_DQL, List.of(), schemas);
+        assertEvaluate("has_table_privilege(" + usersTableOid + ", 'SELECT')", true);
+    }
+
+    @Test
+    public void test_has_table_privilege_function_with_system_table_as_oid() {
+        final RelationName sysHealth = new RelationName("sys", "health");
+        final int sysHealthOid = OidHash.relationOid(OidHash.Type.TABLE, sysHealth);
+
+        Schemas schemas = mock(Schemas.class);
+        when(schemas.getRelation(sysHealthOid)).thenReturn(sysHealth);
+
+        sqlExpressions = new SqlExpressions(tableSources, null, TEST_USER_WITH_SYS_HEALTH_TABLE_DML, List.of(), schemas);
+        assertEvaluate("has_table_privilege(" + sysHealthOid + ", 'UPDATE')", true);
+    }
+
+    @Test
+    public void test_return_true_if_any_of_the_listed_privileges_is_held() {
+        sqlExpressions = new SqlExpressions(tableSources, null, TEST_USER_WITH_SYS_SUMMITS_TABLE_DQL, List.of(), null);
+        assertEvaluate("has_table_privilege('sys.summits', 'SELECT, INSERT')", true); // INSERT(DML) is not held but still returns 'true'
+    }
+
+    @Test
+    public void test_throws_if_listed_privileges_contain_invalid_privilege() {
+        sqlExpressions = new SqlExpressions(tableSources, null, TEST_USER_WITH_SYS_SUMMITS_TABLE_DQL, List.of(), null);
+        assertThatThrownBy(() -> assertEvaluate("has_table_privilege('sys.summits', 'SELECT, TRUNCATE')", true))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Unrecognized permission: truncate");
+    }
+}

--- a/server/src/test/java/io/crate/integrationtests/HasTablePrivilegeFunctionIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/HasTablePrivilegeFunctionIntegrationTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.integrationtests;
+
+import static io.crate.metadata.pgcatalog.OidHash.Type.fromRelationType;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.elasticsearch.test.IntegTestCase;
+import org.junit.Test;
+
+import io.crate.metadata.RelationInfo;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.pgcatalog.OidHash;
+
+public class HasTablePrivilegeFunctionIntegrationTest extends IntegTestCase {
+
+    @Test
+    public void test_has_table_privilege_function_with_different_types_of_relations() {
+        execute("create user john");
+
+        // system table
+        execute("select has_table_privilege('john', 'sys.summits', 'SELECT')");
+        assertThat(response.rows()[0][0]).isEqualTo(false);
+
+        execute("grant dql on table sys.summits to john");
+
+        execute("select has_table_privilege('john', 'sys.summits', 'SELECT')");
+        assertThat(response.rows()[0][0]).isEqualTo(true);
+
+        final RelationName sysSummits = new RelationName("sys", "summits");
+        final int sysSummitsOid = OidHash.relationOid(OidHash.Type.TABLE, sysSummits);
+        execute("select has_table_privilege('john', " + sysSummitsOid + ", 'SELECT')");
+        assertThat(response.rows()[0][0]).isEqualTo(true);
+
+        // view
+        execute("create view doc.v as select * from sys.summits");
+
+        execute("select has_table_privilege('john', 'v', 'SELECT')");
+        assertThat(response.rows()[0][0]).isEqualTo(false);
+
+        execute("grant dql on view doc.v to john");
+
+        execute("select has_table_privilege('john', 'v', 'SELECT')");
+        assertThat(response.rows()[0][0]).isEqualTo(true);
+
+        final RelationName view = new RelationName("doc", "v");
+        final int viewOid = OidHash.relationOid(fromRelationType(RelationInfo.RelationType.VIEW), view);
+        execute("select has_table_privilege('john', " + viewOid + ", 'SELECT')");
+        assertThat(response.rows()[0][0]).isEqualTo(true);
+
+        // foreign table
+        execute("""
+            CREATE SERVER pg
+            FOREIGN DATA WRAPPER jdbc
+            OPTIONS (url 'jdbc:postgresql://example.com:5432/');
+            """);
+        execute("""
+            CREATE FOREIGN TABLE doc.remote_documents (name text)
+            SERVER pg
+            OPTIONS (schema_name 'public', table_name 'documents');
+            """);
+        execute("""
+            CREATE USER MAPPING FOR john
+            SERVER pg
+            OPTIONS ("user" 'foreign-user', password 'foreign-pw');
+            """);
+
+        execute("select has_table_privilege('john', 'remote_documents', 'SELECT')");
+        assertThat(response.rows()[0][0]).isEqualTo(false);
+
+        execute("grant dql on table doc.remote_documents to john");
+
+        execute("select has_table_privilege('john', 'remote_documents', 'SELECT')");
+        assertThat(response.rows()[0][0]).isEqualTo(true);
+
+        final RelationName foreignTable = new RelationName("doc", "remote_documents");
+        final int foreignTableOid = OidHash.relationOid(fromRelationType(RelationInfo.RelationType.FOREIGN), foreignTable);
+        execute("select has_table_privilege('john', " + foreignTableOid + ", 'SELECT')");
+        assertThat(response.rows()[0][0]).isEqualTo(true);
+
+        execute("drop user john");
+    }
+}

--- a/server/src/testFixtures/java/io/crate/testing/SqlExpressions.java
+++ b/server/src/testFixtures/java/io/crate/testing/SqlExpressions.java
@@ -22,7 +22,6 @@
 package io.crate.testing;
 
 import static io.crate.testing.TestingHelpers.createNodeContext;
-import static org.mockito.Mockito.mock;
 
 import java.util.List;
 import java.util.Map;
@@ -46,6 +45,7 @@ import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.settings.CoordinatorSessionSettings;
 import io.crate.metadata.table.Operation;
 import io.crate.role.Role;
@@ -71,14 +71,15 @@ public class SqlExpressions {
     public SqlExpressions(Map<RelationName, AnalyzedRelation> sources,
                           @Nullable FieldResolver fieldResolver,
                           Role sessionUser) {
-        this(sources, fieldResolver, sessionUser, List.of());
+        this(sources, fieldResolver, sessionUser, List.of(), null);
     }
 
     public SqlExpressions(Map<RelationName, AnalyzedRelation> sources,
                           @Nullable FieldResolver fieldResolver,
                           Role sessionUser,
-                          List<Role> additionalUsers) {
-        this.nodeCtx = createNodeContext(null, Lists.concat(additionalUsers, sessionUser));
+                          List<Role> additionalUsers,
+                          Schemas schemas) {
+        this.nodeCtx = createNodeContext(schemas, Lists.concat(additionalUsers, sessionUser));
         // In test_throws_error_when_user_is_not_found we explicitly inject null user but SessionContext user cannot be not null.
         var sessionSettings = new CoordinatorSessionSettings(sessionUser == null ? Role.CRATE_USER : sessionUser);
         coordinatorTxnCtx = new CoordinatorTxnCtx(sessionSettings);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Resolves https://github.com/crate/crate/issues/15748.

Initially discussed to go by extending NodeContext with ClusterState but since system tables are not available in cluster state, went by extending NodeContext with Schemas.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
