### PR TITLE
Let all functions be non-deterministic by default; explicitly set deterministic flag

### DIFF
--- a/benchmarks/src/main/java/io/crate/data/join/RowsBatchIteratorBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/data/join/RowsBatchIteratorBenchmark.java
@@ -57,6 +57,7 @@ import io.crate.execution.engine.join.HashInnerJoinBatchIterator;
 import io.crate.execution.engine.window.WindowFunction;
 import io.crate.execution.engine.window.WindowFunctionBatchIterator;
 import io.crate.metadata.Functions;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.metadata.settings.session.SessionSettingRegistry;
 import io.crate.types.DataTypes;
@@ -86,10 +87,11 @@ public class RowsBatchIteratorBenchmark {
         Functions functions = Functions.load(Settings.EMPTY, new SessionSettingRegistry(Set.of()));
         lastValueIntFunction = (WindowFunction) functions.getQualified(
             Signature.window(
-                LAST_VALUE_NAME,
-                TypeSignature.parse("E"),
-                TypeSignature.parse("E")
-            ).withTypeVariableConstraints(typeVariable("E")),
+                    LAST_VALUE_NAME,
+                    TypeSignature.parse("E"),
+                    TypeSignature.parse("E")
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withTypeVariableConstraints(typeVariable("E")),
             List.of(DataTypes.INTEGER),
             DataTypes.INTEGER
         );

--- a/benchmarks/src/main/java/io/crate/execution/engine/aggregation/AggregateCollectorBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/execution/engine/aggregation/AggregateCollectorBenchmark.java
@@ -49,6 +49,7 @@ import io.crate.expression.symbol.AggregateMode;
 import io.crate.expression.symbol.Literal;
 import io.crate.memory.OnHeapMemoryManager;
 import io.crate.metadata.Functions;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.metadata.settings.session.SessionSettingRegistry;
 import io.crate.types.DataTypes;
@@ -70,10 +71,10 @@ public class AggregateCollectorBenchmark {
         Functions functions = Functions.load(Settings.EMPTY, new SessionSettingRegistry(Set.of()));
         SumAggregation<?> sumAggregation = (SumAggregation<?>) functions.getQualified(
             Signature.aggregate(
-                SumAggregation.NAME,
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.LONG.getTypeSignature()
-            ),
+                    SumAggregation.NAME,
+                    DataTypes.INTEGER.getTypeSignature(),
+                    DataTypes.LONG.getTypeSignature())
+                .withFeature(Scalar.Feature.DETERMINISTIC),
             List.of(DataTypes.INTEGER),
             DataTypes.INTEGER
         );

--- a/benchmarks/src/main/java/io/crate/execution/engine/aggregation/GroupingLongCollectorBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/execution/engine/aggregation/GroupingLongCollectorBenchmark.java
@@ -72,6 +72,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.memory.MemoryManager;
 import io.crate.memory.OnHeapMemoryManager;
 import io.crate.metadata.Functions;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.metadata.settings.session.SessionSettingRegistry;
 import io.crate.types.DataTypes;
@@ -97,10 +98,10 @@ public class GroupingLongCollectorBenchmark {
             Functions functions = Functions.load(Settings.EMPTY, new SessionSettingRegistry(Set.of()));
             SumAggregation<?> sumAgg = (SumAggregation<?>) functions.getQualified(
                 Signature.aggregate(
-                    SumAggregation.NAME,
-                    DataTypes.INTEGER.getTypeSignature(),
-                    DataTypes.LONG.getTypeSignature()
-                ),
+                        SumAggregation.NAME,
+                        DataTypes.INTEGER.getTypeSignature(),
+                        DataTypes.LONG.getTypeSignature())
+                    .withFeature(Scalar.Feature.DETERMINISTIC),
                 List.of(DataTypes.INTEGER),
                 DataTypes.INTEGER
             );

--- a/benchmarks/src/main/java/io/crate/execution/engine/aggregation/GroupingStringCollectorBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/execution/engine/aggregation/GroupingStringCollectorBenchmark.java
@@ -55,6 +55,7 @@ import io.crate.expression.symbol.AggregateMode;
 import io.crate.expression.symbol.Literal;
 import io.crate.memory.OnHeapMemoryManager;
 import io.crate.metadata.Functions;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.metadata.settings.session.SessionSettingRegistry;
 import io.crate.types.DataTypes;
@@ -93,10 +94,10 @@ public class GroupingStringCollectorBenchmark {
 
         MinimumAggregation minAgg = (MinimumAggregation) functions.getQualified(
             Signature.aggregate(
-                MinimumAggregation.NAME,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ),
+                    MinimumAggregation.NAME,
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature())
+                .withFeature(Scalar.Feature.DETERMINISTIC),
             List.of(DataTypes.STRING),
             DataTypes.STRING
         );

--- a/benchmarks/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationBenchmark.java
@@ -57,6 +57,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.memory.OffHeapMemoryManager;
 import io.crate.memory.OnHeapMemoryManager;
 import io.crate.metadata.Functions;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.metadata.settings.session.SessionSettingRegistry;
 import io.crate.types.DataTypes;
@@ -85,10 +86,10 @@ public class HyperLogLogDistinctAggregationBenchmark {
         Functions functions = Functions.load(Settings.EMPTY, new SessionSettingRegistry(Set.of()));
         final HyperLogLogDistinctAggregation hllAggregation = (HyperLogLogDistinctAggregation) functions.getQualified(
             Signature.aggregate(
-                HyperLogLogDistinctAggregation.NAME,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.LONG.getTypeSignature()
-            ),
+                    HyperLogLogDistinctAggregation.NAME,
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.LONG.getTypeSignature())
+                .withFeature(Scalar.Feature.DETERMINISTIC),
             List.of(DataTypes.STRING),
             DataTypes.STRING
         );

--- a/benchmarks/src/main/java/io/crate/operation/aggregation/IntervalAggregationBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/operation/aggregation/IntervalAggregationBenchmark.java
@@ -57,6 +57,7 @@ import io.crate.expression.symbol.AggregateMode;
 import io.crate.expression.symbol.Literal;
 import io.crate.memory.OnHeapMemoryManager;
 import io.crate.metadata.Functions;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.metadata.settings.session.SessionSettingRegistry;
 import io.crate.types.DataTypes;
@@ -91,19 +92,21 @@ public class IntervalAggregationBenchmark {
         Functions functions = Functions.load(Settings.EMPTY, new SessionSettingRegistry(Set.of()));
 
         final IntervalSumAggregation intervalSumAggregation = (IntervalSumAggregation) functions.getQualified(
-                Signature.aggregate(
+            Signature.aggregate(
                     IntervalSumAggregation.NAME,
                     DataTypes.INTERVAL.getTypeSignature(),
-                    DataTypes.INTERVAL.getTypeSignature()),
-                List.of(DataTypes.INTERVAL),
+                    DataTypes.INTERVAL.getTypeSignature())
+                .withFeature(Scalar.Feature.DETERMINISTIC),
+            List.of(DataTypes.INTERVAL),
                 DataTypes.INTERVAL
             );
 
         final IntervalAverageAggregation intervalAvgAggregation = (IntervalAverageAggregation) functions.getQualified(
             Signature.aggregate(
-                AverageAggregation.NAME,
-                DataTypes.INTERVAL.getTypeSignature(),
-                DataTypes.INTERVAL.getTypeSignature()),
+                    AverageAggregation.NAME,
+                    DataTypes.INTERVAL.getTypeSignature(),
+                    DataTypes.INTERVAL.getTypeSignature())
+                .withFeature(Scalar.Feature.DETERMINISTIC),
             List.of(DataTypes.INTERVAL),
             DataTypes.INTERVAL
         );

--- a/extensions/functions/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregation.java
+++ b/extensions/functions/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregation.java
@@ -57,6 +57,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
@@ -88,7 +89,8 @@ public class HyperLogLogDistinctAggregation extends AggregationFunction<HyperLog
                 Signature.aggregate(
                     NAME,
                     supportedType.getTypeSignature(),
-                    DataTypes.LONG.getTypeSignature()),
+                    DataTypes.LONG.getTypeSignature())
+                    .withFeature(Scalar.Feature.DETERMINISTIC),
                 (signature, boundSignature) ->
                     new HyperLogLogDistinctAggregation(signature, boundSignature, supportedType)
             );
@@ -97,8 +99,8 @@ public class HyperLogLogDistinctAggregation extends AggregationFunction<HyperLog
                     NAME,
                     supportedType.getTypeSignature(),
                     DataTypes.INTEGER.getTypeSignature(),
-                    DataTypes.LONG.getTypeSignature()
-                ),
+                    DataTypes.LONG.getTypeSignature())
+                    .withFeature(Scalar.Feature.DETERMINISTIC),
                 (signature, boundSignature) ->
                     new HyperLogLogDistinctAggregation(signature, boundSignature, supportedType)
             );

--- a/extensions/functions/src/main/java/io/crate/window/NthValueFunctions.java
+++ b/extensions/functions/src/main/java/io/crate/window/NthValueFunctions.java
@@ -36,6 +36,7 @@ import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.execution.engine.window.WindowFrameState;
 import io.crate.execution.engine.window.WindowFunction;
 import io.crate.metadata.Functions;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
