### PR TITLE
Fix issue with JDBC FWD and JSONB PostgreSQL type

### DIFF
--- a/docs/admin/fdw.rst
+++ b/docs/admin/fdw.rst
@@ -76,6 +76,8 @@ system::
 The ``jdbc`` foreign data wrapper allows to connect to a foreign database via
 ``JDBC``. Bundled JDBC drivers include:
 
+.. _administration-fdw-jdbc-psql:
+
 - PostgreSQL
 
 

--- a/docs/appendices/release-notes/5.7.3.rst
+++ b/docs/appendices/release-notes/5.7.3.rst
@@ -54,3 +54,7 @@ Fixes
   view definition, e.g.::
 
       CREATE VIEW v AS SELECT a, a['b'] FROM t;
+
+- Fixed an issue that caused ``SQLParseException`` when a
+  :ref:`PostgreSQL foreign table <administration-fdw-jdbc-psql>` has columns of
+  type ``JSONB``, or ``JSONB[]``.

--- a/server/src/main/java/io/crate/types/ResultSetParser.java
+++ b/server/src/main/java/io/crate/types/ResultSetParser.java
@@ -88,7 +88,7 @@ public class ResultSetParser {
             case "byte":
                 value = resultSet.getByte(columnIndex);
                 break;
-            case "_json": {
+            case "_json", "_jsonb": {
                 Array array = resultSet.getArray(columnIndex);
                 if (array == null) {
                     return null;
@@ -100,7 +100,7 @@ public class ResultSetParser {
                 value = jsonObjects;
                 break;
             }
-            case "json":
+            case "json", "jsonb":
                 String json = resultSet.getString(columnIndex);
                 value = jsonToObject(json);
                 break;


### PR DESCRIPTION
Add JSONB and JSONB[] to the switchblock in `ResultSetParser`. They work exactly the same as JSON and JSON[], without any other changes.

Fixes: #16148
Follows: #16114

To test this we need a real PostgreSQL instance (to create jsonb and jsonb[] columns), I'll see if we can do something in crate-qa.
