### PR TITLE
Improve error when less params bound for PK cols in WHERE

### DIFF
--- a/docs/appendices/release-notes/5.7.2.rst
+++ b/docs/appendices/release-notes/5.7.2.rst
@@ -52,6 +52,15 @@ Security Fixes
 Fixes
 =====
 
+- Fixed an issue leading to a ``ArrayIndexOutOfBoundsException``  instead of a
+  user friendly error message when the ``WHERE``` clause of a query contains
+  all columns of a :ref:`PRIMARY KEY <constraints-primary-key>`, uses
+  parameters for them, and binds less actual values than the required, e.g.::
+
+      SELECT * FROM t WHERE pk_col1 = ? AND pk_col2 = ? AND pk_col3 = ?
+
+  and less than 3 values are provided.
+
 - Added memory accounting for multi-phase execution to prevent out-of-memory
   errors caused by sub-queries such as ''SELECT * FROM t1 WHERE id IN
   (SELECT id FROM t2)'' or lookup-joins with large intermediate results.

--- a/server/src/main/java/io/crate/analyze/SymbolEvaluator.java
+++ b/server/src/main/java/io/crate/analyze/SymbolEvaluator.java
@@ -72,7 +72,7 @@ public final class SymbolEvaluator extends BaseImplementationSymbolVisitor<Row> 
     @Override
     public Input<?> visitParameterSymbol(ParameterSymbol parameterSymbol, Row params) {
         return () -> {
-            Object value = params.get(parameterSymbol.index());
+            Object value = parameterSymbol.bind(params);
             try {
                 return parameterSymbol.valueType().implicitCast(value);
             } catch (ConversionException e) {

--- a/server/src/main/java/io/crate/expression/symbol/ParameterSymbol.java
+++ b/server/src/main/java/io/crate/expression/symbol/ParameterSymbol.java
@@ -21,6 +21,7 @@
 
 package io.crate.expression.symbol;
 
+import io.crate.data.Row;
 import io.crate.expression.scalar.cast.CastMode;
 import io.crate.expression.symbol.format.Style;
 import io.crate.types.DataType;
@@ -31,6 +32,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
+import java.util.Locale;
 
 public class ParameterSymbol implements Symbol {
 
@@ -110,5 +112,18 @@ public class ParameterSymbol implements Symbol {
     @Override
     public long ramBytesUsed() {
         return IntegerType.INTEGER_SIZE + internalType.ramBytesUsed();
+    }
+
+    public Object bind(Row params) throws IllegalArgumentException {
+        try {
+            return params.get(index);
+        } catch (IndexOutOfBoundsException e) {
+            throw new IllegalArgumentException(String.format(
+                Locale.ENGLISH,
+                "The query contains a parameter placeholder $%d, but there are only %d parameter values",
+                (index() + 1),
+                params.numColumns()
+            ));
+        }
     }
 }

--- a/server/src/main/java/io/crate/expression/symbol/Symbols.java
+++ b/server/src/main/java/io/crate/expression/symbol/Symbols.java
@@ -45,15 +45,16 @@ import io.crate.sql.tree.ColumnDefinition;
 import io.crate.sql.tree.ColumnPolicy;
 import io.crate.sql.tree.Expression;
 import io.crate.types.DataType;
-import io.crate.types.TypeSignature;
 
-public class Symbols {
+public final class Symbols {
 
     private static final HasColumnVisitor HAS_COLUMN_VISITOR = new HasColumnVisitor();
 
     public static final Predicate<Symbol> IS_COLUMN = s -> s instanceof ScopedSymbol || s instanceof Reference;
-    public static final Predicate<Symbol> IS_GENERATED_COLUMN = input -> input instanceof GeneratedReference;
+    public static final Predicate<Symbol> IS_GENERATED_COLUMN = s -> s instanceof GeneratedReference;
     public static final Predicate<Symbol> IS_CORRELATED_SUBQUERY = Symbols::isCorrelatedSubQuery;
+
+    private Symbols() {}
 
     public static boolean isCorrelatedSubQuery(Symbol symbol) {
         return symbol instanceof SelectSymbol selectSymbol && selectSymbol.isCorrelated();
@@ -73,10 +74,6 @@ public class Symbols {
 
     public static List<DataType<?>> typeView(List<? extends Symbol> symbols) {
         return Lists.mapLazy(symbols, Symbol::valueType);
-    }
-
-    public static List<TypeSignature> typeSignatureView(List<? extends Symbol> symbols) {
-        return Lists.mapLazy(symbols, s -> s.valueType().getTypeSignature());
     }
 
     public static Streamer<?>[] streamerArray(Symbol[] symbols) {
@@ -224,7 +221,7 @@ public class Symbols {
 
     public static Symbol unwrapReferenceFromCast(Symbol symbol) {
         if (symbol instanceof Function fn && fn.isCast()) {
-            return fn.arguments().get(0);
+            return fn.arguments().getFirst();
         }
         return symbol;
     }

--- a/server/src/main/java/io/crate/planner/operators/SubQueryAndParamBinder.java
+++ b/server/src/main/java/io/crate/planner/operators/SubQueryAndParamBinder.java
@@ -41,7 +41,7 @@ public class SubQueryAndParamBinder extends FunctionCopyVisitor<Void> implements
 
     /**
      * Returns a bound symbol with ParameterSymbols or SelectSymbols replaced as literals using the provided arguments.
-     *
+     * <p>
      * If multiple calls with the same params and subQueryResults are made it's better to instantiate the class
      * once using {@link #SubQueryAndParamBinder(Row, SubQueryResults)}
      */

--- a/server/src/main/java/io/crate/planner/operators/SubQueryAndParamBinder.java
+++ b/server/src/main/java/io/crate/planner/operators/SubQueryAndParamBinder.java
@@ -21,7 +21,6 @@
 
 package io.crate.planner.operators;
 
-import java.util.Locale;
 import java.util.function.UnaryOperator;
 
 import io.crate.data.Row;
@@ -85,18 +84,9 @@ public class SubQueryAndParamBinder extends FunctionCopyVisitor<Void> implements
     }
 
     private static Symbol convert(ParameterSymbol parameterSymbol, Row params) {
+        Object value = parameterSymbol.bind(params);
         DataType<?> type = parameterSymbol.valueType();
-        Object value;
-        try {
-            value = params.get(parameterSymbol.index());
-        } catch (IndexOutOfBoundsException e) {
-            throw new IllegalArgumentException(String.format(
-                Locale.ENGLISH,
-                "The query contains a parameter placeholder $%d, but there are only %d parameter values",
-                (parameterSymbol.index() + 1),
-                params.numColumns()
-            ));
-        }
+
         if (type.equals(DataTypes.UNDEFINED)) {
             type = DataTypes.guessType(value);
         }

--- a/server/src/test/java/io/crate/analyze/where/DocKeysTest.java
+++ b/server/src/test/java/io/crate/analyze/where/DocKeysTest.java
@@ -43,12 +43,12 @@ import io.crate.types.DataTypes;
 
 public class DocKeysTest extends ESTestCase {
 
-    private NodeContext nodeCtx = createNodeContext();
+    private final NodeContext nodeCtx = createNodeContext();
 
     @Test
-    public void testClusteredIsFirstInId() throws Exception {
+    public void testClusteredIsFirstInId() {
         // if a the table is clustered and has a pk, the clustering value is put in front in the id computation
-        List<List<Symbol>> pks = List.<List<Symbol>>of(
+        List<List<Symbol>> pks = List.of(
             List.<Symbol>of(Literal.of(1), Literal.of("Ford"))
         );
         DocKeys docKeys = new DocKeys(pks, false, false, 1, null);


### PR DESCRIPTION
Such case is handled already in `SubQueryAndParamBinder`, but when query parameters are used for all PK cols in the `WHERE` clause, then a `Get` plan is used, so the same handling is added in the `SymbolEvalutor`, used by the `DocKeys`.

Fixes: #15997
