### PR TITLE
Set proisstrict in pg_proc table

### DIFF
--- a/docs/appendices/release-notes/5.9.0.rst
+++ b/docs/appendices/release-notes/5.9.0.rst
@@ -64,7 +64,9 @@ None
 SQL Standard and PostgreSQL Compatibility
 -----------------------------------------
 
-None
+- The ``proisstrict`` property of the ``pg_catalog.pg_proc`` table now returns
+  true or false depending on if a function always returns null if any call
+  argument is null. Before the property's value was a static ``null``.
 
 Data Types
 ----------

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgProcTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgProcTable.java
@@ -39,6 +39,7 @@ import java.util.Set;
 import io.crate.common.collections.Lists;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.RelationName;
+import io.crate.metadata.Scalar.Feature;
 import io.crate.metadata.SystemTable;
 import io.crate.metadata.functions.Signature;
 import io.crate.protocols.postgres.types.AnyType;
@@ -76,7 +77,7 @@ public final class PgProcTable {
         .add("prokind", STRING, x -> prokind(x.signature))
         .add("prosecdef", BOOLEAN, x -> null)
         .add("proleakproof", BOOLEAN, x -> null)
-        .add("proisstrict", BOOLEAN, x -> null)
+        .add("proisstrict", BOOLEAN, x -> x.signature.hasFeature(Feature.NULLABLE))
         .add("proretset", BOOLEAN, x -> x.returnSetType)
         .add("provolatile", STRING, x -> null)
         .add("proparallel", STRING, x -> null)


### PR DESCRIPTION
From https://www.postgresql.org/docs/current/catalog-pg-proc.html:

> Function returns null if any call argument is null. In that case the function won't actually be called at all. Functions that are not “strict” must be prepared to handle null inputs.