### PR TITLE
Depend directly on RelationAnalzyer in ViewInfoFactory

### DIFF
--- a/server/src/main/java/io/crate/metadata/NodeContext.java
+++ b/server/src/main/java/io/crate/metadata/NodeContext.java
@@ -64,7 +64,7 @@ public class NodeContext {
                 BlobSchemaInfo.NAME, blobSchemaInfo
             );
             var relationAnalyzer = new RelationAnalyzer(nodeCtx);
-            var viewInfoFactory = new ViewInfoFactory(() -> relationAnalyzer);
+            var viewInfoFactory = new ViewInfoFactory(relationAnalyzer);
             Schemas schemas = new Schemas(
                 systemSchemas,
                 clusterService,

--- a/server/src/main/java/io/crate/metadata/view/ViewInfoFactory.java
+++ b/server/src/main/java/io/crate/metadata/view/ViewInfoFactory.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Locale;
 
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.common.inject.Provider;
 
 import io.crate.analyze.ParamTypeHints;
 import io.crate.analyze.relations.AnalyzedRelation;
@@ -47,9 +46,9 @@ import io.crate.types.ObjectType;
 
 public class ViewInfoFactory {
 
-    private final Provider<RelationAnalyzer> analyzerProvider;
+    private final RelationAnalyzer analyzerProvider;
 
-    public ViewInfoFactory(Provider<RelationAnalyzer> analyzerProvider) {
+    public ViewInfoFactory(RelationAnalyzer analyzerProvider) {
         this.analyzerProvider = analyzerProvider;
     }
 
@@ -67,7 +66,7 @@ public class ViewInfoFactory {
         try {
             CoordinatorTxnCtx transactionContext = CoordinatorTxnCtx.systemTransactionContext();
             transactionContext.sessionSettings().setSearchPath(view.searchPath());
-            AnalyzedRelation relation = analyzerProvider.get().analyze(
+            AnalyzedRelation relation = analyzerProvider.analyze(
                 (Query) SqlParser.createStatement(view.stmt()),
                 transactionContext,
                 ParamTypeHints.EMPTY

--- a/server/src/test/java/io/crate/expression/reference/sys/SysShardsExpressionsTest.java
+++ b/server/src/test/java/io/crate/expression/reference/sys/SysShardsExpressionsTest.java
@@ -96,7 +96,7 @@ public class SysShardsExpressionsTest extends CrateDummyClusterServiceUnitTest {
             clusterService,
             new DocSchemaInfoFactory(
                 new DocTableInfoFactory(nodeCtx),
-                new ViewInfoFactory(() -> new RelationAnalyzer(nodeCtx))
+                new ViewInfoFactory(new RelationAnalyzer(nodeCtx))
             ),
             List::of
         );

--- a/server/src/test/java/io/crate/metadata/doc/DocSchemaInfoTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocSchemaInfoTest.java
@@ -37,6 +37,7 @@ import org.elasticsearch.index.Index;
 import org.junit.Before;
 import org.junit.Test;
 
+import io.crate.analyze.relations.RelationAnalyzer;
 import io.crate.common.collections.Lists;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.RelationName;
@@ -59,7 +60,7 @@ public class DocSchemaInfoTest extends CrateDummyClusterServiceUnitTest {
         docSchemaInfo = new DocSchemaInfo(
             "doc",
             clusterService,
-            new ViewInfoFactory(() -> null),
+            new ViewInfoFactory(new RelationAnalyzer(nodeCtx)),
             new DocTableInfoFactory(nodeCtx)
         );
     }


### PR DESCRIPTION
Relates to https://github.com/crate/crate/pull/16144
The `Provider` indirection is no longer necessary.
