### PR TITLE
Use template mapping as-is in TransportCreatePartitionsAction

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -53,6 +53,7 @@ import org.elasticsearch.indices.mapper.MapperRegistry;
 
 import io.crate.Constants;
 import io.crate.server.xcontent.LoggingDeprecationHandler;
+import io.crate.server.xcontent.XContentHelper;
 
 public class MapperService extends AbstractIndexComponent implements Closeable {
 
@@ -197,8 +198,10 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
                     assert currentSource.equals(newSource) :
                         "expected current mapping [" + currentSource + "] for type [" + Constants.DEFAULT_MAPPING_TYPE + "] "
                             + "to be the same as new mapping [" + newSource + "]";
-                    final CompressedXContent mapperSource = new CompressedXContent(Strings.toString(mapper));
-                    assert currentSource.equals(mapperSource) :
+
+                    Map<String, Object> currentMapping = XContentHelper.toMap(currentSource.uncompressed(), XContentType.JSON);
+                    Map<String, Object> mapperSource = XContentHelper.toMap(mapping.source().uncompressed(), XContentType.JSON);
+                    assert currentMapping.equals(mapperSource) :
                         "expected current mapping [" + currentSource + "] for type [" + Constants.DEFAULT_MAPPING_TYPE + "] "
                             + "to be the same as new mapping [" + mapperSource + "]";
                 }


### PR DESCRIPTION
The TransportCreatePartitionsAction used the mapperService to merge the
template mapping into a new empty mapping.

We can skip that step and use the mapping from the template as is.
It must have passed validation when the template was first created.

Note this PR also relaxes an assertion, because the order of properties
within the mapping is no longer stable.

Something like:

    "date": {
      "format": "epoch_millis||strict_date_optional_time",
      "index": false,
      "position": 2,
      "oid": 4,
      "type": "date"
    },

Can change to:

    "date": {
      "type": "date",
      "index": false,
      "position": 2,
      "oid": 4,
      "format": "epoch_millis||strict_date_optional_time"
    },

This is due to the use of `HashMap` within the `MappingUtil`. The
order of the keys has no semantic impact.
