### PR TITLE
Remove LuceneQueryBuilder.Context.getFieldTypeOrNull()

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/collect/DocValuesAggregates.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/DocValuesAggregates.java
@@ -106,7 +106,6 @@ public final class DocValuesAggregates {
         LuceneQueryBuilder.Context queryContext = luceneQueryBuilder.convert(
             phase.where(),
             collectTask.txnCtx(),
-            indexShard.mapperService(),
             indexShard.shardId().getIndexName(),
             queryShardContext,
             table,

--- a/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
@@ -146,7 +146,6 @@ final class DocValuesGroupByOptimizedIterator {
         LuceneQueryBuilder.Context queryContext = luceneQueryBuilder.convert(
             collectPhase.where(),
             collectTask.txnCtx(),
-            indexShard.mapperService(),
             indexShard.shardId().getIndexName(),
             queryShardContext,
             table,

--- a/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
@@ -171,7 +171,6 @@ final class GroupByOptimizedIterator {
         LuceneQueryBuilder.Context queryContext = luceneQueryBuilder.convert(
             collectPhase.where(),
             collectTask.txnCtx(),
-            indexShard.mapperService(),
             indexShard.shardId().getIndexName(),
             queryShardContext,
             table,

--- a/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
@@ -140,7 +140,6 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
         LuceneQueryBuilder.Context queryContext = luceneQueryBuilder.convert(
             collectPhase.where(),
             collectTask.txnCtx(),
-            sharedShardContextShard.mapperService(),
             sharedShardContextShard.shardId().getIndexName(),
             queryShardContext,
             table,
@@ -220,7 +219,6 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
         final var queryContext = luceneQueryBuilder.convert(
             collectPhase.where(),
             collectTask.txnCtx(),
-            indexService.mapperService(),
             indexShard.shardId().getIndexName(),
             queryShardContext,
             table,

--- a/server/src/main/java/io/crate/execution/engine/collect/count/InternalCountOperation.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/count/InternalCountOperation.java
@@ -154,7 +154,6 @@ public class InternalCountOperation implements CountOperation {
             LuceneQueryBuilder.Context queryCtx = queryBuilder.convert(
                 filter,
                 txnCtx,
-                indexService.mapperService(),
                 indexName,
                 indexService.newQueryShardContext(),
                 table,

--- a/server/src/main/java/io/crate/expression/operator/EqOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/EqOperator.java
@@ -23,7 +23,6 @@ package io.crate.expression.operator;
 
 import static io.crate.lucene.LuceneQueryBuilder.genericFunctionFilter;
 import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
-import static org.elasticsearch.common.lucene.search.Queries.newUnmappedFieldQuery;
 
 import java.util.Collection;
 import java.util.List;
@@ -40,7 +39,6 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermInSetQuery;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.Uid;
 import org.jetbrains.annotations.Nullable;
 
@@ -191,21 +189,13 @@ public final class EqOperator extends Operator<Object> {
                                                Context context,
                                                boolean hasDocValues,
                                                IndexType indexType) {
-        MappedFieldType fieldType = context.getFieldTypeOrNull(column);
-        if (fieldType == null) {
-            if (elementType.id() == ObjectType.ID) {
-                return null; // Fallback to generic filter on ARRAY(OBJECT)
-            }
-            // field doesn't exist, can't match
-            return newUnmappedFieldQuery(column);
-        }
 
         BooleanQuery.Builder filterClauses = new BooleanQuery.Builder();
         Query genericFunctionFilter = genericFunctionFilter(function, context);
         if (values.isEmpty()) {
             // `arrayRef = []` - termsQuery would be null
 
-            if (fieldType.hasDocValues() == false) {
+            if (hasDocValues == false) {
                 //  Cannot use NumTermsPerDocQuery if column store is disabled, for example, ARRAY(GEO_SHAPE).
                 return genericFunctionFilter;
             }

--- a/server/src/main/java/io/crate/expression/operator/any/AnyNeqOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/any/AnyNeqOperator.java
@@ -21,14 +21,11 @@
 
 package io.crate.expression.operator.any;
 
-import static org.elasticsearch.common.lucene.search.Queries.newUnmappedFieldQuery;
-
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.lucene.search.Queries;
-import org.elasticsearch.index.mapper.MappedFieldType;
 
 import io.crate.expression.operator.EqOperator;
 import io.crate.expression.predicate.IsNullPredicate;
@@ -60,11 +57,6 @@ public final class AnyNeqOperator extends AnyOperator {
     protected Query refMatchesAnyArrayLiteral(Function any, Reference probe, Literal<?> candidates, Context context) {
         //  col != ANY ([1,2,3]) --> not(col=1 and col=2 and col=3)
         String columnName = probe.storageIdent();
-        MappedFieldType fieldType = context.getFieldTypeOrNull(columnName);
-        if (fieldType == null) {
-            return newUnmappedFieldQuery(columnName);
-        }
-
         BooleanQuery.Builder andBuilder = new BooleanQuery.Builder();
         for (Object value : (Iterable<?>) candidates.value()) {
             if (value == null) {
@@ -93,11 +85,6 @@ public final class AnyNeqOperator extends AnyOperator {
     protected Query literalMatchesAnyArrayRef(Function any, Literal<?> probe, Reference candidates, Context context) {
         // 1 != any ( col ) -->  gt 1 or lt 1
         String columnName = candidates.storageIdent();
-
-        MappedFieldType fieldType = context.getFieldTypeOrNull(columnName);
-        if (fieldType == null) {
-            return newUnmappedFieldQuery(columnName);
-        }
         StorageSupport<?> storageSupport = probe.valueType().storageSupport();
         if (storageSupport == null) {
             return null;

--- a/server/src/main/java/io/crate/expression/scalar/SubscriptFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/SubscriptFunction.java
@@ -23,7 +23,6 @@ package io.crate.expression.scalar;
 
 import static io.crate.expression.scalar.SubscriptObjectFunction.tryToInferReturnTypeFromObjectTypeAndArguments;
 import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
-import static org.elasticsearch.common.lucene.search.Queries.newUnmappedFieldQuery;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,7 +31,6 @@ import java.util.Map;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
-import org.elasticsearch.index.mapper.MappedFieldType;
 import org.jetbrains.annotations.Nullable;
 
 import io.crate.data.Input;
@@ -256,14 +254,7 @@ public class SubscriptFunction extends Scalar<Object, Object> {
             if (preFilterQueryBuilder == null) {
                 return null;
             }
-            MappedFieldType fieldType = context.getFieldTypeOrNull(ref.storageIdent());
             DataType<?> innerType = ArrayType.unnest(ref.valueType());
-            if (fieldType == null) {
-                if (innerType.id() == ObjectType.ID) {
-                    return null; // fallback to generic query to enable objects[1] = {x=10}
-                }
-                return newUnmappedFieldQuery(ref.storageIdent());
-            }
             StorageSupport<?> storageSupport = innerType.storageSupport();
             //noinspection unchecked
             EqQuery<Object> eqQuery = storageSupport == null ? null : (EqQuery<Object>) storageSupport.eqQuery();

--- a/server/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
+++ b/server/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
@@ -38,7 +38,6 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryCache;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
-import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.jetbrains.annotations.Nullable;
@@ -90,7 +89,6 @@ public class LuceneQueryBuilder {
 
     public Context convert(Symbol query,
                            TransactionContext txnCtx,
-                           MapperService mapperService,
                            String indexName,
                            QueryShardContext queryShardContext,
                            DocTableInfo table,
@@ -104,7 +102,6 @@ public class LuceneQueryBuilder {
             table,
             txnCtx,
             nodeCtx,
-            mapperService,
             queryCache,
             queryShardContext,
             indexName,
@@ -128,7 +125,6 @@ public class LuceneQueryBuilder {
 
         private final DocTableInfo table;
         final DocInputFactory docInputFactory;
-        final MapperService mapperService;
         final QueryCache queryCache;
         private final TransactionContext txnCtx;
         final QueryShardContext queryShardContext;
@@ -139,7 +135,6 @@ public class LuceneQueryBuilder {
         Context(DocTableInfo table,
                 TransactionContext txnCtx,
                 NodeContext nodeCtx,
-                MapperService mapperService,
                 QueryCache queryCache,
                 QueryShardContext queryShardContext,
                 String indexName,
@@ -155,7 +150,6 @@ public class LuceneQueryBuilder {
                     partitionColumns
                 )
             );
-            this.mapperService = mapperService;
             this.queryCache = queryCache;
         }
 
@@ -196,11 +190,6 @@ public class LuceneQueryBuilder {
             "_seq_no", VersioningValidationException.SEQ_NO_AND_PRIMARY_TERM_USAGE_MSG,
             "_primary_term", VersioningValidationException.SEQ_NO_AND_PRIMARY_TERM_USAGE_MSG
         );
-
-        @Nullable
-        public MappedFieldType getFieldTypeOrNull(String fqColumnName) {
-            return mapperService.fieldType(fqColumnName);
-        }
 
         public QueryShardContext queryShardContext() {
             return queryShardContext;

--- a/server/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
+++ b/server/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
@@ -38,7 +38,6 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryCache;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.jetbrains.annotations.Nullable;
 

--- a/server/src/test/java/io/crate/expression/predicate/IsNullPredicateTest.java
+++ b/server/src/test/java/io/crate/expression/predicate/IsNullPredicateTest.java
@@ -64,7 +64,6 @@ public class IsNullPredicateTest extends ScalarTestCase {
             Context context = luceneQueryBuilder.convert(
                 query,
                 txnCtx,
-                indexEnv.mapperService(),
                 indexEnv.indexService().index().getName(),
                 indexEnv.queryShardContext(),
                 table,
@@ -95,7 +94,6 @@ public class IsNullPredicateTest extends ScalarTestCase {
             Query query = luceneQueryBuilder.convert(
                 sqlExpressions.asSymbol("obj_ignored['x'] is NULL"),
                 txnCtx,
-                indexEnv.mapperService(),
                 indexEnv.indexService().index().getName(),
                 indexEnv.queryShardContext(),
                 table,

--- a/server/src/testFixtures/java/io/crate/testing/QueryTester.java
+++ b/server/src/testFixtures/java/io/crate/testing/QueryTester.java
@@ -203,7 +203,6 @@ public final class QueryTester implements AutoCloseable {
                 symbol -> queryBuilder.convert(
                     Optimizer.optimizeCasts(symbol,plannerContext),
                     systemTxnCtx,
-                    indexEnv.mapperService(),
                     indexEnv.indexService().index().getName(),
                     indexEnv.queryShardContext(),
                     table,


### PR DESCRIPTION
This method is a carry-over from elasticsearch, where you can search across multiple indexes with different mappings, and so needs the concept of an unmapped field to handle cases where a field may be present in one index but not another.  In crate, field references are resolved at the DocTableInfo level so this case does not occur, and we can remove the unmapped field handling logic.

This also allows us to remove the MapperService field on LuceneQueryBuilder.Context