### PR TITLE
Don't randomly test nested objects in reference resolver tests

### DIFF
--- a/server/src/test/java/io/crate/types/NestedArrayTypeTest.java
+++ b/server/src/test/java/io/crate/types/NestedArrayTypeTest.java
@@ -45,6 +45,19 @@ public class NestedArrayTypeTest extends DataTypeTestCase<List<List<Object>>> {
 
     @Override
     @SuppressWarnings("unchecked")
+    protected DataDef<List<List<Object>>> getDataDef() {
+        // Exclude float vectors and objects - we don't support arrays of float vector,
+        // and arrays of objects aren't currently handled by data generation code; these
+        // are tested in ObjectTypeTest instead.
+        DataType<Object> randomType = (DataType<Object>) DataTypeTesting.randomTypeExcluding(
+            Set.of(FloatVectorType.INSTANCE_ONE, ObjectType.UNTYPED)
+        );
+        DataType<List<List<Object>>> type = new ArrayType<>(new ArrayType<>(randomType));
+        return new DataDef<>(type, type.getTypeSignature().toString(), DataTypeTesting.getDataGenerator(type));
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
     public DataType<List<List<Object>>> getType() {
         DataType<Object> randomType = (DataType<Object>) DataTypeTesting.randomTypeExcluding(
             Set.of(FloatVectorType.INSTANCE_ONE)

--- a/server/src/test/java/io/crate/types/ObjectTypeTest.java
+++ b/server/src/test/java/io/crate/types/ObjectTypeTest.java
@@ -49,16 +49,12 @@ public class ObjectTypeTest extends DataTypeTestCase<Map<String, Object>> {
     @Override
     protected DataDef<Map<String, Object>> getDataDef() {
         // float vectors will not compare properly so we exclude them here
-        DataType<?> innerType = DataTypeTesting.randomTypeExcluding(Set.of(FloatVectorType.INSTANCE_ONE));
+        DataType<?> innerType
+            = DataTypeTesting.randomTypeExcluding(Set.of(FloatVectorType.INSTANCE_ONE, ObjectType.UNTYPED));
         DataType<Map<String, Object>> objectType
             = new ObjectType.Builder().setInnerType("x", innerType).build();
         String definition = "OBJECT AS (x " + innerType.getTypeSignature() + ")";
         return new DataDef<>(objectType, definition, DataTypeTesting.getDataGenerator(objectType));
-    }
-
-    @Override
-    public void test_lucene_reference_resolver_round_trip() throws Exception {
-        assumeTrue("Ignoring ObjectTypeTest until seed 1BEEC18BF09254DB:3F28A01480C26D50 is resolved", false);
     }
 
     @Test


### PR DESCRIPTION
These need special handling due to the way that we build tables and load 
data in DataTypeTestCase so should be dealt with in their own methods, 
not the base randomized test.