### PR TITLE
Add timeout for wipeAllTables in test teardown

### DIFF
--- a/server/src/testFixtures/java/org/elasticsearch/test/TestCluster.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/TestCluster.java
@@ -424,7 +424,7 @@ public final class TestCluster implements Closeable {
             }
             CompletableFuture<List<AcknowledgedResponse>> allResponses = CompletableFutures.allAsList(futures);
             try {
-                List<AcknowledgedResponse> responses = allResponses.get();
+                List<AcknowledgedResponse> responses = allResponses.get(5, TimeUnit.SECONDS);
                 responses.forEach(r -> assertAcked(r));
             } catch (Exception ignore) {
             }


### PR DESCRIPTION
Just had a test run get stuck. `jcmd <pid> Thread.print` showed:

    java.lang.Thread.State: WAITING (parking)
    	at jdk.internal.misc.Unsafe.park(java.base@22/Native Method)
    	- parking to wait for  <0x0000000431eb57b8> (a java.util.concurrent.CompletableFuture$Signaller)
    	at java.util.concurrent.locks.LockSupport.park(java.base@22/LockSupport.java:221)
    	at java.util.concurrent.CompletableFuture$Signaller.block(java.base@22/CompletableFuture.java:1864)
    	at java.util.concurrent.ForkJoinPool.unmanagedBlock(java.base@22/ForkJoinPool.java:4013)
    	at java.util.concurrent.ForkJoinPool.managedBlock(java.base@22/ForkJoinPool.java:3961)
    	at java.util.concurrent.CompletableFuture.waitingGet(java.base@22/CompletableFuture.java:1898)
    	at java.util.concurrent.CompletableFuture.get(java.base@22/CompletableFuture.java:2072)
    	at org.elasticsearch.test.TestCluster.wipeAllTables(TestCluster.java:427)
    	at org.elasticsearch.test.TestCluster.wipe(TestCluster.java:412)
    	at org.elasticsearch.test.IntegTestCase.lambda$beforeInternal$0(IntegTestCase.java:349)
    	at org.elasticsearch.test.IntegTestCase$$Lambda/0x000075584f99f108.call(Unknown Source)

Note that this is just a mitigation. The underlying root-cause is
related to the `SwapTableITest` flakyness, because the dump also shows:

    "TEST-SwapTableITest.test_swap_two_simple_tables_with_drop_source-seed#[38F19AF2CB9DB729]" #1032 [502435] prio=5 os_prio=0 cpu=42.91ms elapsed=228.71s tid=0x0000755604656e90 nid=502435 waiting on condition  [0x00007558417e7000]
       java.lang.Thread.State: TIMED_WAITING (parking)
    	at jdk.internal.misc.Unsafe.park(java.base@22/Native Method)
    	- parking to wait for  <0x0000000431e92b60> (a java.util.concurrent.FutureTask)
    	at java.util.concurrent.locks.LockSupport.parkNanos(java.base@22/LockSupport.java:269)
    	at java.util.concurrent.FutureTask.awaitDone(java.base@22/FutureTask.java:497)
    	at java.util.concurrent.FutureTask.get(java.base@22/FutureTask.java:203)
    	at org.junit.internal.runners.statements.FailOnTimeout.getResult(FailOnTimeout.java:167)
    	at org.junit.internal.runners.statements.FailOnTimeout.evaluate(FailOnTimeout.java:128)
