### PR TITLE
Always return symbol from haystack in SymbolVisitors

### DIFF
--- a/server/src/main/java/io/crate/planner/operators/Collect.java
+++ b/server/src/main/java/io/crate/planner/operators/Collect.java
@@ -334,11 +334,7 @@ public class Collect implements LogicalPlan {
     public LogicalPlan pruneOutputsExcept(SequencedCollection<Symbol> outputsToKeep) {
         LinkedHashSet<Symbol> newOutputs = new LinkedHashSet<>();
         for (Symbol outputToKeep : outputsToKeep) {
-            SymbolVisitors.intersection(outputToKeep, outputs, needle -> {
-                int index = outputs.indexOf(needle);
-                assert index != -1 : "Consumer is called only when intersection is found";
-                newOutputs.add(outputs.get(index));
-            });
+            SymbolVisitors.intersection(outputToKeep, outputs, newOutputs::add);
         }
         if (newOutputs.size() == outputs.size() && newOutputs.containsAll(outputs)) {
             return this;


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Follow-up for https://github.com/crate/crate/pull/16137#discussion_r1634954768. This makes sure the symbol is always returned from the haystack in the SymbolVisitor. With that change, the new outputs in the pruning methods will always use the reference from `outputs` making the custom logic unnecessary. 

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