@@ -162,10 +163,11 @@ public class NthValueFunctions implements WindowFunction {
     public static void register(Functions.Builder builder) {
         builder.add(
             Signature.window(
-                FIRST_VALUE_NAME,
-                TypeSignature.parse("E"),
-                TypeSignature.parse("E")
-            ).withTypeVariableConstraints(typeVariable("E")),
+                    FIRST_VALUE_NAME,
+                    TypeSignature.parse("E"),
+                    TypeSignature.parse("E")
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withTypeVariableConstraints(typeVariable("E")),
             (signature, boundSignature) ->
                 new NthValueFunctions(
                     signature,
@@ -176,10 +178,11 @@ public class NthValueFunctions implements WindowFunction {
 
         builder.add(
             Signature.window(
-                LAST_VALUE_NAME,
-                TypeSignature.parse("E"),
-                TypeSignature.parse("E")
-            ).withTypeVariableConstraints(typeVariable("E")),
+                    LAST_VALUE_NAME,
+                    TypeSignature.parse("E"),
+                    TypeSignature.parse("E")
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withTypeVariableConstraints(typeVariable("E")),
             (signature, boundSignature) ->
                 new NthValueFunctions(
                     signature,
@@ -190,11 +193,12 @@ public class NthValueFunctions implements WindowFunction {
 
         builder.add(
             Signature.window(
-                NTH_VALUE_NAME,
-                TypeSignature.parse("E"),
-                DataTypes.INTEGER.getTypeSignature(),
-                TypeSignature.parse("E")
-            ).withTypeVariableConstraints(typeVariable("E")),
+                    NTH_VALUE_NAME,
+                    TypeSignature.parse("E"),
+                    DataTypes.INTEGER.getTypeSignature(),
+                    TypeSignature.parse("E")
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withTypeVariableConstraints(typeVariable("E")),
             (signature, boundSignature) ->
                 new NthValueFunctions(
                     signature,

--- a/extensions/functions/src/main/java/io/crate/window/OffsetValueFunctions.java
+++ b/extensions/functions/src/main/java/io/crate/window/OffsetValueFunctions.java
@@ -37,6 +37,7 @@ import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.execution.engine.window.WindowFrameState;
 import io.crate.execution.engine.window.WindowFunction;
 import io.crate.metadata.Functions;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
@@ -263,10 +264,11 @@ public class OffsetValueFunctions implements WindowFunction {
     public static void register(Functions.Builder builder) {
         builder.add(
             Signature.window(
-                LEAD_NAME,
-                TypeSignature.parse("E"),
-                TypeSignature.parse("E")
-            ).withTypeVariableConstraints(typeVariable("E")),
+                    LEAD_NAME,
+                    TypeSignature.parse("E"),
+                    TypeSignature.parse("E")
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withTypeVariableConstraints(typeVariable("E")),
             (signature, boundSignature) ->
                 new OffsetValueFunctions(
                     signature,
@@ -276,11 +278,12 @@ public class OffsetValueFunctions implements WindowFunction {
         );
         builder.add(
             Signature.window(
-                LEAD_NAME,
-                TypeSignature.parse("E"),
-                DataTypes.INTEGER.getTypeSignature(),
-                TypeSignature.parse("E")
-            ).withTypeVariableConstraints(typeVariable("E")),
+                    LEAD_NAME,
+                    TypeSignature.parse("E"),
+                    DataTypes.INTEGER.getTypeSignature(),
+                    TypeSignature.parse("E")
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withTypeVariableConstraints(typeVariable("E")),
             (signature, boundSignature) ->
                 new OffsetValueFunctions(
                     signature,
@@ -290,12 +293,13 @@ public class OffsetValueFunctions implements WindowFunction {
         );
         builder.add(
             Signature.window(
-                LEAD_NAME,
-                TypeSignature.parse("E"),
-                DataTypes.INTEGER.getTypeSignature(),
-                TypeSignature.parse("E"),
-                TypeSignature.parse("E")
-            ).withTypeVariableConstraints(typeVariable("E")),
+                    LEAD_NAME,
+                    TypeSignature.parse("E"),
+                    DataTypes.INTEGER.getTypeSignature(),
+                    TypeSignature.parse("E"),
+                    TypeSignature.parse("E")
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withTypeVariableConstraints(typeVariable("E")),
             (signature, boundSignature) ->
                 new OffsetValueFunctions(
                     signature,
@@ -306,10 +310,11 @@ public class OffsetValueFunctions implements WindowFunction {
 
         builder.add(
             Signature.window(
-                LAG_NAME,
-                TypeSignature.parse("E"),
-                TypeSignature.parse("E")
-            ).withTypeVariableConstraints(typeVariable("E")),
+                    LAG_NAME,
+                    TypeSignature.parse("E"),
+                    TypeSignature.parse("E")
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withTypeVariableConstraints(typeVariable("E")),
             (signature, boundSignature) ->
                 new OffsetValueFunctions(
                     signature,
@@ -319,11 +324,12 @@ public class OffsetValueFunctions implements WindowFunction {
         );
         builder.add(
             Signature.window(
-                LAG_NAME,
-                TypeSignature.parse("E"),
-                DataTypes.INTEGER.getTypeSignature(),
-                TypeSignature.parse("E")
-            ).withTypeVariableConstraints(typeVariable("E")),
+                    LAG_NAME,
+                    TypeSignature.parse("E"),
+                    DataTypes.INTEGER.getTypeSignature(),
+                    TypeSignature.parse("E")
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withTypeVariableConstraints(typeVariable("E")),
             (signature, boundSignature) ->
                 new OffsetValueFunctions(
                     signature,
@@ -333,12 +339,13 @@ public class OffsetValueFunctions implements WindowFunction {
         );
         builder.add(
             Signature.window(
-                LAG_NAME,
-                TypeSignature.parse("E"),
-                DataTypes.INTEGER.getTypeSignature(),
-                TypeSignature.parse("E"),
-                TypeSignature.parse("E")
-            ).withTypeVariableConstraints(typeVariable("E")),
+                    LAG_NAME,
+                    TypeSignature.parse("E"),
+                    DataTypes.INTEGER.getTypeSignature(),
+                    TypeSignature.parse("E"),
+                    TypeSignature.parse("E")
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withTypeVariableConstraints(typeVariable("E")),
             (signature, boundSignature) ->
                 new OffsetValueFunctions(
                     signature,

--- a/extensions/functions/src/main/java/io/crate/window/RankFunctions.java
+++ b/extensions/functions/src/main/java/io/crate/window/RankFunctions.java
@@ -33,6 +33,7 @@ import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.execution.engine.window.WindowFrameState;
 import io.crate.execution.engine.window.WindowFunction;
 import io.crate.metadata.Functions;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
@@ -94,7 +95,7 @@ public class RankFunctions implements WindowFunction {
             Signature.window(
                 RANK_NAME,
                 DataTypes.INTEGER.getTypeSignature()
-                ),
+                ).withFeature(Scalar.Feature.DETERMINISTIC),
             (signature, boundSignature) ->
                 new RankFunctions(
                     signature,
@@ -107,7 +108,7 @@ public class RankFunctions implements WindowFunction {
             Signature.window(
                 DENSE_RANK_NAME,
                 DataTypes.INTEGER.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.DETERMINISTIC),
             (signature, boundSignature) ->
                 new RankFunctions(
                     signature,

--- a/extensions/functions/src/test/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationTest.java
+++ b/extensions/functions/src/test/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationTest.java
@@ -42,6 +42,7 @@ import io.crate.Streamer;
 import io.crate.execution.engine.aggregation.impl.HyperLogLogPlusPlus;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.FunctionImplementation;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.SearchPath;
 import io.crate.metadata.functions.Signature;
 import io.crate.testing.TestingHelpers;
@@ -58,10 +59,10 @@ public class HyperLogLogDistinctAggregationTest extends AggregationTestCase {
     private Object executeAggregation(DataType<?> argumentType, Object[][] data) throws Exception {
         return executeAggregation(
             Signature.aggregate(
-                HyperLogLogDistinctAggregation.NAME,
-                argumentType.getTypeSignature(),
-                DataTypes.LONG.getTypeSignature()
-            ),
+                    HyperLogLogDistinctAggregation.NAME,
+                    argumentType.getTypeSignature(),
+                    DataTypes.LONG.getTypeSignature())
+                .withFeature(Scalar.Feature.DETERMINISTIC),
             data,
             List.of()
         );
@@ -70,11 +71,11 @@ public class HyperLogLogDistinctAggregationTest extends AggregationTestCase {
     private Object executeAggregationWithPrecision(DataType<?> argumentType, Object[][] data, List<Literal<?>> optionalParams) throws Exception {
         return executeAggregation(
             Signature.aggregate(
-                HyperLogLogDistinctAggregation.NAME,
-                argumentType.getTypeSignature(),
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.LONG.getTypeSignature()
-            ),
+                    HyperLogLogDistinctAggregation.NAME,
+                    argumentType.getTypeSignature(),
+                    DataTypes.INTEGER.getTypeSignature(),
+                    DataTypes.LONG.getTypeSignature())
+                .withFeature(Scalar.Feature.DETERMINISTIC),
             data,
             optionalParams
         );

--- a/server/src/main/java/io/crate/analyze/where/EqualityExtractor.java
+++ b/server/src/main/java/io/crate/analyze/where/EqualityExtractor.java
@@ -58,6 +58,7 @@ import io.crate.expression.symbol.Symbols;
 import io.crate.expression.symbol.format.Style;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataType;
@@ -67,7 +68,8 @@ public class EqualityExtractor {
 
     private static final int MAX_ITERATIONS = 10_000;
     private static final Function NULL_MARKER = new Function(
-        Signature.scalar("null_marker", DataTypes.UNDEFINED.getTypeSignature()),
+        Signature.scalar("null_marker", DataTypes.UNDEFINED.getTypeSignature())
+            .withFeature(Scalar.Feature.DETERMINISTIC),
         List.of(),
         DataTypes.UNDEFINED
     );

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregation.java
@@ -47,6 +47,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
@@ -76,11 +77,13 @@ public class ArbitraryAggregation extends AggregationFunction<Object, Object> {
         TypeSignature T = TypeSignature.parse("T");
         builder.add(
             Signature.aggregate(NAME, T, T)
+                .withFeature(Scalar.Feature.DETERMINISTIC)
                 .withTypeVariableConstraints(TypeVariableConstraint.typeVariableOfAnyType("T")),
             ArbitraryAggregation::new
         );
         builder.add(
             Signature.aggregate(ALIAS, T, T)
+                .withFeature(Scalar.Feature.DETERMINISTIC)
                 .withTypeVariableConstraints(TypeVariableConstraint.typeVariableOfAnyType("T")),
             ArbitraryAggregation::new
         );

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/ArrayAgg.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/ArrayAgg.java
@@ -34,6 +34,7 @@ import io.crate.data.breaker.RamAccounting;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.Functions;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataType;
@@ -44,10 +45,11 @@ public final class ArrayAgg extends AggregationFunction<List<Object>, List<Objec
     public static final String NAME = "array_agg";
     public static final Signature SIGNATURE =
         Signature.aggregate(
-            NAME,
-            TypeSignature.parse("E"),
-            TypeSignature.parse("array(E)")
-        ).withTypeVariableConstraints(typeVariable("E"));
+                NAME,
+                TypeSignature.parse("E"),
+                TypeSignature.parse("array(E)"))
+            .withFeature(Scalar.Feature.DETERMINISTIC)
+            .withTypeVariableConstraints(typeVariable("E"));
 
 
     public static void register(Functions.Builder builder) {

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/CmpByAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/CmpByAggregation.java
@@ -46,6 +46,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
@@ -108,26 +109,28 @@ public final class CmpByAggregation extends AggregationFunction<CmpByAggregation
         var variableConstraintB = TypeVariableConstraint.typeVariableOfAnyType("B");
         builder.add(
             Signature.aggregate(
-                MAX_BY,
-                returnValueType,
-                cmpType,
-                returnValueType
-            ).withTypeVariableConstraints(
-                variableConstraintA,
-                variableConstraintB
-            ),
+                    MAX_BY,
+                    returnValueType,
+                    cmpType,
+                    returnValueType)
+                .withFeature(Scalar.Feature.DETERMINISTIC)
+                .withTypeVariableConstraints(
+                    variableConstraintA,
+                    variableConstraintB
+                ),
             (signature, boundSignature) -> new CmpByAggregation(1, signature, boundSignature)
         );
         builder.add(
             Signature.aggregate(
                 MIN_BY,
                 returnValueType,
-                cmpType,
-                returnValueType
-            ).withTypeVariableConstraints(
-                variableConstraintA,
-                variableConstraintB
-            ),
+                    cmpType,
+                    returnValueType)
+                .withFeature(Scalar.Feature.DETERMINISTIC)
+                .withTypeVariableConstraints(
+                    variableConstraintA,
+                    variableConstraintB
+                ),
             (signature, boundSignature) -> new CmpByAggregation(-1, signature, boundSignature)
         );
     }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregation.java
@@ -36,6 +36,7 @@ import io.crate.data.breaker.RamAccounting;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.Functions;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.ArrayType;
@@ -58,10 +59,10 @@ public class CollectSetAggregation extends AggregationFunction<Map<Object, Objec
             var returnType = new ArrayType<>(supportedType);
             builder.add(
                 Signature.aggregate(
-                    NAME,
-                    supportedType.getTypeSignature(),
-                    returnType.getTypeSignature()
-                ),
+                        NAME,
+                        supportedType.getTypeSignature(),
+                        returnType.getTypeSignature())
+                    .withFeature(Scalar.Feature.DETERMINISTIC),
                 CollectSetAggregation::new
             );
         }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/CountAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/CountAggregation.java
@@ -47,6 +47,7 @@ import io.crate.memory.MemoryManager;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.functions.BoundSignature;
@@ -73,13 +74,15 @@ public class CountAggregation extends AggregationFunction<MutableLong, Long> {
     public static final String NAME = "count";
     public static final Signature SIGNATURE =
         Signature.aggregate(
-            NAME,
-            TypeSignature.parse("V"),
-            DataTypes.LONG.getTypeSignature()
-        ).withTypeVariableConstraints(typeVariable("V"));
+                NAME,
+                TypeSignature.parse("V"),
+                DataTypes.LONG.getTypeSignature())
+            .withFeature(Scalar.Feature.DETERMINISTIC)
+            .withTypeVariableConstraints(typeVariable("V"));
 
     public static final Signature COUNT_STAR_SIGNATURE =
-        Signature.aggregate(NAME, DataTypes.LONG.getTypeSignature());
+        Signature.aggregate(NAME, DataTypes.LONG.getTypeSignature())
+            .withFeature(Scalar.Feature.DETERMINISTIC);
 
     static {
         DataTypes.register(CountAggregation.LongStateType.ID, in -> CountAggregation.LongStateType.INSTANCE);

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregation.java
@@ -47,6 +47,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
@@ -76,10 +77,10 @@ public class GeometricMeanAggregation extends AggregationFunction<GeometricMeanA
         for (var supportedType : SUPPORTED_TYPES) {
             builder.add(
                 Signature.aggregate(
-                    NAME,
-                    supportedType.getTypeSignature(),
-                    DataTypes.DOUBLE.getTypeSignature()
-                ),
+                        NAME,
+                        supportedType.getTypeSignature(),
+                        DataTypes.DOUBLE.getTypeSignature())
+                    .withFeature(Scalar.Feature.DETERMINISTIC),
                 GeometricMeanAggregation::new
             );
         }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/IntervalSumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/IntervalSumAggregation.java
@@ -32,6 +32,7 @@ import io.crate.data.breaker.RamAccounting;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.Functions;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataType;
@@ -44,9 +45,10 @@ public class IntervalSumAggregation extends AggregationFunction<Period, Period> 
     public static void register(Functions.Builder builder) {
         builder.add(
             Signature.aggregate(
-                NAME,
-                DataTypes.INTERVAL.getTypeSignature(),
-                DataTypes.INTERVAL.getTypeSignature()),
+                    NAME,
+                    DataTypes.INTERVAL.getTypeSignature(),
+                    DataTypes.INTERVAL.getTypeSignature())
+                .withFeature(Scalar.Feature.DETERMINISTIC),
             IntervalSumAggregation::new
         );
     }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
@@ -44,6 +44,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
@@ -67,13 +68,14 @@ public abstract class MaximumAggregation extends AggregationFunction<Object, Obj
             var fixedWidthType = supportedType instanceof FixedWidthType;
             builder.add(
                 Signature.aggregate(
-                    NAME,
-                    supportedType.getTypeSignature(),
-                    supportedType.getTypeSignature()),
+                        NAME,
+                        supportedType.getTypeSignature(),
+                        supportedType.getTypeSignature())
+                    .withFeature(Scalar.Feature.DETERMINISTIC),
                 (signature, boundSignature) ->
                     fixedWidthType
-                    ? new FixedMaximumAggregation(signature, boundSignature)
-                    : new VariableMaximumAggregation(signature, boundSignature)
+                        ? new FixedMaximumAggregation(signature, boundSignature)
+                        : new VariableMaximumAggregation(signature, boundSignature)
             );
         }
     }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/MinimumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/MinimumAggregation.java
@@ -44,6 +44,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
@@ -67,13 +68,14 @@ public abstract class MinimumAggregation extends AggregationFunction<Object, Obj
             var fixedWidthType = supportedType instanceof FixedWidthType;
             builder.add(
                 Signature.aggregate(
-                    NAME,
-                    supportedType.getTypeSignature(),
-                    supportedType.getTypeSignature()),
+                        NAME,
+                        supportedType.getTypeSignature(),
+                        supportedType.getTypeSignature())
+                    .withFeature(Scalar.Feature.DETERMINISTIC),
                 (signature, boundSignature) ->
                     fixedWidthType
-                    ? new FixedMinimumAggregation(signature, boundSignature)
-                    : new VariableMinimumAggregation(signature, boundSignature)
+                        ? new FixedMinimumAggregation(signature, boundSignature)
+                        : new VariableMinimumAggregation(signature, boundSignature)
             );
         }
     }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/NumericSumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/NumericSumAggregation.java
@@ -45,6 +45,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
@@ -62,10 +63,10 @@ public class NumericSumAggregation extends AggregationFunction<BigDecimal, BigDe
 
     public static final String NAME = "sum";
     public static final Signature SIGNATURE = Signature.aggregate(
-        NAME,
-        DataTypes.NUMERIC.getTypeSignature(),
-        DataTypes.NUMERIC.getTypeSignature()
-    );
+            NAME,
+            DataTypes.NUMERIC.getTypeSignature(),
+            DataTypes.NUMERIC.getTypeSignature())
+        .withFeature(Scalar.Feature.DETERMINISTIC);
     private static final long INIT_BIG_DECIMAL_SIZE = NumericType.size(BigDecimal.ZERO);
 
     public static void register(Functions.Builder builder) {

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/PercentileAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/PercentileAggregation.java
@@ -33,6 +33,7 @@ import io.crate.data.breaker.RamAccounting;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.Functions;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.ArrayType;
@@ -51,20 +52,20 @@ class PercentileAggregation extends AggregationFunction<TDigestState, Object> {
         for (var supportedType : DataTypes.NUMERIC_PRIMITIVE_TYPES) {
             builder.add(
                 Signature.aggregate(
-                    NAME,
-                    supportedType.getTypeSignature(),
-                    DataTypes.DOUBLE.getTypeSignature(),
-                    DataTypes.DOUBLE.getTypeSignature()
-                ),
+                        NAME,
+                        supportedType.getTypeSignature(),
+                        DataTypes.DOUBLE.getTypeSignature(),
+                        DataTypes.DOUBLE.getTypeSignature())
+                    .withFeature(Scalar.Feature.DETERMINISTIC),
                 PercentileAggregation::new
             );
             builder.add(
                 Signature.aggregate(
-                    NAME,
-                    supportedType.getTypeSignature(),
-                    DataTypes.DOUBLE_ARRAY.getTypeSignature(),
-                    DataTypes.DOUBLE_ARRAY.getTypeSignature()
-                ),
+                        NAME,
+                        supportedType.getTypeSignature(),
+                        DataTypes.DOUBLE_ARRAY.getTypeSignature(),
+                        DataTypes.DOUBLE_ARRAY.getTypeSignature())
+                    .withFeature(Scalar.Feature.DETERMINISTIC),
                 PercentileAggregation::new
             );
         }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationAggregation.java
@@ -44,6 +44,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
@@ -76,7 +77,7 @@ public class StandardDeviationAggregation extends AggregationFunction<StandardDe
                     NAME,
                     supportedType.getTypeSignature(),
                     DataTypes.DOUBLE.getTypeSignature()
-                ),
+                ).withFeature(Scalar.Feature.DETERMINISTIC),
                 StandardDeviationAggregation::new
             );
         }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/StringAgg.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/StringAgg.java
@@ -38,6 +38,7 @@ import io.crate.data.breaker.RamAccounting;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.Functions;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataType;
@@ -52,11 +53,11 @@ public final class StringAgg extends AggregationFunction<StringAgg.StringAggStat
     private static final String NAME = "string_agg";
     public static final Signature SIGNATURE =
         Signature.aggregate(
-            NAME,
-            DataTypes.STRING.getTypeSignature(),
-            DataTypes.STRING.getTypeSignature(),
-            DataTypes.STRING.getTypeSignature()
-        );
+                NAME,
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature(),
+                DataTypes.STRING.getTypeSignature())
+            .withFeature(Scalar.Feature.DETERMINISTIC);
 
 
     private static final int LIST_ENTRY_OVERHEAD = 32;

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/SumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/SumAggregation.java
@@ -49,6 +49,7 @@ import io.crate.memory.MemoryManager;
 import io.crate.metadata.FunctionProvider.FunctionFactory;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
@@ -71,27 +72,28 @@ public class SumAggregation<T extends Number> extends AggregationFunction<T, T> 
 
         builder.add(
             Signature.aggregate(
-                NAME,
-                DataTypes.FLOAT.getTypeSignature(),
-                DataTypes.FLOAT.getTypeSignature()
-            ),
+                    NAME,
+                    DataTypes.FLOAT.getTypeSignature(),
+                    DataTypes.FLOAT.getTypeSignature())
+                .withFeature(Scalar.Feature.DETERMINISTIC),
             getSumAggregationForFloatFactory()
         );
         builder.add(
             Signature.aggregate(
-                NAME,
-                DataTypes.DOUBLE.getTypeSignature(),
-                DataTypes.DOUBLE.getTypeSignature()
-            ),
+                    NAME,
+                    DataTypes.DOUBLE.getTypeSignature(),
+                    DataTypes.DOUBLE.getTypeSignature())
+                .withFeature(Scalar.Feature.DETERMINISTIC),
             getSumAggregationForDoubleFactory()
         );
 
         for (var supportedType : List.of(DataTypes.BYTE, DataTypes.SHORT, DataTypes.INTEGER, DataTypes.LONG)) {
             builder.add(
                 Signature.aggregate(
-                    NAME,
-                    supportedType.getTypeSignature(),
-                    DataTypes.LONG.getTypeSignature()),
+                        NAME,
+                        supportedType.getTypeSignature(),
+                        DataTypes.LONG.getTypeSignature())
+                    .withFeature(Scalar.Feature.DETERMINISTIC),
                 (signature, boundSignature) ->
                     new SumAggregation<>(DataTypes.LONG, add, sub, signature, boundSignature)
             );

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
@@ -44,6 +44,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
@@ -73,10 +74,10 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
         for (var supportedType : SUPPORTED_TYPES) {
             builder.add(
                 Signature.aggregate(
-                    NAME,
-                    supportedType.getTypeSignature(),
-                    DataTypes.DOUBLE.getTypeSignature()
-                ),
+                        NAME,
+                        supportedType.getTypeSignature(),
+                        DataTypes.DOUBLE.getTypeSignature())
+                    .withFeature(Scalar.Feature.DETERMINISTIC),
                 VarianceAggregation::new
             );
         }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/AverageAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/AverageAggregation.java
@@ -46,6 +46,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
@@ -79,9 +80,10 @@ public class AverageAggregation extends AggregationFunction<AverageAggregation.A
             for (var supportedType : SUPPORTED_TYPES) {
                 builder.add(
                     Signature.aggregate(
-                        functionName,
-                        supportedType.getTypeSignature(),
-                        DataTypes.DOUBLE.getTypeSignature()),
+                            functionName,
+                            supportedType.getTypeSignature(),
+                            DataTypes.DOUBLE.getTypeSignature())
+                        .withFeature(Scalar.Feature.DETERMINISTIC),
                     (signature, boundSignature) ->
                         new AverageAggregation(signature, boundSignature,
                             supportedType.id() != DataTypes.FLOAT.id() && supportedType.id() != DataTypes.DOUBLE.id())

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/IntervalAverageAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/IntervalAverageAggregation.java
@@ -49,6 +49,7 @@ import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.execution.engine.aggregation.impl.util.OverflowAwareMutableLong;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.Functions;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataType;
@@ -68,9 +69,10 @@ public class IntervalAverageAggregation extends AggregationFunction<IntervalAver
         for (var functionName : NAMES) {
             builder.add(
                 Signature.aggregate(
-                    functionName,
-                    DataTypes.INTERVAL.getTypeSignature(),
-                    DataTypes.INTERVAL.getTypeSignature()),
+                        functionName,
+                        DataTypes.INTERVAL.getTypeSignature(),
+                        DataTypes.INTERVAL.getTypeSignature())
+                    .withFeature(Scalar.Feature.DETERMINISTIC),
                 IntervalAverageAggregation::new
             );
         }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/numeric/NumericAverageAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/numeric/NumericAverageAggregation.java
@@ -48,6 +48,7 @@ import io.crate.expression.symbol.Symbols;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
@@ -71,9 +72,10 @@ public class NumericAverageAggregation extends AggregationFunction<NumericAverag
         for (var functionName : NAMES) {
             builder.add(
                 Signature.aggregate(
-                    functionName,
-                    DataTypes.NUMERIC.getTypeSignature(),
-                    DataTypes.NUMERIC.getTypeSignature()),
+                        functionName,
+                        DataTypes.NUMERIC.getTypeSignature(),
+                        DataTypes.NUMERIC.getTypeSignature())
+                    .withFeature(Scalar.Feature.DETERMINISTIC),
                 NumericAverageAggregation::new
             );
         }

--- a/server/src/main/java/io/crate/execution/engine/window/RowNumberWindowFunction.java
+++ b/server/src/main/java/io/crate/execution/engine/window/RowNumberWindowFunction.java
@@ -30,6 +30,7 @@ import io.crate.data.Input;
 import io.crate.data.Row;
 import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.metadata.Functions;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
@@ -43,7 +44,7 @@ public class RowNumberWindowFunction implements WindowFunction {
             Signature.window(
                 NAME,
                 DataTypes.INTEGER.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.DETERMINISTIC),
             RowNumberWindowFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/operator/AllOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/AllOperator.java
@@ -66,6 +66,7 @@ public final class AllOperator extends Operator<Object> {
                         TypeSignature.parse("array(E)"),
                         Operator.RETURN_TYPE.getTypeSignature()
                     ).withTypeVariableConstraints(typeVariable("E"))
+                    .withFeature(Feature.DETERMINISTIC)
                     .withFeature(Feature.NULLABLE),
                 (signature, boundSignature) ->
                     new AllOperator(

--- a/server/src/main/java/io/crate/expression/operator/AndOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/AndOperator.java
@@ -51,7 +51,7 @@ public class AndOperator extends Operator<Boolean> {
         DataTypes.BOOLEAN.getTypeSignature(),
         DataTypes.BOOLEAN.getTypeSignature(),
         DataTypes.BOOLEAN.getTypeSignature()
-    );
+    ).withFeature(Feature.DETERMINISTIC);
 
     public static void register(Functions.Builder builder) {
         builder.add(SIGNATURE, AndOperator::new);

--- a/server/src/main/java/io/crate/expression/operator/CIDROperator.java
+++ b/server/src/main/java/io/crate/expression/operator/CIDROperator.java
@@ -51,11 +51,12 @@ public final class CIDROperator {
     public static void register(Functions.Builder builder) {
         builder.add(
             Signature.scalar(
-                CONTAINED_WITHIN,
-                DataTypes.IP.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature(),
-                Operator.RETURN_TYPE.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE),
+                    CONTAINED_WITHIN,
+                    DataTypes.IP.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature(),
+                    Operator.RETURN_TYPE.getTypeSignature())
+                .withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE),
             ContainedWithinOperator::new
         );
     }

--- a/server/src/main/java/io/crate/expression/operator/EqOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/EqOperator.java
@@ -75,8 +75,9 @@ public final class EqOperator extends Operator<Object> {
             NAME,
             TypeSignature.parse("E"),
             TypeSignature.parse("E"),
-            Operator.RETURN_TYPE.getTypeSignature()
-        ).withFeature(Feature.NULLABLE)
+            Operator.RETURN_TYPE.getTypeSignature())
+        .withFeature(Feature.DETERMINISTIC)
+        .withFeature(Feature.NULLABLE)
         .withTypeVariableConstraints(typeVariable("E"));
 
     public static void register(Functions.Builder builder) {

--- a/server/src/main/java/io/crate/expression/operator/ExistsOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/ExistsOperator.java
@@ -42,6 +42,7 @@ public class ExistsOperator extends Operator<List<Object>> {
                 TypeSignature.parse("array(E)"),
                 Operator.RETURN_TYPE.getTypeSignature()
             ).withTypeVariableConstraints(TypeVariableConstraint.typeVariable("E"))
+            .withFeature(Feature.DETERMINISTIC)
             .withFeature(Feature.NULLABLE);
         builder.add(signature, ExistsOperator::new);
     }

--- a/server/src/main/java/io/crate/expression/operator/GtOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/GtOperator.java
@@ -34,11 +34,12 @@ public final class GtOperator {
         for (var supportedType : DataTypes.PRIMITIVE_TYPES) {
             builder.add(
                 Signature.scalar(
-                    NAME,
-                    supportedType.getTypeSignature(),
-                    supportedType.getTypeSignature(),
-                    Operator.RETURN_TYPE.getTypeSignature()
-                ).withFeature(Scalar.Feature.NULLABLE),
+                        NAME,
+                        supportedType.getTypeSignature(),
+                        supportedType.getTypeSignature(),
+                        Operator.RETURN_TYPE.getTypeSignature())
+                    .withFeature(Scalar.Feature.DETERMINISTIC)
+                    .withFeature(Scalar.Feature.NULLABLE),
                 (signature, boundSignature) -> new CmpOperator(
                     signature,
                     boundSignature,

--- a/server/src/main/java/io/crate/expression/operator/GteOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/GteOperator.java
@@ -34,11 +34,12 @@ public final class GteOperator {
         for (var supportedType : DataTypes.PRIMITIVE_TYPES) {
             builder.add(
                 Signature.scalar(
-                    NAME,
-                    supportedType.getTypeSignature(),
-                    supportedType.getTypeSignature(),
-                    Operator.RETURN_TYPE.getTypeSignature()
-                ).withFeature(Scalar.Feature.NULLABLE),
+                        NAME,
+                        supportedType.getTypeSignature(),
+                        supportedType.getTypeSignature(),
+                        Operator.RETURN_TYPE.getTypeSignature())
+                    .withFeature(Scalar.Feature.DETERMINISTIC)
+                    .withFeature(Scalar.Feature.NULLABLE),
                 (signature, boundSignature) -> new CmpOperator(
                     signature,
                     boundSignature,

--- a/server/src/main/java/io/crate/expression/operator/LikeOperators.java
+++ b/server/src/main/java/io/crate/expression/operator/LikeOperators.java
@@ -108,21 +108,23 @@ public class LikeOperators {
     public static void register(Functions.Builder builder) {
         builder.add(
             Signature.scalar(
-                OP_LIKE,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature(),
-                Operator.RETURN_TYPE.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE),
+                    OP_LIKE,
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature(),
+                    Operator.RETURN_TYPE.getTypeSignature()
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new LikeOperator(signature, boundSignature, LikeOperators::matches, CaseSensitivity.SENSITIVE)
         );
         builder.add(
             Signature.scalar(
-                OP_ILIKE,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature(),
-                Operator.RETURN_TYPE.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE),
+                    OP_ILIKE,
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature(),
+                    Operator.RETURN_TYPE.getTypeSignature()
+                ).withFeature(Scalar.Feature.NULLABLE)
+                .withFeature(Scalar.Feature.DETERMINISTIC),
             (signature, boundSignature) ->
                 new LikeOperator(signature, boundSignature, LikeOperators::matches, CaseSensitivity.INSENSITIVE)
         );
@@ -134,7 +136,7 @@ public class LikeOperators {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature(),
                 Operator.RETURN_TYPE.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.DETERMINISTIC),
             (signature, boundSignature) ->
                 new LikeOperator(signature, boundSignature, LikeOperators::matches, CaseSensitivity.SENSITIVE)
         );
@@ -145,17 +147,18 @@ public class LikeOperators {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature(),
                 Operator.RETURN_TYPE.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.DETERMINISTIC),
             (signature, boundSignature) ->
                 new LikeOperator(signature, boundSignature, LikeOperators::matches, CaseSensitivity.INSENSITIVE)
         );
         builder.add(
             Signature.scalar(
-                ANY_LIKE,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING_ARRAY.getTypeSignature(),
-                Operator.RETURN_TYPE.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE),
+                    ANY_LIKE,
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING_ARRAY.getTypeSignature(),
+                    Operator.RETURN_TYPE.getTypeSignature()
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new AnyLikeOperator(
                     signature,
@@ -165,11 +168,12 @@ public class LikeOperators {
         );
         builder.add(
             Signature.scalar(
-                ANY_NOT_LIKE,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING_ARRAY.getTypeSignature(),
-                Operator.RETURN_TYPE.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE),
+                    ANY_NOT_LIKE,
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING_ARRAY.getTypeSignature(),
+                    Operator.RETURN_TYPE.getTypeSignature()
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new AnyNotLikeOperator(
                     signature,
@@ -179,11 +183,12 @@ public class LikeOperators {
         );
         builder.add(
             Signature.scalar(
-                ANY_ILIKE,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING_ARRAY.getTypeSignature(),
-                Operator.RETURN_TYPE.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE),
+                    ANY_ILIKE,
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING_ARRAY.getTypeSignature(),
+                    Operator.RETURN_TYPE.getTypeSignature()
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new AnyLikeOperator(
                     signature,
@@ -193,11 +198,12 @@ public class LikeOperators {
         );
         builder.add(
             Signature.scalar(
-                ANY_NOT_ILIKE,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING_ARRAY.getTypeSignature(),
-                Operator.RETURN_TYPE.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE),
+                    ANY_NOT_ILIKE,
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING_ARRAY.getTypeSignature(),
+                    Operator.RETURN_TYPE.getTypeSignature()
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new AnyNotLikeOperator(
                     signature,

--- a/server/src/main/java/io/crate/expression/operator/LtOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/LtOperator.java
@@ -34,11 +34,12 @@ public final class LtOperator {
         for (var supportedType : DataTypes.PRIMITIVE_TYPES) {
             builder.add(
                 Signature.scalar(
-                    NAME,
-                    supportedType.getTypeSignature(),
-                    supportedType.getTypeSignature(),
-                    Operator.RETURN_TYPE.getTypeSignature()
-                ).withFeature(Scalar.Feature.NULLABLE),
+                        NAME,
+                        supportedType.getTypeSignature(),
+                        supportedType.getTypeSignature(),
+                        Operator.RETURN_TYPE.getTypeSignature()
+                    ).withFeature(Scalar.Feature.DETERMINISTIC)
+                    .withFeature(Scalar.Feature.NULLABLE),
                 (signature, boundSignature) ->
                     new CmpOperator(signature, boundSignature, cmpResult -> cmpResult < 0)
             );

--- a/server/src/main/java/io/crate/expression/operator/LteOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/LteOperator.java
@@ -34,11 +34,12 @@ public final class LteOperator {
         for (var supportedType : DataTypes.PRIMITIVE_TYPES) {
             builder.add(
                 Signature.scalar(
-                    NAME,
-                    supportedType.getTypeSignature(),
-                    supportedType.getTypeSignature(),
-                    Operator.RETURN_TYPE.getTypeSignature()
-                ).withFeature(Scalar.Feature.NULLABLE),
+                        NAME,
+                        supportedType.getTypeSignature(),
+                        supportedType.getTypeSignature(),
+                        Operator.RETURN_TYPE.getTypeSignature()
+                    ).withFeature(Scalar.Feature.DETERMINISTIC)
+                    .withFeature(Scalar.Feature.NULLABLE),
                 (signature, boundSignature) -> new CmpOperator(
                     signature,
                     boundSignature,

--- a/server/src/main/java/io/crate/expression/operator/OrOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/OrOperator.java
@@ -46,7 +46,7 @@ public class OrOperator extends Operator<Boolean> {
         DataTypes.BOOLEAN.getTypeSignature(),
         DataTypes.BOOLEAN.getTypeSignature(),
         DataTypes.BOOLEAN.getTypeSignature()
-    );
+    ).withFeature(Feature.DETERMINISTIC);
 
 
     public static void register(Functions.Builder builder) {

--- a/server/src/main/java/io/crate/expression/operator/RegexpMatchCaseInsensitiveOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/RegexpMatchCaseInsensitiveOperator.java
@@ -49,7 +49,7 @@ public class RegexpMatchCaseInsensitiveOperator extends Operator<String> {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature(),
                 Operator.RETURN_TYPE.getTypeSignature()
-            ),
+            ).withFeature(Feature.DETERMINISTIC),
             RegexpMatchCaseInsensitiveOperator::new
         );
     }

--- a/server/src/main/java/io/crate/expression/operator/RegexpMatchOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/RegexpMatchOperator.java
@@ -56,7 +56,7 @@ public class RegexpMatchOperator extends Operator<String> {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature(),
                 Operator.RETURN_TYPE.getTypeSignature()
-            ),
+            ).withFeature(Feature.DETERMINISTIC),
             RegexpMatchOperator::new
         );
     }

--- a/server/src/main/java/io/crate/expression/operator/any/AnyOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/any/AnyOperator.java
@@ -95,11 +95,12 @@ public abstract sealed class AnyOperator extends Operator<Object>
     private static void reg(Functions.Builder builder, String name, FunctionFactory operatorFactory) {
         builder.add(
             Signature.scalar(
-                name,
-                TypeSignature.parse("E"),
-                TypeSignature.parse("array(E)"),
-                Operator.RETURN_TYPE.getTypeSignature()
-            ).withTypeVariableConstraints(TypeVariableConstraint.typeVariable("E")),
+                    name,
+                    TypeSignature.parse("E"),
+                    TypeSignature.parse("array(E)"),
+                    Operator.RETURN_TYPE.getTypeSignature()
+                ).withTypeVariableConstraints(TypeVariableConstraint.typeVariable("E"))
+                .withFeature(Feature.DETERMINISTIC),
             operatorFactory
         );
     }

--- a/server/src/main/java/io/crate/expression/predicate/IsNullPredicate.java
+++ b/server/src/main/java/io/crate/expression/predicate/IsNullPredicate.java
@@ -68,7 +68,8 @@ public class IsNullPredicate<T> extends Scalar<Boolean, T> {
             NAME,
             TypeSignature.parse("E"),
             DataTypes.BOOLEAN.getTypeSignature()
-        ).withFeature(Feature.NON_NULLABLE)
+        ).withFeature(Feature.DETERMINISTIC)
+        .withFeature(Feature.NON_NULLABLE)
         .withTypeVariableConstraints(typeVariable("E"));
 
     public static void register(Functions.Builder builder) {

--- a/server/src/main/java/io/crate/expression/predicate/MatchPredicate.java
+++ b/server/src/main/java/io/crate/expression/predicate/MatchPredicate.java
@@ -96,22 +96,24 @@ public class MatchPredicate implements FunctionImplementation, FunctionToQuery {
      * 4. match_type options - object mapping option name to value (Object) (nullable)
      */
     public static final Signature TEXT_MATCH = Signature.scalar(
-        NAME,
-        DataTypes.UNTYPED_OBJECT.getTypeSignature(),
-        DataTypes.STRING.getTypeSignature(),
-        DataTypes.STRING.getTypeSignature(),
-        DataTypes.UNTYPED_OBJECT.getTypeSignature(),
-        DataTypes.BOOLEAN.getTypeSignature()
-    ).withFeature(Scalar.Feature.NON_NULLABLE);
+            NAME,
+            DataTypes.UNTYPED_OBJECT.getTypeSignature(),
+            DataTypes.STRING.getTypeSignature(),
+            DataTypes.STRING.getTypeSignature(),
+            DataTypes.UNTYPED_OBJECT.getTypeSignature(),
+            DataTypes.BOOLEAN.getTypeSignature()
+        ).withFeature(Scalar.Feature.DETERMINISTIC)
+        .withFeature(Scalar.Feature.NON_NULLABLE);
 
     public static final Signature GEO_MATCH = Signature.scalar(
-        NAME,
-        DataTypes.UNTYPED_OBJECT.getTypeSignature(),
-        DataTypes.GEO_SHAPE.getTypeSignature(),
-        DataTypes.STRING.getTypeSignature(),
-        DataTypes.UNTYPED_OBJECT.getTypeSignature(),
-        DataTypes.BOOLEAN.getTypeSignature()
-    ).withFeature(Scalar.Feature.NON_NULLABLE);
+            NAME,
+            DataTypes.UNTYPED_OBJECT.getTypeSignature(),
+            DataTypes.GEO_SHAPE.getTypeSignature(),
+            DataTypes.STRING.getTypeSignature(),
+            DataTypes.UNTYPED_OBJECT.getTypeSignature(),
+            DataTypes.BOOLEAN.getTypeSignature()
+        ).withFeature(Scalar.Feature.DETERMINISTIC)
+        .withFeature(Scalar.Feature.NON_NULLABLE);
 
 
     public static void register(Functions.Builder builder) {

--- a/server/src/main/java/io/crate/expression/predicate/NotPredicate.java
+++ b/server/src/main/java/io/crate/expression/predicate/NotPredicate.java
@@ -54,9 +54,10 @@ public class NotPredicate extends Scalar<Boolean, Boolean> {
 
     public static final String NAME = "op_not";
     public static final Signature SIGNATURE = Signature.scalar(
-        NAME,
-        DataTypes.BOOLEAN.getTypeSignature(),
-        DataTypes.BOOLEAN.getTypeSignature())
+            NAME,
+            DataTypes.BOOLEAN.getTypeSignature(),
+            DataTypes.BOOLEAN.getTypeSignature())
+        .withFeature(Feature.DETERMINISTIC)
         .withFeature(Feature.NULLABLE);
 
     public static void register(Functions.Builder builder) {

--- a/server/src/main/java/io/crate/expression/scalar/ArrayAppendFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayAppendFunction.java
@@ -49,6 +49,7 @@ public class ArrayAppendFunction extends Scalar<List<Object>, Object> {
                     TypeSignature.parse("E"),
                     TypeSignature.parse("array(E)")
                 ).withTypeVariableConstraints(typeVariable("E"))
+                .withFeature(Feature.DETERMINISTIC)
                 .withFeature(Feature.NON_NULLABLE),
             ArrayAppendFunction::new
         );

--- a/server/src/main/java/io/crate/expression/scalar/ArrayAvgFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayAvgFunction.java
@@ -88,10 +88,11 @@ public class ArrayAvgFunction {
 
         builder.add(
             Signature.scalar(
-                NAME,
-                new ArrayType<>(DataTypes.NUMERIC).getTypeSignature(),
-                DataTypes.NUMERIC.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE),
+                    NAME,
+                    new ArrayType<>(DataTypes.NUMERIC).getTypeSignature(),
+                    DataTypes.NUMERIC.getTypeSignature()
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) -> new UnaryScalar<>(
                 signature,
                 boundSignature,
@@ -102,10 +103,11 @@ public class ArrayAvgFunction {
 
         builder.add(
             Signature.scalar(
-                NAME,
-                new ArrayType<>(DataTypes.FLOAT).getTypeSignature(),
-                DataTypes.FLOAT.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE),
+                    NAME,
+                    new ArrayType<>(DataTypes.FLOAT).getTypeSignature(),
+                    DataTypes.FLOAT.getTypeSignature()
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) -> new UnaryScalar<>(
                 signature,
                 boundSignature,
@@ -116,10 +118,11 @@ public class ArrayAvgFunction {
 
         builder.add(
             Signature.scalar(
-                NAME,
-                new ArrayType<>(DataTypes.DOUBLE).getTypeSignature(),
-                DataTypes.DOUBLE.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE),
+                    NAME,
+                    new ArrayType<>(DataTypes.DOUBLE).getTypeSignature(),
+                    DataTypes.DOUBLE.getTypeSignature()
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) -> new UnaryScalar<>(
                 signature,
                 boundSignature,
@@ -133,10 +136,11 @@ public class ArrayAvgFunction {
             if (supportedType != DataTypes.FLOAT && supportedType != DataTypes.DOUBLE) {
                 builder.add(
                     Signature.scalar(
-                        NAME,
-                        new ArrayType<>(supportedType).getTypeSignature(),
-                        DataTypes.NUMERIC.getTypeSignature()
-                    ).withFeature(Scalar.Feature.NULLABLE),
+                            NAME,
+                            new ArrayType<>(supportedType).getTypeSignature(),
+                            DataTypes.NUMERIC.getTypeSignature()
+                        ).withFeature(Scalar.Feature.DETERMINISTIC)
+                        .withFeature(Scalar.Feature.NULLABLE),
                     (signature, boundSignature) -> new UnaryScalar<>(
                         signature,
                         boundSignature,

--- a/server/src/main/java/io/crate/expression/scalar/ArrayCatFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayCatFunction.java
@@ -45,11 +45,12 @@ public class ArrayCatFunction extends Scalar<List<Object>, List<Object>> {
     public static void register(Functions.Builder module) {
         module.add(
             Signature.scalar(
-                NAME,
-                TypeSignature.parse("array(E)"),
-                TypeSignature.parse("array(E)"),
-                TypeSignature.parse("array(E)")
-            ).withFeature(Feature.NON_NULLABLE)
+                    NAME,
+                    TypeSignature.parse("array(E)"),
+                    TypeSignature.parse("array(E)"),
+                    TypeSignature.parse("array(E)")
+                ).withFeature(Feature.DETERMINISTIC)
+                .withFeature(Feature.NON_NULLABLE)
                 .withTypeVariableConstraints(typeVariable("E")),
             ArrayCatFunction::new
         );

--- a/server/src/main/java/io/crate/expression/scalar/ArrayDifferenceFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayDifferenceFunction.java
@@ -57,7 +57,8 @@ class ArrayDifferenceFunction extends Scalar<List<Object>, List<Object>> {
                     TypeSignature.parse("array(E)"),
                     TypeSignature.parse("array(E)"),
                     TypeSignature.parse("array(E)")
-                ).withTypeVariableConstraints(typeVariable("E"))
+                ).withFeature(Feature.DETERMINISTIC)
+                .withTypeVariableConstraints(typeVariable("E"))
                 .withFeature(Feature.NULLABLE),
             (signature, boundSignature) ->
                 new ArrayDifferenceFunction(

--- a/server/src/main/java/io/crate/expression/scalar/ArrayLowerFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayLowerFunction.java
@@ -49,7 +49,8 @@ class ArrayLowerFunction extends Scalar<Integer, Object> {
                     TypeSignature.parse("array(E)"),
                     DataTypes.INTEGER.getTypeSignature(),
                     DataTypes.INTEGER.getTypeSignature()
-                ).withTypeVariableConstraints(typeVariable("E"))
+                ).withFeature(Feature.DETERMINISTIC)
+                .withTypeVariableConstraints(typeVariable("E"))
                 .withFeature(Feature.NULLABLE),
             ArrayLowerFunction::new
         );

--- a/server/src/main/java/io/crate/expression/scalar/ArrayMaxFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayMaxFunction.java
@@ -50,7 +50,7 @@ public class ArrayMaxFunction<T> extends Scalar<T, List<T>> {
                     NAME,
                     new ArrayType(DataTypes.NUMERIC).getTypeSignature(),
                     DataTypes.NUMERIC.getTypeSignature()
-                )
+                ).withFeature(Feature.DETERMINISTIC)
                 .withFeature(Feature.NULLABLE),
             ArrayMaxFunction::new
         );
@@ -61,7 +61,7 @@ public class ArrayMaxFunction<T> extends Scalar<T, List<T>> {
                     NAME,
                     new ArrayType(supportedType).getTypeSignature(),
                     supportedType.getTypeSignature()
-                )
+                ).withFeature(Feature.DETERMINISTIC)
                 .withFeature(Feature.NULLABLE),
                 ArrayMaxFunction::new
             );

--- a/server/src/main/java/io/crate/expression/scalar/ArrayMinFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayMinFunction.java
@@ -50,7 +50,7 @@ public class ArrayMinFunction<T> extends Scalar<T, List<T>> {
                     NAME,
                     new ArrayType(DataTypes.NUMERIC).getTypeSignature(),
                     DataTypes.NUMERIC.getTypeSignature()
-                )
+                ).withFeature(Feature.DETERMINISTIC)
                 .withFeature(Feature.NULLABLE),
             ArrayMinFunction::new
         );
@@ -61,7 +61,7 @@ public class ArrayMinFunction<T> extends Scalar<T, List<T>> {
                         NAME,
                         new ArrayType(supportedType).getTypeSignature(),
                         supportedType.getTypeSignature()
-                    )
+                    ).withFeature(Feature.DETERMINISTIC)
                     .withFeature(Feature.NULLABLE),
                 ArrayMinFunction::new
             );

--- a/server/src/main/java/io/crate/expression/scalar/ArrayPositionFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayPositionFunction.java
@@ -53,6 +53,7 @@ public class ArrayPositionFunction extends Scalar<Integer, List<Object>> {
                     TypeSignature.parse("T"),
                     DataTypes.INTEGER.getTypeSignature()
                 ).withTypeVariableConstraints(typeVariable("T"))
+                .withFeature(Feature.DETERMINISTIC)
                 .withFeature(Feature.NULLABLE),
             ArrayPositionFunction::new);
 
@@ -63,6 +64,7 @@ public class ArrayPositionFunction extends Scalar<Integer, List<Object>> {
                     DataTypes.INTEGER.getTypeSignature(),
                     DataTypes.INTEGER.getTypeSignature()
                 ).withTypeVariableConstraints(typeVariable("T"))
+                .withFeature(Feature.DETERMINISTIC)
                 .withFeature(Feature.NULLABLE),
             ArrayPositionFunction::new);
     }

--- a/server/src/main/java/io/crate/expression/scalar/ArraySetFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArraySetFunction.java
@@ -51,6 +51,7 @@ public class ArraySetFunction extends Scalar<List<Object>, Object> {
                     arrayESignature,
                     arrayESignature
                 ).withTypeVariableConstraints(typeVariable("E"))
+                .withFeature(Feature.DETERMINISTIC)
                 .withFeature(Feature.NULLABLE),
             ArraySetFunction::new
         );
@@ -62,6 +63,7 @@ public class ArraySetFunction extends Scalar<List<Object>, Object> {
                     TypeSignature.parse("E"),
                     arrayESignature
                 ).withTypeVariableConstraints(typeVariable("E"))
+                .withFeature(Feature.DETERMINISTIC)
                 .withFeature(Feature.NULLABLE),
             SingleArraySetFunction::new
         );

--- a/server/src/main/java/io/crate/expression/scalar/ArraySliceFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArraySliceFunction.java
@@ -50,6 +50,7 @@ public class ArraySliceFunction extends Scalar<List<Object>, Object> {
                     DataTypes.INTEGER.getTypeSignature(),
                     TypeSignature.parse("array(E)")
                 ).withTypeVariableConstraints(typeVariable("E"))
+                .withFeature(Feature.DETERMINISTIC)
                 .withFeature(Feature.NON_NULLABLE),
             ArraySliceFunction::new
         );

--- a/server/src/main/java/io/crate/expression/scalar/ArraySumFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArraySumFunction.java
@@ -47,10 +47,11 @@ public class ArraySumFunction<T extends Number, R extends Number> extends Scalar
 
     private static <T, U> Signature signature(DataType<T> elementType, DataType<U> returnType) {
         return Signature.scalar(
-            NAME,
-            new ArrayType<>(elementType).getTypeSignature(),
-            returnType.getTypeSignature()
-        ).withFeature(Feature.NULLABLE);
+                NAME,
+                new ArrayType<>(elementType).getTypeSignature(),
+                returnType.getTypeSignature()
+            ).withFeature(Feature.DETERMINISTIC)
+            .withFeature(Feature.NULLABLE);
     }
 
     public static void register(Functions.Builder builder) {

--- a/server/src/main/java/io/crate/expression/scalar/ArrayToStringFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayToStringFunction.java
@@ -51,6 +51,7 @@ class ArrayToStringFunction extends Scalar<String, Object> {
                     DataTypes.STRING.getTypeSignature(),
                     DataTypes.STRING.getTypeSignature()
                 ).withTypeVariableConstraints(typeVariable("E"))
+                .withFeature(Feature.DETERMINISTIC)
                 .withFeature(Feature.NULLABLE),
             ArrayToStringFunction::new
         );
@@ -62,6 +63,7 @@ class ArrayToStringFunction extends Scalar<String, Object> {
                     DataTypes.STRING.getTypeSignature(),
                     DataTypes.STRING.getTypeSignature()
                 ).withTypeVariableConstraints(typeVariable("E"))
+                .withFeature(Feature.DETERMINISTIC)
                 .withFeature(Feature.NULLABLE),
             ArrayToStringFunction::new
         );

--- a/server/src/main/java/io/crate/expression/scalar/ArrayUniqueFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayUniqueFunction.java
@@ -52,6 +52,7 @@ public class ArrayUniqueFunction extends Scalar<List<Object>, List<Object>> {
                     TypeSignature.parse("array(E)"),
                     TypeSignature.parse("array(E)")
                 ).withTypeVariableConstraints(typeVariable("E"))
+                .withFeature(Feature.DETERMINISTIC)
                 .withFeature(Feature.NON_NULLABLE),
             ArrayUniqueFunction::new
         );
@@ -62,6 +63,7 @@ public class ArrayUniqueFunction extends Scalar<List<Object>, List<Object>> {
                     TypeSignature.parse("array(E)"),
                     TypeSignature.parse("array(E)")
                 ).withTypeVariableConstraints(typeVariable("E"))
+                .withFeature(Feature.DETERMINISTIC)
                 .withFeature(Feature.NON_NULLABLE),
             ArrayUniqueFunction::new
         );

--- a/server/src/main/java/io/crate/expression/scalar/ArrayUnnestFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayUnnestFunction.java
@@ -52,6 +52,7 @@ public class ArrayUnnestFunction extends Scalar<List<Object>, List<List<Object>>
             TypeSignature.parse("array(array(E))"),
             TypeSignature.parse("array(E)")
         ).withTypeVariableConstraints(typeVariable("E"))
+        .withFeature(Feature.DETERMINISTIC)
         .withFeature(Feature.NULLABLE);
 
     public static void register(Functions.Builder module) {

--- a/server/src/main/java/io/crate/expression/scalar/ArrayUpperFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayUpperFunction.java
@@ -73,6 +73,7 @@ public class ArrayUpperFunction extends Scalar<Integer, Object> {
                         DataTypes.INTEGER.getTypeSignature(),
                         DataTypes.INTEGER.getTypeSignature()
                     ).withTypeVariableConstraints(typeVariable("E"))
+                    .withFeature(Feature.DETERMINISTIC)
                     .withFeature(Feature.NULLABLE),
                 ArrayUpperFunction::new
             );

--- a/server/src/main/java/io/crate/expression/scalar/CollectionAverageFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/CollectionAverageFunction.java
@@ -46,6 +46,7 @@ public class CollectionAverageFunction extends Scalar<Double, List<Object>> {
                     TypeSignature.parse("array(E)"),
                     DataTypes.DOUBLE.getTypeSignature()
                 ).withTypeVariableConstraints(typeVariable("E"))
+                .withFeature(Feature.DETERMINISTIC)
                 .withFeature(Feature.NULLABLE),
             CollectionAverageFunction::new
         );

--- a/server/src/main/java/io/crate/expression/scalar/CollectionCountFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/CollectionCountFunction.java
@@ -46,6 +46,7 @@ public class CollectionCountFunction extends Scalar<Long, List<Object>> {
                     TypeSignature.parse("array(E)"),
                     DataTypes.LONG.getTypeSignature()
                 ).withTypeVariableConstraints(typeVariable("E"))
+                .withFeature(Feature.DETERMINISTIC)
                 .withFeature(Feature.NULLABLE),
             CollectionCountFunction::new
         );

--- a/server/src/main/java/io/crate/expression/scalar/ConcatFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ConcatFunction.java
@@ -48,7 +48,7 @@ public abstract class ConcatFunction extends Scalar<String, String> {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            )
+            ).withFeature(Feature.DETERMINISTIC)
             .withFeature(Feature.NON_NULLABLE),
             StringConcatFunction::new
         );
@@ -58,7 +58,7 @@ public abstract class ConcatFunction extends Scalar<String, String> {
                 NAME,
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            )
+            ).withFeature(Feature.DETERMINISTIC)
             .withFeature(Feature.NON_NULLABLE)
             .withVariableArity(),
             GenericConcatFunction::new
@@ -71,7 +71,7 @@ public abstract class ConcatFunction extends Scalar<String, String> {
                 TypeSignature.parse("array(E)"),
                 TypeSignature.parse("array(E)"),
                 TypeSignature.parse("array(E)")
-            )
+            ).withFeature(Feature.DETERMINISTIC)
             .withFeature(Feature.NON_NULLABLE)
             .withTypeVariableConstraints(typeVariable("E")),
             ArrayCatFunction::new
@@ -83,7 +83,7 @@ public abstract class ConcatFunction extends Scalar<String, String> {
                 DataTypes.UNTYPED_OBJECT.getTypeSignature(),
                 DataTypes.UNTYPED_OBJECT.getTypeSignature(),
                 DataTypes.UNTYPED_OBJECT.getTypeSignature()
-            ),
+            ).withFeature(Feature.DETERMINISTIC),
             ObjectMergeFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/ConcatWsFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ConcatWsFunction.java
@@ -39,7 +39,7 @@ public class ConcatWsFunction extends Scalar<String, String> {
                 NAME,
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            )
+            ).withFeature(Feature.DETERMINISTIC)
             .withVariableArity(),
             ConcatWsFunction::new
         );

