### PR TITLE
Remove jsonassert dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -290,7 +290,6 @@
     <versions.hamcrest>2.2</versions.hamcrest>
     <versions.mockito>5.11.0</versions.mockito>
     <versions.jdbc>42.7.3</versions.jdbc>
-    <versions.jsonassert>1.5.1</versions.jsonassert>
 
     <versions.azure_storage>8.6.6</versions.azure_storage>
     <versions.azure_keyvault>1.2.4</versions.azure_keyvault>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -415,13 +415,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.skyscreamer</groupId>
-      <artifactId>jsonassert</artifactId>
-      <version>${versions.jsonassert}</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15on</artifactId>
       <version>1.70</version>

--- a/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
@@ -113,8 +113,6 @@ import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.concurrent.FutureUtils;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.http.HttpTransportSettings;
@@ -1907,41 +1905,6 @@ public abstract class IntegTestCase extends ESTestCase {
 
             }
         }, 20L, TimeUnit.SECONDS);
-    }
-
-    /**
-     * Get the IndexSettings as JSON String
-     *
-     * @param index the name of the index
-     * @return the IndexSettings as JSON String
-     * @throws IOException
-     */
-    protected String getIndexSettings(String index) throws IOException {
-        ClusterStateRequest request = new ClusterStateRequest()
-            .routingTable(false)
-            .nodes(false)
-            .metadata(true)
-            .indices(index);
-        ClusterStateResponse response = FutureUtils.get(client().admin().cluster().state(request));
-
-        Metadata metadata = response.getState().metadata();
-        XContentBuilder builder = JsonXContent.builder().startObject();
-
-        for (IndexMetadata indexMetadata : metadata) {
-            builder.startObject(indexMetadata.getIndex().getName());
-            builder.startObject("settings");
-            Settings settings = indexMetadata.getSettings();
-            for (String settingName : settings.keySet()) {
-                builder.field(settingName, settings.get(settingName));
-            }
-            builder.endObject();
-
-            builder.endObject();
-        }
-
-        builder.endObject();
-
-        return Strings.toString(builder);
     }
 
     /**


### PR DESCRIPTION
There were only a few test cases left that used JSONAssert and they're
easily replaced with SQL/assertRows which also helps with https://github.com/crate/crate/issues/11939
