### PR TITLE
Optimize PartitionName.templateName

### DIFF
--- a/server/src/main/java/io/crate/metadata/PartitionName.java
+++ b/server/src/main/java/io/crate/metadata/PartitionName.java
@@ -140,8 +140,12 @@ public class PartitionName {
     }
 
     public static String templateName(String indexName) {
-        RelationName relationName = PartitionName.fromIndexOrTemplate(indexName).relationName;
-        return templateName(relationName.schema(), relationName.name());
+        IndexParts indexParts = new IndexParts(indexName);
+        if (!indexParts.isPartitioned()) {
+            throw new IllegalArgumentException(
+                "Cannot convert non-partitioned index name to templateName: " + indexName);
+        }
+        return templateName(indexParts.getSchema(), indexParts.getTable());
     }
 
     /**


### PR DESCRIPTION
It used `PartitionName.fromIndexOrTemplate`, which internally creates
`IndexParts`, `RelationName` and `PartitionName`

To get a `templateName`, only the `IndexParts` are needed.
