### PR TITLE
Amend SWAP TABLE WITH drop_source explanation

### DIFF
--- a/docs/sql/statements/alter-cluster.rst
+++ b/docs/sql/statements/alter-cluster.rst
@@ -97,7 +97,7 @@ Options
 
    A boolean option that if set to ``true`` causes the command to remove the
    ``source`` table after the rename. This causes the command to *replace*
-   ``source`` with ``target``, instead of swapping the names.
+   ``target`` with ``source``, instead of swapping the names.
 
 .. _alter_cluster_gc_dangling_artifacts:
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

```sql
CREATE TABLE test.source (a text);
INSERT INTO test.source (a) VALUES ('This is the data in the source');
REFRESH TABLE test.source;

CREATE TABLE test.target (a text);
INSERT INTO test.target (a) VALUES ('This is the data in the target');
REFRESH TABLE test.target;

ALTER CLUSTER SWAP TABLE test.source TO test.target WITH (drop_source=true);

SELECT * FROM test.target;

/*
+--------------------------------+
| a                              |
+--------------------------------+
| This is the data in the source |
+--------------------------------+
*/
--> target is replaced with source, not the other way around.
```

## Checklist

 - [X] [CLA](https://crate.io/community/contribute/cla/) is signed
