### PR TITLE
Fix column pruning for correlated sub-queries

### DIFF
--- a/server/src/main/java/io/crate/planner/operators/CorrelatedJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/CorrelatedJoin.java
@@ -21,7 +21,6 @@
 
 package io.crate.planner.operators;
 
-import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -163,18 +162,12 @@ public class CorrelatedJoin implements LogicalPlan {
         if (inputPlan == newInputPlan) {
             return this;
         }
-        List<Symbol> newOutputs = new ArrayList<>();
-        for (Symbol output: outputs) {
-            if (toCollect.contains(output)) {
-                newOutputs.add(output);
-            }
-        }
 
         return new CorrelatedJoin(
             newInputPlan,
             selectSymbol,
             subQueryPlan,
-            newOutputs
+            Lists.concat(newInputPlan.outputs(), selectSymbol)
         );
     }
 

--- a/server/src/test/java/io/crate/planner/CorrelatedJoinPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/CorrelatedJoinPlannerTest.java
@@ -131,7 +131,7 @@ public class CorrelatedJoinPlannerTest extends CrateDummyClusterServiceUnitTest 
         );
         CorrelatedJoin join = new CorrelatedJoin(collect, selectSymbol, null);
         assertThat(join.outputs()).containsExactly(a, b, selectSymbol);
-        LogicalPlan pruned = join.pruneOutputsExcept(List.of(selectSymbol));
+        LogicalPlan pruned = join.pruneOutputsExcept(List.of(b, selectSymbol));
         assertThat(pruned.outputs())
             .as("removes unused a")
             .containsExactly(b, selectSymbol);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fix column pruning for correlated sub-queries

Fixes https://github.com/crate/crate/issues/16124


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
