### PR TITLE
Remove IndexShard property from SharedShardContext

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
@@ -119,10 +119,9 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
         SharedShardContext sharedShardContext = collectTask.sharedShardContexts().getOrCreateContext(shardId);
         var searcher = sharedShardContext.acquireSearcher("unordered-iterator: " + formatSource(collectPhase));
         collectTask.addSearcher(sharedShardContext.readerId(), searcher);
-        IndexShard sharedShardContextShard = sharedShardContext.indexShard();
         // A closed shard has no mapper service and cannot be queried with lucene,
         // therefore skip it
-        boolean isClosed = sharedShardContextShard.mapperService() == null;
+        boolean isClosed = indexShard.mapperService() == null;
         if (isClosed) {
             return InMemoryBatchIterator.empty(SentinelRow.SENTINEL);
         }
@@ -131,7 +130,7 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
         LuceneQueryBuilder.Context queryContext = luceneQueryBuilder.convert(
             collectPhase.where(),
             collectTask.txnCtx(),
-            sharedShardContextShard.shardId().getIndexName(),
+            indexShard.shardId().getIndexName(),
             indexService.indexAnalyzers(),
             table,
             indexService.cache()
@@ -217,8 +216,8 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
         int batchSize = collectPhase.shardQueueSize(localNodeId.get());
         if (LOGGER.isTraceEnabled()) {
             LOGGER.trace("[{}][{}] creating LuceneOrderedDocCollector. Expected number of rows to be collected: {}",
-                sharedShardContext.indexShard().routingEntry().currentNodeId(),
-                sharedShardContext.indexShard().shardId(),
+                indexShard.routingEntry().currentNodeId(),
+                indexShard.shardId(),
                 batchSize);
         }
         var optimizeQueryForSearchAfter = new OptimizeQueryForSearchAfter(collectPhase.orderBy());

--- a/server/src/main/java/io/crate/execution/jobs/SharedShardContext.java
+++ b/server/src/main/java/io/crate/execution/jobs/SharedShardContext.java
@@ -23,8 +23,6 @@ package io.crate.execution.jobs;
 
 import java.util.function.UnaryOperator;
 
-import io.crate.common.annotations.NotThreadSafe;
-
 import org.apache.lucene.search.IndexSearcher;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.IndexService;
@@ -32,6 +30,7 @@ import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
 
+import io.crate.common.annotations.NotThreadSafe;
 import io.crate.common.collections.RefCountedItem;
 
 
@@ -40,7 +39,6 @@ public class SharedShardContext {
 
     private final IndexService indexService;
     private final int readerId;
-    private final IndexShard indexShard;
     private final RefCountedItem<Engine.Searcher> searcher;
 
     SharedShardContext(IndexService indexService,
@@ -48,7 +46,7 @@ public class SharedShardContext {
                        int readerId,
                        UnaryOperator<Engine.Searcher> wrapSearcher) {
         this.indexService = indexService;
-        this.indexShard = indexService.getShard(shardId.id());
+        IndexShard indexShard = indexService.getShard(shardId.id());
         this.readerId = readerId;
         this.searcher = new RefCountedItem<Engine.Searcher>(
             source -> wrapSearcher.apply(indexShard.acquireSearcher(source)),
@@ -59,10 +57,6 @@ public class SharedShardContext {
     public RefCountedItem<? extends IndexSearcher> acquireSearcher(String source) throws IndexNotFoundException {
         searcher.markAcquired(source);
         return searcher;
-    }
-
-    public IndexShard indexShard() {
-        return indexShard;
     }
 
     public IndexService indexService() {


### PR DESCRIPTION
The property was only used in LuceneShardCollectorProvider which already
has a reference to the IndexShard
