### PR TITLE
Untangle UserDefinedFunctionService from NodeContext/Schemas

### DIFF
--- a/extensions/lang-js/src/test/java/io/crate/operation/language/JavascriptUserDefinedFunctionTest.java
+++ b/extensions/lang-js/src/test/java/io/crate/operation/language/JavascriptUserDefinedFunctionTest.java
@@ -24,7 +24,6 @@ package io.crate.operation.language;
 import static io.crate.testing.Asserts.isLiteral;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -35,7 +34,6 @@ import java.util.stream.Collectors;
 
 import javax.script.ScriptException;
 
-import org.elasticsearch.cluster.service.ClusterService;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -50,7 +48,6 @@ import io.crate.expression.udf.UserDefinedFunctionService;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.FunctionProvider;
 import io.crate.metadata.Schemas;
-import io.crate.metadata.doc.DocTableInfoFactory;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 
@@ -65,11 +62,7 @@ public class JavascriptUserDefinedFunctionTest extends ScalarTestCase {
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        udfService = new UserDefinedFunctionService(
-            mock(ClusterService.class),
-            new DocTableInfoFactory(sqlExpressions.nodeCtx),
-            sqlExpressions.nodeCtx
-        );
+        udfService = new UserDefinedFunctionService(clusterService, sqlExpressions.nodeCtx);
         new JavaScriptLanguage(udfService);
     }
 
@@ -91,9 +84,7 @@ public class JavascriptUserDefinedFunctionTest extends ScalarTestCase {
             var resolvers = functionImplementations.computeIfAbsent(
                 functionName, k -> new ArrayList<>());
             resolvers.add(udfService.buildFunctionResolver(udf));
-            sqlExpressions.nodeCtx.functions().registerUdfFunctionImplementationsForSchema(
-                Schemas.DOC_SCHEMA_NAME,
-                functionImplementations);
+            sqlExpressions.nodeCtx.functions().setUDFs(functionImplementations);
         } else {
             throw new ScriptException(validation);
         }

--- a/server/src/main/java/io/crate/expression/udf/UserDefinedFunctionService.java
+++ b/server/src/main/java/io/crate/expression/udf/UserDefinedFunctionService.java
@@ -21,16 +21,13 @@
 
 package io.crate.expression.udf;
 
-import static io.crate.metadata.doc.DocSchemaInfo.NO_BLOB_NOR_DANGLING;
-
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import java.util.function.Predicate;
 
 import javax.script.ScriptException;
 
@@ -38,54 +35,46 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateListener;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.jetbrains.annotations.Nullable;
-
-import io.crate.analyze.ParamTypeHints;
-import io.crate.analyze.expressions.ExpressionAnalysisContext;
-import io.crate.analyze.expressions.ExpressionAnalyzer;
-import io.crate.analyze.expressions.TableReferenceResolver;
 import org.jetbrains.annotations.VisibleForTesting;
+
 import io.crate.common.collections.Lists;
 import io.crate.common.unit.TimeValue;
-import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.exceptions.UserDefinedFunctionAlreadyExistsException;
 import io.crate.exceptions.UserDefinedFunctionUnknownException;
-import io.crate.metadata.ColumnIdent;
-import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.SymbolVisitors;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.FunctionProvider;
 import io.crate.metadata.FunctionType;
 import io.crate.metadata.GeneratedReference;
-import io.crate.metadata.IndexParts;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Reference;
 import io.crate.metadata.Scalar;
-import io.crate.metadata.doc.DocTableInfoFactory;
+import io.crate.metadata.Schemas;
+import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
-import io.crate.sql.parser.SqlParser;
-import io.crate.sql.tree.Expression;
 import io.crate.types.DataType;
 
 
