### PR TITLE
Replace JSONAssert for mapping equals with Map based assertThat().isEqualTo

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/DynamicMappingUpdateITest.java
+++ b/server/src/test/java/io/crate/integrationtests/DynamicMappingUpdateITest.java
@@ -22,6 +22,7 @@
 package io.crate.integrationtests;
 
 import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
@@ -35,8 +36,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
-import io.crate.testing.UseNewCluster;
-import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.test.IntegTestCase;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Rule;
@@ -44,7 +43,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import io.crate.common.collections.Maps;
-import io.crate.server.xcontent.XContentHelper;
+import io.crate.testing.UseNewCluster;
 import io.crate.testing.UseRandomizedSchema;
 import io.crate.types.ArrayType;
 import io.crate.types.DataTypes;
@@ -71,7 +70,6 @@ public class DynamicMappingUpdateITest extends IntegTestCase {
         execute_concurrent_statements_that_add_columns_result_in_dynamic_mapping_updates();
     }
 
-    @SuppressWarnings("unchecked")
     private void execute_concurrent_statements_that_add_columns_result_in_dynamic_mapping_updates() throws InterruptedException, IOException {
         // update, insert, alter take slightly different paths to update mappings
         execute("""
@@ -235,9 +233,9 @@ public class DynamicMappingUpdateITest extends IntegTestCase {
             "b| 2",
             "b['x']| 3");
 
-        Map<String, Object> mapping = XContentHelper.convertToMap(JsonXContent.JSON_XCONTENT, getIndexMapping("t"), false);
+        Map<String, Object> mapping = getIndexMapping("t");
         Set<Long> oids = new HashSet<>();
-        collectOID((Map<String, Map<String, Object>>) Maps.getByPath(mapping, "default.properties"), oids);
+        collectOID(Maps.get(mapping, "properties"), oids);
         assertThat(oids).hasSize(48);
         assertThat(oids.stream().max(Long::compareTo).get()).isEqualTo(48);
     }

--- a/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
@@ -154,7 +154,6 @@ import com.carrotsearch.randomizedtesting.generators.RandomNumbers;
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 import com.carrotsearch.randomizedtesting.generators.RandomStrings;
 
-import io.crate.Constants;
 import io.crate.action.sql.Cursors;
 import io.crate.action.sql.Session;
 import io.crate.action.sql.Sessions;
@@ -1859,7 +1858,7 @@ public abstract class IntegTestCase extends ESTestCase {
      * @return the index mapping as String
      * @throws IOException
      */
-    protected String getIndexMapping(String index) throws IOException {
+    protected Map<String, Object> getIndexMapping(String index) throws IOException {
         ClusterStateRequest request = new ClusterStateRequest()
             .routingTable(false)
             .nodes(false)
@@ -1868,14 +1867,8 @@ public abstract class IntegTestCase extends ESTestCase {
         ClusterStateResponse response = FutureUtils.get(client().admin().cluster().state(request));
 
         Metadata metadata = response.getState().metadata();
-        XContentBuilder builder = JsonXContent.builder().startObject();
-
         IndexMetadata indexMetadata = metadata.iterator().next();
-        builder.field(Constants.DEFAULT_MAPPING_TYPE);
-        builder.map(indexMetadata.mapping().sourceAsMap());
-        builder.endObject();
-
-        return Strings.toString(builder);
+        return indexMetadata.mapping().sourceAsMap();
     }
 
     public void assertFunctionIsCreatedOnAll(String schema, String name, List<DataType<?>> argTypes) throws Exception {


### PR DESCRIPTION
This is in preparation to remove the `MapperService` from
`TransportCreateIndexAction` which can cause changes to the key order
(`MappingUtil` uses `HashMap` because the key order has no semantic
impact. Column order is defined via position property)
