### PR TITLE
Fix flaky swap table tests (translog indexing based on outdated mapping)

### DIFF
--- a/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
@@ -352,9 +352,6 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
             List<Reference> newColumns = rawIndexer != null ? rawIndexer.collectSchemaUpdates(item) : indexer.collectSchemaUpdates(item);
 
             if (!newColumns.isEmpty()) {
-                // this forces clearing the cache
-                schemas.tableExists(relationName);
-
                 // Even though the primary waits on all nodes to ack the mapping changes to the master
                 // (see MappingUpdatedAction.updateMappingOnMaster) we still need to protect against missing mappings
                 // and wait for them. The reason is concurrent requests. Request r1 which has new field f triggers a
@@ -526,7 +523,6 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
                 new IntArrayList(0)
             );
             addColumnAction.execute(addColumnRequest).get();
-            schemas.tableExists(relationName); // triggers cache invalidation
             DocTableInfo actualTable = schemas.getTableInfo(relationName);
             if (rawIndexer != null) {
                 rawIndexer.updateTargets(actualTable::getReference);

--- a/server/src/main/java/io/crate/metadata/Schemas.java
+++ b/server/src/main/java/io/crate/metadata/Schemas.java
@@ -436,7 +436,6 @@ public class Schemas extends AbstractLifecycleComponent implements Iterable<Sche
         if (schemaInfo == null) {
             return false;
         }
-        schemaInfo.invalidateTableCache(relationName.name());
         TableInfo tableInfo = schemaInfo.getTableInfo(relationName.name());
         if (tableInfo == null) {
             return false;

--- a/server/src/main/java/io/crate/metadata/blob/BlobSchemaInfo.java
+++ b/server/src/main/java/io/crate/metadata/blob/BlobSchemaInfo.java
@@ -21,18 +21,19 @@
 
 package io.crate.metadata.blob;
 
+import java.util.Collections;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
+
+import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.service.ClusterService;
+
 import io.crate.blob.v2.BlobIndex;
 import io.crate.exceptions.ResourceUnknownException;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.table.SchemaInfo;
 import io.crate.metadata.table.TableInfo;
 import io.crate.metadata.view.ViewInfo;
-import org.elasticsearch.cluster.ClusterChangedEvent;
-import org.elasticsearch.cluster.service.ClusterService;
-
-import java.util.Collections;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Stream;
 
 public class BlobSchemaInfo implements SchemaInfo {
 
@@ -66,11 +67,6 @@ public class BlobSchemaInfo implements SchemaInfo {
     @Override
     public String name() {
         return NAME;
-    }
-
-    @Override
-    public void invalidateTableCache(String tableName) {
-        tableByName.remove(tableName);
     }
 
     @Override

--- a/server/src/main/java/io/crate/metadata/doc/DocSchemaInfo.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocSchemaInfo.java
@@ -33,8 +33,6 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import org.jetbrains.annotations.Nullable;
-
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -43,13 +41,14 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.index.Index;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import com.carrotsearch.hppc.ObjectLookupContainer;
 import com.carrotsearch.hppc.cursors.ObjectCursor;
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 
 import io.crate.blob.v2.BlobIndex;
-import org.jetbrains.annotations.VisibleForTesting;
 import io.crate.exceptions.ResourceUnknownException;
 import io.crate.expression.udf.UserDefinedFunctionService;
 import io.crate.expression.udf.UserDefinedFunctionsMetadata;
@@ -152,8 +151,21 @@ public class DocSchemaInfo implements SchemaInfo {
 
     @Override
     public TableInfo getTableInfo(String name) {
+        Metadata metadata = clusterService.state().metadata();
+        DocTableInfo docTableInfo = docTableByName.get(name);
         try {
-            return docTableByName.computeIfAbsent(name, n -> docTableInfoFactory.create(new RelationName(schemaName, n), clusterService.state().metadata()));
+            if (docTableInfo == null) {
+                return docTableByName.computeIfAbsent(
+                    name,
+                    n -> docTableInfoFactory.create(new RelationName(schemaName, n), metadata)
+                );
+            }
+            if (docTableInfo.metadataVersion() < metadata.version()) {
+                DocTableInfo newTable = docTableInfoFactory.create(new RelationName(schemaName, name), metadata);
+                docTableByName.replace(name, newTable);
+                return newTable;
+            }
+            return docTableInfo;
         } catch (Exception e) {
             if (e instanceof ResourceUnknownException) {
                 return null;
@@ -217,11 +229,6 @@ public class DocSchemaInfo implements SchemaInfo {
     @Override
     public String name() {
         return schemaName;
-    }
-
-    @Override
-    public void invalidateTableCache(String tableName) {
-        docTableByName.remove(tableName);
     }
 
     @Override

--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
@@ -198,6 +198,7 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
     private final boolean closed;
     private final ColumnPolicy columnPolicy;
     private TranslogIndexer translogIndexer; // lazily initialised
+    private final long metadataVersion;
 
     public DocTableInfo(RelationName ident,
                         Map<ColumnIdent, Reference> references,
@@ -213,7 +214,8 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
                         Version versionCreated,
                         @Nullable Version versionUpgraded,
                         boolean closed,
-                        Set<Operation> supportedOperations) {
+                        Set<Operation> supportedOperations,
+                        long metadataVersion) {
         this.notNullColumns = references.values().stream()
             .filter(r -> !r.column().isSystemColumn())
             .filter(r -> !primaryKeys.contains(r.column()))
@@ -286,6 +288,11 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
             .stream()
             .filter(r -> r.defaultExpression() != null)
             .toList();
+        this.metadataVersion = metadataVersion;
+    }
+
+    public long metadataVersion() {
+        return metadataVersion;
     }
 
     @Nullable
@@ -775,7 +782,8 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
             versionCreated,
             versionUpgraded,
             closed,
-            supportedOperations
+            supportedOperations,
+            metadataVersion
         );
     }
 
@@ -842,7 +850,8 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
             versionCreated,
             versionUpgraded,
             closed,
-            supportedOperations
+            supportedOperations,
+            metadataVersion
         );
     }
 
@@ -948,7 +957,8 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
             versionCreated,
             versionUpgraded,
             closed,
-            supportedOperations
+            supportedOperations,
+            metadataVersion
         );
     }
 
@@ -1144,7 +1154,8 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
             versionCreated,
             versionUpgraded,
             closed,
-            supportedOperations
+            supportedOperations,
+            metadataVersion
         );
     }
 

--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfoFactory.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfoFactory.java
@@ -194,7 +194,8 @@ public class DocTableInfoFactory {
             versionCreated,
             versionUpgraded,
             indexMetadata.getState() == IndexMetadata.State.CLOSE,
-            Operation.CLOSED_OPERATIONS
+            Operation.CLOSED_OPERATIONS,
+            0
         );
     }
 