-public class UserDefinedFunctionService {
+public class UserDefinedFunctionService extends AbstractLifecycleComponent implements ClusterStateListener {
 
     private static final Logger LOGGER = LogManager.getLogger(UserDefinedFunctionService.class);
 
     private final ClusterService clusterService;
     private final NodeContext nodeCtx;
     private final Map<String, UDFLanguage> languageRegistry = new HashMap<>();
-    private final DocTableInfoFactory docTableFactory;
 
-    public UserDefinedFunctionService(ClusterService clusterService,
-                                      DocTableInfoFactory docTableFactory,
-                                      NodeContext nodeCtx) {
+    public UserDefinedFunctionService(ClusterService clusterService, NodeContext nodeCtx) {
         this.clusterService = clusterService;
-        this.docTableFactory = docTableFactory;
         this.nodeCtx = nodeCtx;
     }
 
@@ -149,6 +138,7 @@ public class UserDefinedFunctionService {
                 public ClusterState execute(ClusterState currentState) throws Exception {
                     Metadata metadata = currentState.metadata();
                     Metadata.Builder mdBuilder = Metadata.builder(currentState.metadata());
+                    ensureFunctionIsUnused(schema, name, argumentTypes);
                     UserDefinedFunctionsMetadata functions = removeFunction(
                         metadata.custom(UserDefinedFunctionsMetadata.TYPE),
                         schema,
@@ -157,12 +147,6 @@ public class UserDefinedFunctionService {
                         ifExists
                     );
                     mdBuilder.putCustom(UserDefinedFunctionsMetadata.TYPE, functions);
-                    validateFunctionIsNotInUseByGeneratedColumn(
-                        schema,
-                        schema + "." + UserDefinedFunctionMetadata.specificName(name, argumentTypes),
-                        functions,
-                        currentState
-                    );
                     return ClusterState.builder(currentState).metadata(mdBuilder).build();
                 }
 
@@ -224,28 +208,18 @@ public class UserDefinedFunctionService {
         }
     }
 
-
-    public void updateImplementations(String schema, Stream<UserDefinedFunctionMetadata> userDefinedFunctions) {
-        updateImplementations(schema, userDefinedFunctions, nodeCtx);
-    }
-
-    public void updateImplementations(String schema,
-                                      Stream<UserDefinedFunctionMetadata> userDefinedFunctions,
-                                      NodeContext nodeCtx) {
+    public void updateImplementations(List<UserDefinedFunctionMetadata> userDefinedFunctions) {
         final Map<FunctionName, List<FunctionProvider>> implementations = new HashMap<>();
-        Iterator<UserDefinedFunctionMetadata> it = userDefinedFunctions.iterator();
-        while (it.hasNext()) {
-            UserDefinedFunctionMetadata udf = it.next();
-            FunctionProvider resolver = buildFunctionResolver(udf);
-            if (resolver == null) {
+        for (var functionMetadata : userDefinedFunctions) {
+            FunctionProvider provider = buildFunctionResolver(functionMetadata);
+            if (provider == null) {
                 continue;
             }
-            var functionName = new FunctionName(udf.schema(), udf.name());
-            var resolvers = implementations.computeIfAbsent(
-                functionName, k -> new ArrayList<>());
-            resolvers.add(resolver);
+            FunctionName name = provider.signature().getName();
+            var providers = implementations.computeIfAbsent(name, k -> new ArrayList<>());
+            providers.add(provider);
         }
-        nodeCtx.functions().registerUdfFunctionImplementationsForSchema(schema, implementations);
+        nodeCtx.functions().setUDFs(implementations);
     }
 
     @Nullable
@@ -277,62 +251,60 @@ public class UserDefinedFunctionService {
         return new FunctionProvider(signature, (s, args) -> scalar);
     }
 
-    void validateFunctionIsNotInUseByGeneratedColumn(String schema,
-                                                     String functionName,
-                                                     UserDefinedFunctionsMetadata functionsMetadata,
-                                                     ClusterState currentState) {
-        // The iteration of schemas/tables must happen on the node context WITHOUT the UDF already removed.
-        // Otherwise the lazy table factories will already fail while evaluating generated functionsMetadata.
-        // To avoid that, a copy of the node context with the removed UDF function is used on concrete expression evaluation.
-        var nodeCtxWithRemovedFunction = nodeCtx.copy();
-        updateImplementations(schema, functionsMetadata.functionsMetadata().stream(), nodeCtxWithRemovedFunction);
-
-        var metadata = currentState.metadata();
-        var indices = Stream.of(metadata.getConcreteAllIndices()).filter(NO_BLOB_NOR_DANGLING)
-            .map(IndexParts::new)
-            .filter(indexParts -> !indexParts.isPartitioned())
-            .collect(Collectors.toList());
-        var templates = metadata.templates().keysIt();
-        while (templates.hasNext()) {
-            var indexParts = new IndexParts(templates.next());
-            if (indexParts.isPartitioned()) {
-                indices.add(indexParts);
-            }
-        }
-
-        for (var indexParts : indices) {
-            var tableInfo = docTableFactory.create(indexParts.toRelationName(), currentState.metadata());
-            var functionParameters = getReferencedRefs(tableInfo.generatedColumns());
-            TableReferenceResolver tableReferenceResolver = new TableReferenceResolver(
-                functionParameters,
-                tableInfo.ident()
-            );
-            CoordinatorTxnCtx coordinatorTxnCtx = CoordinatorTxnCtx.systemTransactionContext();
-            ExpressionAnalyzer exprAnalyzer = new ExpressionAnalyzer(
-                coordinatorTxnCtx, nodeCtxWithRemovedFunction, ParamTypeHints.EMPTY, tableReferenceResolver, null);
-            for (var ref : tableInfo.columns()) {
-                if (ref instanceof GeneratedReference genRef) {
-                    Expression expression = SqlParser.createExpression(genRef.formattedGeneratedExpression());
-                    try {
-                        exprAnalyzer.convert(expression, new ExpressionAnalysisContext(coordinatorTxnCtx.sessionSettings()));
-                    } catch (UnsupportedFunctionException e) {
-                        throw new IllegalArgumentException(
-                            "Cannot drop function '" + functionName + "', it is still in use by '" +
-                                tableInfo + "." + genRef + "'"
-                        );
+    /**
+     * Verifies that the function is not used in:
+     *
+     * <ul>
+     * <li>A generated column expression</li>
+     * </ul>
+     **/
+    void ensureFunctionIsUnused(String schema, String functionName, List<DataType<?>> argTypes) {
+        Schemas schemas = nodeCtx.schemas();
+        FunctionName name = new FunctionName(schema, functionName);
+        Predicate<Symbol> isFunction = s -> s instanceof Function fn
+            && fn.signature().getName().equals(name)
+            && fn.signature().getArgumentDataTypes().equals(argTypes);
+        for (var schemaInfo : schemas) {
+            for (var tableInfo : schemaInfo.getTables()) {
+                if (!(tableInfo instanceof DocTableInfo docTable)) {
+                    continue;
+                }
+                List<GeneratedReference> generatedColumns = docTable.generatedColumns();
+                for (var genColumn : generatedColumns) {
+                    if (SymbolVisitors.any(isFunction, genColumn.generatedExpression())) {
+                        throw new IllegalArgumentException(String.format(
+                            Locale.ENGLISH,
+                            "Cannot drop function '%s'. It is in use by column '%s' of table '%s'",
+                            name.displayName(),
+                            genColumn.column(),
+                            docTable.ident()
+                        ));
                     }
                 }
             }
         }
     }
 
-    private static Map<ColumnIdent, Reference> getReferencedRefs(List<GeneratedReference> generatedReferences) {
-        Map<ColumnIdent, Reference> referencedReferences = new HashMap<>();
-        for (var generatedRef : generatedReferences) {
-            for (var referencedRef : generatedRef.referencedReferences()) {
-                referencedReferences.put(referencedRef.column(), referencedRef);
-            }
+    @Override
+    public void clusterChanged(ClusterChangedEvent event) {
+        if (event.changedCustomMetadataSet().contains(UserDefinedFunctionsMetadata.TYPE)) {
+            Metadata newMetadata = event.state().metadata();
+            UserDefinedFunctionsMetadata udfMetadata = newMetadata.custom(UserDefinedFunctionsMetadata.TYPE);
+            updateImplementations(udfMetadata == null ? List.of() : udfMetadata.functionsMetadata());
         }
-        return referencedReferences;
+    }
+
+    @Override
+    protected void doStart() {
+        clusterService.addListener(this);
+    }
+
+    @Override
+    protected void doStop() {
+        clusterService.removeListener(this);
+    }
+
+    @Override
+    protected void doClose() throws IOException {
     }
 }

--- a/server/src/main/java/io/crate/metadata/NodeContext.java
+++ b/server/src/main/java/io/crate/metadata/NodeContext.java
@@ -21,8 +21,24 @@
 
 package io.crate.metadata;
 
-import io.crate.role.Roles;
+import java.util.Map;
 import java.util.function.Function;
+
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.env.Environment;
+
+import io.crate.analyze.relations.RelationAnalyzer;
+import io.crate.metadata.blob.BlobSchemaInfo;
+import io.crate.metadata.blob.BlobTableInfoFactory;
+import io.crate.metadata.doc.DocSchemaInfoFactory;
+import io.crate.metadata.doc.DocTableInfoFactory;
+import io.crate.metadata.information.InformationSchemaInfo;
+import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
+import io.crate.metadata.sys.SysSchemaInfo;
+import io.crate.metadata.table.SchemaInfo;
+import io.crate.metadata.view.ViewInfoFactory;
+import io.crate.role.Roles;
+import io.crate.statistics.TableStats;
 
 public class NodeContext {
 
@@ -30,6 +46,35 @@ public class NodeContext {
     private final long serverStartTimeInMs;
     private final Roles roles;
     private final Schemas schemas;
+
+    public static NodeContext of(Environment environment,
+                                 ClusterService clusterService,
+                                 Functions functions,
+                                 Roles roles,
+                                 TableStats tableStats) {
+        return new NodeContext(functions, roles, nodeCtx -> {
+            var tableInfoFactory = new DocTableInfoFactory(nodeCtx);
+            BlobSchemaInfo blobSchemaInfo = new BlobSchemaInfo(
+                clusterService,
+                new BlobTableInfoFactory(clusterService.getSettings(), environment));
+            Map<String, SchemaInfo> systemSchemas = Map.of(
+                SysSchemaInfo.NAME, new SysSchemaInfo(clusterService, nodeCtx.roles()),
+                InformationSchemaInfo.NAME, new InformationSchemaInfo(),
+                PgCatalogSchemaInfo.NAME, new PgCatalogSchemaInfo(tableStats, nodeCtx.roles()),
+                BlobSchemaInfo.NAME, blobSchemaInfo
+            );
+            var relationAnalyzer = new RelationAnalyzer(nodeCtx);
+            var viewInfoFactory = new ViewInfoFactory(() -> relationAnalyzer);
+            Schemas schemas = new Schemas(
+                systemSchemas,
+                clusterService,
+                new DocSchemaInfoFactory(tableInfoFactory, viewInfoFactory),
+                nodeCtx.roles()
+            );
+            schemas.start();
+            return schemas;
+        });
+    }
 
     public NodeContext(Functions functions, Roles roles, Function<NodeContext, Schemas> createSchemas) {
         this.functions = functions;
@@ -52,9 +97,5 @@ public class NodeContext {
 
     public Schemas schemas() {
         return schemas;
-    }
-
-    public NodeContext copy() {
-        return new NodeContext(functions.copyOf(), roles, (nodeContext) -> schemas);
     }
 }

--- a/server/src/main/java/io/crate/metadata/Schemas.java
+++ b/server/src/main/java/io/crate/metadata/Schemas.java
@@ -334,6 +334,14 @@ public class Schemas extends AbstractLifecycleComponent implements Iterable<Sche
         return schemaInfo;
     }
 
+    public SchemaInfo getSystemSchema(String name) {
+        SchemaInfo schemaInfo = builtInSchemas.get(name);
+        if (schemaInfo == null) {
+            throw new SchemaUnknownException(name);
+        }
+        return schemaInfo;
+    }
+
     @NotNull
     public Iterator<SchemaInfo> iterator() {
         return schemas.values().iterator();

--- a/server/src/main/java/io/crate/metadata/doc/DocSchemaInfo.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocSchemaInfo.java
@@ -50,10 +50,7 @@ import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 
 import io.crate.blob.v2.BlobIndex;
 import io.crate.exceptions.ResourceUnknownException;
-import io.crate.expression.udf.UserDefinedFunctionService;
-import io.crate.expression.udf.UserDefinedFunctionsMetadata;
 import io.crate.metadata.IndexParts;
-import io.crate.metadata.NodeContext;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Schemas;
@@ -122,8 +119,6 @@ public class DocSchemaInfo implements SchemaInfo {
     private final ClusterService clusterService;
     private final DocTableInfoFactory docTableInfoFactory;
     private final ViewInfoFactory viewInfoFactory;
-    private final NodeContext nodeCtx;
-    private final UserDefinedFunctionService udfService;
 
     private final ConcurrentHashMap<String, DocTableInfo> docTableByName = new ConcurrentHashMap<>();
 
@@ -137,14 +132,10 @@ public class DocSchemaInfo implements SchemaInfo {
      */
     public DocSchemaInfo(final String schemaName,
                          ClusterService clusterService,
-                         NodeContext nodeCtx,
-                         UserDefinedFunctionService udfService,
                          ViewInfoFactory viewInfoFactory,
                          DocTableInfoFactory docTableInfoFactory) {
-        this.nodeCtx = nodeCtx;
         this.schemaName = schemaName;
         this.clusterService = clusterService;
-        this.udfService = udfService;
         this.viewInfoFactory = viewInfoFactory;
         this.docTableInfoFactory = docTableInfoFactory;
     }
@@ -302,14 +293,6 @@ public class DocSchemaInfo implements SchemaInfo {
             }
         }
 
-        // re register UDFs for this schema
-        UserDefinedFunctionsMetadata udfMetadata = newMetadata.custom(UserDefinedFunctionsMetadata.TYPE);
-        if (udfMetadata != null) {
-            udfService.updateImplementations(
-                schemaName,
-                udfMetadata.functionsMetadata().stream().filter(f -> schemaName.equals(f.schema())));
-        }
-
         PublicationsMetadata prevPublicationsMetadata = prevMetadata.custom(PublicationsMetadata.TYPE);
         PublicationsMetadata newPublicationsMetadata = newMetadata.custom(PublicationsMetadata.TYPE);
         var tablesAffectedByPublicationsChange = getTablesAffectedByPublicationsChange(prevPublicationsMetadata,
@@ -446,6 +429,5 @@ public class DocSchemaInfo implements SchemaInfo {
 
     @Override
     public void close() throws Exception {
-        nodeCtx.functions().deregisterUdfResolversForSchema(schemaName);
     }
 }

--- a/server/src/main/java/io/crate/metadata/doc/DocSchemaInfoFactory.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocSchemaInfoFactory.java
@@ -21,29 +21,22 @@
 
 package io.crate.metadata.doc;
 
-import io.crate.expression.udf.UserDefinedFunctionService;
-import io.crate.metadata.NodeContext;
-import io.crate.metadata.view.ViewInfoFactory;
 import org.elasticsearch.cluster.service.ClusterService;
+
+import io.crate.metadata.view.ViewInfoFactory;
 
 public class DocSchemaInfoFactory {
 
     private final DocTableInfoFactory docTableInfoFactory;
     private final ViewInfoFactory viewInfoFactory;
-    private final NodeContext nodeCtx;
-    private final UserDefinedFunctionService udfService;
 
     public DocSchemaInfoFactory(DocTableInfoFactory docTableInfoFactory,
-                                ViewInfoFactory viewInfoFactory,
-                                NodeContext nodeCtx,
-                                UserDefinedFunctionService udfService) {
+                                ViewInfoFactory viewInfoFactory) {
         this.docTableInfoFactory = docTableInfoFactory;
         this.viewInfoFactory = viewInfoFactory;
-        this.nodeCtx = nodeCtx;
-        this.udfService = udfService;
     }
 
     public DocSchemaInfo create(String schemaName, ClusterService clusterService) {
-        return new DocSchemaInfo(schemaName, clusterService, nodeCtx, udfService, viewInfoFactory, docTableInfoFactory);
+        return new DocSchemaInfo(schemaName, clusterService, viewInfoFactory, docTableInfoFactory);
     }
 }

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -39,7 +39,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
@@ -164,7 +163,6 @@ import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.transport.netty4.Netty4Transport;
 import org.jetbrains.annotations.Nullable;
 
-import io.crate.analyze.relations.RelationAnalyzer;
 import io.crate.auth.AlwaysOKAuthentication;
 import io.crate.auth.AuthSettings;
 import io.crate.auth.Authentication;
@@ -195,19 +193,14 @@ import io.crate.metadata.MetadataModule;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.blob.BlobSchemaInfo;
-import io.crate.metadata.blob.BlobTableInfoFactory;
-import io.crate.metadata.doc.DocSchemaInfoFactory;
-import io.crate.metadata.doc.DocTableInfoFactory;
 import io.crate.metadata.information.InformationSchemaInfo;
 import io.crate.metadata.information.MetadataInformationModule;
 import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
 import io.crate.metadata.settings.session.SessionSettingRegistry;
 import io.crate.metadata.sys.MetadataSysModule;
 import io.crate.metadata.sys.SysSchemaInfo;
-import io.crate.metadata.table.SchemaInfo;
 import io.crate.metadata.upgrade.IndexTemplateUpgrader;
 import io.crate.metadata.upgrade.MetadataIndexUpgrader;
-import io.crate.metadata.view.ViewInfoFactory;
 import io.crate.module.CrateCommonModule;
 import io.crate.monitor.MonitorModule;
 import io.crate.netty.NettyBootstrap;
@@ -393,37 +386,8 @@ public class Node implements Closeable {
 
             final Roles roles = new RolesService(clusterService);
             final TableStats tableStats = new TableStats();
-            AtomicReference<RelationAnalyzer> relationAnalyzerRef = new AtomicReference<>(null);
-            final var viewInfoFactory = new ViewInfoFactory(() -> {
-                var relationAnalyzer = relationAnalyzerRef.get();
-                assert relationAnalyzer != null : "RelationAnalyzer must be set";
-                return relationAnalyzer;
-            });
-            UserDefinedFunctionService[] udfServiceRef = new UserDefinedFunctionService[1];
-            Map<String, SchemaInfo> schemaInfoByName = new HashMap<>();
-            final NodeContext nodeContext = new NodeContext(functions, roles, nodeCtx -> {
-                var tableInfoFactory = new DocTableInfoFactory(nodeCtx);
-                udfServiceRef[0] = new UserDefinedFunctionService(clusterService, tableInfoFactory, nodeCtx);
-                schemaInfoByName.put(SysSchemaInfo.NAME, new SysSchemaInfo(clusterService, nodeCtx.roles()));
-                schemaInfoByName.put(InformationSchemaInfo.NAME, new InformationSchemaInfo());
-                schemaInfoByName.put(PgCatalogSchemaInfo.NAME, new PgCatalogSchemaInfo(udfServiceRef[0], tableStats, nodeCtx.roles()));
-                schemaInfoByName.put(
-                    BlobSchemaInfo.NAME,
-                    new BlobSchemaInfo(
-                        clusterService,
-                        new BlobTableInfoFactory(clusterService.getSettings(), environment)));
-
-                Schemas schemas = new Schemas(
-                    schemaInfoByName,
-                    clusterService,
-                    new DocSchemaInfoFactory(tableInfoFactory, viewInfoFactory, nodeCtx, udfServiceRef[0]),
-                    nodeCtx.roles()
-                );
-                schemas.start();
-                return schemas;
-            });
-            var relationAnalyzer = new RelationAnalyzer(nodeContext);
-            relationAnalyzerRef.set(relationAnalyzer);
+            final NodeContext nodeContext = NodeContext.of(environment, clusterService, functions, roles, tableStats);
+            final var udfService = new UserDefinedFunctionService(clusterService, nodeContext);
 
             SetOnce<RerouteService> rerouteServiceReference = new SetOnce<>();
             final DiskThresholdMonitor diskThresholdMonitor = new DiskThresholdMonitor(
@@ -827,11 +791,12 @@ public class Node implements Closeable {
                     b.bind(FsHealthService.class).toInstance(fsHealthService);
                     b.bind(SessionSettingRegistry.class).toInstance(sessionSettingRegistry);
                     b.bind(Functions.class).toInstance(functions);
-                    b.bind(UserDefinedFunctionService.class).toInstance(udfServiceRef[0]);
-                    b.bind(SysSchemaInfo.class).toInstance((SysSchemaInfo) schemaInfoByName.get(SysSchemaInfo.NAME));
-                    b.bind(PgCatalogSchemaInfo.class).toInstance((PgCatalogSchemaInfo) schemaInfoByName.get(PgCatalogSchemaInfo.NAME));
-                    b.bind(InformationSchemaInfo.class).toInstance((InformationSchemaInfo) schemaInfoByName.get(InformationSchemaInfo.NAME));
-                    b.bind(BlobSchemaInfo.class).toInstance((BlobSchemaInfo) schemaInfoByName.get(BlobSchemaInfo.NAME));
+                    b.bind(UserDefinedFunctionService.class).toInstance(udfService);
+                    Schemas schemas = nodeContext.schemas();
+                    b.bind(SysSchemaInfo.class).toInstance((SysSchemaInfo) schemas.getSystemSchema(SysSchemaInfo.NAME));
+                    b.bind(PgCatalogSchemaInfo.class).toInstance((PgCatalogSchemaInfo) schemas.getSystemSchema(PgCatalogSchemaInfo.NAME));
+                    b.bind(InformationSchemaInfo.class).toInstance((InformationSchemaInfo) schemas.getSystemSchema(InformationSchemaInfo.NAME));
+                    b.bind(BlobSchemaInfo.class).toInstance((BlobSchemaInfo) schemas.getSystemSchema(BlobSchemaInfo.NAME));
                 }
             );
             injector = modules.createInjector();
@@ -974,6 +939,7 @@ public class Node implements Closeable {
         injector.getInstance(SnapshotShardsService.class).start();
         injector.getInstance(FsHealthService.class).start();
         injector.getInstance(RepositoriesService.class).start();
+        injector.getInstance(UserDefinedFunctionService.class).start();
         nodeService.getMonitorService().start();
 
         final ClusterService clusterService = injector.getInstance(ClusterService.class);
@@ -1106,6 +1072,7 @@ public class Node implements Closeable {
 
         injector.getInstance(HttpServerTransport.class).stop();
 
+        injector.getInstance(UserDefinedFunctionService.class).start();
         injector.getInstance(SnapshotsService.class).stop();
         injector.getInstance(SnapshotShardsService.class).stop();
         injector.getInstance(RepositoriesService.class).stop();

--- a/server/src/test/java/io/crate/expression/reference/sys/SysShardsExpressionsTest.java
+++ b/server/src/test/java/io/crate/expression/reference/sys/SysShardsExpressionsTest.java
@@ -62,7 +62,6 @@ import io.crate.analyze.relations.RelationAnalyzer;
 import io.crate.expression.NestableInput;
 import io.crate.expression.reference.ReferenceResolver;
 import io.crate.expression.reference.sys.shard.ShardRowContext;
-import io.crate.expression.udf.UserDefinedFunctionService;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.IndexParts;
 import io.crate.metadata.NodeContext;
@@ -92,19 +91,12 @@ public class SysShardsExpressionsTest extends CrateDummyClusterServiceUnitTest {
     public void prepare() {
         NodeContext nodeCtx = createNodeContext();
         indexShard = mockIndexShard();
-        UserDefinedFunctionService udfService = new UserDefinedFunctionService(
-            clusterService,
-            new DocTableInfoFactory(nodeCtx),
-            nodeCtx
-        );
         schemas = new Schemas(
             Map.of("sys", new SysSchemaInfo(this.clusterService, List::of)),
             clusterService,
             new DocSchemaInfoFactory(
                 new DocTableInfoFactory(nodeCtx),
-                new ViewInfoFactory(() -> new RelationAnalyzer(nodeCtx)),
-                nodeCtx,
-                udfService
+                new ViewInfoFactory(() -> new RelationAnalyzer(nodeCtx))
             ),
             List::of
         );

--- a/server/src/test/java/io/crate/expression/udf/UdfUnitTest.java
+++ b/server/src/test/java/io/crate/expression/udf/UdfUnitTest.java
@@ -21,32 +21,33 @@
 
 package io.crate.expression.udf;
 
-import static io.crate.testing.TestingHelpers.createNodeContext;
-
 import javax.script.ScriptException;
 
 import org.jetbrains.annotations.Nullable;
 import org.junit.Before;
 
+import io.crate.analyze.TableDefinitions;
 import io.crate.data.Input;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
-import io.crate.metadata.doc.DocTableInfoFactory;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
 
 public abstract class UdfUnitTest extends CrateDummyClusterServiceUnitTest {
 
     UserDefinedFunctionService udfService;
+    protected SQLExecutor sqlExecutor;
 
     @Override
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        NodeContext nodeContext = createNodeContext();
-        udfService = new UserDefinedFunctionService(clusterService, new DocTableInfoFactory(nodeContext), nodeContext);
+        sqlExecutor = SQLExecutor.of(clusterService)
+            .addTable(TableDefinitions.USER_TABLE_DEFINITION);
+        udfService = sqlExecutor.udfService();
     }
 
     public static final UDFLanguage DUMMY_LANG = new UDFLanguage() {

--- a/server/src/test/java/io/crate/expression/udf/UserDefinedFunctionsTest.java
+++ b/server/src/test/java/io/crate/expression/udf/UserDefinedFunctionsTest.java
@@ -23,6 +23,8 @@ package io.crate.expression.udf;
 
 import static io.crate.testing.Asserts.assertThat;
 import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -33,29 +35,19 @@ import org.junit.Before;
 import org.junit.Test;
 
 import io.crate.analyze.FunctionArgumentDefinition;
-import io.crate.analyze.TableDefinitions;
-import io.crate.analyze.relations.DocTableRelation;
+import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.FunctionProvider;
-import io.crate.metadata.RelationName;
-import io.crate.metadata.doc.DocTableInfo;
-import io.crate.testing.SQLExecutor;
-import io.crate.testing.SqlExpressions;
+import io.crate.metadata.Functions;
+import io.crate.metadata.SearchPath;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 
 public class UserDefinedFunctionsTest extends UdfUnitTest {
 
-    private SqlExpressions sqlExpressions;
-
-    private Map<FunctionName, List<FunctionProvider>> functionImplementations = new HashMap<>();
 
     @Before
     public void prepare() throws Exception {
-        SQLExecutor sqlExecutor = SQLExecutor.of(clusterService)
-            .addTable(TableDefinitions.USER_TABLE_DEFINITION);
-        DocTableInfo users = sqlExecutor.schemas().getTableInfo(new RelationName("doc", "users"));
-        sqlExpressions = new SqlExpressions(Map.of(users.ident(), new DocTableRelation(users)));
         udfService.registerLanguage(DUMMY_LANG);
     }
 
@@ -63,8 +55,8 @@ public class UserDefinedFunctionsTest extends UdfUnitTest {
         String lang,
         String schema,
         String name,
-        DataType returnType,
-        List<DataType> types,
+        DataType<?> returnType,
+        List<DataType<?>> types,
         String definition) {
 
         var udf = new UserDefinedFunctionMetadata(
@@ -76,12 +68,11 @@ public class UserDefinedFunctionsTest extends UdfUnitTest {
             definition);
 
         var functionName = new FunctionName(udf.schema(), udf.name());
+        Map<FunctionName, List<FunctionProvider>> functionImplementations = new HashMap<>();
         var resolvers = functionImplementations.computeIfAbsent(
             functionName, k -> new ArrayList<>());
         resolvers.add(udfService.buildFunctionResolver(udf));
-        sqlExpressions.nodeCtx.functions().registerUdfFunctionImplementationsForSchema(
-            schema,
-            functionImplementations);
+        sqlExecutor.nodeCtx.functions().setUDFs(functionImplementations);
     }
 
     @Test
@@ -93,7 +84,37 @@ public class UserDefinedFunctionsTest extends UdfUnitTest {
             DataTypes.INTEGER,
             List.of(DataTypes.INTEGER, DataTypes.INTEGER),
             "function subtract(a, b) { return a + b; }");
-        assertThat(sqlExpressions.asSymbol("test.subtract(2::integer, 1::integer)"))
+        assertThat(sqlExecutor.asSymbol("test.subtract(2::integer, 1::integer)"))
             .isLiteral(DummyFunction.RESULT);
+    }
+
+    @Test
+    public void test_cannot_create_invalid_function() throws Exception {
+        UserDefinedFunctionMetadata invalid = new UserDefinedFunctionMetadata(
+            "my_schema",
+            "invalid",
+            List.of(),
+            DataTypes.INTEGER,
+            "burlesque",
+            "this is not valid burlesque code"
+        );
+        UserDefinedFunctionMetadata valid = new UserDefinedFunctionMetadata(
+            "my_schema",
+            "valid",
+            List.of(),
+            DataTypes.INTEGER,
+            DUMMY_LANG.name(),
+            "function valid() { return 42; }"
+        );
+        // if a functionImpl can't be created, it won't be registered
+        udfService.updateImplementations(List.of(invalid, valid));
+
+        Functions functions = sqlExecutor.nodeCtx.functions();
+        SearchPath searchPath = SearchPath.pathWithPGCatalogAndDoc();
+        FunctionImplementation function = functions.get("my_schema", "valid", List.of(), searchPath);
+        assertThat(function).isNotNull();
+
+        assertThatThrownBy(() -> functions.get("my_schema", "invalid", List.of(), searchPath))
+            .hasMessage("Unknown function: my_schema.invalid()");
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/SchemaAndRelationNamesIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SchemaAndRelationNamesIntegrationTest.java
@@ -23,7 +23,7 @@ package io.crate.integrationtests;
 
 import static io.crate.testing.TestingHelpers.printedTable;
 import static org.assertj.core.api.Assertions.assertThat;
-import static io.crate.testing.Asserts.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 
@@ -88,6 +88,6 @@ public class SchemaAndRelationNamesIntegrationTest extends IntegTestCase {
         assertThat(printedTable(response.rows())).isEqualTo("Abc| DUMMY EATS text\n");
 
         assertThatThrownBy(() -> execute("drop function \"_Abc\".func(string)"))
-            .hasMessageContaining("Cannot drop function '_Abc.func(text)', it is still in use by 'abc._T.c AS \"_Abc\".func(b)'");
+            .hasMessageContaining("Cannot drop function '\"_Abc\".func'. It is in use by column 'c' of table 'abc._T'");
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/UserDefinedFunctionsIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/UserDefinedFunctionsIntegrationTest.java
@@ -24,6 +24,7 @@ package io.crate.integrationtests;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.Locale;
@@ -344,6 +345,6 @@ public class UserDefinedFunctionsIntegrationTest extends IntegTestCase {
                 .hasPGError(INTERNAL_ERROR)
                 .hasHTTPError(BAD_REQUEST, 4000)
                 .hasMessageContaining(
-                        "Cannot drop function 'doc.foo(bigint)', it is still in use by 'doc.t1.l AS doc.foo(id)'");
+                        "Cannot drop function 'doc.foo'. It is in use by column 'l' of table 'doc.t1'");
     }
 }

--- a/server/src/test/java/io/crate/metadata/FunctionsTest.java
+++ b/server/src/test/java/io/crate/metadata/FunctionsTest.java
@@ -164,8 +164,7 @@ public class FunctionsTest extends ESTestCase {
             DataTypes.STRING.getTypeSignature(),
             DataTypes.INTEGER.getTypeSignature()
         );
-        functions.registerUdfFunctionImplementationsForSchema(
-            "schema2",
+        functions.setUDFs(
             Map.of(
                 new FunctionName("schema2", "foo"),
                 List.of(new FunctionProvider(signature, (sig, args) -> new DummyFunction(sig)))


### PR DESCRIPTION
Instead of having each `SchemaInfo` instance listen to cluster state
events and filter the UDF metadata by schemaName, to then trigger an
update on the `Functions`, this promotes the
`UserDefinedFunctionService` to a lifecycle
component/ClusterStateListener that always updates UDFs for _all_
schemas.

This avoids the need for the filtering, and lets us replace the
`ConcurrentHashMap` with a regular map that's volatile and gets replaced
on a update.

It also makes the `NodeContext` bootstrapping a bit easier and lets us
share more code between tests and production.