### PR TITLE
Add `pg_table_is_visible` scalar

### DIFF
--- a/docs/appendices/release-notes/5.8.0.rst
+++ b/docs/appendices/release-notes/5.8.0.rst
@@ -113,6 +113,8 @@ Scalar and Aggregation Functions
 
 - Added a :ref:`has_table_privilege <scalar-has-table-priv>` scalar.
 
+- Added a :ref:`pg_table_is_visible <scalar-pg_table_is_visible>` scalar.
+
 Performance and Resilience Improvements
 ---------------------------------------
 

--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -4297,6 +4297,32 @@ Example:
     SELECT 1 row in set (... sec)
 
 
+.. _scalar-pg_table_is_visible:
+
+``pg_table_is_visible()``
+-------------------------
+
+The function ``pg_table_is_visible`` accepts an OID as an argument. It returns
+``true`` if the current user holds at least one of ``DQL``, ``DDL`` or ``DML``
+privilege on the table or view referred by the OID and there are no other
+tables or views with the same name and privileges but with different schema
+names appearing earlier in the search path.
+
+Returns: ``boolean``
+
+Example:
+
+::
+
+    cr> select pg_table_is_visible(912037690) as is_visible;
+    +------------+
+    | is_visible |
+    +------------+
+    | TRUE       |
+    +------------+
+    SELECT 1 row in set (... sec)
+
+
 .. _scalar-pg_get_function_result:
 
 ``pg_get_function_result()``

--- a/server/src/main/java/io/crate/expression/scalar/ScalarFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/ScalarFunctions.java
@@ -65,6 +65,7 @@ import io.crate.expression.scalar.postgres.PgBackendPidFunction;
 import io.crate.expression.scalar.postgres.PgEncodingToCharFunction;
 import io.crate.expression.scalar.postgres.PgGetUserByIdFunction;
 import io.crate.expression.scalar.postgres.PgPostmasterStartTime;
+import io.crate.expression.scalar.postgres.PgTableIsVisibleFunction;
 import io.crate.expression.scalar.regex.RegexpReplaceFunction;
 import io.crate.expression.scalar.string.AsciiFunction;
 import io.crate.expression.scalar.string.ChrFunction;
