### PR TITLE
Make BatchIteratorTester result check stricter

### DIFF
--- a/libs/dex/src/test/java/io/crate/data/AsyncCompositeBatchIteratorTest.java
+++ b/libs/dex/src/test/java/io/crate/data/AsyncCompositeBatchIteratorTest.java
@@ -37,6 +37,7 @@ import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 
 import io.crate.data.testing.BatchIteratorTester;
+import io.crate.data.testing.BatchIteratorTester.ResultOrder;
 import io.crate.data.testing.BatchSimulatingIterator;
 import io.crate.data.testing.TestingBatchIterators;
 import io.crate.data.testing.TestingRowConsumer;
@@ -66,7 +67,7 @@ class AsyncCompositeBatchIteratorTest {
                         TestingBatchIterators.range(0, 5),
                         batchSimulatingItSupplier.get()
                     )
-                )
+                ), ResultOrder.EXACT
             );
             tester.verifyResultAndEdgeCaseBehaviour(EXPECTED_RESULT);
         } finally {

--- a/libs/dex/src/test/java/io/crate/data/AsyncFlatMapBatchIteratorTest.java
+++ b/libs/dex/src/test/java/io/crate/data/AsyncFlatMapBatchIteratorTest.java
@@ -35,6 +35,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 
 import io.crate.data.testing.BatchIteratorTester;
+import io.crate.data.testing.BatchIteratorTester.ResultOrder;
 import io.crate.data.testing.BatchSimulatingIterator;
 import io.crate.data.testing.TestingBatchIterators;
 
@@ -111,7 +112,7 @@ class AsyncFlatMapBatchIteratorTest {
         var tester = BatchIteratorTester.forRows(() -> {
             BatchIterator<Row> source = TestingBatchIterators.range(1, 4);
             return new AsyncFlatMapBatchIterator<>(source, duplicateRow);
-        });
+        }, ResultOrder.EXACT);
         tester.verifyResultAndEdgeCaseBehaviour(
             Arrays.asList(
                 new Object[] { 1 },

--- a/libs/dex/src/test/java/io/crate/data/CollectingBatchIteratorTest.java
+++ b/libs/dex/src/test/java/io/crate/data/CollectingBatchIteratorTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.crate.data.testing.BatchIteratorTester;
+import io.crate.data.testing.BatchIteratorTester.ResultOrder;
 import io.crate.data.testing.BatchSimulatingIterator;
 import io.crate.data.testing.TestingBatchIterators;
 
@@ -57,7 +58,7 @@ class CollectingBatchIteratorTest {
     @Test
     void testCollectingBatchIterator() throws Exception {
         var tester = BatchIteratorTester.forRows(
-            () -> CollectingBatchIterator.summingLong(TestingBatchIterators.range(0L, 10L))
+            () -> CollectingBatchIterator.summingLong(TestingBatchIterators.range(0L, 10L)), ResultOrder.EXACT
         );
         tester.verifyResultAndEdgeCaseBehaviour(EXPECTED_RESULT);
     }
@@ -67,7 +68,7 @@ class CollectingBatchIteratorTest {
         var tester = BatchIteratorTester.forRows(
             () -> CollectingBatchIterator.summingLong(
                 new BatchSimulatingIterator<>(TestingBatchIterators.range(0L, 10L), 2, 5, executor)
-            )
+            ), ResultOrder.EXACT
         );
         tester.verifyResultAndEdgeCaseBehaviour(EXPECTED_RESULT);
     }

--- a/libs/dex/src/test/java/io/crate/data/CompositeBatchIteratorTest.java
+++ b/libs/dex/src/test/java/io/crate/data/CompositeBatchIteratorTest.java
@@ -31,6 +31,7 @@ import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 
 import io.crate.data.testing.BatchIteratorTester;
+import io.crate.data.testing.BatchIteratorTester.ResultOrder;
 import io.crate.data.testing.BatchSimulatingIterator;
 import io.crate.data.testing.TestingBatchIterators;
 
@@ -59,7 +60,7 @@ class CompositeBatchIteratorTest {
         var tester = BatchIteratorTester.forRows(
             () -> CompositeBatchIterator.seqComposite(
                 TestingBatchIterators.range(0, 5),
-                TestingBatchIterators.range(5, 10))
+                TestingBatchIterators.range(5, 10)), ResultOrder.EXACT
         );
         tester.verifyResultAndEdgeCaseBehaviour(EXPECTED_RESULT);
     }
@@ -82,7 +83,7 @@ class CompositeBatchIteratorTest {
             () -> CompositeBatchIterator.seqComposite(
                 new BatchSimulatingIterator<>(TestingBatchIterators.range(0, 5), 2, 6, null),
                 TestingBatchIterators.range(5, 10)
-            )
+            ), ResultOrder.EXACT
         );
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
     }

