### PR TITLE
Calculate and set default for `number_of_routing_shards`

### DIFF
--- a/docs/admin/system-information.rst
+++ b/docs/admin/system-information.rst
@@ -1128,7 +1128,7 @@ For example, you can query shards like this::
   +--------+-----------+----+-----+------+---------+------+---------+---------+-------+
   | schema | t         | id | p_i | docs | primary | r_n  | r_state |  state  | o_p   |
   +--------+-----------+----+-----+------+---------+------+---------+---------+-------+
-  | doc    | locations |  1 |     |    8 | TRUE    | NULL | STARTED | STARTED | FALSE |
+  | doc    | locations |  1 |     |    4 | TRUE    | NULL | STARTED | STARTED | FALSE |
   +--------+-----------+----+-----+------+---------+------+---------+---------+-------+
   SELECT 1 row in set (... sec)
 

--- a/docs/appendices/release-notes/5.8.0.rst
+++ b/docs/appendices/release-notes/5.8.0.rst
@@ -40,6 +40,7 @@ Version 5.8.0 - Unreleased
 .. contents::
    :local:
 
+.. _version_5.8.0_breaking_changes:
 
 Breaking Changes
 ================
@@ -50,8 +51,22 @@ Breaking Changes
   CrateDB 4.2.0.
 
 - Removed ``network`` column from :ref:`sys.nodes <sys-nodes>` table. The column
-  was deprecated since `version_2.3.0_` and all of the sub-columns where
+  was deprecated since :ref:`version_2.3.0` and all of the sub-columns where
   returning 0.
+
+- Tables created with version :ref:`version_5.8.0` onwards will have an
+  automatic
+  :ref:`number_of_routing_shards <sql-create-table-number-of-routing-shards>`
+  value set. As a result, documents maybe distributed across the shards
+  differently, compare with older versions. To maintain the same distribution,
+  as before :ref:`version_5.8.0` the
+  :ref:`number_of_routing_shards <sql-create-table-number-of-routing-shards>`
+  must be set to the same value as the number of shards in the
+  :ref:`CLUSTERED BY <sql-create-table-clustered>` clause of
+  :ref:`sql-create-table`.
+
+  .. NOTE:: If the number of routing shards equals the number of shard,
+            increasing the number of shards will not be supported.
 
 Deprecations
 ============
@@ -68,6 +83,12 @@ SQL Statements
 - `dshunter107 <https://github.com/dshunter107>`_ added support for the
   ``IF NOT EXISTS`` clause to :ref:`CREATE TABLE AS <ref-create-table-as>`
   statement.
+
+- Added a calculated default value for
+  :ref:`number_of_routing_shards <sql-create-table-number-of-routing-shards>` is
+  now set during :ref:`table creation <sql-create-table>`, which allows to
+  :ref:`increase the number of shards <alter-shard-number-increase>` for a
+  table. For more details see also :ref`version_5.8.0_breaking_changes`.
 
 SQL Standard and PostgreSQL Compatibility
 -----------------------------------------

--- a/docs/general/builtins/aggregation.rst
+++ b/docs/general/builtins/aggregation.rst
@@ -744,7 +744,7 @@ exceeded an ``ArithmeticException`` will be raised.
 ::
 
     cr> select sum(name), kind from locations group by kind order by sum(name) desc;
-    SQLParseException[Cannot cast value `North West Ripple` to type `byte`]
+    SQLParseException[Cannot cast value `Aldebaran` to type `byte`]
 
 If the ``sum`` aggregation on a numeric data type with the fixed length can
 potentially exceed its range it is possible to handle the overflow by casting

--- a/docs/general/ddl/alter-table.rst
+++ b/docs/general/ddl/alter-table.rst
@@ -101,11 +101,18 @@ into 4, 2 or 1 primary shards.
 Increase the number of shards
 .............................
 
-Increasing the number of shards is limited to tables which have been created
-with a ``number_of_routing_shards`` setting. For such tables the shards can be
-increased by a factor that depends on this setting. For example, a table with 5
-shards, with  ``number_of_routing_shards`` set to 20 can be changed to have
-either 10 or 20 shards. (5 x 2 (x 2)) = 20 or (5 x 4) = 20.
+To be able to increase the number of shards of a table, a correct value for the
+the :ref:`number_of_routing_shards <sql-create-table-number-of-routing-shards>`
+setting must be set during table creation. If the setting is not explicitly
+defined, a default value is calculated and set implicitly. For such tables the
+shards can be increased by a factor that depends on this setting. For example, a
+table with 5 primary shards, with ``number_of_routing_shards`` set to 20 can be
+changed to have either 10 or 20 shards. (5 x 2 (x 2)) = 20 or (5 x 4) = 20. If
+the table consists of only one primary shard, then the shard number can be
+increased to an arbitrary number (greater than 1 of course). In this case the
+default value for ``number_of_routing_shards`` will be calculated based on the
+new number of shards and set to the table, in order facilitate further increases
+of the number of its shards in the future.
 
 The only condition required for increasing the number of shards is to block
 operations to the table::

--- a/docs/general/ddl/sharding.rst
+++ b/docs/general/ddl/sharding.rst
@@ -59,8 +59,9 @@ is applied.
    The number of shards :ref:`can be changed <alter-shard-number>` after table
    creation, providing the value is a multiple of
    :ref:`number_of_routing_shards <sql-create-table-number-of-routing-shards>`
-   (set at table-creation time). Altering the number of shards will put the
-   table into a read-only state until the operation has completed.
+   (set at table-creation time, automatically, or explicitly). Altering the
+   number of shards will put the table into a read-only state until the
+   operation has completed.
 
 .. CAUTION::
 

--- a/docs/general/dql/fulltext.rst
+++ b/docs/general/dql/fulltext.rst
@@ -55,12 +55,12 @@ relevant the row::
 
     cr> select name, _score from locations
     ... where match(name_description_ft, 'time') order by _score desc;
-    +-----------+------------+
-    | name      |     _score |
-    +-----------+------------+
-    | Bartledan | 0.75782394 |
-    | Altair    | 0.63013375 |
-    +-----------+------------+
+    +-----------+-----------+
+    | name      |    _score |
+    +-----------+-----------+
+    | Altair    | 0.6570115 |
+    | Bartledan | 0.6416173 |
+    +-----------+-----------+
     SELECT 2 rows in set (... sec)
 
 The MATCH predicate in its simplest form performs a fulltext search against a
