### PR TITLE
Correctly parse geopoints within nested arrays

### DIFF
--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/SourceParser.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/SourceParser.java
@@ -183,7 +183,7 @@ public final class SourceParser {
             //   "s" string
             //   )))));
             //   SELECT a['b'] from test; -- resolves to array(array(object))
-            while (type instanceof ArrayType) {
+            if (type instanceof ArrayType) {
                 type = ((ArrayType<?>) type).innerType();
             }
             for (; token != null && token != XContentParser.Token.END_ARRAY; token = parser.nextToken()) {

--- a/server/src/testFixtures/java/io/crate/types/DataTypeTestCase.java
+++ b/server/src/testFixtures/java/io/crate/types/DataTypeTestCase.java
@@ -24,7 +24,6 @@ package io.crate.types;
 import static io.crate.execution.dml.IndexerTest.getIndexer;
 import static io.crate.execution.dml.IndexerTest.item;
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.List;


### PR DESCRIPTION
SourceParser will recursively unwrap array data types if it encounters a nested
array, but this can lead to errors if the leaf data type takes an array as input, 
for example geo_point or float_vector, as the leaf data type will not be able to handle
nested array input.  Instead we need to unwrap one level at a time, and let
`parseObject` correctly identify further nested arrays.