### PR TITLE
Fix ClassCastException from resultSet returned from foreign table

### DIFF
--- a/docs/appendices/release-notes/5.7.2.rst
+++ b/docs/appendices/release-notes/5.7.2.rst
@@ -102,6 +102,9 @@ Fixes
 - Fixed an issue that could lead to errors when loading data from geo_point
   fields inside nested arrays.
 
+- Fixed an issue that caused ``SQLParseException`` when the results returned
+  from foreign tables could not be casted to CrateDB specific data types.
+
 - Fixed an issue that allowed dropped users to run queries if active user was
   set by ``SET SESSION AUTHORIZATION`` and then dropped.
 

--- a/server/src/main/java/io/crate/fdw/JdbcBatchIterator.java
+++ b/server/src/main/java/io/crate/fdw/JdbcBatchIterator.java
@@ -21,12 +21,15 @@
 
 package io.crate.fdw;
 
+import static io.crate.types.ResultSetParser.getObject;
+
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.Collection;
 import java.util.List;
@@ -168,7 +171,8 @@ public class JdbcBatchIterator implements BatchIterator<Row> {
             if (resultSet.next()) {
                 for (int i = 0; i < columns.size(); i ++) {
                     Reference ref = columns.get(i);
-                    Object object = resultSet.getObject(i + 1);
+                    ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
+                    Object object = getObject(resultSet, i, resultSetMetaData.getColumnTypeName(i + 1));
                     try {
                         cells[i] = ref.valueType().implicitCast(object);
                     } catch (ClassCastException | IllegalArgumentException e) {
@@ -262,7 +266,7 @@ public class JdbcBatchIterator implements BatchIterator<Row> {
                 sb.append(quoteString);
             }
             sb.append(quoteString);
-            sb.append(Identifiers.escape(column.name()));
+            sb.append(Identifiers.escape(column.sqlFqn()));
             sb.append(quoteString);
             return sb.toString();
         }

--- a/server/src/main/java/io/crate/types/ResultSetParser.java
+++ b/server/src/main/java/io/crate/types/ResultSetParser.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.types;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.sql.Array;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import org.elasticsearch.common.xcontent.DeprecationHandler;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.locationtech.spatial4j.context.jts.JtsSpatialContext;
+import org.locationtech.spatial4j.shape.impl.PointImpl;
+import org.postgresql.geometric.PGpoint;
+import org.postgresql.util.PGobject;
+
+import io.crate.protocols.postgres.types.PGArray;
+import io.crate.protocols.postgres.types.PgOidVectorType;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+public class ResultSetParser {
+    /**
+     * retrieve the same type of object from the resultSet as the CrateClient would return
+     */
+    public static Object getObject(ResultSet resultSet, int i, String typeName) throws SQLException {
+        Object value;
+        int columnIndex = i + 1;
+        switch (typeName) {
+            // need to use explicit `get<Type>` for some because getObject would return a wrong type.
+            // E.g. int2 would return Integer instead of short.
+            case "int2":
+                Integer intValue = (Integer) resultSet.getObject(columnIndex);
+                if (intValue == null) {
+                    return null;
+                }
+                value = intValue.shortValue();
+                break;
+            case "_char": {
+                Array array = resultSet.getArray(columnIndex);
+                if (array == null) {
+                    return null;
+                }
+                ArrayList<Byte> elements = new ArrayList<>();
+                for (Object o : ((Object[]) array.getArray())) {
+                    elements.add(Byte.parseByte((String) o));
+                }
+                return elements;
+            }
+            case "oidvector": {
+                String textval = resultSet.getString(columnIndex);
+                if (textval == null) {
+                    return null;
+                }
+                return PgOidVectorType.listFromOidVectorString(textval);
+            }
+            case "char":
+                String strValue = resultSet.getString(columnIndex);
+                if (strValue == null) {
+                    return null;
+                }
+                return Byte.valueOf(strValue);
+            case "byte":
+                value = resultSet.getByte(columnIndex);
+                break;
+            case "_json": {
+                Array array = resultSet.getArray(columnIndex);
+                if (array == null) {
+                    return null;
+                }
+                ArrayList<Object> jsonObjects = new ArrayList<>();
+                for (Object item : (Object[]) array.getArray()) {
+                    jsonObjects.add(jsonToObject((String) item));
+                }
+                value = jsonObjects;
+                break;
+            }
+            case "json":
+                String json = resultSet.getString(columnIndex);
+                value = jsonToObject(json);
+                break;
+            case "point":
+                PGpoint pGpoint = resultSet.getObject(columnIndex, PGpoint.class);
+                value = new PointImpl(pGpoint.x, pGpoint.y, JtsSpatialContext.GEO);
+                break;
+            case "record":
+                value = resultSet.getObject(columnIndex, PGobject.class).getValue();
+                break;
+            case "_bit":
+                String pgBitStringArray = resultSet.getString(columnIndex);
+                if (pgBitStringArray == null) {
+                    return null;
+                }
+                byte[] bytes = pgBitStringArray.getBytes(StandardCharsets.UTF_8);
+                ByteBuf buf = Unpooled.wrappedBuffer(bytes);
+                value = PGArray.BIT_ARRAY.readTextValue(buf, bytes.length);
+                buf.release();
+                break;
+
+            default:
+                value = resultSet.getObject(columnIndex);
+                break;
+        }
+        if (value instanceof Timestamp) {
+            value = ((Timestamp) value).getTime();
+        } else if (value instanceof Array) {
+            value = Arrays.asList(((Object[]) ((Array) value).getArray()));
+        }
+        return value;
+    }
+
+    private static Object jsonToObject(String json) {
+        try {
+            if (json != null) {
+                byte[] bytes = json.getBytes(StandardCharsets.UTF_8);
+                XContentParser parser = JsonXContent.JSON_XCONTENT.createParser(
+                    NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, bytes);
+                if (bytes.length >= 1 && bytes[0] == '[') {
+                    parser.nextToken();
+                    return parser.list();
+                } else {
+                    return parser.mapOrdered();
+                }
+            } else {
+                return null;
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes https://github.com/crate/crate/issues/16110. The exceptions are thrown when parsing/casting the `ResultSets` returned from foreign tables.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
