### PR TITLE
Add user mapping example on empty code block

### DIFF
--- a/docs/sql/statements/create-user-mapping.rst
+++ b/docs/sql/statements/create-user-mapping.rst
@@ -75,6 +75,10 @@ For example, for the ``jdbc`` foreign data wrapper, the options ``user`` and
 
 .. code-block:: psql
 
+  CREATE USER MAPPING
+  FOR mylocaluser
+  SERVER myserver
+  OPTIONS ("user" 'myremoteuser', password '*****');
 
 .. seealso::
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The documentation page for `CREATE USER MAPPING` currently has an empty code block.

## Checklist

 - [X] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [X] This does not contain breaking changes