--- a/libs/dex/src/test/java/io/crate/data/FilteringBatchIteratorTest.java
+++ b/libs/dex/src/test/java/io/crate/data/FilteringBatchIteratorTest.java
@@ -29,6 +29,7 @@ import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 
 import io.crate.data.testing.BatchIteratorTester;
+import io.crate.data.testing.BatchIteratorTester.ResultOrder;
 import io.crate.data.testing.TestingBatchIterators;
 
 class FilteringBatchIteratorTest {
@@ -42,7 +43,7 @@ class FilteringBatchIteratorTest {
             l -> new Object[]{l}).collect(Collectors.toList());
 
         var tester = BatchIteratorTester.forRows(
-            () -> new FilteringBatchIterator(TestingBatchIterators.range(0, 20), EVEN_ROW));
+            () -> new FilteringBatchIterator(TestingBatchIterators.range(0, 20), EVEN_ROW), ResultOrder.EXACT);
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
     }
 }

--- a/libs/dex/src/test/java/io/crate/data/FlatMapBatchIteratorTest.java
+++ b/libs/dex/src/test/java/io/crate/data/FlatMapBatchIteratorTest.java
@@ -32,6 +32,7 @@ import java.util.function.Function;
 import org.junit.jupiter.api.Test;
 
 import io.crate.data.testing.BatchIteratorTester;
