### PR TITLE
Reduce memory footprint of top level ColumnIdent

### DIFF
--- a/benchmarks/src/main/java/io/crate/execution/dml/IndexerBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/execution/dml/IndexerBenchmark.java
@@ -101,8 +101,8 @@ public class IndexerBenchmark {
             new CoordinatorTxnCtx(session.sessionSettings()),
             injector.getInstance(NodeContext.class),
             List.of(
-                table.getReference(new ColumnIdent("x")),
-                table.getReference(new ColumnIdent("y"))
+                table.getReference(ColumnIdent.of("x")),
+                table.getReference(ColumnIdent.of("y"))
             ),
             null
         );

--- a/extensions/functions/src/test/java/io/crate/window/NthValueFunctionsTest.java
+++ b/extensions/functions/src/test/java/io/crate/window/NthValueFunctionsTest.java
@@ -39,7 +39,7 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "last_value(x) over()",
             new Object[] {4, 4, 4, 4},
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[] {1},
             new Object[] {2},
             new Object[] {3},
@@ -52,7 +52,7 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "last_value(x) over(order by y)",
             new Object[] {1, 3, 3, 2},
-            List.of(new ColumnIdent("x"), new ColumnIdent("y")),
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("y")),
             new Object[] {1, 1},
             new Object[] {1, 2},
             new Object[] {3, 2},
@@ -65,7 +65,7 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "last_value(x) over(order by y, x)",
             new Object[] {1, 1, 3, 2},
-            List.of(new ColumnIdent("x"), new ColumnIdent("y")),
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("y")),
             new Object[] {1, 1},
             new Object[] {1, 2},
             new Object[] {3, 2},
@@ -78,7 +78,7 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "last_value(x) ignore nulls over(order by y, x)",
             new Object[] {1, 1, 3, 2, 2},
-            List.of(new ColumnIdent("x"), new ColumnIdent("y")),
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("y")),
             new Object[] {1, 1},
             new Object[] {1, 2},
             new Object[] {3, 2},
@@ -92,7 +92,7 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "first_value(x) over()",
             new Object[] {1, 1, 1, 1},
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[] {1},
             new Object[] {2},
             new Object[] {3},
@@ -104,7 +104,7 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
     public void testFirstValueWithOrderByClause() throws Throwable {
         assertEvaluate("first_value(x) over(order by y)",
             new Object[] {1, 1, 1, 1},
-            List.of(new ColumnIdent("x"), new ColumnIdent("y")),
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("y")),
             new Object[] {1, 1},
             new Object[] {1, 2},
             new Object[] {3, 2},
@@ -116,7 +116,7 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
     public void testNthValueWithEmptyOver() throws Throwable {
         assertEvaluate("nth_value(x, 3) over()",
             new Object[] {3, 3, 3, 3},
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[] {1},
             new Object[] {2},
             new Object[] {3},
@@ -129,7 +129,7 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "nth_value(x, 3) over(order by y)",
             new Object[] {null, 3, 3, 3},
-            List.of(new ColumnIdent("x"), new ColumnIdent("y")),
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("y")),
             new Object[] {1, 1},
             new Object[] {1, 2},
             new Object[] {3, 2},
@@ -141,7 +141,7 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
     public void testNthValueWithNullPositionReturnsNull() throws Throwable {
         assertEvaluate("nth_value(x,null) over(order by y)",
             new Object[] {null, null, null, null},
-            List.of(new ColumnIdent("x"), new ColumnIdent("y")),
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("y")),
             new Object[] {1, 1},
             new Object[] {1, 2},
             new Object[] {3, 2},
@@ -154,7 +154,7 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
         assertThatThrownBy(
             () -> assertEvaluate("first_value(x,null) over(order by y)",
                                  new Object[] {null, null, null, null},
-                                 List.of(new ColumnIdent("x"), new ColumnIdent("y")),
+                                 List.of(ColumnIdent.of("x"), ColumnIdent.of("y")),
                                  new Object[] {1, 1},
                                  new Object[] {1, 2},
                                  new Object[] {3, 2},
@@ -169,7 +169,7 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
         assertThatThrownBy(
             () -> assertEvaluate("last_value(x,null) over(order by y)",
                                  new Object[] {null, null, null, null},
-                                 List.of(new ColumnIdent("x"), new ColumnIdent("y")),
+                                 List.of(ColumnIdent.of("x"), ColumnIdent.of("y")),
                                  new Object[] {1, 1},
                                  new Object[] {1, 2},
                                  new Object[] {3, 2},
@@ -183,7 +183,7 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
     public void testNthValueIgnoreNullsWithNullPositionReturnsNull() throws Throwable {
         assertEvaluate("nth_value(x,null) ignore nulls over(order by y)",
                        new Object[] {null, null, null, null},
-                       List.of(new ColumnIdent("x"), new ColumnIdent("y")),
+                       List.of(ColumnIdent.of("x"), ColumnIdent.of("y")),
                        new Object[] {1, 1},
                        new Object[] {null, 2},
                        new Object[] {3, 2},
@@ -197,7 +197,7 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "nth_value(x, 2) over(partition by x > 2)",
             expected,
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[]{1, 1},
             new Object[]{2, 2},
             new Object[]{2, 2},
@@ -213,7 +213,7 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "nth_value(x, 2) ignore nulls over(partition by x > 2)",
             expected,
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[]{1, 1},
             new Object[]{2, 2},
             new Object[]{2, 2},
@@ -229,7 +229,7 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "nth_value(x, 2) over(partition by x > 2 order by x)",
             expected,
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[]{1},
             new Object[]{2},
             new Object[]{2},
@@ -245,7 +245,7 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "nth_value(x, 2) ignore nulls over(partition by x > 2 order by x)",
             expected,
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[]{1},
             new Object[]{2},
             new Object[]{2},
@@ -261,7 +261,7 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "nth_value(x, 2) OVER(PARTITION BY x>2 ORDER BY x RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING)",
             expected,
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[]{1},
             new Object[]{2},
             new Object[]{2},
@@ -277,7 +277,7 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "nth_value(x, 2) ignore nulls OVER(PARTITION BY x>2 ORDER BY x RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING)",
             expected,
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[]{1},
             new Object[]{2},
             new Object[]{2},
@@ -293,7 +293,7 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "nth_value(x, 1) OVER(ORDER BY x RANGE BETWEEN UNBOUNDED PRECEDING and CURRENT ROW)",
             expected,
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[]{1},
             new Object[]{2});
     }
@@ -304,7 +304,7 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "nth_value(x, 1) ignore Nulls OVER(ORDER BY x nulls first RANGE BETWEEN UNBOUNDED PRECEDING and CURRENT ROW)",
             expected,
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[]{null},
             new Object[]{1},
             new Object[]{2});
@@ -316,7 +316,7 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "nth_value(x, 1) OVER(ORDER BY x ROWS BETWEEN UNBOUNDED PRECEDING and CURRENT ROW)",
             expected,
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[]{1},
             new Object[]{2});
     }
@@ -327,7 +327,7 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "nth_value(x, 1) ignore nulls OVER(ORDER BY x nulls first ROWS BETWEEN UNBOUNDED PRECEDING and CURRENT ROW)",
             expected,
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[]{null},
             new Object[]{1},
             new Object[]{2});
@@ -338,14 +338,14 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "last_value(x) ignore nulls over()",
             new Object[] {null, null},
-            List.of(new ColumnIdent("x"), new ColumnIdent("y")),
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("y")),
             new Object[] {null,1},
             new Object[] {null,2}
         );
         assertEvaluate(
             "last_value(x) ignore nulls over()",
             new Object[] {2, 2, 2, 2},
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[] {1,1},
             new Object[] {null,2},
             new Object[] {null,3},
@@ -358,14 +358,14 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "first_value(x) ignore nulls over()",
             new Object[] {null, null},
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[] {null},
             new Object[] {null}
         );
         assertEvaluate(
             "first_value(x) ignore nulls over()",
             new Object[] {1, 1, 1, 1},
-            List.of(new ColumnIdent("x"), new ColumnIdent("y")),
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("y")),
             new Object[] {1,1},
             new Object[] {null,2},
             new Object[] {2,3},
@@ -378,21 +378,21 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "nth_value(x,3) ignore nulls over()",
             new Object[] {null, null},
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[] {null},
             new Object[] {null}
         );
         assertEvaluate(
             "nth_value(x,1) ignore nulls over()",
             new Object[] {1, 1},
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[] {null},
             new Object[] {1}
         );
         assertEvaluate(
             "nth_value(x,2) ignore nulls over()",
             new Object[] {2, 2, 2, 2},
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[] {1},
             new Object[] {null},
             new Object[] {2},
@@ -405,7 +405,7 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "nth_value(x,1) ignore nulls over(order by y range between current row and unbounded following)",
             new Object[] {1, 2, 2, 3},
-            List.of(new ColumnIdent("x"), new ColumnIdent("y")),
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("y")),
             new Object[] {1,1},
             new Object[] {null,2},
             new Object[] {2,3},
@@ -414,7 +414,7 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "nth_value(x,2) ignore nulls over(order by y range between current row and unbounded following)",
             new Object[] {2, 3, 3, null},
-            List.of(new ColumnIdent("x"), new ColumnIdent("y")),
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("y")),
             new Object[] {1,1},
             new Object[] {null,2},
             new Object[] {2,3},
@@ -423,7 +423,7 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "nth_value(x,1) ignore nulls over(order by y range between current row and current row)",
             new Object[] {1, null, 2, null},
-            List.of(new ColumnIdent("x"), new ColumnIdent("y")),
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("y")),
             new Object[] {1,1},
             new Object[] {null,2},
             new Object[] {2,3},
@@ -436,7 +436,7 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "first_value(x) ignore nulls over(order by y range between current row and unbounded following)",
             new Object[] {1, 2, 2, 3},
-            List.of(new ColumnIdent("x"), new ColumnIdent("y")),
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("y")),
             new Object[] {1,1},
             new Object[] {null,2},
             new Object[] {2,3},
@@ -445,7 +445,7 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "first_value(x) ignore nulls over(order by y range between unbounded preceding and unbounded following)",
             new Object[] {2, 2, 2, 2},
-            List.of(new ColumnIdent("x"), new ColumnIdent("y")),
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("y")),
             new Object[] {null,1},
             new Object[] {null,2},
             new Object[] {2,3},
@@ -458,7 +458,7 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "last_value(x) ignore nulls over(order by y range between unbounded preceding and current row)",
             new Object[] {null, 1, 1, 1, 3},
-            List.of(new ColumnIdent("x"), new ColumnIdent("y")),
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("y")),
             new Object[] {null,1},
             new Object[] {1,2},
             new Object[] {null,3},
@@ -468,7 +468,7 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "last_value(x) ignore nulls over(order by y range between unbounded preceding and unbounded following)",
             new Object[] {2, 2, 2, 2},
-            List.of(new ColumnIdent("x"), new ColumnIdent("y")),
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("y")),
             new Object[] {null,1},
             new Object[] {null,2},
             new Object[] {2,3},
@@ -481,7 +481,7 @@ public class NthValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "first_value(x) respect nulls over()",
             new Object[] {null, null, null, null},
-            List.of(new ColumnIdent("x"), new ColumnIdent("y")),
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("y")),
             new Object[] {null,1},
             new Object[] {1,2},
             new Object[] {null,3},

--- a/extensions/functions/src/test/java/io/crate/window/OffsetValueFunctionsTest.java
+++ b/extensions/functions/src/test/java/io/crate/window/OffsetValueFunctionsTest.java
@@ -46,7 +46,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "lag(x) over()",
             new Object[]{null, 1, null, 2},
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[]{1},
             new Object[]{null},
             new Object[]{2},
@@ -59,7 +59,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "lag(x) ignore nulls over()",
             new Object[]{null, 1, 1, 2},
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[]{1},
             new Object[]{null},
             new Object[]{2},
@@ -72,7 +72,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "lag(x) respect nulls over()",
             new Object[]{null, 1, null, 2},
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[]{1},
             new Object[]{null},
             new Object[]{2},
@@ -85,7 +85,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "lag(x, 2) over()",
             new Object[]{null, null, 1, 2},
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[]{1},
             new Object[]{2},
             new Object[]{3},
@@ -98,7 +98,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "lag(x, 2) ignore nulls over()",
             new Object[]{null, null, 1, 1},
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[]{1},
             new Object[]{2},
             new Object[]{null},
@@ -111,7 +111,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "lag(x, null) over()",
             new Object[]{null, null, null},
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[]{1},
             new Object[]{null},
             new Object[]{2}
@@ -123,7 +123,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "lag(x, null) ignore nulls over()",
             new Object[]{null, null, null},
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[]{1},
             new Object[]{null},
             new Object[]{2}
@@ -135,7 +135,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "lag(x, 0) over()",
             new Object[]{1, 2},
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[]{1},
             new Object[]{2}
         );
@@ -146,7 +146,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
         Assertions.assertThatThrownBy(() -> assertEvaluate(
                 "lag(x,0,123) ignore nulls over()",
                 null,
-                List.of(new ColumnIdent("x")),
+                List.of(ColumnIdent.of("x")),
                 new Object[][]{{1}, {2}, {null}, {3}, {null}, {null}, {4}, {5}, {null}, {6}, {null}, {7}}))
             .isExactlyInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("offset 0 is not a valid argument if ignore nulls flag is set");
@@ -157,7 +157,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "lag(x, -1) over()",
             new Object[]{2, null},
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[]{1},
             new Object[]{2}
         );
@@ -168,7 +168,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "lag(x, -1) ignore nulls over()",
             new Object[]{2, 3, 3 ,null},
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[]{1},
             new Object[]{2},
             new Object[]{null},
@@ -181,7 +181,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "lag(x, 1, -1) over()",
             new Object[]{-1, 1, 2, 3},
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[]{1},
             new Object[]{2},
             new Object[]{3},
@@ -194,7 +194,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "lag(x, 1, -1) ignore nulls over()",
             new Object[]{-1, 1, 1, 3},
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[]{1},
             new Object[]{null},
             new Object[]{3},
@@ -207,7 +207,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "lag(coalesce(x, 1), 1, -1) over()",
             new Object[]{-1, 1, 1},
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[]{1},
             new Object[]{null},
             new Object[]{2}
@@ -219,7 +219,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "lag(x) over(order by y)",
             new Object[]{null, 1, 3, 1},
-            List.of(new ColumnIdent("x"), new ColumnIdent("y")),
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("y")),
             new Object[]{1, 1},
             new Object[]{1, 3},
             new Object[]{3, 2},
@@ -232,7 +232,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "lag(x) over(order by y, x)",
             new Object[]{null, 1, 1, 3},
-            List.of(new ColumnIdent("x"), new ColumnIdent("y")),
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("y")),
             new Object[]{1, 1},
             new Object[]{1, 2},
             new Object[]{3, 2},
@@ -245,7 +245,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "lead(x,1) ignore nulls over()",
             new Object[]{null, null, null, null},
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[]{null},
             new Object[]{null},
             new Object[]{null},
@@ -258,7 +258,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "lead(x) ignore nulls over(order by x asc)",
             new Object[]{2, 3, 4, 5, null},
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[]{5},
             new Object[]{4},
             new Object[]{3},
@@ -268,7 +268,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "lead(x) ignore nulls over(order by y asc, z asc)",
             new Object[]{2, 3, 4, 5, null},
-            List.of(new ColumnIdent("x"), new ColumnIdent("y"), new ColumnIdent("z")),
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("y"), ColumnIdent.of("z")),
             new Object[]{3,2,"c"},
             new Object[]{5,2,"e"},
             new Object[]{4,2,"d"},
@@ -281,7 +281,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
     public void testLagOverPartitionedWindow() throws Throwable {
         assertEvaluate("lag(x) over(partition by x > 2)",
             new Object[]{null, 1, 2, null, 3, 4},
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[]{1},
             new Object[]{2},
             new Object[]{2},
@@ -294,7 +294,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
     public void testLagWithIgnoreNullsOverPartitionedWindow() throws Throwable {
         assertEvaluate("lag(x) over(partition by x > 2 order by x)",
                        new Object[]{null, 1, 2, null, 3, 4, null, null},
-                       List.of(new ColumnIdent("x")),
+                       List.of(ColumnIdent.of("x")),
                        new Object[]{1},
                        new Object[]{2},
                        new Object[]{2},
@@ -311,7 +311,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "lag(x) over(RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING)",
             new Object[]{null, 1, 2, 3},
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[]{1},
             new Object[]{2},
             new Object[]{3},
@@ -324,7 +324,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "lead(x,-3,123) ignore nulls over(RANGE BETWEEN CURRENT ROW and CURRENT ROW)",
             new Object[]{123, 123, 123, 123, 1, 1, 1, 2, 3, 3, 4, 4},
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[][]{{1}, {2}, {null}, {3}, {null}, {null}, {4}, {5}, {null}, {6}, {null}, {7}}
         );
     }
@@ -334,7 +334,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "lead(x) over(partition by x > 2)",
             new Object[]{2, 2, null, 4, 5, null},
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[]{1},
             new Object[]{2},
             new Object[]{2},
@@ -347,7 +347,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
     public void testLeadWithOrderBy() throws Throwable {
         assertEvaluate("lead(x) over(order by y)",
                        new Object[]{3, 1, 2, null},
-                       List.of(new ColumnIdent("x"), new ColumnIdent("y")),
+                       List.of(ColumnIdent.of("x"), ColumnIdent.of("y")),
                        new Object[]{1, 1},
                        new Object[]{1, 3},
                        new Object[]{3, 2},
@@ -360,7 +360,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "lag(x) ignore nulls over()",
             new Object[]{null, null, null, 2},
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[]{null},
             new Object[]{null},
             new Object[]{2},
@@ -373,7 +373,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "lag(x) ignore nulls over()",
             new Object[]{null, 1, 1, 1},
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[]{1},
             new Object[]{null},
             new Object[]{null},
@@ -386,7 +386,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "lag(x) ignore nulls over()",
             new Object[]{null, 1, 2, 2},
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[]{1},
             new Object[]{2},
             new Object[]{null},
@@ -399,7 +399,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "lag(x,1) ignore nulls over()",
             new Object[]{null, null, null, null},
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[]{null},
             new Object[]{null},
             new Object[]{null},
@@ -412,7 +412,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "lag(x,3,123) ignore nulls over()",
             new Object[]{123, 123, 123, 123, 1, 1, 1, 2, 3, 3, 4, 4},
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[][]{{1}, {2}, {null}, {3}, {null}, {null}, {4}, {5}, {null}, {6}, {null}, {7}}
         );
     }
@@ -422,7 +422,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "lead(x) ignore nulls over()",
             new Object[]{2, 2, 3, null},
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[]{null},
             new Object[]{null},
             new Object[]{2},
@@ -435,7 +435,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "lead(x) ignore nulls over()",
             new Object[]{2, 2, 2, null},
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[]{1},
             new Object[]{null},
             new Object[]{null},
@@ -448,7 +448,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "lead(x) ignore nulls over()",
             new Object[]{2, null, null, null},
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[]{1},
             new Object[]{2},
             new Object[]{null},
@@ -461,7 +461,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "lead(x,1,123) ignore nulls over()",
             new Object[]{123, 123, 123, 123},
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[]{null},
             new Object[]{null},
             new Object[]{null},
@@ -474,7 +474,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "lead(x,3,123) ignore nulls over()",
             new Object[]{4, 5, 5, 6, 6, 6, 7, 123, 123, 123, 123, 123},
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[][]{{1}, {2}, {null}, {3}, {null}, {null}, {4}, {5}, {null}, {6}, {null}, {7}}
         );
     }
@@ -484,7 +484,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "lag(x,40,123) ignore nulls over()",
             new Object[]{123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123, 123},
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[][]{{null}, {1}, {2}, {null}, {3}, {null}, {null}, {4}, {5}, {null}, {6}, {null}, {7}}
         );
     }
@@ -494,7 +494,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "lead(x,-3,123) ignore nulls over()",
             new Object[]{123, 123, 123, 123, 1, 1, 1, 2, 3, 3, 4, 4},
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[][]{{1}, {2}, {null}, {3}, {null}, {null}, {4}, {5}, {null}, {6}, {null}, {7}}
         );
     }
@@ -504,12 +504,12 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "lag(x,-2,123) ignore nulls over()",
             new Object[]{3, 4, 4, 5, 5, 5, 6, 7, 7, 123, 123, 123},
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[][]{{1}, {2}, {null}, {3}, {null}, {null}, {4}, {5}, {null}, {6}, {null}, {7}}
         );
     }
 
-    private static final List<ColumnIdent> INTERVAL_COLS = List.of(new ColumnIdent("x"), new ColumnIdent("y"));
+    private static final List<ColumnIdent> INTERVAL_COLS = List.of(ColumnIdent.of("x"), ColumnIdent.of("y"));
 
     private static final Object[][] INTERVAL_DATA = new Object[][]{
         new Object[]{7, 1574812800000L},
@@ -577,7 +577,7 @@ public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "lag(x) over(order by x)",
             new Object[]{null, 1},
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             accounting::addBytes,
             new Object[]{1},
             new Object[]{2}

--- a/extensions/functions/src/test/java/io/crate/window/RankFunctionsTest.java
+++ b/extensions/functions/src/test/java/io/crate/window/RankFunctionsTest.java
@@ -37,7 +37,7 @@ public class RankFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "rank() over()",
             new Object[] {1, 1, 1, 1, 1},
-            List.of(new ColumnIdent("x"), new ColumnIdent("y")),
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("y")),
             new Object[] {1, 1},
             new Object[] {2, 1},
             new Object[] {1, 1},
@@ -52,7 +52,7 @@ public class RankFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "rank() over(order by x)",
             new Object[] {1, 1, 1, 4, 4},
-            List.of(new ColumnIdent("x"), new ColumnIdent("y")),
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("y")),
             new Object[] {1, 1},
             new Object[] {2, 1},
             new Object[] {1, 1},
@@ -66,7 +66,7 @@ public class RankFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "rank() over(order by y, x)",
             new Object[] {1, 2, 2, 4, 4},
-            List.of(new ColumnIdent("x"), new ColumnIdent("y")),
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("y")),
             new Object[] {1, 1},
             new Object[] {2, 1},
             new Object[] {1, 1},
@@ -81,7 +81,7 @@ public class RankFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "rank() over(partition by y > 0)",
             expected,
-            List.of(new ColumnIdent("x"), new ColumnIdent("y")),
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("y")),
             new Object[] {1, 1},
             new Object[] {2, 1},
             new Object[] {3, 1},
@@ -96,7 +96,7 @@ public class RankFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "rank() over(partition by y > 0 order by x)",
             expected,
-            List.of(new ColumnIdent("x"), new ColumnIdent("y")),
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("y")),
             new Object[] {1, 1},
             new Object[] {2, 1},
             new Object[] {3, 1},
@@ -110,7 +110,7 @@ public class RankFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "dense_rank() over()",
             new Object[] {1, 1, 1, 1, 1},
-            List.of(new ColumnIdent("x"), new ColumnIdent("y")),
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("y")),
             new Object[] {1, 1},
             new Object[] {2, 1},
             new Object[] {1, 1},
@@ -125,7 +125,7 @@ public class RankFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "dense_rank() over(order by x)",
             new Object[] {1, 1, 1, 2, 2},
-            List.of(new ColumnIdent("x"), new ColumnIdent("y")),
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("y")),
             new Object[] {1, 1},
             new Object[] {2, 1},
             new Object[] {1, 1},
@@ -139,7 +139,7 @@ public class RankFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "dense_rank() over(order by y, x)",
             new Object[] {1, 2, 2, 3, 3},
-            List.of(new ColumnIdent("x"), new ColumnIdent("y")),
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("y")),
             new Object[] {1, 1},
             new Object[] {2, 1},
             new Object[] {1, 1},
@@ -154,7 +154,7 @@ public class RankFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "dense_rank() over(partition by y > 0)",
             expected,
-            List.of(new ColumnIdent("x"), new ColumnIdent("y")),
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("y")),
             new Object[] {1, 1},
             new Object[] {2, 1},
             new Object[] {3, 1},
@@ -169,7 +169,7 @@ public class RankFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "dense_rank() over(partition by y > 0 order by x)",
             expected,
-            List.of(new ColumnIdent("x"), new ColumnIdent("y")),
+            List.of(ColumnIdent.of("x"), ColumnIdent.of("y")),
             new Object[] {1, 1},
             new Object[] {2, 1},
             new Object[] {3, 1},
