### PR TITLE
Move rejectClientInitiatedRenegotiation out of GC section; tweak release notes

### DIFF
--- a/app/src/main/dist/bin/crate
+++ b/app/src/main/dist/bin/crate
@@ -114,7 +114,7 @@ if [ "x$CRATE_USE_IPV4" != "x" ]; then
 fi
 
 ## GC configuration
-JAVA_OPTS="$JAVA_OPTS -XX:+UseG1GC -XX:G1ReservePercent=25 -XX:InitiatingHeapOccupancyPercent=30 -Djdk.tls.rejectClientInitiatedRenegotiation=true"
+JAVA_OPTS="$JAVA_OPTS -XX:+UseG1GC -XX:G1ReservePercent=25 -XX:InitiatingHeapOccupancyPercent=30"
 
 # GC logging options
 # Set CRATE_DISABLE_GC_LOGGING=1 to disable GC logging
@@ -145,6 +145,9 @@ fi
 
 # Disables explicit GC
 JAVA_OPTS="$JAVA_OPTS -XX:+DisableExplicitGC"
+
+# Prevent denial of service attacks via SSL renegotiation
+JAVA_OPTS="$JAVA_OPTS -Djdk.tls.rejectClientInitiatedRenegotiation=true"
 
 # Ensure UTF-8 encoding by default (e.g. filenames)
 JAVA_OPTS="$JAVA_OPTS -Dfile.encoding=UTF-8"

--- a/app/src/main/dist/bin/crate.bat
+++ b/app/src/main/dist/bin/crate.bat
@@ -55,7 +55,7 @@ REM Enable aggressive optimizations in the JVM
 REM    - Disabled by default as it might cause the JVM to crash
 REM set JAVA_OPTS=%JAVA_OPTS% -XX:+AggressiveOpts
 
-set JAVA_OPTS=%JAVA_OPTS% -XX:+UseG1GC -XX:G1ReservePercent=25 -XX:InitiatingHeapOccupancyPercent=30 -Djdk.tls.rejectClientInitiatedRenegotiation=true
+set JAVA_OPTS=%JAVA_OPTS% -XX:+UseG1GC -XX:G1ReservePercent=25 -XX:InitiatingHeapOccupancyPercent=30
 
 REM GC logging default values
 SET GC_LOG_DIR=%CRATE_HOME%\logs
@@ -77,6 +77,9 @@ if NOT DEFINED CRATE_DISABLE_GC_LOGGING (
 
 REM Disables explicit GC
 set JAVA_OPTS=%JAVA_OPTS% -XX:+DisableExplicitGC
+
+REM Prevent denial of service attacks via SSL renegotiation
+set JAVA_OPTS=%JAVA_OPTS% -Djdk.tls.rejectClientInitiatedRenegotiation=true
 
 REM Use our provided JNA always versus the system one
 set JAVA_OPTS=%JAVA_OPTS% -Djna.nosys=true

--- a/docs/appendices/release-notes/5.7.2.rst
+++ b/docs/appendices/release-notes/5.7.2.rst
@@ -46,8 +46,8 @@ See the :ref:`version_5.7.0` release notes for a full list of changes in the
 Security Fixes
 ==============
 
-- Fixed a security issue allowing clients using TLS v1.2 to do client-initiated
-  renegotiation which can lead to DoS.
+- Disabled client-initiated renegotiation for TLS by default.
+  This helps prevent Denial of Service (DoS) attacks.
 
 Fixes
 =====


### PR DESCRIPTION
The JAVA_OPTS assignments are grouped by topic.
`rejectClientInitiatedRenegotiation` is unrelated to GC