+import io.crate.data.testing.BatchIteratorTester.ResultOrder;
 import io.crate.data.testing.TestingBatchIterators;
 
 class FlatMapBatchIteratorTest {
@@ -59,7 +60,7 @@ class FlatMapBatchIteratorTest {
         var tester = BatchIteratorTester.forRows(() -> {
             BatchIterator<Row> source = TestingBatchIterators.range(1, 4);
             return new FlatMapBatchIterator<>(source, duplicateRow);
-        });
+        }, ResultOrder.EXACT);
         tester.verifyResultAndEdgeCaseBehaviour(
             Arrays.asList(
                 new Object[] { 1 },

--- a/libs/dex/src/test/java/io/crate/data/InMemoryBatchIteratorTest.java
+++ b/libs/dex/src/test/java/io/crate/data/InMemoryBatchIteratorTest.java
@@ -30,6 +30,7 @@ import java.util.stream.StreamSupport;
 import org.junit.jupiter.api.Test;
 
 import io.crate.data.testing.BatchIteratorTester;
+import io.crate.data.testing.BatchIteratorTester.ResultOrder;
 import io.crate.data.testing.BatchSimulatingIterator;
 import io.crate.data.testing.RowGenerator;
 
@@ -39,7 +40,7 @@ class InMemoryBatchIteratorTest {
     void testCollectRows() throws Exception {
         List<Row> rows = Arrays.asList(new Row1(10), new Row1(20));
         Supplier<BatchIterator<Row>> batchIteratorSupplier = () -> InMemoryBatchIterator.of(rows, SentinelRow.SENTINEL, false);
-        var tester = BatchIteratorTester.forRows(batchIteratorSupplier);
+        var tester = BatchIteratorTester.forRows(batchIteratorSupplier, ResultOrder.EXACT);
         List<Object[]> expectedResult = Arrays.asList(new Object[]{10}, new Object[]{20});
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
     }
@@ -53,7 +54,7 @@ class InMemoryBatchIteratorTest {
             5,
             null
         );
-        var tester = BatchIteratorTester.forRows(batchIteratorSupplier);
+        var tester = BatchIteratorTester.forRows(batchIteratorSupplier, ResultOrder.EXACT);
         List<Object[]> expectedResult = StreamSupport.stream(rows.spliterator(), false)
             .map(Row::materialize)
             .collect(Collectors.toList());

--- a/libs/dex/src/test/java/io/crate/data/LimitingBatchIteratorTest.java
+++ b/libs/dex/src/test/java/io/crate/data/LimitingBatchIteratorTest.java
@@ -28,6 +28,7 @@ import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 
 import io.crate.data.testing.BatchIteratorTester;
+import io.crate.data.testing.BatchIteratorTester.ResultOrder;
 import io.crate.data.testing.BatchSimulatingIterator;
 import io.crate.data.testing.TestingBatchIterators;
 
@@ -40,7 +41,7 @@ class LimitingBatchIteratorTest {
     @Test
     void testLimitingBatchIterator() throws Exception {
         var tester = BatchIteratorTester.forRows(
-            () -> LimitingBatchIterator.newInstance(TestingBatchIterators.range(0, 10), LIMIT)
+            () -> LimitingBatchIterator.newInstance(TestingBatchIterators.range(0, 10), LIMIT), ResultOrder.EXACT
         );
         tester.verifyResultAndEdgeCaseBehaviour(EXPECTED_RESULT);
     }
@@ -52,7 +53,7 @@ class LimitingBatchIteratorTest {
                 BatchSimulatingIterator<Row> batchSimulatingIt = new BatchSimulatingIterator<>(
                     TestingBatchIterators.range(0, 10), 2, 5, null);
                 return LimitingBatchIterator.newInstance(batchSimulatingIt, LIMIT);
-            }
+            }, ResultOrder.EXACT
         );
         tester.verifyResultAndEdgeCaseBehaviour(EXPECTED_RESULT);
     }

--- a/libs/dex/src/test/java/io/crate/data/SkippingBatchIteratorTest.java
+++ b/libs/dex/src/test/java/io/crate/data/SkippingBatchIteratorTest.java
@@ -28,6 +28,7 @@ import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 
 import io.crate.data.testing.BatchIteratorTester;
+import io.crate.data.testing.BatchIteratorTester.ResultOrder;
 import io.crate.data.testing.BatchSimulatingIterator;
 import io.crate.data.testing.TestingBatchIterators;
 
@@ -42,7 +43,7 @@ class SkippingBatchIteratorTest {
     @Test
     void testSkippingBatchIterator() throws Exception {
         var tester = BatchIteratorTester.forRows(
-            () -> new SkippingBatchIterator<>(TestingBatchIterators.range(0, 10), OFFSET)
+            () -> new SkippingBatchIterator<>(TestingBatchIterators.range(0, 10), OFFSET), ResultOrder.EXACT
         );
         tester.verifyResultAndEdgeCaseBehaviour(EXPECTED_RESULT);
     }
@@ -54,7 +55,7 @@ class SkippingBatchIteratorTest {
                 BatchIterator<Row> source = TestingBatchIterators.range(0, 10);
                 source = new BatchSimulatingIterator<>(source, 2, 5, null);
                 return new SkippingBatchIterator<>(source, OFFSET);
-            }
+            }, ResultOrder.EXACT
         );
         tester.verifyResultAndEdgeCaseBehaviour(EXPECTED_RESULT);
     }

--- a/libs/dex/src/test/java/io/crate/data/TopNDistinctBatchIteratorTest.java
+++ b/libs/dex/src/test/java/io/crate/data/TopNDistinctBatchIteratorTest.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
 import io.crate.data.testing.BatchIteratorTester;
