### PR TITLE
Fix issue with slow query because of PK extraction

### DIFF
--- a/docs/appendices/release-notes/5.7.2.rst
+++ b/docs/appendices/release-notes/5.7.2.rst
@@ -52,6 +52,15 @@ Security Fixes
 Fixes
 =====
 
+- Fixed an issue leading to slow query processing during the analysis phase,
+  when the ``WHERE``` clause of a query contains columns of a
+  :ref:`PRIMARY KEY <constraints-primary-key>` and combines them using complex
+  logical expressions, e.g.::
+
+      SELECT * FROM t WHERE pk_col1 = ? AND pk_col2 = ? OR
+                            pk_col1 = ? AND pk_col2 = ? OR
+                            ...
+
 - Fixed an issue leading to a ``UnsupportedFeatureException`` when using a
   correlated sub-query in a case function as part of a select statement where
   some of its outputs weren't used in the outer-query.

--- a/server/src/test/java/io/crate/analyze/where/EqualityExtractorBaseTest.java
+++ b/server/src/test/java/io/crate/analyze/where/EqualityExtractorBaseTest.java
@@ -45,8 +45,9 @@ import io.crate.testing.T3;
  */
 public abstract class EqualityExtractorBaseTest extends CrateDummyClusterServiceUnitTest {
 
-    private final CoordinatorTxnCtx coordinatorTxnCtx = new CoordinatorTxnCtx(CoordinatorSessionSettings.systemDefaults());
+    protected final CoordinatorTxnCtx coordinatorTxnCtx = new CoordinatorTxnCtx(CoordinatorSessionSettings.systemDefaults());
     private SqlExpressions expressions;
+    protected EvaluatingNormalizer normalizer;
     private EqualityExtractor ee;
 
     @Before
@@ -55,7 +56,7 @@ public abstract class EqualityExtractorBaseTest extends CrateDummyClusterService
 
         DocTableRelation tr1 = (DocTableRelation) sources.get(T3.T1);
         expressions = new SqlExpressions(sources, tr1);
-        EvaluatingNormalizer normalizer = EvaluatingNormalizer.functionOnlyNormalizer(expressions.nodeCtx);
+        normalizer = EvaluatingNormalizer.functionOnlyNormalizer(expressions.nodeCtx);
         ee = new EqualityExtractor(normalizer);
     }
 


### PR DESCRIPTION
When a query in the `WHERE` clause uses PK columns and combines them into complex expressions using logical operators, `EqualityExtractor`, which calculates a cartesian product over those sub-expressions, can end up using lots of time because of the large number of iterations over this product.

Add an iteration counter and a limit of 10k iterations to break early and avoid spending too much time during this pk extraction phase. If after those 10k iterations not all PKs are detected, then a `Collect` plan will be used instead of a `Get`.

Relates: #16066
