### PR TITLE
Fix current_setting(<setting>, <boolean>) nullability

### DIFF
--- a/server/src/main/java/io/crate/expression/scalar/postgres/CurrentSettingFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/postgres/CurrentSettingFunction.java
@@ -62,7 +62,7 @@ public class CurrentSettingFunction extends Scalar<String, Object> {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.BOOLEAN.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ).withFeature(Feature.NULLABLE),
+            ),
             (signature, boundSignature) ->
                 new CurrentSettingFunction(
                     signature,

--- a/server/src/test/java/io/crate/lucene/ThreeValuedLogicQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/ThreeValuedLogicQueryBuilderTest.java
@@ -108,5 +108,9 @@ public class ThreeValuedLogicQueryBuilderTest extends LuceneQueryBuilderTest {
     public void test_not_on_current_setting() {
         assertThat(convert("NOT (CURRENT_SETTING(name))"))
             .hasToString("+(+*:* -pg_catalog.current_setting(name)) #(NOT pg_catalog.current_setting(name))");
+
+        // overload with 2 arguments
+        assertThat(convert("NOT (CURRENT_SETTING(name, true))"))
+            .hasToString("+(+*:* -pg_catalog.current_setting(name, true)) #(NOT pg_catalog.current_setting(name, true))");
     }
 }


### PR DESCRIPTION
`current_setting` one-arg was fixed with #16039, but there is also the overload version with two arguments, which also needs to not be explicitly delcared as `NULLABLE`.

Follows: #16039
Fixes: #16062
