### PR TITLE
Remove mapperService.merge from AlterTableClusterStateExecutor

### DIFF
--- a/server/src/main/java/io/crate/metadata/cluster/AlterTableClusterStateExecutor.java
+++ b/server/src/main/java/io/crate/metadata/cluster/AlterTableClusterStateExecutor.java
@@ -51,13 +51,11 @@ import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
-import org.elasticsearch.index.mapper.DocumentMapper;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.InvalidIndexTemplateException;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import io.crate.analyze.TableParameters;
-import org.jetbrains.annotations.VisibleForTesting;
 import io.crate.execution.ddl.tables.AlterTableRequest;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.PartitionName;
@@ -159,15 +157,8 @@ public class AlterTableClusterStateExecutor extends DDLClusterStateTaskExecutor<
                 return currentState;
             }
             indexMapping.put(ColumnPolicy.MAPPING_KEY, mappingDelta.get(ColumnPolicy.MAPPING_KEY));
-
-
-            MapperService mapperService = indicesService.createIndexMapperService(indexMetadata);
-
-            mapperService.merge(indexMapping, MapperService.MergeReason.MAPPING_UPDATE);
-            DocumentMapper mapper = mapperService.documentMapper();
-
             IndexMetadata.Builder imBuilder = IndexMetadata.builder(indexMetadata);
-            imBuilder.putMapping(new MappingMetadata(mapper.mappingSource())).mappingVersion(1 + imBuilder.mappingVersion());
+            imBuilder.putMapping(new MappingMetadata(indexMapping)).mappingVersion(1 + imBuilder.mappingVersion());
             metadataBuilder.put(imBuilder); // implicitly increments metadata version.
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -38,14 +38,12 @@ import org.apache.lucene.analysis.DelegatingAnalyzerWrapper;
 import org.elasticsearch.Assertions;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.AbstractIndexComponent;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.analysis.IndexAnalyzers;
@@ -222,11 +220,6 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
                 }
             }
         }
-    }
-
-    public DocumentMapper merge(Map<String, Object> mappings, MergeReason reason) throws IOException {
-        CompressedXContent content = new CompressedXContent(Strings.toString(JsonXContent.builder().map(mappings)));
-        return internalMerge(content, reason);
     }
 
     public void merge(IndexMetadata indexMetadata, MergeReason reason) {


### PR DESCRIPTION
`ALTER TABLE ... SET` can only update settings, not mappings. The only
exception to that is `column_policy`, which already had special
handling.
`mapperService.merge(indexMapping)` is not necessary