@@ -183,7 +183,7 @@ public class RankFunctionsTest extends AbstractWindowFunctionTest {
         Assertions.assertThatThrownBy(() -> assertEvaluate(
                 "rank() ignore nulls over()",
                 null,
-                List.of(new ColumnIdent("x")),
+                List.of(ColumnIdent.of("x")),
                 new Object[] {1}
             ))
             .isExactlyInstanceOf(IllegalArgumentException.class)

--- a/server/src/main/java/io/crate/analyze/AnalyzedCopyFromReturnSummary.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedCopyFromReturnSummary.java
@@ -50,14 +50,14 @@ public class AnalyzedCopyFromReturnSummary extends AnalyzedCopyFrom implements A
                                   Symbol uri) {
         super(tableInfo, targetColumns, table, properties, uri);
         this.fields = List.of(
-            new ScopedSymbol(tableInfo.ident(), new ColumnIdent("node"), ObjectType.builder()
+            new ScopedSymbol(tableInfo.ident(), ColumnIdent.of("node"), ObjectType.builder()
                 .setInnerType("id", DataTypes.STRING)
                 .setInnerType("name", DataTypes.STRING)
                 .build()),
-            new ScopedSymbol(tableInfo.ident(), new ColumnIdent("uri"), DataTypes.STRING),
-            new ScopedSymbol(tableInfo.ident(), new ColumnIdent("success_count"), DataTypes.LONG),
-            new ScopedSymbol(tableInfo.ident(), new ColumnIdent("error_count"), DataTypes.LONG),
-            new ScopedSymbol(tableInfo.ident(), new ColumnIdent("errors"), DataTypes.UNTYPED_OBJECT)
+            new ScopedSymbol(tableInfo.ident(), ColumnIdent.of("uri"), DataTypes.STRING),
+            new ScopedSymbol(tableInfo.ident(), ColumnIdent.of("success_count"), DataTypes.LONG),
+            new ScopedSymbol(tableInfo.ident(), ColumnIdent.of("error_count"), DataTypes.LONG),
+            new ScopedSymbol(tableInfo.ident(), ColumnIdent.of("errors"), DataTypes.UNTYPED_OBJECT)
         );
     }
 

--- a/server/src/main/java/io/crate/analyze/AnalyzedShowCreateTable.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedShowCreateTable.java
@@ -47,7 +47,7 @@ public class AnalyzedShowCreateTable implements AnalyzedRelation {
     public AnalyzedShowCreateTable(TableInfo tableInfo) {
         String columnName = "SHOW CREATE TABLE " + tableInfo.ident().fqn();
         relationName = new RelationName(null, "SHOW CREATE TABLE");
-        this.fields = Collections.singletonList(new ScopedSymbol(relationName, new ColumnIdent(columnName), DataTypes.STRING));
+        this.fields = Collections.singletonList(new ScopedSymbol(relationName, ColumnIdent.of(columnName), DataTypes.STRING));
         this.tableInfo = tableInfo;
     }
 

--- a/server/src/main/java/io/crate/analyze/ExplainAnalyzedStatement.java
+++ b/server/src/main/java/io/crate/analyze/ExplainAnalyzedStatement.java
@@ -63,14 +63,14 @@ public class ExplainAnalyzedStatement implements AnalyzedRelation {
         if (options.contains(Explain.Option.VERBOSE)) {
             ScopedSymbol stepField = new ScopedSymbol(
                 relationName,
-                new ColumnIdent(STEP_COLUMN_NAME),
+                ColumnIdent.of(STEP_COLUMN_NAME),
                 DataTypes.STRING
             );
             outputs.add(stepField);
         }
         ScopedSymbol queryPlanField = new ScopedSymbol(
             relationName,
-            new ColumnIdent(PLAN_COLUMN_NAME),
+            ColumnIdent.of(PLAN_COLUMN_NAME),
             context == null ? DataTypes.STRING : DataTypes.UNTYPED_OBJECT
         );
         outputs.add(queryPlanField);

--- a/server/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
@@ -568,7 +568,7 @@ public class TableElementsAnalyzer implements FieldProvider<Reference> {
         public Void visitColumnDefinition(ColumnDefinition<?> node, ColumnIdent parent) {
             ColumnDefinition<Expression> columnDefinition = (ColumnDefinition<Expression>) node;
             ColumnIdent columnName = parent == null
-                ? new ColumnIdent(columnDefinition.ident())
+                ? ColumnIdent.of(columnDefinition.ident())
                 : ColumnIdent.getChildSafe(parent, columnDefinition.ident());
             RefBuilder builder = columns.get(columnName);
 
@@ -725,7 +725,7 @@ public class TableElementsAnalyzer implements FieldProvider<Reference> {
         public Void visitIndexDefinition(IndexDefinition<?> node, ColumnIdent parent) {
             IndexDefinition<Expression> indexDefinition = (IndexDefinition<Expression>) node;
             String name = indexDefinition.ident();
-            ColumnIdent columnIdent = parent == null ? new ColumnIdent(name) : ColumnIdent.getChildSafe(parent, name);
+            ColumnIdent columnIdent = parent == null ? ColumnIdent.of(name) : ColumnIdent.getChildSafe(parent, name);
             RefBuilder builder = columns.get(columnIdent);
             builder.indexMethod = indexDefinition.method();
             builder.indexProperties = indexDefinition.properties().map(toSymbol);

--- a/server/src/main/java/io/crate/analyze/TableInfoToAST.java
+++ b/server/src/main/java/io/crate/analyze/TableInfoToAST.java
@@ -255,27 +255,25 @@ public class TableInfoToAST {
         if (!(tableInfo instanceof DocTableInfo docTable)) {
             return List.of();
         }
-        List<IndexDefinition<Expression>> elements = new ArrayList<>();
         Collection<IndexReference> indexColumns = docTable.indexColumns();
-        if (indexColumns != null) {
-            for (var indexRef : indexColumns) {
-                String name = indexRef.column().name();
-                List<Expression> columns = expressionsFromReferences(indexRef.columns());
-                if (indexRef.indexType().equals(IndexType.FULLTEXT)) {
-                    String analyzer = indexRef.analyzer();
-                    GenericProperties<Expression> properties;
-                    if (analyzer == null) {
-                        properties = GenericProperties.empty();
-                    } else {
-                        properties = new GenericProperties<>(Map.of(
-                            FulltextAnalyzerResolver.CustomType.ANALYZER.getName(),
-                            new StringLiteral(analyzer))
-                        );
-                    }
-                    elements.add(new IndexDefinition<>(name, "fulltext", columns, properties));
-                } else if (indexRef.indexType().equals(IndexType.PLAIN)) {
-                    elements.add(new IndexDefinition<>(name, "plain", columns, GenericProperties.empty()));
+        List<IndexDefinition<Expression>> elements = new ArrayList<>(indexColumns.size());
+        for (var indexRef : indexColumns) {
+            String name = indexRef.column().name();
+            List<Expression> columns = expressionsFromReferences(indexRef.columns());
+            if (indexRef.indexType().equals(IndexType.FULLTEXT)) {
+                String analyzer = indexRef.analyzer();
+                GenericProperties<Expression> properties;
+                if (analyzer == null) {
+                    properties = GenericProperties.empty();
+                } else {
+                    properties = new GenericProperties<>(Map.of(
+                        FulltextAnalyzerResolver.CustomType.ANALYZER.getName(),
+                        new StringLiteral(analyzer))
+                    );
                 }
+                elements.add(new IndexDefinition<>(name, "fulltext", columns, properties));
+            } else if (indexRef.indexType().equals(IndexType.PLAIN)) {
+                elements.add(new IndexDefinition<>(name, "plain", columns, GenericProperties.empty()));
             }
         }
         return elements;

--- a/server/src/main/java/io/crate/analyze/relations/AliasedAnalyzedRelation.java
+++ b/server/src/main/java/io/crate/analyze/relations/AliasedAnalyzedRelation.java
@@ -70,7 +70,7 @@ public class AliasedAnalyzedRelation implements AnalyzedRelation, FieldResolver 
             ColumnIdent childColumn = Symbols.pathFromSymbol(childOutput);
             ColumnIdent columnAlias = childColumn;
             if (i < columnAliases.size()) {
-                columnAlias = new ColumnIdent(columnAliases.get(i));
+                columnAlias = ColumnIdent.of(columnAliases.get(i));
             }
             aliasToColumnMapping.put(columnAlias, childColumn);
             var scopedSymbol = new ScopedSymbol(alias, columnAlias, childOutput.valueType());
@@ -82,7 +82,7 @@ public class AliasedAnalyzedRelation implements AnalyzedRelation, FieldResolver 
             ColumnIdent childColumn = Symbols.pathFromSymbol(childOutput);
             ColumnIdent columnAlias = childColumn;
             if (i + relation.outputs().size() < columnAliases.size()) {
-                columnAlias = new ColumnIdent(columnAliases.get(i));
+                columnAlias = ColumnIdent.of(columnAliases.get(i));
             }
             aliasToColumnMapping.putIfAbsent(columnAlias, childColumn);
         }
@@ -103,14 +103,14 @@ public class AliasedAnalyzedRelation implements AnalyzedRelation, FieldResolver 
                 // The column ident maybe a quoted subscript which points to an alias of a sub relation.
                 // Aliases are always strings but due to the support for quoted subscript expressions,
                 // the select column ident may already be expanded to a subscript.
-                var maybeQuotedSubscriptColumnAlias = new ColumnIdent(column.sqlFqn());
+                var maybeQuotedSubscriptColumnAlias = ColumnIdent.of(column.sqlFqn());
                 childColumnName = aliasToColumnMapping.get(maybeQuotedSubscriptColumnAlias);
                 if (childColumnName == null) {
                     return null;
                 }
                 column = maybeQuotedSubscriptColumnAlias;
             } else {
-                childColumnName = new ColumnIdent(childColumnName.name(), column.path());
+                childColumnName = ColumnIdent.of(childColumnName.name(), column.path());
             }
         }
         Symbol field = relation.getField(childColumnName, operation, errorOnUnknownObjectKey);
@@ -170,7 +170,7 @@ public class AliasedAnalyzedRelation implements AnalyzedRelation, FieldResolver 
         ColumnIdent childColumnName = aliasToColumnMapping.get(column);
         if (childColumnName == null && !column.isRoot()) {
             var childCol = aliasToColumnMapping.get(column.getRoot());
-            childColumnName = new ColumnIdent(childCol.name(), column.path());
+            childColumnName = ColumnIdent.of(childCol.name(), column.path());
         }
         assert childColumnName != null
             : "If a ScopedSymbol has been retrieved via `getField`, it must be possible to get the columnIdent";

--- a/server/src/main/java/io/crate/analyze/relations/FieldProvider.java
+++ b/server/src/main/java/io/crate/analyze/relations/FieldProvider.java
@@ -48,5 +48,5 @@ public interface FieldProvider<T extends Symbol> {
     ));
 
     FieldProvider<Literal<?>> TO_LITERAL_UNSAFE = ((qualifiedName, path, operation, errorOnUnknownObjectKey) ->
-        Literal.of(new ColumnIdent(qualifiedName.toString(), path).fqn()));
+        Literal.of(ColumnIdent.of(qualifiedName.toString(), path).fqn()));
 }

--- a/server/src/main/java/io/crate/analyze/relations/FullQualifiedNameFieldProvider.java
+++ b/server/src/main/java/io/crate/analyze/relations/FullQualifiedNameFieldProvider.java
@@ -63,7 +63,7 @@ public class FullQualifiedNameFieldProvider implements FieldProvider<Symbol> {
         List<String> parts = qualifiedName.getParts();
         String columnSchema = null;
         String columnTableName = null;
-        ColumnIdent columnIdent = new ColumnIdent(parts.get(parts.size() - 1), path);
+        ColumnIdent columnIdent = ColumnIdent.of(parts.get(parts.size() - 1), path);
         switch (parts.size()) {
             case 1:
                 break;

--- a/server/src/main/java/io/crate/analyze/relations/NameFieldProvider.java
+++ b/server/src/main/java/io/crate/analyze/relations/NameFieldProvider.java
@@ -51,7 +51,7 @@ public class NameFieldProvider implements FieldProvider<Symbol> {
                                Operation operation,
                                boolean errorOnUnknownObjectKey) {
         List<String> parts = qualifiedName.getParts();
-        ColumnIdent columnIdent = new ColumnIdent(parts.get(parts.size() - 1), path);
+        ColumnIdent columnIdent = ColumnIdent.of(parts.get(parts.size() - 1), path);
         if (parts.size() != 1) {
             throw new IllegalArgumentException(String.format(Locale.ENGLISH,
                 "Column reference \"%s\" has too many parts. " +

--- a/server/src/main/java/io/crate/analyze/relations/select/SelectAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/relations/select/SelectAnalyzer.java
@@ -63,9 +63,9 @@ public class SelectAnalyzer {
             Symbol symbol = context.toSymbol(node.getExpression());
             String alias = node.getAlias();
             if (alias != null) {
-                context.add(new ColumnIdent(alias), new AliasSymbol(alias, symbol));
+                context.add(ColumnIdent.of(alias), new AliasSymbol(alias, symbol));
             } else {
-                context.add(new ColumnIdent(OutputNameFormatter.format(node.getExpression())), symbol);
+                context.add(ColumnIdent.of(OutputNameFormatter.format(node.getExpression())), symbol);
             }
             return null;
         }

--- a/server/src/main/java/io/crate/execution/ddl/tables/RenameColumnRequest.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/RenameColumnRequest.java
@@ -49,7 +49,7 @@ public class RenameColumnRequest extends AcknowledgedRequest<RenameColumnRequest
         super(in);
         this.relationName = new RelationName(in);
         this.refToRename = (Reference) Symbols.fromStream(in);
-        this.newName = new ColumnIdent(in);
+        this.newName = ColumnIdent.of(in);
     }
 
     @Override

--- a/server/src/main/java/io/crate/execution/dml/RawIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/RawIndexer.java
@@ -82,7 +82,7 @@ public class RawIndexer {
         currentRowIndexer = indexers.computeIfAbsent(doc.keySet(), keys -> {
             List<Reference> targetRefs = new ArrayList<>();
             for (String key : keys) {
-                ColumnIdent column = new ColumnIdent(key);
+                ColumnIdent column = ColumnIdent.of(key);
                 Reference reference = table.getReference(column);
                 if (reference == null) {
                     reference = table.getDynamic(column, true, txnCtx.sessionSettings().errorOnUnknownObjectKey());

--- a/server/src/main/java/io/crate/execution/dsl/phases/PKLookupPhase.java
+++ b/server/src/main/java/io/crate/execution/dsl/phases/PKLookupPhase.java
@@ -93,7 +93,7 @@ public final class PKLookupPhase extends AbstractProjectionsPhase implements Col
         } else {
             partitionedByColumns = new ArrayList<>(numPartitionedByCols);
             for (int i = 0; i < numPartitionedByCols; i++) {
-                partitionedByColumns.add(new ColumnIdent(in));
+                partitionedByColumns.add(ColumnIdent.of(in));
             }
         }
     }

--- a/server/src/main/java/io/crate/execution/dsl/projection/AbstractIndexWriterProjection.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/AbstractIndexWriterProjection.java
@@ -93,7 +93,7 @@ public abstract class AbstractIndexWriterProjection extends Projection {
         int numPks = in.readVInt();
         primaryKeys = new ArrayList<>(numPks);
         for (int i = 0; i < numPks; i++) {
-            primaryKeys.add(new ColumnIdent(in));
+            primaryKeys.add(ColumnIdent.of(in));
         }
 
         partitionedBySymbols = Symbols.listFromStream(in);
@@ -103,7 +103,7 @@ public abstract class AbstractIndexWriterProjection extends Projection {
             clusteredBySymbol = null;
         }
         if (in.readBoolean()) {
-            clusteredByColumn = new ColumnIdent(in);
+            clusteredByColumn = ColumnIdent.of(in);
         }
         bulkActions = in.readVInt();
         autoCreateIndices = in.readBoolean();

--- a/server/src/main/java/io/crate/execution/dsl/projection/WriterProjection.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/WriterProjection.java
@@ -142,7 +142,7 @@ public class WriterProjection extends Projection {
         int numOverwrites = in.readVInt();
         overwrites = new HashMap<>(numOverwrites);
         for (int i = 0; i < numOverwrites; i++) {
-            overwrites.put(new ColumnIdent(in), Symbols.fromStream(in));
+            overwrites.put(ColumnIdent.of(in), Symbols.fromStream(in));
         }
         int compressionTypeOrdinal = in.readInt();
         compressionType = compressionTypeOrdinal >= 0 ? CompressionType.values()[compressionTypeOrdinal] : null;

--- a/server/src/main/java/io/crate/execution/engine/collect/stats/NodeStatsRequest.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/stats/NodeStatsRequest.java
@@ -63,7 +63,7 @@ public class NodeStatsRequest extends NodeRequest<NodeStatsRequest.StatsRequest>
             columns = new HashSet<>();
             int columnIdentsSize = in.readVInt();
             for (int i = 0; i < columnIdentsSize; i++) {
-                columns.add(new ColumnIdent(in));
+                columns.add(ColumnIdent.of(in));
             }
         }
 

--- a/server/src/main/java/io/crate/expression/reference/file/SourceLineNumberExpression.java
+++ b/server/src/main/java/io/crate/expression/reference/file/SourceLineNumberExpression.java
@@ -33,7 +33,7 @@ import io.crate.types.DataTypes;
 public class SourceLineNumberExpression extends LineCollectorExpression<Long> {
 
     public static final String COLUMN_NAME = "_line_number";
-    private static final ColumnIdent COLUMN_IDENT = new ColumnIdent(COLUMN_NAME);
+    private static final ColumnIdent COLUMN_IDENT = ColumnIdent.of(COLUMN_NAME);
 
     public static Reference getReferenceForRelation(RelationName relationName) {
         return new SimpleReference(

--- a/server/src/main/java/io/crate/expression/reference/file/SourceParsingFailureExpression.java
+++ b/server/src/main/java/io/crate/expression/reference/file/SourceParsingFailureExpression.java
@@ -35,7 +35,7 @@ import io.crate.types.DataTypes;
 public class SourceParsingFailureExpression extends LineCollectorExpression<String> {
 
     public static final String COLUMN_NAME = "_parsing_failure";
-    private static final ColumnIdent COLUMN_IDENT = new ColumnIdent(COLUMN_NAME);
+    private static final ColumnIdent COLUMN_IDENT = ColumnIdent.of(COLUMN_NAME);
 
     private LineContext lineContext;
 

--- a/server/src/main/java/io/crate/expression/reference/file/SourceUriExpression.java
+++ b/server/src/main/java/io/crate/expression/reference/file/SourceUriExpression.java
@@ -33,7 +33,7 @@ import io.crate.types.DataTypes;
 public class SourceUriExpression extends LineCollectorExpression<String> {
 
     public static final String COLUMN_NAME = "_uri";
-    private static final ColumnIdent COLUMN_IDENT = new ColumnIdent(COLUMN_NAME);
+    private static final ColumnIdent COLUMN_IDENT = ColumnIdent.of(COLUMN_NAME);
 
     private LineContext context;
 

--- a/server/src/main/java/io/crate/expression/reference/file/SourceUriFailureExpression.java
+++ b/server/src/main/java/io/crate/expression/reference/file/SourceUriFailureExpression.java
@@ -35,7 +35,7 @@ import io.crate.types.DataTypes;
 public class SourceUriFailureExpression extends LineCollectorExpression<String> {
 
     public static final String COLUMN_NAME = "_uri_failure";
-    private static final ColumnIdent COLUMN_IDENT = new ColumnIdent(COLUMN_NAME);
+    private static final ColumnIdent COLUMN_IDENT = ColumnIdent.of(COLUMN_NAME);
 
     private LineContext lineContext;
 

--- a/server/src/main/java/io/crate/expression/symbol/Symbols.java
+++ b/server/src/main/java/io/crate/expression/symbol/Symbols.java
@@ -176,13 +176,13 @@ public final class Symbols {
 
     public static ColumnIdent pathFromSymbol(Symbol symbol) {
         if (symbol instanceof AliasSymbol aliasSymbol) {
-            return new ColumnIdent(aliasSymbol.alias());
+            return ColumnIdent.of(aliasSymbol.alias());
         } else if (symbol instanceof ScopedSymbol scopedSymbol) {
             return scopedSymbol.column();
         } else if (symbol instanceof Reference ref) {
             return ref.column();
         }
-        return new ColumnIdent(symbol.toString(Style.UNQUALIFIED));
+        return ColumnIdent.of(symbol.toString(Style.UNQUALIFIED));
     }
 
     public static boolean isDeterministic(Symbol symbol) {

--- a/server/src/main/java/io/crate/fdw/ForeignTable.java
+++ b/server/src/main/java/io/crate/fdw/ForeignTable.java
@@ -76,7 +76,7 @@ public record ForeignTable(RelationName name,
     ForeignTable(StreamInput in) throws IOException {
         this(
             new RelationName(in),
-            in.readMap(LinkedHashMap::new, ColumnIdent::new, Reference::fromStream),
+            in.readMap(LinkedHashMap::new, ColumnIdent::of, Reference::fromStream),
             in.readString(),
             Settings.readSettingsFromStream(in)
         );

--- a/server/src/main/java/io/crate/metadata/ReferenceIdent.java
+++ b/server/src/main/java/io/crate/metadata/ReferenceIdent.java
@@ -40,7 +40,7 @@ public final class ReferenceIdent implements Accountable {
     private final ColumnIdent columnIdent;
 
     public ReferenceIdent(StreamInput in) throws IOException {
-        columnIdent = new ColumnIdent(in);
+        columnIdent = ColumnIdent.of(in);
         relationName = new RelationName(in);
     }
 
@@ -50,11 +50,11 @@ public final class ReferenceIdent implements Accountable {
     }
 
     public ReferenceIdent(RelationName relationName, String column) {
-        this(relationName, new ColumnIdent(column));
+        this(relationName, ColumnIdent.of(column));
     }
 
     public ReferenceIdent(RelationName relationName, String column, @Nullable List<String> path) {
-        this(relationName, new ColumnIdent(column, path));
+        this(relationName, ColumnIdent.of(column, path));
     }
 
     public RelationName tableIdent() {

--- a/server/src/main/java/io/crate/metadata/SystemTable.java
+++ b/server/src/main/java/io/crate/metadata/SystemTable.java
@@ -258,11 +258,11 @@ public final class SystemTable<T> implements TableInfo {
         }
 
         public <U> RelationBuilder<T> add(String column, DataType<U> type, Function<T, U> getProperty) {
-            return add(new Column<>(new ColumnIdent(column), type, getProperty));
+            return add(new Column<>(ColumnIdent.of(column), type, getProperty));
         }
 
         public <U> RelationBuilder<T> addNonNull(String column, DataType<U> type, Function<T, U> getProperty) {
-            return add(new Column<>(new ColumnIdent(column), type, getProperty, false));
+            return add(new Column<>(ColumnIdent.of(column), type, getProperty, false));
         }
 
         @Override
@@ -272,7 +272,7 @@ public final class SystemTable<T> implements TableInfo {
         }
 
         public RelationBuilder<T> addDynamicObject(String column, DataType<?> leafType, Function<T, Map<String, Object>> getObject) {
-            return add(new DynamicColumn<>(new ColumnIdent(column), leafType, getObject));
+            return add(new DynamicColumn<>(ColumnIdent.of(column), leafType, getObject));
         }
 
         public SystemTable<T> build() {
@@ -327,15 +327,15 @@ public final class SystemTable<T> implements TableInfo {
         }
 
         public ObjectBuilder<T, RelationBuilder<T>> startObject(String column) {
-            return new ObjectBuilder<>(this, new ColumnIdent(column), t -> false);
+            return new ObjectBuilder<>(this, ColumnIdent.of(column), t -> false);
         }
 
         public ObjectBuilder<T, RelationBuilder<T>> startObject(String column, Predicate<T> objectIsNull) {
-            return new ObjectBuilder<>(this, new ColumnIdent(column), objectIsNull);
+            return new ObjectBuilder<>(this, ColumnIdent.of(column), objectIsNull);
         }
 
         public <U> ObjectArrayBuilder<U, T, RelationBuilder<T>> startObjectArray(String column, Function<T, ? extends Collection<U>> getItems) {
-            return new ObjectArrayBuilder<>(this, new ColumnIdent(column), getItems);
+            return new ObjectArrayBuilder<>(this, ColumnIdent.of(column), getItems);
         }
 
         public RelationBuilder<T> setPrimaryKeys(ColumnIdent ... primaryKeys) {

--- a/server/src/main/java/io/crate/metadata/blob/BlobTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/blob/BlobTableInfo.java
@@ -68,7 +68,7 @@ public class BlobTableInfo implements TableInfo, ShardedTable, StoredTable {
     private final boolean closed;
 
     private final Map<ColumnIdent, Reference> infos = new LinkedHashMap<>();
-    private static final List<ColumnIdent> PRIMARY_KEY = List.of(new ColumnIdent("digest"));
+    private static final List<ColumnIdent> PRIMARY_KEY = List.of(ColumnIdent.of("digest"));
 
     public BlobTableInfo(RelationName ident,
                          String index,

--- a/server/src/main/java/io/crate/metadata/doc/DocSysColumns.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocSysColumns.java
@@ -66,7 +66,7 @@ public class DocSysColumns {
     }
 
     public static class ID {
-        public static final ColumnIdent COLUMN = new ColumnIdent(Names.ID);
+        public static final ColumnIdent COLUMN = ColumnIdent.of(Names.ID);
         public static final FieldType FIELD_TYPE = new FieldType();
 
         static {
@@ -105,19 +105,19 @@ public class DocSysColumns {
         }
     }
 
-    public static final ColumnIdent VERSION = new ColumnIdent(Names.VERSION);
-    public static final ColumnIdent SCORE = new ColumnIdent(Names.SCORE);
-    public static final ColumnIdent UID = new ColumnIdent(Names.UID);
-    public static final ColumnIdent DOC = new ColumnIdent(Names.DOC);
-    public static final ColumnIdent RAW = new ColumnIdent(Names.RAW);
-    public static final ColumnIdent SEQ_NO = new ColumnIdent(Names.SEQ_NO);
-    public static final ColumnIdent PRIMARY_TERM = new ColumnIdent(Names.PRIMARY_TERM);
+    public static final ColumnIdent VERSION = ColumnIdent.of(Names.VERSION);
+    public static final ColumnIdent SCORE = ColumnIdent.of(Names.SCORE);
+    public static final ColumnIdent UID = ColumnIdent.of(Names.UID);
+    public static final ColumnIdent DOC = ColumnIdent.of(Names.DOC);
+    public static final ColumnIdent RAW = ColumnIdent.of(Names.RAW);
+    public static final ColumnIdent SEQ_NO = ColumnIdent.of(Names.SEQ_NO);
+    public static final ColumnIdent PRIMARY_TERM = ColumnIdent.of(Names.PRIMARY_TERM);
 
     /**
      * See {@link Names#FETCHID}
      */
-    public static final ColumnIdent FETCHID = new ColumnIdent(Names.FETCHID);
-    public static final ColumnIdent DOCID = new ColumnIdent(Names.DOCID);
+    public static final ColumnIdent FETCHID = ColumnIdent.of(Names.FETCHID);
+    public static final ColumnIdent DOCID = ColumnIdent.of(Names.DOCID);
 
     public static final Map<ColumnIdent, DataType<?>> COLUMN_IDENTS = Map.of(
         DOC, DataTypes.UNTYPED_OBJECT,

--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfoFactory.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfoFactory.java
@@ -380,7 +380,7 @@ public class DocTableInfoFactory {
             String columnName = entry.getKey();
             Map<String, Object> columnProperties = (Map<String, Object>) entry.getValue();
             final DataType<?> type = getColumnDataType(columnProperties);
-            ColumnIdent column = parent == null ? new ColumnIdent(columnName) : parent.getChild(columnName);
+            ColumnIdent column = parent == null ? ColumnIdent.of(columnName) : parent.getChild(columnName);
             ReferenceIdent refIdent = new ReferenceIdent(relationName, column);
             columnProperties = innerProperties(columnProperties);
 

--- a/server/src/main/java/io/crate/metadata/information/InformationColumnsTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/information/InformationColumnsTableInfo.java
@@ -120,10 +120,10 @@ public class InformationColumnsTableInfo {
             .add("path", STRING_ARRAY, r -> r.ref().column().path())
         .endObject()
         .setPrimaryKeys(
-            new ColumnIdent("table_catalog"),
-            new ColumnIdent("table_name"),
-            new ColumnIdent("table_schema"),
-            new ColumnIdent("column_name")
+            ColumnIdent.of("table_catalog"),
+            ColumnIdent.of("table_name"),
+            ColumnIdent.of("table_schema"),
+            ColumnIdent.of("column_name")
         )
         .build();
 

--- a/server/src/main/java/io/crate/metadata/information/InformationKeyColumnUsageTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/information/InformationKeyColumnUsageTableInfo.java
@@ -49,10 +49,10 @@ public class InformationKeyColumnUsageTableInfo {
         .add("column_name", STRING, InformationSchemaIterables.KeyColumnUsage::getPkColumnIdent)
         .add("ordinal_position", INTEGER, InformationSchemaIterables.KeyColumnUsage::getOrdinal)
         .setPrimaryKeys(
-            new ColumnIdent("constraint_catalog"),
-            new ColumnIdent("constraint_schema"),
-            new ColumnIdent("constraint_name"),
-            new ColumnIdent("column_name")
+            ColumnIdent.of("constraint_catalog"),
+            ColumnIdent.of("constraint_schema"),
+            ColumnIdent.of("constraint_name"),
+            ColumnIdent.of("column_name")
         )
         .build();
 }

--- a/server/src/main/java/io/crate/metadata/information/InformationPartitionsTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/information/InformationPartitionsTableInfo.java
@@ -126,9 +126,9 @@ public class InformationPartitionsTableInfo {
 
         .endObject()
         .setPrimaryKeys(
-            new ColumnIdent("table_schema"),
-            new ColumnIdent("table_name"),
-            new ColumnIdent("partition_ident")
+            ColumnIdent.of("table_schema"),
+            ColumnIdent.of("table_name"),
+            ColumnIdent.of("partition_ident")
         )
         .build();
 

--- a/server/src/main/java/io/crate/metadata/information/InformationReferentialConstraintsTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/information/InformationReferentialConstraintsTableInfo.java
@@ -43,9 +43,9 @@ public class InformationReferentialConstraintsTableInfo {
         .add("update_rule", STRING, ignored -> null)
         .add("delete_rule", STRING, ignored -> null)
         .setPrimaryKeys(
-            new ColumnIdent("constraint_catalog"),
-            new ColumnIdent("constraint_schema"),
-            new ColumnIdent("constraint_name")
+            ColumnIdent.of("constraint_catalog"),
+            ColumnIdent.of("constraint_schema"),
+            ColumnIdent.of("constraint_name")
         )
         .build();
 }

--- a/server/src/main/java/io/crate/metadata/information/InformationSchemataTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/information/InformationSchemataTableInfo.java
@@ -35,6 +35,6 @@ public class InformationSchemataTableInfo {
 
     public static SystemTable<SchemaInfo> INSTANCE = SystemTable.<SchemaInfo>builder(IDENT)
         .add("schema_name", STRING, SchemaInfo::name)
-        .setPrimaryKeys(new ColumnIdent("schema_name"))
+        .setPrimaryKeys(ColumnIdent.of("schema_name"))
         .build();
 }

--- a/server/src/main/java/io/crate/metadata/information/InformationSqlFeaturesTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/information/InformationSqlFeaturesTableInfo.java
@@ -44,12 +44,12 @@ public class InformationSqlFeaturesTableInfo {
         .add("is_verified_by", STRING, SqlFeatureContext::getIsVerifiedBy)
         .add("comments", STRING, SqlFeatureContext::getComments)
         .setPrimaryKeys(
-            new ColumnIdent("feature_id"),
-            new ColumnIdent("feature_name"),
-            new ColumnIdent("sub_feature_id"),
-            new ColumnIdent("sub_feature_name"),
-            new ColumnIdent("is_supported"),
-            new ColumnIdent("is_verified_by")
+            ColumnIdent.of("feature_id"),
+            ColumnIdent.of("feature_name"),
+            ColumnIdent.of("sub_feature_id"),
+            ColumnIdent.of("sub_feature_name"),
+            ColumnIdent.of("is_supported"),
+            ColumnIdent.of("is_verified_by")
         )
         .build();
 }

--- a/server/src/main/java/io/crate/metadata/information/InformationTableConstraintsTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/information/InformationTableConstraintsTableInfo.java
@@ -45,9 +45,9 @@ public class InformationTableConstraintsTableInfo {
         .add("is_deferrable", STRING, ignored -> "NO")
         .add("initially_deferred", STRING, ignored -> "NO")
         .setPrimaryKeys(
-            new ColumnIdent("constraint_catalog"),
-            new ColumnIdent("constraint_schema"),
-            new ColumnIdent("constraint_name")
+            ColumnIdent.of("constraint_catalog"),
+            ColumnIdent.of("constraint_schema"),
+            ColumnIdent.of("constraint_name")
         )
         .build();
 }

--- a/server/src/main/java/io/crate/metadata/information/InformationTablesTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/information/InformationTablesTableInfo.java
@@ -224,9 +224,9 @@ public class InformationTablesTableInfo {
 
         .endObject()
         .setPrimaryKeys(
-            new ColumnIdent("table_catalog"),
-            new ColumnIdent("table_schema"),
-            new ColumnIdent("table_name")
+            ColumnIdent.of("table_catalog"),
+            ColumnIdent.of("table_schema"),
+            ColumnIdent.of("table_name")
         )
         .build();
 

--- a/server/src/main/java/io/crate/metadata/information/InformationViewsTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/information/InformationViewsTableInfo.java
@@ -46,9 +46,9 @@ public class InformationViewsTableInfo {
         .add("is_updatable", BOOLEAN, r -> false)
         .add("owner", STRING, ViewInfo::owner)
         .setPrimaryKeys(
-            new ColumnIdent("table_catalog"),
-            new ColumnIdent("table_name"),
-            new ColumnIdent("table_schema")
+            ColumnIdent.of("table_catalog"),
+            ColumnIdent.of("table_name"),
+            ColumnIdent.of("table_schema")
         )
         .build();
 }

--- a/server/src/main/java/io/crate/metadata/sys/SysAllocationsTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/sys/SysAllocationsTableInfo.java
@@ -50,10 +50,10 @@ public class SysAllocationsTableInfo {
             .add("explanations", STRING_ARRAY, SysAllocation.SysAllocationNodeDecision::explanations)
         .endObjectArray()
         .setPrimaryKeys(
-            new ColumnIdent("table_schema"),
-            new ColumnIdent("table_name"),
-            new ColumnIdent("partition_ident"),
-            new ColumnIdent("shard_id")
+            ColumnIdent.of("table_schema"),
+            ColumnIdent.of("table_name"),
+            ColumnIdent.of("partition_ident"),
+            ColumnIdent.of("shard_id")
         )
         .build();
 }

--- a/server/src/main/java/io/crate/metadata/sys/SysChecksTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/sys/SysChecksTableInfo.java
@@ -39,6 +39,6 @@ public final class SysChecksTableInfo {
         .add("severity", INTEGER, x -> x.severity().value())
         .add("description", STRING, SysCheck::description)
         .add("passed", BOOLEAN, SysCheck::isValid)
-        .setPrimaryKeys(new ColumnIdent("id"))
+        .setPrimaryKeys(ColumnIdent.of("id"))
         .build();
 }

--- a/server/src/main/java/io/crate/metadata/sys/SysJobsLogTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/sys/SysJobsLogTableInfo.java
@@ -57,7 +57,7 @@ public class SysJobsLogTableInfo {
                 .add("name", STRING, ignored -> localNode.get().getName())
             .endObject()
             .withRouting((state, routingProvider, sessionSettings) -> Routing.forTableOnAllNodes(IDENT, state.nodes()))
-            .setPrimaryKeys(new ColumnIdent("id"))
+            .setPrimaryKeys(ColumnIdent.of("id"))
             .build();
     }
 }

--- a/server/src/main/java/io/crate/metadata/sys/SysJobsTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/sys/SysJobsTableInfo.java
@@ -49,7 +49,7 @@ public class SysJobsTableInfo {
             .add("stmt", STRING, JobContext::stmt)
             .add("started", TIMESTAMPZ, JobContext::started)
             .withRouting((state, routingProvider, sessionSettings) -> Routing.forTableOnAllNodes(IDENT, state.nodes()))
-            .setPrimaryKeys(new ColumnIdent("id"))
+            .setPrimaryKeys(ColumnIdent.of("id"))
             .build();
     }
 }

--- a/server/src/main/java/io/crate/metadata/sys/SysNodeChecksTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/sys/SysNodeChecksTableInfo.java
@@ -44,7 +44,7 @@ public class SysNodeChecksTableInfo {
     private static final Set<Operation> SUPPORTED_OPERATIONS = EnumSet.of(Operation.READ, Operation.UPDATE);
 
     public static class Columns {
-        public static final ColumnIdent ACKNOWLEDGED = new ColumnIdent("acknowledged");
+        public static final ColumnIdent ACKNOWLEDGED = ColumnIdent.of("acknowledged");
     }
 
     public static SystemTable<SysNodeCheck> INSTANCE = SystemTable.<SysNodeCheck>builder(IDENT)
@@ -58,8 +58,8 @@ public class SysNodeChecksTableInfo {
         .withRouting((state, routingProvider, sessionSettings) -> Routing.forTableOnAllNodes(IDENT, state.nodes()))
         .withSupportedOperations(SUPPORTED_OPERATIONS)
         .setPrimaryKeys(
-            new ColumnIdent("id"),
-            new ColumnIdent("node_id")
+            ColumnIdent.of("id"),
+            ColumnIdent.of("node_id")
         )
         .build();
 }

--- a/server/src/main/java/io/crate/metadata/sys/SysNodesTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/sys/SysNodesTableInfo.java
@@ -63,34 +63,34 @@ public class SysNodesTableInfo {
     private static final String SYS_COL_FS = "fs";
 
     public static class Columns {
-        public static final ColumnIdent ID = new ColumnIdent(SYS_COL_ID);
-        public static final ColumnIdent NAME = new ColumnIdent(SYS_COL_NODE_NAME);
-        public static final ColumnIdent HOSTNAME = new ColumnIdent(SYS_COL_HOSTNAME);
-        public static final ColumnIdent REST_URL = new ColumnIdent(SYS_COL_REST_URL);
-        public static final ColumnIdent ATTRIBUTES = new ColumnIdent(SYS_COL_ATTRIBUTES);
+        public static final ColumnIdent ID = ColumnIdent.of(SYS_COL_ID);
+        public static final ColumnIdent NAME = ColumnIdent.of(SYS_COL_NODE_NAME);
+        public static final ColumnIdent HOSTNAME = ColumnIdent.of(SYS_COL_HOSTNAME);
+        public static final ColumnIdent REST_URL = ColumnIdent.of(SYS_COL_REST_URL);
+        public static final ColumnIdent ATTRIBUTES = ColumnIdent.of(SYS_COL_ATTRIBUTES);
 
-        public static final ColumnIdent PORT = new ColumnIdent(SYS_COL_PORT);
-        public static final ColumnIdent CLUSTER_STATE_VERSION = new ColumnIdent(SYS_COL_CLUSTER_STATE_VERSION);
+        public static final ColumnIdent PORT = ColumnIdent.of(SYS_COL_PORT);
+        public static final ColumnIdent CLUSTER_STATE_VERSION = ColumnIdent.of(SYS_COL_CLUSTER_STATE_VERSION);
 
-        public static final ColumnIdent LOAD = new ColumnIdent(SYS_COL_LOAD);
+        public static final ColumnIdent LOAD = ColumnIdent.of(SYS_COL_LOAD);
 
-        public static final ColumnIdent MEM = new ColumnIdent(SYS_COL_MEM);
+        public static final ColumnIdent MEM = ColumnIdent.of(SYS_COL_MEM);
 
-        public static final ColumnIdent HEAP = new ColumnIdent(SYS_COL_HEAP);
+        public static final ColumnIdent HEAP = ColumnIdent.of(SYS_COL_HEAP);
 
-        public static final ColumnIdent VERSION = new ColumnIdent(SYS_COL_VERSION);
+        public static final ColumnIdent VERSION = ColumnIdent.of(SYS_COL_VERSION);
 
-        public static final ColumnIdent THREAD_POOLS = new ColumnIdent(SYS_COL_THREAD_POOLS);
+        public static final ColumnIdent THREAD_POOLS = ColumnIdent.of(SYS_COL_THREAD_POOLS);
 
-        public static final ColumnIdent CONNECTIONS = new ColumnIdent("connections");
+        public static final ColumnIdent CONNECTIONS = ColumnIdent.of("connections");
 
-        public static final ColumnIdent OS = new ColumnIdent(SYS_COL_OS);
+        public static final ColumnIdent OS = ColumnIdent.of(SYS_COL_OS);
 
-        public static final ColumnIdent OS_INFO = new ColumnIdent(SYS_COL_OS_INFO);
+        public static final ColumnIdent OS_INFO = ColumnIdent.of(SYS_COL_OS_INFO);
 
-        public static final ColumnIdent PROCESS = new ColumnIdent(SYS_COL_PROCESS);
+        public static final ColumnIdent PROCESS = ColumnIdent.of(SYS_COL_PROCESS);
 
-        public static final ColumnIdent FS = new ColumnIdent(SYS_COL_FS);
+        public static final ColumnIdent FS = ColumnIdent.of(SYS_COL_FS);
     }
 
 
@@ -231,6 +231,6 @@ public class SysNodesTableInfo {
                 .add("path", STRING, FsInfo.Path::getPath)
             .endObjectArray()
         .endObject()
-        .setPrimaryKeys(new ColumnIdent("id"))
+        .setPrimaryKeys(ColumnIdent.of("id"))
         .build();
 }

--- a/server/src/main/java/io/crate/metadata/sys/SysRepositoriesTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/sys/SysRepositoriesTableInfo.java
@@ -43,7 +43,7 @@ public class SysRepositoriesTableInfo {
             .add("name", STRING, (Repository r) -> r.getMetadata().name())
             .add("type", STRING, (Repository r) -> r.getMetadata().type())
             .addDynamicObject("settings", STRING, r -> r.getMetadata().settings().getAsStructuredMap(maskedSettingNames))
-            .setPrimaryKeys(new ColumnIdent("name"))
+            .setPrimaryKeys(ColumnIdent.of("name"))
             .withRouting((state, routingProvider, sessionSettings) -> routingProvider.forRandomMasterOrDataNode(IDENT, state.nodes()))
             .build();
     }

--- a/server/src/main/java/io/crate/metadata/sys/SysShardsTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/sys/SysShardsTableInfo.java
@@ -73,30 +73,30 @@ public class SysShardsTableInfo {
          *  - {@link #unassignedShardsExpressions()}
          */
 
-        public static final ColumnIdent ID = new ColumnIdent("id");
-        static final ColumnIdent SCHEMA_NAME = new ColumnIdent("schema_name");
-        public static final ColumnIdent TABLE_NAME = new ColumnIdent("table_name");
-        public static final ColumnIdent PARTITION_IDENT = new ColumnIdent("partition_ident");
-        static final ColumnIdent NUM_DOCS = new ColumnIdent("num_docs");
-        public static final ColumnIdent PRIMARY = new ColumnIdent("primary");
-        static final ColumnIdent RELOCATING_NODE = new ColumnIdent("relocating_node");
-        public static final ColumnIdent SIZE = new ColumnIdent("size");
-        static final ColumnIdent STATE = new ColumnIdent("state");
-        static final ColumnIdent CLOSED = new ColumnIdent("closed");
-        static final ColumnIdent ROUTING_STATE = new ColumnIdent("routing_state");
-        static final ColumnIdent ORPHAN_PARTITION = new ColumnIdent("orphan_partition");
+        public static final ColumnIdent ID = ColumnIdent.of("id");
+        static final ColumnIdent SCHEMA_NAME = ColumnIdent.of("schema_name");
+        public static final ColumnIdent TABLE_NAME = ColumnIdent.of("table_name");
+        public static final ColumnIdent PARTITION_IDENT = ColumnIdent.of("partition_ident");
+        static final ColumnIdent NUM_DOCS = ColumnIdent.of("num_docs");
+        public static final ColumnIdent PRIMARY = ColumnIdent.of("primary");
+        static final ColumnIdent RELOCATING_NODE = ColumnIdent.of("relocating_node");
+        public static final ColumnIdent SIZE = ColumnIdent.of("size");
+        static final ColumnIdent STATE = ColumnIdent.of("state");
+        static final ColumnIdent CLOSED = ColumnIdent.of("closed");
+        static final ColumnIdent ROUTING_STATE = ColumnIdent.of("routing_state");
+        static final ColumnIdent ORPHAN_PARTITION = ColumnIdent.of("orphan_partition");
 
-        static final ColumnIdent RECOVERY = new ColumnIdent("recovery");
+        static final ColumnIdent RECOVERY = ColumnIdent.of("recovery");
 
-        static final ColumnIdent PATH = new ColumnIdent("path");
-        static final ColumnIdent BLOB_PATH = new ColumnIdent("blob_path");
+        static final ColumnIdent PATH = ColumnIdent.of("path");
+        static final ColumnIdent BLOB_PATH = ColumnIdent.of("blob_path");
 
-        static final ColumnIdent MIN_LUCENE_VERSION = new ColumnIdent("min_lucene_version");
-        static final ColumnIdent NODE = new ColumnIdent("node");
-        static final ColumnIdent SEQ_NO_STATS = new ColumnIdent("seq_no_stats");
-        static final ColumnIdent TRANSLOG_STATS = new ColumnIdent("translog_stats");
-        static final ColumnIdent RETENTION_LEASES = new ColumnIdent("retention_leases");
-        static final ColumnIdent FLUSH_STATS = new ColumnIdent("flush_stats");
+        static final ColumnIdent MIN_LUCENE_VERSION = ColumnIdent.of("min_lucene_version");
+        static final ColumnIdent NODE = ColumnIdent.of("node");
+        static final ColumnIdent SEQ_NO_STATS = ColumnIdent.of("seq_no_stats");
+        static final ColumnIdent TRANSLOG_STATS = ColumnIdent.of("translog_stats");
+        static final ColumnIdent RETENTION_LEASES = ColumnIdent.of("retention_leases");
+        static final ColumnIdent FLUSH_STATS = ColumnIdent.of("flush_stats");
     }
 
     public static Map<ColumnIdent, RowCollectExpressionFactory<UnassignedShard>> unassignedShardsExpressions() {

--- a/server/src/main/java/io/crate/metadata/sys/SysSnapshotRestoreTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/sys/SysSnapshotRestoreTableInfo.java
@@ -52,9 +52,9 @@ public class SysSnapshotRestoreTableInfo {
         .endObjectArray()
         .add("state", STRING, SysSnapshotRestoreInProgress::state)
         .setPrimaryKeys(
-            new ColumnIdent("id"),
-            new ColumnIdent("name"),
-            new ColumnIdent("repository"))
+            ColumnIdent.of("id"),
+            ColumnIdent.of("name"),
+            ColumnIdent.of("repository"))
         .withRouting((state, routingProvider, sessionSettings) ->
                             routingProvider.forRandomMasterOrDataNode(IDENT, state.nodes()))
         .build();

--- a/server/src/main/java/io/crate/metadata/sys/SysSnapshotsTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/sys/SysSnapshotsTableInfo.java
@@ -55,7 +55,7 @@ public class SysSnapshotsTableInfo {
         .add("version", STRING, SysSnapshot::version)
         .add("state", STRING, SysSnapshot::state)
         .add("failures", STRING_ARRAY, SysSnapshot::failures)
-        .setPrimaryKeys(new ColumnIdent("name"), new ColumnIdent("repository"))
+        .setPrimaryKeys(ColumnIdent.of("name"), ColumnIdent.of("repository"))
         .withRouting(SysSnapshotsTableInfo::getRouting)
         .build();
 

--- a/server/src/main/java/io/crate/metadata/sys/SysSummitsTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/sys/SysSummitsTableInfo.java
@@ -44,6 +44,6 @@ public class SysSummitsTableInfo {
         .add("region", STRING, SummitsContext::region)
         .add("country", STRING, SummitsContext::country)
         .add("first_ascent", INTEGER, SummitsContext::firstAscent)
-        .setPrimaryKeys(new ColumnIdent("mountain"))
+        .setPrimaryKeys(ColumnIdent.of("mountain"))
         .build();
 }

--- a/server/src/main/java/io/crate/role/metadata/SysPrivilegesTableInfo.java
+++ b/server/src/main/java/io/crate/role/metadata/SysPrivilegesTableInfo.java
@@ -47,11 +47,11 @@ public class SysPrivilegesTableInfo {
         .add("class", STRING, x -> x.privilege.subject().securable().toString())
         .add("ident", STRING, x -> x.privilege.subject().ident())
         .setPrimaryKeys(
-            new ColumnIdent("grantee"),
-            new ColumnIdent("state"),
-            new ColumnIdent("type"),
-            new ColumnIdent("class"),
-            new ColumnIdent("ident")
+            ColumnIdent.of("grantee"),
+            ColumnIdent.of("state"),
+            ColumnIdent.of("type"),
+            ColumnIdent.of("class"),
+            ColumnIdent.of("ident")
         )
         .build();
 

--- a/server/src/main/java/io/crate/role/metadata/SysRolesTableInfo.java
+++ b/server/src/main/java/io/crate/role/metadata/SysRolesTableInfo.java
@@ -42,6 +42,6 @@ public class SysRolesTableInfo {
             .add("role", STRING, GrantedRole::roleName)
             .add("grantor", STRING, GrantedRole::grantor)
         .endObjectArray()
-        .setPrimaryKeys(new ColumnIdent("name"))
+        .setPrimaryKeys(ColumnIdent.of("name"))
         .build();
 }

--- a/server/src/main/java/io/crate/role/metadata/SysUsersTableInfo.java
+++ b/server/src/main/java/io/crate/role/metadata/SysUsersTableInfo.java
@@ -54,7 +54,7 @@ public class SysUsersTableInfo {
                 .add("role", STRING, GrantedRole::roleName)
                 .add("grantor", STRING, GrantedRole::grantor)
             .endObjectArray()
-            .setPrimaryKeys(new ColumnIdent("name"))
+            .setPrimaryKeys(ColumnIdent.of("name"))
             .build();
     }
 }

--- a/server/src/main/java/io/crate/statistics/Stats.java
+++ b/server/src/main/java/io/crate/statistics/Stats.java
@@ -72,7 +72,7 @@ public class Stats implements Writeable {
         int numColumnStats = in.readVInt();
         this.statsByColumn = new HashMap<>();
         for (int i = 0; i < numColumnStats; i++) {
-            statsByColumn.put(new ColumnIdent(in), new ColumnStats<>(in));
+            statsByColumn.put(ColumnIdent.of(in), new ColumnStats<>(in));
         }
     }
 

--- a/server/src/test/java/io/crate/analyze/AlterTableAddColumnAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/AlterTableAddColumnAnalyzerTest.java
@@ -194,7 +194,7 @@ public class AlterTableAddColumnAnalyzerTest extends CrateDummyClusterServiceUni
                 """);
 
         Map<ColumnIdent, RefBuilder> columns = analysis.columns();
-        RefBuilder rb = columns.get(new ColumnIdent("col3"));
+        RefBuilder rb = columns.get(ColumnIdent.of("col3"));
         assertThat(rb.isExplicitlyNull()).isTrue();
     }
 

--- a/server/src/test/java/io/crate/analyze/AlterTableDropColumnAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/AlterTableDropColumnAnalyzerTest.java
@@ -130,7 +130,7 @@ public class AlterTableDropColumnAnalyzerTest extends CrateDummyClusterServiceUn
         assertThat(d.columns()).satisfiesExactly(
             dc -> assertThat(dc.ref())
                 .isReference()
-                .hasColumnIdent(new ColumnIdent("o", List.of("oo", "ooa")))
+                .hasColumnIdent(ColumnIdent.of("o", List.of("oo", "ooa")))
                 .hasTableIdent(d.table().ident())
                 .hasType(DataTypes.INTEGER)
         );
@@ -197,12 +197,12 @@ public class AlterTableDropColumnAnalyzerTest extends CrateDummyClusterServiceUn
         assertThat(d3.columns()).satisfiesExactly(
             dc -> assertThat(dc.ref())
                 .isReference()
-                .hasColumnIdent(new ColumnIdent("o", "oa"))
+                .hasColumnIdent(ColumnIdent.of("o", "oa"))
                 .hasTableIdent(d3.table().ident())
                 .hasType(DataTypes.INTEGER),
             dc -> assertThat(dc.ref())
                 .isReference()
-                .hasColumnIdent(new ColumnIdent("o", List.of("oo", "ooa")))
+                .hasColumnIdent(ColumnIdent.of("o", List.of("oo", "ooa")))
                 .hasTableIdent(d3.table().ident())
                 .hasType(DataTypes.INTEGER)
         );

--- a/server/src/test/java/io/crate/analyze/AlterTableRenameColumnAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/AlterTableRenameColumnAnalyzerTest.java
@@ -50,7 +50,7 @@ public class AlterTableRenameColumnAnalyzerTest extends CrateDummyClusterService
 
         AnalyzedAlterTableRenameColumn analyzed = e.analyze("alter table t rename column a to b");
         assertThat(analyzed.refToRename()).isReference().hasName("a");
-        assertThat(analyzed.newName()).isEqualTo(new ColumnIdent("b"));
+        assertThat(analyzed.newName()).isEqualTo(ColumnIdent.of("b"));
         assertThat(analyzed.table()).isEqualTo(new RelationName("doc", "t"));
     }
 
@@ -60,8 +60,8 @@ public class AlterTableRenameColumnAnalyzerTest extends CrateDummyClusterService
             .addTable("create table t (o object as (o2 object as (o3 object)))");
 
         AnalyzedAlterTableRenameColumn analyzed = e.analyze("alter table t rename column o['o2']['o3'] to o['o2']['x']");
-        assertThat(analyzed.refToRename()).isReference().hasColumnIdent(new ColumnIdent("o", List.of("o2", "o3")));
-        assertThat(analyzed.newName()).isEqualTo(new ColumnIdent("o", List.of("o2", "x")));
+        assertThat(analyzed.refToRename()).isReference().hasColumnIdent(ColumnIdent.of("o", List.of("o2", "o3")));
+        assertThat(analyzed.newName()).isEqualTo(ColumnIdent.of("o", List.of("o2", "x")));
         assertThat(analyzed.table()).isEqualTo(new RelationName("doc", "t"));
     }
 
@@ -71,8 +71,8 @@ public class AlterTableRenameColumnAnalyzerTest extends CrateDummyClusterService
             .addTable("create table t (o object as (o2 object as (o3 object)))");
 
         AnalyzedAlterTableRenameColumn analyzed = e.analyze("alter table t rename column o['o2']['o3'] to o['o2']['x']");
-        assertThat(analyzed.refToRename()).isReference().hasColumnIdent(new ColumnIdent("o", List.of("o2", "o3")));
-        assertThat(analyzed.newName()).isEqualTo(new ColumnIdent("o", List.of("o2", "x")));
+        assertThat(analyzed.refToRename()).isReference().hasColumnIdent(ColumnIdent.of("o", List.of("o2", "o3")));
+        assertThat(analyzed.newName()).isEqualTo(ColumnIdent.of("o", List.of("o2", "x")));
         assertThat(analyzed.table()).isEqualTo(new RelationName("doc", "t"));
     }
 

--- a/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -239,7 +239,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
 
         AnalyzedCreateTable analysis = e.analyze("create table foo (name string null)");
         Map<ColumnIdent, RefBuilder> columns = analysis.columns();
-        RefBuilder rb = columns.get(new ColumnIdent("name"));
+        RefBuilder rb = columns.get(ColumnIdent.of("name"));
         assertThat(rb.isExplicitlyNull()).isTrue();
     }
 
@@ -259,7 +259,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
 
         AnalyzedCreateTable analysis = e.analyze("create table foo (a int, b int, c int null, primary key(a, b))");
         Map<ColumnIdent, RefBuilder> columns = analysis.columns();
-        RefBuilder rb = columns.get(new ColumnIdent("c"));
+        RefBuilder rb = columns.get(ColumnIdent.of("c"));
         assertThat(rb.isExplicitlyNull()).isTrue();
     }
 
@@ -746,9 +746,9 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
         BoundCreateTable analysis = analyze("create table test (o object as (_id integer), name string)");
         Map<ColumnIdent, Reference> columns = analysis.columns();
         assertThat(columns).containsOnlyKeys(
-            new ColumnIdent("o"),
-            new ColumnIdent("o", "_id"),
-            new ColumnIdent("name")
+            ColumnIdent.of("o"),
+            ColumnIdent.of("o", "_id"),
+            ColumnIdent.of("name")
         );
     }
 
@@ -909,7 +909,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
             "name string" +
             ")");
         Map<ColumnIdent, Reference> columns = analysis.columns();
-        ColumnIdent ft = new ColumnIdent("ft");
+        ColumnIdent ft = ColumnIdent.of("ft");
         assertThat(columns).containsKey(ft);
         Reference ftRef = columns.get(ft);
         assertThat(ftRef).isExactlyInstanceOf(IndexReference.class);
@@ -1542,7 +1542,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
         BoundCreateTable createTable = analyze(
             "create table t (i int, o1 object as (o2 object as (b int check (o1['o2']['b'] > 100))))");
 
-        ColumnIdent o2b = new ColumnIdent("o1", List.of("o2", "b"));
+        ColumnIdent o2b = ColumnIdent.of("o1", List.of("o2", "b"));
         Map<ColumnIdent, Reference> columns = createTable.columns();
         assertThat(columns).containsKey(o2b);
         assertThat(columns.get(o2b)).isReference().hasName("o1['o2']['b']").hasType(DataTypes.INTEGER);
@@ -1586,7 +1586,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
     @Test
     public void testGeneratedColumnInsideObjectIsProcessed() {
         BoundCreateTable stmt = analyze("create table t (obj object as (c as 1 + 1))");
-        Reference reference = stmt.columns().get(new ColumnIdent("obj", "c"));
+        Reference reference = stmt.columns().get(ColumnIdent.of("obj", "c"));
 
         assertThat(reference.valueType()).isEqualTo(DataTypes.INTEGER);
         assertThat(((GeneratedReference) reference).formattedGeneratedExpression()).isEqualTo("2");
@@ -1879,7 +1879,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
     @Test
     public void test_create_nested_array_column() throws Exception {
         BoundCreateTable createTable = analyze("create table tbl (x int[][])");
-        ColumnIdent x = new ColumnIdent("x");
+        ColumnIdent x = ColumnIdent.of("x");
         Map<ColumnIdent, Reference> columns = createTable.columns();
         assertThat(columns).containsKeys(x);
         Reference xRef = columns.get(x);
@@ -1891,7 +1891,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
     public void test_can_use_vector_in_create_table() throws Exception {
         BoundCreateTable stmt = analyze("create table tbl (x float_vector)");
         assertThat(stmt.columns()).hasEntrySatisfying(
-            new ColumnIdent("x"), Asserts.isReference("x", FloatVectorType.INSTANCE_ONE)
+            ColumnIdent.of("x"), Asserts.isReference("x", FloatVectorType.INSTANCE_ONE)
         );
     }
 

--- a/server/src/test/java/io/crate/analyze/IdTest.java
+++ b/server/src/test/java/io/crate/analyze/IdTest.java
@@ -40,7 +40,7 @@ public class IdTest extends ESTestCase {
     private static final List<String> EMPTY_PK_VALUES = List.of();
 
     private static ColumnIdent ci(String ident) {
-        return new ColumnIdent(ident);
+        return ColumnIdent.of(ident);
     }
 
     private static String generateId(List<ColumnIdent> pkColumns, List<String> values, ColumnIdent clusteredBy) {

--- a/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -2798,7 +2798,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         assertThat(analyzed.outputs()).hasSize(1);
         assertThat(analyzed.outputs().getFirst())
             .isVoidReference()
-            .hasColumnIdent(new ColumnIdent("o", "unknown_key"))
+            .hasColumnIdent(ColumnIdent.of("o", "unknown_key"))
             .hasTableIdent(new RelationName(null, "alias"));
     }
 

--- a/server/src/test/java/io/crate/analyze/TableInfoToASTTest.java
+++ b/server/src/test/java/io/crate/analyze/TableInfoToASTTest.java
@@ -358,14 +358,14 @@ public class TableInfoToASTTest extends CrateDummyClusterServiceUnitTest {
                      "   \"col_d\" OBJECT(DYNAMIC) AS (\n" +
                      "      \"a\" TEXT\n" +
                      "   ),\n" +
-                     "   INDEX \"col_a_col_b_ft\" USING FULLTEXT (\"col_a\", \"col_b\") WITH (\n" +
-                     "      analyzer = 'english'\n" +
+                     "   INDEX \"col_a_col_b_plain\" USING FULLTEXT (\"col_a\", \"col_b\") WITH (\n" +
+                     "      analyzer = 'keyword'\n" +
                      "   ),\n" +
                      "   INDEX \"col_d_a_ft\" USING FULLTEXT (\"col_d\"['a']) WITH (\n" +
                      "      analyzer = 'custom_analyzer'\n" +
                      "   ),\n" +
-                     "   INDEX \"col_a_col_b_plain\" USING FULLTEXT (\"col_a\", \"col_b\") WITH (\n" +
-                     "      analyzer = 'keyword'\n" +
+                     "   INDEX \"col_a_col_b_ft\" USING FULLTEXT (\"col_a\", \"col_b\") WITH (\n" +
+                     "      analyzer = 'english'\n" +
                      "   )\n" +
                      ")\n" +
                      "CLUSTERED INTO 5 SHARDS\n" +
@@ -530,7 +530,7 @@ public class TableInfoToASTTest extends CrateDummyClusterServiceUnitTest {
                    )
                 """)
         );
-        Reference reference = table.getReference(new ColumnIdent("geo_arr"));
+        Reference reference = table.getReference(ColumnIdent.of("geo_arr"));
         Assertions.assertThat(reference.valueType()).isEqualTo(new ArrayType<>(DataTypes.GEO_SHAPE));
         GeoReference geoRef = (GeoReference) reference;
         Assertions.assertThat(geoRef.geoTree()).isEqualTo(GeoShapeType.Names.TREE_QUADTREE);

--- a/server/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
@@ -270,9 +270,9 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         RelationName usersRelation = new RelationName("doc", "users");
         assertThat(update.assignmentByTargetCol()).hasSize(3);
         DocTableInfo tableInfo = e.schemas().getTableInfo(usersRelation);
-        Reference name = tableInfo.getReference(new ColumnIdent("name"));
-        Reference friendsRef = tableInfo.getReference(new ColumnIdent("friends"));
-        Reference otherId = tableInfo.getReference(new ColumnIdent("other_id"));
+        Reference name = tableInfo.getReference(ColumnIdent.of("name"));
+        Reference friendsRef = tableInfo.getReference(ColumnIdent.of("friends"));
+        Reference otherId = tableInfo.getReference(ColumnIdent.of("other_id"));
         assertThat(update.assignmentByTargetCol().get(name)).isExactlyInstanceOf(ParameterSymbol.class);
         assertThat(update.assignmentByTargetCol().get(friendsRef)).isExactlyInstanceOf(ParameterSymbol.class);
         assertThat(update.assignmentByTargetCol().get(otherId)).isExactlyInstanceOf(ParameterSymbol.class);

--- a/server/src/test/java/io/crate/analyze/ValueNormalizerTest.java
+++ b/server/src/test/java/io/crate/analyze/ValueNormalizerTest.java
@@ -93,7 +93,7 @@ public class ValueNormalizerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testNormalizePrimitiveLiteral() throws Exception {
         SimpleReference ref = new SimpleReference(
-            new ReferenceIdent(TEST_TABLE_IDENT, new ColumnIdent("bool")), RowGranularity.DOC, DataTypes.BOOLEAN, 0, null
+            new ReferenceIdent(TEST_TABLE_IDENT, ColumnIdent.of("bool")), RowGranularity.DOC, DataTypes.BOOLEAN, 0, null
         );
         Literal<Boolean> trueLiteral = Literal.of(true);
 
@@ -105,7 +105,7 @@ public class ValueNormalizerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     @SuppressWarnings({"unchecked", "rawtypes"})
     public void testNormalizeDynamicEmptyObjectLiteral() throws Exception {
-        Reference objRef = userTableInfo.getReference(new ColumnIdent("dyn_empty"));
+        Reference objRef = userTableInfo.getReference(ColumnIdent.of("dyn_empty"));
         Map<String, Object> map = new HashMap<>();
         map.put("time", "2014-02-16T00:00:01");
         map.put("false", true);
@@ -117,7 +117,7 @@ public class ValueNormalizerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test(expected = ColumnValidationException.class)
     public void testNormalizeObjectLiteralInvalidNested() throws Exception {
-        Reference objRef = userTableInfo.getReference(new ColumnIdent("dyn"));
+        Reference objRef = userTableInfo.getReference(ColumnIdent.of("dyn"));
         Map<String, Object> map = new HashMap<>();
         map.put("d", "2014-02-16T00:00:01");
         normalizeInputForReference(Literal.of(map), objRef);
@@ -125,7 +125,7 @@ public class ValueNormalizerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testNormalizeObjectLiteralConvertFromString() throws Exception {
-        Reference objInfo = userTableInfo.getReference(new ColumnIdent("dyn"));
+        Reference objInfo = userTableInfo.getReference(ColumnIdent.of("dyn"));
         Map<String, Object> map = new HashMap<>();
         map.put("d", "2.9");
 
@@ -135,7 +135,7 @@ public class ValueNormalizerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testNormalizeObjectLiteral() throws Exception {
-        Reference objInfo = userTableInfo.getReference(new ColumnIdent("dyn"));
+        Reference objInfo = userTableInfo.getReference(ColumnIdent.of("dyn"));
         Map<String, Object> map = Map.of(
             "d", 2.9d,
             "inner_strict", Map.of(
@@ -147,7 +147,7 @@ public class ValueNormalizerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testNormalizeDynamicObjectLiteralWithAdditionalColumn() throws Exception {
-        Reference objInfo = userTableInfo.getReference(new ColumnIdent("dyn"));
+        Reference objInfo = userTableInfo.getReference(ColumnIdent.of("dyn"));
         Map<String, Object> map = new HashMap<>();
         map.put("d", 2.9d);
         map.put("half", "1.45");
@@ -157,7 +157,7 @@ public class ValueNormalizerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testNormalizeDynamicObjectWithRestrictedAdditionalColumn() throws Exception {
-        Reference objInfo = userTableInfo.getReference(new ColumnIdent("dyn"));
+        Reference objInfo = userTableInfo.getReference(ColumnIdent.of("dyn"));
         Map<String, Object> map = new HashMap<>();
         map.put("_invalid.column_name", 0);
         assertThatThrownBy(() -> normalizeInputForReference(Literal.of(map), objInfo))
@@ -168,7 +168,7 @@ public class ValueNormalizerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test(expected = ColumnUnknownException.class)
     public void testNormalizeStrictObjectLiteralWithAdditionalColumn() throws Exception {
-        Reference objInfo = userTableInfo.getReference(new ColumnIdent("strict"));
+        Reference objInfo = userTableInfo.getReference(ColumnIdent.of("strict"));
         Map<String, Object> map = new HashMap<>();
         map.put("inner_d", 2.9d);
         map.put("half", "1.45");
@@ -177,7 +177,7 @@ public class ValueNormalizerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test(expected = ColumnUnknownException.class)
     public void testNormalizeStrictObjectLiteralWithAdditionalNestedColumn() throws Exception {
-        Reference objInfo = userTableInfo.getReference(new ColumnIdent("strict"));
+        Reference objInfo = userTableInfo.getReference(ColumnIdent.of("strict"));
         Map<String, Object> map = Map.of(
             "inner_d", 2.9d,
             "inner_map", Map.of(
@@ -187,7 +187,7 @@ public class ValueNormalizerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test(expected = ColumnUnknownException.class)
     public void testNormalizeNestedStrictObjectLiteralWithAdditionalColumn() throws Exception {
-        Reference objInfo = userTableInfo.getReference(new ColumnIdent("dyn"));
+        Reference objInfo = userTableInfo.getReference(ColumnIdent.of("dyn"));
 
         Map<String, Object> map = Map.of(
             "inner_strict", Map.of(
@@ -199,7 +199,7 @@ public class ValueNormalizerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testNormalizeDynamicNewColumnTimestamp() throws Exception {
-        Reference objInfo = userTableInfo.getReference(new ColumnIdent("dyn"));
+        Reference objInfo = userTableInfo.getReference(ColumnIdent.of("dyn"));
         Map<String, Object> map = Map.of("time", "1970-01-01T00:00:00");
         Symbol symbol = normalizeInputForReference(Literal.of(map), objInfo);
         assertThat(symbol).isLiteral(Map.of("time", "1970-01-01T00:00:00"));
@@ -207,7 +207,7 @@ public class ValueNormalizerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testNormalizeIgnoredNewColumnTimestamp() throws Exception {
-        Reference objInfo = userTableInfo.getReference(new ColumnIdent("ignored"));
+        Reference objInfo = userTableInfo.getReference(ColumnIdent.of("ignored"));
         Map<String, Object> map = Map.of("time", "1970-01-01T00:00:00");
         Symbol symbol = normalizeInputForReference(Literal.of(map), objInfo);
         assertThat(symbol).isLiteral(Map.of("time", "1970-01-01T00:00:00"));
@@ -215,7 +215,7 @@ public class ValueNormalizerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testNormalizeDynamicNewColumnNoTimestamp() throws Exception {
-        Reference objInfo = userTableInfo.getReference(new ColumnIdent("ignored"));
+        Reference objInfo = userTableInfo.getReference(ColumnIdent.of("ignored"));
         Map<String, Object> map = Map.of("no_time", "1970");
         Symbol symbol = normalizeInputForReference(Literal.of(map), objInfo);
         assertThat(symbol).isLiteral(Map.of("no_time", "1970"));
@@ -223,7 +223,7 @@ public class ValueNormalizerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testNormalizeStringToNumberColumn() throws Exception {
-        Reference objInfo = userTableInfo.getReference(new ColumnIdent("d"));
+        Reference objInfo = userTableInfo.getReference(ColumnIdent.of("d"));
         Literal<String> stringDoubleLiteral = Literal.of("298.444");
         Symbol literal = normalizeInputForReference(stringDoubleLiteral, objInfo);
         assertThat(literal).isLiteral(298.444d, DataTypes.DOUBLE);

--- a/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -449,7 +449,7 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
             ArraySliceFunction.NAME,
             arg1 -> assertThat(arg1)
                     .isReference()
-                    .hasColumnIdent(new ColumnIdent("xs"))
+                    .hasColumnIdent(ColumnIdent.of("xs"))
                     .hasTableIdent(new RelationName("doc", "tarr"))
                 .hasType(DataTypes.INTEGER_ARRAY),
             arg2 -> assertThat(arg2).isLiteral(1),

--- a/server/src/test/java/io/crate/analyze/relations/DocTableRelationTest.java
+++ b/server/src/test/java/io/crate/analyze/relations/DocTableRelationTest.java
@@ -43,7 +43,7 @@ public class DocTableRelationTest extends CrateDummyClusterServiceUnitTest {
             clusterService);
         DocTableRelation rel = new DocTableRelation(tableInfo);
 
-        assertThatThrownBy(() -> rel.ensureColumnCanBeUpdated(new ColumnIdent("i")))
+        assertThatThrownBy(() -> rel.ensureColumnCanBeUpdated(ColumnIdent.of("i")))
             .isExactlyInstanceOf(ColumnValidationException.class)
             .hasMessage("Validation failed for i: Updating a primary key is not supported");
     }
@@ -56,7 +56,7 @@ public class DocTableRelationTest extends CrateDummyClusterServiceUnitTest {
             clusterService);
         DocTableRelation rel = new DocTableRelation(tableInfo);
 
-        assertThatThrownBy(() -> rel.ensureColumnCanBeUpdated(new ColumnIdent("i")))
+        assertThatThrownBy(() -> rel.ensureColumnCanBeUpdated(ColumnIdent.of("i")))
             .isExactlyInstanceOf(ColumnValidationException.class)
             .hasMessage("Validation failed for i: Updating a primary key is not supported");
     }
@@ -69,7 +69,7 @@ public class DocTableRelationTest extends CrateDummyClusterServiceUnitTest {
             clusterService);
         DocTableRelation rel = new DocTableRelation(tableInfo);
 
-        assertThatThrownBy(() -> rel.ensureColumnCanBeUpdated(new ColumnIdent("i")))
+        assertThatThrownBy(() -> rel.ensureColumnCanBeUpdated(ColumnIdent.of("i")))
             .isExactlyInstanceOf(ColumnValidationException.class)
             .hasMessage("Validation failed for i: Updating a clustered-by column is not supported");
     }

--- a/server/src/test/java/io/crate/analyze/relations/ExcludedFieldProviderTest.java
+++ b/server/src/test/java/io/crate/analyze/relations/ExcludedFieldProviderTest.java
@@ -47,7 +47,7 @@ public class ExcludedFieldProviderTest {
         FieldProvider<?> fieldProvider = (qualifiedName, path, operation, errorOnUnknownObjectKey) ->
             new ScopedSymbol(
                 new RelationName("doc", "dummy"),
-                new ColumnIdent(qualifiedName.toString()),
+                ColumnIdent.of(qualifiedName.toString()),
                 DataTypes.INTEGER);
         ValuesResolver valuesResolver = argumentColumn -> {
             assertThat(argumentColumn).isField("field3");

--- a/server/src/test/java/io/crate/analyze/relations/QuerySplitterTest.java
+++ b/server/src/test/java/io/crate/analyze/relations/QuerySplitterTest.java
@@ -142,7 +142,7 @@ public class QuerySplitterTest extends CrateDummyClusterServiceUnitTest {
             1,
             null
         );
-        ScopedSymbol scopedSymbol = new ScopedSymbol(tr1, new ColumnIdent("c"), DataTypes.BOOLEAN);
+        ScopedSymbol scopedSymbol = new ScopedSymbol(tr1, ColumnIdent.of("c"), DataTypes.BOOLEAN);
         Symbol matchPredicate = asSymbol("Match(t1.a, 'abc')");
 
         Symbol query = AndOperator.join(List.of(bool_a, bool_b, scopedSymbol, matchPredicate));

--- a/server/src/test/java/io/crate/analyze/where/EqualityExtractorTest.java
+++ b/server/src/test/java/io/crate/analyze/where/EqualityExtractorTest.java
@@ -40,8 +40,8 @@ import io.crate.testing.T3;
 
 public class EqualityExtractorTest extends EqualityExtractorBaseTest {
 
-    private static final ColumnIdent x = new ColumnIdent("x");
-    private static final ColumnIdent i = new ColumnIdent("i");
+    private static final ColumnIdent x = ColumnIdent.of("x");
+    private static final ColumnIdent i = ColumnIdent.of("i");
 
     private List<List<Symbol>> analyzeParentX(Symbol query) {
         return analyzeParent(query, List.of(x));
@@ -309,7 +309,7 @@ public class EqualityExtractorTest extends EqualityExtractorBaseTest {
         Map<RelationName, AnalyzedRelation> sources = T3.sources(List.of(T3.T4), clusterService);
         DocTableRelation tr4 = (DocTableRelation) sources.get(T3.T4);
         var expressionsT4 = new SqlExpressions(sources, tr4);
-        var pkCol = new ColumnIdent("obj");
+        var pkCol = ColumnIdent.of("obj");
 
         var query = expressionsT4.normalize(expressionsT4.asSymbol("obj = any([{i = 1}])"));
         List<List<Symbol>> matches = analyzeExact(query, List.of(pkCol));

--- a/server/src/test/java/io/crate/auth/AccessControlMaySeeTest.java
+++ b/server/src/test/java/io/crate/auth/AccessControlMaySeeTest.java
@@ -144,7 +144,7 @@ public class AccessControlMaySeeTest extends ESTestCase {
         // select x from empty_row;
         accessControl.ensureMaySee(
             new ColumnUnknownException(
-                new ColumnIdent("x"), new RelationName("doc", "empty_row")));
+                ColumnIdent.of("x"), new RelationName("doc", "empty_row")));
         assertAskedAnyForTable("doc.empty_row");
     }
 

--- a/server/src/test/java/io/crate/execution/ddl/tables/DropColumnTaskTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/tables/DropColumnTaskTest.java
@@ -57,7 +57,7 @@ public class DropColumnTaskTest extends CrateDummyClusterServiceUnitTest {
         ClusterState initialState = clusterService.state();
         var dropColumnTask = new AlterTableTask<>(
             e.nodeCtx, tbl.ident(), TransportDropColumnAction.DROP_COLUMN_OPERATOR);
-        Reference colToDrop = tbl.getReference(new ColumnIdent("y"));
+        Reference colToDrop = tbl.getReference(ColumnIdent.of("y"));
         var request = new DropColumnRequest(tbl.ident(), List.of(new DropColumn(colToDrop, false)));
         ClusterState newState = dropColumnTask.execute(initialState, request);
 
@@ -90,13 +90,13 @@ public class DropColumnTaskTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo tbl = e.resolveTableInfo("tbl");
         var dropColumnTask = new AlterTableTask<>(
             e.nodeCtx, tbl.ident(), TransportDropColumnAction.DROP_COLUMN_OPERATOR);
-        Reference colToDrop = tbl.getReference(new ColumnIdent("o", "oo"));
+        Reference colToDrop = tbl.getReference(ColumnIdent.of("o", "oo"));
         var request = new DropColumnRequest(tbl.ident(), List.of(new DropColumn(colToDrop, false)));
         ClusterState newState = dropColumnTask.execute(clusterService.state(), request);
         DocTableInfo newTable = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
 
         assertThat(newTable.getReference(colToDrop.column())).isNull();
-        Reference o = newTable.getReference(new ColumnIdent("o"));
+        Reference o = newTable.getReference(ColumnIdent.of("o"));
         assertThat(o.valueType()).isExactlyInstanceOf(ObjectType.class);
         ObjectType objectType = (ObjectType) o.valueType();
         assertThat(objectType.innerTypes())
@@ -118,8 +118,8 @@ public class DropColumnTaskTest extends CrateDummyClusterServiceUnitTest {
             TransportDropColumnAction.DROP_COLUMN_OPERATOR
         );
         // parent specified first then its child
-        Reference colToDrop1 = tbl.getReference(new ColumnIdent("o", "o2"));
-        Reference colToDrop2 = tbl.getReference(new ColumnIdent("o", List.of("o2", "c")));
+        Reference colToDrop1 = tbl.getReference(ColumnIdent.of("o", "o2"));
+        Reference colToDrop2 = tbl.getReference(ColumnIdent.of("o", List.of("o2", "c")));
         var request = new DropColumnRequest(tbl.ident(), List.of(
             new DropColumn(colToDrop1, false),
             new DropColumn(colToDrop2, false)));
@@ -183,7 +183,7 @@ public class DropColumnTaskTest extends CrateDummyClusterServiceUnitTest {
         ClusterState state = clusterService.state();
         var dropColumnTask = new AlterTableTask<>(
             e.nodeCtx, tbl.ident(), TransportDropColumnAction.DROP_COLUMN_OPERATOR);
-        Reference ref = tbl.getReference(new ColumnIdent("y"));
+        Reference ref = tbl.getReference(ColumnIdent.of("y"));
 
         DropColumnRequest request = new DropColumnRequest(tbl.ident(), List.of(new DropColumn(ref, true)));
         assertThatThrownBy(() -> dropColumnTask.execute(state, request))

--- a/server/src/test/java/io/crate/execution/ddl/tables/RenameColumnTaskTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/tables/RenameColumnTaskTest.java
@@ -56,8 +56,8 @@ public class RenameColumnTaskTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo tbl = e.resolveTableInfo("tbl");
         var renameColumnTask = new AlterTableTask<>(
             e.nodeCtx, tbl.ident(), TransportRenameColumnAction.RENAME_COLUMN_OPERATOR);
-        Reference refToRename = tbl.getReference(new ColumnIdent("x"));
-        var newName = new ColumnIdent("y");
+        Reference refToRename = tbl.getReference(ColumnIdent.of("x"));
+        var newName = ColumnIdent.of("y");
         var request = new RenameColumnRequest(tbl.ident(), refToRename, newName);
         ClusterState newState = renameColumnTask.execute(clusterService.state(), request);
         DocTableInfo newTable = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
@@ -76,24 +76,24 @@ public class RenameColumnTaskTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo tbl = e.resolveTableInfo("tbl");
         var renameColumnTask = new AlterTableTask<>(
             e.nodeCtx, tbl.ident(), TransportRenameColumnAction.RENAME_COLUMN_OPERATOR);
-        Reference refToRename1 = tbl.getReference(new ColumnIdent("o"));
-        var newName1 = new ColumnIdent("p");
+        Reference refToRename1 = tbl.getReference(ColumnIdent.of("o"));
+        var newName1 = ColumnIdent.of("p");
         var request = new RenameColumnRequest(tbl.ident(), refToRename1, newName1);
         ClusterState newState = renameColumnTask.execute(clusterService.state(), request);
         tbl = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
         assertThat(tbl.getReference(refToRename1.column())).isNull();
         assertThat(tbl.getReference(newName1)).isReference().hasName(newName1.sqlFqn());
 
-        Reference refToRename2 = tbl.getReference(new ColumnIdent("p", List.of("o2")));
-        var newName2 = new ColumnIdent("p", List.of("p2"));
+        Reference refToRename2 = tbl.getReference(ColumnIdent.of("p", List.of("o2")));
+        var newName2 = ColumnIdent.of("p", List.of("p2"));
         request = new RenameColumnRequest(tbl.ident(), refToRename2, newName2);
         newState = renameColumnTask.execute(newState, request);
         tbl = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
         assertThat(tbl.getReference(refToRename2.column())).isNull();
         assertThat(tbl.getReference(newName2)).isReference().hasName(newName2.sqlFqn());
 
-        Reference refToRename3 = tbl.getReference(new ColumnIdent("p", List.of("p2", "x")));
-        var newName3 = new ColumnIdent("p", List.of("p2", "y"));
+        Reference refToRename3 = tbl.getReference(ColumnIdent.of("p", List.of("p2", "x")));
+        var newName3 = ColumnIdent.of("p", List.of("p2", "y"));
         request = new RenameColumnRequest(tbl.ident(), refToRename3, newName3);
         newState = renameColumnTask.execute(newState, request);
         tbl = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
@@ -113,8 +113,8 @@ public class RenameColumnTaskTest extends CrateDummyClusterServiceUnitTest {
             e.nodeCtx,
             tbl.ident(),
             TransportRenameColumnAction.RENAME_COLUMN_OPERATOR);
-        Reference refToRename = tbl.getReference(new ColumnIdent("x"));
-        var newName = new ColumnIdent("y");
+        Reference refToRename = tbl.getReference(ColumnIdent.of("x"));
+        var newName = ColumnIdent.of("y");
         var request = new RenameColumnRequest(tbl.ident(), refToRename, newName);
         ClusterState newState = renameColumnTask.execute(clusterService.state(), request);
         DocTableInfo newTable = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
@@ -125,10 +125,10 @@ public class RenameColumnTaskTest extends CrateDummyClusterServiceUnitTest {
 
         // alter table tbl rename column o to p;
         // -- causes partitioned by col to be renamed: o['o2']['x'] -> p['o2']['x']
-        refToRename = tbl.getReference(new ColumnIdent("o"));
-        newName = new ColumnIdent("p");
-        var oldNameOfChild = new ColumnIdent("o", List.of("o2", "x"));
-        var newNameOfChild = new ColumnIdent("p", List.of("o2", "x"));
+        refToRename = tbl.getReference(ColumnIdent.of("o"));
+        newName = ColumnIdent.of("p");
+        var oldNameOfChild = ColumnIdent.of("o", List.of("o2", "x"));
+        var newNameOfChild = ColumnIdent.of("p", List.of("o2", "x"));
         request = new RenameColumnRequest(tbl.ident(), refToRename, newName);
         newState = renameColumnTask.execute(newState, request);
         newTable = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
@@ -146,13 +146,13 @@ public class RenameColumnTaskTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo tbl = e.resolveTableInfo("tbl");
         var renameColumnTask = new AlterTableTask<>(
             e.nodeCtx, tbl.ident(), TransportRenameColumnAction.RENAME_COLUMN_OPERATOR);
-        Reference refToRename = tbl.getReference(new ColumnIdent("o", List.of("o2")));
-        var newName = new ColumnIdent("o", List.of("p2"));
+        Reference refToRename = tbl.getReference(ColumnIdent.of("o", List.of("o2")));
+        var newName = ColumnIdent.of("o", List.of("p2"));
         var request = new RenameColumnRequest(tbl.ident(), refToRename, newName);
         ClusterState newState = renameColumnTask.execute(clusterService.state(), request);
         DocTableInfo newTable = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
-        var oldPkCol = new ColumnIdent("o", List.of("o2", "o3", "x"));
-        var newPkCol = new ColumnIdent("o", List.of("p2", "o3", "x"));
+        var oldPkCol = ColumnIdent.of("o", List.of("o2", "o3", "x"));
+        var newPkCol = ColumnIdent.of("o", List.of("p2", "o3", "x"));
         assertThat(newTable.getReference(refToRename.column())).isNull();
         assertThat(newTable.getReference(newName)).isReference().hasName(newName.sqlFqn());
         assertThat(newTable.primaryKey()).doesNotContain(oldPkCol).contains(newPkCol);
@@ -168,14 +168,14 @@ public class RenameColumnTaskTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo tbl = e.resolveTableInfo("tbl");
         var renameColumnTask = new AlterTableTask<>(
             e.nodeCtx, tbl.ident(), TransportRenameColumnAction.RENAME_COLUMN_OPERATOR);
-        Reference refToRename = tbl.getReference(new ColumnIdent("o", List.of("a")));
-        var newName = new ColumnIdent("o", List.of("b"));
+        Reference refToRename = tbl.getReference(ColumnIdent.of("o", List.of("a")));
+        var newName = ColumnIdent.of("o", List.of("b"));
         var request = new RenameColumnRequest(tbl.ident(), refToRename, newName);
         ClusterState newState = renameColumnTask.execute(clusterService.state(), request);
         tbl = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
 
-        refToRename = tbl.getReference(new ColumnIdent("o"));
-        newName = new ColumnIdent("p");
+        refToRename = tbl.getReference(ColumnIdent.of("o"));
+        newName = ColumnIdent.of("p");
         request = new RenameColumnRequest(tbl.ident(), refToRename, newName);
         newState = renameColumnTask.execute(newState, request);
         tbl = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
@@ -194,13 +194,13 @@ public class RenameColumnTaskTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo tbl = e.resolveTableInfo("tbl");
         var renameColumnTask = new AlterTableTask<>(
             e.nodeCtx, tbl.ident(), TransportRenameColumnAction.RENAME_COLUMN_OPERATOR);
-        Reference refToRename = tbl.getReference(new ColumnIdent("o"));
-        var newName = new ColumnIdent("o2");
+        Reference refToRename = tbl.getReference(ColumnIdent.of("o"));
+        var newName = ColumnIdent.of("o2");
         var request = new RenameColumnRequest(tbl.ident(), refToRename, newName);
         ClusterState newState = renameColumnTask.execute(clusterService.state(), request);
         DocTableInfo newTable = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
         assertThat(newTable.generatedColumns()).hasSize(1);
-        assertThat(newTable.generatedColumns().getFirst().column()).isEqualTo(new ColumnIdent("o2", List.of("b")));
+        assertThat(newTable.generatedColumns().getFirst().column()).isEqualTo(ColumnIdent.of("o2", List.of("b")));
         assertThat(newTable.generatedColumns().getFirst().formattedGeneratedExpression()).isEqualTo("(o2['a'] + 1)");
     }
 
@@ -211,8 +211,8 @@ public class RenameColumnTaskTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo tbl = e.resolveTableInfo("tbl");
         var renameColumnTask = new AlterTableTask<>(
             e.nodeCtx, tbl.ident(), TransportRenameColumnAction.RENAME_COLUMN_OPERATOR);
-        Reference refToRename = tbl.getReference(new ColumnIdent("a"));
-        var newName = new ColumnIdent("b");
+        Reference refToRename = tbl.getReference(ColumnIdent.of("a"));
+        var newName = ColumnIdent.of("b");
         var request = new RenameColumnRequest(tbl.ident(), refToRename, newName);
         assertThatThrownBy(() -> renameColumnTask.execute(clusterService.state(), request))
             .isExactlyInstanceOf(IllegalArgumentException.class)
@@ -240,7 +240,7 @@ public class RenameColumnTaskTest extends CrateDummyClusterServiceUnitTest {
             false,
             null
         );
-        var newName = new ColumnIdent("b");
+        var newName = ColumnIdent.of("b");
         var request = new RenameColumnRequest(tbl.ident(), refToRename, newName);
         assertThatThrownBy(() -> renameColumnTask.execute(clusterService.state(), request))
             .isExactlyInstanceOf(ColumnUnknownException.class)
@@ -254,8 +254,8 @@ public class RenameColumnTaskTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo tbl = e.resolveTableInfo("tbl");
         var renameColumnTask = new AlterTableTask<>(
             e.nodeCtx, tbl.ident(), TransportRenameColumnAction.RENAME_COLUMN_OPERATOR);
-        Reference refToRename = tbl.getReference(new ColumnIdent("x"));
-        var newName = new ColumnIdent("y");
+        Reference refToRename = tbl.getReference(ColumnIdent.of("x"));
+        var newName = ColumnIdent.of("y");
         var request = new RenameColumnRequest(tbl.ident(), refToRename, newName);
         ClusterState newState = renameColumnTask.execute(clusterService.state(), request);
         DocTableInfo newTable = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
@@ -269,21 +269,21 @@ public class RenameColumnTaskTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo tbl = e.resolveTableInfo("tbl");
         var renameColumnTask = new AlterTableTask<>(
             e.nodeCtx, tbl.ident(), TransportRenameColumnAction.RENAME_COLUMN_OPERATOR);
-        Reference refToRename = tbl.getReference(new ColumnIdent("x"));
-        var newName = new ColumnIdent("x2");
+        Reference refToRename = tbl.getReference(ColumnIdent.of("x"));
+        var newName = ColumnIdent.of("x2");
         var request = new RenameColumnRequest(tbl.ident(), refToRename, newName);
         ClusterState newState = renameColumnTask.execute(clusterService.state(), request);
         tbl = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
 
-        refToRename = tbl.indexColumn(new ColumnIdent("i"));
-        newName = new ColumnIdent("i2");
+        refToRename = tbl.indexColumn(ColumnIdent.of("i"));
+        newName = ColumnIdent.of("i2");
         request = new RenameColumnRequest(tbl.ident(), refToRename, newName);
         newState = renameColumnTask.execute(newState, request);
         tbl = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
 
-        var renamedIndexColumn = tbl.indexColumn(new ColumnIdent("i2"));
+        var renamedIndexColumn = tbl.indexColumn(ColumnIdent.of("i2"));
         assertThat(renamedIndexColumn.columns()).hasSize(1);
         assertThat(renamedIndexColumn.columns().getFirst()).isReference().hasName("x2");
-        assertThat(renamedIndexColumn.column()).isEqualTo(new ColumnIdent("i2"));
+        assertThat(renamedIndexColumn.column()).isEqualTo(ColumnIdent.of("i2"));
     }
 }

--- a/server/src/test/java/io/crate/execution/dml/IndexerTest.java
+++ b/server/src/test/java/io/crate/execution/dml/IndexerTest.java
@@ -143,7 +143,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         SQLExecutor executor = SQLExecutor.of(clusterService)
             .addTable("create table tbl (o object as (x int))");
         DocTableInfo table = executor.resolveTableInfo("tbl");
-        Reference o = table.getReference(new ColumnIdent("o"));
+        Reference o = table.getReference(ColumnIdent.of("o"));
         Indexer indexer = new Indexer(
             table.ident().indexNameOrAlias(),
             table,
@@ -182,7 +182,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         SQLExecutor executor = SQLExecutor.of(clusterService)
             .addTable("create table tbl (o object as (x int))");
         DocTableInfo table = executor.resolveTableInfo("tbl");
-        Reference o = table.getReference(new ColumnIdent("o"));
+        Reference o = table.getReference(ColumnIdent.of("o"));
         Indexer indexer = new Indexer(
             table.ident().indexNameOrAlias(),
             table,
@@ -245,7 +245,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         SQLExecutor executor = SQLExecutor.of(clusterService)
             .addTable("create table tbl (o object as (x int))");
         DocTableInfo table = executor.resolveTableInfo("tbl");
-        Reference o = table.getReference(new ColumnIdent("o"));
+        Reference o = table.getReference(ColumnIdent.of("o"));
         Indexer indexer = new Indexer(
             table.ident().indexNameOrAlias(),
             table,
@@ -287,8 +287,8 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
             .addTable("create table tbl (x int, y int default 0)");
         CoordinatorTxnCtx txnCtx = new CoordinatorTxnCtx(executor.getSessionSettings());
         DocTableInfo table = executor.resolveTableInfo("tbl");
-        Reference x = table.getReference(new ColumnIdent("x"));
-        Reference y = table.getReference(new ColumnIdent("y"));
+        Reference x = table.getReference(ColumnIdent.of("x"));
+        Reference y = table.getReference(ColumnIdent.of("y"));
         var indexer = new Indexer(
             table.ident().indexNameOrAlias(),
             table,
@@ -325,7 +325,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         SQLExecutor executor = SQLExecutor.of(clusterService)
             .addTable("create table tbl (x int, y int as x + 2)");
         DocTableInfo table = executor.resolveTableInfo("tbl");
-        Reference x = table.getReference(new ColumnIdent("x"));
+        Reference x = table.getReference(ColumnIdent.of("x"));
         Indexer indexer = new Indexer(
             table.ident().indexNameOrAlias(),
             table,
@@ -349,7 +349,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
                 partition
             );
         DocTableInfo table = executor.resolveTableInfo("tbl");
-        Reference x = table.getReference(new ColumnIdent("x"));
+        Reference x = table.getReference(ColumnIdent.of("x"));
         Indexer indexer = new Indexer(
             partition,
             table,
@@ -369,7 +369,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         SQLExecutor executor = SQLExecutor.of(clusterService)
             .addTable("create table tbl (o object as (x int default 0, y int as o['x'] + 2, z int))");
         DocTableInfo table = executor.resolveTableInfo("tbl");
-        Reference o = table.getReference(new ColumnIdent("o"));
+        Reference o = table.getReference(ColumnIdent.of("o"));
         Indexer indexer = new Indexer(
             table.ident().indexNameOrAlias(),
             table,
@@ -399,7 +399,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         var executor = SQLExecutor.of(clusterService)
             .addTable("create table tbl (x int, o object as (x int) default {x=10})");
         DocTableInfo table = executor.resolveTableInfo("tbl");
-        Reference x = table.getReference(new ColumnIdent("x"));
+        Reference x = table.getReference(ColumnIdent.of("x"));
         Indexer indexer = new Indexer(
             table.ident().indexNameOrAlias(),
             table,
@@ -424,9 +424,9 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         SQLExecutor executor = SQLExecutor.of(clusterService)
             .addTable("create table tbl (x int, y int as x + 2, o object as (z int as x + 3))");
         DocTableInfo table = executor.resolveTableInfo("tbl");
-        Reference x = table.getReference(new ColumnIdent("x"));
-        Reference y = table.getReference(new ColumnIdent("y"));
-        Reference o = table.getReference(new ColumnIdent("o"));
+        Reference x = table.getReference(ColumnIdent.of("x"));
+        Reference y = table.getReference(ColumnIdent.of("y"));
+        Reference o = table.getReference(ColumnIdent.of("o"));
         Indexer indexer1 = new Indexer(
             table.ident().indexNameOrAlias(),
             table,
@@ -461,7 +461,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
             new CoordinatorTxnCtx(executor.getSessionSettings()),
             executor.nodeCtx,
             List.of(
-                table.getReference(new ColumnIdent("x"))
+                table.getReference(ColumnIdent.of("x"))
             ),
             null
         );
@@ -491,8 +491,8 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
             new CoordinatorTxnCtx(executor.getSessionSettings()),
             executor.nodeCtx,
             List.of(
-                table.getReference(new ColumnIdent("x")),
-                table.getReference(new ColumnIdent("z"))
+                table.getReference(ColumnIdent.of("x")),
+                table.getReference(ColumnIdent.of("z"))
             ),
             null
         );
@@ -522,7 +522,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
             new CoordinatorTxnCtx(executor.getSessionSettings()),
             executor.nodeCtx,
             List.of(
-                table.getReference(new ColumnIdent("o"))
+                table.getReference(ColumnIdent.of("o"))
             ),
             null
         );
@@ -547,7 +547,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
             new CoordinatorTxnCtx(executor.getSessionSettings()),
             executor.nodeCtx,
             List.of(
-                table.getReference(new ColumnIdent("o"))
+                table.getReference(ColumnIdent.of("o"))
             ),
             null
         );
@@ -572,12 +572,12 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
             new CoordinatorTxnCtx(e.getSessionSettings()),
             e.nodeCtx,
             List.of(
-                table.getReference(new ColumnIdent("x"))
+                table.getReference(ColumnIdent.of("x"))
             ),
             new Symbol[] {
-                table.getReference(new ColumnIdent("_id")),
-                table.getReference(new ColumnIdent("x")),
-                table.getReference(new ColumnIdent("y")),
+                table.getReference(ColumnIdent.of("_id")),
+                table.getReference(ColumnIdent.of("x")),
+                table.getReference(ColumnIdent.of("y")),
             }
         );
 
@@ -597,8 +597,8 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
             new CoordinatorTxnCtx(e.getSessionSettings()),
             e.nodeCtx,
             List.of(
-                table.getReference(new ColumnIdent("x")),
-                table.getReference(new ColumnIdent("o"))
+                table.getReference(ColumnIdent.of("x")),
+                table.getReference(ColumnIdent.of("o"))
             ),
             null
         );
@@ -616,7 +616,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         SQLExecutor e = SQLExecutor.of(clusterService)
             .addTable("create table tbl (x float)");
         DocTableInfo table = e.resolveTableInfo("tbl");
-        var ref = table.getReference(new ColumnIdent("x"));
+        var ref = table.getReference(ColumnIdent.of("x"));
 
         Indexer indexer = getIndexer(e, "tbl", "x");
         ParsedDocument doc = indexer.index(item(42.2f));
@@ -634,7 +634,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         SQLExecutor e = SQLExecutor.of(clusterService)
             .addTable("create table tbl (x text index using fulltext with (analyzer = 'english'))");
         DocTableInfo table = e.resolveTableInfo("tbl");
-        var ref = table.getReference(new ColumnIdent("x"));
+        var ref = table.getReference(ColumnIdent.of("x"));
 
         var indexer = getIndexer(e, "tbl", "x");
         ParsedDocument doc = indexer.index(item("Hello World"));
@@ -680,7 +680,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
             }
             Object value = DataTypeTesting.getDataGenerator(type).get();
             values.add(value);
-            columns.add(new ColumnIdent("c_" + type.getName()));
+            columns.add(ColumnIdent.of("c_" + type.getName()));
             stmtBuilder
                 .append("\"c_" + type.getName() + "\" ")
                 .append(type);
@@ -733,9 +733,9 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
             new CoordinatorTxnCtx(e.getSessionSettings()),
             e.nodeCtx,
             List.of(
-                table.getReference(new ColumnIdent("x")),
-                table.getDynamic(new ColumnIdent("y"), true, false),
-                table.getDynamic(new ColumnIdent("z"), true, false)
+                table.getReference(ColumnIdent.of("x")),
+                table.getDynamic(ColumnIdent.of("y"), true, false),
+                table.getDynamic(ColumnIdent.of("z"), true, false)
             ),
             null
         );
@@ -811,7 +811,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         SQLExecutor e = SQLExecutor.of(clusterService)
             .addTable("create table tbl (xs text[], index ft using fulltext (xs))");
         DocTableInfo table = e.resolveTableInfo("tbl");
-        var refFt = table.indexColumn(new ColumnIdent("ft"));
+        var refFt = table.indexColumn(ColumnIdent.of("ft"));
         var indexer = getIndexer(e, "tbl", "xs");
         ParsedDocument doc = indexer.index(item(List.of("foo", "bar", "baz")));
         assertThat(doc.doc().getFields(refFt.storageIdent())).hasSize(3);
@@ -834,9 +834,9 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
             new CoordinatorTxnCtx(e.getSessionSettings()),
             e.nodeCtx,
             List.of(
-                table.getReference(new ColumnIdent("o")),
-                table.getDynamic(new ColumnIdent("n1"), true, false),
-                table.getDynamic(new ColumnIdent("n2"), true, false)
+                table.getReference(ColumnIdent.of("o")),
+                table.getDynamic(ColumnIdent.of("n1"), true, false),
+                table.getDynamic(ColumnIdent.of("n2"), true, false)
             ),
             null
         );
@@ -961,7 +961,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         }
 
         DocTableInfo newTable = addColumns(e, table, newColumns);
-        Reference oRef = newTable.getReference(new ColumnIdent("o"));
+        Reference oRef = newTable.getReference(ColumnIdent.of("o"));
         assertThat(((ObjectType) oRef.valueType()).innerTypes().keySet()).containsExactlyElementsOf(keys);
         indexer = new Indexer(
             newTable.ident().indexNameOrAlias(),
@@ -969,7 +969,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
             new CoordinatorTxnCtx(e.getSessionSettings()),
             e.nodeCtx,
             List.of("x", "o", "y").stream()
-                .map(x -> newTable.getReference(new ColumnIdent(x)))
+                .map(x -> newTable.getReference(ColumnIdent.of(x)))
                 .toList(),
             null
         );
@@ -1054,7 +1054,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         SQLExecutor executor = SQLExecutor.of(clusterService)
             .addTable("create table tbl (x int) with (column_policy = 'dynamic')");
         DocTableInfo table = executor.resolveTableInfo("tbl");
-        Reference x = table.getReference(new ColumnIdent("x"));
+        Reference x = table.getReference(ColumnIdent.of("x"));
         Reference y = new DynamicReference(new ReferenceIdent(table.ident(), "y"), RowGranularity.DOC, 2);
         Indexer indexer = new Indexer(
             table.ident().indexNameOrAlias(),
@@ -1098,7 +1098,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
             new CoordinatorTxnCtx(executor.getSessionSettings()),
             executor.nodeCtx,
             List.of(
-                table.getReference(new ColumnIdent("a"))
+                table.getReference(ColumnIdent.of("a"))
                 // 'Parted' is not in targets to imitate insert-from-subquery behavior
                 //  which excludes partitioned columns from targets
             ),
@@ -1123,7 +1123,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         SQLExecutor executor = SQLExecutor.of(clusterService)
             .addTable("create table tbl (obj object as (x int check (obj['x'] > 10)))");
         DocTableInfo table = executor.resolveTableInfo("tbl");
-        Reference x = table.getReference(new ColumnIdent("obj"));
+        Reference x = table.getReference(ColumnIdent.of("obj"));
         Indexer indexer = new Indexer(
             table.ident().indexNameOrAlias(),
             table,

--- a/server/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
+++ b/server/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
@@ -182,7 +182,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
                 false,
                 null
         );
-        when(tableInfo.getReference(new ColumnIdent("dynamic_long_col"))).thenReturn(dynamicLongColRef);
+        when(tableInfo.getReference(ColumnIdent.of("dynamic_long_col"))).thenReturn(dynamicLongColRef);
         when(tableInfo.iterator()).thenReturn(List.<Reference>of(ID_REF, dynamicLongColRef).iterator());
 
         transportShardUpsertAction = new TestingTransportShardUpsertAction(
@@ -297,7 +297,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
         // The follow-up dynamic insert to replica tries to resolve the DynamicReference to a SimpleReference
         // and there can be a potential ClassCastException.
         DynamicReference dynamicRefConvertedToSimpleRef = new DynamicReference(
-            new ReferenceIdent(TABLE_IDENT, new ColumnIdent("dynamic_long_col")),
+            new ReferenceIdent(TABLE_IDENT, ColumnIdent.of("dynamic_long_col")),
             RowGranularity.DOC,
             0
         );

--- a/server/src/test/java/io/crate/execution/dml/upsert/UpdateToInsertTest.java
+++ b/server/src/test/java/io/crate/execution/dml/upsert/UpdateToInsertTest.java
@@ -252,7 +252,7 @@ public class UpdateToInsertTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo table = e.resolveTableInfo("tbl");
 
         // INSERT INTO tbl (z) VALUES (?) ON CONFLICT (...) DO UPDATE SET y = ?
-        Reference[] insertColumns = new Reference[] { table.getReference(new ColumnIdent("z")) };
+        Reference[] insertColumns = new Reference[] { table.getReference(ColumnIdent.of("z")) };
         String[] updateColumns = new String[] { "y" };
         UpdateToInsert updateToInsert = new UpdateToInsert(
             e.nodeCtx,
@@ -291,7 +291,7 @@ public class UpdateToInsertTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo table = e.resolveTableInfo("tbl");
 
         // INSERT INTO tbl (z) VALUES (?) ON CONFLICT (...) DO UPDATE SET y['a'] = ?
-        Reference[] insertColumns = new Reference[] { table.getReference(new ColumnIdent("z")) };
+        Reference[] insertColumns = new Reference[] { table.getReference(ColumnIdent.of("z")) };
         String[] updateColumns = new String[] { "y.a" };
         UpdateToInsert updateToInsert = new UpdateToInsert(
                 e.nodeCtx,
@@ -334,8 +334,8 @@ public class UpdateToInsertTest extends CrateDummyClusterServiceUnitTest {
 
         // insert into tbl (x, z) values (1, 20) on conflict (..) do update set z = excluded.z
         Reference[] insertColumns = new Reference[] {
-            table.getReference(new ColumnIdent("x")),
-            table.getReference(new ColumnIdent("z"))
+            table.getReference(ColumnIdent.of("x")),
+            table.getReference(ColumnIdent.of("z"))
         };
         String[] updateColumns = new String[] { "z" };
         UpdateToInsert updateToInsert = new UpdateToInsert(
@@ -377,8 +377,8 @@ public class UpdateToInsertTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo table = e.resolveTableInfo("tbl");
         // insert into tbl (x, z) values (1, 20) on conflict (..) do update set z = excluded.z
         Reference[] insertColumns = new Reference[] {
-            table.getReference(new ColumnIdent("x")),
-            table.getReference(new ColumnIdent("z"))
+            table.getReference(ColumnIdent.of("x")),
+            table.getReference(ColumnIdent.of("z"))
         };
         String[] updateColumns = new String[] { "z" };
         UpdateToInsert updateToInsert = new UpdateToInsert(
@@ -418,8 +418,8 @@ public class UpdateToInsertTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo table = e.resolveTableInfo("tbl");
         // insert into tbl (x, z) values (1, 20) on conflict (..) do update set z = excluded.z
         Reference[] insertColumns = new Reference[] {
-            table.getReference(new ColumnIdent("x")),
-            table.getReference(new ColumnIdent("z"))
+            table.getReference(ColumnIdent.of("x")),
+            table.getReference(ColumnIdent.of("z"))
         };
         String[] updateColumns = new String[] { "z" };
         UpdateToInsert updateToInsert = new UpdateToInsert(

--- a/server/src/test/java/io/crate/execution/dsl/projection/ColumnIndexWriterProjectionTest.java
+++ b/server/src/test/java/io/crate/execution/dsl/projection/ColumnIndexWriterProjectionTest.java
@@ -55,7 +55,7 @@ public class ColumnIndexWriterProjectionTest {
         int numColumns = 200;
         ArrayList<Reference> targetColumns = new ArrayList<>(numColumns);
         for (int i = 0; i < numColumns; i++) {
-            var ident = new ColumnIdent(String.valueOf(i));
+            var ident = ColumnIdent.of(String.valueOf(i));
             targetColumns.add(ref(ident, DataTypes.INTEGER));
         }
         var projection = new ColumnIndexWriterProjection(

--- a/server/src/test/java/io/crate/execution/dsl/projection/SourceIndexWriterProjectionSerializationTest.java
+++ b/server/src/test/java/io/crate/execution/dsl/projection/SourceIndexWriterProjectionSerializationTest.java
@@ -71,9 +71,9 @@ public class SourceIndexWriterProjectionSerializationTest {
         );
         String partitionIdent = "pIdent";
         InputColumn inputColumn = new InputColumn(123);
-        List<ColumnIdent> primaryKeys = List.of(new ColumnIdent("colIdent"));
+        List<ColumnIdent> primaryKeys = List.of(ColumnIdent.of("colIdent"));
         List<Symbol> partitionedBySymbols = List.of(reference);
-        ColumnIdent clusteredByColumn = new ColumnIdent("col1");
+        ColumnIdent clusteredByColumn = ColumnIdent.of("col1");
         Settings settings = Settings.builder().put("fail_fast", true).build();
         // fail_fast property set to true
         SourceIndexWriterProjection expected = new SourceIndexWriterProjection(
@@ -131,9 +131,9 @@ public class SourceIndexWriterProjectionSerializationTest {
         );
         String partitionIdent = "pIdent";
         InputColumn inputColumn = new InputColumn(123);
-        List<ColumnIdent> primaryKeys = List.of(new ColumnIdent("colIdent"));
+        List<ColumnIdent> primaryKeys = List.of(ColumnIdent.of("colIdent"));
         List<Symbol> partitionedBySymbols = List.of(reference);
-        ColumnIdent clusteredByColumn = new ColumnIdent("col1");
+        ColumnIdent clusteredByColumn = ColumnIdent.of("col1");
         Settings settings = Settings.builder().put("validation", false).build();
         // validation property set to false
         SourceIndexWriterProjection validationFlagSetToFalse = new SourceIndexWriterProjection(

--- a/server/src/test/java/io/crate/execution/dsl/projection/WriterProjectionTest.java
+++ b/server/src/test/java/io/crate/execution/dsl/projection/WriterProjectionTest.java
@@ -47,7 +47,7 @@ public class WriterProjectionTest extends ESTestCase {
             Literal.of("/foo.json"),
             WriterProjection.CompressionType.GZIP,
             MapBuilder.<ColumnIdent, Symbol>newMapBuilder().put(
-                new ColumnIdent("partitionColumn"), Literal.of(1)).map(),
+                ColumnIdent.of("partitionColumn"), Literal.of(1)).map(),
             List.of("foo"),
             WriterProjection.OutputFormat.JSON_OBJECT,
             Settings.builder().put("protocol", "http").build()
@@ -70,7 +70,7 @@ public class WriterProjectionTest extends ESTestCase {
             Literal.of("/foo.json"),
             WriterProjection.CompressionType.GZIP,
             MapBuilder.<ColumnIdent, Symbol>newMapBuilder().put(
-                new ColumnIdent("partitionColumn"), Literal.of(1)).map(),
+                ColumnIdent.of("partitionColumn"), Literal.of(1)).map(),
             List.of("foo"),
             WriterProjection.OutputFormat.JSON_OBJECT,
             Settings.builder().put("protocol", "dummyHTTPS").build()
@@ -81,7 +81,7 @@ public class WriterProjectionTest extends ESTestCase {
             Literal.of("/foo.json"),
             WriterProjection.CompressionType.GZIP,
             MapBuilder.<ColumnIdent, Symbol>newMapBuilder().put(
-                new ColumnIdent("partitionColumn"), Literal.of(1)).map(),
+                ColumnIdent.of("partitionColumn"), Literal.of(1)).map(),
             List.of("foo"),
             WriterProjection.OutputFormat.JSON_OBJECT,
             Settings.EMPTY

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/CountAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/CountAggregationTest.java
@@ -121,7 +121,7 @@ public class CountAggregationTest extends AggregationTestCase {
 
     private void helper_count_on_object_with_not_null_immediate_child(DataType<?> childType, Class<?> expectedAggregatorClass) {
         SimpleReference notNullImmediateChild = new SimpleReference(
-            new ReferenceIdent(null, new ColumnIdent("top_level_object", "not_null_subcol")),
+            new ReferenceIdent(null, ColumnIdent.of("top_level_object", "not_null_subcol")),
             RowGranularity.DOC,
             childType,
             ColumnPolicy.DYNAMIC,
@@ -133,7 +133,7 @@ public class CountAggregationTest extends AggregationTestCase {
             false,
             null);
         SimpleReference countedObject = new SimpleReference(
-            new ReferenceIdent(null, new ColumnIdent("top_level_object")),
+            new ReferenceIdent(null, ColumnIdent.of("top_level_object")),
             RowGranularity.DOC,
             ObjectType.builder().setInnerType(notNullImmediateChild.column().leafName(), notNullImmediateChild.valueType()).build(),
             ColumnPolicy.DYNAMIC,
@@ -173,7 +173,7 @@ public class CountAggregationTest extends AggregationTestCase {
         SimpleReference notNullGrandChild = new SimpleReference(
             new ReferenceIdent(
                 null,
-                new ColumnIdent("top_level_object", List.of("second_level_object", "not_null_subcol"))),
+                ColumnIdent.of("top_level_object", List.of("second_level_object", "not_null_subcol"))),
             RowGranularity.DOC,
             DataTypes.STRING,
             ColumnPolicy.DYNAMIC,
@@ -185,7 +185,7 @@ public class CountAggregationTest extends AggregationTestCase {
             false,
             null);
         SimpleReference immediateChild = new SimpleReference(
-            new ReferenceIdent(null, new ColumnIdent("top_level_object", "second_level_object")),
+            new ReferenceIdent(null, ColumnIdent.of("top_level_object", "second_level_object")),
             RowGranularity.DOC,
             ObjectType.builder().setInnerType(notNullGrandChild.column().leafName(), notNullGrandChild.valueType()).build(),
             ColumnPolicy.DYNAMIC,
@@ -198,7 +198,7 @@ public class CountAggregationTest extends AggregationTestCase {
             null
         );
         SimpleReference countedObject = new SimpleReference(
-            new ReferenceIdent(null, new ColumnIdent("top_level_object")),
+            new ReferenceIdent(null, ColumnIdent.of("top_level_object")),
             RowGranularity.DOC,
             ObjectType.builder().setInnerType(immediateChild.column().leafName(), immediateChild.valueType()).build(),
             ColumnPolicy.DYNAMIC,
@@ -224,13 +224,13 @@ public class CountAggregationTest extends AggregationTestCase {
         SimpleReference notNullSibling = new SimpleReference(
             new ReferenceIdent(
                 null,
-                new ColumnIdent("top_level_Integer")),
+                ColumnIdent.of("top_level_Integer")),
             RowGranularity.DOC,
             DataTypes.INTEGER,
             0,
             null);
         SimpleReference countedObject = new SimpleReference(
-            new ReferenceIdent(null, new ColumnIdent("top_level_object")),
+            new ReferenceIdent(null, ColumnIdent.of("top_level_object")),
             RowGranularity.DOC,
             ObjectType.UNTYPED,
             0,
@@ -250,21 +250,21 @@ public class CountAggregationTest extends AggregationTestCase {
         SimpleReference notNullSibilingsChild = new SimpleReference(
             new ReferenceIdent(
                 null,
-                new ColumnIdent("top_level_sibling", List.of("not_null_subcol"))),
+                ColumnIdent.of("top_level_sibling", List.of("not_null_subcol"))),
             RowGranularity.DOC,
             DataTypes.STRING,
             0,
             null);
         @SuppressWarnings("unused")
         SimpleReference sibling = new SimpleReference(
-            new ReferenceIdent(null, new ColumnIdent("top_level_sibling")),
+            new ReferenceIdent(null, ColumnIdent.of("top_level_sibling")),
             RowGranularity.DOC,
             ObjectType.builder().setInnerType(notNullSibilingsChild.column().leafName(), notNullSibilingsChild.valueType()).build(),
             0,
             null
         );
         SimpleReference countedObject = new SimpleReference(
-            new ReferenceIdent(null, new ColumnIdent("top_level_object")),
+            new ReferenceIdent(null, ColumnIdent.of("top_level_object")),
             RowGranularity.DOC,
             ObjectType.UNTYPED,
             0,
@@ -282,13 +282,13 @@ public class CountAggregationTest extends AggregationTestCase {
     @Test
     public void test_count_on_object_with_nullable_subcolumn_not_use_DocValueAggregator() {
         SimpleReference nullableChild = new SimpleReference(
-            new ReferenceIdent(null, new ColumnIdent("top_level_object", "nullable_subcol")),
+            new ReferenceIdent(null, ColumnIdent.of("top_level_object", "nullable_subcol")),
             RowGranularity.DOC,
             DataTypes.INTEGER,
             0,
             null);
         SimpleReference countedObject = new SimpleReference(
-            new ReferenceIdent(null, new ColumnIdent("top_level_object")),
+            new ReferenceIdent(null, ColumnIdent.of("top_level_object")),
             RowGranularity.DOC,
             ObjectType.builder().setInnerType(nullableChild.column().leafName(), nullableChild.valueType()).build(),
             0,
@@ -308,7 +308,7 @@ public class CountAggregationTest extends AggregationTestCase {
         SimpleReference notNullGrandChild1 = new SimpleReference(
             new ReferenceIdent(
                 null,
-                new ColumnIdent("top_level_object", List.of("second_level_object", "not_null_subcol1"))),
+                ColumnIdent.of("top_level_object", List.of("second_level_object", "not_null_subcol1"))),
             RowGranularity.DOC,
             DataTypes.STRING,
             ColumnPolicy.DYNAMIC,
@@ -322,7 +322,7 @@ public class CountAggregationTest extends AggregationTestCase {
         SimpleReference notNullGrandChild2 = new SimpleReference(
             new ReferenceIdent(
                 null,
-                new ColumnIdent("top_level_object", List.of("second_level_object", "not_null_subcol2"))),
+                ColumnIdent.of("top_level_object", List.of("second_level_object", "not_null_subcol2"))),
             RowGranularity.DOC,
             DataTypes.BYTE,
             ColumnPolicy.DYNAMIC,
@@ -334,7 +334,7 @@ public class CountAggregationTest extends AggregationTestCase {
             false,
             null);
         SimpleReference immediateChild = new SimpleReference(
-            new ReferenceIdent(null, new ColumnIdent("top_level_object", "second_level_object")),
+            new ReferenceIdent(null, ColumnIdent.of("top_level_object", "second_level_object")),
             RowGranularity.DOC,
             ObjectType.builder()
                 .setInnerType(notNullGrandChild1.column().leafName(), notNullGrandChild1.valueType())
@@ -350,7 +350,7 @@ public class CountAggregationTest extends AggregationTestCase {
             null
         );
         SimpleReference notNullImmediateChild = new SimpleReference(
-            new ReferenceIdent(null, new ColumnIdent("top_level_object", "not_null_subcol")),
+            new ReferenceIdent(null, ColumnIdent.of("top_level_object", "not_null_subcol")),
             RowGranularity.DOC,
             DataTypes.IP,
             ColumnPolicy.DYNAMIC,
@@ -362,7 +362,7 @@ public class CountAggregationTest extends AggregationTestCase {
             false,
             null);
         SimpleReference countedObject = new SimpleReference(
-            new ReferenceIdent(null, new ColumnIdent("top_level_object")),
+            new ReferenceIdent(null, ColumnIdent.of("top_level_object")),
             RowGranularity.DOC,
             ObjectType.builder()
                 .setInnerType(immediateChild.column().leafName(), immediateChild.valueType())

--- a/server/src/test/java/io/crate/execution/engine/collect/DocLevelCollectTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/DocLevelCollectTest.java
@@ -209,8 +209,8 @@ public class DocLevelCollectTest extends IntegTestCase {
             CoordinatorSessionSettings.systemDefaults());
         RoutedCollectPhase collectNode = getCollectNode(
             Arrays.asList(
-                tableInfo.getReference(new ColumnIdent("id")),
-                tableInfo.getReference(new ColumnIdent("date"))
+                tableInfo.getReference(ColumnIdent.of("id")),
+                tableInfo.getReference(ColumnIdent.of("date"))
             ),
             routing,
             WhereClause.MATCH_ALL

--- a/server/src/test/java/io/crate/execution/engine/collect/HandlerSideLevelCollectTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/HandlerSideLevelCollectTest.java
@@ -120,7 +120,7 @@ public class HandlerSideLevelCollectTest extends IntegTestCase {
             routingProvider,
             WhereClause.MATCH_ALL, RoutingProvider.ShardSelection.ANY, CoordinatorSessionSettings.systemDefaults());
         SimpleReference clusterNameRef = new SimpleReference(
-            new ReferenceIdent(SysClusterTableInfo.IDENT, new ColumnIdent("name")),
+            new ReferenceIdent(SysClusterTableInfo.IDENT, ColumnIdent.of("name")),
             RowGranularity.CLUSTER,
             DataTypes.STRING,
             1,

--- a/server/src/test/java/io/crate/execution/engine/collect/MapSideDataCollectOperationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/MapSideDataCollectOperationTest.java
@@ -86,7 +86,7 @@ public class MapSideDataCollectOperationTest extends CrateDummyClusterServiceUni
             List.of("a", "b"),
             Arrays.asList(
                 createReference("name", DataTypes.STRING),
-                createReference(new ColumnIdent("details", "age"), DataTypes.INTEGER)
+                createReference(ColumnIdent.of("details", "age"), DataTypes.INTEGER)
             ),
             Collections.emptyList(),
             null,

--- a/server/src/test/java/io/crate/execution/engine/collect/RowShardResolverTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/RowShardResolverTest.java
@@ -43,7 +43,7 @@ import io.crate.metadata.doc.DocSysColumns;
 
 public class RowShardResolverTest extends ESTestCase {
 
-    private static final ColumnIdent ID_IDENT = new ColumnIdent("_id");
+    private static final ColumnIdent ID_IDENT = ColumnIdent.of("_id");
 
     private Row row(Object... cells) {
         if (cells == null) {
@@ -53,7 +53,7 @@ public class RowShardResolverTest extends ESTestCase {
     }
 
     private ColumnIdent ci(String ident) {
-        return new ColumnIdent(ident);
+        return ColumnIdent.of(ident);
     }
 
     private final TransactionContext txnCtx = CoordinatorTxnCtx.systemTransactionContext();
@@ -176,7 +176,7 @@ public class RowShardResolverTest extends ESTestCase {
         var rowShardResolver = new RowShardResolver(
             txnCtx,
             nodeCtx,
-            List.of(new ColumnIdent("my_pk")),
+            List.of(ColumnIdent.of("my_pk")),
             primaryKeySymbols,
             null,
             null
@@ -191,7 +191,7 @@ public class RowShardResolverTest extends ESTestCase {
         var rowShardResolver = new RowShardResolver(
             txnCtx,
             nodeCtx,
-            List.of(DocSysColumns.ID.COLUMN, new ColumnIdent("my_pk")),
+            List.of(DocSysColumns.ID.COLUMN, ColumnIdent.of("my_pk")),
             primaryKeySymbols,
             null,
             null

--- a/server/src/test/java/io/crate/execution/engine/export/FileWriterCountCollectorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/export/FileWriterCountCollectorTest.java
@@ -43,7 +43,7 @@ public class FileWriterCountCollectorTest extends ESTestCase {
     @Test
     public void testToNestedStringObjectMap() {
         Map<ColumnIdent, Object> columnIdentMap = new HashMap<>();
-        columnIdentMap.put(new ColumnIdent("some", Arrays.asList("nested", "column")), "foo");
+        columnIdentMap.put(ColumnIdent.of("some", Arrays.asList("nested", "column")), "foo");
         Map<String, Object> convertedMap = FileWriterCountCollector.toNestedStringObjectMap(columnIdentMap);
 
         Map<?, ?> someMap = (Map<?, ?>) convertedMap.get("some");

--- a/server/src/test/java/io/crate/execution/engine/fetch/FetchTaskTest.java
+++ b/server/src/test/java/io/crate/execution/engine/fetch/FetchTaskTest.java
@@ -122,7 +122,7 @@ public class FetchTaskTest extends CrateDummyClusterServiceUnitTest {
                 null,
                 ibb.build(),
                 tableIndices,
-                List.of(createReference("i1", new ColumnIdent("x"), DataTypes.STRING))),
+                List.of(createReference("i1", ColumnIdent.of("x"), DataTypes.STRING))),
             0,
             "dummy",
             sharedShardContexts,

--- a/server/src/test/java/io/crate/execution/engine/indexing/IndexWriterProjectorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/indexing/IndexWriterProjectorTest.java
@@ -66,7 +66,7 @@ import io.crate.types.DataTypes;
 
 public class IndexWriterProjectorTest extends IntegTestCase {
 
-    private static final ColumnIdent ID_IDENT = new ColumnIdent("id");
+    private static final ColumnIdent ID_IDENT = ColumnIdent.of("id");
 
 
     @Test

--- a/server/src/test/java/io/crate/execution/engine/indexing/IndexWriterProjectorUnitTest.java
+++ b/server/src/test/java/io/crate/execution/engine/indexing/IndexWriterProjectorUnitTest.java
@@ -66,7 +66,7 @@ import io.crate.types.DataTypes;
 
 public class IndexWriterProjectorUnitTest extends CrateDummyClusterServiceUnitTest {
 
-    private static final ColumnIdent ID_IDENT = new ColumnIdent("id");
+    private static final ColumnIdent ID_IDENT = ColumnIdent.of("id");
     private static final RelationName BULK_IMPORT_IDENT = new RelationName(Schemas.DOC_SCHEMA_NAME, "bulk_import");
     private static final SimpleReference RAW_SOURCE_REFERENCE = new SimpleReference(
         new ReferenceIdent(BULK_IMPORT_IDENT, "_raw"),

--- a/server/src/test/java/io/crate/execution/engine/window/AggregationWindowFunctionsTest.java
+++ b/server/src/test/java/io/crate/execution/engine/window/AggregationWindowFunctionsTest.java
@@ -48,7 +48,7 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
                             "PARTITION BY x>2 ORDER BY x RANGE BETWEEN UNBOUNDED PRECEDING and UNBOUNDED FOLLOWING" +
                        ")",
             expected,
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             INPUT_ROWS
         );
     }
@@ -60,7 +60,7 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
                             "PARTITION BY x>2 ORDER BY x RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING" +
                        ")",
             expected,
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             INPUT_ROWS
         );
     }
@@ -73,7 +73,7 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
             "   PARTITION BY x>2 ORDER BY x RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING" +
             ")",
             expected,
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             INPUT_ROWS);
     }
 
@@ -85,7 +85,7 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
             "   PARTITION BY x>2 ORDER BY x RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING" +
             ")",
             expected,
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             INPUT_ROWS);
     }
 
@@ -97,7 +97,7 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
             "   PARTITION BY x>2 ORDER BY x RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING" +
             ")",
             expected,
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             INPUT_ROWS);
     }
 
@@ -109,7 +109,7 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
             "   PARTITION BY x>2 ORDER BY x RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING" +
             ")",
             expected,
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             INPUT_ROWS);
     }
 
@@ -121,7 +121,7 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
             "   PARTITION BY z>'b' ORDER BY z RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING" +
             ")",
             expected,
-            List.of(new ColumnIdent("z")),
+            List.of(ColumnIdent.of("z")),
             new Object[]{"a"},
             new Object[]{"b"},
             new Object[]{"b"},
@@ -149,7 +149,7 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
             "   PARTITION BY x>2 ORDER BY x RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING" +
             ")",
             expected,
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[]{1},
             new Object[]{2},
             new Object[]{2},
@@ -177,7 +177,7 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
                             "PARTITION BY x>2 ORDER BY x ROWS BETWEEN UNBOUNDED PRECEDING and CURRENT ROW" +
                        ")",
             expected,
-            List.of(new ColumnIdent("x")),
+            List.of(ColumnIdent.of("x")),
             new Object[]{1, 1},
             new Object[]{2, 2},
             new Object[]{2, 2},
@@ -204,7 +204,7 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
                             "ORDER BY d RANGE BETWEEN 3 PRECEDING and CURRENT ROW" +
                        ")",
             expected,
-            List.of(new ColumnIdent("d")),
+            List.of(ColumnIdent.of("d")),
             new Object[]{2.5, 2.5},
             new Object[]{4.0, 4.0},
             new Object[]{5.0, 5.0},
@@ -232,7 +232,7 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
                             "ORDER BY d ROWS BETWEEN 3 PRECEDING and CURRENT ROW" +
                        ")",
             expected,
-            List.of(new ColumnIdent("d")),
+            List.of(ColumnIdent.of("d")),
             new Object[]{2.5, 2.5},
             new Object[]{4.0, 4.0},
             new Object[]{5.0, 5.0},
@@ -260,7 +260,7 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
                                "ORDER BY d RANGE BETWEEN CURRENT ROW and 3 FOLLOWING" +
                        ")",
                        expected,
-                       List.of(new ColumnIdent("d")),
+                       List.of(ColumnIdent.of("d")),
                        new Object[]{2.5, 2.5},
                        new Object[]{4.0, 4.0},
                        new Object[]{5.0, 5.0},
@@ -288,7 +288,7 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
                             "ORDER BY d ROWS BETWEEN CURRENT ROW and 3 FOLLOWING" +
                        ")",
                        expected,
-                       List.of(new ColumnIdent("d")),
+                       List.of(ColumnIdent.of("d")),
                        new Object[]{2.5, 2.5},
                        new Object[]{4.0, 4.0},
                        new Object[]{5.0, 5.0},
@@ -328,7 +328,7 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
         assertEvaluate(
             "sum(d) over (partition by z order by d range between 1000 preceding and 1000 following)",
             expected,
-            List.of(new ColumnIdent("z"), new ColumnIdent("d")),
+            List.of(ColumnIdent.of("z"), ColumnIdent.of("d")),
             rows
         );
     }

--- a/server/src/test/java/io/crate/execution/engine/window/RowNumberWindowFunctionTest.java
+++ b/server/src/test/java/io/crate/execution/engine/window/RowNumberWindowFunctionTest.java
@@ -36,7 +36,7 @@ public class RowNumberWindowFunctionTest extends AbstractWindowFunctionTest {
 
         assertEvaluate("row_number() over(order by x)",
                        expected,
-                       List.of(new ColumnIdent("x")),
+                       List.of(ColumnIdent.of("x")),
                        new Object[] {4},
                        new Object[] {3},
                        new Object[] {2},
@@ -49,7 +49,7 @@ public class RowNumberWindowFunctionTest extends AbstractWindowFunctionTest {
         Object[] expected = new Object[]{1, 2, 3, 1, 2, 3, 1};
         assertEvaluate("row_number() over(partition by x>2)",
                        expected,
-                       List.of(new ColumnIdent("x")),
+                       List.of(ColumnIdent.of("x")),
                        new Object[]{1},
                        new Object[]{2},
                        new Object[]{2},
@@ -64,7 +64,7 @@ public class RowNumberWindowFunctionTest extends AbstractWindowFunctionTest {
         Object[] expected = new Object[]{1, 2, 3, 1, 2, 3, 1};
         assertEvaluate("row_number() over(partition by x>2 order by x)",
                        expected,
-                       List.of(new ColumnIdent("x")),
+                       List.of(ColumnIdent.of("x")),
                        new Object[]{1, 1},
                        new Object[]{2, 2},
                        new Object[]{2, 2},
@@ -81,7 +81,7 @@ public class RowNumberWindowFunctionTest extends AbstractWindowFunctionTest {
                             "PARTITION BY x>2 ORDER BY x RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING" +
                        ")",
                        expected,
-                       List.of(new ColumnIdent("x")),
+                       List.of(ColumnIdent.of("x")),
                        new Object[]{1, 1},
                        new Object[]{2, 2},
                        new Object[]{2, 2},
@@ -96,7 +96,7 @@ public class RowNumberWindowFunctionTest extends AbstractWindowFunctionTest {
         Assertions.assertThatThrownBy(() -> assertEvaluate(
                 "row_number() ignore nulls over()",
                 null,
-                List.of(new ColumnIdent("x")),
+                List.of(ColumnIdent.of("x")),
                 new Object[] {1}
             ))
             .isExactlyInstanceOf(IllegalArgumentException.class)

--- a/server/src/test/java/io/crate/expression/reference/doc/lucene/LuceneReferenceResolverTest.java
+++ b/server/src/test/java/io/crate/expression/reference/doc/lucene/LuceneReferenceResolverTest.java
@@ -117,7 +117,7 @@ public class LuceneReferenceResolverTest extends CrateDummyClusterServiceUnitTes
             partitionName.asIndexName(),
             table.partitionedByColumns()
         );
-        Reference year = table.getReference(new ColumnIdent("year"));
+        Reference year = table.getReference(ColumnIdent.of("year"));
         LuceneCollectorExpression<?> impl1 = refResolver.getImplementation(year);
         assertThat(impl1).isExactlyInstanceOf(LuceneReferenceResolver.LiteralValueExpression.class);
         assertThat(impl1.value()).isEqualTo(2023L);

--- a/server/src/test/java/io/crate/expression/reference/doc/lucene/SourceParserTest.java
+++ b/server/src/test/java/io/crate/expression/reference/doc/lucene/SourceParserTest.java
@@ -50,7 +50,7 @@ public class SourceParserTest extends ESTestCase {
     @Test
     public void test_extract_single_value_from_json_with_multiple_columns() throws Exception {
         SourceParser sourceParser = new SourceParser(Set.of(), UnaryOperator.identity());
-        var column = new ColumnIdent("_doc", List.of("x"));
+        var column = ColumnIdent.of("_doc", List.of("x"));
         sourceParser.register(column, DataTypes.INTEGER);
         Map<String, Object> result = sourceParser.parse(new BytesArray(
             """
@@ -64,8 +64,8 @@ public class SourceParserTest extends ESTestCase {
     @Test
     public void test_unnecessary_leafs_of_object_columns_are_not_collected() throws Exception {
         SourceParser sourceParser = new SourceParser(Set.of(), UnaryOperator.identity());
-        var x = new ColumnIdent("_doc", List.of("obj", "x"));
-        var z = new ColumnIdent("_doc", List.of("obj", "z"));
+        var x = ColumnIdent.of("_doc", List.of("obj", "x"));
+        var z = ColumnIdent.of("_doc", List.of("obj", "z"));
         sourceParser.register(x, DataTypes.INTEGER);
         sourceParser.register(z, DataTypes.LONG);
         Map<String, Object> result = sourceParser.parse(new BytesArray(
@@ -81,8 +81,8 @@ public class SourceParserTest extends ESTestCase {
     @Test
     public void test_full_object_is_collected_if_full_object_requested() throws Exception {
         SourceParser sourceParser = new SourceParser(Set.of(), UnaryOperator.identity());
-        var obj = new ColumnIdent("_doc", List.of("obj"));
-        var x = new ColumnIdent("_doc", List.of("obj", "x"));
+        var obj = ColumnIdent.of("_doc", List.of("obj"));
+        var x = ColumnIdent.of("_doc", List.of("obj", "x"));
         // the order in which the columns are registered must not matter
         boolean xFirst = randomBoolean();
         if (xFirst) {
@@ -104,14 +104,14 @@ public class SourceParserTest extends ESTestCase {
     @Test
     public void test_string_encoded_numbers_will_be_parsed_by_data_type() {
         SourceParser sourceParser = new SourceParser(Set.of(), UnaryOperator.identity());
-        sourceParser.register(new ColumnIdent("_doc", List.of("i")), DataTypes.INTEGER);
-        sourceParser.register(new ColumnIdent("_doc", List.of("l")), DataTypes.LONG);
-        sourceParser.register(new ColumnIdent("_doc", List.of("f")), DataTypes.FLOAT);
-        sourceParser.register(new ColumnIdent("_doc", List.of("d")), DataTypes.DOUBLE);
-        sourceParser.register(new ColumnIdent("_doc", List.of("s")), DataTypes.SHORT);
-        sourceParser.register(new ColumnIdent("_doc", List.of("b")), DataTypes.BYTE);
-        sourceParser.register(new ColumnIdent("_doc", List.of("ts")), DataTypes.TIMESTAMP);
-        sourceParser.register(new ColumnIdent("_doc", List.of("tsz")), DataTypes.TIMESTAMPZ);
+        sourceParser.register(ColumnIdent.of("_doc", List.of("i")), DataTypes.INTEGER);
+        sourceParser.register(ColumnIdent.of("_doc", List.of("l")), DataTypes.LONG);
+        sourceParser.register(ColumnIdent.of("_doc", List.of("f")), DataTypes.FLOAT);
+        sourceParser.register(ColumnIdent.of("_doc", List.of("d")), DataTypes.DOUBLE);
+        sourceParser.register(ColumnIdent.of("_doc", List.of("s")), DataTypes.SHORT);
+        sourceParser.register(ColumnIdent.of("_doc", List.of("b")), DataTypes.BYTE);
+        sourceParser.register(ColumnIdent.of("_doc", List.of("ts")), DataTypes.TIMESTAMP);
+        sourceParser.register(ColumnIdent.of("_doc", List.of("tsz")), DataTypes.TIMESTAMPZ);
         Map<String, Object> result = sourceParser.parse(new BytesArray(
             """
             {"i": "1", "l": "2", "f": "0.12", "d": "0.23", "s": "4", "b": "5", "ts": "915757200000", "tsz": "915757200000"}
@@ -130,7 +130,7 @@ public class SourceParserTest extends ESTestCase {
     @Test
     public void test_string_encoded_boolean_will_be_parsed_by_data_type() {
         SourceParser sourceParser = new SourceParser(Set.of(), UnaryOperator.identity());
-        sourceParser.register(new ColumnIdent("_doc", List.of("b")), DataTypes.BOOLEAN);
+        sourceParser.register(ColumnIdent.of("_doc", List.of("b")), DataTypes.BOOLEAN);
         Map<String, Object> result = sourceParser.parse(new BytesArray(
             """
                 {"b": "true"}
@@ -146,7 +146,7 @@ public class SourceParserTest extends ESTestCase {
         ObjectType objectType = ObjectType.builder()
             .setInnerType("bs", bitStringType)
             .build();
-        sourceParser.register(new ColumnIdent("_doc", List.of("o")), objectType);
+        sourceParser.register(ColumnIdent.of("_doc", List.of("o")), objectType);
         Map<String, Object> result = sourceParser.parse(new BytesArray(
             """
             {
@@ -172,7 +172,7 @@ public class SourceParserTest extends ESTestCase {
             .setInnerType("inner_object", innerObjectType)
             .setInnerType("target", DataTypes.STRING)
             .build();
-        sourceParser.register(new ColumnIdent("_doc", List.of("outer_object")), outerObjectType);
+        sourceParser.register(ColumnIdent.of("_doc", List.of("outer_object")), outerObjectType);
         Map<String, Object> result = sourceParser.parse(new BytesArray(
             """
             {
@@ -200,8 +200,8 @@ public class SourceParserTest extends ESTestCase {
         ObjectType objectType = ObjectType.builder()
             .setInnerType("target", DataTypes.FLOAT)
             .build();
-        sourceParser.register(new ColumnIdent("_doc", List.of("obj")), objectType);
-        sourceParser.register(new ColumnIdent("_doc", List.of("target")), DataTypes.STRING);
+        sourceParser.register(ColumnIdent.of("_doc", List.of("obj")), objectType);
+        sourceParser.register(ColumnIdent.of("_doc", List.of("target")), DataTypes.STRING);
         Map<String, Object> result = sourceParser.parse(new BytesArray(
             """
             {
@@ -231,7 +231,7 @@ public class SourceParserTest extends ESTestCase {
         //   )))));
         //   SELECT a['b'] from test; -- a['b'] is array(array(object))
         ArrayType<?> type = new ArrayType<>(new ArrayType<>(ObjectType.builder().setInnerType("s", DataTypes.STRING).build()));
-        sourceParser.register(new ColumnIdent("_doc", List.of("a", "b")), type);
+        sourceParser.register(ColumnIdent.of("_doc", List.of("a", "b")), type);
         var result = sourceParser.parse(new BytesArray(
             """
             {
@@ -264,7 +264,7 @@ public class SourceParserTest extends ESTestCase {
     public void test_nested_array_of_geotype() {
         SourceParser sourceParser = new SourceParser(Set.of(), UnaryOperator.identity());
         ArrayType<?> type = new ArrayType<>(new ArrayType<>(GeoPointType.INSTANCE));
-        sourceParser.register(new ColumnIdent("_doc", List.of("a")), type);
+        sourceParser.register(ColumnIdent.of("_doc", List.of("a")), type);
         var result = sourceParser.parse(new BytesArray("""
             { "a" : [ [ [1, 2], [1, 2], [3, 4] ], [ [5, 6], [7, 8] ] ] }
             """));
@@ -279,7 +279,7 @@ public class SourceParserTest extends ESTestCase {
     public void test_convert_empty_or_null_arrays_added_dynamically_to_nulls() {
         SourceParser sourceParser = new SourceParser(Set.of(), UnaryOperator.identity());
         var type = ObjectType.UNTYPED;
-        sourceParser.register(new ColumnIdent("_doc", List.of("x")), type);
+        sourceParser.register(ColumnIdent.of("_doc", List.of("x")), type);
         var result = sourceParser.parse(
             new BytesArray(
                 """
@@ -297,7 +297,7 @@ public class SourceParserTest extends ESTestCase {
     @Test
     public void test_nested_arrays_from_ignored_objects() {
         SourceParser sourceParser = new SourceParser(Set.of(), UnaryOperator.identity());
-        sourceParser.register(new ColumnIdent("_doc", List.of("obj", "x")), UndefinedType.INSTANCE);
+        sourceParser.register(ColumnIdent.of("_doc", List.of("obj", "x")), UndefinedType.INSTANCE);
         var result = sourceParser.parse(
             new BytesArray(
                 """
@@ -315,8 +315,8 @@ public class SourceParserTest extends ESTestCase {
     public void test_dropped_leaf_sub_column() {
         SourceParser sourceParser = new SourceParser(
             Set.of(
-                createReference(new ColumnIdent("o", List.of("oo", "b")), DataTypes.INTEGER),
-                createReference(new ColumnIdent("o", List.of("oo", "s")), DataTypes.INTEGER)
+                createReference(ColumnIdent.of("o", List.of("oo", "b")), DataTypes.INTEGER),
+                createReference(ColumnIdent.of("o", List.of("oo", "s")), DataTypes.INTEGER)
             ),
             UnaryOperator.identity()
         );
@@ -334,7 +334,7 @@ public class SourceParserTest extends ESTestCase {
             .setInnerType("t", DataTypes.INTEGER)
             .build();
 
-        sourceParser.register(new ColumnIdent("_doc", List.of("o")), oType);
+        sourceParser.register(ColumnIdent.of("_doc", List.of("o")), oType);
         Map<String, Object> result = sourceParser.parse(new BytesArray(
             """
                 {"o": {"a":1, "b":2, "oo":{"a": 11, "b":22, "c":33, "s":33, "t":44}, "s":3, "t":4}}
@@ -363,11 +363,11 @@ public class SourceParserTest extends ESTestCase {
             .build();
 
         SourceParser sourceParser = new SourceParser(
-                Set.of(createReference(new ColumnIdent("o", List.of("oo")), ooType)),
+                Set.of(createReference(ColumnIdent.of("o", List.of("oo")), ooType)),
                 UnaryOperator.identity()
         );
         // Register parent column in order to collect ony this one, ignoring any other column
-        sourceParser.register(new ColumnIdent("_doc", List.of("o")), oType);
+        sourceParser.register(ColumnIdent.of("_doc", List.of("o")), oType);
         Map<String, Object> result = sourceParser.parse(new BytesArray(
             """
                 {"o": {"a" : 1, "b": 2, "oo": {"a": 11, "b": 22, "c": 3}}, "x": 4}
@@ -382,7 +382,7 @@ public class SourceParserTest extends ESTestCase {
     @Test
     public void test_drop_sub_column_with_children_collect_all() {
         SourceParser sourceParser = new SourceParser(
-                Set.of(createReference(new ColumnIdent("o", List.of("oo")), DataTypes.UNTYPED_OBJECT)),
+                Set.of(createReference(ColumnIdent.of("o", List.of("oo")), DataTypes.UNTYPED_OBJECT)),
                 UnaryOperator.identity()
         );
 
@@ -402,8 +402,8 @@ public class SourceParserTest extends ESTestCase {
     public void test_alter_table_drop_leaf_subcolumn_with_parent_object_array() {
         SourceParser sourceParser = new SourceParser(
             Set.of(
-                createReference(new ColumnIdent("o", List.of("oo", "b")), DataTypes.INTEGER),
-                createReference(new ColumnIdent("o", List.of("oo", "t")), DataTypes.INTEGER)
+                createReference(ColumnIdent.of("o", List.of("oo", "b")), DataTypes.INTEGER),
+                createReference(ColumnIdent.of("o", List.of("oo", "t")), DataTypes.INTEGER)
             ),
             UnaryOperator.identity()
         );
@@ -421,7 +421,7 @@ public class SourceParserTest extends ESTestCase {
             .setInnerType("t", DataTypes.INTEGER)
             .build();
 
-        sourceParser.register(new ColumnIdent("_doc", List.of("o")), oType);
+        sourceParser.register(ColumnIdent.of("_doc", List.of("o")), oType);
         Map<String, Object> result = sourceParser.parse(new BytesArray(
             """
             {
@@ -467,11 +467,11 @@ public class SourceParserTest extends ESTestCase {
                 .build();
 
         SourceParser sourceParser = new SourceParser(
-                Set.of(createReference(new ColumnIdent("o", List.of("oo")), ooType)),
+                Set.of(createReference(ColumnIdent.of("o", List.of("oo")), ooType)),
                 UnaryOperator.identity()
         );
 
-        sourceParser.register(new ColumnIdent("_doc", List.of("o")), oType);
+        sourceParser.register(ColumnIdent.of("_doc", List.of("o")), oType);
         Map<String, Object> result = sourceParser.parse(new BytesArray(
                 """
                     {"o": {"a" : 1, "b": 2, "oo": {"a": 11, "b": 22, "c": 3}}}
@@ -495,7 +495,7 @@ public class SourceParserTest extends ESTestCase {
             .setInnerType("x", DataTypes.LONG)
             .build();
         var objArray = new ArrayType<>(objType);
-        sourceParser.register(new ColumnIdent("_doc", "os"), objArray);
+        sourceParser.register(ColumnIdent.of("_doc", "os"), objArray);
         Map<String, Object> result = sourceParser.parse(new BytesArray(
             """
             {

--- a/server/src/test/java/io/crate/expression/reference/file/LineContextTest.java
+++ b/server/src/test/java/io/crate/expression/reference/file/LineContextTest.java
@@ -40,8 +40,8 @@ public class LineContextTest extends ESTestCase {
         String source = "{\"name\": \"foo\", \"details\": {\"age\": 43}}";
         context.rawSource(source.getBytes(StandardCharsets.UTF_8));
 
-        assertNull(context.get(new ColumnIdent("invalid", "column")));
-        assertNull(context.get(new ColumnIdent("details", "invalid")));
-        assertThat(context.get(new ColumnIdent("details", "age"))).isEqualTo(43);
+        assertNull(context.get(ColumnIdent.of("invalid", "column")));
+        assertNull(context.get(ColumnIdent.of("details", "invalid")));
+        assertThat(context.get(ColumnIdent.of("details", "age"))).isEqualTo(43);
     }
 }

--- a/server/src/test/java/io/crate/expression/reference/sys/SysShardsExpressionsTest.java
+++ b/server/src/test/java/io/crate/expression/reference/sys/SysShardsExpressionsTest.java
@@ -334,7 +334,7 @@ public class SysShardsExpressionsTest extends CrateDummyClusterServiceUnitTest {
     public void test_recovery_type_is_null_if_recovery_state_is_null() {
         when(indexShard.recoveryState()).thenReturn(null);
 
-        var ref = sysShards.getReference(new ColumnIdent("recovery", "type"));
+        var ref = sysShards.getReference(ColumnIdent.of("recovery", "type"));
         var input = resolver.getImplementation(ref);
         assertThat(input.value(), Matchers.nullValue());
     }

--- a/server/src/test/java/io/crate/expression/reference/sys/cluster/ClusterSettingsExpressionTest.java
+++ b/server/src/test/java/io/crate/expression/reference/sys/cluster/ClusterSettingsExpressionTest.java
@@ -42,7 +42,7 @@ public class ClusterSettingsExpressionTest extends CrateDummyClusterServiceUnitT
         clusterService.getClusterSettings().applySettings(settings);
         var sysCluster = SysClusterTableInfo.of(clusterService);
 
-        var expressionFactory = sysCluster.expressions().get(new ColumnIdent("settings", List.of("bulk", "request_timeout")));
+        var expressionFactory = sysCluster.expressions().get(ColumnIdent.of("settings", List.of("bulk", "request_timeout")));
         var expression = expressionFactory.create();
         expression.setNextRow(null);
         assertThat(expression.value()).isEqualTo("20s");
@@ -61,17 +61,17 @@ public class ClusterSettingsExpressionTest extends CrateDummyClusterServiceUnitT
         clusterService.getClusterSettings().applySettings(settings);
 
         var jobsLogSize = sysCluster.expressions()
-            .get(new ColumnIdent("settings", List.of("stats", "jobs_log_size")))
+            .get(ColumnIdent.of("settings", List.of("stats", "jobs_log_size")))
             .create();
         assertThat(jobsLogSize.value()).isEqualTo(1);
 
         var statsEnabled = sysCluster.expressions()
-            .get(new ColumnIdent("settings", List.of("stats", "enabled")))
+            .get(ColumnIdent.of("settings", List.of("stats", "enabled")))
             .create();
         assertThat(statsEnabled.value()).isEqualTo(false);
 
         var minAvailability = sysCluster.expressions()
-            .get(new ColumnIdent("settings", List.of("cluster", "graceful_stop", "min_availability")))
+            .get(ColumnIdent.of("settings", List.of("cluster", "graceful_stop", "min_availability")))
             .create();
         assertThat(minAvailability.value()).isEqualTo("FULL");
     }

--- a/server/src/test/java/io/crate/expression/reference/sys/node/NodeStatsContextFieldResolverTest.java
+++ b/server/src/test/java/io/crate/expression/reference/sys/node/NodeStatsContextFieldResolverTest.java
@@ -166,7 +166,7 @@ public class NodeStatsContextFieldResolverTest {
     @Test
     public void testPSQLPortResolution() throws IOException {
         NodeStatsContext context = resolver.forTopColumnIdents(Set.of(
-            new ColumnIdent(SysNodesTableInfo.Columns.PORT.name())
+            ColumnIdent.of(SysNodesTableInfo.Columns.PORT.name())
         ));
         assertThat(context.isComplete()).isTrue();
         assertThat(context.pgPort()).isEqualTo(5432);
@@ -175,7 +175,7 @@ public class NodeStatsContextFieldResolverTest {
     @Test
     public void testClusterStateVersion() throws IOException {
         NodeStatsContext context = resolver.forTopColumnIdents(Set.of(
-            new ColumnIdent(SysNodesTableInfo.Columns.CLUSTER_STATE_VERSION.name())
+            ColumnIdent.of(SysNodesTableInfo.Columns.CLUSTER_STATE_VERSION.name())
         ));
         assertThat(context.isComplete()).isTrue();
         assertThat(context.clusterStateVersion()).isEqualTo(1L);
@@ -184,7 +184,7 @@ public class NodeStatsContextFieldResolverTest {
     @Test
     public void testResolveForNonExistingColumnIdent() {
         assertThatThrownBy(() ->
-            resolver.forTopColumnIdents(Set.of(SysNodesTableInfo.Columns.ID, new ColumnIdent("dummy"))))
+            resolver.forTopColumnIdents(Set.of(SysNodesTableInfo.Columns.ID, ColumnIdent.of("dummy"))))
             .isExactlyInstanceOf(IllegalArgumentException.class)
             .hasMessage("Cannot resolve NodeStatsContext field for \"dummy\" column ident.");
     }

--- a/server/src/test/java/io/crate/expression/symbol/FetchMarkerTest.java
+++ b/server/src/test/java/io/crate/expression/symbol/FetchMarkerTest.java
@@ -47,7 +47,7 @@ public class FetchMarkerTest {
         Symbol symbol = Symbols.fromStream(in);
         assertThat(symbol)
             .isReference()
-            .hasColumnIdent(new ColumnIdent("_fetchid"))
+            .hasColumnIdent(ColumnIdent.of("_fetchid"))
             .hasTableIdent(relationName)
             .hasType(DataTypes.LONG);
     }

--- a/server/src/test/java/io/crate/expression/symbol/SymbolsTest.java
+++ b/server/src/test/java/io/crate/expression/symbol/SymbolsTest.java
@@ -64,6 +64,6 @@ public class SymbolsTest extends CrateDummyClusterServiceUnitTest {
         var e = SQLExecutor.of(clusterService)
             .addTable("create table tbl (x int)");
         Symbol symbol = e.asSymbol("x + 10 > 100");
-        assertThat(symbol.ramBytesUsed()).isEqualTo(928L);
+        assertThat(symbol.ramBytesUsed()).isEqualTo(920L);
     }
 }

--- a/server/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
+++ b/server/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
@@ -154,7 +154,7 @@ public class SymbolPrinterTest extends CrateDummyClusterServiceUnitTest {
         SimpleReference r = new SimpleReference(
             new ReferenceIdent(
                 new RelationName("sys", "table"),
-                new ColumnIdent("column", Arrays.asList("path", "nested"))),
+                ColumnIdent.of("column", Arrays.asList("path", "nested"))),
             RowGranularity.DOC,
             DataTypes.STRING,
             1,
@@ -168,7 +168,7 @@ public class SymbolPrinterTest extends CrateDummyClusterServiceUnitTest {
         SimpleReference r = new SimpleReference(
             new ReferenceIdent(
                 new RelationName("doc", "table"),
-                new ColumnIdent("column", Arrays.asList("path", "nested"))),
+                ColumnIdent.of("column", Arrays.asList("path", "nested"))),
             RowGranularity.DOC,
             DataTypes.STRING,
             0,
@@ -181,7 +181,7 @@ public class SymbolPrinterTest extends CrateDummyClusterServiceUnitTest {
     public void testDynamicReference() {
         Reference r = new DynamicReference(
             new ReferenceIdent(new RelationName("schema", "table"),
-                               new ColumnIdent("column", Arrays.asList("path", "nested"))),
+                               ColumnIdent.of("column", Arrays.asList("path", "nested"))),
             RowGranularity.DOC,
             0);
         assertPrint(r, "schema.\"table\".\"column\"['path']['nested']");
@@ -191,7 +191,7 @@ public class SymbolPrinterTest extends CrateDummyClusterServiceUnitTest {
     public void testVoidReference() {
         Reference r = new VoidReference(
             new ReferenceIdent(new RelationName("schema", "table"),
-                               new ColumnIdent("column", Arrays.asList("path", "nested"))),
+                               ColumnIdent.of("column", Arrays.asList("path", "nested"))),
             0);
         assertPrint(r, "schema.\"table\".\"column\"['path']['nested']");
     }
@@ -200,7 +200,7 @@ public class SymbolPrinterTest extends CrateDummyClusterServiceUnitTest {
     public void testReferenceEscaped() {
         SimpleReference r = new SimpleReference(
             new ReferenceIdent(new RelationName("doc", "table"),
-                               new ColumnIdent("colum\"n")),
+                               ColumnIdent.of("colum\"n")),
             RowGranularity.DOC,
             DataTypes.STRING,
             0,

--- a/server/src/test/java/io/crate/fdw/ForeignTablesMetadataTest.java
+++ b/server/src/test/java/io/crate/fdw/ForeignTablesMetadataTest.java
@@ -59,7 +59,7 @@ public class ForeignTablesMetadataTest extends ESTestCase {
             .put("table_name", "tbl2")
             .build();
         Map<ColumnIdent, Reference> references1 = Map.of(
-            new ColumnIdent("x"),
+            ColumnIdent.of("x"),
             new SimpleReference(
                 new ReferenceIdent(rel1, "x"),
                 RowGranularity.DOC,

--- a/server/src/test/java/io/crate/fdw/JdbcBatchIteratorTest.java
+++ b/server/src/test/java/io/crate/fdw/JdbcBatchIteratorTest.java
@@ -46,7 +46,7 @@ public class JdbcBatchIteratorTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo table = e.resolveTableInfo("doc.summits");
         Symbol query = e.asSymbol("x > 10 and x < 40");
         List<Reference> columns = List.of(
-            table.getReadReference(new ColumnIdent("x"))
+            table.getReadReference(ColumnIdent.of("x"))
         );
         String statement = JdbcBatchIterator.generateStatement(
             table.ident(),

--- a/server/src/test/java/io/crate/integrationtests/ForeignDataWrapperITest.java
+++ b/server/src/test/java/io/crate/integrationtests/ForeignDataWrapperITest.java
@@ -150,7 +150,7 @@ public class ForeignDataWrapperITest extends IntegTestCase {
         execute("explain select * from doc.dummy order by x");
         assertThat(response).hasLines(
             "OrderBy[x ASC] (rows=unknown)",
-            "  └ ForeignCollect[doc.dummy | [y, x] | true] (rows=unknown)"
+            "  └ ForeignCollect[doc.dummy | [x, y] | true] (rows=unknown)"
         );
 
         var roles = cluster().getInstance(Roles.class);

--- a/server/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
@@ -1675,8 +1675,8 @@ public class PartitionedTableIntegrationTest extends IntegTestCase {
         // Verify that ADD COLUMN gets advanced OID.
         Schemas schemas = cluster().getMasterNodeInstance(NodeContext.class).schemas();
         DocTableInfo table = schemas.getTableInfo(RelationName.fromIndexName("t"));
-        var dateRef = table.getReference(new ColumnIdent("date"));
-        var nameRef = table.getReference(new ColumnIdent("name"));
+        var dateRef = table.getReference(ColumnIdent.of("date"));
+        var nameRef = table.getReference(ColumnIdent.of("name"));
         assertThat(nameRef.oid()).isGreaterThan(dateRef.oid());
     }
 

--- a/server/src/test/java/io/crate/metadata/ColumnIdentTest.java
+++ b/server/src/test/java/io/crate/metadata/ColumnIdentTest.java
@@ -39,32 +39,32 @@ public class ColumnIdentTest {
 
     @Test
     public void testSqlFqn() throws Exception {
-        ColumnIdent ident = new ColumnIdent("foo", Arrays.asList("x", "y", "z"));
+        ColumnIdent ident = ColumnIdent.of("foo", Arrays.asList("x", "y", "z"));
         assertThat(ident.sqlFqn()).isEqualTo("foo['x']['y']['z']");
 
-        ident = new ColumnIdent("a");
+        ident = ColumnIdent.of("a");
         assertThat(ident.sqlFqn()).isEqualTo("a");
 
-        ident = new ColumnIdent("a", Collections.singletonList(""));
+        ident = ColumnIdent.of("a", Collections.singletonList(""));
         assertThat(ident.sqlFqn()).isEqualTo("a['']");
 
-        ident = new ColumnIdent("a.b", Collections.singletonList("c"));
+        ident = ColumnIdent.of("a.b", Collections.singletonList("c"));
         assertThat(ident.sqlFqn()).isEqualTo("a.b['c']");
     }
 
     @Test
     public void testShiftRight() throws Exception {
-        assertThat(new ColumnIdent("foo", "bar").shiftRight()).isEqualTo(new ColumnIdent("bar"));
-        assertThat(new ColumnIdent("foo", Arrays.asList("x", "y", "z")).shiftRight()).isEqualTo(new ColumnIdent("x", Arrays.asList("y", "z")));
-        assertThat(new ColumnIdent("foo").shiftRight(), Matchers.nullValue());
+        assertThat(ColumnIdent.of("foo", "bar").shiftRight()).isEqualTo(ColumnIdent.of("bar"));
+        assertThat(ColumnIdent.of("foo", Arrays.asList("x", "y", "z")).shiftRight()).isEqualTo(ColumnIdent.of("x", Arrays.asList("y", "z")));
+        assertThat(ColumnIdent.of("foo").shiftRight(), Matchers.nullValue());
     }
 
     @Test
     public void testIsChildOf() throws Exception {
-        ColumnIdent root = new ColumnIdent("root");
-        ColumnIdent rootX = new ColumnIdent("root", "x");
-        ColumnIdent rootXY = new ColumnIdent("root", Arrays.asList("x", "y"));
-        ColumnIdent rootYX = new ColumnIdent("root", Arrays.asList("y", "x"));
+        ColumnIdent root = ColumnIdent.of("root");
+        ColumnIdent rootX = ColumnIdent.of("root", "x");
+        ColumnIdent rootXY = ColumnIdent.of("root", Arrays.asList("x", "y"));
+        ColumnIdent rootYX = ColumnIdent.of("root", Arrays.asList("y", "x"));
 
         assertThat(root.isChildOf(root)).isFalse();
 
@@ -78,29 +78,29 @@ public class ColumnIdentTest {
 
     @Test
     public void testPrepend() throws Exception {
-        ColumnIdent foo = new ColumnIdent("foo");
-        assertThat(foo.prepend(DocSysColumns.DOC.name())).isEqualTo(new ColumnIdent(DocSysColumns.DOC.name(), "foo"));
+        ColumnIdent foo = ColumnIdent.of("foo");
+        assertThat(foo.prepend(DocSysColumns.DOC.name())).isEqualTo(ColumnIdent.of(DocSysColumns.DOC.name(), "foo"));
 
-        ColumnIdent fooBar = new ColumnIdent("foo", "bar");
-        assertThat(fooBar.prepend("x")).isEqualTo(new ColumnIdent("x", Arrays.asList("foo", "bar")));
+        ColumnIdent fooBar = ColumnIdent.of("foo", "bar");
+        assertThat(fooBar.prepend("x")).isEqualTo(ColumnIdent.of("x", Arrays.asList("foo", "bar")));
     }
 
     @Test
     public void test_get_parents() throws Exception {
-        assertThat(new ColumnIdent("foo").parents()).hasSize(0);
-        assertThat(new ColumnIdent("foo", "x").parents()).containsExactly(
-            new ColumnIdent("foo")
+        assertThat(ColumnIdent.of("foo").parents()).hasSize(0);
+        assertThat(ColumnIdent.of("foo", "x").parents()).containsExactly(
+            ColumnIdent.of("foo")
         );
 
-        assertThat(new ColumnIdent("foo", List.of("x", "y")).parents()).containsExactly(
-            new ColumnIdent("foo", "x"),
-            new ColumnIdent("foo")
+        assertThat(ColumnIdent.of("foo", List.of("x", "y")).parents()).containsExactly(
+            ColumnIdent.of("foo", "x"),
+            ColumnIdent.of("foo")
         );
 
-        assertThat(new ColumnIdent("foo", List.of("x", "y", "z")).parents()).containsExactly(
-            new ColumnIdent("foo", List.of("x", "y")),
-            new ColumnIdent("foo", "x"),
-            new ColumnIdent("foo")
+        assertThat(ColumnIdent.of("foo", List.of("x", "y", "z")).parents()).containsExactly(
+            ColumnIdent.of("foo", List.of("x", "y")),
+            ColumnIdent.of("foo", "x"),
+            ColumnIdent.of("foo")
         );
     }
 
@@ -152,16 +152,16 @@ public class ColumnIdentTest {
 
     @Test
     public void test_replace_paths() {
-        var a = new ColumnIdent("a");
-        var b = new ColumnIdent("b");
-        var aa = new ColumnIdent("a", List.of("a"));
-        var ba = new ColumnIdent("b", List.of("a"));
-        var ab = new ColumnIdent("a", List.of("b"));
-        var bb = new ColumnIdent("b", List.of("b"));
-        var aaa = new ColumnIdent("a", List.of("a", "a"));
-        var baa = new ColumnIdent("b", List.of("a", "a"));
-        var aba = new ColumnIdent("a", List.of("b", "a"));
-        var aab = new ColumnIdent("a", List.of("a", "b"));
+        var a = ColumnIdent.of("a");
+        var b = ColumnIdent.of("b");
+        var aa = ColumnIdent.of("a", List.of("a"));
+        var ba = ColumnIdent.of("b", List.of("a"));
+        var ab = ColumnIdent.of("a", List.of("b"));
+        var bb = ColumnIdent.of("b", List.of("b"));
+        var aaa = ColumnIdent.of("a", List.of("a", "a"));
+        var baa = ColumnIdent.of("b", List.of("a", "a"));
+        var aba = ColumnIdent.of("a", List.of("b", "a"));
+        var aab = ColumnIdent.of("a", List.of("a", "b"));
 
         assertThat(a.replacePrefix(a)).isEqualTo(a);
         assertThat(a.replacePrefix(b)).isEqualTo(b);

--- a/server/src/test/java/io/crate/metadata/DocReferencesTest.java
+++ b/server/src/test/java/io/crate/metadata/DocReferencesTest.java
@@ -86,7 +86,7 @@ public class DocReferencesTest {
         var references = List.of(stringRef("name"), stringRef("first_name"));
         var referenceMap = references.stream()
                 .collect(Collectors.toMap(Reference::column, reference -> reference));
-        var indexReference = new IndexReference.Builder(new ReferenceIdent(RELATION_ID, new ColumnIdent("ft")))
+        var indexReference = new IndexReference.Builder(new ReferenceIdent(RELATION_ID, ColumnIdent.of("ft")))
                 .sources(List.of("name", "first_name"))
                 .build(referenceMap);
         long[] oid = new long[1];

--- a/server/src/test/java/io/crate/metadata/GeneratedReferenceTest.java
+++ b/server/src/test/java/io/crate/metadata/GeneratedReferenceTest.java
@@ -55,7 +55,7 @@ public class GeneratedReferenceTest extends CrateDummyClusterServiceUnitTest {
         t1Info = executor.schemas().getTableInfo(T1);
 
         DocTableRelation tableRelation = new DocTableRelation(t1Info);
-        tableRelation.getField(new ColumnIdent("a"));   // allocate field so it can be resolved
+        tableRelation.getField(ColumnIdent.of("a"));   // allocate field so it can be resolved
         expressions = new SqlExpressions(Collections.emptyMap(), tableRelation);
     }
 

--- a/server/src/test/java/io/crate/metadata/IndexReferenceTest.java
+++ b/server/src/test/java/io/crate/metadata/IndexReferenceTest.java
@@ -72,9 +72,9 @@ public class IndexReferenceTest extends CrateDummyClusterServiceUnitTest {
             );
 
         DocTableInfo table = e.resolveTableInfo("tbl");
-        IndexReference reference = table.indexColumn(new ColumnIdent("title_desc_fulltext"));
-        var titleRef = table.getReference(new ColumnIdent("title"));
-        var descRef = table.getReference(new ColumnIdent("description"));
+        IndexReference reference = table.indexColumn(ColumnIdent.of("title_desc_fulltext"));
+        var titleRef = table.getReference(ColumnIdent.of("title"));
+        var descRef = table.getReference(ColumnIdent.of("description"));
 
         Map<String, Object> mapping = reference.toMapping(reference.position());
         assertThat(mapping)

--- a/server/src/test/java/io/crate/metadata/MapBackedRefResolverTest.java
+++ b/server/src/test/java/io/crate/metadata/MapBackedRefResolverTest.java
@@ -40,10 +40,10 @@ public class MapBackedRefResolverTest {
     @Test
     public void testGetImplementation() throws Exception {
         ReferenceResolver<NestableInput<?>> refResolver = new MapBackedRefResolver(
-            Collections.singletonMap(new ColumnIdent("obj"), mock(NestableInput.class)));
+            Collections.singletonMap(ColumnIdent.of("obj"), mock(NestableInput.class)));
         NestableInput<?> implementation = refResolver.getImplementation(
             new SimpleReference(
-                new ReferenceIdent(USERS_TI, new ColumnIdent("obj", Arrays.asList("x", "z"))),
+                new ReferenceIdent(USERS_TI, ColumnIdent.of("obj", Arrays.asList("x", "z"))),
                 RowGranularity.DOC,
                 DataTypes.STRING,
                 0,

--- a/server/src/test/java/io/crate/metadata/ReferenceTest.java
+++ b/server/src/test/java/io/crate/metadata/ReferenceTest.java
@@ -144,7 +144,7 @@ public class ReferenceTest extends CrateDummyClusterServiceUnitTest {
         SQLExecutor e = SQLExecutor.of(clusterService)
             .addTable("create table tbl (xs varchar(40))");
         DocTableInfo table = e.resolveTableInfo("tbl");
-        Reference reference = table.getReference(new ColumnIdent("xs"));
+        Reference reference = table.getReference(ColumnIdent.of("xs"));
         Map<String, Object> mapping = reference.toMapping(reference.position());
         assertThat(mapping)
             .containsEntry("length_limit", 40)
@@ -163,7 +163,7 @@ public class ReferenceTest extends CrateDummyClusterServiceUnitTest {
         SQLExecutor e = SQLExecutor.of(clusterService)
             .addTable("create table tbl (xs string storage with (columnstore = false))");
         DocTableInfo table = e.resolveTableInfo("tbl");
-        Reference reference = table.getReference(new ColumnIdent("xs"));
+        Reference reference = table.getReference(ColumnIdent.of("xs"));
         Map<String, Object> mapping = reference.toMapping(reference.position());
         assertThat(mapping)
             .containsEntry("position", 1)
@@ -182,7 +182,7 @@ public class ReferenceTest extends CrateDummyClusterServiceUnitTest {
         SQLExecutor e = SQLExecutor.of(clusterService)
                 .addTable("create table tbl (xs float storage with (columnstore = false))");
         DocTableInfo table = e.resolveTableInfo("tbl");
-        Reference reference = table.getReference(new ColumnIdent("xs"));
+        Reference reference = table.getReference(ColumnIdent.of("xs"));
         Map<String, Object> mapping = reference.toMapping(reference.position());
         assertThat(mapping)
             .containsEntry("position", 1)
@@ -201,7 +201,7 @@ public class ReferenceTest extends CrateDummyClusterServiceUnitTest {
         SQLExecutor e = SQLExecutor.of(clusterService)
             .addTable("create table tbl (xs string default 'foo')");
         DocTableInfo table = e.resolveTableInfo("tbl");
-        Reference reference = table.getReference(new ColumnIdent("xs"));
+        Reference reference = table.getReference(ColumnIdent.of("xs"));
         Map<String, Object> mapping = reference.toMapping(reference.position());
         assertThat(mapping)
             .containsEntry("position", 1)

--- a/server/src/test/java/io/crate/metadata/SchemasITest.java
+++ b/server/src/test/java/io/crate/metadata/SchemasITest.java
@@ -72,8 +72,8 @@ public class SchemasITest extends IntegTestCase {
 
         assertThat(ti.columns()).hasSize(3);
         assertThat(ti.primaryKey()).hasSize(1);
-        assertThat(ti.primaryKey().get(0)).isEqualTo(new ColumnIdent("id"));
-        assertThat(ti.clusteredBy()).isEqualTo(new ColumnIdent("id"));
+        assertThat(ti.primaryKey().get(0)).isEqualTo(ColumnIdent.of("id"));
+        assertThat(ti.clusteredBy()).isEqualTo(ColumnIdent.of("id"));
         List<CheckConstraint<Symbol>> checkConstraints = ti.checkConstraints();
         assertThat(checkConstraints.size()).isEqualTo(1);
         assertThat("not_miguel").isEqualTo(checkConstraints.get(0).name());

--- a/server/src/test/java/io/crate/metadata/SysNodesTableInfoTest.java
+++ b/server/src/test/java/io/crate/metadata/SysNodesTableInfoTest.java
@@ -68,7 +68,7 @@ public class SysNodesTableInfoTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void test_column_that_is_a_child_of_an_array_has_array_type_on_select() {
         var table = SysNodesTableInfo.INSTANCE;
-        Reference ref = table.getReference(new ColumnIdent("fs", List.of("data", "path")));
+        Reference ref = table.getReference(ColumnIdent.of("fs", List.of("data", "path")));
         assertThat(ref.valueType()).isEqualTo(new ArrayType<>(DataTypes.STRING));
 
         SQLExecutor e = SQLExecutor.builder(clusterService).build();
@@ -79,7 +79,7 @@ public class SysNodesTableInfoTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void test_fs_data_is_a_object_array() {
         var table = SysNodesTableInfo.INSTANCE;
-        Reference ref = table.getReference(new ColumnIdent("fs", "data"));
+        Reference ref = table.getReference(ColumnIdent.of("fs", "data"));
         assertThat(ref.valueType().id()).isEqualTo(ArrayType.ID);
         assertThat(((ArrayType<?>) ref.valueType()).innerType().id()).isEqualTo(ObjectType.ID);
     }

--- a/server/src/test/java/io/crate/metadata/SystemTableTest.java
+++ b/server/src/test/java/io/crate/metadata/SystemTableTest.java
@@ -46,18 +46,18 @@ public class SystemTableTest {
             .build();
 
         assertThat(table.columns()).satisfiesExactly(isReference("obj_a"));
-        assertThat(table.getReference(new ColumnIdent("obj_a", List.of("obj_b", "x"))))
+        assertThat(table.getReference(ColumnIdent.of("obj_a", List.of("obj_b", "x"))))
             .isReference().hasName("obj_a['obj_b']['x']");
 
-        var x = table.expressions().get(new ColumnIdent("obj_a", List.of("obj_b", "x"))).create();
+        var x = table.expressions().get(ColumnIdent.of("obj_a", List.of("obj_b", "x"))).create();
         x.setNextRow(null);
         assertThat(x.value()).isEqualTo(1);
 
-        var objB = table.expressions().get(new ColumnIdent("obj_a", "obj_b")).create();
+        var objB = table.expressions().get(ColumnIdent.of("obj_a", "obj_b")).create();
         objB.setNextRow(null);
         assertThat(objB.value()).isEqualTo(Map.of("x", 1));
 
-        var objA = table.expressions().get(new ColumnIdent("obj_a")).create();
+        var objA = table.expressions().get(ColumnIdent.of("obj_a")).create();
         objA.setNextRow(null);
         System.out.println(objA.value());
         assertThat(objA.value()).isEqualTo(Map.of("obj_b", Map.of("x", 1)));
@@ -83,22 +83,22 @@ public class SystemTableTest {
                 .add("y", DataTypes.INTEGER, point -> point.y)
             .endObjectArray()
             .build();
-        assertThat(table.getReference(new ColumnIdent("points"))).isReference().hasName("points");
-        var points = table.expressions().get(new ColumnIdent("points")).create();
+        assertThat(table.getReference(ColumnIdent.of("points"))).isReference().hasName("points");
+        var points = table.expressions().get(ColumnIdent.of("points")).create();
         points.setNextRow(null);
         assertThat(points.value()).isEqualTo(
             List.of(
                 Map.of("x", 10, "y", 20),
                 Map.of("x", 30, "y", 40)));
-        assertThat(table.getReference(new ColumnIdent("points", "x")))
+        assertThat(table.getReference(ColumnIdent.of("points", "x")))
             .isReference()
             .hasName("points['x']")
             .hasType(new ArrayType<>(DataTypes.INTEGER));
-        var xs = table.expressions().get(new ColumnIdent("points", "x")).create();
+        var xs = table.expressions().get(ColumnIdent.of("points", "x")).create();
         xs.setNextRow(null);
         assertThat(xs.value()).isEqualTo(List.of(10, 30));
 
-        var ys = table.expressions().get(new ColumnIdent("points", "y")).create();
+        var ys = table.expressions().get(ColumnIdent.of("points", "y")).create();
         ys.setNextRow(null);
         assertThat(ys.value()).isEqualTo(List.of(20, 40));
     }

--- a/server/src/test/java/io/crate/metadata/blob/BlobTableInfoTest.java
+++ b/server/src/test/java/io/crate/metadata/blob/BlobTableInfoTest.java
@@ -51,18 +51,18 @@ public class BlobTableInfoTest extends ESTestCase {
 
     @Test
     public void testGetColumnInfo() throws Exception {
-        Reference foobar = info.getReference(new ColumnIdent("digest"));
+        Reference foobar = info.getReference(ColumnIdent.of("digest"));
         assertNotNull(foobar);
         assertThat(foobar.valueType()).isEqualTo(DataTypes.STRING);
     }
 
     @Test
     public void testPrimaryKey() throws Exception {
-        assertThat(info.primaryKey()).isEqualTo(Collections.singletonList(new ColumnIdent("digest")));
+        assertThat(info.primaryKey()).isEqualTo(Collections.singletonList(ColumnIdent.of("digest")));
     }
 
     @Test
     public void testClusteredBy() throws Exception {
-        assertThat(info.clusteredBy()).isEqualTo(new ColumnIdent("digest"));
+        assertThat(info.clusteredBy()).isEqualTo(ColumnIdent.of("digest"));
     }
 }

--- a/server/src/test/java/io/crate/metadata/doc/DocIndexMetadataTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocIndexMetadataTest.java
@@ -158,7 +158,7 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
         IndexMetadata metadata = getIndexMetadata("test1", builder);
         DocTableInfo table = newTable(metadata, "test1");
 
-        Reference reference = table.getReference(new ColumnIdent("person", Arrays.asList("addresses", "city")));
+        Reference reference = table.getReference(ColumnIdent.of("person", Arrays.asList("addresses", "city")));
         assertThat(reference).isNotNull();
     }
 
@@ -220,10 +220,10 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo table = newTable(metadata, "test1");
         assertThat(table.columns()).hasSize(4);
         assertThat(table).hasSize(20);
-        assertThat(table.getReference(new ColumnIdent("implicit_dynamic")).columnPolicy()).isEqualTo(ColumnPolicy.DYNAMIC);
-        assertThat(table.getReference(new ColumnIdent("explicit_dynamic")).columnPolicy()).isEqualTo(ColumnPolicy.DYNAMIC);
-        assertThat(table.getReference(new ColumnIdent("ignored")).columnPolicy()).isEqualTo(ColumnPolicy.IGNORED);
-        assertThat(table.getReference(new ColumnIdent("strict")).columnPolicy()).isEqualTo(ColumnPolicy.STRICT);
+        assertThat(table.getReference(ColumnIdent.of("implicit_dynamic")).columnPolicy()).isEqualTo(ColumnPolicy.DYNAMIC);
+        assertThat(table.getReference(ColumnIdent.of("explicit_dynamic")).columnPolicy()).isEqualTo(ColumnPolicy.DYNAMIC);
+        assertThat(table.getReference(ColumnIdent.of("ignored")).columnPolicy()).isEqualTo(ColumnPolicy.IGNORED);
+        assertThat(table.getReference(ColumnIdent.of("strict")).columnPolicy()).isEqualTo(ColumnPolicy.STRICT);
     }
 
     @Test
@@ -306,48 +306,48 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
         assertThat(table.columns()).hasSize(11);
         assertThat(table).hasSize(23);
 
-        Reference birthday = table.getReference(new ColumnIdent("person", "birthday"));
+        Reference birthday = table.getReference(ColumnIdent.of("person", "birthday"));
         assertThat(birthday.valueType()).isEqualTo(DataTypes.TIMESTAMPZ);
         assertThat(birthday.indexType()).isEqualTo(IndexType.PLAIN);
         assertThat(birthday.defaultExpression()).isNull();
 
-        Reference integerIndexed = table.getReference(new ColumnIdent("integerIndexed"));
+        Reference integerIndexed = table.getReference(ColumnIdent.of("integerIndexed"));
         assertThat(integerIndexed.indexType()).isEqualTo(IndexType.PLAIN);
         assertThat(integerIndexed.defaultExpression()).isNull();
 
-        Reference integerIndexedBWC = table.getReference(new ColumnIdent("integerIndexedBWC"));
+        Reference integerIndexedBWC = table.getReference(ColumnIdent.of("integerIndexedBWC"));
         assertThat(integerIndexedBWC.indexType()).isEqualTo(IndexType.PLAIN);
         assertThat(integerIndexedBWC.defaultExpression()).isNull();
 
-        Reference integerNotIndexed = table.getReference(new ColumnIdent("integerNotIndexed"));
+        Reference integerNotIndexed = table.getReference(ColumnIdent.of("integerNotIndexed"));
         assertThat(integerNotIndexed.indexType()).isEqualTo(IndexType.NONE);
         assertThat(integerNotIndexed.defaultExpression()).isNull();
 
-        Reference integerNotIndexedBWC = table.getReference(new ColumnIdent("integerNotIndexedBWC"));
+        Reference integerNotIndexedBWC = table.getReference(ColumnIdent.of("integerNotIndexedBWC"));
         assertThat(integerNotIndexedBWC.indexType()).isEqualTo(IndexType.NONE);
         assertThat(integerNotIndexedBWC.defaultExpression()).isNull();
 
-        Reference stringNotIndexed = table.getReference(new ColumnIdent("stringNotIndexed"));
+        Reference stringNotIndexed = table.getReference(ColumnIdent.of("stringNotIndexed"));
         assertThat(stringNotIndexed.indexType()).isEqualTo(IndexType.NONE);
         assertThat(stringNotIndexed.defaultExpression()).isNull();
 
-        Reference stringNotIndexedBWC = table.getReference(new ColumnIdent("stringNotIndexedBWC"));
+        Reference stringNotIndexedBWC = table.getReference(ColumnIdent.of("stringNotIndexedBWC"));
         assertThat(stringNotIndexedBWC.indexType()).isEqualTo(IndexType.NONE);
         assertThat(stringNotIndexedBWC.defaultExpression()).isNull();
 
-        Reference stringNotAnalyzed = table.getReference(new ColumnIdent("stringNotAnalyzed"));
+        Reference stringNotAnalyzed = table.getReference(ColumnIdent.of("stringNotAnalyzed"));
         assertThat(stringNotAnalyzed.indexType()).isEqualTo(IndexType.PLAIN);
         assertThat(stringNotAnalyzed.defaultExpression()).isNull();
 
-        Reference stringNotAnalyzedBWC = table.getReference(new ColumnIdent("stringNotAnalyzedBWC"));
+        Reference stringNotAnalyzedBWC = table.getReference(ColumnIdent.of("stringNotAnalyzedBWC"));
         assertThat(stringNotAnalyzedBWC.indexType()).isEqualTo(IndexType.PLAIN);
         assertThat(stringNotAnalyzedBWC.defaultExpression()).isNull();
 
-        Reference stringAnalyzed = table.getReference(new ColumnIdent("stringAnalyzed"));
+        Reference stringAnalyzed = table.getReference(ColumnIdent.of("stringAnalyzed"));
         assertThat(stringAnalyzed.indexType()).isEqualTo(IndexType.FULLTEXT);
         assertThat(stringAnalyzed.defaultExpression()).isNull();
 
-        Reference stringAnalyzedBWC = table.getReference(new ColumnIdent("stringAnalyzedBWC"));
+        Reference stringAnalyzedBWC = table.getReference(ColumnIdent.of("stringAnalyzedBWC"));
         assertThat(stringAnalyzedBWC.indexType()).isEqualTo(IndexType.FULLTEXT);
         assertThat(stringAnalyzedBWC.defaultExpression()).isNull();
 
@@ -421,35 +421,35 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
         assertThat(table.columns()).hasSize(7);
         assertThat(table).hasSize(17);
 
-        Reference birthday = table.getReference(new ColumnIdent("birthday"));
+        Reference birthday = table.getReference(ColumnIdent.of("birthday"));
         assertThat(birthday.valueType()).isEqualTo(DataTypes.TIMESTAMPZ);
         assertThat(birthday.defaultExpression())
             .isFunction("current_timestamp", List.of(DataTypes.INTEGER));
 
-        Reference integerIndexed = table.getReference(new ColumnIdent("integerIndexed"));
+        Reference integerIndexed = table.getReference(ColumnIdent.of("integerIndexed"));
         assertThat(integerIndexed.indexType()).isEqualTo(IndexType.PLAIN);
         assertThat(integerIndexed.defaultExpression()).isLiteral(1);
 
 
-        Reference integerNotIndexed = table.getReference(new ColumnIdent("integerNotIndexed"));
+        Reference integerNotIndexed = table.getReference(ColumnIdent.of("integerNotIndexed"));
         assertThat(integerNotIndexed.indexType()).isEqualTo(IndexType.NONE);
         assertThat(integerNotIndexed.defaultExpression()).isLiteral(1);
 
-        Reference stringNotIndexed = table.getReference(new ColumnIdent("stringNotIndexed"));
+        Reference stringNotIndexed = table.getReference(ColumnIdent.of("stringNotIndexed"));
         assertThat(stringNotIndexed.indexType()).isEqualTo(IndexType.NONE);
         assertThat(stringNotIndexed.defaultExpression()).isLiteral("default");
 
-        Reference stringNotAnalyzed = table.getReference(new ColumnIdent("stringNotAnalyzed"));
+        Reference stringNotAnalyzed = table.getReference(ColumnIdent.of("stringNotAnalyzed"));
         assertThat(stringNotAnalyzed.indexType()).isEqualTo(IndexType.PLAIN);
         assertThat(stringNotAnalyzed.defaultExpression()).isLiteral("default");
 
-        Reference stringAnalyzed = table.getReference(new ColumnIdent("stringAnalyzed"));
+        Reference stringAnalyzed = table.getReference(ColumnIdent.of("stringAnalyzed"));
         assertThat(stringAnalyzed).isExactlyInstanceOf(IndexReference.class);
         assertThat(stringAnalyzed.indexType()).isEqualTo(IndexType.FULLTEXT);
         assertThat(stringAnalyzed.defaultExpression()).isLiteral("default");
         assertThat(((IndexReference) stringAnalyzed).analyzer()).isEqualTo("standard");
 
-        Reference integerWithCast = table.getReference(new ColumnIdent("integerWithCast"));
+        Reference integerWithCast = table.getReference(ColumnIdent.of("integerWithCast"));
         assertThat(integerWithCast.indexType()).isEqualTo(IndexType.PLAIN);
         assertThat(integerWithCast.defaultExpression().valueType()).isEqualTo(DataTypes.INTEGER);
         assertThat(integerWithCast.defaultExpression().symbolType()).isEqualTo(SymbolType.FUNCTION);
@@ -669,16 +669,16 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
             .endObject();
 
         DocTableInfo table = newTable(getIndexMetadata("test", builder), "test");
-        Reference id = table.getReference(new ColumnIdent("_id"));
+        Reference id = table.getReference(ColumnIdent.of("_id"));
         assertThat(id).isNotNull();
 
-        Reference version = table.getReference(new ColumnIdent("_version"));
+        Reference version = table.getReference(ColumnIdent.of("_version"));
         assertThat(version).isNotNull();
 
-        Reference score = table.getReference(new ColumnIdent("_score"));
+        Reference score = table.getReference(ColumnIdent.of("_score"));
         assertThat(score).isNotNull();
 
-        Reference docId = table.getReference(new ColumnIdent("_docid"));
+        Reference docId = table.getReference(ColumnIdent.of("_docid"));
         assertThat(docId).isNotNull();
     }
 
@@ -718,7 +718,7 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo table = newTable(metadata, "test3");
 
 
-        assertThat(table.primaryKey()).containsExactly(new ColumnIdent("id"));
+        assertThat(table.primaryKey()).containsExactly(ColumnIdent.of("id"));
 
         builder = JsonXContent.builder()
             .startObject()
@@ -911,8 +911,8 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
         IndexMetadata metadata = getIndexMetadata("test_notnull_columns", builder);
         DocTableInfo table = newTable(metadata, "test_notnull_columns");
 
-        ColumnIdent level1 = new ColumnIdent("nested", "level1");
-        ColumnIdent level2 = new ColumnIdent("nested", Arrays.asList("level1", "level2"));
+        ColumnIdent level1 = ColumnIdent.of("nested", "level1");
+        ColumnIdent level2 = ColumnIdent.of("nested", Arrays.asList("level1", "level2"));
         assertThat(table.notNullColumns()).containsExactlyInAnyOrder(level1, level2);
         assertThat(table.getReference(level1).isNullable()).isFalse();
         assertThat(table.getReference(level2).isNullable()).isFalse();
@@ -944,7 +944,7 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo table = newTable(metadata, "test1");
 
         assertThat(table.columns()).hasSize(2);
-        Reference week = table.getReference(new ColumnIdent("week"));
+        Reference week = table.getReference(ColumnIdent.of("week"));
         assertThat(week)
             .isNotNull()
             .isExactlyInstanceOf(GeneratedReference.class);
@@ -979,7 +979,7 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
             .endObject();
 
         DocTableInfo table = newTable(getIndexMetadata("test8", builder), "test8");
-        assertThat(table.clusteredBy()).isEqualTo(new ColumnIdent("id"));
+        assertThat(table.clusteredBy()).isEqualTo(ColumnIdent.of("id"));
 
         builder = JsonXContent.builder()
             .startObject()
@@ -994,7 +994,7 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
             .endObject();
 
         table = newTable(getIndexMetadata("test9", builder), "test9");
-        assertThat(table.clusteredBy()).isEqualTo(new ColumnIdent("_id"));
+        assertThat(table.clusteredBy()).isEqualTo(ColumnIdent.of("_id"));
 
         builder = JsonXContent.builder()
             .startObject()
@@ -1022,7 +1022,7 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
             .endObject();
 
         table = newTable(getIndexMetadata("test10", builder), "test10");
-        assertThat(table.clusteredBy()).isEqualTo(new ColumnIdent("num"));
+        assertThat(table.clusteredBy()).isEqualTo(ColumnIdent.of("num"));
     }
 
     @Test
@@ -1033,7 +1033,7 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
             .endObject()
             .endObject();
         DocTableInfo table = newTable(getIndexMetadata("test11", builder), "test11");
-        assertThat(table.clusteredBy()).isEqualTo(new ColumnIdent("_id"));
+        assertThat(table.clusteredBy()).isEqualTo(ColumnIdent.of("_id"));
     }
 
     @Test
@@ -1045,7 +1045,7 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
             .endObject();
         DocTableInfo table = newTable(getIndexMetadata("test11", builder), "test11");
         assertThat(table.primaryKey()).hasSize(1);
-        assertThat(table.primaryKey().get(0)).isEqualTo(new ColumnIdent("_id"));
+        assertThat(table.primaryKey().get(0)).isEqualTo(ColumnIdent.of("_id"));
         assertThat(table.hasAutoGeneratedPrimaryKey()).isTrue();
     }
 
@@ -1067,7 +1067,7 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
             .endObject();
         DocTableInfo table = newTable(getIndexMetadata("test11", builder), "test11");
         assertThat(table.primaryKey()).hasSize(1);
-        assertThat(table.primaryKey().get(0)).isEqualTo(new ColumnIdent("id"));
+        assertThat(table.primaryKey().get(0)).isEqualTo(ColumnIdent.of("id"));
         assertThat(table.hasAutoGeneratedPrimaryKey()).isFalse();
     }
 
@@ -1121,8 +1121,8 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
                                                                ") partitioned by (date)");
 
         assertThat(table.columns()).hasSize(4);
-        assertThat(table.primaryKey()).containsExactly(new ColumnIdent("id"), new ColumnIdent("date"));
-        assertThat(table.getReference(new ColumnIdent("tags")).valueType()).isEqualTo(
+        assertThat(table.primaryKey()).containsExactly(ColumnIdent.of("id"), ColumnIdent.of("date"));
+        assertThat(table.getReference(ColumnIdent.of("tags")).valueType()).isEqualTo(
             new ArrayType<>(DataTypes.STRING));
     }
 
@@ -1133,7 +1133,7 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
             "id int primary key," +
             "details object as (names array(string))" +
             ") with (number_of_replicas=0)");
-        DataType<?> type = table.getReference(new ColumnIdent("details", "names")).valueType();
+        DataType<?> type = table.getReference(ColumnIdent.of("details", "names")).valueType();
         assertThat(type).isEqualTo(new ArrayType<>(DataTypes.STRING));
     }
 
@@ -1498,10 +1498,10 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testCreateTableWithNestedPrimaryKey() throws Exception {
         DocTableInfo table = getDocIndexMetadataFromStatement("create table t (o object as (x int primary key))");
-        assertThat(table.primaryKey()).containsExactly(new ColumnIdent("o", "x"));
+        assertThat(table.primaryKey()).containsExactly(ColumnIdent.of("o", "x"));
 
         table = getDocIndexMetadataFromStatement("create table t (x object as (y object as (z int primary key)))");
-        assertThat(table.primaryKey()).containsExactly(new ColumnIdent("x", Arrays.asList("y", "z")));
+        assertThat(table.primaryKey()).containsExactly(ColumnIdent.of("x", Arrays.asList("y", "z")));
     }
 
     @Test
@@ -1529,7 +1529,7 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo table = newTable(metadata, "test1");
 
         assertThat(table.columns()).hasSize(2);
-        Reference week = table.getReference(new ColumnIdent("week"));
+        Reference week = table.getReference(ColumnIdent.of("week"));
         assertThat(week)
             .isNotNull()
             .isExactlyInstanceOf(GeneratedReference.class);
@@ -1553,7 +1553,7 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
     public void testColumnWithDefaultExpression() throws Exception {
         DocTableInfo table = getDocIndexMetadataFromStatement("create table t1 (" +
                                                                " ts timestamp with time zone default current_timestamp)");
-        Reference reference = table.getReference(new ColumnIdent("ts"));
+        Reference reference = table.getReference(ColumnIdent.of("ts"));
         assertThat(reference.valueType()).isEqualTo(DataTypes.TIMESTAMPZ);
         assertThat(reference.defaultExpression()).isFunction("current_timestamp");
     }
@@ -1579,8 +1579,8 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo table = newTable(getIndexMetadata("test", builder), "test");
 
         assertThat(table.columns()).hasSize(2);
-        assertThat(table.getReference(new ColumnIdent("tz")).valueType()).isEqualTo(DataTypes.TIMESTAMPZ);
-        assertThat(table.getReference(new ColumnIdent("t")).valueType()).isEqualTo(DataTypes.TIMESTAMP);
+        assertThat(table.getReference(ColumnIdent.of("tz")).valueType()).isEqualTo(DataTypes.TIMESTAMPZ);
+        assertThat(table.getReference(ColumnIdent.of("t")).valueType()).isEqualTo(DataTypes.TIMESTAMP);
     }
 
     @Test
@@ -1622,7 +1622,7 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
         IndexMetadata metadata = getIndexMetadata("test", builder);
         DocTableInfo table = newTable(metadata, "test");
 
-        ObjectType objectType = (ObjectType) table.getReference(new ColumnIdent("object")).valueType();
+        ObjectType objectType = (ObjectType) table.getReference(ColumnIdent.of("object")).valueType();
         assertThat(objectType.resolveInnerType(List.of("nestedString"))).isEqualTo(DataTypes.STRING);
         assertThat(objectType.resolveInnerType(List.of("nestedObject")).id()).isEqualTo(ObjectType.ID);
         assertThat(objectType.resolveInnerType(List.of("nestedObject", "nestedNestedString"))).isEqualTo(DataTypes.STRING);
@@ -1633,7 +1633,7 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo table = getDocIndexMetadataFromStatement(
             "create table tbl (x int, y object as (z geo_shape))");
         assertThat(table.columns()).satisfiesExactlyInAnyOrder(isReference("x"), isReference("y"));
-        assertThat(table.getReference(new ColumnIdent("y", "z"))).isNotNull();
+        assertThat(table.getReference(ColumnIdent.of("y", "z"))).isNotNull();
     }
 
     @Test
@@ -1653,7 +1653,7 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
             .endObject();
         var docIndexMetadata = newTable(getIndexMetadata("test", builder), "test");
 
-        var column = docIndexMetadata.getReference(new ColumnIdent("col"));
+        var column = docIndexMetadata.getReference(ColumnIdent.of("col"));
         assertThat(column).isNotNull();
         assertThat(column.valueType()).isEqualTo(StringType.of(10));
     }
@@ -1661,7 +1661,7 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void test_geo_shape_column_has_generated_expression() throws Exception {
         DocTableInfo table = getDocIndexMetadataFromStatement("create table t (g geo_shape generated always as 'POLYGON (( 5 5, 30 5, 30 30, 5 30, 5 5 ))')");
-        Reference reference = table.getReference(new ColumnIdent("g"));
+        Reference reference = table.getReference(ColumnIdent.of("g"));
         assertThat(reference.valueType()).isEqualTo(DataTypes.GEO_SHAPE);
         GeneratedReference genRef = (GeneratedReference) reference;
         assertThat(genRef.formattedGeneratedExpression()).isEqualTo("'POLYGON (( 5 5, 30 5, 30 30, 5 30, 5 5 ))'");
@@ -1670,7 +1670,7 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void test_geo_shape_column_has_default_expression() throws Exception {
         DocTableInfo table = getDocIndexMetadataFromStatement("create table t (g geo_shape default 'POLYGON (( 5 5, 30 5, 30 30, 5 30, 5 5 ))')");
-        Reference reference = table.getReference(new ColumnIdent("g"));
+        Reference reference = table.getReference(ColumnIdent.of("g"));
         assertThat(reference.valueType()).isEqualTo(DataTypes.GEO_SHAPE);
         assertThat(reference.defaultExpression().toString(Style.UNQUALIFIED))
             .isEqualTo("'POLYGON (( 5 5, 30 5, 30 30, 5 30, 5 5 ))'");
@@ -1680,12 +1680,12 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
     public void test_column_of_index_has_nullable_from_real_column() throws Exception {
         var table = getDocIndexMetadataFromStatement(
             "create table tbl (x string, index ft using fulltext (x))");
-        var indexReference = table.indexColumn(new ColumnIdent("ft"));
+        var indexReference = table.indexColumn(ColumnIdent.of("ft"));
         assertThat(indexReference.columns().get(0).isNullable()).isTrue();
 
         table = getDocIndexMetadataFromStatement(
             "create table tbl (x string not null, index ft using fulltext (x))");
-        indexReference = table.indexColumn(new ColumnIdent("ft"));
+        indexReference = table.indexColumn(ColumnIdent.of("ft"));
         assertThat(indexReference.columns().get(0).isNullable()).isFalse();
     }
 

--- a/server/src/test/java/io/crate/metadata/sys/SysClusterTableInfoTest.java
+++ b/server/src/test/java/io/crate/metadata/sys/SysClusterTableInfoTest.java
@@ -38,19 +38,19 @@ public class SysClusterTableInfoTest extends CrateDummyClusterServiceUnitTest {
         var clusterTable = SysClusterTableInfo.of(clusterService);
 
         StaticTableReferenceResolver<Void> refResolver = new StaticTableReferenceResolver<>(clusterTable.expressions());
-        NestableCollectExpression<Void, ?> expiryDate = refResolver.getImplementation(clusterTable.getReference(new ColumnIdent(
+        NestableCollectExpression<Void, ?> expiryDate = refResolver.getImplementation(clusterTable.getReference(ColumnIdent.of(
             "license",
             "expiry_date")));
         expiryDate.setNextRow(null);
         assertThat(expiryDate.value(), Matchers.nullValue());
 
-        NestableCollectExpression<Void, ?> issuedTo = refResolver.getImplementation(clusterTable.getReference(new ColumnIdent(
+        NestableCollectExpression<Void, ?> issuedTo = refResolver.getImplementation(clusterTable.getReference(ColumnIdent.of(
             "license",
             "issued_to")));
         issuedTo.setNextRow(null);
         assertThat(issuedTo.value(), Matchers.nullValue());
 
-        NestableCollectExpression<Void, ?> maxNodes = refResolver.getImplementation(clusterTable.getReference(new ColumnIdent(
+        NestableCollectExpression<Void, ?> maxNodes = refResolver.getImplementation(clusterTable.getReference(ColumnIdent.of(
             "license",
             "max_nodes")));
         maxNodes.setNextRow(null);

--- a/server/src/test/java/io/crate/metadata/sys/SysOperationsLogTableInfoTest.java
+++ b/server/src/test/java/io/crate/metadata/sys/SysOperationsLogTableInfoTest.java
@@ -37,7 +37,7 @@ public class SysOperationsLogTableInfoTest {
     @Test
     public void test_job_id_returns_job_id_of_operation_context_log() {
         var table = SysOperationsLogTableInfo.INSTANCE;
-        var expressionFactory = table.expressions().get(new ColumnIdent("job_id"));
+        var expressionFactory = table.expressions().get(ColumnIdent.of("job_id"));
         var expression = expressionFactory.create();
 
         int id = 1;

--- a/server/src/test/java/io/crate/planner/RoutingBuilderTest.java
+++ b/server/src/test/java/io/crate/planner/RoutingBuilderTest.java
@@ -65,7 +65,7 @@ public class RoutingBuilderTest extends CrateDummyClusterServiceUnitTest {
         WhereClause whereClause = new WhereClause(
             new Function(
                 EqOperator.SIGNATURE,
-                List.of(tableInfo.getReference(new ColumnIdent("id")), Literal.of(2)),
+                List.of(tableInfo.getReference(ColumnIdent.of("id")), Literal.of(2)),
                 EqOperator.RETURN_TYPE
             ));
 

--- a/server/src/test/java/io/crate/planner/operators/GroupHashAggregateTest.java
+++ b/server/src/test/java/io/crate/planner/operators/GroupHashAggregateTest.java
@@ -61,8 +61,8 @@ public class GroupHashAggregateTest extends CrateDummyClusterServiceUnitTest {
             numDocs,
             DataTypes.INTEGER.fixedSize(),
             Map.of(
-                new ColumnIdent("x"), columnStats,
-                new ColumnIdent("i"), columnStats
+                ColumnIdent.of("x"), columnStats,
+                ColumnIdent.of("i"), columnStats
             )
         );
         tableStats = new TableStats();

--- a/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -75,7 +75,7 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
         TableInfo t1 = sqlExecutor.resolveTableInfo("t1");
         ColumnStats<Integer> columnStats = new ColumnStats<>(
             0.0, 50L, 2, DataTypes.INTEGER, MostCommonValues.empty(), List.of());
-        sqlExecutor.updateTableStats(Map.of(t1.ident(), new Stats(2L, 100L, Map.of(new ColumnIdent("x"), columnStats))));
+        sqlExecutor.updateTableStats(Map.of(t1.ident(), new Stats(2L, 100L, Map.of(ColumnIdent.of("x"), columnStats))));
 
         // stats present -> size derived FROM them (although bogus fake stats in this case)
         plan = plan("SELECT x FROM t1");

--- a/server/src/test/java/io/crate/planner/operators/SelectivityFunctionsCalculationTest.java
+++ b/server/src/test/java/io/crate/planner/operators/SelectivityFunctionsCalculationTest.java
@@ -49,7 +49,7 @@ public class SelectivityFunctionsCalculationTest extends CrateDummyClusterServic
             .boxed()
             .collect(Collectors.toList());
         ColumnStats<Integer> cs = StatsUtils.statsFromValues(DataTypes.INTEGER, numbers);
-        columnStats.put(new ColumnIdent("x"), cs);
+        columnStats.put(ColumnIdent.of("x"), cs);
         SQLExecutor e = SQLExecutor.of(clusterService)
             .addTable("create table doc.tbl (x int)");
 
@@ -75,7 +75,7 @@ public class SelectivityFunctionsCalculationTest extends CrateDummyClusterServic
         Stats stats = new Stats(
             numDocs,
             DataTypes.INTEGER.fixedSize(),
-            Map.of(new ColumnIdent("x"), cs)
+            Map.of(ColumnIdent.of("x"), cs)
         );
 
         e.updateTableStats(Map.of(new RelationName("doc", "tbl"), stats));

--- a/server/src/test/java/io/crate/planner/optimizer/costs/PlanStatsTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/costs/PlanStatsTest.java
@@ -189,7 +189,7 @@ public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
 
         TableStats tableStats = new TableStats();
         Map<ColumnIdent, ColumnStats<?>> columnStats = Map.of(
-            new ColumnIdent("x"),
+            ColumnIdent.of("x"),
             new ColumnStats<>(
                 0,
                 DataTypes.INTEGER.fixedSize(),
@@ -198,7 +198,7 @@ public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
                 MostCommonValues.empty(),
                 List.of()
             ),
-            new ColumnIdent("y"),
+            ColumnIdent.of("y"),
             new ColumnStats<>(
                 0,
                 DataTypes.INTEGER.fixedSize(),
@@ -245,8 +245,8 @@ public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
         TableStats tableStats = new TableStats();
         tableStats.updateTableStats(
             Map.of(
-                aDoc.ident(), new Stats(9L, 9 * DataTypes.INTEGER.fixedSize(), Map.of(new ColumnIdent("x"), xStats)),
-                bDoc.ident(), new Stats(2L, 2 * DataTypes.INTEGER.fixedSize(), Map.of(new ColumnIdent("y"), yStats))
+                aDoc.ident(), new Stats(9L, 9 * DataTypes.INTEGER.fixedSize(), Map.of(ColumnIdent.of("x"), xStats)),
+                bDoc.ident(), new Stats(2L, 2 * DataTypes.INTEGER.fixedSize(), Map.of(ColumnIdent.of("y"), yStats))
             )
         );
 
@@ -285,7 +285,7 @@ public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
 
         TableStats tableStats = new TableStats();
         Map<ColumnIdent, ColumnStats<?>> columnStats = Map.of(
-            new ColumnIdent("x"),
+            ColumnIdent.of("x"),
             new ColumnStats<>(
                 0.0,
                 DataTypes.INTEGER.fixedSize(),

--- a/server/src/test/java/io/crate/planner/selectivity/SelectivityFunctionsTest.java
+++ b/server/src/test/java/io/crate/planner/selectivity/SelectivityFunctionsTest.java
@@ -76,7 +76,7 @@ public class SelectivityFunctionsTest extends CrateDummyClusterServiceUnitTest {
             .boxed()
             .collect(Collectors.toList());
         var columnStats = StatsUtils.statsFromValues(DataTypes.INTEGER, numbers);
-        statsByColumn.put(new ColumnIdent("x"), columnStats);
+        statsByColumn.put(ColumnIdent.of("x"), columnStats);
         Stats stats = new Stats(20_000, 16, statsByColumn);
         assertThat(SelectivityFunctions.estimateNumRows(nodeContext, txnCtx, stats, query, null)).isEqualTo(1L);
     }
@@ -90,7 +90,7 @@ public class SelectivityFunctionsTest extends CrateDummyClusterServiceUnitTest {
             .collect(Collectors.toList());
         var columnStats = StatsUtils.statsFromValues(DataTypes.INTEGER, numbers);
         var statsByColumn = new HashMap<ColumnIdent, ColumnStats<?>>();
-        statsByColumn.put(new ColumnIdent("x"), columnStats);
+        statsByColumn.put(ColumnIdent.of("x"), columnStats);
         Stats stats = new Stats(20_000, 16, statsByColumn);
         assertThat(estimate(stats, query)).isEqualTo(0L);
     }
@@ -104,7 +104,7 @@ public class SelectivityFunctionsTest extends CrateDummyClusterServiceUnitTest {
             IntStream.range(11, 15).boxed().collect(Collectors.toList())
         );
         var columnStats = StatsUtils.statsFromValues(DataTypes.INTEGER, numbers);
-        var statsByColumn = Map.<ColumnIdent, ColumnStats<?>>of(new ColumnIdent("x"), columnStats);
+        var statsByColumn = Map.<ColumnIdent, ColumnStats<?>>of(ColumnIdent.of("x"), columnStats);
         Stats stats = new Stats(numbers.size(), 16, statsByColumn);
         assertThat(estimate(stats, query)).isEqualTo(3L);
     }
@@ -119,7 +119,7 @@ public class SelectivityFunctionsTest extends CrateDummyClusterServiceUnitTest {
         );
         var columnStats = StatsUtils.statsFromValues(DataTypes.INTEGER, numbers);
         double frequencyOf10 = columnStats.mostCommonValues().frequencies()[0];
-        var statsByColumn = Map.<ColumnIdent, ColumnStats<?>>of(new ColumnIdent("x"), columnStats);
+        var statsByColumn = Map.<ColumnIdent, ColumnStats<?>>of(ColumnIdent.of("x"), columnStats);
         Stats stats = new Stats(numbers.size(), 16, statsByColumn);
         assertThat(estimate(stats, query, new Row1(10)))
             .isEqualTo((long)(frequencyOf10 * numbers.size()));
@@ -133,7 +133,7 @@ public class SelectivityFunctionsTest extends CrateDummyClusterServiceUnitTest {
             .boxed()
             .collect(Collectors.toList());
         var columnStats = StatsUtils.statsFromValues(DataTypes.INTEGER, numbers);
-        Stats stats = new Stats(20_000, 16, Map.of(new ColumnIdent("x"), columnStats));
+        Stats stats = new Stats(20_000, 16, Map.of(ColumnIdent.of("x"), columnStats));
         assertThat(estimate(stats, query)).isEqualTo(19998L);
     }
 
@@ -148,7 +148,7 @@ public class SelectivityFunctionsTest extends CrateDummyClusterServiceUnitTest {
         listWithNulls.add(null);
         var columnStats = StatsUtils.statsFromValues(DataTypes.INTEGER, listWithNulls);
         assertThat(columnStats.nullFraction()).isEqualTo(0.5);
-        Stats stats = new Stats(100, 16, Map.of(new ColumnIdent("x"), columnStats));
+        Stats stats = new Stats(100, 16, Map.of(ColumnIdent.of("x"), columnStats));
         assertThat(estimate(stats, query)).isEqualTo(50L);
     }
 
@@ -182,9 +182,9 @@ public class SelectivityFunctionsTest extends CrateDummyClusterServiceUnitTest {
             .as("Test case depends on most common values")
             .isFalse();
         Map<ColumnIdent, ColumnStats<?>> columnStats = Map.of(
-            new ColumnIdent("x"),
+            ColumnIdent.of("x"),
             xStats,
-            new ColumnIdent("y"),
+            ColumnIdent.of("y"),
             yStats
         );
         Stats stats = new Stats(numTotalRows, 32, columnStats);
@@ -205,7 +205,7 @@ public class SelectivityFunctionsTest extends CrateDummyClusterServiceUnitTest {
         }
         SqlExpressions expressions = new SqlExpressions(T3.sources(clusterService));
         ColumnStats<Integer> xStats = StatsUtils.statsFromValues(DataTypes.INTEGER, xValues);
-        Map<ColumnIdent, ColumnStats<?>> columnStats = Map.of(new ColumnIdent("x"), xStats);
+        Map<ColumnIdent, ColumnStats<?>> columnStats = Map.of(ColumnIdent.of("x"), xStats);
         Stats stats = new Stats(numTotalRows, DataTypes.INTEGER.fixedSize(), columnStats);
 
         assertThat(estimate(stats, expressions.asSymbol("x < 5"))).isEqualTo(30);

--- a/server/src/test/java/io/crate/protocols/ErrorMappingTest.java
+++ b/server/src/test/java/io/crate/protocols/ErrorMappingTest.java
@@ -54,7 +54,7 @@ public class ErrorMappingTest {
 
     @Test
     public void test_ambiguous_column_exception_error_mapping() {
-        isError(new AmbiguousColumnException(new ColumnIdent("x"), createReference("x", DataTypes.STRING)),
+        isError(new AmbiguousColumnException(ColumnIdent.of("x"), createReference("x", DataTypes.STRING)),
                 is("Column \"x\" is ambiguous"),
                 AMBIGUOUS_COLUMN,
                 BAD_REQUEST,

--- a/server/src/testFixtures/java/io/crate/testing/TestingHelpers.java
+++ b/server/src/testFixtures/java/io/crate/testing/TestingHelpers.java
@@ -230,7 +230,7 @@ public class TestingHelpers {
     }
 
     public static Reference createReference(String columnName, DataType<?> dataType) {
-        return createReference("dummyTable", new ColumnIdent(columnName), dataType);
+        return createReference("dummyTable", ColumnIdent.of(columnName), dataType);
     }
 
     public static Reference createReference(ColumnIdent columnIdent, DataType<?> dataType) {

--- a/server/src/testFixtures/java/io/crate/types/DataTypeTestCase.java
+++ b/server/src/testFixtures/java/io/crate/types/DataTypeTestCase.java
@@ -82,7 +82,7 @@ public abstract class DataTypeTestCase<T> extends CrateDummyClusterServiceUnitTe
             .addTable("create table tbl (id int, x " + dataDef.definition + ")");
 
         DocTableInfo table = sqlExecutor.resolveTableInfo("tbl");
-        Reference reference = table.getReference(new ColumnIdent("x"));
+        Reference reference = table.getReference(ColumnIdent.of("x"));
         assertThat(reference).isNotNull();
 
         try (var indexEnv = new IndexEnv(
@@ -146,7 +146,7 @@ public abstract class DataTypeTestCase<T> extends CrateDummyClusterServiceUnitTe
 
         Supplier<T> dataGenerator = DataTypeTesting.getDataGenerator(type);
         DocTableInfo table = sqlExecutor.resolveTableInfo("tbl");
-        Reference reference = table.getReference(new ColumnIdent("x"));
+        Reference reference = table.getReference(ColumnIdent.of("x"));
         assertThat(reference).isNotNull();
 
         T value = dataGenerator.get();

--- a/server/src/testFixtures/java/org/elasticsearch/index/engine/TranslogHandler.java
+++ b/server/src/testFixtures/java/org/elasticsearch/index/engine/TranslogHandler.java
@@ -71,7 +71,7 @@ public class TranslogHandler implements Engine.TranslogRecoveryRunner {
             null);
         DocTableInfo table = new DocTableInfo(
             relation,
-            Map.of(new ColumnIdent("value"), column),
+            Map.of(ColumnIdent.of("value"), column),
             Map.of(),
             Map.of(),
             null,


### PR DESCRIPTION
I'm not entirely sure if this is worth changing.

Splits `ColumnIdent` into two internal representations: `Col0` and `ColN`, where `Col0` lacks the `path` field:

```
***** Hotspot Layout Simulation (JDK 15, 64-bit model, compressed references, compressed classes, 8-byte aligned)
io.crate.metadata.ColumnIdent$Col0 object internals:
OFF  SZ               TYPE DESCRIPTION               VALUE
  0   8                    (object header: mark)     N/A
  8   4                    (object header: class)    N/A
 12   4   java.lang.String Col0.name                 N/A
Instance size: 16 bytes
Space losses: 0 bytes internal + 0 bytes external = 0 bytes total

***** Hotspot Layout Simulation (JDK 15, 64-bit model, NO compressed references, compressed classes, 8-byte aligned)
io.crate.metadata.ColumnIdent$Col0 object internals:
OFF  SZ               TYPE DESCRIPTION               VALUE
  0   8                    (object header: mark)     N/A
  8   4                    (object header: class)    N/A
 12   4                    (alignment/padding gap)   
 16   8   java.lang.String Col0.name                 N/A
Instance size: 24 bytes
Space losses: 4 bytes internal + 0 bytes external = 4 bytes total
```



```
***** Hotspot Layout Simulation (JDK 15, 64-bit model, compressed references, compressed classes, 8-byte aligned)
io.crate.metadata.ColumnIdent$ColN object internals:
OFF  SZ               TYPE DESCRIPTION               VALUE
  0   8                    (object header: mark)     N/A
  8   4                    (object header: class)    N/A
 12   4   java.lang.String ColN.name                 N/A
 16   4     java.util.List ColN.path                 N/A
 20   4                    (object alignment gap)
Instance size: 24 bytes
Space losses: 0 bytes internal + 4 bytes external = 4 bytes total

***** Hotspot Layout Simulation (JDK 15, 64-bit model, NO compressed references, compressed classes, 8-byte aligned)
io.crate.metadata.ColumnIdent$ColN object internals:
OFF  SZ               TYPE DESCRIPTION               VALUE
  0   8                    (object header: mark)     N/A
  8   4                    (object header: class)    N/A
 12   4                    (alignment/padding gap)
 16   8   java.lang.String ColN.name                 N/A
 24   8     java.util.List ColN.path                 N/A
Instance size: 32 bytes
Space losses: 4 bytes internal + 0 bytes external = 4 bytes total
```
