### PR TITLE
Migrate tests to use jdk HttpClient instead of apache HttpClient

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -366,8 +366,8 @@
 
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
-      <version>1.70</version>
+      <artifactId>bcpkix-jdk18on</artifactId>
+      <version>1.78.1</version>
       <scope>test</scope>
     </dependency>
 

--- a/server/src/main/java/io/crate/netty/channel/PipelineRegistry.java
+++ b/server/src/main/java/io/crate/netty/channel/PipelineRegistry.java
@@ -25,14 +25,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 
-import org.jetbrains.annotations.Nullable;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.http.netty4.cors.Netty4CorsConfig;
 import org.elasticsearch.transport.Netty4Plugin;
+import org.jetbrains.annotations.Nullable;
 
 import io.crate.auth.AuthenticationHttpAuthHandlerRegistry;
 import io.crate.auth.Protocol;
@@ -114,7 +113,6 @@ public class PipelineRegistry {
         for (PipelineRegistry.ChannelPipelineItem item : addBeforeList) {
             pipeline.addBefore(item.base, item.name, item.handlerFactory.apply(corsConfig));
         }
-
         if (sslContextProvider != null) {
             SslContext sslContext = sslContextProvider.getServerContext(Protocol.HTTP);
             if (sslContext != null) {

--- a/server/src/main/java/io/crate/rest/action/SqlHttpHandler.java
+++ b/server/src/main/java/io/crate/rest/action/SqlHttpHandler.java
@@ -46,6 +46,7 @@ import org.elasticsearch.http.netty4.cors.Netty4CorsHandler;
 import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.elasticsearch.transport.netty4.Netty4Utils;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import io.crate.action.sql.DescribeResult;
 import io.crate.action.sql.ResultReceiver;
@@ -58,7 +59,6 @@ import io.crate.auth.AuthSettings;
 import io.crate.auth.Credentials;
 import io.crate.auth.HttpAuthUpstreamHandler;
 import io.crate.breaker.TypedRowAccounting;
-import org.jetbrains.annotations.VisibleForTesting;
 import io.crate.data.breaker.BlockBasedRamAccounting;
 import io.crate.data.breaker.RamAccounting;
 import io.crate.exceptions.SQLExceptions;

--- a/server/src/test/java/io/crate/auth/AuthenticationIntegrationTest.java
+++ b/server/src/test/java/io/crate/auth/AuthenticationIntegrationTest.java
@@ -23,20 +23,22 @@ package io.crate.auth;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INVALID_AUTHORIZATION_SPECIFICATION;
 import static io.crate.testing.Asserts.assertSQLError;
-import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Locale;
 import java.util.Properties;
 
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpOptions;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.http.HttpServerTransport;
 import org.elasticsearch.test.IntegTestCase;
@@ -92,13 +94,17 @@ public class AuthenticationIntegrationTest extends IntegTestCase {
         HttpServerTransport httpTransport = cluster().getInstance(HttpServerTransport.class);
         InetSocketAddress address = httpTransport.boundAddress().publishAddress().address();
         String uri = String.format(Locale.ENGLISH, "http://%s:%s/", address.getHostName(), address.getPort());
-        HttpOptions request = new HttpOptions(uri);
-        request.setHeader(HttpHeaderNames.AUTHORIZATION.toString(), "Basic QXJ0aHVyOkV4Y2FsaWJ1cg==");
-        request.setHeader(HttpHeaderNames.ORIGIN.toString(), "http://example.com");
-        request.setHeader(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD.toString(), "GET");
-        try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
-            CloseableHttpResponse resp = httpClient.execute(request);
-            assertThat(resp.getStatusLine().getReasonPhrase()).isEqualTo("OK");
+
+        try (var httpClient = HttpClient.newHttpClient()) {
+            HttpRequest request = HttpRequest.newBuilder(URI.create(uri))
+                .method("OPTIONS", BodyPublishers.noBody())
+                .setHeader(HttpHeaderNames.AUTHORIZATION.toString(), "Basic QXJ0aHVyOkV4Y2FsaWJ1cg==")
+                .setHeader(HttpHeaderNames.ORIGIN.toString(), "http://example.com")
+                .setHeader(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD.toString(), "GET")
+                .build();
+
+            HttpResponse<String> response = httpClient.send(request, BodyHandlers.ofString());
+            assertThat(response.statusCode()).isEqualTo(200);
         }
     }
 

--- a/server/src/test/java/io/crate/auth/JwtAuthenticationIntegrationTest.java
+++ b/server/src/test/java/io/crate/auth/JwtAuthenticationIntegrationTest.java
@@ -27,7 +27,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
-import java.nio.charset.StandardCharsets;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse.BodyHandlers;
 import java.security.KeyFactory;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
@@ -39,11 +42,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.function.BiConsumer;
 
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.util.EntityUtils;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.http.HttpServerTransport;
 import org.elasticsearch.test.IntegTestCase;
@@ -58,7 +56,6 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import io.crate.http.HttpTestServer;
 import io.crate.testing.UseJdbc;
 import io.netty.handler.codec.http.HttpHeaderNames;
-import io.netty.handler.codec.http.HttpRequest;
 
 @UseJdbc(value = 0) // jwt is supported only for http
 public class JwtAuthenticationIntegrationTest extends IntegTestCase {
@@ -86,8 +83,8 @@ public class JwtAuthenticationIntegrationTest extends IntegTestCase {
      *    ]
      * }
      */
-    private static final BiConsumer<HttpRequest, JsonGenerator> jwkRequestHandler =
-        (HttpRequest msg, JsonGenerator generator) -> {
+    private static final BiConsumer<io.netty.handler.codec.http.HttpRequest, JsonGenerator> jwkRequestHandler =
+        (io.netty.handler.codec.http.HttpRequest msg, JsonGenerator generator) -> {
             try {
                 KeyFactory keyFactory = KeyFactory.getInstance("RSA");
                 EncodedKeySpec publicKeySpec = new X509EncodedKeySpec(BASE_64_DECODER.decode(PUBLIC_KEY_256));
@@ -169,15 +166,16 @@ public class JwtAuthenticationIntegrationTest extends IntegTestCase {
 
         HttpServerTransport httpTransport = cluster().getInstance(HttpServerTransport.class);
         InetSocketAddress address = httpTransport.boundAddress().publishAddress().address();
-        String uri = String.format(Locale.ENGLISH, "http://%s:%s/", address.getHostName(), address.getPort());
-        HttpGet request = new HttpGet(uri);
-        request.setHeader(HttpHeaderNames.AUTHORIZATION.toString(), "Bearer " + jwt);
-        request.setHeader(HttpHeaderNames.ORIGIN.toString(), "http://example.com");
-        request.setHeader(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD.toString(), "GET");
-        try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
-            CloseableHttpResponse resp = httpClient.execute(request);
-            String bodyAsString = EntityUtils.toString(resp.getEntity(), StandardCharsets.UTF_8);
-            assertThat(bodyAsString).containsIgnoringWhitespaces("""
+        URI uri = URI.create(String.format(Locale.ENGLISH, "http://%s:%s/", address.getHostName(), address.getPort()));
+
+        try (var client = HttpClient.newHttpClient()) {
+            HttpRequest request = HttpRequest.newBuilder(uri)
+                .header(HttpHeaderNames.AUTHORIZATION.toString(), "Bearer " + jwt)
+                .header(HttpHeaderNames.ORIGIN.toString(), "http://example.com")
+                .header(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD.toString(), "GET")
+                .build();
+            var resp = client.send(request, BodyHandlers.ofString());
+            assertThat(resp.body()).containsIgnoringWhitespaces("""
                 {
                   "ok" : true,
                   "status" : 200
@@ -207,15 +205,15 @@ public class JwtAuthenticationIntegrationTest extends IntegTestCase {
 
         HttpServerTransport httpTransport = cluster().getInstance(HttpServerTransport.class);
         InetSocketAddress address = httpTransport.boundAddress().publishAddress().address();
-        String uri = String.format(Locale.ENGLISH, "http://%s:%s/", address.getHostName(), address.getPort());
-        HttpGet request = new HttpGet(uri);
-        request.setHeader(HttpHeaderNames.AUTHORIZATION.toString(), "Bearer " + jwt);
-        request.setHeader(HttpHeaderNames.ORIGIN.toString(), "http://example.com");
-        request.setHeader(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD.toString(), "GET");
-        try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
-            CloseableHttpResponse resp = httpClient.execute(request);
-            String bodyAsString = EntityUtils.toString(resp.getEntity(), StandardCharsets.UTF_8);
-            assertThat(bodyAsString).contains("jwt authentication failed for user John. Reason: Cannot obtain jwks from url");
+        URI uri = URI.create(String.format(Locale.ENGLISH, "http://%s:%s/", address.getHostName(), address.getPort()));
+        try (var httpClient = HttpClient.newHttpClient()) {
+            var request = HttpRequest.newBuilder(uri)
+                .header(HttpHeaderNames.AUTHORIZATION.toString(), "Bearer " + jwt)
+                .header(HttpHeaderNames.ORIGIN.toString(), "http://example.com")
+                .header(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD.toString(), "GET")
+                .build();
+            var resp = httpClient.send(request, BodyHandlers.ofString());
+            assertThat(resp.body()).contains("jwt authentication failed for user John. Reason: Cannot obtain jwks from url");
         }
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/BlobHttpClient.java
+++ b/server/src/test/java/io/crate/integrationtests/BlobHttpClient.java
@@ -21,14 +21,13 @@
 
 package io.crate.integrationtests;
 
-import java.io.IOException;
 import java.net.InetSocketAddress;
-
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
 
 import io.crate.common.Hex;
 import io.crate.test.utils.Blobs;
@@ -41,13 +40,15 @@ class BlobHttpClient {
         this.address = address;
     }
 
-    public CloseableHttpResponse put(String table, String body) throws IOException {
-        try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
+    public HttpResponse<String> put(String table, String body) throws Exception {
+        try (var httpClient = HttpClient.newHttpClient()) {
             String digest = Hex.encodeHexString(Blobs.digest(body));
-            String url = Blobs.url(false, address, table + "/" + digest);
-            HttpPut httpPut = new HttpPut(url);
-            httpPut.setEntity(new StringEntity(body));
-            return httpClient.execute(httpPut);
+            URI uri = Blobs.url(false, address, table + "/" + digest);
+            HttpRequest request = HttpRequest.newBuilder(uri)
+                .PUT(BodyPublishers.ofString(body))
+                .build();
+
+            return httpClient.send(request, BodyHandlers.ofString());
         }
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
@@ -601,7 +601,7 @@ public class CopyIntegrationTest extends SQLHttpIntegrationTest {
 
         String r1 = "{\"id\": 1, \"name\":\"Marvin\"}";
         String r2 = "{\"id\": 2, \"name\":\"Slartibartfast\"}";
-        List<String> urls = List.of(upload("blobs", r1), upload("blobs", r2));
+        List<String> urls = List.of(upload("blobs", r1).toString(), upload("blobs", r2).toString());
 
         execute("copy names from ?", new Object[]{urls});
         assertThat(response).hasRowCount(2L);
@@ -621,7 +621,7 @@ public class CopyIntegrationTest extends SQLHttpIntegrationTest {
         String r2 = "{\"id\": 2, \"name\":\"Slartibartfast\"}";
 
         Files.write(file.toPath(), Collections.singletonList(r1), StandardCharsets.UTF_8);
-        List<String> urls = List.of(tmpDir.toUri().toString() + "*.json", upload("blobs", r2));
+        List<String> urls = List.of(tmpDir.toUri().toString() + "*.json", upload("blobs", r2).toString());
 
         execute("copy names from ?", new Object[]{urls});
         assertThat(response).hasRowCount(2L);

--- a/server/src/test/java/io/crate/protocols/http/CrateHttpsTransportIntegrationTest.java
+++ b/server/src/test/java/io/crate/protocols/http/CrateHttpsTransportIntegrationTest.java
@@ -23,17 +23,14 @@ package io.crate.protocols.http;
 
 import static io.crate.protocols.ssl.SslContextProviderTest.getAbsoluteFilePathFromClassPath;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.isEmptyOrNullString;
-import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
 
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.util.EntityUtils;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.IntegTestCase;
 import org.junit.AfterClass;
@@ -85,25 +82,24 @@ public class CrateHttpsTransportIntegrationTest extends SQLHttpIntegrationTest {
 
     @Test
     public void testCheckEncryptedConnection() throws Throwable {
-        CloseableHttpResponse response = post("{\"stmt\": \"select 'sslWorks'\"}");
+        HttpResponse<String> response = post("{\"stmt\": \"select 'sslWorks'\"}");
         assertThat(response).isNotNull();
-        assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
-        String result = EntityUtils.toString(response.getEntity());
-        assertThat(result, containsString("\"rowcount\":1"));
-        assertThat(result, containsString("sslWorks"));
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.body()).contains("\"rowcount\":1");
+        assertThat(response.body()).contains("sslWorks");
     }
 
     @Test
-    public void testBlobLayer() throws IOException {
+    public void testBlobLayer() throws Exception {
         try {
             execute("create blob table test");
-            String blob = "abcdefghijklmnopqrstuvwxyz".repeat(1024 * 600);
-            String blobUrl = upload("test", blob);
-            assertThat(blobUrl, not(isEmptyOrNullString()));
-            HttpGet httpGet = new HttpGet(blobUrl);
-            CloseableHttpResponse response = httpClient.execute(httpGet);
-            assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
-            assertThat(response.getEntity().getContentLength()).isEqualTo((long) blob.length());
+            String blob = "abcdefghijklmnopqrstuvwxyz".repeat(600);
+            URI blobUrl = upload("test", blob);
+            HttpRequest httpRequest = HttpRequest.newBuilder(blobUrl)
+                .build();
+            var response = httpClient.send(httpRequest, BodyHandlers.ofString());
+            assertThat(response.statusCode()).isEqualTo(200);
+            assertThat(response.body().length()).isEqualTo(blob.length());
         } finally {
             execute("drop table if exists test");
         }

--- a/server/src/test/java/io/crate/rest/AdminUIHttpIntegrationTest.java
+++ b/server/src/test/java/io/crate/rest/AdminUIHttpIntegrationTest.java
@@ -24,12 +24,19 @@ package io.crate.rest;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.elasticsearch.common.network.NetworkModule.HTTP_DEFAULT_TYPE_SETTING;
 
-import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpClient.Redirect;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpRequest.Builder;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -37,27 +44,20 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 
-import org.apache.http.Header;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.client.protocol.HttpClientContext;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.message.BasicHeader;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.http.HttpServerTransport;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.IntegTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.Netty4Plugin;
+import org.junit.After;
 import org.junit.Before;
 
 public abstract class AdminUIHttpIntegrationTest extends IntegTestCase {
 
     protected InetSocketAddress address;
-    protected CloseableHttpClient httpClient = HttpClients.createDefault();
+    protected HttpClient httpClient;
 
     @Override
     protected boolean addMockHttpTransport() {
@@ -72,14 +72,17 @@ public abstract class AdminUIHttpIntegrationTest extends IntegTestCase {
             .build();
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
         return Arrays.asList(Netty4Plugin.class);
     }
 
     @Before
-    public void setup() throws IOException {
+    public void setup() throws Exception {
+        httpClient = HttpClient.newBuilder()
+            .followRedirects(Redirect.NORMAL)
+            .executor(cluster().getInstance(ThreadPool.class).generic())
+            .build();
         Iterable<HttpServerTransport> transports = cluster().getInstances(HttpServerTransport.class);
         Iterator<HttpServerTransport> httpTransports = transports.iterator();
         address = httpTransports.next().boundAddress().publishAddress().address();
@@ -90,56 +93,58 @@ public abstract class AdminUIHttpIntegrationTest extends IntegTestCase {
         Files.write(indexFile, Collections.singletonList("<h1>Crate Admin</h1>"), Charset.forName("UTF-8"));
     }
 
-    private CloseableHttpResponse executeAndDefaultAssertions(HttpUriRequest request) throws IOException {
-        CloseableHttpResponse resp = httpClient.execute(request);
-        assertThat(resp.containsHeader("Connection")).isFalse();
+    @After
+    public void closeClient() {
+        httpClient.close();
+    }
+
+    private HttpResponse<String> executeAndDefaultAssertions(HttpRequest request) throws Exception {
+        var resp = httpClient.send(request, BodyHandlers.ofString());
+        assertThat(resp.headers().firstValue("Connection")).isNotPresent();
         return resp;
     }
 
-    CloseableHttpResponse get(String uri) throws IOException {
-        return get(uri, null);
-    }
-
-    CloseableHttpResponse get(String uri, Header[] headers) throws IOException {
-        HttpGet httpGet = new HttpGet(String.format(Locale.ENGLISH, "http://%s:%s/%s", address.getHostName(), address.getPort(), uri));
-        if (headers != null) {
-            httpGet.setHeaders(headers);
+    HttpResponse<String> get(String path, String[] ... headers) throws Exception {
+        URI uri = URI.create(String.format(Locale.ENGLISH, "http://%s:%s%s", address.getHostName(), address.getPort(), path));
+        Builder builder = HttpRequest.newBuilder(uri);
+        for (String[] header : headers) {
+            builder.header(header[0], header[1]);
         }
-        return executeAndDefaultAssertions(httpGet);
+        return executeAndDefaultAssertions(builder.build());
     }
 
-    CloseableHttpResponse browserGet(String uri) throws IOException {
-        Header[] headers = {
-            browserHeader()
+    HttpResponse<String> browserGet(String uri) throws Exception {
+        return get(uri, browserHeader());
+    }
+
+    HttpResponse<String> post(String path) throws Exception {
+        URI uri = URI.create(String.format(Locale.ENGLISH, "http://%s:%s%s", address.getHostName(), address.getPort(), path));
+        HttpRequest request = HttpRequest.newBuilder(uri)
+            .POST(BodyPublishers.noBody())
+            .build();
+        return executeAndDefaultAssertions(request);
+    }
+
+    List<String> getAllRedirectLocations(String path, String[] ... headers) throws Exception {
+        URI uri = URI.create(String.format(Locale.ENGLISH, "http://%s:%s%s", address.getHostName(), address.getPort(), path));
+        Builder builder = HttpRequest.newBuilder(uri);
+        for (String[] header : headers) {
+            builder.header(header[0], header[1]);
+        }
+        var response = httpClient.send(builder.build(), BodyHandlers.discarding());
+        response = response.previousResponse().orElse(null);
+        List<String> redirects = new ArrayList<>();
+        while (response != null) {
+            redirects.addAll(response.headers().allValues("location"));
+            response = response.previousResponse().orElse(null);
+        }
+        return redirects;
+    }
+
+    static String[] browserHeader() {
+        return new String[] {
+            "User-Agent",
+            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.106 Safari/537.36"
         };
-        return get(uri, headers);
-    }
-
-    CloseableHttpResponse post(String uri) throws IOException {
-        HttpPost httpPost = new HttpPost(String.format(Locale.ENGLISH, "http://%s:%s/%s", address.getHostName(), address.getPort(), uri));
-        return executeAndDefaultAssertions(httpPost);
-    }
-
-    List<URI> getAllRedirectLocations(String uri, Header[] headers) throws IOException {
-        CloseableHttpResponse response = null;
-        try {
-            HttpClientContext context = HttpClientContext.create();
-            HttpGet httpGet = new HttpGet(String.format(Locale.ENGLISH, "http://%s:%s/%s", address.getHostName(), address.getPort(), uri));
-            if (headers != null) {
-                httpGet.setHeaders(headers);
-            }
-            response = httpClient.execute(httpGet, context);
-
-            // get all redirection locations
-            return context.getRedirectLocations();
-        } finally {
-            if (response != null) {
-                response.close();
-            }
-        }
-    }
-
-    static BasicHeader browserHeader() {
-        return new BasicHeader("User-Agent", "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.106 Safari/537.36");
     }
 }

--- a/server/src/test/java/io/crate/rest/AdminUIIntegrationTest.java
+++ b/server/src/test/java/io/crate/rest/AdminUIIntegrationTest.java
@@ -22,89 +22,59 @@
 package io.crate.rest;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertThat;
 
-import java.io.IOException;
-import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.http.HttpResponse;
 import java.util.List;
-import java.util.Locale;
 
-import org.apache.http.Header;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.entity.ContentType;
-import org.apache.http.message.BasicHeader;
-import org.apache.http.util.EntityUtils;
 import org.elasticsearch.test.IntegTestCase;
-import org.hamcrest.Matchers;
 import org.junit.Test;
 
 
 @IntegTestCase.ClusterScope(scope = IntegTestCase.Scope.SUITE, numDataNodes = 2)
 public class AdminUIIntegrationTest extends AdminUIHttpIntegrationTest {
 
-    private URI adminURI() throws URISyntaxException {
-        return new URI(String.format(Locale.ENGLISH, "http://%s:%d/", address.getHostName(), address.getPort()));
-    }
-
     @Test
-    public void testNonBrowserRequestToRoot() throws IOException {
+    public void testNonBrowserRequestToRoot() throws Exception {
         //request to root
         assertIsJsonInfoResponse(get(""));
     }
 
     @Test
-    public void testBrowserJsonRequestToRoot() throws IOException {
-        Header[] headers = {
-            browserHeader(),
-            new BasicHeader("Accept", "application/json")
-        };
-        assertIsJsonInfoResponse(get("/", headers));
+    public void testBrowserJsonRequestToRoot() throws Exception {
+        assertIsJsonInfoResponse(get("/", browserHeader(), new String[] { "Accept", "application/json" }));
     }
 
     @Test
-    public void testLegacyRedirect() throws IOException, URISyntaxException {
+    public void testLegacyRedirect() throws Exception, URISyntaxException {
         //request to '/admin' is redirected to '/index.html'
-        Header[] headers = {
-            browserHeader()
-        };
-
-        List<URI> allRedirectLocations = getAllRedirectLocations("/admin", headers);
-
-        // all redirect locations should not be null
-        assertThat(allRedirectLocations).isNotNull();
-        // all redirect locations should contain the crateAdminUI URI
-        assertThat(allRedirectLocations.contains(adminURI())).isTrue();
+        List<String> allRedirectLocations = getAllRedirectLocations("/admin", browserHeader());
+        assertThat(allRedirectLocations).contains("/");
     }
 
     @Test
-    public void testPluginURLRedirect() throws IOException, URISyntaxException {
+    public void testPluginURLRedirect() throws Exception, URISyntaxException {
         //request to '/_plugin/crate-admin' is redirected to '/'
-        Header[] headers = {
-            browserHeader()
-        };
 
-        List<URI> allRedirectLocations = getAllRedirectLocations("/_plugin/crate-admin", headers);
-
-        // all redirect locations should contain the crateAdminUI URI
-        assertThat(allRedirectLocations.contains(adminURI())).isTrue();
+        List<String> allRedirectLocations = getAllRedirectLocations("/_plugin/crate-admin", browserHeader());
+        assertThat(allRedirectLocations).contains("/");
     }
 
     @Test
-    public void testPluginURLRedirectReturnsIndex() throws IOException, URISyntaxException {
+    public void testPluginURLRedirectReturnsIndex() throws Exception, URISyntaxException {
         //request to '/_plugins/crate-admin' is redirected to '/index.html'
         assertIsIndexResponse(browserGet("/_plugin/crate-admin"));
     }
 
     @Test
-    public void testPostForbidden() throws IOException {
-        CloseableHttpResponse response = post("/static/");
+    public void testPostForbidden() throws Exception {
+        var response = post("/static/");
         //status should be 403 FORBIDDEN
-        assertThat(response.getStatusLine().getStatusCode()).isEqualTo(403);
+        assertThat(response.statusCode()).isEqualTo(403);
     }
 
     @Test
-    public void testGetHTML() throws IOException {
+    public void testGetHTML() throws Exception {
         assertIsIndexResponse(browserGet("/"));
         assertIsIndexResponse(browserGet("/index.html"));
         assertIsIndexResponse(browserGet("//index.html"));
@@ -112,27 +82,24 @@ public class AdminUIIntegrationTest extends AdminUIHttpIntegrationTest {
 
     @Test
     public void testNotFound() throws Exception {
-        CloseableHttpResponse response = browserGet("/static/does/not/exist.html");
-        assertThat(response.getStatusLine().getStatusCode()).isEqualTo(404);
+        var response = browserGet("/static/does/not/exist.html");
+        assertThat(response.statusCode()).isEqualTo(404);
     }
 
-    private static void assertIsIndexResponse(CloseableHttpResponse response) throws IOException {
+    private static void assertIsIndexResponse(HttpResponse<String> response) throws Exception {
         //response body should not be null
-        String bodyAsString = EntityUtils.toString(response.getEntity());
-        assertThat(bodyAsString, Matchers.startsWith("<h1>Crate Admin</h1>"));
-        assertThat(response.getHeaders("Content-Type")[0].getValue()).isEqualTo("text/html");
+        assertThat(response.body()).startsWith("<h1>Crate Admin</h1>");
+        assertThat(response.headers().firstValue("Content-Type")).hasValue("text/html");
     }
 
-    private static void assertIsJsonInfoResponse(CloseableHttpResponse response) throws IOException {
+    private static void assertIsJsonInfoResponse(HttpResponse<String> response) throws Exception {
         //status should be 200 OK
-        assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
+        assertThat(response.statusCode()).isEqualTo(200);
 
-        //response body should not be null
-        String bodyAsString = EntityUtils.toString(response.getEntity());
-        assertThat(bodyAsString).isNotNull();
+        assertThat(response.body()).isNotNull();
 
         //check content-type of response is json
-        String contentMimeType = ContentType.getOrDefault(response.getEntity()).getMimeType();
-        assertThat(contentMimeType).isEqualTo(ContentType.APPLICATION_JSON.getMimeType());
+        String contentMimeType = response.headers().firstValue("Content-Type").orElse("");
+        assertThat(contentMimeType).isEqualTo("application/json");
     }
 }

--- a/server/src/testFixtures/java/io/crate/test/utils/Blobs.java
+++ b/server/src/testFixtures/java/io/crate/test/utils/Blobs.java
@@ -22,6 +22,7 @@
 package io.crate.test.utils;
 
 import java.net.InetSocketAddress;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -40,13 +41,13 @@ public class Blobs {
         }
     }
 
-    public static String url(boolean https, InetSocketAddress address, String table, String digest) {
+    public static URI url(boolean https, InetSocketAddress address, String table, String digest) {
         return url(https, address, table + "/" + digest);
     }
 
-    public static String url(boolean https, InetSocketAddress address, String tableAndDigest) {
+    public static URI url(boolean https, InetSocketAddress address, String tableAndDigest) {
         String protocol = https ? "https" : "http";
-        return String.format(Locale.ENGLISH, "%s://%s:%s/_blobs/%s",
-            protocol, address.getHostName(), address.getPort(), tableAndDigest);
+        return URI.create(String.format(Locale.ENGLISH, "%s://%s:%s/_blobs/%s",
+            protocol, address.getHostName(), address.getPort(), tableAndDigest));
     }
 }


### PR DESCRIPTION
Tests depended on the undeclared apache http client dependency, which got pulled in via the aws s3 sdk.

(This isn't removing the aws s3 sdk yet, because the `DnsResolver` from the package is also used)