### PR TITLE
tests: Remove superfluous method for StackOverflowException test in the parser

### DIFF
--- a/libs/sql-parser/src/test/java/io/crate/sql/parser/TestSqlParser.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/parser/TestSqlParser.java
@@ -488,14 +488,6 @@ public class TestSqlParser {
     }
 
     @Test
-    public void testStackOverflowExpression() {
-        assertThatThrownBy(
-            () -> SqlParser.createExpression(Lists.joinOn(" OR ", nCopies(12000, "x = y"), x -> x)))
-            .isExactlyInstanceOf(ParsingException.class)
-            .hasMessage("line 1:1: expression is too large (stack overflow while parsing)");
-    }
-
-    @Test
     public void testStackOverflowStatement() {
         assertThatThrownBy(
             () -> SqlParser.createStatement("SELECT " + Lists.joinOn(" OR ", nCopies(12000, "x = y"), x -> x)))


### PR DESCRIPTION
`createStatement()` and `createExpression()` follow the same code path
    and the `StackOverflowException` is caught in both cases in the the same
    try/catch block.
