### PR TITLE
Take into account connection payload on HBA method matching

### DIFF
--- a/docs/admin/auth/hba.rst
+++ b/docs/admin/auth/hba.rst
@@ -108,10 +108,11 @@ For example, a host based configuration can look like this:
 
    In the ``auth.host_based.config`` setting, the order of the entries is
    defined by the natural order of the group keys of the setting. The
-   authentication method of the first entry that matches the client user and
-   address will be used. If the authentication attempt fails, subsequent
-   entries will not be considered. The entry look-up order is determined by the
-   ``order`` identifier of each entry.
+   authentication method of the first entry that matches the client user,
+   address, protocol and connection properties will be used. If the
+   authentication attempt fails, subsequent entries will not be considered.
+   The entry look-up order is determined by the  ``order`` identifier of each
+   entry.
 
 In the example above:
 

--- a/docs/appendices/release-notes/5.7.2.rst
+++ b/docs/appendices/release-notes/5.7.2.rst
@@ -104,3 +104,14 @@ Fixes
 
 - Fixed an issue that allowed dropped users to run queries if active user was
   set by ``SET SESSION AUTHORIZATION`` and then dropped.
+
+- Fixed an issue leading to authentication errors when
+  :ref:`Host-Based Authentication <admin_hba>` was enabled and had entries
+  matching multiple authentication methods simultaneously, e.g.::
+
+    auth.host_based.config.1.method=password
+    auth.host_based.config.2.method=jwt
+    auth.host_based.config.2.protocol=http
+
+  This example configuration were rejecting authentication via JWT as only
+  the first entry was checked.

--- a/server/src/main/java/io/crate/auth/ClientCertAuth.java
+++ b/server/src/main/java/io/crate/auth/ClientCertAuth.java
@@ -24,6 +24,8 @@ package io.crate.auth;
 import java.security.cert.Certificate;
 import java.util.Objects;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 
 import io.crate.protocols.SSL;
@@ -32,6 +34,8 @@ import io.crate.role.Role;
 import io.crate.role.Roles;
 
 public class ClientCertAuth implements AuthenticationMethod {
+
+    private static final Logger LOGGER = LogManager.getLogger(ConnectionProperties.class);
 
     static final String NAME = "cert";
     private final Roles roles;
@@ -58,6 +62,7 @@ public class ClientCertAuth implements AuthenticationMethod {
                     "Common name \"" + commonName + "\" in client certificate doesn't match username \"" + username + "\"");
             }
         }
+        LOGGER.debug("Client certificate not available");
         throw new RuntimeException("Client certificate authentication failed for user \"" + username + "\"");
     }
 

--- a/server/src/main/java/io/crate/auth/HostBasedAuthentication.java
+++ b/server/src/main/java/io/crate/auth/HostBasedAuthentication.java
@@ -36,6 +36,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
@@ -172,6 +173,7 @@ public class HostBasedAuthentication implements Authentication {
             .filter(e -> Matchers.isValidAddress(e.getValue().get(KEY_ADDRESS), connectionProperties.address(), dnsResolver))
             .filter(e -> Matchers.isValidProtocol(e.getValue().get(KEY_PROTOCOL), connectionProperties.protocol()))
             .filter(e -> Matchers.isValidConnection(e.getValue().get(SSL.KEY), connectionProperties))
+            .filter(e -> Matchers.isValidMethod(e.getValue().get(KEY_METHOD), connectionProperties.clientMethods()))
             .findFirst();
     }
 
@@ -240,6 +242,22 @@ public class HostBasedAuthentication implements Authentication {
                 case NEVER -> !connectionProperties.hasSSL();
                 case REQUIRED -> connectionProperties.hasSSL();
             };
