### PR TITLE
Increase recursion level in TestSqlParser

### DIFF
--- a/libs/sql-parser/src/test/java/io/crate/sql/parser/TestSqlParser.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/parser/TestSqlParser.java
@@ -490,7 +490,7 @@ public class TestSqlParser {
     @Test
     public void testStackOverflowExpression() {
         assertThatThrownBy(
-            () -> SqlParser.createExpression(Lists.joinOn(" OR ", nCopies(6000, "x = y"), x -> x)))
+            () -> SqlParser.createExpression(Lists.joinOn(" OR ", nCopies(12000, "x = y"), x -> x)))
             .isExactlyInstanceOf(ParsingException.class)
             .hasMessage("line 1:1: expression is too large (stack overflow while parsing)");
     }
@@ -498,7 +498,7 @@ public class TestSqlParser {
     @Test
     public void testStackOverflowStatement() {
         assertThatThrownBy(
-            () -> SqlParser.createStatement("SELECT " + Lists.joinOn(" OR ", nCopies(6000, "x = y"), x -> x)))
+            () -> SqlParser.createStatement("SELECT " + Lists.joinOn(" OR ", nCopies(12000, "x = y"), x -> x)))
             .isExactlyInstanceOf(ParsingException.class)
             .hasMessage("line 1:1: statement is too large (stack overflow while parsing)");
     }


### PR DESCRIPTION
JVM changes in #16111 meant that some stack overflow handling tests were 
broken on Macs.  This ups the recursion level to make the tests pass again.