### PR TITLE
Disable lookup-join optimization by default

### DIFF
--- a/docs/appendices/release-notes/5.8.0.rst
+++ b/docs/appendices/release-notes/5.8.0.rst
@@ -118,10 +118,11 @@ Performance and Resilience Improvements
 
 - Extended the lookup-join optimization to make it applicable to more complex
   queries when they include sub-queries, an inner-equi-join and if there is a
-  large imbalance in size between the joined tables. This optimization can be
-  disabled with the session setting::
+  large imbalance in size between the joined tables. This optimization is
+  experimental and can lead to large memory consumptions and is therefore
+  disabled by default. It can be activated with the session setting::
 
-     SET optimizer_equi_join_to_lookup_join = false
+     SET optimizer_equi_join_to_lookup_join = true
 
   Note that this setting is experimental, and may change in the future.
 

--- a/server/src/main/java/io/crate/action/sql/Sessions.java
+++ b/server/src/main/java/io/crate/action/sql/Sessions.java
@@ -48,6 +48,7 @@ import io.crate.metadata.NodeContext;
 import io.crate.metadata.settings.CoordinatorSessionSettings;
 import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Planner;
+import io.crate.planner.optimizer.LoadedRules;
 import io.crate.protocols.postgres.KeyData;
 import io.crate.role.Permission;
 import io.crate.role.Role;