--- a/server/src/main/java/io/crate/expression/scalar/CurrentDatabaseFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/CurrentDatabaseFunction.java
@@ -40,9 +40,10 @@ final class CurrentDatabaseFunction extends Scalar<String, Void> {
     public static void register(Functions.Builder module) {
         module.add(
             Signature.scalar(
-                FQN,
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Feature.NON_NULLABLE),
+                    FQN,
+                    DataTypes.STRING.getTypeSignature()
+                ).withFeature(Feature.DETERMINISTIC)
+                .withFeature(Feature.NON_NULLABLE),
             CurrentDatabaseFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/CurrentDateFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/CurrentDateFunction.java
@@ -39,9 +39,9 @@ public final class CurrentDateFunction extends Scalar<Long, String> {
     public static void register(Functions.Builder module) {
         module.add(
             Signature.scalar(
-                NAME,
-                DataTypes.DATE.getTypeSignature()
-            ).withFeatures(EnumSet.of(Feature.NON_NULLABLE)),
+                    NAME,
+                    DataTypes.DATE.getTypeSignature()
+                ).withFeatures(EnumSet.of(Feature.NON_NULLABLE)),
             CurrentDateFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/DateFormatFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/DateFormatFunction.java
@@ -51,7 +51,8 @@ public class DateFormatFunction extends Scalar<String, Object> {
                     NAME,
                     dataType.getTypeSignature(),
                     DataTypes.STRING.getTypeSignature()
-                ), DateFormatFunction::new
+                ).withFeature(Feature.DETERMINISTIC),
+                DateFormatFunction::new
             );
 
             // with format
@@ -61,7 +62,8 @@ public class DateFormatFunction extends Scalar<String, Object> {
                     DataTypes.STRING.getTypeSignature(),
                     dataType.getTypeSignature(),
                     DataTypes.STRING.getTypeSignature()
-                ), DateFormatFunction::new
+                ).withFeature(Feature.DETERMINISTIC),
+                DateFormatFunction::new
             );
 
             // time zone aware variant
