### PR TITLE
Remove filters from tablesStream

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/collect/sources/InformationSchemaIterables.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/sources/InformationSchemaIterables.java
@@ -270,9 +270,7 @@ public class InformationSchemaIterables implements ClusterStateListener {
 
     public static Stream<TableInfo> tablesStream(Schemas schemas) {
         return sequentialStream(schemas)
-            .flatMap(s -> sequentialStream(s.getTables()))
-            .filter(i -> !(IndexParts.isPartitioned(i.ident().indexNameOrAlias()) ||
-                           IndexParts.isDangling(i.ident().indexNameOrAlias())));
+            .flatMap(s -> sequentialStream(s.getTables()));
     }
 
     private static <T> Stream<T> sequentialStream(Iterable<T> iterable) {


### PR DESCRIPTION
Remove filters from tablesStream

Predicate never results in true. 

`SchemaInfo.getTables` returns table infos with normalized names, 
prefix "partitioned" is trimmed. 

It also filters out dangling indices, no need to do the same check.