### PR TITLE
Fix blob file transfer to clients via HTTPS

### DIFF
--- a/docs/appendices/release-notes/5.7.2.rst
+++ b/docs/appendices/release-notes/5.7.2.rst
@@ -52,6 +52,9 @@ Security Fixes
 Fixes
 =====
 
+- Fixed an issue that could lead to requests getting stuck when trying to
+  download a blob via HTTPS.
+
 - Fixed an issue leading to slow query processing during the analysis phase,
   when the ``WHERE``` clause of a query contains columns of a
   :ref:`PRIMARY KEY <constraints-primary-key>` and combines them using complex

--- a/server/src/main/java/io/crate/protocols/http/HttpBlobHandler.java
+++ b/server/src/main/java/io/crate/protocols/http/HttpBlobHandler.java
@@ -21,6 +21,26 @@
 
 package io.crate.protocols.http;
 
+import static io.netty.handler.codec.http.HttpResponseStatus.CONTINUE;
+import static io.netty.handler.codec.http.HttpResponseStatus.PARTIAL_CONTENT;
+import static io.netty.handler.codec.http.HttpResponseStatus.TEMPORARY_REDIRECT;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.channels.ClosedChannelException;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
+import org.elasticsearch.http.netty4.cors.Netty4CorsConfig;
+import org.elasticsearch.http.netty4.cors.Netty4CorsHandler;
+import org.elasticsearch.index.IndexNotFoundException;
+import org.jetbrains.annotations.Nullable;
+
 import io.crate.blob.BlobService;
 import io.crate.blob.RemoteDigestBlob;
 import io.crate.blob.exceptions.DigestMismatchException;
@@ -39,7 +59,6 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelProgressiveFuture;
 import io.netty.channel.ChannelProgressiveFutureListener;
 import io.netty.channel.DefaultFileRegion;
-import io.netty.channel.FileRegion;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.DefaultHttpResponse;
@@ -55,25 +74,6 @@ import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.ssl.NotSslRecordException;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.stream.ChunkedFile;
-import org.apache.logging.log4j.Logger;
-import org.jetbrains.annotations.Nullable;
-import org.apache.logging.log4j.LogManager;
-import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
-import org.elasticsearch.http.netty4.cors.Netty4CorsConfig;
-import org.elasticsearch.http.netty4.cors.Netty4CorsHandler;
-import org.elasticsearch.index.IndexNotFoundException;
-
-import java.io.IOException;
-import java.io.RandomAccessFile;
-import java.nio.channels.ClosedChannelException;
-import java.util.Locale;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import static io.netty.handler.codec.http.HttpResponseStatus.CONTINUE;
-import static io.netty.handler.codec.http.HttpResponseStatus.PARTIAL_CONTENT;
-import static io.netty.handler.codec.http.HttpResponseStatus.TEMPORARY_REDIRECT;
-import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 
 
 public class HttpBlobHandler extends SimpleChannelInboundHandler<Object> {
@@ -93,8 +93,6 @@ public class HttpBlobHandler extends SimpleChannelInboundHandler<Object> {
     private final BlobService blobService;
     private final BlobIndicesService blobIndicesService;
     private final Netty4CorsConfig corsConfig;
-    private String activeScheme;
-    private boolean sslEnabled;
     private HttpRequest currentMessage;
 
     private RemoteDigestBlob digestBlob;
@@ -107,8 +105,6 @@ public class HttpBlobHandler extends SimpleChannelInboundHandler<Object> {
         this.blobService = blobService;
         this.blobIndicesService = blobIndicesService;
         this.corsConfig = corsConfig;
-        this.activeScheme = SCHEME_HTTP;
-        this.sslEnabled = false;
     }
 
     private boolean possibleRedirect(HttpRequest request, String index, String digest) {
@@ -127,7 +123,7 @@ public class HttpBlobHandler extends SimpleChannelInboundHandler<Object> {
 
             if (redirectAddress != null) {
                 LOGGER.trace("redirectAddress: {}", redirectAddress);
-                sendRedirect(request, activeScheme + redirectAddress);
+                sendRedirect(request, activeScheme() + redirectAddress);
                 return true;
             }
         }
@@ -385,13 +381,14 @@ public class HttpBlobHandler extends SimpleChannelInboundHandler<Object> {
         Netty4CorsHandler.setCorsResponseHeaders(request, response, corsConfig);
         final RandomAccessFile raf = blobShard.blobContainer().getRandomAccessFile(digest);
         try {
+            maybeSetConnectionCloseHeader(response);
             HttpUtil.setContentLength(response, raf.length());
             setDefaultGetHeaders(response);
             LOGGER.trace("HttpResponse: {}", response);
-            Channel channel = ctx.channel();
-            channel.write(response);
+            boolean keepAlive = HttpUtil.isKeepAlive(request);
+            ctx.channel().write(response);
             ChannelFuture writeFuture = transferFile(digest, raf, 0, raf.length());
-            if (!HttpUtil.isKeepAlive(request)) {
+            if (!keepAlive) {
                 writeFuture.addListener(ChannelFutureListener.CLOSE);
             }
         } catch (Throwable t) {
@@ -405,23 +402,31 @@ public class HttpBlobHandler extends SimpleChannelInboundHandler<Object> {
         }
     }
 
-    private ChannelFuture transferFile(final String digest, RandomAccessFile raf, long position, long count)
-        throws IOException {
+    private boolean sslEnabled() {
+        return ctx.pipeline().get(SslHandler.class) != null;
+    }
 
+    private String activeScheme() {
+        return sslEnabled() ? SCHEME_HTTPS : SCHEME_HTTP;
+    }
+
+    private ChannelFuture transferFile(final String digest,
+                                       RandomAccessFile raf,
+                                       long position,
+                                       long count) throws IOException {
         Channel channel = ctx.channel();
         final ChannelFuture fileFuture;
-        final ChannelFuture endMarkerFuture;
-        if (sslEnabled) {
-            HttpChunkedInput httpChunkedInput =
-                new HttpChunkedInput(new ChunkedFile(raf, 0, count, HTTPS_CHUNK_SIZE));
-            fileFuture = channel.writeAndFlush(httpChunkedInput, ctx.newProgressivePromise());
-            // HttpChunkedInput also writes the end marker (LastHttpContent) for us.
-            endMarkerFuture = fileFuture;
+        final ChannelFuture lastContentFuture;
+        if (sslEnabled()) {
+            var chunkedFile = new ChunkedFile(raf, 0, count, HTTPS_CHUNK_SIZE);
+            fileFuture = channel.writeAndFlush(new HttpChunkedInput(chunkedFile), ctx.newProgressivePromise());
+
+            // HttpChunkedInput also writes the end marker (LastHttpContent)
+            lastContentFuture = fileFuture;
         } else {
-            FileRegion region = new DefaultFileRegion(raf.getChannel(), position, count);
+            var region = new DefaultFileRegion(raf.getChannel(), position, count);
             fileFuture = channel.write(region, ctx.newProgressivePromise());
-            // Flushes and sets the ending marker
-            endMarkerFuture = channel.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT);
+            lastContentFuture = channel.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT);
         }
 
         fileFuture.addListener(new ChannelProgressiveFutureListener() {
@@ -436,7 +441,7 @@ public class HttpBlobHandler extends SimpleChannelInboundHandler<Object> {
             }
         });
 
-        return endMarkerFuture;
+        return lastContentFuture;
     }
 
     private void setDefaultGetHeaders(HttpResponse response) {
@@ -515,12 +520,5 @@ public class HttpBlobHandler extends SimpleChannelInboundHandler<Object> {
     @Override
     public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
         this.ctx = ctx;
-        if (ctx.pipeline().get(SslHandler.class) == null) {
-            this.sslEnabled = false;
-            this.activeScheme = SCHEME_HTTP;
-        } else {
-            this.sslEnabled = true;
-            this.activeScheme = SCHEME_HTTPS;
-        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
+++ b/server/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
@@ -123,6 +123,7 @@ import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpRequestDecoder;
 import io.netty.handler.codec.http.HttpResponseEncoder;
+import io.netty.handler.stream.ChunkedWriteHandler;
 import io.netty.handler.timeout.ReadTimeoutHandler;
 import io.netty.util.concurrent.Future;
 
@@ -546,6 +547,7 @@ public class Netty4HttpServerTransport extends AbstractLifecycleComponent implem
             ch.pipeline().addLast("encoder", new HttpResponseEncoder());
             final HttpObjectAggregator aggregator = new HttpObjectAggregator(Math.toIntExact(transport.maxContentLength.getBytes()));
             aggregator.setMaxCumulationBufferComponents(transport.maxCompositeBufferComponents);
+            ch.pipeline().addLast("chunked", new ChunkedWriteHandler());
             ch.pipeline().addLast("aggregator", aggregator);
             if (transport.compression) {
                 ch.pipeline().addLast("encoder_compress", new HttpContentCompressor(transport.compressionLevel));


### PR DESCRIPTION
Blob download via HTTPS could get stuck due to:

- Wrong `sslEnabled` detection. `handlerAdded` was called _before_ the
  SslHandler was added to the pipeline. So it never observed SSL being
  active.

- `ChunkedWriteHandler` missing in the pipeline

In the following example the second request never returned:

    http --verify no put https://localhost:4200/_blobs/tbl/4a756ca07e9487f482465a99e8286abc86ba4dc7 --raw="contents"
    http --verify no get https://localhost:4200/_blobs/tbl/4a756ca07e9487f482465a99e8286abc86ba4dc7

For some reason the Apache HTTP client wasn't affected, which is why the
`CrateHttpsTransportIntegrationTest.testBlobLayer` test case which
covers the scenario didn't fail.

This commit doesn't add a new test because switching to the JDK
HttpClient (https://github.com/crate/crate/pull/16135) surfaced the
issue.