@@ -72,7 +74,8 @@ public class DateFormatFunction extends Scalar<String, Object> {
                     DataTypes.STRING.getTypeSignature(),
                     dataType.getTypeSignature(),
                     DataTypes.STRING.getTypeSignature()
-                ), DateFormatFunction::new
+                ).withFeature(Feature.DETERMINISTIC),
+                DateFormatFunction::new
             );
         }
     }

--- a/server/src/main/java/io/crate/expression/scalar/ExtractFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/ExtractFunctions.java
@@ -81,10 +81,11 @@ public class ExtractFunctions {
                 final DateTimeField dtf = entry.dtf();
                 module.add(
                     Signature.scalar(
-                        functionNameFrom(entry.extractField()),
-                        argType.getTypeSignature(),
-                        DataTypes.INTEGER.getTypeSignature()
-                    ).withFeature(Scalar.Feature.NULLABLE),
+                            functionNameFrom(entry.extractField()),
+                            argType.getTypeSignature(),
+                            DataTypes.INTEGER.getTypeSignature()
+                        ).withFeature(Scalar.Feature.DETERMINISTIC)
+                        .withFeature(Scalar.Feature.NULLABLE),
                     (signature, boundSignature) ->
                         new UnaryScalar<Number, Long>(signature, boundSignature, argType, dtf::get)
                 );
@@ -92,10 +93,11 @@ public class ExtractFunctions {
             // extract(epoch from ...) is different as is returns a `double precision`
             module.add(
                 Signature.scalar(
-                    functionNameFrom(EPOCH),
-                    argType.getTypeSignature(),
-                    DataTypes.DOUBLE.getTypeSignature()
-                ).withFeature(Scalar.Feature.NULLABLE),
+                        functionNameFrom(EPOCH),
+                        argType.getTypeSignature(),
+                        DataTypes.DOUBLE.getTypeSignature()
+                    ).withFeature(Scalar.Feature.DETERMINISTIC)
+                    .withFeature(Scalar.Feature.NULLABLE),
                 (signature, boundSignature) ->
                     new UnaryScalar<>(signature, boundSignature, argType, v -> (double) v / 1000)
             );
@@ -116,10 +118,11 @@ public class ExtractFunctions {
             final Function<Period, Integer> function = entry.function();
             module.add(
                 Signature.scalar(
-                    functionNameFrom(entry.extractField()),
-                    DataTypes.INTERVAL.getTypeSignature(),
-                    DataTypes.INTEGER.getTypeSignature()
-                ).withFeature(Scalar.Feature.NULLABLE),
+                        functionNameFrom(entry.extractField()),
+                        DataTypes.INTERVAL.getTypeSignature(),
+                        DataTypes.INTEGER.getTypeSignature()
+                    ).withFeature(Scalar.Feature.DETERMINISTIC)
+                    .withFeature(Scalar.Feature.NULLABLE),
                 (signature, boundSignature) ->
                     new UnaryScalar<Number, Period>(signature, boundSignature, DataTypes.INTERVAL, function::apply)
             );