@@ -139,9 +140,18 @@ public class Sessions {
     public Session newSession(@Nullable String defaultSchema, Role authenticatedUser) {
         CoordinatorSessionSettings sessionSettings;
         if (defaultSchema == null) {
-            sessionSettings = new CoordinatorSessionSettings(authenticatedUser);
+            sessionSettings = new CoordinatorSessionSettings(
+                authenticatedUser,
+                authenticatedUser,
+                LoadedRules.INSTANCE.disabledRules()
+            );
         } else {
-            sessionSettings = new CoordinatorSessionSettings(authenticatedUser, defaultSchema);
+            sessionSettings = new CoordinatorSessionSettings(
+                authenticatedUser,
+                authenticatedUser,
+                LoadedRules.INSTANCE.disabledRules(),
+                defaultSchema
+            );
         }
         sessionSettings.statementTimeout(defaultStatementTimeout);
         sessionSettings.memoryLimit(memoryLimit);

--- a/server/src/main/java/io/crate/metadata/settings/CoordinatorSessionSettings.java
+++ b/server/src/main/java/io/crate/metadata/settings/CoordinatorSessionSettings.java
@@ -28,6 +28,7 @@ import java.util.Set;
 
 import io.crate.common.unit.TimeValue;
 import io.crate.metadata.SearchPath;
+import io.crate.planner.optimizer.LoadedRules;
 import io.crate.planner.optimizer.Rule;
 import io.crate.role.Role;
 
@@ -49,16 +50,28 @@ public class CoordinatorSessionSettings extends SessionSettings {
     private TimeValue statementTimeout;
 
     public CoordinatorSessionSettings(Role authenticatedUser, String ... searchPath) {
-        this(authenticatedUser, authenticatedUser, searchPath);
+        this(authenticatedUser, authenticatedUser, Set.of(), searchPath);
     }
 
     public CoordinatorSessionSettings(Role authenticatedUser, Role sessionUser, String ... searchPath) {
         this(
             authenticatedUser,
             sessionUser,
+            Set.of(),
+            searchPath
+        );
+    }
+
+    public CoordinatorSessionSettings(Role authenticatedUser,
+                                      Role sessionUser,
+                                      Set<Class<? extends Rule<?>>> excludedOptimizerRules,
+                                      String ... searchPath) {
+        this(
+            authenticatedUser,
+            sessionUser,
             SearchPath.createSearchPathFrom(searchPath),
             true,
-            Set.of(),
+            excludedOptimizerRules,
             true,
             0
         );
@@ -100,7 +113,7 @@ public class CoordinatorSessionSettings extends SessionSettings {
     }
 
     public static CoordinatorSessionSettings systemDefaults() {
-        return new CoordinatorSessionSettings(Role.CRATE_USER);
+        return new CoordinatorSessionSettings(Role.CRATE_USER, Role.CRATE_USER, LoadedRules.INSTANCE.disabledRules());
     }
 
     public void setErrorOnUnknownObjectKey(boolean newValue) {

--- a/server/src/main/java/io/crate/planner/optimizer/LoadedRules.java
+++ b/server/src/main/java/io/crate/planner/optimizer/LoadedRules.java
@@ -23,10 +23,11 @@ package io.crate.planner.optimizer;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 
-import org.elasticsearch.common.inject.Singleton;
 import org.jetbrains.annotations.VisibleForTesting;
 
 import io.crate.common.collections.Lists;
@@ -36,32 +37,32 @@ import io.crate.metadata.settings.session.SessionSettingProvider;
 import io.crate.planner.operators.LogicalPlanner;
 import io.crate.types.DataTypes;
 
-@Singleton
 public class LoadedRules implements SessionSettingProvider {
 
-    public static final List<Class<? extends Rule<?>>> RULES = buildRules();
+    private final Set<Class<? extends Rule<?>>> disabledRules;
+    private final List<Class<? extends Rule<?>>> rules;
     public static final LoadedRules INSTANCE = new LoadedRules();
 
-    private LoadedRules() {
-        super();
-    }
-
     @SuppressWarnings("unchecked")
-    private static List<Class<? extends Rule<?>>> buildRules() {
+    private LoadedRules() {
         List<Collection<Rule<?>>> rules = List.of(
             LogicalPlanner.ITERATIVE_OPTIMIZER_RULES,
             LogicalPlanner.JOIN_ORDER_OPTIMIZER_RULES,
             LogicalPlanner.FETCH_OPTIMIZER_RULES
         );
-        var result = new ArrayList<Class<? extends Rule<?>>>();
+        this.rules = new ArrayList<>();
+        this.disabledRules = new HashSet<>();
         for (var ruleCollection : rules) {
             for (Rule<?> rule : ruleCollection) {
+                Class<? extends Rule<?>> clazz = (Class<? extends Rule<?>>) rule.getClass();
+                if (!rule.defaultEnabled()) {
+                    disabledRules.add(clazz);
+                }
                 if (!rule.mandatory()) {
-                    result.add((Class<? extends Rule<?>>) rule.getClass());
+                    this.rules.add(clazz);
                 }
             }
         }
-        return result;
     }
 
     @VisibleForTesting
@@ -91,8 +92,16 @@ public class LoadedRules implements SessionSettingProvider {
         );
     }
 
+    public Set<Class<? extends Rule<?>>> disabledRules() {
+        return disabledRules;
+    }
+
+    public List<Class<? extends Rule<?>>> rules() {
+        return rules;
+    }
+
     @Override
     public List<SessionSetting<?>> sessionSettings() {
-        return Lists.map(RULES, LoadedRules::buildRuleSessionSetting);
+        return Lists.map(rules, LoadedRules::buildRuleSessionSetting);
     }
 }

--- a/server/src/main/java/io/crate/planner/optimizer/Rule.java
+++ b/server/src/main/java/io/crate/planner/optimizer/Rule.java
@@ -68,6 +68,14 @@ public interface Rule<T> {
         return false;
     }
 
+    /**
+     * Every rule is enabled by default, but rules can be disabled by default when they are
+     * not suited for general usage because they are experimental.
+     */
+    default boolean defaultEnabled() {
+        return true;
+    }
+
     default String sessionSettingName() {
         return sessionSettingName(getClass());
     }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/EquiJoinToLookupJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/EquiJoinToLookupJoin.java
@@ -83,6 +83,11 @@ public class EquiJoinToLookupJoin implements Rule<JoinPlan> {
     );
 
     @Override
+    public boolean defaultEnabled() {
+        return false;
+    }
+
+    @Override
     public Pattern<JoinPlan> pattern() {
         return pattern;
     }

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -229,7 +229,7 @@ public class PgCatalogITest extends IntegTestCase {
             "memory.operation_limit| 0| Memory limit in bytes for an individual operation. 0 by-passes the operation limit, relying entirely on the global circuit breaker limits| NULL| NULL",
             "optimizer_deduplicate_order| true| Indicates if the optimizer rule DeduplicateOrder is activated.| NULL| NULL",
             "optimizer_eliminate_cross_join| true| Indicates if the optimizer rule EliminateCrossJoin is activated.| NULL| NULL",
-            "optimizer_equi_join_to_lookup_join| true| Indicates if the optimizer rule EquiJoinToLookupJoin is activated.| NULL| NULL",
+            "optimizer_equi_join_to_lookup_join| false| Indicates if the optimizer rule EquiJoinToLookupJoin is activated.| NULL| NULL",
             "optimizer_merge_aggregate_and_collect_to_count| true| Indicates if the optimizer rule MergeAggregateAndCollectToCount is activated.| NULL| NULL",
             "optimizer_merge_aggregate_rename_and_collect_to_count| true| Indicates if the optimizer rule MergeAggregateRenameAndCollectToCount is activated.| NULL| NULL",
             "optimizer_merge_filter_and_collect| true| Indicates if the optimizer rule MergeFilterAndCollect is activated.| NULL| NULL",

--- a/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
@@ -407,7 +407,7 @@ public class ShowIntegrationTest extends IntegTestCase {
             "memory.operation_limit| 0| Memory limit in bytes for an individual operation. 0 by-passes the operation limit, relying entirely on the global circuit breaker limits",
             "optimizer_deduplicate_order| true| Indicates if the optimizer rule DeduplicateOrder is activated.",
             "optimizer_eliminate_cross_join| true| Indicates if the optimizer rule EliminateCrossJoin is activated.",
-            "optimizer_equi_join_to_lookup_join| true| Indicates if the optimizer rule EquiJoinToLookupJoin is activated.",
+            "optimizer_equi_join_to_lookup_join| false| Indicates if the optimizer rule EquiJoinToLookupJoin is activated.",
             "optimizer_merge_aggregate_and_collect_to_count| true| Indicates if the optimizer rule MergeAggregateAndCollectToCount is activated.",
             "optimizer_merge_aggregate_rename_and_collect_to_count| true| Indicates if the optimizer rule MergeAggregateRenameAndCollectToCount is activated.",
             "optimizer_merge_filter_and_collect| true| Indicates if the optimizer rule MergeFilterAndCollect is activated.",

--- a/server/src/test/java/io/crate/planner/optimizer/OptimizerRuleSessionSettingProviderTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/OptimizerRuleSessionSettingProviderTest.java
@@ -73,14 +73,12 @@ public class OptimizerRuleSessionSettingProviderTest {
 
         assertThat(sessionSetting.getValue(mergefilterSettings)).isEqualTo("false");
 
-        var sessionSettings = new CoordinatorSessionSettings(RolesHelper.userOf("user"));
-
         // Disable MergeFilters 'SET SESSION optimizer_merge_filters = false'
-        sessionSetting.apply(sessionSettings, List.of(Literal.of(false)), eval);
-        assertThat(sessionSettings.excludedOptimizerRules(), containsInAnyOrder(MergeFilters.class));
+        sessionSetting.apply(mergefilterSettings, List.of(Literal.of(false)), eval);
+        assertThat(mergefilterSettings.excludedOptimizerRules(), containsInAnyOrder(MergeFilters.class));
 
         // Enable MergeFilters 'SET SESSION optimizer_merge_filters = true'
-        sessionSetting.apply(sessionSettings, List.of(Literal.of(true)), eval);
-        assertThat(sessionSettings.excludedOptimizerRules()).isEmpty();
+        sessionSetting.apply(mergefilterSettings, List.of(Literal.of(true)), eval);
+        assertThat(mergefilterSettings.excludedOptimizerRules()).isEmpty();
     }
 }

--- a/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
@@ -434,7 +434,7 @@ public class SQLExecutor {
                         sessionSettingRegistry
                     ),
                 relationAnalyzer,
-                new CoordinatorSessionSettings(Role.CRATE_USER),
+                new CoordinatorSessionSettings(Role.CRATE_USER, Role.CRATE_USER, LoadedRules.INSTANCE.disabledRules()),
                 nodeCtx.schemas(),
                 Randomness.get(),
                 fulltextAnalyzerResolver,

--- a/server/src/testFixtures/java/io/crate/testing/SQLTransportExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLTransportExecutor.java
@@ -213,7 +213,7 @@ public class SQLTransportExecutor {
             sessionList.addAll(buildRandomizedRuleSessionSettings(
                 random,
                 config.amountOfRulesToDisable(),
-                LoadedRules.RULES,
+                LoadedRules.INSTANCE.rules(),
                 config.rulesToKeep()));
         }
 

--- a/server/src/testFixtures/java/io/crate/testing/SqlExpressions.java
+++ b/server/src/testFixtures/java/io/crate/testing/SqlExpressions.java
@@ -48,6 +48,7 @@ import io.crate.metadata.RowGranularity;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.settings.CoordinatorSessionSettings;
 import io.crate.metadata.table.Operation;
+import io.crate.planner.optimizer.LoadedRules;
 import io.crate.role.Role;
 import io.crate.sql.parser.SqlParser;
 
@@ -81,7 +82,8 @@ public class SqlExpressions {
                           Schemas schemas) {
         this.nodeCtx = createNodeContext(schemas, Lists.concat(additionalUsers, sessionUser));
         // In test_throws_error_when_user_is_not_found we explicitly inject null user but SessionContext user cannot be not null.
-        var sessionSettings = new CoordinatorSessionSettings(sessionUser == null ? Role.CRATE_USER : sessionUser);
+        Role role = sessionUser == null ? Role.CRATE_USER : sessionUser;
+        var sessionSettings = new CoordinatorSessionSettings(role, role, LoadedRules.INSTANCE.disabledRules());
         coordinatorTxnCtx = new CoordinatorTxnCtx(sessionSettings);
         expressionAnalyzer = new ExpressionAnalyzer(
             coordinatorTxnCtx,

--- a/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
@@ -193,6 +193,7 @@ import io.crate.planner.Plan;
 import io.crate.planner.Planner;
 import io.crate.planner.PlannerContext;
 import io.crate.planner.operators.SubQueryResults;
+import io.crate.planner.optimizer.LoadedRules;
 import io.crate.planner.optimizer.rule.MergeFilterAndCollect;
 import io.crate.protocols.postgres.PostgresNetty;
 import io.crate.protocols.postgres.TransactionState;
@@ -1737,6 +1738,8 @@ public abstract class IntegTestCase extends ESTestCase {
 
         CoordinatorSessionSettings sessionSettings = new CoordinatorSessionSettings(
             Role.CRATE_USER,
+            Role.CRATE_USER,
+            LoadedRules.INSTANCE.disabledRules(),
             sqlExecutor.getCurrentSchema()
         );
         CoordinatorTxnCtx coordinatorTxnCtx = new CoordinatorTxnCtx(sessionSettings);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This disables the rule `optimizer_equi_join_to_lookup_join` with the following steps:

- Add `Rule.defaultEnabled()` which can be set to `false` to disable a rule programmatically
- Adapt `LoadedRules` and `CoordinatorSessionSettings` to make it work with `Rule.defaultEnabled()`
- Adapt tests and test setup 

Fixes https://github.com/crate/crate-alerts/issues/644
Fixes https://github.com/crate/crate/issues/16029


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
