### PR TITLE
Remove quote/search analyzers

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/analysis/IndexAnalyzers.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/IndexAnalyzers.java
@@ -19,16 +19,17 @@
 
 package org.elasticsearch.index.analysis;
 
-import io.crate.common.io.IOUtils;
-import org.elasticsearch.index.AbstractIndexComponent;
-import org.elasticsearch.index.IndexSettings;
+import static java.util.Collections.unmodifiableMap;
 
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import static java.util.Collections.unmodifiableMap;
+import org.elasticsearch.index.AbstractIndexComponent;
+import org.elasticsearch.index.IndexSettings;
+
+import io.crate.common.io.IOUtils;
 
 /**
  * IndexAnalyzers contains a name to analyzer mapping for a specific index.
@@ -45,9 +46,13 @@ public final class IndexAnalyzers extends AbstractIndexComponent implements Clos
     private final Map<String, NamedAnalyzer> normalizers;
     private final Map<String, NamedAnalyzer> whitespaceNormalizers;
 
-    public IndexAnalyzers(IndexSettings indexSettings, NamedAnalyzer defaultIndexAnalyzer, NamedAnalyzer defaultSearchAnalyzer,
-                          NamedAnalyzer defaultSearchQuoteAnalyzer, Map<String, NamedAnalyzer> analyzers,
-                          Map<String, NamedAnalyzer> normalizers, Map<String, NamedAnalyzer> whitespaceNormalizers) {
+    public IndexAnalyzers(IndexSettings indexSettings,
+                          NamedAnalyzer defaultIndexAnalyzer,
+                          NamedAnalyzer defaultSearchAnalyzer,
+                          NamedAnalyzer defaultSearchQuoteAnalyzer,
+                          Map<String, NamedAnalyzer> analyzers,
+                          Map<String, NamedAnalyzer> normalizers,
+                          Map<String, NamedAnalyzer> whitespaceNormalizers) {
         super(indexSettings);
         this.defaultIndexAnalyzer = defaultIndexAnalyzer;
         this.defaultSearchAnalyzer = defaultSearchAnalyzer;

--- a/server/src/main/java/org/elasticsearch/index/mapper/ArrayFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ArrayFieldType.java
@@ -56,24 +56,4 @@ class ArrayFieldType extends MappedFieldType {
     public void setIndexAnalyzer(NamedAnalyzer analyzer) {
         innerFieldType.setIndexAnalyzer(analyzer);
     }
-
-    @Override
-    public NamedAnalyzer searchAnalyzer() {
-        return innerFieldType.searchAnalyzer();
-    }
-
-    @Override
-    public void setSearchAnalyzer(NamedAnalyzer analyzer) {
-        innerFieldType.setSearchAnalyzer(analyzer);
-    }
-
-    @Override
-    public NamedAnalyzer searchQuoteAnalyzer() {
-        return innerFieldType.searchQuoteAnalyzer();
-    }
-
-    @Override
-    public void setSearchQuoteAnalyzer(NamedAnalyzer analyzer) {
-        innerFieldType.setSearchQuoteAnalyzer(analyzer);
-    }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -303,17 +303,8 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
             }
         } else {
             boolean hasDefaultIndexAnalyzer = fieldType().indexAnalyzer().name().equals("default");
-            final String searchAnalyzerName = fieldType().searchAnalyzer().name();
-            boolean hasDifferentSearchAnalyzer = searchAnalyzerName.equals(fieldType().indexAnalyzer().name()) == false;
-            boolean hasDifferentSearchQuoteAnalyzer = searchAnalyzerName.equals(fieldType().searchQuoteAnalyzer().name()) == false;
-            if (includeDefaults || hasDefaultIndexAnalyzer == false || hasDifferentSearchAnalyzer || hasDifferentSearchQuoteAnalyzer) {
+            if (includeDefaults || hasDefaultIndexAnalyzer == false) {
                 builder.field("analyzer", fieldType().indexAnalyzer().name());
-                if (includeDefaults || hasDifferentSearchAnalyzer || hasDifferentSearchQuoteAnalyzer) {
-                    builder.field("search_analyzer", searchAnalyzerName);
-                    if (includeDefaults || hasDifferentSearchQuoteAnalyzer) {
-                        builder.field("search_quote_analyzer", fieldType().searchQuoteAnalyzer().name());
-                    }
-                }
             }
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/IdFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IdFieldMapper.java
@@ -71,7 +71,6 @@ public class IdFieldMapper extends MetadataFieldMapper {
         private IdFieldType() {
             super(NAME, true, false);
             setIndexAnalyzer(Lucene.KEYWORD_ANALYZER);
-            setSearchAnalyzer(Lucene.KEYWORD_ANALYZER);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -146,7 +146,6 @@ public final class KeywordFieldMapper extends FieldMapper {
                                 boolean hasNorms) {
             super(name, isSearchable, hasDocValues, hasNorms);
             setIndexAnalyzer(Lucene.KEYWORD_ANALYZER);
-            setSearchAnalyzer(Lucene.KEYWORD_ANALYZER);
         }
 
         public KeywordFieldType(String name, boolean isSearchable, boolean hasDocValues) {
@@ -213,7 +212,6 @@ public final class KeywordFieldMapper extends FieldMapper {
                 "mapper [" + name() + "] has different blank_padding settings, current ["
                 + this.blankPadding + "], merged [" + k.blankPadding + "]");
         }
-        this.fieldType().setSearchAnalyzer(k.fieldType().searchAnalyzer());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
@@ -33,8 +33,6 @@ public abstract class MappedFieldType {
     private final boolean isIndexed;
     private final boolean hasNorms;
     private NamedAnalyzer indexAnalyzer;
-    private NamedAnalyzer searchAnalyzer;
-    private NamedAnalyzer searchQuoteAnalyzer;
     protected boolean hasPositions;
 
     public MappedFieldType(String name, boolean isIndexed, boolean hasDocValues) {
@@ -73,22 +71,6 @@ public abstract class MappedFieldType {
 
     public void setIndexAnalyzer(NamedAnalyzer analyzer) {
         this.indexAnalyzer = analyzer;
-    }
-
-    public NamedAnalyzer searchAnalyzer() {
-        return searchAnalyzer;
-    }
-
-    public void setSearchAnalyzer(NamedAnalyzer analyzer) {
-        this.searchAnalyzer = analyzer;
-    }
-
-    public NamedAnalyzer searchQuoteAnalyzer() {
-        return searchQuoteAnalyzer == null ? searchAnalyzer : searchQuoteAnalyzer;
-    }
-
-    public void setSearchQuoteAnalyzer(NamedAnalyzer analyzer) {
-        this.searchQuoteAnalyzer = analyzer;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -85,8 +85,6 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
     private final DocumentMapperParser documentParser;
 
     private final MapperAnalyzerWrapper indexAnalyzer;
-    private final MapperAnalyzerWrapper searchAnalyzer;
-    private final MapperAnalyzerWrapper searchQuoteAnalyzer;
 
     final MapperRegistry mapperRegistry;
 
@@ -101,8 +99,6 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
             mapperRegistry
         );
         this.indexAnalyzer = new MapperAnalyzerWrapper(indexAnalyzers.getDefaultIndexAnalyzer(), MappedFieldType::indexAnalyzer);
-        this.searchAnalyzer = new MapperAnalyzerWrapper(indexAnalyzers.getDefaultSearchAnalyzer(), MappedFieldType::searchAnalyzer);
-        this.searchQuoteAnalyzer = new MapperAnalyzerWrapper(indexAnalyzers.getDefaultSearchQuoteAnalyzer(), MappedFieldType::searchQuoteAnalyzer);
         this.mapperRegistry = mapperRegistry;
     }
 
@@ -378,14 +374,6 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
 
     public Analyzer indexAnalyzer() {
         return this.indexAnalyzer;
-    }
-
-    public Analyzer searchAnalyzer() {
-        return this.searchAnalyzer;
-    }
-
-    public Analyzer searchQuoteAnalyzer() {
-        return this.searchQuoteAnalyzer;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -62,8 +62,6 @@ public class TextFieldMapper extends FieldMapper {
     public static class Builder extends FieldMapper.Builder {
 
         protected NamedAnalyzer indexAnalyzer;
-        protected NamedAnalyzer searchAnalyzer;
-        protected NamedAnalyzer searchQuoteAnalyzer;
         protected boolean omitNormsSet = false;
         private List<String> sources = new ArrayList<>();
 
@@ -80,14 +78,6 @@ public class TextFieldMapper extends FieldMapper {
 
         public void indexAnalyzer(NamedAnalyzer indexAnalyzer) {
             this.indexAnalyzer = indexAnalyzer;
-        }
-
-        public void searchAnalyzer(NamedAnalyzer searchAnalyzer) {
-            this.searchAnalyzer = searchAnalyzer;
-        }
-
-        public void searchQuoteAnalyzer(NamedAnalyzer searchQuoteAnalyzer) {
-            this.searchQuoteAnalyzer = searchQuoteAnalyzer;
         }
 
         public void omitNorms(boolean omitNorms) {
@@ -132,8 +122,6 @@ public class TextFieldMapper extends FieldMapper {
                 indexed,
                 fieldType.indexOptions().compareTo(IndexOptions.DOCS_AND_FREQS_AND_POSITIONS) >= 0);
             ft.setIndexAnalyzer(indexAnalyzer);
-            ft.setSearchAnalyzer(searchAnalyzer);
-            ft.setSearchQuoteAnalyzer(searchQuoteAnalyzer);
             return ft;
         }
 
@@ -163,8 +151,6 @@ public class TextFieldMapper extends FieldMapper {
         public Mapper.Builder parse(String fieldName, Map<String, Object> node, ParserContext parserContext) throws MapperParsingException {
             TextFieldMapper.Builder builder = new TextFieldMapper.Builder(fieldName);
             builder.indexAnalyzer(parserContext.getIndexAnalyzers().getDefaultIndexAnalyzer());
-            builder.searchAnalyzer(parserContext.getIndexAnalyzers().getDefaultSearchAnalyzer());
-            builder.searchQuoteAnalyzer(parserContext.getIndexAnalyzers().getDefaultSearchQuoteAnalyzer());
             parseTextField(builder, fieldName, node, parserContext);
             return builder;
         }

--- a/server/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryShardContext.java
@@ -19,7 +19,6 @@
 
 package org.elasticsearch.index.query;
 
-import org.apache.lucene.analysis.Analyzer;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 
@@ -36,28 +35,6 @@ public class QueryShardContext {
 
     public MappedFieldType fieldMapper(String name) {
         return mapperService.fieldType(name);
-    }
-
-    /**
-     * Gets the search analyzer for the given field, or the default if there is none present for the field
-     * TODO: remove this by moving defaults into mappers themselves
-     */
-    public Analyzer getSearchAnalyzer(MappedFieldType fieldType) {
-        if (fieldType.searchAnalyzer() != null) {
-            return fieldType.searchAnalyzer();
-        }
-        return getMapperService().searchAnalyzer();
-    }
-
-    /**
-     * Gets the search quote analyzer for the given field, or the default if there is none present for the field
-     * TODO: remove this by moving defaults into mappers themselves
-     */
-    public Analyzer getSearchQuoteAnalyzer(MappedFieldType fieldType) {
-        if (fieldType.searchQuoteAnalyzer() != null) {
-            return fieldType.searchQuoteAnalyzer();
-        }
-        return getMapperService().searchQuoteAnalyzer();
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/search/MatchQuery.java
+++ b/server/src/main/java/org/elasticsearch/index/search/MatchQuery.java
@@ -126,14 +126,6 @@ public class MatchQuery {
         return analyzer;
     }
 
-    protected Analyzer getAnalyzer(MappedFieldType fieldType, boolean quoted) {
-        if (analyzer == null) {
-            return quoted ? context.getSearchQuoteAnalyzer(fieldType) : context.getSearchAnalyzer(fieldType);
-        } else {
-            return analyzer;
-        }
-    }
-
     public Query parse(Type type, String fieldName, Object value) {
         MappedFieldType fieldType = context.fieldMapper(fieldName);
         if (fieldType == null) {
@@ -141,7 +133,7 @@ public class MatchQuery {
         }
         final String field = fieldType.name();
 
-        Analyzer analyzer = getAnalyzer(fieldType, type == Type.PHRASE);
+        Analyzer analyzer = fieldType.indexAnalyzer();
         assert analyzer != null;
 
         /*

--- a/server/src/main/java/org/elasticsearch/index/search/MultiMatchQuery.java
+++ b/server/src/main/java/org/elasticsearch/index/search/MultiMatchQuery.java
@@ -151,7 +151,7 @@ public class MultiMatchQuery extends MatchQuery {
                 String name = entry.getKey();
                 MappedFieldType fieldType = context.fieldMapper(name);
                 if (fieldType != null) {
-                    Analyzer actualAnalyzer = getAnalyzer(fieldType, type == MultiMatchQueryType.PHRASE);
+                    Analyzer actualAnalyzer = fieldType.indexAnalyzer();
                     name = fieldType.name();
                     if (!groups.containsKey(actualAnalyzer)) {
                         groups.put(actualAnalyzer, new ArrayList<>());


### PR DESCRIPTION
CrateDB only allows to set index analyzers.

This is an intermediate step to remove the
MapperService/QueryShardContext from the match queries and
LuceneQueryBuilder