@@ -127,10 +130,11 @@ public class ExtractFunctions {
         // extract(epoch from ...) is different as is returns a `double precision`
         module.add(
             Signature.scalar(
-                functionNameFrom(EPOCH),
-                DataTypes.INTERVAL.getTypeSignature(),
-                DataTypes.DOUBLE.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE),
+                    functionNameFrom(EPOCH),
+                    DataTypes.INTERVAL.getTypeSignature(),
+                    DataTypes.DOUBLE.getTypeSignature()
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new UnaryScalar<>(signature, boundSignature, DataTypes.INTERVAL, ExtractFunctions::toMillis)
         );

--- a/server/src/main/java/io/crate/expression/scalar/FormatFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/FormatFunction.java
@@ -41,11 +41,12 @@ public class FormatFunction extends Scalar<String, Object> {
 
     public static final Signature SIGNATURE =
         Signature.scalar(
-            NAME,
-            DataTypes.STRING.getTypeSignature(),
-            TypeSignature.parse("E"),
-            DataTypes.STRING.getTypeSignature()
-        )
+                NAME,
+                DataTypes.STRING.getTypeSignature(),
+                TypeSignature.parse("E"),
+                DataTypes.STRING.getTypeSignature()
+            )
+            .withFeature(Feature.DETERMINISTIC)
             .withFeature(Feature.NON_NULLABLE)
             .withTypeVariableConstraints(typeVariableOfAnyType("E"))
             .withVariableArity();

--- a/server/src/main/java/io/crate/expression/scalar/GenRandomTextUUIDFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/GenRandomTextUUIDFunction.java
@@ -41,9 +41,9 @@ public final class GenRandomTextUUIDFunction extends Scalar<String, Void> {
     public static void register(Functions.Builder module) {
         module.add(
             Signature.scalar(
-                NAME,
-                DataTypes.STRING.getTypeSignature()
-            ).withFeatures(EnumSet.of(Feature.NON_NULLABLE)),
+                    NAME,
+                    DataTypes.STRING.getTypeSignature()
+                ).withFeatures(EnumSet.of(Feature.NON_NULLABLE)),
             GenRandomTextUUIDFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/Ignore3vlFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/Ignore3vlFunction.java
@@ -52,10 +52,11 @@ public class Ignore3vlFunction extends Scalar<Boolean, Boolean> {
 
     public static final String NAME = "ignore3vl";
     public static final Signature SIGNATURE = Signature.scalar(
-        NAME,
-        DataTypes.BOOLEAN.getTypeSignature(),
-        DataTypes.BOOLEAN.getTypeSignature()
-    ).withFeature(Feature.NON_NULLABLE);
+            NAME,
+            DataTypes.BOOLEAN.getTypeSignature(),
+            DataTypes.BOOLEAN.getTypeSignature()
+        ).withFeature(Feature.DETERMINISTIC)
+        .withFeature(Feature.NON_NULLABLE);
 
     public static void register(Functions.Builder module) {
         module.add(

--- a/server/src/main/java/io/crate/expression/scalar/KnnMatch.java
+++ b/server/src/main/java/io/crate/expression/scalar/KnnMatch.java
@@ -54,7 +54,7 @@ public class KnnMatch extends Scalar<Boolean, Object> {
                 TypeSignature.parse(FloatVectorType.NAME),
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.BOOLEAN.getTypeSignature()
-            ),
+            ).withFeature(Feature.DETERMINISTIC),
             KnnMatch::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/NullOrEmptyFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/NullOrEmptyFunction.java
@@ -54,9 +54,10 @@ public final class NullOrEmptyFunction extends Scalar<Boolean, Object> {
     public static void register(Functions.Builder module) {
         module.add(
             Signature.scalar(
-                "null_or_empty",
-                DataTypes.UNTYPED_OBJECT.getTypeSignature(),
-                DataTypes.BOOLEAN.getTypeSignature())
+                    "null_or_empty",
+                    DataTypes.UNTYPED_OBJECT.getTypeSignature(),
+                    DataTypes.BOOLEAN.getTypeSignature())
+                .withFeature(Feature.DETERMINISTIC)
                 .withFeature(Feature.NON_NULLABLE),
             NullOrEmptyFunction::new
         );
@@ -66,6 +67,7 @@ public final class NullOrEmptyFunction extends Scalar<Boolean, Object> {
                     TypeSignature.parse("array(E)"),
                     DataTypes.BOOLEAN.getTypeSignature()
                 ).withTypeVariableConstraints(TypeVariableConstraint.typeVariableOfAnyType("E"))
+                .withFeature(Feature.DETERMINISTIC)
                 .withFeature(Feature.NON_NULLABLE),
             NullOrEmptyFunction::new
         );

--- a/server/src/main/java/io/crate/expression/scalar/PiFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/PiFunction.java
@@ -39,7 +39,7 @@ public final class PiFunction extends Scalar<Double, Object> {
             Signature.scalar(
                 NAME,
                 DataTypes.DOUBLE.getTypeSignature()
-            )
+            ).withFeature(Feature.DETERMINISTIC)
             .withFeature(Feature.NON_NULLABLE),
             PiFunction::new
         );

--- a/server/src/main/java/io/crate/expression/scalar/StringToArrayFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/StringToArrayFunction.java
@@ -49,7 +49,7 @@ public class StringToArrayFunction extends Scalar<List<String>, String> {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING_ARRAY.getTypeSignature()
-            ),
+            ).withFeature(Feature.DETERMINISTIC),
             StringToArrayFunction::new
         );
         module.add(
@@ -59,7 +59,7 @@ public class StringToArrayFunction extends Scalar<List<String>, String> {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING_ARRAY.getTypeSignature()
-            ),
+            ).withFeature(Feature.DETERMINISTIC),
             StringToArrayFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/SubscriptFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/SubscriptFunction.java
@@ -81,11 +81,12 @@ public class SubscriptFunction extends Scalar<Object, Object> {
         // subscript(array(object)), text) -> array(undefined)
         module.add(
             Signature.scalar(
-                NAME,
-                TypeSignature.parse("array(object)"),
-                DataTypes.STRING.getTypeSignature(),
-                TypeSignature.parse("array(undefined)")
-            ).withForbiddenCoercion(),
+                    NAME,
+                    TypeSignature.parse("array(object)"),
+                    DataTypes.STRING.getTypeSignature(),
+                    TypeSignature.parse("array(undefined)")
+                ).withFeature(Feature.DETERMINISTIC)
+                .withForbiddenCoercion(),
             (signature, boundSignature) ->
                 new SubscriptFunction(
                     signature,
@@ -101,6 +102,7 @@ public class SubscriptFunction extends Scalar<Object, Object> {
                     TypeSignature.parse("array(E)"),
                     DataTypes.INTEGER.getTypeSignature(),
                     TypeSignature.parse("E"))
+                .withFeature(Feature.DETERMINISTIC)
                 .withTypeVariableConstraints(typeVariable("E")),
             (signature, boundSignature) ->
                 new SubscriptFunction(
@@ -112,11 +114,12 @@ public class SubscriptFunction extends Scalar<Object, Object> {
         // subscript(object(text, element), text) -> undefined
         module.add(
             Signature.scalar(
-                NAME,
-                DataTypes.UNTYPED_OBJECT.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.UNDEFINED.getTypeSignature()
-            ).withForbiddenCoercion(),
+                    NAME,
+                    DataTypes.UNTYPED_OBJECT.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.UNDEFINED.getTypeSignature()
+                ).withFeature(Feature.DETERMINISTIC)
+                .withForbiddenCoercion(),
             (signature, boundSignature) ->
                 new SubscriptFunction(
                     signature,
@@ -133,11 +136,12 @@ public class SubscriptFunction extends Scalar<Object, Object> {
         // must be resolved for the `subscript(undefined, text)` signature.
         module.add(
             Signature.scalar(
-                NAME,
-                DataTypes.UNDEFINED.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.UNDEFINED.getTypeSignature()
-            ).withForbiddenCoercion(),
+                    NAME,
+                    DataTypes.UNDEFINED.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.UNDEFINED.getTypeSignature()
+                ).withFeature(Feature.DETERMINISTIC)
+                .withForbiddenCoercion(),
             (signature, boundSignature) ->
                 new SubscriptFunction(
                     signature,

--- a/server/src/main/java/io/crate/expression/scalar/SubscriptObjectFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/SubscriptObjectFunction.java
@@ -54,6 +54,7 @@ public class SubscriptObjectFunction extends Scalar<Object, Map<String, Object>>
             DataTypes.UNTYPED_OBJECT.getTypeSignature(),
             DataTypes.STRING.getTypeSignature(),
             DataTypes.UNDEFINED.getTypeSignature())
+        .withFeature(Feature.DETERMINISTIC)
         .withVariableArity();
 
     public static void register(Functions.Builder module) {

--- a/server/src/main/java/io/crate/expression/scalar/SubscriptRecordFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/SubscriptRecordFunction.java
@@ -40,7 +40,7 @@ public final class SubscriptRecordFunction extends Scalar<Object, Object> {
         RowType.EMPTY.getTypeSignature(),
         DataTypes.STRING.getTypeSignature(),
         DataTypes.UNDEFINED.getTypeSignature()
-    );
+    ).withFeature(Feature.DETERMINISTIC);
 
     public static void register(Functions.Builder module) {
         module.add(

--- a/server/src/main/java/io/crate/expression/scalar/SubstrFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/SubstrFunction.java
@@ -50,15 +50,15 @@ public class SubstrFunction extends Scalar<String, Object> {
         TypeSignature intType = DataTypes.INTEGER.getTypeSignature();
         for (var name : List.of(NAME, ALIAS)) {
             builder.add(
-                Signature.scalar(name, stringType, intType, stringType),
+                Signature.scalar(name, stringType, intType, stringType).withFeature(Feature.DETERMINISTIC),
                 SubstrFunction::new
             );
             builder.add(
-                Signature.scalar(name, stringType, intType, intType, stringType),
+                Signature.scalar(name, stringType, intType, intType, stringType).withFeature(Feature.DETERMINISTIC),
                 SubstrFunction::new
             );
             builder.add(
-                Signature.scalar(name, stringType, stringType, stringType),
+                Signature.scalar(name, stringType, stringType, stringType).withFeature(Feature.DETERMINISTIC),
                 SubstrExtractFunction::new
             );
         }

--- a/server/src/main/java/io/crate/expression/scalar/VectorSimilarityFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/VectorSimilarityFunction.java
@@ -36,11 +36,12 @@ public class VectorSimilarityFunction extends Scalar<Float, float[]> {
     public static void register(Functions.Builder module) {
         module.add(
             Signature.scalar(
-                "vector_similarity",
-                FloatVectorType.INSTANCE_ONE.getTypeSignature(),
-                FloatVectorType.INSTANCE_ONE.getTypeSignature(),
-                DataTypes.FLOAT.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE),
+                    "vector_similarity",
+                    FloatVectorType.INSTANCE_ONE.getTypeSignature(),
+                    FloatVectorType.INSTANCE_ONE.getTypeSignature(),
+                    DataTypes.FLOAT.getTypeSignature()
+                ).withFeature(Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE),
             VectorSimilarityFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/AbsFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/AbsFunction.java
@@ -38,6 +38,7 @@ public final class AbsFunction {
             var typeSignature = type.getTypeSignature();
             builder.add(
                 scalar(NAME, typeSignature, typeSignature)
+                    .withFeature(Scalar.Feature.DETERMINISTIC)
                     .withFeature(Scalar.Feature.NULLABLE),
                 (signature, boundSignature) -> {
                     DataType<?> argType = boundSignature.argTypes().get(0);

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/ArrayFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/ArrayFunction.java
@@ -47,6 +47,7 @@ public class ArrayFunction extends Scalar<Object, Object> {
             .returnType(TypeSignature.parse("array(E)"))
             .setVariableArity(true)
             .feature(Feature.NON_NULLABLE)
+            .feature(Feature.DETERMINISTIC)
             .build();
 
 

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/CeilFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/CeilFunction.java
@@ -44,6 +44,7 @@ public final class CeilFunction {
             for (var name : List.of(CEIL, CEILING)) {
                 module.add(
                     scalar(name, typeSignature, returnType.getTypeSignature())
+                        .withFeature(Scalar.Feature.DETERMINISTIC)
                         .withFeature(Scalar.Feature.NULLABLE),
                     (signature, boundSignature) ->
                         new UnaryScalar<>(

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/ExpFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/ExpFunction.java
@@ -37,6 +37,7 @@ public class ExpFunction {
         var signature = type.getTypeSignature();
         module.add(
             scalar(NAME, signature, signature)
+                .withFeature(Scalar.Feature.DETERMINISTIC)
                 .withFeature(Scalar.Feature.NULLABLE),
             (declaredSignature, boundSignature) ->
                 new UnaryScalar<>(

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/FloorFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/FloorFunction.java
@@ -40,6 +40,7 @@ public final class FloorFunction {
             assert returnType != null : "Could not get integral type of " + type;
             module.add(
                 scalar(NAME, typeSignature, returnType.getTypeSignature())
+                    .withFeature(Scalar.Feature.DETERMINISTIC)
                     .withFeature(Scalar.Feature.NULLABLE),
                 (signature, boundSignature) ->
                     new UnaryScalar<>(

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/IntervalArithmeticFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/IntervalArithmeticFunctions.java
@@ -41,40 +41,44 @@ public class IntervalArithmeticFunctions {
     public static void register(Functions.Builder module) {
         module.add(
             Signature.scalar(
-                ArithmeticFunctions.Names.ADD,
-                DataTypes.INTERVAL.getTypeSignature(),
-                DataTypes.INTERVAL.getTypeSignature(),
-                DataTypes.INTERVAL.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE),
+                    ArithmeticFunctions.Names.ADD,
+                    DataTypes.INTERVAL.getTypeSignature(),
+                    DataTypes.INTERVAL.getTypeSignature(),
+                    DataTypes.INTERVAL.getTypeSignature()
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new IntervalIntervalArithmeticScalar(Period::plus, signature, boundSignature)
         );
         module.add(
             Signature.scalar(
-                ArithmeticFunctions.Names.SUBTRACT,
-                DataTypes.INTERVAL.getTypeSignature(),
-                DataTypes.INTERVAL.getTypeSignature(),
-                DataTypes.INTERVAL.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE),
+                    ArithmeticFunctions.Names.SUBTRACT,
+                    DataTypes.INTERVAL.getTypeSignature(),
+                    DataTypes.INTERVAL.getTypeSignature(),
+                    DataTypes.INTERVAL.getTypeSignature()
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new IntervalIntervalArithmeticScalar(Period::minus, signature, boundSignature)
         );
         module.add(
                 Signature.scalar(
-                ArithmeticFunctions.Names.MULTIPLY,
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.INTERVAL.getTypeSignature(),
-                DataTypes.INTERVAL.getTypeSignature()
-                ).withFeature(Scalar.Feature.NULLABLE),
+                        ArithmeticFunctions.Names.MULTIPLY,
+                        DataTypes.INTEGER.getTypeSignature(),
+                        DataTypes.INTERVAL.getTypeSignature(),
+                        DataTypes.INTERVAL.getTypeSignature()
+                    ).withFeature(Scalar.Feature.DETERMINISTIC)
+                    .withFeature(Scalar.Feature.NULLABLE),
             MultiplyIntervalByIntegerScalar::new
         );
         module.add(
                 Signature.scalar(
-                ArithmeticFunctions.Names.MULTIPLY,
-                DataTypes.INTERVAL.getTypeSignature(),
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.INTERVAL.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE),
+                        ArithmeticFunctions.Names.MULTIPLY,
+                        DataTypes.INTERVAL.getTypeSignature(),
+                        DataTypes.INTEGER.getTypeSignature(),
+                        DataTypes.INTERVAL.getTypeSignature()
+                    ).withFeature(Scalar.Feature.DETERMINISTIC)
+                    .withFeature(Scalar.Feature.NULLABLE),
             MultiplyIntervalByIntegerScalar::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/IntervalTimestampArithmeticScalar.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/IntervalTimestampArithmeticScalar.java
@@ -45,11 +45,12 @@ public class IntervalTimestampArithmeticScalar extends Scalar<Long, Object> impl
         for (var timestampType : List.of(DataTypes.TIMESTAMP, DataTypes.TIMESTAMPZ)) {
             module.add(
                 Signature.scalar(
-                    ArithmeticFunctions.Names.ADD,
-                    DataTypes.INTERVAL.getTypeSignature(),
-                    timestampType.getTypeSignature(),
-                    timestampType.getTypeSignature()
-                ).withForbiddenCoercion(),
+                        ArithmeticFunctions.Names.ADD,
+                        DataTypes.INTERVAL.getTypeSignature(),
+                        timestampType.getTypeSignature(),
+                        timestampType.getTypeSignature()
+                    ).withFeature(Feature.DETERMINISTIC)
+                    .withForbiddenCoercion(),
                 (signature, boundSignature) ->
                     new IntervalTimestampArithmeticScalar(
                         "+",
@@ -81,11 +82,12 @@ public class IntervalTimestampArithmeticScalar extends Scalar<Long, Object> impl
 
     public static Signature signatureFor(DataType<?> timestampType, String name) {
         return Signature.scalar(
-            name,
-            timestampType.getTypeSignature(),
-            DataTypes.INTERVAL.getTypeSignature(),
-            timestampType.getTypeSignature()
-        ).withForbiddenCoercion();
+                name,
+                timestampType.getTypeSignature(),
+                DataTypes.INTERVAL.getTypeSignature(),
+                timestampType.getTypeSignature()
+            ).withFeature(Feature.DETERMINISTIC)
+            .withForbiddenCoercion();
     }
 
     private final BiFunction<DateTime, Period, DateTime> operation;

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/LogFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/LogFunction.java
@@ -72,6 +72,7 @@ public abstract class LogFunction extends Scalar<Number, Number> {
                     DataTypes.DOUBLE.getTypeSignature(),
                     DataTypes.DOUBLE.getTypeSignature(),
                     TypeSignature.parse("double precision"))
+                    .withFeature(Feature.DETERMINISTIC)
                     .withFeature(Feature.NULLABLE),
                 LogBaseFunction::new
             );
@@ -110,6 +111,7 @@ public abstract class LogFunction extends Scalar<Number, Number> {
                     NAME,
                     DataTypes.DOUBLE.getTypeSignature(),
                     DataTypes.DOUBLE.getTypeSignature())
+                    .withFeature(Feature.DETERMINISTIC)
                     .withFeature(Feature.NULLABLE),
                 Log10Function::new
             );
@@ -144,6 +146,7 @@ public abstract class LogFunction extends Scalar<Number, Number> {
                     LnFunction.NAME,
                     DataTypes.DOUBLE.getTypeSignature(),
                     DataTypes.DOUBLE.getTypeSignature())
+                    .withFeature(Feature.DETERMINISTIC)
                     .withFeature(Feature.NULLABLE),
                 LnFunction::new
             );

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/MapFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/MapFunction.java
@@ -61,6 +61,7 @@ public class MapFunction extends Scalar<Object, Object> {
             // This is *ok* as the returnType is currently not used directly, only for function description.
             .returnType(TypeSignature.parse("object(text, V)"))
             .variableArityGroup(List.of(TypeSignature.parse("text"), TypeSignature.parse("V")))
+            .feature(Feature.DETERMINISTIC)
             .build();
 
 

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/NegateFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/NegateFunctions.java
@@ -37,60 +37,66 @@ public final class NegateFunctions {
     public static void register(Functions.Builder builder) {
         builder.add(
             Signature.scalar(
-                NAME,
-                TypeSignature.parse("double precision"),
-                TypeSignature.parse("double precision")
-            ).withFeature(Scalar.Feature.NULLABLE)
+                    NAME,
+                    TypeSignature.parse("double precision"),
+                    TypeSignature.parse("double precision")
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE)
                 .withForbiddenCoercion(),
             (signature, boundSignature) ->
                 new UnaryScalar<>(signature, boundSignature, DataTypes.DOUBLE, x -> x * -1)
         );
         builder.add(
             Signature.scalar(
-                NAME,
-                DataTypes.FLOAT.getTypeSignature(),
-                DataTypes.FLOAT.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE)
+                    NAME,
+                    DataTypes.FLOAT.getTypeSignature(),
+                    DataTypes.FLOAT.getTypeSignature()
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE)
                 .withForbiddenCoercion(),
             (signature, boundSignature) ->
                 new UnaryScalar<>(signature, boundSignature, DataTypes.FLOAT, x -> x * -1)
         );
         builder.add(
             Signature.scalar(
-                NAME,
-                TypeSignature.parse("integer"),
-                TypeSignature.parse("integer")
-            ).withFeature(Scalar.Feature.NULLABLE)
+                    NAME,
+                    TypeSignature.parse("integer"),
+                    TypeSignature.parse("integer")
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE)
                 .withForbiddenCoercion(),
             (signature, boundSignature) ->
                 new UnaryScalar<>(signature, boundSignature, DataTypes.INTEGER, x -> x * -1)
         );
         builder.add(
             Signature.scalar(
-                NAME,
-                TypeSignature.parse("bigint"),
-                TypeSignature.parse("bigint")
-            ).withFeature(Scalar.Feature.NULLABLE)
+                    NAME,
+                    TypeSignature.parse("bigint"),
+                    TypeSignature.parse("bigint")
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE)
                 .withForbiddenCoercion(),
             (signature, boundSignature) ->
                 new UnaryScalar<>(signature, boundSignature, DataTypes.LONG, x -> x * -1)
         );
         builder.add(
             Signature.scalar(
-                NAME,
-                TypeSignature.parse("smallint"),
-                TypeSignature.parse("smallint")
-            ).withFeature(Scalar.Feature.NULLABLE)
+                    NAME,
+                    TypeSignature.parse("smallint"),
+                    TypeSignature.parse("smallint")
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE)
                 .withForbiddenCoercion(),
             (signature, boundSignature) ->
                 new UnaryScalar<>(signature, boundSignature, DataTypes.SHORT, x -> (short) (x * -1))
         );
         builder.add(
             Signature.scalar(
-                NAME,
-                DataTypes.NUMERIC.getTypeSignature(),
-                DataTypes.NUMERIC.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE)
+                    NAME,
+                    DataTypes.NUMERIC.getTypeSignature(),
+                    DataTypes.NUMERIC.getTypeSignature()
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE)
                 .withForbiddenCoercion(),
             (signature, boundSignature) ->
                 new UnaryScalar<>(signature, boundSignature, DataTypes.NUMERIC, BigDecimal::negate)

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/RadiansDegreesFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/RadiansDegreesFunctions.java
@@ -36,7 +36,8 @@ public class RadiansDegreesFunctions {
                 "radians",
                 DataTypes.DOUBLE.getTypeSignature(),
                 DataTypes.DOUBLE.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE),
+            ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new UnaryScalar<>(signature, boundSignature, DataTypes.DOUBLE, Math::toRadians));
 
@@ -45,7 +46,8 @@ public class RadiansDegreesFunctions {
                 "degrees",
                 DataTypes.DOUBLE.getTypeSignature(),
                 DataTypes.DOUBLE.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE),
+            ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new UnaryScalar<>(signature, boundSignature, DataTypes.DOUBLE, Math::toDegrees));
     }

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/RoundFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/RoundFunction.java
@@ -40,6 +40,7 @@ public final class RoundFunction {
             assert returnType != null : "Could not get integral type of " + type;
             module.add(
                 scalar(NAME, typeSignature, returnType.getTypeSignature())
+                    .withFeature(Scalar.Feature.DETERMINISTIC)
                     .withFeature(Scalar.Feature.NULLABLE),
                 (signature, boundSignature) -> {
                     if (returnType.equals(DataTypes.INTEGER)) {

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/SignFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/SignFunction.java
@@ -39,6 +39,7 @@ public class SignFunction {
     public static void register(Functions.Builder builder) {
         builder.add(
             scalar(NAME, DataTypes.NUMERIC.getTypeSignature(), DataTypes.NUMERIC.getTypeSignature())
+                .withFeature(Scalar.Feature.DETERMINISTIC)
                 .withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) -> {
                 DataType<?> argType = boundSignature.argTypes().getFirst();
@@ -54,6 +55,7 @@ public class SignFunction {
 
         builder.add(
             scalar(NAME, DataTypes.DOUBLE.getTypeSignature(), DataTypes.DOUBLE.getTypeSignature())
+                .withFeature(Scalar.Feature.DETERMINISTIC)
                 .withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new DoubleScalar(signature, boundSignature, Math::signum)

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/SquareRootFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/SquareRootFunction.java
@@ -37,6 +37,7 @@ public final class SquareRootFunction {
             var typeSignature = type.getTypeSignature();
             module.add(
                 scalar(NAME, typeSignature, DataTypes.DOUBLE.getTypeSignature())
+                    .withFeature(Scalar.Feature.DETERMINISTIC)
                     .withFeature(Scalar.Feature.NULLABLE),
                 (signature, boundSignature) ->
                     new DoubleScalar(signature, boundSignature, SquareRootFunction::sqrt)

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/SubtractTimestampScalar.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/SubtractTimestampScalar.java
@@ -45,7 +45,7 @@ public class SubtractTimestampScalar extends Scalar<Period, Object> {
                     timestampType.getTypeSignature(),
                     timestampType.getTypeSignature(),
                     DataTypes.INTERVAL.getTypeSignature()
-                ),
+                ).withFeature(Feature.DETERMINISTIC),
                 SubtractTimestampScalar::new
             );
         }

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/TrigonometricFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/TrigonometricFunctions.java
@@ -66,7 +66,8 @@ public final class TrigonometricFunctions {
                 name,
                 DataTypes.DOUBLE.getTypeSignature(),
                 DataTypes.DOUBLE.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE),
+            ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new DoubleScalar(signature, boundSignature, func)
         );

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/TruncFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/TruncFunction.java
@@ -54,7 +54,7 @@ public final class TruncFunction {
                         NAME,
                         type.getTypeSignature(),
                         returnType.getTypeSignature()
-                    )
+                    ).withFeature(Scalar.Feature.DETERMINISTIC)
                     .withForbiddenCoercion()
                     .withFeature(Scalar.Feature.NULLABLE),
                 (signature, boundSignature) ->
@@ -78,7 +78,8 @@ public final class TruncFunction {
                 DataTypes.DOUBLE.getTypeSignature(),
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.DOUBLE.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE),
+            ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE),
             TruncFunction::createTruncWithMode
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/bitwise/BitwiseFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/bitwise/BitwiseFunctions.java
@@ -57,7 +57,7 @@ public class BitwiseFunctions {
                 typeSignature,
                 typeSignature,
                 typeSignature
-            )
+            ).withFeature(Scalar.Feature.DETERMINISTIC)
             .withFeatures(Scalar.DETERMINISTIC_ONLY)
             .withFeature(Scalar.Feature.NULLABLE);
         module.add(scalar, (signature, boundSignature) -> new BinaryScalar<>(operator, signature, boundSignature, type));

--- a/server/src/main/java/io/crate/expression/scalar/cast/ExplicitCastFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/cast/ExplicitCastFunction.java
@@ -48,6 +48,7 @@ public class ExplicitCastFunction extends Scalar<Object, Object> {
                     TypeSignature.parse("E"),
                     TypeSignature.parse("V"),
                     TypeSignature.parse("V"))
+                .withFeature(Feature.DETERMINISTIC)
                 .withTypeVariableConstraints(typeVariable("E"), typeVariable("V")),
             ExplicitCastFunction::new
         );

--- a/server/src/main/java/io/crate/expression/scalar/cast/ImplicitCastFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/cast/ImplicitCastFunction.java
@@ -49,11 +49,12 @@ public class ImplicitCastFunction extends Scalar<Object, Object> {
     public static void register(Functions.Builder module) {
         module.add(
             Signature.scalar(
-                NAME,
-                TypeSignature.parse("E"),
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.UNDEFINED.getTypeSignature()
-            ).withTypeVariableConstraints(typeVariable("E")),
+                    NAME,
+                    TypeSignature.parse("E"),
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.UNDEFINED.getTypeSignature()
+                ).withFeature(Feature.DETERMINISTIC)
+                .withTypeVariableConstraints(typeVariable("E")),
             ImplicitCastFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/cast/TryCastFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/cast/TryCastFunction.java
@@ -47,6 +47,7 @@ public class TryCastFunction extends Scalar<Object, Object> {
                     TypeSignature.parse("E"),
                     TypeSignature.parse("V"),
                     TypeSignature.parse("V"))
+                .withFeature(Feature.DETERMINISTIC)
                 .withTypeVariableConstraints(typeVariable("E"), typeVariable("V")),
             TryCastFunction::new
         );

--- a/server/src/main/java/io/crate/expression/scalar/conditional/CaseFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/conditional/CaseFunction.java
@@ -74,6 +74,7 @@ public class CaseFunction extends Scalar<Object, Object> {
                 .argumentTypes(bool, t)
                 .returnType(t)
                 .variableArityGroup(List.of(bool, t))
+                .feature(Feature.DETERMINISTIC)
                 .build(),
             CaseFunction::new
         );

--- a/server/src/main/java/io/crate/expression/scalar/conditional/CoalesceFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/conditional/CoalesceFunction.java
@@ -43,6 +43,7 @@ public class CoalesceFunction extends Scalar<Object, Object> {
                     NAME,
                     TypeSignature.parse("E"),
                     TypeSignature.parse("E"))
+                .withFeature(Feature.DETERMINISTIC)
                 .withVariableArity()
                 .withTypeVariableConstraints(typeVariable("E")),
             CoalesceFunction::new

--- a/server/src/main/java/io/crate/expression/scalar/conditional/GreatestFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/conditional/GreatestFunction.java
@@ -40,6 +40,7 @@ public class GreatestFunction extends ConditionalCompareFunction {
                     NAME,
                     TypeSignature.parse("E"),
                     TypeSignature.parse("E"))
+                .withFeature(Feature.DETERMINISTIC)
                 .withVariableArity()
                 .withTypeVariableConstraints(typeVariable("E")),
             GreatestFunction::new

--- a/server/src/main/java/io/crate/expression/scalar/conditional/IfFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/conditional/IfFunction.java
@@ -56,22 +56,24 @@ public class IfFunction extends Scalar<Object, Object> {
         // if (condition, result)
         module.add(
             Signature.scalar(
-                NAME,
-                DataTypes.BOOLEAN.getTypeSignature(),
-                TypeSignature.parse("E"),
-                TypeSignature.parse("E")
-            ).withTypeVariableConstraints(typeVariable("E")),
+                    NAME,
+                    DataTypes.BOOLEAN.getTypeSignature(),
+                    TypeSignature.parse("E"),
+                    TypeSignature.parse("E")
+                ).withFeature(Feature.DETERMINISTIC)
+                .withTypeVariableConstraints(typeVariable("E")),
             IfFunction::new
         );
         // if (condition, result, default)
         module.add(
             Signature.scalar(
-                NAME,
-                DataTypes.BOOLEAN.getTypeSignature(),
-                TypeSignature.parse("E"),
-                TypeSignature.parse("E"),
-                TypeSignature.parse("E")
-            ).withTypeVariableConstraints(typeVariable("E")),
+                    NAME,
+                    DataTypes.BOOLEAN.getTypeSignature(),
+                    TypeSignature.parse("E"),
+                    TypeSignature.parse("E"),
+                    TypeSignature.parse("E")
+                ).withFeature(Feature.DETERMINISTIC)
+                .withTypeVariableConstraints(typeVariable("E")),
             IfFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/conditional/LeastFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/conditional/LeastFunction.java
@@ -40,6 +40,7 @@ public class LeastFunction extends ConditionalCompareFunction {
                     NAME,
                     TypeSignature.parse("E"),
                     TypeSignature.parse("E"))
+                .withFeature(Feature.DETERMINISTIC)
                 .withVariableArity()
                 .withTypeVariableConstraints(typeVariable("E")),
             LeastFunction::new

--- a/server/src/main/java/io/crate/expression/scalar/conditional/NullIfFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/conditional/NullIfFunction.java
@@ -41,7 +41,8 @@ public class NullIfFunction extends Scalar<Object, Object> {
                     TypeSignature.parse("E"),
                     TypeSignature.parse("E"),
                     TypeSignature.parse("E")
-                ).withTypeVariableConstraints(typeVariable("E")),
+                ).withFeature(Feature.DETERMINISTIC)
+                .withTypeVariableConstraints(typeVariable("E")),
             NullIfFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/formatting/ToCharFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/formatting/ToCharFunction.java
@@ -56,7 +56,7 @@ public class ToCharFunction extends Scalar<String, Object> {
                         type.getTypeSignature(),
                         DataTypes.STRING.getTypeSignature(),
                         DataTypes.STRING.getTypeSignature()
-                    ),
+                    ).withFeature(Feature.DETERMINISTIC),
                     (signature, boundSignature) ->
                         new ToCharFunction(
                             signature,
@@ -72,7 +72,7 @@ public class ToCharFunction extends Scalar<String, Object> {
                 DataTypes.INTERVAL.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Feature.DETERMINISTIC),
             (signature, boundSignature) ->
                 new ToCharFunction(
                     signature,

--- a/server/src/main/java/io/crate/expression/scalar/geo/AreaFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/geo/AreaFunction.java
@@ -62,7 +62,8 @@ public final class AreaFunction {
                 FUNCTION_NAME,
                 DataTypes.GEO_SHAPE.getTypeSignature(),
                 DataTypes.DOUBLE.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE),
+            ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new UnaryScalar<>(
                     signature,

--- a/server/src/main/java/io/crate/expression/scalar/geo/CoordinateFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/geo/CoordinateFunction.java
@@ -36,7 +36,8 @@ public final class CoordinateFunction {
                 "latitude",
                 DataTypes.GEO_POINT.getTypeSignature(),
                 DataTypes.DOUBLE.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE),
+            ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new UnaryScalar<>(
                     signature,
@@ -50,7 +51,8 @@ public final class CoordinateFunction {
                 "longitude",
                 DataTypes.GEO_POINT.getTypeSignature(),
                 DataTypes.DOUBLE.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE),
+            ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new UnaryScalar<>(
                     signature,

--- a/server/src/main/java/io/crate/expression/scalar/geo/DistanceFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/geo/DistanceFunction.java
@@ -66,7 +66,8 @@ public class DistanceFunction extends Scalar<Double, Point> {
                 DataTypes.GEO_POINT.getTypeSignature(),
                 DataTypes.GEO_POINT.getTypeSignature(),
                 DataTypes.DOUBLE.getTypeSignature()
-            ).withFeature(Feature.NULLABLE),
+            ).withFeature(Feature.DETERMINISTIC)
+                .withFeature(Feature.NULLABLE),
             DistanceFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/geo/GeoHashFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/geo/GeoHashFunction.java
@@ -40,7 +40,8 @@ public final class GeoHashFunction {
                 "geohash",
                 DataTypes.GEO_POINT.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE),
+            ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new UnaryScalar<>(
                     signature,

--- a/server/src/main/java/io/crate/expression/scalar/geo/IntersectsFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/geo/IntersectsFunction.java
@@ -49,7 +49,8 @@ public class IntersectsFunction extends Scalar<Boolean, Object> {
                 DataTypes.GEO_SHAPE.getTypeSignature(),
                 DataTypes.GEO_SHAPE.getTypeSignature(),
                 DataTypes.BOOLEAN.getTypeSignature()
-            ).withFeature(Feature.NULLABLE),
+            ).withFeature(Feature.DETERMINISTIC)
+                .withFeature(Feature.NULLABLE),
             IntersectsFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/geo/WithinFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/geo/WithinFunction.java
@@ -68,7 +68,7 @@ public class WithinFunction extends Scalar<Boolean, Object> {
                 DataTypes.GEO_SHAPE.getTypeSignature(),
                 DataTypes.GEO_SHAPE.getTypeSignature(),
                 DataTypes.BOOLEAN.getTypeSignature()
-            ),
+            ).withFeature(Feature.DETERMINISTIC),
             WithinFunction::new
         );
         // Needed to avoid casts on references of `geo_point` and thus to avoid generic function filter on lucene.
@@ -81,7 +81,8 @@ public class WithinFunction extends Scalar<Boolean, Object> {
                     DataTypes.GEO_POINT.getTypeSignature(),
                     type.getTypeSignature(),
                     DataTypes.BOOLEAN.getTypeSignature()
-                ).withForbiddenCoercion(),
+                ).withFeature(Feature.DETERMINISTIC)
+                    .withForbiddenCoercion(),
                 WithinFunction::new
             );
         }

--- a/server/src/main/java/io/crate/expression/scalar/object/ObjectKeysFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/object/ObjectKeysFunction.java
@@ -37,7 +37,8 @@ public final class ObjectKeysFunction {
                 "object_keys",
                 DataTypes.UNTYPED_OBJECT.getTypeSignature(),
                 DataTypes.STRING_ARRAY.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE),
+            ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
             new UnaryScalar<>(
                 signature,

--- a/server/src/main/java/io/crate/expression/scalar/postgres/CurrentSettingFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/postgres/CurrentSettingFunction.java
@@ -47,7 +47,7 @@ public class CurrentSettingFunction extends Scalar<String, Object> {
                 FQN,
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Feature.DETERMINISTIC),
             (signature, boundSignature) ->
                 new CurrentSettingFunction(
                     signature,
@@ -62,7 +62,7 @@ public class CurrentSettingFunction extends Scalar<String, Object> {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.BOOLEAN.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Feature.DETERMINISTIC),
             (signature, boundSignature) ->
                 new CurrentSettingFunction(
                     signature,

--- a/server/src/main/java/io/crate/expression/scalar/postgres/PgEncodingToCharFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/postgres/PgEncodingToCharFunction.java
@@ -44,7 +44,7 @@ public class PgEncodingToCharFunction extends Scalar<String, Integer> {
                 FQN,
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Feature.DETERMINISTIC),
             PgEncodingToCharFunction:: new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/postgres/PgGetUserByIdFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/postgres/PgGetUserByIdFunction.java
@@ -40,7 +40,8 @@ public class PgGetUserByIdFunction {
                 name,
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE),
+            ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new UnaryScalar<>(
                     signature,

--- a/server/src/main/java/io/crate/expression/scalar/postgres/PgTableIsVisibleFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/postgres/PgTableIsVisibleFunction.java
@@ -51,10 +51,11 @@ public class PgTableIsVisibleFunction extends Scalar<Boolean, Integer> {
     public static void register(Functions.Builder module) {
         module.add(
             Signature.scalar(
-                NAME,
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.BOOLEAN.getTypeSignature()
-            ).withFeature(Feature.NULLABLE),
+                    NAME,
+                    DataTypes.INTEGER.getTypeSignature(),
+                    DataTypes.BOOLEAN.getTypeSignature()
+                ).withFeature(Feature.DETERMINISTIC)
+                .withFeature(Feature.NULLABLE),
             PgTableIsVisibleFunction::new);
     }
 

--- a/server/src/main/java/io/crate/expression/scalar/regex/RegexpReplaceFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/regex/RegexpReplaceFunction.java
@@ -54,7 +54,7 @@ public final class RegexpReplaceFunction extends Scalar<String, String> {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Feature.DETERMINISTIC),
             RegexpReplaceFunction::new
         );
         builder.add(
@@ -65,7 +65,7 @@ public final class RegexpReplaceFunction extends Scalar<String, String> {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Feature.DETERMINISTIC),
             RegexpReplaceFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/string/AsciiFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/AsciiFunction.java
@@ -32,10 +32,11 @@ public final class AsciiFunction {
     public static void register(Functions.Builder module) {
         module.add(
             Signature.scalar(
-                "ascii",
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.INTEGER.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE),
+                    "ascii",
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.INTEGER.getTypeSignature()
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new UnaryScalar<>(signature, boundSignature, DataTypes.STRING, AsciiFunction::ascii)
         );

--- a/server/src/main/java/io/crate/expression/scalar/string/ChrFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/ChrFunction.java
@@ -35,10 +35,11 @@ public final class ChrFunction extends Scalar<String, Object> {
     public static void register(Functions.Builder module) {
         module.add(
             Signature.scalar(
-                "chr",
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Feature.NULLABLE),
+                    "chr",
+                    DataTypes.INTEGER.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature()
+                ).withFeature(Feature.DETERMINISTIC)
+                .withFeature(Feature.NULLABLE),
             ChrFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/string/EncodeDecodeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/EncodeDecodeFunction.java
@@ -40,26 +40,28 @@ public class EncodeDecodeFunction {
     public static void register(Functions.Builder module) {
         module.add(
             Signature.scalar(
-                "encode",
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE),
+                    "encode",
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature()
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new BinaryScalar<>(
-                        new Encode(),
-                        signature,
-                        boundSignature,
-                        DataTypes.STRING
+                    new Encode(),
+                    signature,
+                    boundSignature,
+                    DataTypes.STRING
                 )
         );
         module.add(
             Signature.scalar(
-                "decode",
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE),
+                    "decode",
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature()
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new BinaryScalar<>(
                         new Decode(),

--- a/server/src/main/java/io/crate/expression/scalar/string/HashFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/HashFunctions.java
@@ -46,10 +46,11 @@ public final class HashFunctions {
     private static void register(Functions.Builder builder, String name, UnaryOperator<String> func) {
         builder.add(
             Signature.scalar(
-                name,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE),
+                    name,
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature()
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new UnaryScalar<>(signature, boundSignature, DataTypes.STRING, func)
         );

--- a/server/src/main/java/io/crate/expression/scalar/string/InitCapFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/InitCapFunction.java
@@ -32,10 +32,11 @@ public final class InitCapFunction {
     public static void register(Functions.Builder module) {
         module.add(
             Signature.scalar(
-                "initcap",
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE),
+                    "initcap",
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature()
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new UnaryScalar<>(
                     signature,

--- a/server/src/main/java/io/crate/expression/scalar/string/LengthFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/LengthFunction.java
@@ -42,10 +42,11 @@ public final class LengthFunction {
     private static void register(Functions.Builder builder, String name, Function<String, Integer> func) {
         builder.add(
             Signature.scalar(
-                name,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.INTEGER.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE),
+                    name,
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.INTEGER.getTypeSignature()
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) -> new UnaryScalar<>(signature, boundSignature, DataTypes.STRING, func)
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/string/ParseURIFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/ParseURIFunction.java
@@ -43,10 +43,11 @@ public final class ParseURIFunction extends Scalar<Object, String> {
     public static void register(Functions.Builder module) {
         module.add(
             Signature.scalar(
-                NAME,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.UNTYPED_OBJECT.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE),
+                    NAME,
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.UNTYPED_OBJECT.getTypeSignature()
+                ).withFeature(Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE),
             ParseURIFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/string/ParseURLFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/ParseURLFunction.java
@@ -51,10 +51,11 @@ public final class ParseURLFunction extends Scalar<Object, String> {
     public static void register(Functions.Builder module) {
         module.add(
             Signature.scalar(
-                NAME,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.UNTYPED_OBJECT.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE),
+                    NAME,
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.UNTYPED_OBJECT.getTypeSignature()
+                ).withFeature(Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE),
             ParseURLFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/string/QuoteIdentFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/QuoteIdentFunction.java
@@ -41,10 +41,11 @@ public final class QuoteIdentFunction {
     public static void register(Functions.Builder module) {
         module.add(
             Signature.scalar(
-                FQNAME,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE),
+                    FQNAME,
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature()
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new UnaryScalar<>(
                     signature,

--- a/server/src/main/java/io/crate/expression/scalar/string/ReplaceFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/ReplaceFunction.java
@@ -37,12 +37,13 @@ public final class ReplaceFunction {
     public static void register(Functions.Builder module) {
         module.add(
             Signature.scalar(
-                NAME,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE),
+                    NAME,
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature()
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new TripleScalar<>(
                     signature,

--- a/server/src/main/java/io/crate/expression/scalar/string/ReverseFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/ReverseFunction.java
@@ -34,10 +34,11 @@ public final class ReverseFunction {
     public static void register(Functions.Builder module) {
         module.add(
             Signature.scalar(
-                NAME,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE),
+                    NAME,
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature()
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) -> {
                 return new UnaryScalar<>(
                     signature,

--- a/server/src/main/java/io/crate/expression/scalar/string/StringCaseFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/StringCaseFunction.java
@@ -34,10 +34,11 @@ public final class StringCaseFunction {
     public static void register(Functions.Builder module) {
         module.add(
             Signature.scalar(
-                "upper",
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE),
+                    "upper",
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature()
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new UnaryScalar<>(
                     signature,
@@ -48,10 +49,11 @@ public final class StringCaseFunction {
         );
         module.add(
             Signature.scalar(
-                "lower",
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE),
+                    "lower",
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature()
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new UnaryScalar<>(
                     signature,

--- a/server/src/main/java/io/crate/expression/scalar/string/StringLeftRightFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/StringLeftRightFunction.java
@@ -42,7 +42,7 @@ public class StringLeftRightFunction extends Scalar<String, Object> {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Feature.DETERMINISTIC),
             (signature, boundSignature) ->
                 new StringLeftRightFunction(signature, boundSignature, StringLeftRightFunction::left)
         );
@@ -52,7 +52,7 @@ public class StringLeftRightFunction extends Scalar<String, Object> {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Feature.DETERMINISTIC),
             (signature, boundSignature) ->
                 new StringLeftRightFunction(signature, boundSignature, StringLeftRightFunction::right)
         );

--- a/server/src/main/java/io/crate/expression/scalar/string/StringPaddingFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/StringPaddingFunction.java
@@ -48,7 +48,7 @@ public class StringPaddingFunction extends Scalar<String, Object> {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Feature.DETERMINISTIC),
             (signature, boundSignature) ->
                 new StringPaddingFunction(
                     signature,
@@ -64,7 +64,7 @@ public class StringPaddingFunction extends Scalar<String, Object> {
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Feature.DETERMINISTIC),
             (signature, boundSignature) ->
                 new StringPaddingFunction(
                     signature,
@@ -79,7 +79,7 @@ public class StringPaddingFunction extends Scalar<String, Object> {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Feature.DETERMINISTIC),
             (signature, boundSignature) ->
                 new StringPaddingFunction(
                     signature,
@@ -95,7 +95,7 @@ public class StringPaddingFunction extends Scalar<String, Object> {
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Feature.DETERMINISTIC),
             (signature, boundSignature) ->
                 new StringPaddingFunction(
                     signature,

--- a/server/src/main/java/io/crate/expression/scalar/string/StringPositionFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/StringPositionFunction.java
@@ -39,7 +39,7 @@ public final class StringPositionFunction extends Scalar<Integer , String> {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.INTEGER.getTypeSignature()
-            ),
+            ).withFeature(Feature.DETERMINISTIC),
             StringPositionFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/string/StringRepeatFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/StringRepeatFunction.java
@@ -39,7 +39,7 @@ public final class StringRepeatFunction extends Scalar<String, Object> {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Feature.DETERMINISTIC),
             StringRepeatFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/string/StringSplitPartFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/StringSplitPartFunction.java
@@ -45,7 +45,7 @@ public final class StringSplitPartFunction extends Scalar<String, Object> {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Feature.DETERMINISTIC),
             StringSplitPartFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/string/TranslateFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/TranslateFunction.java
@@ -43,11 +43,12 @@ public class TranslateFunction extends Scalar<String, String> {
     public static void register(Functions.Builder module) {
         module.add(
             Signature.scalar(
-                "translate",
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()),
+                    "translate",
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature())
+                .withFeature(Feature.DETERMINISTIC),
             TranslateFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/string/TrimFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/TrimFunctions.java
@@ -52,10 +52,11 @@ public final class TrimFunctions {
         // trim(text)
         module.add(
             Signature.scalar(
-                TRIM_NAME,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE),
+                    TRIM_NAME,
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature()
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new OneCharTrimFunction(
                     signature,
@@ -66,22 +67,24 @@ public final class TrimFunctions {
         // trim(MODE trimmingText from text)
         module.add(
             Signature.scalar(
-                TRIM_NAME,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE),
+                    TRIM_NAME,
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature()
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE),
             TrimFunction::new
         );
 
         // ltrim(text)
         module.add(
             Signature.scalar(
-                LTRIM_NAME,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE),
+                    LTRIM_NAME,
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature()
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new SideTrimFunction(
                     signature,
@@ -92,11 +95,12 @@ public final class TrimFunctions {
         // ltrim(text, trimmingText)
         module.add(
             Signature.scalar(
-                LTRIM_NAME,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE),
+                    LTRIM_NAME,
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature()
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new SideTrimFunction(
                     signature,
@@ -108,10 +112,11 @@ public final class TrimFunctions {
         // rtrim(text)
         module.add(
             Signature.scalar(
-                RTRIM_NAME,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE),
+                    RTRIM_NAME,
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature()
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new SideTrimFunction(
                     signature,
@@ -122,11 +127,12 @@ public final class TrimFunctions {
         // rtrim(text, trimmingText)
         module.add(
             Signature.scalar(
-                RTRIM_NAME,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE),
+                    RTRIM_NAME,
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature()
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new SideTrimFunction(
                     signature,
@@ -139,10 +145,11 @@ public final class TrimFunctions {
         // btrim(text)
         module.add(
             Signature.scalar(
-                BTRIM_NAME,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE),
+                    BTRIM_NAME,
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature()
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new SideTrimFunction(
                     signature,
@@ -153,11 +160,12 @@ public final class TrimFunctions {
         // btrim(text, trimmingText)
         module.add(
             Signature.scalar(
-                BTRIM_NAME,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE),
+                    BTRIM_NAME,
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature()
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) ->
                 new SideTrimFunction(
                     signature,

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/ColDescriptionFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/ColDescriptionFunction.java
@@ -44,7 +44,7 @@ public final class ColDescriptionFunction extends Scalar<String, Object> {
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Feature.DETERMINISTIC),
             ColDescriptionFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/FormatTypeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/FormatTypeFunction.java
@@ -42,11 +42,12 @@ public final class FormatTypeFunction extends Scalar<String, Object> {
     public static void register(Functions.Builder module) {
         module.add(
             Signature.scalar(
-                FQN,
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Feature.NULLABLE),
+                    FQN,
+                    DataTypes.INTEGER.getTypeSignature(),
+                    DataTypes.INTEGER.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature()
+                ).withFeature(Feature.DETERMINISTIC)
+                .withFeature(Feature.NULLABLE),
             FormatTypeFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/ObjDescriptionFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/ObjDescriptionFunction.java
@@ -44,7 +44,7 @@ public final class ObjDescriptionFunction extends Scalar<String, Object> {
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Feature.DETERMINISTIC),
             ObjDescriptionFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/PgFunctionIsVisibleFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/PgFunctionIsVisibleFunction.java
@@ -37,10 +37,11 @@ public final class PgFunctionIsVisibleFunction extends Scalar<Boolean, Integer> 
     public static void register(Functions.Builder module) {
         module.add(
             Signature.scalar(
-                NAME,
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.BOOLEAN.getTypeSignature()
-            ).withFeature(Feature.NULLABLE),
+                    NAME,
+                    DataTypes.INTEGER.getTypeSignature(),
+                    DataTypes.BOOLEAN.getTypeSignature()
+                ).withFeature(Feature.DETERMINISTIC)
+                .withFeature(Feature.NULLABLE),
             PgFunctionIsVisibleFunction::new);
     }
 

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetExpr.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetExpr.java
@@ -44,7 +44,7 @@ public class PgGetExpr extends Scalar<String, Object> {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Feature.DETERMINISTIC),
             PgGetExpr::new
         );
         module.add(
@@ -54,7 +54,7 @@ public class PgGetExpr extends Scalar<String, Object> {
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.BOOLEAN.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Feature.DETERMINISTIC),
             PgGetExpr::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetFunctionResultFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetFunctionResultFunction.java
@@ -43,7 +43,7 @@ public final class PgGetFunctionResultFunction extends Scalar<String, Integer> {
                 FQN,
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Feature.DETERMINISTIC),
             PgGetFunctionResultFunction::new);
     }
 

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetPartkeydefFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetPartkeydefFunction.java
@@ -43,7 +43,7 @@ public class PgGetPartkeydefFunction extends Scalar<String, Integer> {
                 FQN,
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Feature.DETERMINISTIC),
             PgGetPartkeydefFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetSerialSequenceFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetSerialSequenceFunction.java
@@ -37,11 +37,12 @@ public class PgGetSerialSequenceFunction {
     public static void register(Functions.Builder module) {
         module.add(
             Signature.scalar(
-                FQN,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE),
+                    FQN,
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature()
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NULLABLE),
             (signature, boundSignature) -> new BinaryScalar<>(
                         (table,column) -> null,
                         signature,

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/PgTypeofFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/PgTypeofFunction.java
@@ -45,7 +45,7 @@ public final class PgTypeofFunction extends Scalar<String, Object> {
                     FQNAME,
                     TypeSignature.parse("E"),
                     DataTypes.STRING.getTypeSignature()
-                )
+                ).withFeature(Feature.DETERMINISTIC)
                 .withTypeVariableConstraints(typeVariable("E"))
                 .withFeature(Feature.NON_NULLABLE),
             PgTypeofFunction::new

--- a/server/src/main/java/io/crate/expression/scalar/timestamp/CurrentTimeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/timestamp/CurrentTimeFunction.java
@@ -43,17 +43,19 @@ public class CurrentTimeFunction extends Scalar<TimeTZ, Integer> {
     public static void register(Functions.Builder module) {
         module.add(
             Signature.scalar(
-                NAME,
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.TIMETZ.getTypeSignature()
-            ).withFeature(Feature.NON_NULLABLE),
+                    NAME,
+                    DataTypes.INTEGER.getTypeSignature(),
+                    DataTypes.TIMETZ.getTypeSignature()
+                ).withFeature(Feature.DETERMINISTIC)
+                .withFeature(Feature.NON_NULLABLE),
             CurrentTimeFunction::new
         );
         module.add(
             Signature.scalar(
-                NAME,
-                DataTypes.TIMETZ.getTypeSignature()
-            ).withFeature(Feature.NON_NULLABLE),
+                    NAME,
+                    DataTypes.TIMETZ.getTypeSignature()
+                ).withFeature(Feature.DETERMINISTIC)
+                .withFeature(Feature.NON_NULLABLE),
             CurrentTimeFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/timestamp/CurrentTimestampFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/timestamp/CurrentTimestampFunction.java
@@ -43,17 +43,17 @@ public class CurrentTimestampFunction extends Scalar<Long, Integer> {
     public static void register(Functions.Builder module) {
         module.add(
             Signature.scalar(
-                NAME,
-                DataTypes.TIMESTAMPZ.getTypeSignature()
-            ).withFeatures(EnumSet.of(Feature.NON_NULLABLE)),
+                    NAME,
+                    DataTypes.TIMESTAMPZ.getTypeSignature()
+                ).withFeatures(EnumSet.of(Feature.NON_NULLABLE)),
             CurrentTimestampFunction::new
         );
         module.add(
             Signature.scalar(
-                NAME,
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.TIMESTAMPZ.getTypeSignature()
-            ).withFeatures(EnumSet.of(Feature.NON_NULLABLE)),
+                    NAME,
+                    DataTypes.INTEGER.getTypeSignature(),
+                    DataTypes.TIMESTAMPZ.getTypeSignature()
+                ).withFeatures(EnumSet.of(Feature.NON_NULLABLE)),
             CurrentTimestampFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/timestamp/NowFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/timestamp/NowFunction.java
@@ -41,9 +41,9 @@ public final class NowFunction extends Scalar<Long, Object> {
     public static void register(Functions.Builder module) {
         module.add(
             Signature.scalar(
-                NAME,
-                DataTypes.TIMESTAMPZ.getTypeSignature()
-            ).withFeatures(EnumSet.of(Feature.NON_NULLABLE)),
+                    NAME,
+                    DataTypes.TIMESTAMPZ.getTypeSignature()
+                ).withFeatures(EnumSet.of(Feature.NON_NULLABLE)),
             NowFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/timestamp/TimezoneFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/timestamp/TimezoneFunction.java
@@ -50,7 +50,7 @@ public class TimezoneFunction extends Scalar<Long, Object> {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.TIMESTAMPZ.getTypeSignature(),
                 DataTypes.TIMESTAMP.getTypeSignature()
-            ),
+            ).withFeature(Feature.DETERMINISTIC),
             TimezoneFunction::new
         );
         module.add(
@@ -59,7 +59,7 @@ public class TimezoneFunction extends Scalar<Long, Object> {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.TIMESTAMP.getTypeSignature(),
                 DataTypes.TIMESTAMPZ.getTypeSignature()
-            ),
+            ).withFeature(Feature.DETERMINISTIC),
             TimezoneFunction::new
         );
         module.add(
@@ -68,7 +68,7 @@ public class TimezoneFunction extends Scalar<Long, Object> {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.LONG.getTypeSignature(),
                 DataTypes.TIMESTAMPZ.getTypeSignature()
-            ),
+            ).withFeature(Feature.DETERMINISTIC),
             TimezoneFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/symbol/Symbol.java
+++ b/server/src/main/java/io/crate/expression/symbol/Symbol.java
@@ -34,6 +34,7 @@ import io.crate.expression.scalar.cast.ExplicitCastFunction;
 import io.crate.expression.scalar.cast.ImplicitCastFunction;
 import io.crate.expression.scalar.cast.TryCastFunction;
 import io.crate.expression.symbol.format.Style;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.metadata.functions.TypeVariableConstraint;
 import io.crate.types.ArrayType;
@@ -121,7 +122,8 @@ public interface Symbol extends Writeable, Accountable {
                         TypeSignature.parse("V")
                     ).withTypeVariableConstraints(
                         TypeVariableConstraint.typeVariable("E"),
-                        TypeVariableConstraint.typeVariable("V")),
+                        TypeVariableConstraint.typeVariable("V"))
+                    .withFeature(Scalar.Feature.DETERMINISTIC),
                 // a literal with a NULL value is passed as an argument
                 // to match the method signature
                 List.of(sourceSymbol, Literal.of(targetType, null)),
@@ -135,6 +137,7 @@ public interface Symbol extends Writeable, Accountable {
                         TypeSignature.parse("E"),
                         DataTypes.STRING.getTypeSignature(),
                         DataTypes.UNDEFINED.getTypeSignature())
+                    .withFeature(Scalar.Feature.DETERMINISTIC)
                     .withTypeVariableConstraints(TypeVariableConstraint.typeVariable("E")),
                 List.of(
                     sourceSymbol,

--- a/server/src/main/java/io/crate/expression/tablefunctions/EmptyRowTableFunction.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/EmptyRowTableFunction.java
@@ -43,7 +43,9 @@ public class EmptyRowTableFunction {
 
     public static void register(Functions.Builder builder) {
         builder.add(
-            Signature.table(NAME, RowType.EMPTY.getTypeSignature()).withFeature(Scalar.Feature.NON_NULLABLE),
+            Signature.table(NAME, RowType.EMPTY.getTypeSignature())
+                .withFeature(Scalar.Feature.NON_NULLABLE)
+                .withFeature(Scalar.Feature.DETERMINISTIC),
             EmptyRowTableFunctionImplementation::new
         );
     }

--- a/server/src/main/java/io/crate/expression/tablefunctions/GenerateSeries.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/GenerateSeries.java
@@ -69,11 +69,12 @@ public final class GenerateSeries<T extends Number> extends TableFunctionImpleme
         // without step
         builder.add(
             Signature.table(
-                NAME,
-                DataTypes.LONG.getTypeSignature(),
-                DataTypes.LONG.getTypeSignature(),
-                DataTypes.LONG.getTypeSignature()
-            ).withFeature(Feature.NON_NULLABLE),
+                    NAME,
+                    DataTypes.LONG.getTypeSignature(),
+                    DataTypes.LONG.getTypeSignature(),
+                    DataTypes.LONG.getTypeSignature()
+                ).withFeature(Feature.DETERMINISTIC)
+                .withFeature(Feature.NON_NULLABLE),
             (signature, boundSignature) -> new GenerateSeries<>(
                 signature,
                 boundSignature,
@@ -86,11 +87,12 @@ public final class GenerateSeries<T extends Number> extends TableFunctionImpleme
         );
         builder.add(
             Signature.table(
-                NAME,
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.INTEGER.getTypeSignature()
-            ).withFeature(Feature.NON_NULLABLE),
+                    NAME,
+                    DataTypes.INTEGER.getTypeSignature(),
+                    DataTypes.INTEGER.getTypeSignature(),
+                    DataTypes.INTEGER.getTypeSignature()
+                ).withFeature(Feature.DETERMINISTIC)
+                .withFeature(Feature.NON_NULLABLE),
             (signature, boundSignature) -> new GenerateSeries<>(
                 signature,
                 boundSignature,
@@ -105,12 +107,13 @@ public final class GenerateSeries<T extends Number> extends TableFunctionImpleme
         // with step
         builder.add(
             Signature.table(
-                NAME,
-                DataTypes.LONG.getTypeSignature(),
-                DataTypes.LONG.getTypeSignature(),
-                DataTypes.LONG.getTypeSignature(),
-                DataTypes.LONG.getTypeSignature()
-            ).withFeature(Feature.NON_NULLABLE),
+                    NAME,
+                    DataTypes.LONG.getTypeSignature(),
+                    DataTypes.LONG.getTypeSignature(),
+                    DataTypes.LONG.getTypeSignature(),
+                    DataTypes.LONG.getTypeSignature()
+                ).withFeature(Feature.DETERMINISTIC)
+                .withFeature(Feature.NON_NULLABLE),
             (signature, boundSignature) -> new GenerateSeries<>(
                 signature,
                 boundSignature,
@@ -123,12 +126,13 @@ public final class GenerateSeries<T extends Number> extends TableFunctionImpleme
         );
         builder.add(
             Signature.table(
-                NAME,
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.INTEGER.getTypeSignature()
-            ).withFeature(Feature.NON_NULLABLE),
+                    NAME,
+                    DataTypes.INTEGER.getTypeSignature(),
+                    DataTypes.INTEGER.getTypeSignature(),
+                    DataTypes.INTEGER.getTypeSignature(),
+                    DataTypes.INTEGER.getTypeSignature()
+                ).withFeature(Feature.DETERMINISTIC)
+                .withFeature(Feature.NON_NULLABLE),
             (signature, boundSignature) -> new GenerateSeries<>(
                 signature,
                 boundSignature,
@@ -144,12 +148,13 @@ public final class GenerateSeries<T extends Number> extends TableFunctionImpleme
         for (var supportedType : List.of(DataTypes.TIMESTAMP, DataTypes.TIMESTAMPZ)) {
             builder.add(
                 Signature.table(
-                    NAME,
-                    supportedType.getTypeSignature(),
-                    supportedType.getTypeSignature(),
-                    DataTypes.INTERVAL.getTypeSignature(),
-                    supportedType.getTypeSignature()
-                ).withFeature(Feature.NON_NULLABLE),
+                        NAME,
+                        supportedType.getTypeSignature(),
+                        supportedType.getTypeSignature(),
+                        DataTypes.INTERVAL.getTypeSignature(),
+                        supportedType.getTypeSignature()
+                    ).withFeature(Feature.DETERMINISTIC)
+                    .withFeature(Feature.NON_NULLABLE),
                 (signature, boundSignature) -> new GenerateSeriesIntervals(
                     signature,
                     boundSignature,
@@ -161,7 +166,7 @@ public final class GenerateSeries<T extends Number> extends TableFunctionImpleme
                     supportedType.getTypeSignature(),
                     supportedType.getTypeSignature(),
                     supportedType.getTypeSignature()
-                ),
+                ).withFeature(Feature.DETERMINISTIC),
                 (signature, boundSignature) -> {
                     throw new IllegalArgumentException(
                         "generate_series(start, stop) has type `" + boundSignature.argTypes().get(0).getName() +

--- a/server/src/main/java/io/crate/expression/tablefunctions/GenerateSubscripts.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/GenerateSubscripts.java
@@ -55,6 +55,7 @@ public final class GenerateSubscripts<T> extends TableFunctionImplementation<T> 
                     DataTypes.INTEGER.getTypeSignature(),
                     DataTypes.INTEGER.getTypeSignature()
                 ).withTypeVariableConstraints(typeVariable("E"))
+                .withFeature(Feature.DETERMINISTIC)
                 .withFeature(Feature.NON_NULLABLE),
             GenerateSubscripts::new
         );
@@ -66,6 +67,7 @@ public final class GenerateSubscripts<T> extends TableFunctionImplementation<T> 
                     DataTypes.BOOLEAN.getTypeSignature(),
                     DataTypes.INTEGER.getTypeSignature()
                 ).withTypeVariableConstraints(typeVariable("E"))
+                .withFeature(Feature.DETERMINISTIC)
                 .withFeature(Feature.NON_NULLABLE),
             GenerateSubscripts::new
         );

--- a/server/src/main/java/io/crate/expression/tablefunctions/MatchesFunction.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/MatchesFunction.java
@@ -66,11 +66,12 @@ public final class MatchesFunction extends TableFunctionImplementation<List<Obje
 
         builder.add(
             Signature.table(
-                NAME,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING_ARRAY.getTypeSignature()
-            ).withFeature(Feature.NON_NULLABLE),
+                    NAME,
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING_ARRAY.getTypeSignature()
+                ).withFeature(Feature.DETERMINISTIC)
+                .withFeature(Feature.NON_NULLABLE),
             (signature, boundSignature) -> new MatchesFunction(
                 signature,
                 boundSignature,
@@ -79,12 +80,13 @@ public final class MatchesFunction extends TableFunctionImplementation<List<Obje
         );
         builder.add(
             Signature.table(
-                NAME,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING_ARRAY.getTypeSignature()
-            ).withFeature(Feature.NON_NULLABLE),
+                    NAME,
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING_ARRAY.getTypeSignature()
+                ).withFeature(Feature.DETERMINISTIC)
+                .withFeature(Feature.NON_NULLABLE),
             (signature, boundSignature) -> new MatchesFunction(
                 signature,
                 boundSignature,

--- a/server/src/main/java/io/crate/expression/tablefunctions/PgExpandArray.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/PgExpandArray.java
@@ -54,6 +54,7 @@ public final class PgExpandArray extends TableFunctionImplementation<List<Object
                     TypeSignature.parse("array(E)"),
                     TypeSignature.parse("record(x E, n integer)")
                 ).withTypeVariableConstraints(typeVariable("E"))
+                .withFeature(Feature.DETERMINISTIC)
                 .withFeature(Feature.NON_NULLABLE),
             PgExpandArray::new
         );

--- a/server/src/main/java/io/crate/expression/tablefunctions/PgGetKeywordsFunction.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/PgGetKeywordsFunction.java
@@ -56,7 +56,8 @@ public final class PgGetKeywordsFunction extends TableFunctionImplementation<Lis
             Signature.table(
                     FUNCTION_NAME,
                     RETURN_TYPE.getTypeSignature()
-                ).withFeature(Feature.NON_NULLABLE),
+                ).withFeature(Feature.DETERMINISTIC)
+                .withFeature(Feature.NON_NULLABLE),
             PgGetKeywordsFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/tablefunctions/TableFunctionFactory.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/TableFunctionFactory.java
@@ -82,7 +82,7 @@ public class TableFunctionFactory {
                         functionImplementation.signature().getArgumentTypes(),
                         functionImplementation.signature().getReturnType()
                     ).toArray(new TypeSignature[0])
-                ),
+                ).withFeature(Feature.DETERMINISTIC),
                 new BoundSignature(
                     functionImplementation.boundSignature().argTypes(),
                     functionImplementation.boundSignature().returnType()

--- a/server/src/main/java/io/crate/expression/tablefunctions/UnnestFunction.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/UnnestFunction.java
@@ -62,6 +62,7 @@ public class UnnestFunction {
                 )
                 .withTypeVariableConstraints(typeVariableOfAnyType("N"))
                 .withFeature(Scalar.Feature.NON_NULLABLE)
+                .withFeature(Scalar.Feature.DETERMINISTIC)
                 .withVariableArity(),
             (signature, boundSignature) -> {
                 List<DataType<?>> fieldTypes = Lists.map(boundSignature.argTypes(), ArrayType::unnest);
@@ -89,9 +90,10 @@ public class UnnestFunction {
         // unnest() to keep it compatible with previous versions
         builder.add(
             Signature.table(
-                NAME,
-                DataTypes.UNTYPED_OBJECT.getTypeSignature()
-            ).withFeature(Scalar.Feature.NON_NULLABLE),
+                    NAME,
+                    DataTypes.UNTYPED_OBJECT.getTypeSignature()
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withFeature(Scalar.Feature.NON_NULLABLE),
             (signature, boundSignature) -> new UnnestTableFunctionImplementation(
                 signature,
                 boundSignature,

--- a/server/src/main/java/io/crate/expression/tablefunctions/ValuesFunction.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/ValuesFunction.java
@@ -32,6 +32,7 @@ import io.crate.data.Input;
 import io.crate.data.Row;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
@@ -51,6 +52,7 @@ public class ValuesFunction {
             TypeSignature.parse("array(E)"),
             RowType.EMPTY.getTypeSignature())
         .withTypeVariableConstraints(typeVariableOfAnyType("E"))
+        .withFeature(Scalar.Feature.DETERMINISTIC)
         .withVariableArity();
 
     public static void register(Functions.Builder builder) {

--- a/server/src/main/java/io/crate/expression/udf/UserDefinedFunctionService.java
+++ b/server/src/main/java/io/crate/expression/udf/UserDefinedFunctionService.java
@@ -233,6 +233,7 @@ public class UserDefinedFunctionService extends AbstractLifecycleComponent imple
                     udf.argumentTypes(),
                     DataType::getTypeSignature))
             .returnType(udf.returnType().getTypeSignature())
+            .feature(Scalar.Feature.DETERMINISTIC)
             .build();
 
         final Scalar<?, ?> scalar;

--- a/server/src/main/java/io/crate/metadata/Scalar.java
+++ b/server/src/main/java/io/crate/metadata/Scalar.java
@@ -65,7 +65,6 @@ import io.crate.role.Roles;
  */
 public abstract class Scalar<ReturnType, InputType> implements FunctionImplementation, FunctionToQuery {
 
-    public static final Set<Feature> NO_FEATURES = Set.of();
     public static final Set<Feature> DETERMINISTIC_ONLY = EnumSet.of(Feature.DETERMINISTIC);
     public static final Set<Feature> DETERMINISTIC_AND_COMPARISON_REPLACEMENT = EnumSet.of(
         Feature.DETERMINISTIC, Feature.COMPARISON_REPLACEMENT);

--- a/server/src/main/java/io/crate/metadata/functions/Signature.java
+++ b/server/src/main/java/io/crate/metadata/functions/Signature.java
@@ -150,7 +150,7 @@ public final class Signature implements Writeable, Accountable {
         private FunctionType kind;
         private List<TypeSignature> argumentTypes = Collections.emptyList();
         private TypeSignature returnType;
-        private Set<Scalar.Feature> features = Scalar.DETERMINISTIC_ONLY;
+        private Set<Scalar.Feature> features = Set.of();
         private List<TypeVariableConstraint> typeVariableConstraints = Collections.emptyList();
         private List<TypeSignature> variableArityGroup = Collections.emptyList();
         private boolean variableArity = false;
@@ -207,7 +207,7 @@ public final class Signature implements Writeable, Accountable {
         }
 
         public Builder features(Set<Scalar.Feature> features) {
-            this.features = features;
+            this.features = Sets.union(this.features, features);
             return this;
         }
 

--- a/server/src/main/java/io/crate/role/scalar/UserFunction.java
+++ b/server/src/main/java/io/crate/role/scalar/UserFunction.java
@@ -45,14 +45,14 @@ public class UserFunction extends Scalar<String, Object> {
             Signature.scalar(
                 CURRENT_USER_FUNCTION_NAME,
                 DataTypes.STRING.getTypeSignature()
-            ).withFeatures(Scalar.NO_FEATURES),
+            ),
             UserFunction::new
         );
         builder.add(
             Signature.scalar(
                 SESSION_USER_FUNCTION_NAME,
                 DataTypes.STRING.getTypeSignature()
-            ).withFeatures(Scalar.NO_FEATURES),
+            ),
             UserFunction::new
         );
     }

--- a/server/src/main/java/io/crate/types/Regproc.java
+++ b/server/src/main/java/io/crate/types/Regproc.java
@@ -21,6 +21,7 @@
 
 package io.crate.types;
 
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.metadata.pgcatalog.OidHash;
 
@@ -36,7 +37,7 @@ public class Regproc {
 
     public static Regproc of(@NotNull String name) {
         return new Regproc(
-            OidHash.functionOid(Signature.scalar(name, DataTypes.UNDEFINED.getTypeSignature())),
+            OidHash.functionOid(Signature.scalar(name, DataTypes.UNDEFINED.getTypeSignature()).withFeature(Scalar.Feature.DETERMINISTIC)),
             name
         );
     }
@@ -56,7 +57,7 @@ public class Regproc {
     }
 
     public Signature asDummySignature() {
-        return Signature.scalar(name, DataTypes.UNDEFINED.getTypeSignature());
+        return Signature.scalar(name, DataTypes.UNDEFINED.getTypeSignature()).withFeature(Scalar.Feature.DETERMINISTIC);
     }
 
     public int oid() {

--- a/server/src/test/java/io/crate/execution/dsl/projection/WindowAggProjectionSerialisationTest.java
+++ b/server/src/test/java/io/crate/execution/dsl/projection/WindowAggProjectionSerialisationTest.java
@@ -41,6 +41,7 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.WindowFunction;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.Functions;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.metadata.settings.session.SessionSettingRegistry;
 import io.crate.types.DataTypes;
@@ -132,9 +133,10 @@ public class WindowAggProjectionSerialisationTest {
     private FunctionImplementation getSumFunction() {
         return functions.getQualified(
             Signature.aggregate(
-                SumAggregation.NAME,
-                DataTypes.LONG.getTypeSignature(),
-                DataTypes.LONG.getTypeSignature()),
+                    SumAggregation.NAME,
+                    DataTypes.LONG.getTypeSignature(),
+                    DataTypes.LONG.getTypeSignature())
+                .withFeature(Scalar.Feature.DETERMINISTIC),
             List.of(DataTypes.LONG),
             DataTypes.LONG
         );

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregationTest.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import org.junit.Test;
 
 import io.crate.expression.symbol.Literal;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.SearchPath;
 import io.crate.metadata.functions.Signature;
 import io.crate.operation.aggregation.AggregationTestCase;
@@ -40,10 +41,10 @@ public class ArbitraryAggregationTest extends AggregationTestCase {
     private Object executeAggregation(DataType<?> argumentType, Object[][] data) throws Exception {
         return executeAggregation(
             Signature.aggregate(
-                ArbitraryAggregation.NAME,
-                argumentType.getTypeSignature(),
-                argumentType.getTypeSignature()
-            ),
+                    ArbitraryAggregation.NAME,
+                    argumentType.getTypeSignature(),
+                    argumentType.getTypeSignature())
+                .withFeature(Scalar.Feature.DETERMINISTIC),
             data,
             List.of()
         );
@@ -140,7 +141,7 @@ public class ArbitraryAggregationTest extends AggregationTestCase {
             "any_value",
             DataTypes.INTEGER.getTypeSignature(),
             DataTypes.INTEGER.getTypeSignature()
-        );
+        ).withFeature(Scalar.Feature.DETERMINISTIC);
         Object result = executeAggregation(aggregate, new Object[][] { new Object[] { 1 } }, List.of());
         assertThat(result).isEqualTo(1);
     }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/AverageAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/AverageAggregationTest.java
@@ -39,6 +39,7 @@ import io.crate.execution.engine.aggregation.impl.average.AverageAggregation;
 import io.crate.execution.engine.aggregation.impl.average.numeric.NumericAverageState;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.FunctionImplementation;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.SearchPath;
 import io.crate.metadata.functions.Signature;
 import io.crate.operation.aggregation.AggregationTestCase;
@@ -52,7 +53,7 @@ public class AverageAggregationTest extends AggregationTestCase {
         AverageAggregation.NAME,
         DataTypes.NUMERIC.getTypeSignature(),
         DataTypes.NUMERIC.getTypeSignature()
-    );
+    ).withFeature(Scalar.Feature.DETERMINISTIC);
 
     private Object executeAvgAgg(DataType<?> argumentType, Object[][] data) throws Exception {
         return executeAggregation(
@@ -60,7 +61,7 @@ public class AverageAggregationTest extends AggregationTestCase {
                 AverageAggregation.NAME,
                 argumentType.getTypeSignature(),
                 DataTypes.DOUBLE.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.DETERMINISTIC),
             data,
             List.of()
         );
@@ -72,7 +73,7 @@ public class AverageAggregationTest extends AggregationTestCase {
                 AverageAggregation.NAME,
                 DataTypes.INTERVAL.getTypeSignature(),
                 DataTypes.INTERVAL.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.DETERMINISTIC),
             data,
             List.of()
         );

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/CmpByAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/CmpByAggregationTest.java
@@ -29,6 +29,7 @@ import java.util.Map;
 
 import org.junit.Test;
 
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.operation.aggregation.AggregationTestCase;
 import io.crate.types.DataTypes;
@@ -42,7 +43,7 @@ public class CmpByAggregationTest extends AggregationTestCase {
             DataTypes.STRING.getTypeSignature(),
             DataTypes.INTEGER.getTypeSignature(),
             DataTypes.STRING.getTypeSignature()
-        );
+        ).withFeature(Scalar.Feature.DETERMINISTIC);
         Object result = executeAggregation(
             signature,
             new Object[][] {
@@ -63,7 +64,7 @@ public class CmpByAggregationTest extends AggregationTestCase {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            );
+            ).withFeature(Scalar.Feature.DETERMINISTIC);
             Object result = executeAggregation(
                 signature,
                 new Object[][] {
@@ -85,7 +86,7 @@ public class CmpByAggregationTest extends AggregationTestCase {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            );
+            ).withFeature(Scalar.Feature.DETERMINISTIC);
             Object result = executeAggregation(
                 signature,
                 new Object[][] {
@@ -106,7 +107,7 @@ public class CmpByAggregationTest extends AggregationTestCase {
             DataTypes.STRING.getTypeSignature(),
             DataTypes.INTEGER.getTypeSignature(),
             DataTypes.STRING.getTypeSignature()
-        );
+        ).withFeature(Scalar.Feature.DETERMINISTIC);
         Object result = executeAggregation(
             signature,
             new Object[][] {
@@ -127,7 +128,7 @@ public class CmpByAggregationTest extends AggregationTestCase {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            );
+            ).withFeature(Scalar.Feature.DETERMINISTIC);
             Object result = executeAggregation(
                 signature,
                 new Object[][] {
@@ -148,7 +149,7 @@ public class CmpByAggregationTest extends AggregationTestCase {
             DataTypes.STRING.getTypeSignature(),
             DataTypes.INTEGER.getTypeSignature(),
             DataTypes.STRING.getTypeSignature()
-        );
+        ).withFeature(Scalar.Feature.DETERMINISTIC);
         Object result = executeAggregation(
             signature,
             new Object[][] {
@@ -169,7 +170,7 @@ public class CmpByAggregationTest extends AggregationTestCase {
             DataTypes.STRING.getTypeSignature(),
             DataTypes.UNTYPED_OBJECT.getTypeSignature(),
             DataTypes.STRING.getTypeSignature()
-        );
+        ).withFeature(Scalar.Feature.DETERMINISTIC);
         assertThatThrownBy(() -> executeAggregation(
             signature,
             new Object[][] {
@@ -188,7 +189,7 @@ public class CmpByAggregationTest extends AggregationTestCase {
             DataTypes.STRING.getTypeSignature(),
             DataTypes.LONG.getTypeSignature(),
             DataTypes.STRING.getTypeSignature()
-        );
+        ).withFeature(Scalar.Feature.DETERMINISTIC);
         Object result = executeAggregation(
             signature,
             new Object[][] {

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregationTest.java
@@ -33,6 +33,7 @@ import io.crate.data.Input;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.FunctionImplementation;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.SearchPath;
 import io.crate.metadata.functions.Signature;
 import io.crate.operation.aggregation.AggregationTestCase;
@@ -48,7 +49,7 @@ public class CollectSetAggregationTest extends AggregationTestCase {
                 "collect_set",
                 argumentType.getTypeSignature(),
                 new ArrayType<>(argumentType).getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.DETERMINISTIC),
             data,
             List.of()
         );

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregationTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.FunctionImplementation;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.SearchPath;
 import io.crate.metadata.functions.Signature;
 import io.crate.operation.aggregation.AggregationTestCase;
@@ -46,7 +47,7 @@ public class GeometricMeanAggregationTest extends AggregationTestCase {
                 GeometricMeanAggregation.NAME,
                 argumentType.getTypeSignature(),
                 DataTypes.DOUBLE.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.DETERMINISTIC),
             data,
             List.of()
         );

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/MaximumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/MaximumAggregationTest.java
@@ -30,6 +30,7 @@ import org.joda.time.Period;
 import org.junit.Test;
 
 import io.crate.exceptions.UnsupportedFunctionException;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.operation.aggregation.AggregationTestCase;
 import io.crate.types.DataType;
@@ -43,7 +44,7 @@ public class MaximumAggregationTest extends AggregationTestCase {
                 "max",
                 argumentType.getTypeSignature(),
                 argumentType.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.DETERMINISTIC),
             data,
             List.of()
         );

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/MinimumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/MinimumAggregationTest.java
@@ -30,6 +30,7 @@ import org.joda.time.Period;
 import org.junit.Test;
 
 import io.crate.exceptions.UnsupportedFunctionException;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.operation.aggregation.AggregationTestCase;
 import io.crate.types.DataType;
@@ -43,7 +44,7 @@ public class MinimumAggregationTest extends AggregationTestCase {
                 MinimumAggregation.NAME,
                 argumentType.getTypeSignature(),
                 argumentType.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.DETERMINISTIC),
             data,
             List.of()
         );

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/PercentileAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/PercentileAggregationTest.java
@@ -36,6 +36,7 @@ import io.crate.data.breaker.RamAccounting;
 import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.expression.symbol.Literal;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.operation.aggregation.AggregationTestCase;
 import io.crate.testing.PlainRamAccounting;
@@ -51,7 +52,7 @@ public class PercentileAggregationTest extends AggregationTestCase {
                 argumentType.getTypeSignature(),
                 DataTypes.DOUBLE.getTypeSignature(),
                 DataTypes.DOUBLE.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.DETERMINISTIC),
             rows,
             List.of()
         );
@@ -64,7 +65,7 @@ public class PercentileAggregationTest extends AggregationTestCase {
                 argumentType.getTypeSignature(),
                 DataTypes.DOUBLE_ARRAY.getTypeSignature(),
                 DataTypes.DOUBLE_ARRAY.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.DETERMINISTIC),
             rows,
             List.of()
         );
@@ -81,7 +82,7 @@ public class PercentileAggregationTest extends AggregationTestCase {
                 DataTypes.DOUBLE.getTypeSignature(),
                 DataTypes.DOUBLE.getTypeSignature(),
                 DataTypes.DOUBLE.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.DETERMINISTIC),
             List.of(DataTypes.DOUBLE, DataTypes.DOUBLE),
             DataTypes.DOUBLE
         );
@@ -91,7 +92,7 @@ public class PercentileAggregationTest extends AggregationTestCase {
                 DataTypes.DOUBLE.getTypeSignature(),
                 DataTypes.DOUBLE_ARRAY.getTypeSignature(),
                 DataTypes.DOUBLE_ARRAY.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.DETERMINISTIC),
             List.of(DataTypes.DOUBLE, DataTypes.DOUBLE_ARRAY),
             DataTypes.DOUBLE_ARRAY
         );
@@ -234,7 +235,7 @@ public class PercentileAggregationTest extends AggregationTestCase {
                 DataTypes.LONG.getTypeSignature(),
                 DataTypes.DOUBLE_ARRAY.getTypeSignature(),
                 DataTypes.DOUBLE_ARRAY.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.DETERMINISTIC),
             List.of(DataTypes.LONG, DataTypes.DOUBLE_ARRAY),
             DataTypes.DOUBLE_ARRAY
         );
@@ -258,7 +259,7 @@ public class PercentileAggregationTest extends AggregationTestCase {
                 DataTypes.LONG.getTypeSignature(),
                 DataTypes.DOUBLE_ARRAY.getTypeSignature(),
                 DataTypes.DOUBLE_ARRAY.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.DETERMINISTIC),
             List.of(DataTypes.LONG, DataTypes.DOUBLE_ARRAY),
             DataTypes.DOUBLE_ARRAY
         );

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/StdDevAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/StdDevAggregationTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.FunctionImplementation;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.SearchPath;
 import io.crate.metadata.functions.Signature;
 import io.crate.operation.aggregation.AggregationTestCase;
@@ -46,7 +47,7 @@ public class StdDevAggregationTest extends AggregationTestCase {
                 "stddev",
                 argumentType.getTypeSignature(),
                 DataTypes.DOUBLE.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.DETERMINISTIC),
             data,
             List.of()
         );

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/SumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/SumAggregationTest.java
@@ -35,6 +35,7 @@ import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.FunctionImplementation;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.SearchPath;
 import io.crate.metadata.functions.Signature;
 import io.crate.operation.aggregation.AggregationTestCase;
@@ -52,7 +53,7 @@ public class SumAggregationTest extends AggregationTestCase {
                 SumAggregation.NAME,
                 argumentType.getTypeSignature(),
                 returnType.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.DETERMINISTIC),
             data,
             List.of()
         );
@@ -117,7 +118,7 @@ public class SumAggregationTest extends AggregationTestCase {
             SumAggregation.NAME,
             DataTypes.FLOAT.getTypeSignature(),
             DataTypes.FLOAT.getTypeSignature()
-        );
+        ).withFeature(Scalar.Feature.DETERMINISTIC);
         Object result = executeAggregation(
             signature,
             signature.getArgumentDataTypes(),
@@ -172,9 +173,10 @@ public class SumAggregationTest extends AggregationTestCase {
         assertThat(execPartialAggregationWithoutDocValues(
                 (IntervalSumAggregation) nodeCtx.functions().getQualified(
                     Signature.aggregate(
-                        IntervalSumAggregation.NAME,
-                        DataTypes.INTERVAL.getTypeSignature(),
-                        DataTypes.INTERVAL.getTypeSignature()),
+                            IntervalSumAggregation.NAME,
+                            DataTypes.INTERVAL.getTypeSignature(),
+                            DataTypes.INTERVAL.getTypeSignature())
+                        .withFeature(Scalar.Feature.DETERMINISTIC),
                     List.of(DataTypes.INTERVAL),
                     DataTypes.INTERVAL
                 ),

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/VarianceAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/VarianceAggregationTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 
 import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.expression.symbol.Literal;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.SearchPath;
 import io.crate.metadata.functions.Signature;
 import io.crate.operation.aggregation.AggregationTestCase;
@@ -44,7 +45,7 @@ public class VarianceAggregationTest extends AggregationTestCase {
                 VarianceAggregation.NAME,
                 argumentType.getTypeSignature(),
                 DataTypes.DOUBLE.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.DETERMINISTIC),
             data,
             List.of()
         );

--- a/server/src/test/java/io/crate/execution/engine/collect/DocValuesAggregatesTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/DocValuesAggregatesTest.java
@@ -44,6 +44,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.SimpleReference;
 import io.crate.metadata.doc.DocSchemaInfo;
 import io.crate.metadata.doc.DocTableInfo;
@@ -122,7 +123,7 @@ public class DocValuesAggregatesTest extends CrateDummyClusterServiceUnitTest {
                     SumAggregation.NAME,
                     DataTypes.LONG.getTypeSignature(),
                     DataTypes.LONG.getTypeSignature()
-                ),
+                ).withFeature(Scalar.Feature.DETERMINISTIC),
                 DataTypes.LONG,
                 List.of(Literal.of(1L)))
             ),
@@ -217,7 +218,7 @@ public class DocValuesAggregatesTest extends CrateDummyClusterServiceUnitTest {
                 SumAggregation.NAME,
                 DataTypes.LONG.getTypeSignature(),
                 DataTypes.LONG.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.DETERMINISTIC),
             DataTypes.LONG,
             List.of(new InputColumn(inputCol, DataTypes.LONG))
         );

--- a/server/src/test/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitorTest.java
@@ -79,6 +79,7 @@ import io.crate.memory.OnHeapMemoryManager;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.RowGranularity;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.SearchPath;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -117,7 +118,7 @@ public class ProjectionToProjectorVisitorTest extends CrateDummyClusterServiceUn
             "avg",
             DataTypes.INTEGER.getTypeSignature(),
             DataTypes.DOUBLE.getTypeSignature()
-        );
+        ).withFeature(Scalar.Feature.DETERMINISTIC);
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/engine/window/WindowBatchIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/window/WindowBatchIteratorTest.java
@@ -53,6 +53,7 @@ import io.crate.data.testing.TestingBatchIterators;
 import io.crate.data.testing.TestingRowConsumer;
 import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.execution.engine.sort.OrderingByPosition;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 import io.crate.sql.tree.FrameBound;
@@ -399,7 +400,7 @@ public class WindowBatchIteratorTest {
 
             @Override
             public Signature signature() {
-                return Signature.window("first_cell_value", DataTypes.INTEGER.getTypeSignature());
+                return Signature.window("first_cell_value", DataTypes.INTEGER.getTypeSignature()).withFeature(Scalar.Feature.DETERMINISTIC);
             }
 
             @Override
@@ -423,7 +424,7 @@ public class WindowBatchIteratorTest {
 
             @Override
             public Signature signature() {
-                return Signature.window("a_frame_bounded_window_function", DataTypes.INTEGER.getTypeSignature());
+                return Signature.window("a_frame_bounded_window_function", DataTypes.INTEGER.getTypeSignature()).withFeature(Scalar.Feature.DETERMINISTIC);
             }
 
             @Override
@@ -448,7 +449,7 @@ public class WindowBatchIteratorTest {
 
             @Override
             public Signature signature() {
-                return Signature.window("row_number", DataTypes.INTEGER.getTypeSignature());
+                return Signature.window("row_number", DataTypes.INTEGER.getTypeSignature()).withFeature(Scalar.Feature.DETERMINISTIC);
             }
 
             @Override

--- a/server/src/test/java/io/crate/expression/scalar/cast/CastFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/cast/CastFunctionTest.java
@@ -47,6 +47,7 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.format.Style;
 import io.crate.geo.GeoJSONUtils;
 import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
@@ -246,11 +247,12 @@ public class CastFunctionTest extends ScalarTestCase {
             .build();
 
         var signature = Signature.scalar(
-            ExplicitCastFunction.NAME,
-            TypeSignature.parse("E"),
-            TypeSignature.parse("V"),
-            TypeSignature.parse("V")
-        ).withTypeVariableConstraints(typeVariable("E"), typeVariable("V"));
+                ExplicitCastFunction.NAME,
+                TypeSignature.parse("E"),
+                TypeSignature.parse("V"),
+                TypeSignature.parse("V")
+            ).withFeature(Scalar.Feature.DETERMINISTIC)
+            .withTypeVariableConstraints(typeVariable("E"), typeVariable("V"));
         var functionImpl = sqlExpressions.nodeCtx.functions().getQualified(
             signature,
             List.of(DataTypes.UNTYPED_OBJECT, returnType),

--- a/server/src/test/java/io/crate/expression/symbol/FunctionTest.java
+++ b/server/src/test/java/io/crate/expression/symbol/FunctionTest.java
@@ -46,10 +46,11 @@ public class FunctionTest extends ESTestCase {
     private DataType<?> returnType = TestingHelpers.randomPrimitiveType();
 
     private Signature signature = Signature.scalar(
-        randomAsciiLettersOfLength(10),
-        DataTypes.BOOLEAN.getTypeSignature(),
-        returnType.getTypeSignature()
-    ).withFeatures(randomFeatures());
+            randomAsciiLettersOfLength(10),
+            DataTypes.BOOLEAN.getTypeSignature(),
+            returnType.getTypeSignature()
+        ).withFeature(Scalar.Feature.DETERMINISTIC)
+        .withFeatures(randomFeatures());
 
 
     @Test

--- a/server/src/test/java/io/crate/expression/symbol/WindowFunctionSerializationTest.java
+++ b/server/src/test/java/io/crate/expression/symbol/WindowFunctionSerializationTest.java
@@ -38,6 +38,7 @@ import io.crate.analyze.WindowDefinition;
 import io.crate.execution.engine.aggregation.impl.SumAggregation;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.Functions;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.metadata.settings.session.SessionSettingRegistry;
 import io.crate.types.DataTypes;
@@ -49,9 +50,10 @@ public class WindowFunctionSerializationTest {
     private FunctionImplementation dummyFunction =
         functions.getQualified(
             Signature.aggregate(
-                SumAggregation.NAME,
-                DataTypes.FLOAT.getTypeSignature(),
-                DataTypes.FLOAT.getTypeSignature()),
+                    SumAggregation.NAME,
+                    DataTypes.FLOAT.getTypeSignature(),
+                    DataTypes.FLOAT.getTypeSignature())
+                .withFeature(Scalar.Feature.DETERMINISTIC),
             List.of(DataTypes.FLOAT),
             DataTypes.FLOAT
         );

--- a/server/src/test/java/io/crate/expression/symbol/format/SymbolFormatterTest.java
+++ b/server/src/test/java/io/crate/expression/symbol/format/SymbolFormatterTest.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbols;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
@@ -46,7 +47,7 @@ public class SymbolFormatterTest extends ESTestCase {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.UNDEFINED.getTypeSignature(),
                 DataTypes.DOUBLE.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.DETERMINISTIC),
             List.of(Literal.of("bar"), Literal.of(3.4)),
             DataTypes.DOUBLE
         );

--- a/server/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
+++ b/server/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
@@ -47,6 +47,7 @@ import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.SimpleReference;
 import io.crate.metadata.doc.DocSchemaInfo;
 import io.crate.metadata.doc.DocTableInfo;
@@ -139,7 +140,7 @@ public class SymbolPrinterTest extends CrateDummyClusterServiceUnitTest {
             "agg",
             DataTypes.INTEGER.getTypeSignature(),
             DataTypes.LONG.getTypeSignature()
-        );
+        ).withFeature(Scalar.Feature.DETERMINISTIC);
         Aggregation a = new Aggregation(
             signature,
             DataTypes.LONG,

--- a/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -57,6 +57,7 @@ import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.lucene.match.CrateRegexQuery;
 import io.crate.metadata.RelationName;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.doc.DocSchemaInfo;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.functions.Signature;
@@ -623,7 +624,7 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
                 TypeSignature.parse("array(E)"),
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.INTEGER.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.DETERMINISTIC),
             List.of(alias, Literal.of(1)), // 1 is a dummy argument for dimension.
             DataTypes.INTEGER
         );

--- a/server/src/test/java/io/crate/metadata/FunctionsTest.java
+++ b/server/src/test/java/io/crate/metadata/FunctionsTest.java
@@ -86,7 +86,7 @@ public class FunctionsTest extends ESTestCase {
                 "foo",
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.DETERMINISTIC),
             (signature, args) -> new DummyFunction(signature));
         var impl = resolve("foo", List.of(Literal.of("hoschi")));
         assertThat(impl.boundSignature().argTypes()).containsExactly(DataTypes.STRING);
@@ -99,7 +99,7 @@ public class FunctionsTest extends ESTestCase {
                 "foo",
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.DETERMINISTIC),
             (signature, args) -> new DummyFunction(signature));
         var impl = resolve("foo", List.of(Literal.of(1L)));
         assertThat(impl.boundSignature().argTypes()).containsExactly(DataTypes.INTEGER);
@@ -112,14 +112,14 @@ public class FunctionsTest extends ESTestCase {
                 "foo",
                 DataTypes.DOUBLE.getTypeSignature(),
                 DataTypes.DOUBLE.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.DETERMINISTIC),
             (signature, args) -> new DummyFunction(signature));
         functionsBuilder.add(
             Signature.scalar(
                 "foo",
                 DataTypes.FLOAT.getTypeSignature(),
                 DataTypes.FLOAT.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.DETERMINISTIC),
             (signature, args) -> new DummyFunction(signature));
 
         var impl = resolve("foo", List.of(Literal.of(1L)));
@@ -135,14 +135,15 @@ public class FunctionsTest extends ESTestCase {
                 "foo",
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.INTEGER.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.DETERMINISTIC),
             (signature, args) -> new DummyFunction(signature));
         functionsBuilder.add(
             Signature.scalar(
-                "foo",
-                TypeSignature.parse("array(E)"),
-                DataTypes.INTEGER.getTypeSignature()
-            ).withTypeVariableConstraints(typeVariable("E")),
+                    "foo",
+                    TypeSignature.parse("array(E)"),
+                    DataTypes.INTEGER.getTypeSignature()
+                ).withFeature(Scalar.Feature.DETERMINISTIC)
+                .withTypeVariableConstraints(typeVariable("E")),
             (signature, args) -> new DummyFunction(signature));
 
         var impl = resolve("foo", List.of(Literal.of(DataTypes.UNDEFINED, null)));
@@ -156,14 +157,14 @@ public class FunctionsTest extends ESTestCase {
                 new FunctionName("schema1", "foo"),
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.INTEGER.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.DETERMINISTIC),
             (signature, args) -> new DummyFunction(signature));
         Functions functions = functionsBuilder.build();
         Signature signature = Signature.scalar(
             new FunctionName("schema2", "foo"),
             DataTypes.STRING.getTypeSignature(),
             DataTypes.INTEGER.getTypeSignature()
-        );
+        ).withFeature(Scalar.Feature.DETERMINISTIC);
         functions.setUDFs(
             Map.of(
                 new FunctionName("schema2", "foo"),
@@ -183,13 +184,15 @@ public class FunctionsTest extends ESTestCase {
                 "foo",
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.INTEGER.getTypeSignature()
-            ), (signature, args) -> new DummyFunction(signature));
+            ).withFeature(Scalar.Feature.DETERMINISTIC),
+            (signature, args) -> new DummyFunction(signature));
         functionsBuilder.add(
             Signature.scalar(
-                "foo",
-                TypeSignature.parse("array(E)"),
-                TypeSignature.parse("array(E)")
-            ).withTypeVariableConstraints(typeVariable("E")),
+                    "foo",
+                    TypeSignature.parse("array(E)"),
+                    TypeSignature.parse("array(E)")
+                ).withTypeVariableConstraints(typeVariable("E"))
+                .withFeature(Scalar.Feature.DETERMINISTIC),
             (signature, args) -> new DummyFunction(signature));
 
         var impl = resolve("foo", List.of(Literal.of(DataTypes.UNDEFINED, null)));
@@ -206,7 +209,7 @@ public class FunctionsTest extends ESTestCase {
                 DataTypes.BOOLEAN.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.INTEGER.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.DETERMINISTIC),
             (signature, args) -> new DummyFunction(signature));
         functionsBuilder.add(
             Signature.scalar(
@@ -214,7 +217,7 @@ public class FunctionsTest extends ESTestCase {
                 DataTypes.STRING.getTypeSignature(),
                 DataTypes.SHORT.getTypeSignature(),
                 DataTypes.INTEGER.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.DETERMINISTIC),
             (signature, args) -> new DummyFunction(signature));
         functionsBuilder.add(
             Signature.scalar(
@@ -222,7 +225,7 @@ public class FunctionsTest extends ESTestCase {
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.INTEGER.getTypeSignature()
-            ),
+            ).withFeature(Scalar.Feature.DETERMINISTIC),
             (signature, args) -> new DummyFunction(signature));
 
         var impl = resolve("foo", List.of(Literal.of(1), Literal.of(1L)));
@@ -235,7 +238,7 @@ public class FunctionsTest extends ESTestCase {
             "foo",
             DataTypes.STRING.getTypeSignature(),
             DataTypes.INTEGER.getTypeSignature()
-        );
+        ).withFeature(Scalar.Feature.DETERMINISTIC);
         var dummyFunction = new DummyFunction(signature);
 
         functionsBuilder.add(signature, (s, args) -> dummyFunction);
@@ -252,7 +255,7 @@ public class FunctionsTest extends ESTestCase {
             "foo",
             DataTypes.STRING.getTypeSignature(),
             DataTypes.INTEGER.getTypeSignature()
-        );
+        ).withFeature(Scalar.Feature.DETERMINISTIC);
         var dummyFunction = new DummyFunction(signature);
 
         functionsBuilder.add(signature, (s, args) -> dummyFunction);
@@ -287,13 +290,15 @@ public class FunctionsTest extends ESTestCase {
                     new FunctionProvider(
                         Signature.scalar(new FunctionName("foo", "bar"),
                                         DataTypes.STRING.getTypeSignature(),
-                                        DataTypes.STRING.getTypeSignature()),
+                                        DataTypes.STRING.getTypeSignature())
+                            .withFeature(Scalar.Feature.DETERMINISTIC),
                         ((signature, dataTypes) -> null)
                     ),
                     new FunctionProvider(
                         Signature.scalar(new FunctionName("foo", "bar"),
                                         DataTypes.DOUBLE.getTypeSignature(),
-                                        DataTypes.DOUBLE.getTypeSignature()),
+                                        DataTypes.DOUBLE.getTypeSignature())
+                            .withFeature(Scalar.Feature.DETERMINISTIC),
                         ((signature, dataTypes) -> null)
                     )
                 )
@@ -314,13 +319,15 @@ public class FunctionsTest extends ESTestCase {
                     new FunctionProvider(
                         Signature.scalar(new FunctionName("foo", "bar"),
                                         DataTypes.STRING.getTypeSignature(),
-                                        DataTypes.STRING.getTypeSignature()),
+                                        DataTypes.STRING.getTypeSignature())
+                            .withFeature(Scalar.Feature.DETERMINISTIC),
                         ((signature, dataTypes) -> null)
                     ),
                     new FunctionProvider(
                         Signature.scalar(new FunctionName("foo", "bar"),
                                         DataTypes.DOUBLE.getTypeSignature(),
-                                        DataTypes.DOUBLE.getTypeSignature()),
+                                        DataTypes.DOUBLE.getTypeSignature())
+                            .withFeature(Scalar.Feature.DETERMINISTIC),
                         ((signature, dataTypes) -> null)
                     )
                 )

--- a/server/src/test/java/io/crate/planner/operators/FetchRewriteTest.java
+++ b/server/src/test/java/io/crate/planner/operators/FetchRewriteTest.java
@@ -45,6 +45,7 @@ import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
+import io.crate.metadata.Scalar;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.functions.Signature;
 import io.crate.metadata.table.Operation;
@@ -72,7 +73,7 @@ public class FetchRewriteTest extends CrateDummyClusterServiceUnitTest {
                         DataTypes.INTEGER.getTypeSignature(),
                         DataTypes.INTEGER.getTypeSignature(),
                         DataTypes.INTEGER.getTypeSignature()
-                    ),
+                    ).withFeature(Scalar.Feature.DETERMINISTIC),
                     List.of(x, x),
                     DataTypes.INTEGER
                 )

--- a/server/src/testFixtures/java/io/crate/testing/SleepScalarFunction.java
+++ b/server/src/testFixtures/java/io/crate/testing/SleepScalarFunction.java
@@ -38,7 +38,7 @@ public class SleepScalarFunction extends Scalar<Boolean, Long> {
         NAME,
         DataTypes.LONG.getTypeSignature(),
         DataTypes.BOOLEAN.getTypeSignature()
-    ).withFeatures(NO_FEATURES);
+    );
 
     public SleepScalarFunction(Signature signature, BoundSignature boundSignature) {
         super(signature, boundSignature);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
~~The motivation of this PR are:~~
- ~~`Signature.Builder.features(Set)` overrode the given set with the set of features accumulated.~~
- ~~`deterministic` flag was set by default but it was not visible.~~
- ~~Most of the functions exist are `deterministic`, makes more sense to tag non-deterministic functions.~~

Update: As mentioned, https://github.com/crate/crate/pull/16174#issuecomment-2175362528, it is safer to mis-tag `deterministic` as `non-deterministic`. So setting all functions as `non-deterministic` by default. Also, updating `Signature.Builder.features(Set)` to union the existing set with the given set instead of overriding.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