+        }
+
+        /**
+         * Last Matcher in the chain.
+         * @param method can be null and in this case we return true so that we can fall back to trust later.
+         */
+        static boolean isValidMethod(@Nullable String method, List<ConnectionProperties.ClientMethod> clientMethods) {
+            if (method == null) {
+                return true;
+            }
+            for (ConnectionProperties.ClientMethod clientMethod: clientMethods) {
+                if (clientMethod.toString().equalsIgnoreCase(method)) {
+                    return true;
+                }
+            }
+            return false;
         }
 
         static long inetAddressToInt(InetAddress address) {

--- a/server/src/main/java/io/crate/auth/HttpAuthUpstreamHandler.java
+++ b/server/src/main/java/io/crate/auth/HttpAuthUpstreamHandler.java
@@ -116,7 +116,8 @@ public class HttpAuthUpstreamHandler extends SimpleChannelInboundHandler<Object>
         }
 
         InetAddress address = addressFromRequestOrChannel(request, ctx.channel());
-        ConnectionProperties connectionProperties = new ConnectionProperties(address, Protocol.HTTP, session);
+        ConnectionProperties connectionProperties = new ConnectionProperties(credentials, address, Protocol.HTTP, session);
+
         AuthenticationMethod authMethod = authService.resolveAuthenticationType(username, connectionProperties);
         if (authMethod == null) {
             String errorMessage = String.format(

--- a/server/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
+++ b/server/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
@@ -413,7 +413,8 @@ public class PostgresWireProtocol {
         InetAddress address = Netty4HttpServerTransport.getRemoteAddress(channel);
 
         SSLSession sslSession = getSession(channel);
-        ConnectionProperties connProperties = new ConnectionProperties(address, Protocol.POSTGRES, sslSession);
+        var credentials = new Credentials(userName, null);
+        ConnectionProperties connProperties = new ConnectionProperties(credentials, address, Protocol.POSTGRES, sslSession);
 
         AuthenticationMethod authMethod = authService.resolveAuthenticationType(userName, connProperties);
         if (authMethod == null) {
@@ -427,7 +428,7 @@ public class PostgresWireProtocol {
             authContext = new AuthenticationContext(
                 authMethod,
                 connProperties,
-                new Credentials(userName, null),
+                credentials,
                 LOGGER
             );
             if (PASSWORD_AUTH_NAME.equals(authMethod.name())) {

--- a/server/src/test/java/io/crate/auth/AuthenticationWithSSLIntegrationTest.java
+++ b/server/src/test/java/io/crate/auth/AuthenticationWithSSLIntegrationTest.java
@@ -143,7 +143,10 @@ public class AuthenticationWithSSLIntegrationTest extends IntegTestCase {
             })
             .isExactlyInstanceOf(PSQLException.class)
             .hasPGError(INVALID_AUTHORIZATION_SPECIFICATION)
-            .hasMessageContaining("Client certificate authentication failed for user \"localhost\"");
+            // <=5.7.1 used to fail with different message "authentication failed".
+            // After 5.7.2 we take connection properties into account (client cert, password or token headers) for matching an auth method.
+            // Thus, a connection without client cert doesn't even qualify as matching anymore
+            .hasMessageContaining("No valid auth.host_based entry found for host \"127.0.0.1\", user \"localhost\". Did you enable TLS in your client?");
     }
 
 

--- a/server/src/test/java/io/crate/protocols/postgres/AuthenticationContextTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/AuthenticationContextTest.java
@@ -46,8 +46,13 @@ public class AuthenticationContextTest extends ESTestCase {
     public void testAuthenticationContextCycle() throws Exception {
         String userName = "crate";
         char[] passwd = "passwd".toCharArray();
+        var credentials = new Credentials(userName, passwd);
         ConnectionProperties connProperties = new ConnectionProperties(
-            InetAddress.getByName("127.0.0.1"), Protocol.POSTGRES, null);
+            credentials,
+            InetAddress.getByName("127.0.0.1"),
+            Protocol.POSTGRES,
+            null
+        );
         AuthenticationMethod authMethod = AUTHENTICATION.resolveAuthenticationType(userName, connProperties);
         AuthenticationContext authContext = new AuthenticationContext(
             authMethod, connProperties, new Credentials(userName, null), LogManager.getLogger(AuthenticationContextTest.class));


### PR DESCRIPTION
Take into account connection payload on HBA method matching

If a request matches multiple authentication methods,
we need to ensure that we don't fallback to an inappropriate method.


Closes https://github.com/crate/crate/issues/16059
