### PR TITLE
Fix scalar functions falsely marked as NON_NULLABLE

### DIFF
--- a/docs/appendices/release-notes/5.7.2.rst
+++ b/docs/appendices/release-notes/5.7.2.rst
@@ -56,6 +56,11 @@ Fixes
   errors caused by sub-queries such as ''SELECT * FROM t1 WHERE id IN
   (SELECT id FROM t2)'' or lookup-joins with large intermediate results.
 
+- Fixed an issue that caused ``WHERE`` clause to fail to filter rows when
+  the clause contained ``CONCAT``, ``CURRENT_SETTING``,
+  ``PG_GET_FUNCTION_RESULT``, or ``PG_ENCODING_TO_CHAR`` scalar functions under
+  ``NOT`` operator.
+
 - Fixed an issue leading to restoring data into wrong tables when restoring a
   snapshot with partitioned tables using one of the renaming parameters
   ``schema_rename_pattern``, ``schema_rename_replacement``,

--- a/server/src/main/java/io/crate/expression/scalar/ConcatFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ConcatFunction.java
@@ -83,8 +83,7 @@ public abstract class ConcatFunction extends Scalar<String, String> {
                 DataTypes.UNTYPED_OBJECT.getTypeSignature(),
                 DataTypes.UNTYPED_OBJECT.getTypeSignature(),
                 DataTypes.UNTYPED_OBJECT.getTypeSignature()
-            )
-            .withFeature(Feature.NON_NULLABLE),
+            ),
             ObjectMergeFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/postgres/CurrentSettingFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/postgres/CurrentSettingFunction.java
@@ -47,7 +47,7 @@ public class CurrentSettingFunction extends Scalar<String, Object> {
                 FQN,
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ).withFeature(Feature.NULLABLE),
+            ),
             (signature, boundSignature) ->
                 new CurrentSettingFunction(
                     signature,

--- a/server/src/main/java/io/crate/expression/scalar/postgres/PgEncodingToCharFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/postgres/PgEncodingToCharFunction.java
@@ -44,7 +44,7 @@ public class PgEncodingToCharFunction extends Scalar<String, Integer> {
                 FQN,
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ).withFeature(Feature.NON_NULLABLE),
+            ),
             PgEncodingToCharFunction:: new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetFunctionResultFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetFunctionResultFunction.java
@@ -40,7 +40,7 @@ public final class PgGetFunctionResultFunction extends Scalar<String, Integer> {
                 NAME,
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ).withFeature(Feature.NULLABLE),
+            ),
             PgGetFunctionResultFunction::new);
     }
 

--- a/server/src/test/java/io/crate/lucene/ThreeValuedLogicQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/ThreeValuedLogicQueryBuilderTest.java
@@ -91,4 +91,22 @@ public class ThreeValuedLogicQueryBuilderTest extends LuceneQueryBuilderTest {
         assertThat(convert("NOT (x OR y) > true")).hasToString(
             "+(+*:* -((x OR y) > true)) #(NOT ((x OR y) > true))");
     }
+
+    @Test
+    public void test_not_on_pg_encoding_to_char() {
+        assertThat(convert("NOT (PG_ENCODING_TO_CHAR(x))"))
+            .hasToString("+(+*:* -pg_catalog.pg_encoding_to_char(x)) #(NOT pg_catalog.pg_encoding_to_char(x))");
+    }
+
+    @Test
+    public void test_not_on_pg_get_function_result() {
+        assertThat(convert("NOT (PG_GET_FUNCTION_RESULT(x))"))
+            .hasToString("+(+*:* -pg_get_function_result(x)) #(NOT pg_get_function_result(x))");
+    }
+
+    @Test
+    public void test_not_on_current_setting() {
+        assertThat(convert("NOT (CURRENT_SETTING(name))"))
+            .hasToString("+(+*:* -pg_catalog.current_setting(name)) #(NOT pg_catalog.current_setting(name))");
+    }
 }

--- a/server/src/testFixtures/java/io/crate/expression/scalar/ScalarTestCase.java
+++ b/server/src/testFixtures/java/io/crate/expression/scalar/ScalarTestCase.java
@@ -23,7 +23,6 @@ package io.crate.expression.scalar;
 
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.isNull;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.LinkedList;
@@ -257,6 +256,9 @@ public abstract class ScalarTestCase extends CrateDummyClusterServiceUnitTest {
 
         actualValue = scalar.evaluate(txnCtx, sqlExpressions.nodeCtx, arguments);
         assertThat((T) actualValue).satisfies(expectedValue);
+        if (scalar.signature().hasFeature(Scalar.Feature.NON_NULLABLE)) {
+            assertThat(actualValue).isNotNull();
+        }
     }
 
     @SuppressWarnings("rawtypes")


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes https://github.com/crate/crate/issues/16026

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
