### PR TITLE
Fix column pruning in collect operator

### DIFF
--- a/docs/appendices/release-notes/5.7.2.rst
+++ b/docs/appendices/release-notes/5.7.2.rst
@@ -52,6 +52,10 @@ Security Fixes
 Fixes
 =====
 
+- Fixed an issue leading to a ``UnsupportedFeatureException`` when using a
+  correlated sub-query in a case function as part of a select statement where
+  some of its outputs weren't used in the outer-query.
+
 - Fixed an issue leading to a ``ArrayIndexOutOfBoundsException``  instead of a
   user friendly error message when the ``WHERE``` clause of a query contains
   all columns of a :ref:`PRIMARY KEY <constraints-primary-key>`, uses

--- a/server/src/main/java/io/crate/planner/operators/Collect.java
+++ b/server/src/main/java/io/crate/planner/operators/Collect.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.SequencedCollection;
@@ -331,16 +332,14 @@ public class Collect implements LogicalPlan {
 
     @Override
     public LogicalPlan pruneOutputsExcept(SequencedCollection<Symbol> outputsToKeep) {
-        ArrayList<Symbol> newOutputs = new ArrayList<>();
-        for (Symbol output : outputs) {
-            if (outputsToKeep.contains(output)) {
-                newOutputs.add(output);
-            }
+        LinkedHashSet<Symbol> newOutputs = new LinkedHashSet<>();
+        for (Symbol outputToKeep : outputsToKeep) {
+            SymbolVisitors.intersection(outputToKeep, outputs, newOutputs::add);
         }
-        if (newOutputs.equals(outputs)) {
+        if (newOutputs.size() == outputs.size() && newOutputs.containsAll(outputs)) {
             return this;
         }
-        return new Collect(relation, newOutputs, immutableWhere);
+        return new Collect(relation, List.copyOf(newOutputs), immutableWhere);
     }
 
     @Nullable

--- a/server/src/test/java/io/crate/planner/operators/CollectTest.java
+++ b/server/src/test/java/io/crate/planner/operators/CollectTest.java
@@ -24,16 +24,21 @@ package io.crate.planner.operators;
 import static io.crate.testing.Asserts.assertThat;
 import static org.mockito.Mockito.mock;
 
+import java.util.List;
 import java.util.Set;
 
 import org.elasticsearch.common.settings.Settings;
 import org.junit.Test;
 
 import io.crate.analyze.QueriedSelectRelation;
+import io.crate.analyze.WhereClause;
+import io.crate.analyze.relations.DocTableRelation;
 import io.crate.data.Row;
 import io.crate.execution.dsl.phases.RoutedCollectPhase;
 import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
+import io.crate.expression.symbol.Symbol;
 import io.crate.fdw.ForeignDataWrappers;
+import io.crate.metadata.doc.DocTableInfo;
 import io.crate.planner.DependencyCarrier;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.PlannerContext;
@@ -69,4 +74,24 @@ public class CollectTest extends CrateDummyClusterServiceUnitTest {
         );
         assertThat((((RoutedCollectPhase) ((io.crate.planner.node.dql.Collect) build).collectPhase())).orderBy()).isNull();
     }
+
+    /*
+     * https://github.com/crate/crate/issues/16047
+     */
+    @Test
+    public void test_pruning_keeps_outputs_used_in_scalars() throws Exception {
+        SQLExecutor e = SQLExecutor.of(clusterService)
+            .addTable("create table tbl (a int, b int)");
+        DocTableInfo tbl = e.resolveTableInfo("tbl");
+        var tableRelation = new DocTableRelation(tbl);
+
+        Symbol a = e.asSymbol("a");
+        Symbol b = e.asSymbol("b");
+
+        Symbol caseFunction = e.asSymbol("case when a is not null then a else b end");
+        Collect collect = new Collect(tableRelation, List.of(a, b), WhereClause.MATCH_ALL);
+        LogicalPlan pruned = collect.pruneOutputsExcept(List.of(caseFunction));
+        assertThat(pruned.outputs()).containsExactly(a, b);
+    }
+
 }

--- a/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -577,22 +577,21 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
             UNION
             SELECT a::int ai, avg(x), i::long FROM t1 WHERE a='3' GROUP BY 1,3
             """);
-        assertThat(plan).isEqualTo(
-            """
-            GroupHashAggregate[ai, "avg(x)", "cast(i AS bigint)"]
-              └ Union[ai, "avg(x)", "cast(i AS bigint)"]
-                ├ GroupHashAggregate[ai, "avg(x)", "cast(i AS bigint)"]
-                │  └ Union[ai, "avg(x)", "cast(i AS bigint)"]
-                │    ├ Eval[cast(a AS integer) AS ai, avg(x), cast(i AS bigint)]
-                │    │  └ GroupHashAggregate[cast(a AS integer) AS ai, cast(i AS bigint) | avg(x)]
-                │    │    └ Collect[doc.t1 | [x, cast(a AS integer) AS ai, cast(i AS bigint)] | (a = '1')]
-                │    └ Eval[cast(a AS integer) AS ai, avg(x), cast(i AS bigint)]
-                │      └ GroupHashAggregate[cast(a AS integer) AS ai, cast(i AS bigint) | avg(x)]
-                │        └ Collect[doc.t1 | [x, cast(a AS integer) AS ai, cast(i AS bigint)] | (a = '2')]
-                └ Eval[cast(a AS integer) AS ai, avg(x), cast(i AS bigint)]
-                  └ GroupHashAggregate[cast(a AS integer) AS ai, cast(i AS bigint) | avg(x)]
-                    └ Collect[doc.t1 | [x, cast(a AS integer) AS ai, cast(i AS bigint)] | (a = '3')]
-            """);
+        assertThat(plan).hasOperators(
+            "GroupHashAggregate[ai, \"avg(x)\", \"cast(i AS bigint)\"]",
+            "  └ Union[ai, \"avg(x)\", \"cast(i AS bigint)\"]",
+            "    ├ GroupHashAggregate[ai, \"avg(x)\", \"cast(i AS bigint)\"]",
+            "    │  └ Union[ai, \"avg(x)\", \"cast(i AS bigint)\"]",
+            "    │    ├ Eval[cast(a AS integer) AS ai, avg(x), cast(i AS bigint)]",
+            "    │    │  └ GroupHashAggregate[cast(a AS integer) AS ai, cast(i AS bigint) | avg(x)]",
+            "    │    │    └ Collect[doc.t1 | [cast(a AS integer) AS ai, cast(i AS bigint), x] | (a = '1')]",
+            "    │    └ Eval[cast(a AS integer) AS ai, avg(x), cast(i AS bigint)]",
+            "    │      └ GroupHashAggregate[cast(a AS integer) AS ai, cast(i AS bigint) | avg(x)]",
+            "    │        └ Collect[doc.t1 | [cast(a AS integer) AS ai, cast(i AS bigint), x] | (a = '2')]",
+            "    └ Eval[cast(a AS integer) AS ai, avg(x), cast(i AS bigint)]",
+            "      └ GroupHashAggregate[cast(a AS integer) AS ai, cast(i AS bigint) | avg(x)]",
+            "        └ Collect[doc.t1 | [cast(a AS integer) AS ai, cast(i AS bigint), x] | (a = '3')]"
+        );
     }
 
     // tracks a bug: https://github.com/crate/crate/issues/14330
@@ -606,21 +605,21 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
             SELECT a::int ai, avg(x), i::long FROM t1 WHERE a='3' GROUP BY 1,3
             LIMIT 10
             """);
-        assertThat(plan).isEqualTo(
-            """
-                LimitDistinct[10::bigint;0 | [ai, "avg(x)", "cast(i AS bigint)"]]
-                  └ Union[ai, "avg(x)", "cast(i AS bigint)"]
-                    ├ GroupHashAggregate[ai, "avg(x)", "cast(i AS bigint)"]
-                    │  └ Union[ai, "avg(x)", "cast(i AS bigint)"]
-                    │    ├ Eval[cast(a AS integer) AS ai, avg(x), cast(i AS bigint)]
-                    │    │  └ GroupHashAggregate[cast(a AS integer) AS ai, cast(i AS bigint) | avg(x)]
-                    │    │    └ Collect[doc.t1 | [x, cast(a AS integer) AS ai, cast(i AS bigint)] | (a = '1')]
-                    │    └ Eval[cast(a AS integer) AS ai, avg(x), cast(i AS bigint)]
-                    │      └ GroupHashAggregate[cast(a AS integer) AS ai, cast(i AS bigint) | avg(x)]
-                    │        └ Collect[doc.t1 | [x, cast(a AS integer) AS ai, cast(i AS bigint)] | (a = '2')]
-                    └ Eval[cast(a AS integer) AS ai, avg(x), cast(i AS bigint)]
-                      └ GroupHashAggregate[cast(a AS integer) AS ai, cast(i AS bigint) | avg(x)]
-                        └ Collect[doc.t1 | [x, cast(a AS integer) AS ai, cast(i AS bigint)] | (a = '3')]""");
+        assertThat(plan).hasOperators(
+            "LimitDistinct[10::bigint;0 | [ai, \"avg(x)\", \"cast(i AS bigint)\"]]",
+            "  └ Union[ai, \"avg(x)\", \"cast(i AS bigint)\"]",
+            "    ├ GroupHashAggregate[ai, \"avg(x)\", \"cast(i AS bigint)\"]",
+            "    │  └ Union[ai, \"avg(x)\", \"cast(i AS bigint)\"]",
+            "    │    ├ Eval[cast(a AS integer) AS ai, avg(x), cast(i AS bigint)]",
+            "    │    │  └ GroupHashAggregate[cast(a AS integer) AS ai, cast(i AS bigint) | avg(x)]",
+            "    │    │    └ Collect[doc.t1 | [cast(a AS integer) AS ai, cast(i AS bigint), x] | (a = '1')]",
+            "    │    └ Eval[cast(a AS integer) AS ai, avg(x), cast(i AS bigint)]",
+            "    │      └ GroupHashAggregate[cast(a AS integer) AS ai, cast(i AS bigint) | avg(x)]",
+            "    │        └ Collect[doc.t1 | [cast(a AS integer) AS ai, cast(i AS bigint), x] | (a = '2')]",
+            "    └ Eval[cast(a AS integer) AS ai, avg(x), cast(i AS bigint)]",
+            "      └ GroupHashAggregate[cast(a AS integer) AS ai, cast(i AS bigint) | avg(x)]",
+            "        └ Collect[doc.t1 | [cast(a AS integer) AS ai, cast(i AS bigint), x] | (a = '3')]"
+        );
     }
 
     @Test
@@ -628,12 +627,12 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
         LogicalPlan plan = sqlExecutor.logicalPlan("""
             SELECT i, avgx FROM (SELECT a, avg(x) OVER(ORDER BY i) as avgx, i FROM t1) as vt
             """);
-        assertThat(plan).isEqualTo(
-            """
-                Rename[i, avgx] AS vt
-                  └ Eval[i, avg(x) OVER (ORDER BY i ASC) AS avgx]
-                    └ WindowAgg[x, i, avg(x) OVER (ORDER BY i ASC)]
-                      └ Collect[doc.t1 | [x, i] | true]""");
+        assertThat(plan).hasOperators(
+            "Rename[i, avgx] AS vt",
+            "  └ Eval[i, avg(x) OVER (ORDER BY i ASC) AS avgx]",
+            "    └ WindowAgg[i, x, avg(x) OVER (ORDER BY i ASC)]",
+            "      └ Collect[doc.t1 | [i, x] | true]"
+        );
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This fixes the column pruning on the collect operator when the outputs to keep consist of a scalar function.

Fixes https://github.com/crate/crate/issues/16047


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