@@ -302,8 +302,8 @@ A fulltext search is done using the :ref:`predicates_match` predicate::
     +-----------+
     | name      |
     +-----------+
-    | Bartledan |
     | Altair    |
+    | Bartledan |
     +-----------+
     SELECT 2 rows in set (... sec)
 
@@ -313,12 +313,12 @@ the :ref:`_score <sql_administration_system_column_score>` can be selected::
 
     cr> select name, _score
     ... from locations where match(name_description_ft, 'time') order by _score desc;
-    +-----------+------------+
-    | name      |     _score |
-    +-----------+------------+
-    | Bartledan | 0.75782394 |
-    | Altair    | 0.63013375 |
-    +-----------+------------+
+    +-----------+-----------+
+    | name      |    _score |
+    +-----------+-----------+
+    | Altair    | 0.6570115 |
+    | Bartledan | 0.6416173 |
+    +-----------+-----------+
     SELECT 2 rows in set (... sec)
 
 .. NOTE::
@@ -361,11 +361,11 @@ For searching of matching phrases (tokens are in the exact same order) use
     +-------------------+------------+
     | name              |     _score |
     +-------------------+------------+
-    | NULL              | 1.5614427  |
-    | Altair            | 0.63013375 |
-    | Aldebaran         | 0.55650693 |
-    | Outer Eastern Rim | 0.38915473 |
-    | North West Ripple | 0.37936807 |
+    | NULL              | 1.2599468  |
+    | Altair            | 0.49754602 |
+    | Outer Eastern Rim | 0.47476405 |
+    | North West Ripple | 0.46413797 |
+    | Aldebaran         | 0.23530701 |
     +-------------------+------------+
     SELECT 5 rows in set (... sec)
 
@@ -378,7 +378,7 @@ For searching of matching phrases (tokens are in the exact same order) use
     +------+-------------------------+-----------+
     | name | description             |    _score |
     +------+-------------------------+-----------+
-    | NULL | The end of the Galaxy.% | 1.5614427 |
+    | NULL | The end of the Galaxy.% | 1.2599468 |
     +------+-------------------------+-----------+
     SELECT 1 row in set (... sec)
 
@@ -432,8 +432,8 @@ Anyway let's do it here for demonstration purpose::
     +-----------+-----------+
     | name      |    _score |
     +-----------+-----------+
-    | Altair    | 1.6301337 |
-    | Bartledan | 1.757824  |
+    | Bartledan | 1.6416173 |
+    | Altair    | 1.6570115 |
     +-----------+-----------+
     SELECT 2 rows in set (... sec)
 

--- a/docs/general/dql/selects.rst
+++ b/docs/general/dql/selects.rst
@@ -474,13 +474,14 @@ does always return ``NULL`` when comparing ``NULL``.
 
 ::
 
-    cr> select name from locations where inhabitants['interests'] is not null;
+    cr> select name from locations where inhabitants['interests'] is not null
+    ... order by name;
     +-------------------+
     | name              |
     +-------------------+
+    | Argabuthon        |
     | Arkintoofle Minor |
     | Bartledan         |
-    | Argabuthon        |
     +-------------------+
     SELECT 3 rows in set (... sec)
 
@@ -658,12 +659,12 @@ The following query negates ``ANY`` using ``!=`` to return all rows where
 element that is not ``netball``::
 
     cr> select inhabitants['name'], inhabitants['interests'] from locations
-    ... where 'netball' != ANY(inhabitants['interests']);
+    ... where 'netball' != ANY(inhabitants['interests']) order by 1;
     +---------------------+------------------------------+
     | inhabitants['name'] | inhabitants['interests']     |
     +---------------------+------------------------------+
-    | Minories            | ["netball", "short stories"] |
     | Argabuthonians      | ["science", "reason"]        |
+    | Minories            | ["netball", "short stories"] |
     +---------------------+------------------------------+
     SELECT 2 rows in set (... sec)
 

--- a/docs/sql/statements/create-table.rst
+++ b/docs/sql/statements/create-table.rst
@@ -409,8 +409,12 @@ This number specifies the hashing space that is used internally to distribute
 documents across shards.
 
 This is an optional setting that enables users to later on increase the number
-of shards using :ref:`sql-alter-table`. It's not possible to update this
-setting after table creation.
+of shards using :ref:`sql-alter-table`. If it's not set explicitly, it's
+automatically set to a default value based on the number of shards defined in
+the :ref:`sql-create-table-clustered`, which allows to increase the shards by
+a factor of `2` each time, up until the maximum of `1024` shards per table.
+
+.. NOTE:: It's not possible to update this setting after table creation.
 
 
 .. _sql-create-table-refresh-interval:

--- a/plugins/es-analysis-common/src/test/java/io/crate/analysis/common/FulltextITest.java
+++ b/plugins/es-analysis-common/src/test/java/io/crate/analysis/common/FulltextITest.java
@@ -23,8 +23,8 @@ package io.crate.analysis.common;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertSQLError;
+import static io.crate.testing.Asserts.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -35,7 +35,6 @@ import org.elasticsearch.test.IntegTestCase;
 import org.junit.Test;
 
 import io.crate.integrationtests.Setup;