@@ -236,6 +237,7 @@ public class ScalarFunctions implements FunctionsProvider {
         ObjDescriptionFunction.register(builder);
         FormatTypeFunction.register(builder);
         PgFunctionIsVisibleFunction.register(builder);
+        PgTableIsVisibleFunction.register(builder);
         PgGetFunctionResultFunction.register(builder);
         PgPostmasterStartTime.register(builder);
         PgGetSerialSequenceFunction.register(builder);

--- a/server/src/main/java/io/crate/expression/scalar/postgres/PgTableIsVisibleFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/postgres/PgTableIsVisibleFunction.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar.postgres;
+
+import static io.crate.role.Permission.READ_WRITE_DEFINE;
+
+import io.crate.data.Input;
+import io.crate.exceptions.RelationUnknown;
+import io.crate.expression.scalar.HasTablePrivilegeFunction;
+import io.crate.metadata.FunctionName;
+import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.Schemas;
+import io.crate.metadata.SearchPath;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.BoundSignature;
+import io.crate.metadata.functions.Signature;
+import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
+import io.crate.metadata.settings.SessionSettings;
+import io.crate.metadata.table.Operation;
+import io.crate.role.Role;
+import io.crate.role.Roles;
+import io.crate.sql.tree.QualifiedName;
+import io.crate.types.DataTypes;
+
+public class PgTableIsVisibleFunction extends Scalar<Boolean, Integer> {
+
+    private static final FunctionName NAME = new FunctionName(PgCatalogSchemaInfo.NAME, "pg_table_is_visible");
+
+    public static void register(Functions.Builder module) {
+        module.add(
+            Signature.scalar(
+                NAME,
+                DataTypes.INTEGER.getTypeSignature(),
+                DataTypes.BOOLEAN.getTypeSignature()
+            ).withFeature(Feature.NULLABLE),
+            PgTableIsVisibleFunction::new);
+    }
+
+    protected PgTableIsVisibleFunction(Signature signature, BoundSignature boundSignature) {
+        super(signature, boundSignature);
+    }
+
+    @SafeVarargs
+    @Override
+    public final Boolean evaluate(TransactionContext txnCtx, NodeContext nodeContext, Input<Integer>... args) {
+        assert args.length == 1 : NAME + " expects exactly 1 argument, got " + args.length;
+        Integer tableOid = args[0].value();
+        if (tableOid == null) {
+            return null;
+        }
+
+        Schemas schemas = nodeContext.schemas();
+        RelationName relationName = schemas.getRelation(tableOid);
+        if (relationName == null) {
+            return false;
+        }
+
+        SessionSettings sessionSettings = txnCtx.sessionSettings();
+        Roles roles = nodeContext.roles();
+        Role user = roles.findUser(sessionSettings.userName());
+        for (String searchPathIdx : sessionSettings.searchPath()) {
+            try {
+                schemas.findRelation(
+                    QualifiedName.of(searchPathIdx, relationName.name()),
+                    Operation.READ,
+                    user,
+                    SearchPath.createSearchPathFrom(searchPathIdx));
+            } catch (RelationUnknown e) {
+                continue;
+            }
+            boolean foundMatchingSchemaName = searchPathIdx.equals(relationName.schema());
+            if (HasTablePrivilegeFunction.checkByTableName(
+                roles,
+                user,
+                new RelationName(searchPathIdx, relationName.name()).fqn(),
+                READ_WRITE_DEFINE,
+                schemas)) {
+                // return true if the found relation is from the correct schema or return false.
+                return foundMatchingSchemaName;
+            }
+            // do not iterate further if the matching schema is found from searchPaths
+            if (foundMatchingSchemaName) {
+                break;
+            }
+        }
+        return false;
+    }
+}

--- a/server/src/test/java/io/crate/expression/scalar/postgres/PgTableIsVisibleFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/postgres/PgTableIsVisibleFunctionTest.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar.postgres;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Test;
+
+import io.crate.expression.scalar.ScalarTestCase;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.Schemas;
+import io.crate.metadata.pgcatalog.OidHash;
+import io.crate.role.Permission;
+import io.crate.role.Policy;
+import io.crate.role.Privilege;
+import io.crate.role.Role;
+import io.crate.role.Securable;
+import io.crate.role.metadata.RolesHelper;
+import io.crate.testing.SQLExecutor;
+import io.crate.testing.SqlExpressions;
+
+public class PgTableIsVisibleFunctionTest extends ScalarTestCase {
+
+    @Test
+    public void test_returns_null_for_null_input() {
+        assertEvaluateNull("pg_catalog.pg_table_is_visible(null)");
+    }
+
+    @Test
+    public void test_return_false_for_unknown_table() {
+        Schemas schemas = mock(Schemas.class);
+        when(schemas.getRelation(anyInt())).thenReturn(null);
+        sqlExpressions = new SqlExpressions(tableSources, null, Role.CRATE_USER, List.of(), schemas);
+
+        assertEvaluate("pg_table_is_visible(-1)", false);
+    }
+
+    @Test
+    public void test_table_is_not_visible_without_one_of_DQL_DML_DDL() throws IOException {
+        String[] searchPaths = new String[]{"my_schema"};
+        Schemas schemas = SQLExecutor.of(clusterService)
+            .addTable("create table my_schema.my_table(id int)")
+            .schemas();
+        sqlExpressions = new SqlExpressions(tableSources, null, RolesHelper.userOf("dummy_user"), List.of(), schemas, searchPaths);
+
+        final RelationName usersTable = new RelationName("my_schema", "my_table");
+        final int usersTableOid = OidHash.relationOid(OidHash.Type.TABLE, usersTable);
+
+        assertEvaluate("pg_table_is_visible(" + usersTableOid + ")", false);
+    }
+
+    @Test
+    public void test_table_is_visible_with_DQL_or_DML_or_DDL_on_table() throws IOException {
+        String[] searchPaths = new String[]{"my_schema"};
+        Schemas schemas = SQLExecutor.of(clusterService)
+            .addTable("create table my_schema.my_table(id int)")
+            .schemas();
+
+        // DQL
+        sqlExpressions = new SqlExpressions(tableSources,
+            null,
+            RolesHelper.userOf(
+                "dummy_user",
+                Set.of(new Privilege(Policy.GRANT, Permission.DQL, Securable.TABLE, "my_schema.my_table", "crate")),
+                null
+                ),
+            List.of(),
+            schemas,
+            searchPaths);
+        final RelationName usersTable = new RelationName("my_schema", "my_table");
+        final int usersTableOid = OidHash.relationOid(OidHash.Type.TABLE, usersTable);
+        assertEvaluate("pg_table_is_visible(" + usersTableOid + ")", true);
+
+        // DML
+        sqlExpressions = new SqlExpressions(tableSources,
+            null,
+            RolesHelper.userOf(
+                "dummy_user",
+                Set.of(new Privilege(Policy.GRANT, Permission.DML, Securable.TABLE, "my_schema.my_table", "crate")),
+                null
+            ),
+            List.of(),
+            schemas,
+            searchPaths);
+        assertEvaluate("pg_table_is_visible(" + usersTableOid + ")", true);
+
+        // DDL
+        sqlExpressions = new SqlExpressions(tableSources,
+            null,
+            RolesHelper.userOf(
+                "dummy_user",
+                Set.of(new Privilege(Policy.GRANT, Permission.DDL, Securable.TABLE, "my_schema.my_table", "crate")),
+                null
+            ),
+            List.of(),
+            schemas,
+            searchPaths);
+        assertEvaluate("pg_table_is_visible(" + usersTableOid + ")", true);
+    }
+
+    @Test
+    public void test_table_is_not_visible_if_same_name_table_earlier_in_search_path_is_visible() throws IOException {
+        String[] searchPaths = new String[]{"my_schema1", "my_schema2"};
+        Schemas schemas = SQLExecutor.of(clusterService)
+            .addTable("create table my_schema1.my_table(id int)")
+            .addTable("create table my_schema2.my_table(id int)")
+            .schemas();
+        sqlExpressions = new SqlExpressions(tableSources,
+            null,
+            RolesHelper.userOf(
+                "dummy_user",
+                Set.of(
+                    new Privilege(Policy.GRANT, Permission.DQL, Securable.TABLE, "my_schema1.my_table", "crate"),
+                    new Privilege(Policy.GRANT, Permission.DQL, Securable.TABLE, "my_schema2.my_table", "crate")
+                ),
+                null
+            ),
+            List.of(),
+            schemas,
+            searchPaths);
+
+        // my_schema1.my_table is visible
+        final RelationName mySchema1MyTable = new RelationName("my_schema1", "my_table");
+        final int mySchema1MyTableOid = OidHash.relationOid(OidHash.Type.TABLE, mySchema1MyTable);
+        assertEvaluate("pg_table_is_visible(" + mySchema1MyTableOid + ")", true);
+
+        // since my_schema1.my_table is visible(my_schema1 appears earlier in searchPaths),
+        // my_schema2.my_table is not visible
+        final RelationName mySchema2MyTable = new RelationName("my_schema2", "my_table");
+        final int mySchema2MyTableOid = OidHash.relationOid(OidHash.Type.TABLE, mySchema2MyTable);
+        assertEvaluate("pg_table_is_visible(" + mySchema2MyTableOid + ")", false);
+    }
+
+    @Test
+    public void test_table_is_visible_if_same_name_table_earlier_in_search_path_is_not_visible() throws IOException {
+        String[] searchPaths = new String[]{"my_schema1", "my_schema2"};
+        Schemas schemas = SQLExecutor.of(clusterService)
+            .addTable("create table my_schema1.my_table(id int)")
+            .addTable("create table my_schema2.my_table(id int)")
+            .schemas();
+        sqlExpressions = new SqlExpressions(tableSources,
+            null,
+            RolesHelper.userOf(
+                "dummy_user",
+                Set.of(
+                    new Privilege(Policy.GRANT, Permission.DQL, Securable.TABLE, "my_schema2.my_table", "crate")
+                ),
+                null
+            ),
+            List.of(),
+            schemas,
+            searchPaths);
+
+        // my_schema1.my_table is NOT visible, user is missing privileges
+        final RelationName mySchema1MyTable = new RelationName("my_schema1", "my_table");
+        final int mySchema1MyTableOid = OidHash.relationOid(OidHash.Type.TABLE, mySchema1MyTable);
+        assertEvaluate("pg_table_is_visible(" + mySchema1MyTableOid + ")", false);
+
+        // since my_schema1.my_table is NOT visible, my_schema2.my_table is visible
+        final RelationName mySchema2MyTable = new RelationName("my_schema2", "my_table");
+        final int mySchema2MyTableOid = OidHash.relationOid(OidHash.Type.TABLE, mySchema2MyTable);
+        assertEvaluate("pg_table_is_visible(" + mySchema2MyTableOid + ")", true);
+    }
+}

--- a/server/src/testFixtures/java/io/crate/testing/SqlExpressions.java
+++ b/server/src/testFixtures/java/io/crate/testing/SqlExpressions.java
@@ -79,11 +79,12 @@ public class SqlExpressions {
                           @Nullable FieldResolver fieldResolver,
                           Role sessionUser,
                           List<Role> additionalUsers,
-                          Schemas schemas) {
+                          Schemas schemas,
+                          String... searchPaths) {
         this.nodeCtx = createNodeContext(schemas, Lists.concat(additionalUsers, sessionUser));
         // In test_throws_error_when_user_is_not_found we explicitly inject null user but SessionContext user cannot be not null.
         Role role = sessionUser == null ? Role.CRATE_USER : sessionUser;
-        var sessionSettings = new CoordinatorSessionSettings(role, role, LoadedRules.INSTANCE.disabledRules());
+        var sessionSettings = new CoordinatorSessionSettings(role, role, LoadedRules.INSTANCE.disabledRules(), searchPaths);
         coordinatorTxnCtx = new CoordinatorTxnCtx(sessionSettings);
         expressionAnalyzer = new ExpressionAnalyzer(
             coordinatorTxnCtx,


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Resolves https://github.com/crate/crate/issues/7988

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
