### PR TITLE
Fix has_table_privilege for unknown tables

### DIFF
--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -4007,7 +4007,26 @@ Example::
     +----------+
     SELECT 1 row in set (... sec)
     
-    
+.. NOTE::
+
+    For unknown tables:
+
+    - Returns ``TRUE`` for superusers.
+
+    - For a user with ``DQL`` on cluster scope, returns ``TRUE`` if the
+      privilege type is ``SELECT``.
+
+    - For a user with ``DML`` on cluster scope, returns ``TRUE`` if the
+      privilege type is ``INSERT``, ``UPDATE`` or ``DELETE``.
+
+    - For a user with ``DQL`` on the schema, returns ``TRUE`` if the privilege
+      type is ``SELECT``.
+
+    - For a user with ``DML`` on the schema, returns ``TRUE`` if the privilege
+      type is ``INSERT``, ``UPDATE`` or ``DELETE``.
+
+    - Returns ``FALSE`` otherwise.
+
 .. _scalar-pg_backend_pid:
 
 ``pg_backend_pid()``

--- a/server/src/main/java/io/crate/expression/scalar/HasTablePrivilegeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/HasTablePrivilegeFunction.java
@@ -51,10 +51,16 @@ public class HasTablePrivilegeFunction {
     public static boolean checkByTableOid(Roles roles, Role user, Object table, Collection<Permission> permissions, Schemas schemas) {
         int tableOid = (int) table;
         RelationName relationName = schemas.getRelation(tableOid);
+        String tableFqn;
         if (relationName == null) {
-            throw new IllegalArgumentException("Cannot find corresponding relation by the given oid");
+            // Proceed to checkPrivileges with tableFqn as 'null' which will return 'true' for a superuser or a
+            // user with appropriate cluster scope privileges.
+            // Note that a user with schema privileges will always get a 'false' since we cannot identify the schema
+            // name from the given table oid(since relationName is null, schema name is unknown).
+            tableFqn = null;
+        } else {
+            tableFqn = relationName.fqn();
         }
-        String tableFqn = relationName.fqn();
         return checkPrivileges(roles, user, tableFqn, permissions);
     }
 

--- a/server/src/main/java/io/crate/role/RolePrivileges.java
+++ b/server/src/main/java/io/crate/role/RolePrivileges.java
@@ -127,9 +127,13 @@ public class RolePrivileges implements Iterable<Privilege> {
                     foundPrivilege = privilegeByIdent.get(new Subject(permission, Securable.CLUSTER, null));
                     break;
                 case TABLE, VIEW:
-                    String schemaIdent = new IndexParts(ident).getSchema();
-                    foundPrivilege = privilegeByIdent.get(new Subject(permission, Securable.SCHEMA, schemaIdent));
-                    if (foundPrivilege == null) {
+                    if (ident != null) {
+                        String schemaIdent = new IndexParts(ident).getSchema();
+                        foundPrivilege = privilegeByIdent.get(new Subject(permission, Securable.SCHEMA, schemaIdent));
+                        if (foundPrivilege == null) {
+                            foundPrivilege = privilegeByIdent.get(new Subject(permission, Securable.CLUSTER, null));
+                        }
+                    } else {
                         foundPrivilege = privilegeByIdent.get(new Subject(permission, Securable.CLUSTER, null));
                     }
                     break;


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Continuation from https://github.com/crate/crate/pull/16004. `has_table_privilege` is new to `5.8`, no need backporting.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