+import io.crate.data.testing.BatchIteratorTester.ResultOrder;
 
 class TopNDistinctBatchIteratorTest {
 
@@ -67,7 +68,7 @@ class TopNDistinctBatchIteratorTest {
                 false
             );
             return new TopNDistinctBatchIterator<>(source, 3, x -> x);
-        });
+        }, ResultOrder.EXACT);
         tester.verifyResultAndEdgeCaseBehaviour(
             List.of(
                 new Object[] { 1 },

--- a/libs/dex/src/test/java/io/crate/data/join/CrossJoinBlockNLBatchIteratorTest.java
+++ b/libs/dex/src/test/java/io/crate/data/join/CrossJoinBlockNLBatchIteratorTest.java
@@ -39,6 +39,7 @@ import io.crate.data.InMemoryBatchIterator;
 import io.crate.data.Row;
 import io.crate.data.breaker.RowAccounting;
 import io.crate.data.testing.BatchIteratorTester;
+import io.crate.data.testing.BatchIteratorTester.ResultOrder;
 import io.crate.data.testing.BatchSimulatingIterator;
 import io.crate.data.testing.TestingBatchIterators;
 import io.crate.data.testing.TestingRowConsumer;
@@ -139,7 +140,8 @@ public class CrossJoinBlockNLBatchIteratorTest {
                 new CombinedRow(1, 1),
                 params.blockSizeCalculator,
                 params.testingRowAccounting
-            )
+            ),
+            ResultOrder.ANY
         );
         tester.verifyResultAndEdgeCaseBehaviour(params.expectedResults,
             it -> {
@@ -169,7 +171,8 @@ public class CrossJoinBlockNLBatchIteratorTest {
                 new CombinedRow(1, 1),
                 params.blockSizeCalculator,
                 params.testingRowAccounting
-            )
+            ),
+            ResultOrder.ANY
         );
         tester.verifyResultAndEdgeCaseBehaviour(params.expectedResults,
             it -> {

--- a/libs/dex/src/test/java/io/crate/data/join/NestedLoopBatchIteratorsTest.java
+++ b/libs/dex/src/test/java/io/crate/data/join/NestedLoopBatchIteratorsTest.java
@@ -37,6 +37,7 @@ import io.crate.data.BatchIterator;
 import io.crate.data.InMemoryBatchIterator;
 import io.crate.data.Row;
 import io.crate.data.testing.BatchIteratorTester;
+import io.crate.data.testing.BatchIteratorTester.ResultOrder;
 import io.crate.data.testing.BatchSimulatingIterator;
 import io.crate.data.testing.TestingBatchIterators;
 import io.crate.data.testing.TestingRowConsumer;
@@ -102,7 +103,7 @@ class NestedLoopBatchIteratorsTest {
                 TestingBatchIterators.range(0, 3),
                 TestingBatchIterators.range(0, 3),
                 new CombinedRow(1, 1)
-            )
+            ), ResultOrder.EXACT
         );
         tester.verifyResultAndEdgeCaseBehaviour(threeXThreeRows);
     }
@@ -114,7 +115,7 @@ class NestedLoopBatchIteratorsTest {
                 new BatchSimulatingIterator<>(TestingBatchIterators.range(0, 3), 2, 2, null),
                 new BatchSimulatingIterator<>(TestingBatchIterators.range(0, 3), 2, 2, null),
                 new CombinedRow(1, 1)
-            )
+            ), ResultOrder.EXACT
         );
         tester.verifyResultAndEdgeCaseBehaviour(threeXThreeRows);
     }
@@ -164,7 +165,7 @@ class NestedLoopBatchIteratorsTest {
             new CombinedRow(1, 1),
             getCol0EqCol1JoinCondition()
         );
-        var tester = BatchIteratorTester.forRows(batchIteratorSupplier);
+        var tester = BatchIteratorTester.forRows(batchIteratorSupplier, ResultOrder.EXACT);
         tester.verifyResultAndEdgeCaseBehaviour(leftJoinResult);
     }
 
@@ -176,7 +177,7 @@ class NestedLoopBatchIteratorsTest {
             new CombinedRow(1, 1),
             getCol0EqCol1JoinCondition()
         );
-        var tester = BatchIteratorTester.forRows(batchIteratorSupplier);
+        var tester = BatchIteratorTester.forRows(batchIteratorSupplier, ResultOrder.EXACT);
         tester.verifyResultAndEdgeCaseBehaviour(leftJoinResult);
     }
 
@@ -188,7 +189,7 @@ class NestedLoopBatchIteratorsTest {
             new CombinedRow(1, 1),
             getCol0EqCol1JoinCondition()
         );
-        var tester = BatchIteratorTester.forRows(batchIteratorSupplier);
+        var tester = BatchIteratorTester.forRows(batchIteratorSupplier, ResultOrder.EXACT);
         tester.verifyResultAndEdgeCaseBehaviour(rightJoinResult);
     }
 
@@ -200,7 +201,7 @@ class NestedLoopBatchIteratorsTest {
             new CombinedRow(1, 1),
             getCol0EqCol1JoinCondition()
         );
-        var tester = BatchIteratorTester.forRows(batchIteratorSupplier);
+        var tester = BatchIteratorTester.forRows(batchIteratorSupplier, ResultOrder.EXACT);
         tester.verifyResultAndEdgeCaseBehaviour(rightJoinResult);
     }
 
