### PR TITLE
Docs: clarify has_schema_privilege regarding unknown schemas

### DIFF
--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -3962,6 +3962,19 @@ Example::
     +----------+
     SELECT 1 row in set (... sec)
 
+.. NOTE::
+
+    For unknown schemas:
+
+    - Returns ``TRUE`` for superusers.
+
+    - For a user with ``DQL`` on cluster scope, returns ``TRUE`` if the
+      privilege type is ``USAGE``.
+
+    - For a user with ``DML`` on cluster scope, returns ``TRUE`` if the
+      privilege type is ``CREATE``.
+
+    - Returns ``FALSE`` otherwise.
 
 .. _scalar-has-table-priv:
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes the following scenario:
```
cr> select pg_catalog.has_schema_privilege('unknown_schema', 'usage');                                                                                                   
+------+
| true |
+------+
| TRUE |
+------+
=> should throw a SchemaUnknownException instead of returning true
```

update: instead of throwing, it was decided to return false to prevent information leaks.

update2: below is the final decision:
```
   For unknown schemas:

     - Returns ``TRUE`` for superusers.

     - For a user with ``DQL`` on cluster scope, returns ``TRUE`` if the
       privilege type is ``USAGE``.

     - For a user with ``DML`` on cluster scope, returns ``TRUE`` if the
       privilege type is ``CREATE``.

     - Returns ``FALSE`` otherwise.
```
Please follow the discussions in the current PR for details.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