@@ -322,7 +323,8 @@ public class DocTableInfoFactory {
                 tableParameters,
                 state,
                 publicationsMetadata == null ? false : publicationsMetadata.isPublished(relation)
-            )
+            ),
+            metadata.version()
         );
     }
 

--- a/server/src/main/java/io/crate/metadata/information/InformationSchemaInfo.java
+++ b/server/src/main/java/io/crate/metadata/information/InformationSchemaInfo.java
@@ -70,10 +70,6 @@ public class InformationSchemaInfo implements SchemaInfo {
     }
 
     @Override
-    public void invalidateTableCache(String tableName) {
-    }
-
-    @Override
     public Iterable<TableInfo> getTables() {
         return tableInfoMap.values();
     }

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
@@ -101,10 +101,6 @@ public final class PgCatalogSchemaInfo implements SchemaInfo {
     }
 
     @Override
-    public void invalidateTableCache(String tableName) {
-    }
-
-    @Override
     public void close() throws Exception {
     }
 

--- a/server/src/main/java/io/crate/metadata/sys/SysSchemaInfo.java
+++ b/server/src/main/java/io/crate/metadata/sys/SysSchemaInfo.java
@@ -77,11 +77,6 @@ public class SysSchemaInfo implements SchemaInfo {
     }
 
     @Override