@@ -212,7 +213,7 @@ class NestedLoopBatchIteratorsTest {
             new CombinedRow(1, 1),
             getCol0EqCol1JoinCondition()
         );
-        var tester = BatchIteratorTester.forRows(batchIteratorSupplier);
+        var tester = BatchIteratorTester.forRows(batchIteratorSupplier, ResultOrder.EXACT);
         tester.verifyResultAndEdgeCaseBehaviour(fullJoinResult);
     }
 
@@ -224,7 +225,7 @@ class NestedLoopBatchIteratorsTest {
             new CombinedRow(1, 1),
             getCol0EqCol1JoinCondition()
         );
-        var tester = BatchIteratorTester.forRows(batchIteratorSupplier);
+        var tester = BatchIteratorTester.forRows(batchIteratorSupplier, ResultOrder.EXACT);
         tester.verifyResultAndEdgeCaseBehaviour(fullJoinResult);
     }
 
@@ -255,7 +256,7 @@ class NestedLoopBatchIteratorsTest {
             new CombinedRow(1, 0),
             getCol0EqCol1JoinCondition()
         );
-        var tester = BatchIteratorTester.forRows(batchIteratorSupplier);
+        var tester = BatchIteratorTester.forRows(batchIteratorSupplier, ResultOrder.EXACT);
         tester.verifyResultAndEdgeCaseBehaviour(semiJoinResult);
     }
 
@@ -267,7 +268,7 @@ class NestedLoopBatchIteratorsTest {
             new CombinedRow(1, 1),
             getCol0EqCol1JoinCondition()
         );
-        var tester = BatchIteratorTester.forRows(batchIteratorSupplier);
+        var tester = BatchIteratorTester.forRows(batchIteratorSupplier, ResultOrder.EXACT);
         tester.verifyResultAndEdgeCaseBehaviour(semiJoinResult);
     }
 
@@ -305,7 +306,7 @@ class NestedLoopBatchIteratorsTest {
             new CombinedRow(1, 1),
             getCol0EqCol1JoinCondition()
         );
-        var tester = BatchIteratorTester.forRows(batchIteratorSupplier);
+        var tester = BatchIteratorTester.forRows(batchIteratorSupplier, ResultOrder.EXACT);
         tester.verifyResultAndEdgeCaseBehaviour(antiJoinResult);
     }
 
@@ -317,7 +318,7 @@ class NestedLoopBatchIteratorsTest {
             new CombinedRow(1, 1),
             getCol0EqCol1JoinCondition()
         );
-        var tester = BatchIteratorTester.forRows(batchIteratorSupplier);
+        var tester = BatchIteratorTester.forRows(batchIteratorSupplier, ResultOrder.EXACT);
         tester.verifyResultAndEdgeCaseBehaviour(antiJoinResult);
     }
 
@@ -342,7 +343,7 @@ class NestedLoopBatchIteratorsTest {
             new CombinedRow(1, 1),
             getCol0EqCol1JoinCondition()
         );
-        var tester = BatchIteratorTester.forRows(batchIteratorSupplier);
+        var tester = BatchIteratorTester.forRows(batchIteratorSupplier, ResultOrder.EXACT);
         tester.verifyResultAndEdgeCaseBehaviour(Arrays.asList(
             new Object[] { 0 },
             new Object[] { 1 },

--- a/server/src/test/java/io/crate/execution/engine/collect/GroupByOptimizedIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/GroupByOptimizedIteratorTest.java
@@ -62,6 +62,7 @@ import io.crate.data.BatchIterator;
 import io.crate.data.Row;
 import io.crate.data.breaker.RamAccounting;
 import io.crate.data.testing.BatchIteratorTester;
+import io.crate.data.testing.BatchIteratorTester.ResultOrder;
 import io.crate.exceptions.JobKilledException;
 import io.crate.execution.dml.StringIndexer;
 import io.crate.execution.dsl.projection.GroupProjection;
@@ -258,7 +259,7 @@ public class GroupByOptimizedIteratorTest extends CrateDummyClusterServiceUnitTe
 
     @Test
     public void test_optimized_iterator_behaviour() throws Exception {
-        var tester = BatchIteratorTester.forRows(() -> createBatchIterator(() -> {}));
+        var tester = BatchIteratorTester.forRows(() -> createBatchIterator(() -> {}), ResultOrder.ANY);
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
     }
 

--- a/server/src/test/java/io/crate/execution/engine/collect/collectors/LuceneBatchIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/collectors/LuceneBatchIteratorTest.java
@@ -40,6 +40,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import io.crate.data.testing.BatchIteratorTester;
+import io.crate.data.testing.BatchIteratorTester.ResultOrder;
 import io.crate.expression.reference.doc.lucene.CollectorContext;
 import io.crate.expression.reference.doc.lucene.LongColumnReference;
 
@@ -78,7 +79,7 @@ public class LuceneBatchIteratorTest {
                 new CollectorContext(Set.of(), UnaryOperator.identity()),
                 columnRefs,
                 columnRefs
-            )
+            ), ResultOrder.EXACT
         );
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
     }

