### PR TITLE
Give IndexShard access to DocTableInfo supplier

### DIFF
--- a/server/src/main/java/io/crate/metadata/Schemas.java
+++ b/server/src/main/java/io/crate/metadata/Schemas.java
@@ -53,7 +53,6 @@ import io.crate.common.collections.Sets;
 import io.crate.exceptions.OperationOnInaccessibleRelationException;
 import io.crate.exceptions.RelationUnknown;
 import io.crate.exceptions.SchemaUnknownException;
-import io.crate.execution.dml.TranslogIndexer;
 import io.crate.expression.udf.UserDefinedFunctionMetadata;
 import io.crate.expression.udf.UserDefinedFunctionsMetadata;
 import io.crate.fdw.ForeignTable;
@@ -324,11 +323,6 @@ public class Schemas extends AbstractLifecycleComponent implements Iterable<Sche
                 info.ident(),
                 "The relation " + info.ident().sqlFqn() + " doesn't support the operation");
         }
-    }
-
-    public TranslogIndexer getTranslogIndexer(RelationName ident) {
-        DocTableInfo ti = getTableInfo(ident);
-        return ti.getTranslogIndexer();
     }
 
     private SchemaInfo getSchemaInfo(RelationName ident) {

--- a/server/src/main/java/org/elasticsearch/index/IndexModule.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexModule.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import org.apache.lucene.search.QueryCache;
 import org.apache.lucene.store.MMapDirectory;
@@ -53,8 +54,7 @@ import org.elasticsearch.indices.mapper.MapperRegistry;
 import org.elasticsearch.plugins.IndexStorePlugin;
 import org.elasticsearch.threadpool.ThreadPool;
 
-import io.crate.execution.dml.TranslogIndexer;
-import io.crate.metadata.RelationName;
+import io.crate.metadata.doc.DocTableInfo;
 import io.crate.types.DataTypes;
 
 /**
@@ -276,7 +276,7 @@ public final class IndexModule {
             BigArrays bigArrays,
             ThreadPool threadPool,
             QueryCache indicesQueryCache,
-            Function<RelationName, TranslogIndexer> translogIndexer,
+            Supplier<DocTableInfo> getDocTable,
             MapperRegistry mapperRegistry) throws IOException {
 
         final IndexEventListener eventListener = freeze();
@@ -302,7 +302,7 @@ public final class IndexModule {
             directoryFactory,
             eventListener,
             mapperRegistry,
-            translogIndexer,
+            getDocTable,
             indexOperationListeners
         );
     }

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -116,6 +116,7 @@ import io.crate.common.collections.Iterables;
 import io.crate.common.collections.Sets;
 import io.crate.common.io.IOUtils;
 import io.crate.common.unit.TimeValue;
+import io.crate.metadata.RelationName;
 import io.crate.metadata.Schemas;
 
 public class IndicesService extends AbstractLifecycleComponent
@@ -449,6 +450,7 @@ public class IndicesService extends AbstractLifecycleComponent
         for (IndexEventListener listener : builtInListeners) {
             indexModule.addIndexEventListener(listener);
         }
+        String indexName = indexMetadata.getIndex().getName();
         return indexModule.newIndexService(
             indexCreationContext,
             nodeEnv,
@@ -457,7 +459,7 @@ public class IndicesService extends AbstractLifecycleComponent
             bigArrays,
             threadPool,
             indicesQueryCache,
-            n -> schemas.getTranslogIndexer(n),
+            () -> schemas.getTableInfo(RelationName.fromIndexName(indexName)),
             mapperRegistry
         );
     }

--- a/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
+++ b/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
@@ -524,7 +524,7 @@ public abstract class AggregationTestCase extends ESTestCase {
                 store,
                 queryCache,
                 mapperService,
-                _ -> null,
+                () -> null,
                 List.of(),
                 EMPTY_EVENT_LISTENER,
                 threadPool,

--- a/server/src/testFixtures/java/io/crate/testing/IndexEnv.java
+++ b/server/src/testFixtures/java/io/crate/testing/IndexEnv.java
@@ -112,7 +112,7 @@ public final class IndexEnv implements AutoCloseable {
             BigArrays.NON_RECYCLING_INSTANCE,
             threadPool,
             IndicesQueryCache.createCache(Settings.EMPTY),
-            _ -> null,
+            () -> table,
             mapperRegistry
         );
         IndexWriterConfig conf = new IndexWriterConfig(new StandardAnalyzer());


### PR DESCRIPTION
Replaces the function to access a TranslogIndexer.
This is in preparation for moving away from the MapperService and
relates to https://github.com/crate/crate/issues/11939
