### PR TITLE
Fix joins with foreign tables on multi-node clusters

### DIFF
--- a/docs/appendices/release-notes/5.7.3.rst
+++ b/docs/appendices/release-notes/5.7.3.rst
@@ -48,6 +48,9 @@ See the :ref:`version_5.7.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that resulted in an ``unsupported ExecutionNode`` error if
+  joining a foreign table with another table that's sharded across many nodes.
+
 - Fixed an issue that prevented sub-columns of a view to be shown in the
   ``information_schema.columns`` table if only top-level columns were used in
   the view's SELECT query. Workaround: explicitly select sub-columns in the

--- a/server/src/main/java/io/crate/planner/node/StreamerVisitor.java
+++ b/server/src/main/java/io/crate/planner/node/StreamerVisitor.java
@@ -21,11 +21,14 @@
 
 package io.crate.planner.node;
 
+import java.util.Locale;
+
 import io.crate.Streamer;
 import io.crate.execution.dsl.phases.CountPhase;
 import io.crate.execution.dsl.phases.ExecutionPhase;
 import io.crate.execution.dsl.phases.ExecutionPhaseVisitor;
 import io.crate.execution.dsl.phases.FileUriCollectPhase;
+import io.crate.execution.dsl.phases.ForeignCollectPhase;
 import io.crate.execution.dsl.phases.HashJoinPhase;
 import io.crate.execution.dsl.phases.MergePhase;
 import io.crate.execution.dsl.phases.NestedLoopPhase;
@@ -33,8 +36,6 @@ import io.crate.execution.dsl.phases.PKLookupPhase;
 import io.crate.execution.dsl.phases.RoutedCollectPhase;
 import io.crate.execution.dsl.phases.TableFunctionCollectPhase;
 import io.crate.types.DataTypes;
-
-import java.util.Locale;
 
 /**
  * Get output {@link io.crate.Streamer}s for {@link ExecutionPhase}s
@@ -76,6 +77,11 @@ public class StreamerVisitor {
 
         @Override
         public Streamer<?>[] visitNestedLoopPhase(NestedLoopPhase phase, Void context) {
+            return DataTypes.getStreamers(phase.outputTypes());
+        }
+
+        @Override
+        public Streamer<?>[] visitForeignCollect(ForeignCollectPhase phase, Void context) {
             return DataTypes.getStreamers(phase.outputTypes());
         }
 

--- a/server/src/test/java/io/crate/integrationtests/ForeignDataWrapperITest.java
+++ b/server/src/test/java/io/crate/integrationtests/ForeignDataWrapperITest.java
@@ -315,14 +315,17 @@ public class ForeignDataWrapperITest extends IntegTestCase {
             """;
         execute(stmt);
 
+        execute("create table mountains (name text, country text)");
+        execute("insert into mountains (name, country) values ('Mont Blanc', 'FR/IT'), ('Monte Rosa', 'CH'), ('Dom', 'CH')");
+        execute("refresh table mountains");
         execute(
             """
             SELECT
                 f_summits.mountain,
-                sys_summits.country
+                mountains.country
             FROM
                 doc.summits f_summits
-                INNER JOIN sys.summits sys_summits ON f_summits.mountain = sys_summits.mountain
+                INNER JOIN mountains ON f_summits.mountain = mountains.name
             ORDER BY
                 f_summits.height DESC
             LIMIT 3


### PR DESCRIPTION
The `StreamerVisitor` implementation for `ForeignCollectPhase` was
missing and the existing join test didn't capture it due to using a
system table that always runs non-distributed.
