### PR TITLE
Fix `pg_get_partkeydef` incorrectly marked as NON_NULLABLE

### DIFF
--- a/docs/appendices/release-notes/5.7.3.rst
+++ b/docs/appendices/release-notes/5.7.3.rst
@@ -62,3 +62,7 @@ Fixes
 - Fixed an issue that caused ``WHERE`` clause to fail to filter rows when
   the clause contained :ref:`scalar-pg_get_partkeydef` scalar function under
   ``NOT`` operator.
+
+- Changed :ref:`scalar-pg_get_function_result` functions to be registered under
+  :ref:`postgres-pg_catalog` schema, in order to be compatible with PostgreSQL
+  behaviour.

--- a/docs/appendices/release-notes/5.7.3.rst
+++ b/docs/appendices/release-notes/5.7.3.rst
@@ -58,3 +58,7 @@ Fixes
 - Fixed an issue that caused ``SQLParseException`` when a
   :ref:`PostgreSQL foreign table <administration-fdw-jdbc-psql>` has columns of
   type ``JSONB``, or ``JSONB[]``.
+
+- Fixed an issue that caused ``WHERE`` clause to fail to filter rows when
+  the clause contained :ref:`scalar-pg_get_partkeydef` scalar function under
+  ``NOT`` operator.

--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -4432,7 +4432,7 @@ Example:
 ---------------------------------
 
 Returns the type name of a type. The first argument is the ``OID`` of the type.
-The second argument is the type modifier. This function exits for PostgreSQL
+The second argument is the type modifier. This function exists for PostgreSQL
 compatibility and the type modifier is always ignored.
 
 Returns: ``text``

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetFunctionResultFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetFunctionResultFunction.java
@@ -22,22 +22,25 @@
 package io.crate.expression.scalar.systeminformation;
 
 import io.crate.data.Input;
+import io.crate.metadata.FunctionName;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
+import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
 import io.crate.types.DataTypes;
 
 public final class PgGetFunctionResultFunction extends Scalar<String, Integer> {
 
     public static final String NAME = "pg_get_function_result";
+    private static final FunctionName FQN = new FunctionName(PgCatalogSchemaInfo.NAME, NAME);
 
     public static void register(Functions.Builder module) {
         module.add(
             Signature.scalar(
-                NAME,
+                FQN,
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
             ),

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetPartkeydefFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetPartkeydefFunction.java
@@ -21,15 +21,18 @@
 
 package io.crate.expression.scalar.systeminformation;
 
-import io.crate.expression.scalar.UnaryScalar;
+import io.crate.data.Input;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
 import io.crate.types.DataTypes;
 
-public class PgGetPartkeydefFunction {
+public class PgGetPartkeydefFunction extends Scalar<String, Integer> {
 
     public static final String NAME = "pg_get_partkeydef";
     private static final FunctionName FQN = new FunctionName(PgCatalogSchemaInfo.NAME, NAME);
@@ -40,14 +43,17 @@ public class PgGetPartkeydefFunction {
                 FQN,
                 DataTypes.INTEGER.getTypeSignature(),
                 DataTypes.STRING.getTypeSignature()
-            ).withFeature(Scalar.Feature.NULLABLE),
-            (signature, boundSignature) ->
-            new UnaryScalar<>(
-                signature,
-                boundSignature,
-                DataTypes.INTEGER,
-                oid -> null
-            )
+            ),
+            PgGetPartkeydefFunction::new
         );
+    }
+
+    public PgGetPartkeydefFunction(Signature signature, BoundSignature boundSignature) {
+        super(signature, boundSignature);
+    }
+
+    @Override
+    public String evaluate(TransactionContext txnCtx, NodeContext nodeContext, Input<Integer>... args) {
+        return null;
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/systeminformation/PgGetFunctionResultFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/systeminformation/PgGetFunctionResultFunctionTest.java
@@ -30,7 +30,7 @@ public class PgGetFunctionResultFunctionTest extends ScalarTestCase {
 
     @Test
     public void test_null_oid_results_in_null() {
-        assertEvaluateNull("pg_function_is_visible(null)");
+        assertEvaluateNull("pg_catalog.pg_get_function_result(null)");
     }
 
     @Test

--- a/server/src/test/java/io/crate/lucene/ThreeValuedLogicQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/ThreeValuedLogicQueryBuilderTest.java
@@ -101,7 +101,7 @@ public class ThreeValuedLogicQueryBuilderTest extends LuceneQueryBuilderTest {
     @Test
     public void test_not_on_pg_get_function_result() {
         assertThat(convert("NOT (PG_GET_FUNCTION_RESULT(x))"))
-            .hasToString("+(+*:* -pg_get_function_result(x)) #(NOT pg_get_function_result(x))");
+            .hasToString("+(+*:* -pg_catalog.pg_get_function_result(x)) #(NOT pg_catalog.pg_get_function_result(x))");
     }
 
     @Test

--- a/server/src/test/java/io/crate/lucene/ThreeValuedLogicQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/ThreeValuedLogicQueryBuilderTest.java
@@ -105,6 +105,12 @@ public class ThreeValuedLogicQueryBuilderTest extends LuceneQueryBuilderTest {
     }
 
     @Test
+    public void test_not_on_pg_get_partkeydef() {
+        assertThat(convert("NOT (PG_GET_PARTKEYDEF(x))"))
+            .hasToString("+(+*:* -pg_catalog.pg_get_partkeydef(x)) #(NOT pg_catalog.pg_get_partkeydef(x))");
+    }
+
+    @Test
     public void test_not_on_current_setting() {
         assertThat(convert("NOT (CURRENT_SETTING(name))"))
             .hasToString("+(+*:* -pg_catalog.current_setting(name)) #(NOT pg_catalog.current_setting(name))");


### PR DESCRIPTION
- Fix `pg_get_function_result` to be registered under `pg_catalog`

- Fix `pg_get_partkeydef` incorrectly marked as NON_NULLABLE
  Fixes: #16172

- docs: Fix typo