--- a/server/src/test/java/io/crate/execution/engine/collect/collectors/NodeStatsTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/collectors/NodeStatsTest.java
@@ -48,6 +48,7 @@ import org.mockito.ArgumentCaptor;
 import io.crate.analyze.OrderBy;
 import io.crate.common.unit.TimeValue;
 import io.crate.data.testing.BatchIteratorTester;
+import io.crate.data.testing.BatchIteratorTester.ResultOrder;
 import io.crate.execution.dsl.phases.RoutedCollectPhase;
 import io.crate.execution.engine.collect.stats.NodeStatsRequest;
 import io.crate.execution.engine.collect.stats.NodeStatsResponse;
@@ -203,7 +204,7 @@ public class NodeStatsTest extends ESTestCase {
             nodes,
             txnCtx,
             new InputFactory(nodeCtx)
-        ));
+        ), ResultOrder.EXACT);
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorFactoryTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorFactoryTest.java
@@ -67,6 +67,7 @@ import io.crate.data.Row;
 import io.crate.data.breaker.RamAccounting;
 import io.crate.data.breaker.RowAccounting;
 import io.crate.data.testing.BatchIteratorTester;
+import io.crate.data.testing.BatchIteratorTester.ResultOrder;
 import io.crate.data.testing.TestingRowConsumer;
 import io.crate.execution.engine.sort.OrderingByPosition;
 import io.crate.expression.reference.doc.lucene.CollectorContext;
@@ -143,7 +144,7 @@ public class OrderedLuceneBatchIteratorFactoryTest extends ESTestCase {
                     () -> 1,
                     true
                 );
-            }
+            }, ResultOrder.EXACT
         );
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
     }

--- a/server/src/test/java/io/crate/execution/engine/collect/files/FileReadingIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/files/FileReadingIteratorTest.java
@@ -57,6 +57,7 @@ import org.mockito.ArgumentCaptor;
 
 import io.crate.data.BatchIterator;
 import io.crate.data.testing.BatchIteratorTester;
+import io.crate.data.testing.BatchIteratorTester.ResultOrder;
 import io.crate.execution.engine.collect.files.FileReadingIterator.LineCursor;
 
 public class FileReadingIteratorTest extends ESTestCase {
@@ -130,7 +131,7 @@ public class FileReadingIteratorTest extends ESTestCase {
             "name,id,age",
             "Trillian,5,33"
         );
-        var tester = new BatchIteratorTester<>(() -> batchIteratorSupplier.get().map(LineCursor::line));
+        var tester = new BatchIteratorTester<>(() -> batchIteratorSupplier.get().map(LineCursor::line), ResultOrder.EXACT);
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
     }
 
@@ -178,7 +179,7 @@ public class FileReadingIteratorTest extends ESTestCase {
                 }
             };
 
-        var tester = new BatchIteratorTester<>(() -> batchIteratorSupplier.get().map(LineCursor::line));
+        var tester = new BatchIteratorTester<>(() -> batchIteratorSupplier.get().map(LineCursor::line), ResultOrder.EXACT);
         tester.verifyResultAndEdgeCaseBehaviour(lines);
     }
 

--- a/server/src/test/java/io/crate/execution/engine/distribution/merge/BatchPagingIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/distribution/merge/BatchPagingIteratorTest.java
@@ -45,6 +45,7 @@ import io.crate.data.BatchIterator;
 import io.crate.data.Row;
 import io.crate.data.RowN;
 import io.crate.data.testing.BatchIteratorTester;
