### PR TITLE
Add memory accounting for caching rows in lag/lead

### DIFF
--- a/benchmarks/src/main/java/io/crate/data/join/RowsBatchIteratorBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/data/join/RowsBatchIteratorBenchmark.java
@@ -195,6 +195,7 @@ public class RowsBatchIteratorBenchmark {
         RowCollectExpression input = new RowCollectExpression(0);
         BatchIterator<Row> batchIterator = WindowFunctionBatchIterator.of(
             new InMemoryBatchIterator<>(rows, SENTINEL, false),
+            ignored -> {},
             new NoRowAccounting<>(),
             (partitionStart, partitionEnd, currentIndex, sortedRows) -> 0,
             (partitionStart, partitionEnd, currentIndex, sortedRows) -> currentIndex,

--- a/docs/appendices/release-notes/5.7.2.rst
+++ b/docs/appendices/release-notes/5.7.2.rst
@@ -82,3 +82,6 @@ Fixes
 - Fixed an issue leading to a ``ArrayIndexOutOfBoundsException`` when using a
   correlated sub-query where some of its outputs weren't used in a parent
   query.
+
+- Fixed an issue that could lead to out-of-memory errors when executing
+  ``lead`` or ``lag`` window functions on a large table.

--- a/extensions/functions/src/main/java/io/crate/window/NthValueFunctions.java
+++ b/extensions/functions/src/main/java/io/crate/window/NthValueFunctions.java
@@ -25,6 +25,7 @@ import static io.crate.execution.engine.window.WindowFrameState.isLowerBoundIncr
 import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
 
 import java.util.List;
+import java.util.function.LongConsumer;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -233,7 +234,8 @@ public class NthValueFunctions implements WindowFunction {
     }
 
     @Override
-    public Object execute(int idxInPartition,
+    public Object execute(LongConsumer allocateBytes,
+                          int idxInPartition,
                           WindowFrameState currentFrame,
                           List<? extends CollectExpression<Row, ?>> expressions,
                           @Nullable Boolean ignoreNulls,

--- a/extensions/functions/src/main/java/io/crate/window/RankFunctions.java
+++ b/extensions/functions/src/main/java/io/crate/window/RankFunctions.java
@@ -23,6 +23,7 @@ package io.crate.window;
 
 import java.util.List;
 import java.util.function.IntBinaryOperator;
+import java.util.function.LongConsumer;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -65,7 +66,8 @@ public class RankFunctions implements WindowFunction {
     }
 
     @Override
-    public Object execute(int idxInPartition,
+    public Object execute(LongConsumer allocateBytes,
+                          int idxInPartition,
                           WindowFrameState currentFrame,
                           List<? extends CollectExpression<Row, ?>> expressions,
                           @Nullable Boolean ignoreNulls,

--- a/server/src/main/java/io/crate/execution/engine/window/AggregateToWindowFunctionAdapter.java
+++ b/server/src/main/java/io/crate/execution/engine/window/AggregateToWindowFunctionAdapter.java
@@ -24,6 +24,7 @@ package io.crate.execution.engine.window;
 import static io.crate.execution.engine.window.WindowFrameState.isLowerBoundIncreasing;
 
 import java.util.List;
+import java.util.function.LongConsumer;
 
 import org.elasticsearch.Version;
 import org.jetbrains.annotations.Nullable;
@@ -93,7 +94,8 @@ public class AggregateToWindowFunctionAdapter implements WindowFunction {
     }
 
     @Override
-    public Object execute(int idxInPartition,
+    public Object execute(LongConsumer allocateBytes,
+                          int idxInPartition,
                           WindowFrameState frame,
                           List<? extends CollectExpression<Row, ?>> expressions,
                           @Nullable Boolean ignoreNulls,

--- a/server/src/main/java/io/crate/execution/engine/window/RowNumberWindowFunction.java
+++ b/server/src/main/java/io/crate/execution/engine/window/RowNumberWindowFunction.java
@@ -22,6 +22,7 @@
 package io.crate.execution.engine.window;
 
 import java.util.List;
+import java.util.function.LongConsumer;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -56,7 +57,8 @@ public class RowNumberWindowFunction implements WindowFunction {
     }
 
     @Override
-    public Object execute(int idxInPartition,
+    public Object execute(LongConsumer allocateBytes,
+                          int idxInPartition,
                           WindowFrameState currentFrame,
                           List<? extends CollectExpression<Row, ?>> expressions,
                           @Nullable Boolean ignoreNulls,

--- a/server/src/main/java/io/crate/execution/engine/window/WindowFunction.java
+++ b/server/src/main/java/io/crate/execution/engine/window/WindowFunction.java
@@ -22,6 +22,7 @@
 package io.crate.execution.engine.window;
 
 import java.util.List;
+import java.util.function.LongConsumer;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -40,7 +41,8 @@ public interface WindowFunction extends FunctionImplementation {
      * @param currentFrame the frame the row identified by {@param rowIdx} is part of.
      * @param ignoreNulls
      */
-    Object execute(int rowIdx,
+    Object execute(LongConsumer allocateBytes,
+                   int rowIdx,
                    WindowFrameState currentFrame,
                    List<? extends CollectExpression<Row, ?>> expressions,
                    @Nullable Boolean ignoreNulls,

--- a/server/src/main/java/io/crate/execution/engine/window/WindowProjector.java
+++ b/server/src/main/java/io/crate/execution/engine/window/WindowProjector.java
@@ -154,6 +154,7 @@ public class WindowProjector {
         );
         return sourceRows -> WindowFunctionBatchIterator.of(
             sourceRows,
+            ramAccounting::addBytes,
             accounting,
             computeFrameStart,
             computeFrameEnd,

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/PercentileAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/PercentileAggregationTest.java
@@ -38,6 +38,7 @@ import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.functions.Signature;
 import io.crate.operation.aggregation.AggregationTestCase;
+import io.crate.testing.PlainRamAccounting;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 
@@ -261,30 +262,7 @@ public class PercentileAggregationTest extends AggregationTestCase {
             List.of(DataTypes.LONG, DataTypes.DOUBLE_ARRAY),
             DataTypes.DOUBLE_ARRAY
         );
-        RamAccounting ramAccounting = new RamAccounting() {
-
-            long total = 0;
-
-            @Override
-            public void addBytes(long bytes) {
-                total += bytes;
-            }
-
-            @Override
-            public long totalBytes() {
-                return total;
-            }
-
-            @Override
-            public void release() {
-                total = 0;
-            }
-
-            @Override
-            public void close() {
-                release();
-            }
-        };
+        RamAccounting ramAccounting = new PlainRamAccounting();
         Object state = impl.newState(ramAccounting, Version.CURRENT, Version.CURRENT, memoryManager);
         assertThat(ramAccounting.totalBytes()).isEqualTo(72L);
         Literal<List<Double>> fractions = Literal.of(Collections.singletonList(0.95D), DataTypes.DOUBLE_ARRAY);

--- a/server/src/test/java/io/crate/execution/engine/window/WindowFunctionBatchIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/window/WindowFunctionBatchIteratorTest.java
@@ -31,6 +31,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.function.LongConsumer;
 
 import org.elasticsearch.test.ESTestCase;
 import org.hamcrest.Matchers;
@@ -59,6 +60,7 @@ public class WindowFunctionBatchIteratorTest extends ESTestCase {
                 new Object[]{"a", 8, null},
                 new Object[]{"b", 2, null}
             ),
+            ignored -> {},
             (partitionStart, partitionEnd, currentIndex, sortedRows) -> 0,
             (partitionStart, partitionEnd, currentIndex, sortedRows) -> currentIndex,
             OrderingByPosition.arrayOrdering(DataTypes.STRING, 0, false, false),
@@ -68,7 +70,8 @@ public class WindowFunctionBatchIteratorTest extends ESTestCase {
             Runnable::run,
             List.of(new WindowFunction() {
                 @Override
-                public Object execute(int idxInPartition,
+                public Object execute(LongConsumer allocateBytes,
+                                      int idxInPartition,
                                       WindowFrameState currentFrame,
                                       List<? extends CollectExpression<Row, ?>> expressions,
                                       Boolean ignoreNulls,

--- a/server/src/testFixtures/java/io/crate/testing/PlainRamAccounting.java
+++ b/server/src/testFixtures/java/io/crate/testing/PlainRamAccounting.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.testing;
+
+import io.crate.data.breaker.RamAccounting;
+
+public class PlainRamAccounting implements RamAccounting {
+
+    long total;
+    long breakingThreshold;
+    boolean closed;
+
+    public PlainRamAccounting() {
+        this.breakingThreshold = -1;
+    }
+
+    public PlainRamAccounting(long breakingThreshold) {
+        this.breakingThreshold = breakingThreshold;
+    }
+
+    @Override
+    public void addBytes(long bytes) {
+        total += bytes;
+        if (breakingThreshold != -1 && total > breakingThreshold) {
+            // break when more than two block sizes have been added to the Sketch
+            throw new RuntimeException("Circuit break! " + total);
+        }
+
+    }
+
+    @Override
+    public long totalBytes() {
+        return total;
+    }
+
+    @Override
+    public void release() {
+        total = 0;
+    }
+
+    @Override
+    public void close() {
+        closed = true;
+    }
+
+    public boolean closed() {
+        return closed;
+    }
+}


### PR DESCRIPTION
See commits

Main changes for the second commit are https://github.com/crate/crate/pull/16054/files#diff-46daebe2eb560bde12d41b4efe0654082dac0a81bf4d8eda51d1a1506cecb0afR160-R172 

and https://github.com/crate/crate/pull/16054/files#diff-46daebe2eb560bde12d41b4efe0654082dac0a81bf4d8eda51d1a1506cecb0afR236-R237,

other code is boilerplate