-import io.crate.testing.TestingHelpers;
 
 public class FulltextITest extends IntegTestCase {
 
@@ -51,73 +50,61 @@ public class FulltextITest extends IntegTestCase {
     @Test
     public void testMatchOptions() throws Exception {
         this.setup.setUpLocationsWithFTIndex();
-        refresh();
+        execute("refresh table locations");
 
         execute("select name, _score from locations where match((kind, name_description_ft), 'galaxy') " +
                 "using best_fields with (analyzer='english') order by _score desc");
-        assertThat(TestingHelpers.printedTable(response.rows()))
-            .isEqualTo("""
-                           End of the Galaxy| 0.74187315
-                           Altair| 0.63013375
-                           Outer Eastern Rim| 0.39226836
-                           North West Ripple| 0.38249224
-                           """);
+        assertThat(response).hasRows(
+            "End of the Galaxy| 0.895417",
+            "Altair| 0.49754602",
+            "Outer Eastern Rim| 0.47476405",
+            "North West Ripple| 0.46413797");
 
         execute("select name, _score from locations where match((kind, name_description_ft), 'galaxy') " +
                 "using best_fields with (fuzziness=0.5) order by _score desc");
-        assertThat(TestingHelpers.printedTable(response.rows()))
-            .isEqualTo("""
-                           End of the Galaxy| 0.74187315
-                           Altair| 0.63013375
-                           Outer Eastern Rim| 0.39226836
-                           North West Ripple| 0.38249224
-                           """);
+        assertThat(response).hasRows(
+            "End of the Galaxy| 0.895417",
+            "Altair| 0.49754602",
+            "Outer Eastern Rim| 0.47476405",
+            "North West Ripple| 0.46413797");
 
         execute("select name, _score from locations where match((kind, name_description_ft), 'galay') " +
                 "using best_fields with (fuzziness='AUTO') order by _score desc");
-        assertThat(TestingHelpers.printedTable(response.rows()))
-            .isEqualTo("""
-                           End of the Galaxy| 0.5934985
-                           Altair| 0.504107
-                           Outer Eastern Rim| 0.3138147
-                           North West Ripple| 0.3059938
-                           """);
+        assertThat(response).hasRows(
+            "End of the Galaxy| 0.7163336",
+            "Altair| 0.3980368",
+            "Outer Eastern Rim| 0.37981126",
+            "North West Ripple| 0.37131035");
 
         execute("select name, _score from locations where match((kind, name_description_ft), 'gala') " +
                 "using best_fields with (operator='or', minimum_should_match=2) order by _score desc");
-        assertThat(TestingHelpers.printedTable(response.rows())).isEmpty();
+        assertThat(response).hasRowCount(0);
 
         execute("select name, _score from locations where match((kind, name_description_ft), 'gala') " +
                 "using phrase_prefix with (slop=1) order by _score desc");
-        assertThat(TestingHelpers.printedTable(response.rows()))
-            .isEqualTo("""
-                           Outer Eastern Rim| 1.1364496
-                           Algol| 0.8532188
-                           Galactic Sector QQ7 Active J Gamma| 0.7837707
-                           End of the Galaxy| 0.74187315
-                           Altair| 0.63013375
-                           North West Ripple| 0.38249224
-                           """);
+        assertThat(response).hasRows(
+            "Outer Eastern Rim| 1.3327041",
+            "End of the Galaxy| 0.895417",
+            "Galactic Sector QQ7 Active J Gamma| 0.8121827",
+            "Algol| 0.70797026",
+            "Altair| 0.49754602",
+            "North West Ripple| 0.46413797");
 
         execute("select name, _score from locations where match((kind, name_description_ft), 'galaxy') " +
                 "using phrase with (tie_breaker=1.0) order by _score desc");
-        assertThat(TestingHelpers.printedTable(response.rows()))
-            .isEqualTo("""
-                           End of the Galaxy| 0.74187315
-                           Altair| 0.63013375
-                           Outer Eastern Rim| 0.39226836
-                           North West Ripple| 0.38249224
-                           """);
+        assertThat(response).hasRows(
+            "End of the Galaxy| 0.895417",
+            "Altair| 0.49754602",
+            "Outer Eastern Rim| 0.47476405",
+            "North West Ripple| 0.46413797");
 
         execute("select name, _score from locations where match((kind, name_description_ft), 'galaxy') " +
                 "using best_fields with (zero_terms_query='all') order by _score desc");
-        assertThat(TestingHelpers.printedTable(response.rows()))
-            .isEqualTo("""
-                           End of the Galaxy| 0.74187315
-                           Altair| 0.63013375
-                           Outer Eastern Rim| 0.39226836
-                           North West Ripple| 0.38249224
-                           """);
+        assertThat(response).hasRows(
+            "End of the Galaxy| 0.895417",
+            "Altair| 0.49754602",
+            "Outer Eastern Rim| 0.47476405",
+            "North West Ripple| 0.46413797");
     }
 
     @Test
@@ -131,21 +118,21 @@ public class FulltextITest extends IntegTestCase {
                 "  o_ignored object(ignored)" +
                 ") with (number_of_replicas=0)");
         execute("insert into matchbox (s, o) values ('Arthur Dent', {s='Zaphod Beeblebroox', m='Ford Prefect'})");
-        refresh();
+        execute("refresh table matchbox");
         execute("select * from matchbox where match(s, 'Arthur')");
-        assertThat(response.rowCount()).isEqualTo(1L);
+        assertThat(response).hasRowCount(1);
 
         execute("select * from matchbox where match(o['s'], 'Arthur')");
-        assertThat(response.rowCount()).isEqualTo(0L);
+        assertThat(response).hasRowCount(0);
 
         execute("select * from matchbox where match(o['s'], 'Zaphod')");
-        assertThat(response.rowCount()).isEqualTo(1L);
+        assertThat(response).hasRowCount(1);
 
         execute("select * from matchbox where match(s, 'Zaphod')");
-        assertThat(response.rowCount()).isEqualTo(0L);
+        assertThat(response).hasRowCount(0);
 
         execute("select * from matchbox where match(o['m'], 'Ford')");
-        assertThat(response.rowCount()).isEqualTo(1L);
+        assertThat(response).hasRowCount(1);
 
         assertSQLError(() -> execute("select * from matchbox where match(o_ignored['a'], 'Ford')"))
             .hasPGError(INTERNAL_ERROR)
@@ -156,63 +143,61 @@ public class FulltextITest extends IntegTestCase {
     @Test
     public void testMatchTypes() throws Exception {
         this.setup.setUpLocationsWithFTIndex();
-        refresh();
+        execute("refresh table locations");
 
         execute("select name, _score from locations where match((kind 0.8, name_description_ft 0.6), 'planet earth') " +
                 "using best_fields order by _score desc");
-        assertThat(TestingHelpers.printedTable(response.rows()))
-            .isEqualTo("""
-                           Alpha Centauri| 0.62114334
-                           Bartledan| 0.45822048
-                           | 0.2120642
-                           Allosimanius Syneca| 0.1592113
-                           Galactic Sector QQ7 Active J Gamma| 0.12744746
-                           """);
+        assertThat(response).hasRows(
+            "Alpha Centauri| 0.6880375",
+            "Bartledan| 0.3849704",
+            "Galactic Sector QQ7 Active J Gamma| 0.34459937",
+            "| 0.2462059",
+            "Allosimanius Syneca| 0.16214824");
 
         execute("select name, _score from locations where match((kind 0.6, name_description_ft 0.8), 'planet earth') using most_fields order by _score desc");
-        assertThat(TestingHelpers.printedTable(response.rows()))
-            .isEqualTo("Alpha Centauri| 0.8281911\nBartledan| 0.6109606\n| 0.28275228\nAllosimanius Syneca| 0.21228172\nGalactic Sector QQ7 Active J Gamma| 0.16992995\n");
+        assertThat(response).hasRows(
+            "Alpha Centauri| 0.91738325",
+            "Bartledan| 0.5132938",
+            "Galactic Sector QQ7 Active J Gamma| 0.4594658",
+            "| 0.3282745",
+            "Allosimanius Syneca| 0.21619764");
 
         execute("select name, _score from locations where match((kind 0.4, name_description_ft 1.0), 'planet earth') using cross_fields order by _score desc");
-        assertThat(TestingHelpers.printedTable(response.rows()))
-            .isEqualTo("Alpha Centauri| 1.0352387\nBartledan| 0.7637007\n| 0.35344034\nAllosimanius Syneca| 0.26535213\nGalactic Sector QQ7 Active J Gamma| 0.21241242\n");
+        assertThat(response).hasRows(
+            "Alpha Centauri| 1.1467291",
+            "Bartledan| 0.6416173",
+            "Galactic Sector QQ7 Active J Gamma| 0.57433224",
+            "| 0.41034314",
+            "Allosimanius Syneca| 0.27024707");
 
         execute("select name, _score from locations where match((kind 1.0, name_description_ft 0.4), 'Alpha Centauri') using phrase");
-        assertThat(TestingHelpers.printedTable(response.rows()))
-            .isEqualTo("Alpha Centauri| 0.8281911\n");
+        assertThat(response).hasRows("Alpha Centauri| 0.91738325");
 
         execute("select name, _score from locations where match(name_description_ft, 'Alpha Centauri') using phrase_prefix");
-        assertThat(TestingHelpers.printedTable(response.rows()))
-            .isEqualTo("Alpha Centauri| 2.0704775\n");
+        assertThat(response).hasRows("Alpha Centauri| 2.2934582");
     }
 
     @Test
     public void testSelectWhereMultiColumnMatchDifferentTypesDifferentScore() throws Exception {
         this.setup.setUpLocationsWithFTIndex();
-        refresh();
+        execute("refresh table locations");
         execute("select name, description, kind, _score from locations " +
                 "where match((kind, name_description_ft 0.5), 'Planet earth') using most_fields with (analyzer='english') order by _score desc");
-        assertThat(response.rowCount()).isEqualTo(5L);
-        assertThat(TestingHelpers.printedTable(response.rows()))
-            .isEqualTo("""
-                           Alpha Centauri| 4.1 light-years northwest of earth| Star System| 0.5176194
-                           Bartledan| An Earthlike planet on which Arthur Dent lived for a short time, Bartledan is inhabited by Bartledanians, a race that appears human but only physically.| Planet| 0.38185036
-                           | This Planet doesn't really exist| Planet| 0.17672017
-                           Allosimanius Syneca| Allosimanius Syneca is a planet noted for ice, snow, mind-hurtling beauty and stunning cold.| Planet| 0.13267606
-                           Galactic Sector QQ7 Active J Gamma| Galactic Sector QQ7 Active J Gamma contains the Sun Zarss, the planet Preliumtarn of the famed Sevorbeupstry and Quentulus Quazgar Mountains.| Galaxy| 0.10620621
-                           """);
+        assertThat(response).hasRows(
+            "Alpha Centauri| 4.1 light-years northwest of earth| Star System| 0.57336456",
+            "Bartledan| An Earthlike planet on which Arthur Dent lived for a short time, Bartledan is inhabited by Bartledanians, a race that appears human but only physically.| Planet| 0.32080865",
+            "Galactic Sector QQ7 Active J Gamma| Galactic Sector QQ7 Active J Gamma contains the Sun Zarss, the planet Preliumtarn of the famed Sevorbeupstry and Quentulus Quazgar Mountains.| Galaxy| 0.28716612",
+            "| This Planet doesn't really exist| Planet| 0.20517157",
+            "Allosimanius Syneca| Allosimanius Syneca is a planet noted for ice, snow, mind-hurtling beauty and stunning cold.| Planet| 0.13512354");
 
         execute("select name, description, kind, _score from locations " +
                 "where match((kind, name_description_ft 0.5), 'Planet earth') using cross_fields order by _score desc");
-        assertThat(response.rowCount()).isEqualTo(5L);
-        assertThat(TestingHelpers.printedTable(response.rows()))
-            .isEqualTo("""
-                           Alpha Centauri| 4.1 light-years northwest of earth| Star System| 1.0352387
-                           Bartledan| An Earthlike planet on which Arthur Dent lived for a short time, Bartledan is inhabited by Bartledanians, a race that appears human but only physically.| Planet| 0.7637007
-                           | This Planet doesn't really exist| Planet| 0.35344034
-                           Allosimanius Syneca| Allosimanius Syneca is a planet noted for ice, snow, mind-hurtling beauty and stunning cold.| Planet| 0.26535213
-                           Galactic Sector QQ7 Active J Gamma| Galactic Sector QQ7 Active J Gamma contains the Sun Zarss, the planet Preliumtarn of the famed Sevorbeupstry and Quentulus Quazgar Mountains.| Galaxy| 0.21241242
-                           """);
+        assertThat(response).hasRows(
+            "Alpha Centauri| 4.1 light-years northwest of earth| Star System| 1.1467291",
+            "Bartledan| An Earthlike planet on which Arthur Dent lived for a short time, Bartledan is inhabited by Bartledanians, a race that appears human but only physically.| Planet| 0.6416173",
+            "Galactic Sector QQ7 Active J Gamma| Galactic Sector QQ7 Active J Gamma contains the Sun Zarss, the planet Preliumtarn of the famed Sevorbeupstry and Quentulus Quazgar Mountains.| Galaxy| 0.57433224",
+            "| This Planet doesn't really exist| Planet| 0.41034314",
+            "Allosimanius Syneca| Allosimanius Syneca is a planet noted for ice, snow, mind-hurtling beauty and stunning cold.| Planet| 0.27024707");
     }
 
     @Test
@@ -227,7 +212,7 @@ public class FulltextITest extends IntegTestCase {
         execute("refresh table quotes");
 
         execute("select quote from quotes where match(quote_fulltext, 'time') and id = 1");
-        assertThat(response.rowCount()).isEqualTo(1L);
+        assertThat(response).hasRowCount(1);
     }
 
     @Test
@@ -245,15 +230,10 @@ public class FulltextITest extends IntegTestCase {
             new Object[]{2, "Trillian", " No, it's a country. Off the coast of Africa."},
             new Object[]{3, "Marvin", " It won't work, I have an exceptionally large mind."}
         });
-        refresh();
+        execute("refresh table characters");
         execute("select characters.name AS characters_name, _score " +
                 "from characters " +
                 "where match(characters.quote_ft 2.0, 'country') order by _score desc");
-        System.out.println(TestingHelpers.printedTable(response.rows()));
-        assertThat(response.rows().length).isEqualTo(2);
-        assertThat(response.rows()[0][0]).isEqualTo("Arthur");
-        assertThat(response.rows()[0][1]).isEqualTo(0.3596026F);
-        assertThat(response.rows()[1][0]).isEqualTo("Trillian");
-        assertThat(response.rows()[1][1]).isEqualTo(0.26152915F);
+        assertThat(response).hasRows("Arthur| 0.3596026", "Trillian| 0.26152915");
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/TransportResizeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/TransportResizeAction.java
@@ -193,7 +193,12 @@ public class TransportResizeAction extends TransportMasterNodeAction<ResizeReque
             throw new IllegalArgumentException("cannot provide a routing partition size value when resizing an index");
         }
         if (IndexMetadata.INDEX_NUMBER_OF_ROUTING_SHARDS_SETTING.exists(targetIndexSettings)) {
-            throw new IllegalArgumentException("cannot provide index.number_of_routing_shards on resize");
+            // if we have a source index with 1 shards it's legal to set this
+            final boolean splitFromSingleShards = resizeRequest.getResizeType() == ResizeType.SPLIT
+                && metadata.getNumberOfShards() == 1;
+            if (splitFromSingleShards == false) {
+                throw new IllegalArgumentException("cannot provide index.number_of_routing_shards on resize");
+            }
         }
         if (IndexSettings.INDEX_SOFT_DELETES_SETTING.exists(metadata.getSettings()) &&
             IndexSettings.INDEX_SOFT_DELETES_SETTING.get(metadata.getSettings()) &&

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -1341,25 +1341,33 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
      * @return a the source shard ID to split off from
      */
     public static ShardId selectSplitShard(int shardId, IndexMetadata sourceIndexMetadata, int numTargetShards) {
+        int numSourceShards = sourceIndexMetadata.getNumberOfShards();
         if (shardId >= numTargetShards) {
             throw new IllegalArgumentException("the number of target shards (" + numTargetShards + ") must be greater than the shard id: "
                 + shardId);
         }
-        int numSourceShards = sourceIndexMetadata.getNumberOfShards();
+        final int routingFactor = getRoutingFactor(numSourceShards, numTargetShards);
+        assertSplitMetadata(numSourceShards, numTargetShards, sourceIndexMetadata);
+        return new ShardId(sourceIndexMetadata.getIndex(), shardId / routingFactor);
+    }
+
+    private static void assertSplitMetadata(int numSourceShards, int numTargetShards, IndexMetadata sourceIndexMetadata) {
         if (numSourceShards > numTargetShards) {
             throw new IllegalArgumentException("the number of source shards [" + numSourceShards
-                 + "] must be less that the number of target shards [" + numTargetShards + "]");
+                + "] must be less that the number of target shards [" + numTargetShards + "]");
         }
-        int routingFactor = getRoutingFactor(numSourceShards, numTargetShards);
         // now we verify that the numRoutingShards is valid in the source index
-        int routingNumShards = sourceIndexMetadata.getRoutingNumShards();
+        // note: if the number of shards is 1 in the source index we can just assume it's correct since from 1 we can split into anything
+        // this is important to special case here since we use this to validate this in various places in the code but allow to split form
+        // 1 to N but we never modify the sourceIndexMetadata to accommodate for that
+        int routingNumShards = numSourceShards == 1 ? numTargetShards : sourceIndexMetadata.getRoutingNumShards();
         if (routingNumShards % numTargetShards != 0) {
             throw new IllegalStateException("the number of routing shards ["
                 + routingNumShards + "] must be a multiple of the target shards [" + numTargetShards + "]");
         }
         // this is just an additional assertion that ensures we are a factor of the routing num shards.
-        assert getRoutingFactor(numTargetShards, sourceIndexMetadata.getRoutingNumShards()) >= 0;
-        return new ShardId(sourceIndexMetadata.getIndex(), shardId / routingFactor);
+        assert sourceIndexMetadata.getNumberOfShards() == 1 // special case - we can split into anything from 1 shard
+            || getRoutingFactor(numTargetShards, routingNumShards) >= 0;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -380,15 +380,25 @@ public class MetadataCreateIndexService {
             indexSettingsBuilder.put(IndexMetadata.SETTING_INDEX_PROVIDED_NAME, request.getProvidedName());
             indexSettingsBuilder.put(SETTING_INDEX_UUID, UUIDs.randomBase64UUID());
             final IndexMetadata.Builder tmpImdBuilder = IndexMetadata.builder(request.index());
-
+            final Settings idxSettings = indexSettingsBuilder.build();
+            int numTargetShards = IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.get(idxSettings);
             final int routingNumShards;
-            if (recoverFromIndex == null) {
-                Settings idxSettings = indexSettingsBuilder.build();
-                routingNumShards = IndexMetadata.INDEX_NUMBER_OF_ROUTING_SHARDS_SETTING.get(idxSettings);
+            final Version indexVersionCreated = idxSettings.getAsVersion(IndexMetadata.SETTING_VERSION_CREATED, null);
+            final IndexMetadata sourceMetadata = recoverFromIndex == null ? null :
+                currentState.metadata().getIndexSafe(recoverFromIndex);
+            if (sourceMetadata == null || sourceMetadata.getNumberOfShards() == 1) {
+                // in this case we either have no index to recover from or
+                // we have a source index with 1 shard and without an explicit split factor
+                // or one that is valid in that case we can split into whatever and auto-generate a new factor.
+                if (IndexMetadata.INDEX_NUMBER_OF_ROUTING_SHARDS_SETTING.exists(idxSettings)) {
+                    routingNumShards = IndexMetadata.INDEX_NUMBER_OF_ROUTING_SHARDS_SETTING.get(idxSettings);
+                } else {
+                    routingNumShards = calculateNumRoutingShards(numTargetShards, indexVersionCreated);
+                }
             } else {
                 assert IndexMetadata.INDEX_NUMBER_OF_ROUTING_SHARDS_SETTING.exists(indexSettingsBuilder.build()) == false
-                    : "index.number_of_routing_shards should be present on the target index on resize";
-                final IndexMetadata sourceMetadata = currentState.metadata().getIndexSafe(recoverFromIndex);
+                    : "index.number_of_routing_shards should not be present on the target index on resize";
+
                 routingNumShards = sourceMetadata.getRoutingNumShards();
             }
             // remove the setting it's temporary and is only relevant once we create the index
@@ -415,7 +425,6 @@ public class MetadataCreateIndexService {
                     * the maximum primary term on all the shards in the source index. This ensures that we have correct
                     * document-level semantics regarding sequence numbers in the shrunken index.
                     */
-                final IndexMetadata sourceMetadata = currentState.metadata().getIndexSafe(recoverFromIndex);
                 final long primaryTerm =
                     IntStream
                         .range(0, sourceMetadata.getNumberOfShards())
@@ -711,4 +720,26 @@ public class MetadataCreateIndexService {
         }
     }
 
+    /**
+     * Returns a default number of routing shards based on the number of shards of the index. The default number of routing shards will
+     * allow any index to be split at least once and at most 10 times by a factor of two. The closer the number or shards gets to 1024
+     * the less default split operations are supported
+     */
+    public static int calculateNumRoutingShards(int numShards, Version indexVersionCreated) {
+        if (indexVersionCreated.onOrAfter(Version.V_5_8_0)) {
+            // only select this automatically for indices that are created on or after 5.8, this will prevent this new behaviour
+            // until we have a fully upgraded cluster. Additionally, it will make integrating testing easier since mixed clusters
+            // will always have the behavior of the min node in the cluster.
+            //
+            // We use as a default number of routing shards the higher number that can be expressed
+            // as {@code numShards * 2^x`} that is less than or equal to the maximum number of shards: 1024.
+            int log2MaxNumShards = 10; // logBase2(1024)
+            int log2NumShards = 32 - Integer.numberOfLeadingZeros(numShards - 1); // ceil(logBase2(numShards))
+            int numSplits = log2MaxNumShards - log2NumShards;
+            numSplits = Math.max(1, numSplits); // Ensure the index can be split at least once
+            return numShards << numSplits;
+        } else {
+            return numShards;
+        }
+    }
 }

--- a/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -26,7 +26,6 @@ import static io.crate.metadata.FulltextAnalyzerResolver.CustomType.ANALYZER;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_ROUTING_EXCLUDE_GROUP_SETTING;
 import static org.elasticsearch.index.engine.EngineConfig.INDEX_CODEC_SETTING;

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/shrink/TransportResizeActionTest.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/shrink/TransportResizeActionTest.java
@@ -1,0 +1,233 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.action.admin.indices.shrink;
+
+import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.apache.lucene.index.IndexWriter;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.admin.indices.create.CreateIndexClusterStateUpdateRequest;
+import org.elasticsearch.action.support.ActiveShardCount;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.EmptyClusterInfoService;
+import org.elasticsearch.cluster.block.ClusterBlocks;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.routing.RoutingTable;
+import org.elasticsearch.cluster.routing.ShardRoutingState;
+import org.elasticsearch.cluster.routing.allocation.AllocationService;
+import org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator;
+import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
+import org.elasticsearch.cluster.routing.allocation.decider.MaxRetryAllocationDecider;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.shard.DocsStats;
+import org.elasticsearch.snapshots.EmptySnapshotsInfoService;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.gateway.TestGatewayAllocator;
+import org.junit.Test;
+
+public class TransportResizeActionTest extends ESTestCase {
+
+    private ClusterState createClusterState(String name, int numShards, int numReplicas, Settings settings) {
+        return createClusterState(name, numShards, numReplicas, numShards, settings);
+    }
+
+    private ClusterState createClusterState(String name, int numShards, int numReplicas, int numRoutingShards, Settings settings) {
+        Metadata.Builder metaBuilder = Metadata.builder();
+        IndexMetadata indexMetadata = IndexMetadata.builder(name).settings(settings(Version.CURRENT)
+            .put(settings))
+            .numberOfShards(numShards).numberOfReplicas(numReplicas).setRoutingNumShards(numRoutingShards).build();
+        metaBuilder.put(indexMetadata, false);
+        Metadata metadata = metaBuilder.build();
+        RoutingTable.Builder routingTableBuilder = RoutingTable.builder();
+        routingTableBuilder.addAsNew(metadata.index(name));
+
+        RoutingTable routingTable = routingTableBuilder.build();
+        ClusterState clusterState = ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
+            .metadata(metadata).routingTable(routingTable).blocks(ClusterBlocks.builder().addBlocks(indexMetadata)).build();
+        return clusterState;
+    }
+
+    @Test
+    public void testErrorCondition() {
+        ClusterState state = createClusterState("source", randomIntBetween(2, 42), randomIntBetween(0, 10),
+            Settings.builder().put("index.blocks.write", true).build());
+        assertThatThrownBy(() -> TransportResizeAction.prepareCreateIndexRequest(new ResizeRequest("target", "source"),
+                state,
+                (i) -> new DocsStats(Integer.MAX_VALUE, between(1, 1000), between(1, 100)), "source", "target"))
+            .isExactlyInstanceOf(IllegalStateException.class)
+            .hasMessageStartingWith("Can't merge index with more than [2147483519] docs - too many documents in shards ");
+
+
+        ResizeRequest req = new ResizeRequest("target", "source");
+        req.getTargetIndexRequest().settings(Settings.builder().put("index.number_of_shards", 4));
+        final ClusterState cs = createClusterState("source", 8, 1,
+            Settings.builder().put("index.blocks.write", true).build());
+        assertThatThrownBy(() -> TransportResizeAction.prepareCreateIndexRequest(req, cs,
+                        (i) -> i == 2 || i == 3 ? new DocsStats(Integer.MAX_VALUE / 2, between(1, 1000), between(1, 10000)) : null,
+                        "source", "target"))
+            .isExactlyInstanceOf(IllegalStateException.class)
+            .hasMessageStartingWith("Can't merge index with more than [2147483519] docs - too many documents in shards ");
+
+        // create one that won't fail
+        ClusterState clusterState = ClusterState.builder(createClusterState("source", randomIntBetween(2, 10), 0,
+            Settings.builder().put("index.blocks.write", true).build())).nodes(DiscoveryNodes.builder().add(newNode("node1")))
+            .build();
+        AllocationService service = new AllocationService(
+            new AllocationDeciders(Collections.singleton(new MaxRetryAllocationDecider())),
+            new TestGatewayAllocator(),
+            new BalancedShardsAllocator(Settings.EMPTY),
+            EmptyClusterInfoService.INSTANCE,
+            EmptySnapshotsInfoService.INSTANCE);
+
+        RoutingTable routingTable = service.reroute(clusterState, "reroute").routingTable();
+        clusterState = ClusterState.builder(clusterState).routingTable(routingTable).build();
+        // now we start the shard
+        routingTable = service.applyStartedShards(clusterState,
+            routingTable.index("source").shardsWithState(ShardRoutingState.INITIALIZING)).routingTable();
+        clusterState = ClusterState.builder(clusterState).routingTable(routingTable).build();
+
+        TransportResizeAction.prepareCreateIndexRequest(new ResizeRequest("target", "source"), clusterState,
+            (i) -> new DocsStats(between(1, 1000), between(1, 1000), between(0, 10000)), "source", "target");
+    }
+
+    @Test
+    public void testPassNumRoutingShards() {
+        ClusterState clusterState = ClusterState.builder(createClusterState("source", 1, 0,
+            Settings.builder().put("index.blocks.write", true).build())).nodes(DiscoveryNodes.builder().add(newNode("node1")))
+            .build();
+        AllocationService service = new AllocationService(
+            new AllocationDeciders(Collections.singleton(new MaxRetryAllocationDecider())),
+            new TestGatewayAllocator(),
+            new BalancedShardsAllocator(Settings.EMPTY),
+            EmptyClusterInfoService.INSTANCE,
+            EmptySnapshotsInfoService.INSTANCE);
+
+        RoutingTable routingTable = service.reroute(clusterState, "reroute").routingTable();
+        clusterState = ClusterState.builder(clusterState).routingTable(routingTable).build();
+        // now we start the shard
+        routingTable = service.applyStartedShards(clusterState,
+            routingTable.index("source").shardsWithState(ShardRoutingState.INITIALIZING)).routingTable();
+        clusterState = ClusterState.builder(clusterState).routingTable(routingTable).build();
+
+        ResizeRequest resizeRequest = new ResizeRequest("target", "source");
+        resizeRequest.setResizeType(ResizeType.SPLIT);
+        resizeRequest.getTargetIndexRequest()
+            .settings(Settings.builder().put("index.number_of_shards", 2).build());
+        TransportResizeAction.prepareCreateIndexRequest(resizeRequest, clusterState, null, "source", "target");
+
+        resizeRequest.getTargetIndexRequest()
+            .settings(Settings.builder()
+                .put("index.number_of_routing_shards", randomIntBetween(2, 10))
+                .put("index.number_of_shards", 2)
+                .build());
+        TransportResizeAction.prepareCreateIndexRequest(resizeRequest, clusterState, null, "source", "target");
+    }
+
+    @Test
+    public void testPassNumRoutingShardsAndFail() {
+        int numShards = randomIntBetween(2, 100);
+        ClusterState clusterState = ClusterState.builder(createClusterState("source", numShards, 0, numShards * 4,
+            Settings.builder().put("index.blocks.write", true).build())).nodes(DiscoveryNodes.builder().add(newNode("node1")))
+            .build();
+        AllocationService service = new AllocationService(
+            new AllocationDeciders(Collections.singleton(new MaxRetryAllocationDecider())),
+            new TestGatewayAllocator(),
+            new BalancedShardsAllocator(Settings.EMPTY),
+            EmptyClusterInfoService.INSTANCE,
+            EmptySnapshotsInfoService.INSTANCE);
+
+        RoutingTable routingTable = service.reroute(clusterState, "reroute").routingTable();
+        clusterState = ClusterState.builder(clusterState).routingTable(routingTable).build();
+        // now we start the shard
+        routingTable = service.applyStartedShards(clusterState,
+            routingTable.index("source").shardsWithState(ShardRoutingState.INITIALIZING)).routingTable();
+        clusterState = ClusterState.builder(clusterState).routingTable(routingTable).build();
+
+        ResizeRequest resizeRequest = new ResizeRequest("target", "source");
+        resizeRequest.setResizeType(ResizeType.SPLIT);
+        resizeRequest.getTargetIndexRequest()
+            .settings(Settings.builder().put("index.number_of_shards", numShards * 2).build());
+        TransportResizeAction.prepareCreateIndexRequest(resizeRequest, clusterState, null, "source", "target");
+
+        resizeRequest.getTargetIndexRequest()
+            .settings(Settings.builder()
+                .put("index.number_of_shards", numShards * 2)
+                .put("index.number_of_routing_shards", numShards * 2).build());
+        ClusterState finalState = clusterState;
+        assertThatThrownBy(() -> TransportResizeAction.prepareCreateIndexRequest(
+            resizeRequest, finalState, null, "source", "target"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("cannot provide index.number_of_routing_shards on resize");
+    }
+
+    public void testShrinkIndexSettings() {
+        String indexName = randomAlphaOfLength(10);
+        // create one that won't fail
+        ClusterState clusterState = ClusterState.builder(createClusterState(indexName, randomIntBetween(2, 10), 0,
+            Settings.builder()
+                .put("index.blocks.write", true)
+                .build())).nodes(DiscoveryNodes.builder().add(newNode("node1")))
+            .build();
+        AllocationService service = new AllocationService(
+            new AllocationDeciders(Collections.singleton(new MaxRetryAllocationDecider())),
+            new TestGatewayAllocator(),
+            new BalancedShardsAllocator(Settings.EMPTY),
+            EmptyClusterInfoService.INSTANCE,
+            EmptySnapshotsInfoService.INSTANCE);
+
+        RoutingTable routingTable = service.reroute(clusterState, "reroute").routingTable();
+        clusterState = ClusterState.builder(clusterState).routingTable(routingTable).build();
+        // now we start the shard
+        routingTable = service.applyStartedShards(clusterState,
+            routingTable.index(indexName).shardsWithState(ShardRoutingState.INITIALIZING)).routingTable();
+        clusterState = ClusterState.builder(clusterState).routingTable(routingTable).build();
+        int numSourceShards = clusterState.metadata().index(indexName).getNumberOfShards();
+        DocsStats stats = new DocsStats(between(0, (IndexWriter.MAX_DOCS) / numSourceShards), between(1, 1000), between(1, 10000));
+        ResizeRequest target = new ResizeRequest("target", indexName);
+        final ActiveShardCount activeShardCount = randomBoolean() ? ActiveShardCount.ALL : ActiveShardCount.ONE;
+        target.setWaitForActiveShards(activeShardCount);
+        CreateIndexClusterStateUpdateRequest request = TransportResizeAction.prepareCreateIndexRequest(
+            target, clusterState, (i) -> stats, indexName, "target");
+        assertThat(request.recoverFrom()).isNotNull();
+        assertThat(request.recoverFrom().getName()).isEqualTo(indexName);
+        assertThat(request.settings().get("index.number_of_shards")).isEqualTo("1");
+        assertThat(request.cause()).isEqualTo("shrink_index");
+        assertThat(request.waitForActiveShards()).isEqualTo(activeShardCount);
+    }
+
+    private DiscoveryNode newNode(String nodeId) {
+        return new DiscoveryNode(
+            nodeId,
+            buildNewFakeTransportAddress(),
+            emptyMap(),
+            Set.of(DiscoveryNodeRole.MASTER_ROLE, DiscoveryNodeRole.DATA_ROLE),
+            Version.CURRENT);
+    }
+}

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexServiceTest.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexServiceTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.cluster.metadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.VersionUtils;
+import org.junit.Test;
+
+public class MetadataCreateIndexServiceTest extends ESTestCase {
+
+    @Test
+    public void testCalculateNumRoutingShards() {
+        assertThat(MetadataCreateIndexService.calculateNumRoutingShards(1, Version.CURRENT)).isEqualTo(1024);
+        assertThat(MetadataCreateIndexService.calculateNumRoutingShards(2, Version.CURRENT)).isEqualTo(1024);
+        assertThat(MetadataCreateIndexService.calculateNumRoutingShards(3, Version.CURRENT)).isEqualTo(768);
+        assertThat(MetadataCreateIndexService.calculateNumRoutingShards(9, Version.CURRENT)).isEqualTo(576);
+        assertThat(MetadataCreateIndexService.calculateNumRoutingShards(512, Version.CURRENT)).isEqualTo(1024);
+        assertThat(MetadataCreateIndexService.calculateNumRoutingShards(1024, Version.CURRENT)).isEqualTo(2048);
+        assertThat(MetadataCreateIndexService.calculateNumRoutingShards(2048, Version.CURRENT)).isEqualTo(4096);
+
+        Version latestBeforeChange = VersionUtils.getPreviousVersion(Version.V_5_8_0);
+        int numShards = randomIntBetween(1, 1000);
+        assertThat(MetadataCreateIndexService.calculateNumRoutingShards(numShards, latestBeforeChange)).isEqualTo(numShards);
+        assertThat(MetadataCreateIndexService.calculateNumRoutingShards(numShards,
+            VersionUtils.randomVersionBetween(random(), VersionUtils.getFirstVersion(), latestBeforeChange))).isEqualTo(numShards);
+
+        for (int i = 0; i < 1000; i++) {
+            int randomNumShards = randomIntBetween(1, 10000);
+            int numRoutingShards = MetadataCreateIndexService.calculateNumRoutingShards(randomNumShards, Version.CURRENT);
+            if (numRoutingShards <= 1024) {
+                assertThat(randomNumShards).isLessThanOrEqualTo(512);
+                assertThat(numRoutingShards).isGreaterThan(512);
+            } else {
+                assertThat(numRoutingShards / 2).isEqualTo(randomNumShards);
+            }
+
+            double ratio = numRoutingShards / (double) randomNumShards;
+            int intRatio = (int) ratio;
+            assertThat((double)(intRatio)).isEqualTo(ratio);
+            assertThat(ratio).isGreaterThan(1);
+            assertThat(ratio).isLessThanOrEqualTo(1024);
+            assertThat(intRatio % 2).isZero();
+            assertThat(intRatio).as("ratio is not a power of two").isEqualTo(Integer.highestOneBit(intRatio));
+        }
+    }
+}


### PR DESCRIPTION
Previously, if no value was provided for `number_of_routing_shards` during table creation, it was not possible to increase the number of shards for that table later on. With this change, a default value, which is calculated based on the number of shards in the `CLUSTERED BY` clause, is always set, thus allowing to increase the shards for any table up to the default maximum of `1024`.

Custom backport of: https://github.com/elastic/elasticsearch/commit/fadbe0de08313d42494da34f7a4ba5e437622173

Closes: #11320