+import io.crate.data.testing.BatchIteratorTester.ResultOrder;
 import io.crate.data.testing.BatchSimulatingIterator;
 import io.crate.data.testing.RowGenerator;
 import io.crate.data.testing.TestingBatchIterators;
@@ -79,7 +80,7 @@ public class BatchPagingIteratorTest {
                 () -> true,
                 throwable -> {}
             );
-        });
+        }, ResultOrder.EXACT);
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
     }
 
@@ -130,7 +131,7 @@ public class BatchPagingIteratorTest {
                 }
             );
         };
-        var tester = BatchIteratorTester.forRows(batchIteratorSupplier);
+        var tester = BatchIteratorTester.forRows(batchIteratorSupplier, ResultOrder.EXACT);
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
     }
 

--- a/server/src/test/java/io/crate/execution/engine/join/HashInnerJoinBatchIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/join/HashInnerJoinBatchIteratorTest.java
@@ -46,6 +46,7 @@ import io.crate.data.Row;
 import io.crate.data.breaker.RowAccounting;
 import io.crate.data.join.CombinedRow;
 import io.crate.data.testing.BatchIteratorTester;
+import io.crate.data.testing.BatchIteratorTester.ResultOrder;
 import io.crate.data.testing.BatchSimulatingIterator;
 import io.crate.data.testing.TestingBatchIterators;
 
@@ -138,7 +139,7 @@ public class HashInnerJoinBatchIteratorTest {
             getHashForRight(),
             ignored -> 5
         );
-        var tester = BatchIteratorTester.forRows(batchIteratorSupplier);
+        var tester = BatchIteratorTester.forRows(batchIteratorSupplier, ResultOrder.EXACT);
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
     }
 
@@ -154,7 +155,7 @@ public class HashInnerJoinBatchIteratorTest {
             getHashWithCollisions(),
             ignored -> 5
         );
-        var tester = BatchIteratorTester.forRows(batchIteratorSupplier);
+        var tester = BatchIteratorTester.forRows(batchIteratorSupplier, ResultOrder.EXACT);
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
     }
 
@@ -170,7 +171,7 @@ public class HashInnerJoinBatchIteratorTest {
             getHashForRight(),
             ignored -> 1
         );
-        var tester = BatchIteratorTester.forRows(batchIteratorSupplier);
+        var tester = BatchIteratorTester.forRows(batchIteratorSupplier, ResultOrder.EXACT);
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
     }
 
@@ -186,7 +187,7 @@ public class HashInnerJoinBatchIteratorTest {
             getHashForRight(),
             ignored -> 3
         );
-        var tester = BatchIteratorTester.forRows(batchIteratorSupplier);
+        var tester = BatchIteratorTester.forRows(batchIteratorSupplier, ResultOrder.EXACT);
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/window/WindowBatchIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/window/WindowBatchIteratorTest.java
@@ -50,6 +50,7 @@ import io.crate.data.Input;
 import io.crate.data.Row;
 import io.crate.data.breaker.RamAccounting;
 import io.crate.data.testing.BatchIteratorTester;
+import io.crate.data.testing.BatchIteratorTester.ResultOrder;
 import io.crate.data.testing.BatchSimulatingIterator;
 import io.crate.data.testing.TestingBatchIterators;
 import io.crate.data.testing.TestingRowConsumer;
@@ -88,7 +89,7 @@ public class WindowBatchIteratorTest {
                     Collections.emptyList(),
                     new Boolean[]{null},
                     new Input[0]);
-            }
+            }, ResultOrder.EXACT
         );
         tester.verifyResultAndEdgeCaseBehaviour(expectedRowNumberResult);
     }
@@ -113,7 +114,7 @@ public class WindowBatchIteratorTest {
                     Collections.emptyList(),
                     new Boolean[]{null},
                     new Input[0]);
-            }
+            }, ResultOrder.EXACT
         );
         tester.verifyResultAndEdgeCaseBehaviour(expectedRowNumberResult);
     }


### PR DESCRIPTION
https://github.com/crate/crate/commit/eef4afeeb60e65a0c8591e500f167327703fa0a1
made the assertion in the BatchIteratorTester more lenient - allowing
the results to be in any order.
But this exception towards ordering doesn't apply to any other
`BatchIterator` implementation. They must return results in an exact
order.

Solution:

Parameterize the expected order.