-    public void invalidateTableCache(String tableName) {
-
-    }
-
-    @Override
     public Iterable<TableInfo> getTables() {
         return tableInfos.values();
     }

--- a/server/src/main/java/io/crate/metadata/table/SchemaInfo.java
+++ b/server/src/main/java/io/crate/metadata/table/SchemaInfo.java
@@ -21,10 +21,10 @@
 
 package io.crate.metadata.table;
 
-import io.crate.metadata.view.ViewInfo;
 import org.elasticsearch.cluster.ClusterChangedEvent;
-
 import org.jetbrains.annotations.Nullable;
+
+import io.crate.metadata.view.ViewInfo;
 
 public interface SchemaInfo extends AutoCloseable {
 
@@ -37,8 +37,6 @@ public interface SchemaInfo extends AutoCloseable {
     }
 
     String name();
-
-    void invalidateTableCache(String tableName);
 
     /**
      * Called when cluster state and so the table definitions changes.

--- a/server/src/test/java/io/crate/metadata/doc/DocSchemaInfoTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocSchemaInfoTest.java
@@ -262,7 +262,8 @@ public class DocSchemaInfoTest extends CrateDummyClusterServiceUnitTest {
             Version.CURRENT,
             null,
             false,
-            Operation.ALL
+            Operation.ALL,
+            0
         );
     }
 }

--- a/server/src/test/java/io/crate/metadata/doc/DocTableInfoTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocTableInfoTest.java
@@ -97,7 +97,8 @@ public class DocTableInfoTest extends CrateDummyClusterServiceUnitTest {
             Version.CURRENT,
             null,
             false,
-            Operation.ALL
+            Operation.ALL,
+            0
         );
         final ColumnIdent col = new ColumnIdent("o", List.of("foobar"));
         Reference foobar = info.getReference(col);
@@ -162,7 +163,8 @@ public class DocTableInfoTest extends CrateDummyClusterServiceUnitTest {
             Version.CURRENT,
             null,
             false,
-            Operation.ALL
+            Operation.ALL,
+            0
         );
 
         final ColumnIdent columnIdent = new ColumnIdent("foobar", Arrays.asList("foo", "bar"));
@@ -293,7 +295,8 @@ public class DocTableInfoTest extends CrateDummyClusterServiceUnitTest {
                 Version.CURRENT,
                 null,
                 false,
-                Operation.ALL
+                Operation.ALL,
+                0
         );
 
         assertThat(info.lookupNameBySourceKey().apply("2")).isEqualTo("b");

--- a/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
+++ b/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
@@ -368,7 +368,8 @@ public abstract class AggregationTestCase extends ESTestCase {
             Version.CURRENT,
             null,
             false,
-            Set.of()
+            Set.of(),
+            0
         );
         Indexer indexer = new Indexer(
             shard.shardId().getIndexName(),

--- a/server/src/testFixtures/java/org/elasticsearch/index/engine/TranslogHandler.java
+++ b/server/src/testFixtures/java/org/elasticsearch/index/engine/TranslogHandler.java
@@ -84,7 +84,9 @@ public class TranslogHandler implements Engine.TranslogRecoveryRunner {
             Version.CURRENT,
             Version.CURRENT,
             false,
-            Set.of());
+            Set.of(),
+            0
+        );
         return new TranslogIndexer(table);
     }
 


### PR DESCRIPTION
The swap table integration tests were flaky because it could happen that
the shards for the swapped tables were recovered based on an outdated
view of a table.

For example in:

    table=source, columns=s, records=(1, 2)
    table=target, columns=t, records=(3, 4)

The translog indexer was called with `source={s=1}`, but it had a `table`
with `columns=t`

Solution:

Replace explicit cache invalidation with a metadata version check in
`DocSchemaInfo.getTableInfo`.

(To avoid unnecessary rebuilds, the `metadataVersion` should later on be
replaced with a more granular `tableMappingVersion` once we've unified
the mapping for indices and templates into a table mapping)
