### PR TITLE
Replace deprecated expectedException with assertThatThrownBy

### DIFF
--- a/server/src/main/java/io/crate/expression/scalar/timestamp/TimezoneFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/timestamp/TimezoneFunction.java
@@ -92,7 +92,7 @@ public class TimezoneFunction extends Scalar<Long, Object> {
             zoneId = ZoneId.of(zoneStr);
         } catch (DateTimeException e) {
             throw new IllegalArgumentException(String.format(Locale.ENGLISH,
-                                                             " time zone \"%s\" not recognized",
+                                                             "time zone \"%s\" not recognized",
                                                              zoneStr));
         }
         Number utcTimestamp = (Number) args[1].value();

--- a/server/src/test/java/io/crate/analyze/MatchOptionsAnalyzedStatementTest.java
+++ b/server/src/test/java/io/crate/analyze/MatchOptionsAnalyzedStatementTest.java
@@ -21,6 +21,8 @@
 
 package io.crate.analyze;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -41,35 +43,45 @@ public class MatchOptionsAnalyzedStatementTest extends ESTestCase {
 
     @Test
     public void testUnknownMatchOptions() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("unknown match option 'analyzer_wrong'");
+        assertThatThrownBy(() -> {
+            Map<String, Object> options = new HashMap<>();
+            options.put("analyzer_wrong", "english");
+            MatchOptionsAnalysis.validate(options);
 
-        Map<String, Object> options = new HashMap<>();
-        options.put("analyzer_wrong", "english");
-        MatchOptionsAnalysis.validate(options);
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("unknown match option 'analyzer_wrong'");
     }
 
     @Test
     public void testInvalidMatchValue() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("invalid value for option 'max_expansions': abc");
+        assertThatThrownBy(() -> {
+            Map<String, Object> options = new HashMap<>();
+            options.put("max_expansions", "abc");
+            MatchOptionsAnalysis.validate(options);
 
-        Map<String, Object> options = new HashMap<>();
-        options.put("max_expansions", "abc");
-        MatchOptionsAnalysis.validate(options);
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("invalid value for option 'max_expansions': abc");
     }
 
     @Test
     public void testZeroTermsQueryMustBeAString() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("invalid value for option 'zero_terms_query': 12.6");
-        MatchOptionsAnalysis.validate(Map.of("zero_terms_query", 12.6));
+        assertThatThrownBy(() -> {
+            MatchOptionsAnalysis.validate(Map.of("zero_terms_query", 12.6));
+
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("invalid value for option 'zero_terms_query': 12.6");
     }
 
     @Test
     public void testUnknownOption() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("unknown match option 'oh'");
-        MatchOptionsAnalysis.validate(Map.of("oh", 1));
+        assertThatThrownBy(() -> {
+            MatchOptionsAnalysis.validate(Map.of("oh", 1));
+
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("unknown match option 'oh'");
     }
 }

--- a/server/src/test/java/io/crate/analyze/OptimizeTableAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/OptimizeTableAnalyzerTest.java
@@ -26,6 +26,7 @@ import static io.crate.analyze.OptimizeTableSettings.MAX_NUM_SEGMENTS;
 import static io.crate.analyze.OptimizeTableSettings.ONLY_EXPUNGE_DELETES;
 import static io.crate.analyze.OptimizeTableSettings.UPGRADE_SEGMENTS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.junit.Assert.assertThat;
 
@@ -73,10 +74,13 @@ public class OptimizeTableAnalyzerTest extends CrateDummyClusterServiceUnitTest 
 
     @Test
     public void testOptimizeSystemTable() throws Exception {
-        expectedException.expect(OperationOnInaccessibleRelationException.class);
-        expectedException.expectMessage("The relation \"sys.shards\" doesn't support or allow OPTIMIZE " +
-                                        "operations");
-        analyze("OPTIMIZE TABLE sys.shards");
+        assertThatThrownBy(() -> {
+            analyze("OPTIMIZE TABLE sys.shards");
+
+        })
+              .isExactlyInstanceOf(OperationOnInaccessibleRelationException.class)
+              .hasMessage("The relation \"sys.shards\" doesn't support or allow OPTIMIZE " +
+                      "operations");
     }
 
     @Test
@@ -113,16 +117,22 @@ public class OptimizeTableAnalyzerTest extends CrateDummyClusterServiceUnitTest 
 
     @Test
     public void testOptimizeTableWithInvalidParamName() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Setting 'invalidparam' is not supported");
-        analyze("OPTIMIZE TABLE users WITH (invalidParam=123)");
+        assertThatThrownBy(() -> {
+            analyze("OPTIMIZE TABLE users WITH (invalidParam=123)");
+
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Setting 'invalidparam' is not supported");
     }
 
     @Test
     public void testOptimizeTableWithUpgradeSegmentsAndOtherParam() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("cannot use other parameters if upgrade_segments is set to true");
-        analyze("OPTIMIZE TABLE users WITH (flush=false, upgrade_segments=true)");
+        assertThatThrownBy(() -> {
+            analyze("OPTIMIZE TABLE users WITH (flush=false, upgrade_segments=true)");
+
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("cannot use other parameters if upgrade_segments is set to true");
     }
 
     @Test
@@ -159,30 +169,42 @@ public class OptimizeTableAnalyzerTest extends CrateDummyClusterServiceUnitTest 
 
     @Test
     public void testOptimizeMultipleTablesUnknown() throws Exception {
-        expectedException.expect(RelationUnknown.class);
-        expectedException.expectMessage("Relation 'foo' unknown");
-        analyze("OPTIMIZE TABLE parted, foo, bar");
+        assertThatThrownBy(() -> {
+            analyze("OPTIMIZE TABLE parted, foo, bar");
+
+        })
+            .isExactlyInstanceOf(RelationUnknown.class)
+            .hasMessage("Relation 'foo' unknown");
     }
 
     @Test
     public void testOptimizeInvalidPartitioned() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("\"invalid_column\" is no known partition column");
-        analyze("OPTIMIZE TABLE parted PARTITION (invalid_column='hddsGNJHSGFEFZÜ')");
+        assertThatThrownBy(() -> {
+            analyze("OPTIMIZE TABLE parted PARTITION (invalid_column='hddsGNJHSGFEFZÜ')");
+
+        })
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("\"invalid_column\" is no known partition column");
     }
 
     @Test
     public void testOptimizeNonPartitioned() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("table 'doc.users' is not partitioned");
-        analyze("OPTIMIZE TABLE users PARTITION (foo='n')");
+        assertThatThrownBy(() -> {
+            analyze("OPTIMIZE TABLE users PARTITION (foo='n')");
+
+        })
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("table 'doc.users' is not partitioned");
     }
 
     @Test
     public void testOptimizeSysPartitioned() throws Exception {
-        expectedException.expect(OperationOnInaccessibleRelationException.class);
-        expectedException.expectMessage("The relation \"sys.shards\" doesn't support or allow OPTIMIZE " +
-                                        "operations");
-        analyze("OPTIMIZE TABLE sys.shards PARTITION (id='n')");
+        assertThatThrownBy(() -> {
+            analyze("OPTIMIZE TABLE sys.shards PARTITION (id='n')");
+
+        })
+            .isExactlyInstanceOf(OperationOnInaccessibleRelationException.class)
+            .hasMessage("The relation \"sys.shards\" doesn't support or allow OPTIMIZE " +
+                    "operations");
     }
 }

--- a/server/src/test/java/io/crate/analyze/RefreshAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/RefreshAnalyzerTest.java
@@ -24,6 +24,7 @@ package io.crate.analyze;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.isLiteral;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.util.List;
@@ -55,18 +56,24 @@ public class RefreshAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testRefreshSystemTable() throws Exception {
-        expectedException.expect(OperationOnInaccessibleRelationException.class);
-        expectedException.expectMessage("The relation \"sys.shards\" doesn't support or allow REFRESH " +
-                                        "operations");
-        e.analyze("refresh table sys.shards");
+        assertThatThrownBy(() -> {
+            e.analyze("refresh table sys.shards");
+
+        })
+                .isExactlyInstanceOf(OperationOnInaccessibleRelationException.class)
+                .hasMessage("The relation \"sys.shards\" doesn't support or allow REFRESH " +
+                        "operations");
     }
 
     @Test
     public void testRefreshBlobTable() throws Exception {
-        expectedException.expect(OperationOnInaccessibleRelationException.class);
-        expectedException.expectMessage("The relation \"blob.blobs\" doesn't support or allow REFRESH " +
-                                        "operations");
-        e.analyze("refresh table blob.blobs");
+        assertThatThrownBy(() -> {
+            e.analyze("refresh table blob.blobs");
+
+        })
+                .isExactlyInstanceOf(OperationOnInaccessibleRelationException.class)
+                .hasMessage("The relation \"blob.blobs\" doesn't support or allow REFRESH " +
+                        "operations");
     }
 
     @Test
@@ -83,25 +90,34 @@ public class RefreshAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testRefreshMultipleTablesUnknown() throws Exception {
-        expectedException.expect(RelationUnknown.class);
-        expectedException.expectMessage("Relation 'foo' unknown");
-        e.analyze("REFRESH TABLE parted, foo, bar");
+        assertThatThrownBy(() -> {
+            e.analyze("REFRESH TABLE parted, foo, bar");
+
+        })
+                .isExactlyInstanceOf(RelationUnknown.class)
+                .hasMessage("Relation 'foo' unknown");
     }
 
     @Test
     public void testRefreshSysPartitioned() throws Exception {
-        expectedException.expect(OperationOnInaccessibleRelationException.class);
-        expectedException.expectMessage("The relation \"sys.shards\" doesn't support or allow REFRESH" +
-                                        " operations");
-        e.analyze("refresh table sys.shards partition (id='n')");
+        assertThatThrownBy(() -> {
+            e.analyze("refresh table sys.shards partition (id='n')");
+
+        })
+                .isExactlyInstanceOf(OperationOnInaccessibleRelationException.class)
+                .hasMessage("The relation \"sys.shards\" doesn't support or allow REFRESH" +
+                        " operations");
     }
 
     @Test
     public void testRefreshBlobPartitioned() throws Exception {
-        expectedException.expect(OperationOnInaccessibleRelationException.class);
-        expectedException.expectMessage("The relation \"blob.blobs\" doesn't support or allow REFRESH " +
-                                        "operations");
-        e.analyze("refresh table blob.blobs partition (n='n')");
+        assertThatThrownBy(() -> {
+            e.analyze("refresh table blob.blobs partition (n='n')");
+
+        })
+                .isExactlyInstanceOf(OperationOnInaccessibleRelationException.class)
+                .hasMessage("The relation \"blob.blobs\" doesn't support or allow REFRESH " +
+                        "operations");
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/RepositoryParamValidatorTest.java
+++ b/server/src/test/java/io/crate/analyze/RepositoryParamValidatorTest.java
@@ -21,6 +21,8 @@
 
 package io.crate.analyze;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.util.Map;
 
 import org.elasticsearch.common.settings.Settings;
@@ -46,16 +48,22 @@ public class RepositoryParamValidatorTest extends ESTestCase {
 
     @Test
     public void testValidate() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Invalid repository type \"invalid_type\"");
-        validator.validate("invalid_type", GenericProperties.empty(), Settings.EMPTY);
+        assertThatThrownBy(() -> {
+            validator.validate("invalid_type", GenericProperties.empty(), Settings.EMPTY);
+
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Invalid repository type \"invalid_type\"");
     }
 
     @Test
     public void testRequiredTypeIsMissing() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage(
-            "The following required parameters are missing to create a repository of type \"fs\": [location]");
-        validator.validate("fs", GenericProperties.empty(), Settings.EMPTY);
+        assertThatThrownBy(() -> {
+            validator.validate("fs", GenericProperties.empty(), Settings.EMPTY);
+
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage(
+                        "The following required parameters are missing to create a repository of type \"fs\": [location]");
     }
 }

--- a/server/src/test/java/io/crate/analyze/SwapTableAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SwapTableAnalyzerTest.java
@@ -21,9 +21,9 @@
 
 package io.crate.analyze;
 
-
 import static io.crate.testing.Asserts.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -58,19 +58,28 @@ public class SwapTableAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testSwapTableFailsIfOneTableIsMissing() {
-        expectedException.expectMessage("Relation 't4' unknown");
-        e.analyze("alter cluster swap table t1 to t4");
+        assertThatThrownBy(() -> {
+            e.analyze("alter cluster swap table t1 to t4");
+
+        })
+                .hasMessage("Relation 't4' unknown");
     }
 
     @Test
     public void testSwapTableStatementFailsWithInvalidOptions() {
-        expectedException.expectMessage("Invalid options for ALTER CLUSTER SWAP TABLE: foo");
-        e.analyze("alter cluster swap table t1 to t2 with (foo = 'bar')");
+        assertThatThrownBy(() -> {
+            e.analyze("alter cluster swap table t1 to t2 with (foo = 'bar')");
+
+        })
+                .hasMessage("Invalid options for ALTER CLUSTER SWAP TABLE: foo");
     }
 
     @Test
     public void testSwapTableDoesNotWorkOnSystemTables() {
-        expectedException.expectMessage("The relation \"sys.cluster\" doesn't support or allow ALTER operations");
-        e.analyze("alter cluster swap table sys.cluster to t2");
+        assertThatThrownBy(() -> {
+            e.analyze("alter cluster swap table sys.cluster to t2");
+
+        })
+                .hasMessage("The relation \"sys.cluster\" doesn't support or allow ALTER operations");
     }
 }

--- a/server/src/test/java/io/crate/analyze/UnionAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/UnionAnalyzerTest.java
@@ -126,21 +126,27 @@ public class UnionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testUnionDifferentNumberOfOutputs() {
-        expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("Number of output columns must be the same for all parts of a UNION");
-        analyze("select 1, 2 from users " +
-                "union all " +
-                "select 3 from users_multi_pk");
+        assertThatThrownBy(() -> {
+            analyze("select 1, 2 from users " +
+                    "union all " +
+                    "select 3 from users_multi_pk");
+
+        })
+                .isExactlyInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("Number of output columns must be the same for all parts of a UNION");
     }
 
     @Test
     public void testUnionDifferentTypesOfOutputs() {
-        expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("Output columns at position 2 " +
-                                        "must be compatible for all parts of a UNION. Got `integer` and `object_array`");
-        analyze("select 1, 2 from users " +
-                "union all " +
-                "select 3, friends from users_multi_pk");
+        assertThatThrownBy(() -> {
+            analyze("select 1, 2 from users " +
+                    "union all " +
+                    "select 3, friends from users_multi_pk");
+
+        })
+            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .hasMessage("Output columns at position 2 " +
+                "must be compatible for all parts of a UNION. Got `integer` and `object_array`");
     }
 
     @Test
@@ -165,22 +171,28 @@ public class UnionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testUnionOrderByRefersToColumnFromRightTable() {
-        expectedException.expect(ColumnUnknownException.class);
-        expectedException.expectMessage("Column name unknown");
-        analyze("select id, text from users " +
-                "union all " +
-                "select id, name from users_multi_pk " +
-                "order by name");
+        assertThatThrownBy(() -> {
+            analyze("select id, text from users " +
+                    "union all " +
+                    "select id, name from users_multi_pk " +
+                    "order by name");
+
+        })
+                .isExactlyInstanceOf(ColumnUnknownException.class)
+                .hasMessage("Column name unknown");
     }
 
     @Test
     public void testUnionOrderByColumnRefersToOriginalColumn() {
-        expectedException.expect(ColumnUnknownException.class);
-        expectedException.expectMessage("Column id unknown");
-        analyze("select id + 10, text from users " +
-                "union all " +
-                "select id, name from users_multi_pk " +
-                "order by id");
+        assertThatThrownBy(() -> {
+            analyze("select id + 10, text from users " +
+                    "union all " +
+                    "select id, name from users_multi_pk " +
+                    "order by id");
+
+        })
+            .isExactlyInstanceOf(ColumnUnknownException.class)
+            .hasMessage("Column id unknown");
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/ValuesAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/ValuesAnalyzerTest.java
@@ -21,14 +21,16 @@
 
 package io.crate.analyze;
 
-import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.isField;
 import static io.crate.testing.Asserts.isReference;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.Before;
 import org.junit.Test;
 
 import io.crate.analyze.relations.AnalyzedRelation;
+import io.crate.exceptions.ConversionException;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.types.DataTypes;
@@ -46,15 +48,15 @@ public class ValuesAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void test_error_is_raised_if_number_of_items_within_rows_are_not_equal() {
-        expectedException.expectMessage("VALUES lists must all be the same length");
-        e.analyze("VALUES (1), (2, 3)");
+        assertThatThrownBy(() -> e.analyze("VALUES (1), (2, 3)"))
+            .hasMessageStartingWith("VALUES lists must all be the same length");
     }
 
     @Test
     public void test_error_is_raised_if_the_types_of_the_rows_are_not_compatible() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `integer`");
-        e.analyze("VALUES (1), ('foo')");
+        assertThatThrownBy(() -> e.analyze("VALUES (1), ('foo')"))
+            .isExactlyInstanceOf(ConversionException.class)
+            .hasMessage("Cannot cast `'foo'` of type `text` to type `integer`");
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/SumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/SumAggregationTest.java
@@ -22,6 +22,7 @@
 package io.crate.execution.engine.aggregation.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -190,11 +191,11 @@ public class SumAggregationTest extends AggregationTestCase {
 
     @Test
     public void testUnsupportedType() throws Exception {
-        expectedException.expect(UnsupportedFunctionException.class);
-        expectedException.expectMessage(
-            "Unknown function: sum(NULL)," +
-            " no overload found for matching argument types: (geo_point).");
-        getSum(DataTypes.GEO_POINT);
+        assertThatThrownBy(() -> getSum(DataTypes.GEO_POINT))
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
+            .hasMessageStartingWith(
+                "Unknown function: sum(NULL)," +
+                " no overload found for matching argument types: (geo_point).");
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/VarianceAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/VarianceAggregationTest.java
@@ -22,6 +22,7 @@
 package io.crate.execution.engine.aggregation.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
@@ -126,9 +127,9 @@ public class VarianceAggregationTest extends AggregationTestCase {
 
     @Test
     public void testUnsupportedType() throws Exception {
-        expectedException.expect(UnsupportedFunctionException.class);
-        expectedException.expectMessage("Unknown function: variance(INPUT(0))," +
-                                        " no overload found for matching argument types: (geo_point).");
-        executeAggregation(DataTypes.GEO_POINT, new Object[][]{});
+        assertThatThrownBy(() -> executeAggregation(DataTypes.GEO_POINT, new Object[][] {}))
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
+            .hasMessageStartingWith("Unknown function: variance(INPUT(0))," +
+                    " no overload found for matching argument types: (geo_point).");
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/collect/files/URLFileInputTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/files/URLFileInputTest.java
@@ -21,6 +21,8 @@
 
 package io.crate.execution.engine.collect.files;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -42,8 +44,8 @@ public class URLFileInputTest extends ESTestCase {
             expectedMessage = "doesnt_exist (The system cannot find the file specified)";
         }
 
-        expectedException.expect(FileNotFoundException.class);
-        expectedException.expectMessage(expectedMessage);
-        input.getStream(file.toURI());
+        assertThatThrownBy(() -> input.getStream(file.toURI()))
+            .isExactlyInstanceOf(FileNotFoundException.class)
+            .hasMessageContaining(expectedMessage);
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/fetch/NodeFetchResponseTest.java
+++ b/server/src/test/java/io/crate/execution/engine/fetch/NodeFetchResponseTest.java
@@ -22,6 +22,7 @@
 package io.crate.execution.engine.fetch;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
@@ -89,19 +90,19 @@ public class NodeFetchResponseTest extends ESTestCase {
         orig.writeTo(out);
         StreamInput in = out.bytes().streamInput();
 
-        expectedException.expect(CircuitBreakingException.class);
-        new NodeFetchResponse(
-            in,
-            streamers,
-            ConcurrentRamAccounting.forCircuitBreaker(
-                "test",
-                new MemoryCircuitBreaker(
-                    new ByteSizeValue(2, ByteSizeUnit.BYTES),
-                    1.0,
-                    LogManager.getLogger(NodeFetchResponseTest.class)),
-                0
-            )
-        );
+        assertThatThrownBy(() -> {
+            new NodeFetchResponse(
+                    in,
+                    streamers,
+                    ConcurrentRamAccounting.forCircuitBreaker(
+                            "test",
+                            new MemoryCircuitBreaker(
+                                    new ByteSizeValue(2, ByteSizeUnit.BYTES),
+                                    1.0,
+                                    LogManager.getLogger(NodeFetchResponseTest.class)),
+                            0));
 
+        })
+                .isExactlyInstanceOf(CircuitBreakingException.class);
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/pipeline/LimitAndOffsetProjectorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/pipeline/LimitAndOffsetProjectorTest.java
@@ -23,6 +23,7 @@ package io.crate.execution.engine.pipeline;
 
 import static io.crate.data.SentinelRow.SENTINEL;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.Matchers.emptyIterable;
 import static org.junit.Assert.assertThat;
 
@@ -127,16 +128,16 @@ public class LimitAndOffsetProjectorTest extends ESTestCase {
 
     @Test
     public void testNegativeOffset() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Invalid OFFSET");
-        new LimitAndOffsetProjector(10, -10);
+        assertThatThrownBy(() -> new LimitAndOffsetProjector(10, -10))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Invalid OFFSET: value must be >= 0; got: -10");
     }
 
     @Test
     public void testNegativeLimit() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Invalid LIMIT");
-        new LimitAndOffsetProjector(-100, LimitAndOffset.NO_OFFSET);
+        assertThatThrownBy(() -> new LimitAndOffsetProjector(-100, LimitAndOffset.NO_OFFSET))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Invalid LIMIT: value must be >= 0; got: -100");
     }
 
     @Test
@@ -186,9 +187,10 @@ public class LimitAndOffsetProjectorTest extends ESTestCase {
 
     @Test
     public void testProjectNoLimitNoOffset() throws Throwable {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Invalid LIMIT");
-
-        prepareProjector(LimitAndOffset.NO_LIMIT, LimitAndOffset.NO_OFFSET);
+        assertThatThrownBy(() -> {
+            prepareProjector(LimitAndOffset.NO_LIMIT, LimitAndOffset.NO_OFFSET);
+        })
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Invalid LIMIT: value must be >= 0; got: -1");
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/window/WindowDefinitionTest.java
+++ b/server/src/test/java/io/crate/execution/engine/window/WindowDefinitionTest.java
@@ -26,6 +26,7 @@ import static io.crate.sql.tree.FrameBound.Type.UNBOUNDED_FOLLOWING;
 import static io.crate.sql.tree.FrameBound.Type.UNBOUNDED_PRECEDING;
 import static io.crate.testing.Asserts.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.util.List;
@@ -56,44 +57,54 @@ public class WindowDefinitionTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testStartUnboundedFollowingIsIllegal() {
-        expectedException.expect(IllegalStateException.class);
-        expectedException.expectMessage(
-            "Frame start cannot be UNBOUNDED_FOLLOWING");
-        e.analyze(
-            "select sum(unnest) over(RANGE BETWEEN UNBOUNDED FOLLOWING and CURRENT ROW) FROM " +
-            "unnest([1, 2, 1, 1, 1, 4])");
+        assertThatThrownBy(() -> {
+            e.analyze(
+                    "select sum(unnest) over(RANGE BETWEEN UNBOUNDED FOLLOWING and CURRENT ROW) FROM " +
+                            "unnest([1, 2, 1, 1, 1, 4])");
 
+        })
+                .isExactlyInstanceOf(IllegalStateException.class)
+                .hasMessage(
+                        "Frame start cannot be UNBOUNDED_FOLLOWING");
     }
 
     @Test
     public void testStartFollowingIsIllegal() {
-        expectedException.expect(IllegalStateException.class);
-        expectedException.expectMessage(
-            "Frame start cannot be FOLLOWING");
-        e.analyze(
-            "select sum(unnest) over(RANGE BETWEEN 1 FOLLOWING and CURRENT ROW) FROM " +
-            "unnest([1, 2, 1, 1, 1, 4])");
+        assertThatThrownBy(() -> {
+            e.analyze(
+                    "select sum(unnest) over(RANGE BETWEEN 1 FOLLOWING and CURRENT ROW) FROM " +
+                            "unnest([1, 2, 1, 1, 1, 4])");
 
+        })
+                .isExactlyInstanceOf(IllegalStateException.class)
+                .hasMessage(
+                        "Frame start cannot be FOLLOWING");
     }
 
     @Test
     public void testEndPrecedingIsIllegal() {
-        expectedException.expect(IllegalStateException.class);
-        expectedException.expectMessage(
-            "Frame end cannot be PRECEDING");
-        e.analyze(
-            "select sum(unnest) over(RANGE BETWEEN CURRENT ROW and 1 PRECEDING) FROM " +
-            "unnest([1, 2, 1, 1, 1, 4])");
+        assertThatThrownBy(() -> {
+            e.analyze(
+                    "select sum(unnest) over(RANGE BETWEEN CURRENT ROW and 1 PRECEDING) FROM " +
+                            "unnest([1, 2, 1, 1, 1, 4])");
+
+        })
+                .isExactlyInstanceOf(IllegalStateException.class)
+                .hasMessage(
+                        "Frame end cannot be PRECEDING");
     }
 
     @Test
     public void testEndUnboundedPrecedingIsIllegal() {
-        expectedException.expect(IllegalStateException.class);
-        expectedException.expectMessage(
-            "Frame end cannot be UNBOUNDED_PRECEDING");
-        e.analyze(
-            "select sum(unnest) over(RANGE BETWEEN CURRENT ROW and UNBOUNDED PRECEDING) FROM " +
-            "unnest([1, 2, 1, 1, 1, 4])");
+        assertThatThrownBy(() -> {
+            e.analyze(
+                    "select sum(unnest) over(RANGE BETWEEN CURRENT ROW and UNBOUNDED PRECEDING) FROM " +
+                            "unnest([1, 2, 1, 1, 1, 4])");
+
+        })
+                .isExactlyInstanceOf(IllegalStateException.class)
+                .hasMessage(
+                        "Frame end cannot be UNBOUNDED_PRECEDING");
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/jobs/DistResultRXTaskTest.java
+++ b/server/src/test/java/io/crate/execution/jobs/DistResultRXTaskTest.java
@@ -22,6 +22,7 @@
 package io.crate.execution.jobs;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
@@ -93,9 +94,12 @@ public class DistResultRXTaskTest extends ESTestCase {
         bucketReceiver.setBucket(1, bucket, false, pageResultListener);
         bucketReceiver.setBucket(1, bucket, false, pageResultListener);
 
-        expectedException.expect(IllegalStateException.class);
-        expectedException.expectMessage("Same bucket of a page set more than once. node=n1 method=setBucket phaseId=1 bucket=1");
-        batchConsumer.getResult();
+        assertThatThrownBy(() -> {
+            batchConsumer.getResult();
+
+        })
+                .isExactlyInstanceOf(IllegalStateException.class)
+                .hasMessage("Same bucket of a page set more than once. node=n1 method=setBucket phaseId=1 bucket=1");
     }
 
     @Test
@@ -115,8 +119,11 @@ public class DistResultRXTaskTest extends ESTestCase {
         ctx.kill(new InterruptedException());
         assertThat(throwable.get()).isExactlyInstanceOf(CompletionException.class);
 
-        expectedException.expect(InterruptedException.class);
-        batchConsumer.getResult();
+        assertThatThrownBy(() -> {
+            batchConsumer.getResult();
+
+        })
+                .isExactlyInstanceOf(InterruptedException.class);
     }
 
     @Test
@@ -250,9 +257,12 @@ public class DistResultRXTaskTest extends ESTestCase {
         bucketReceiver.setBucket(0, bucket, true, pageResultListener);
         bucketReceiver.setBucket(1, bucket, true, pageResultListener);
 
-        expectedException.expect(RuntimeException.class);
-        expectedException.expectMessage("raised on merge");
-        batchConsumer.getResult();
+        assertThatThrownBy(() -> {
+            batchConsumer.getResult();
+
+        })
+                .isExactlyInstanceOf(RuntimeException.class)
+                .hasMessage("raised on merge");
     }
 
     @Test
@@ -267,9 +277,12 @@ public class DistResultRXTaskTest extends ESTestCase {
         Bucket bucket = new CollectionBucket(Collections.singletonList(new Object[] { "foo" }));
         bucketReceiver.setBucket(0, bucket, true, pageResultListener);
 
-        expectedException.expect(RuntimeException.class);
-        expectedException.expectMessage("raised on merge");
-        batchConsumer.getResult();
+        assertThatThrownBy(() -> {
+            batchConsumer.getResult();
+
+        })
+                .isExactlyInstanceOf(RuntimeException.class)
+                .hasMessage("raised on merge");
     }
 
     private static class CheckPageResultListener implements PageResultListener {

--- a/server/src/test/java/io/crate/expression/operator/CIDROperatorTest.java
+++ b/server/src/test/java/io/crate/expression/operator/CIDROperatorTest.java
@@ -21,8 +21,11 @@
 
 package io.crate.expression.operator;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import org.junit.Test;
 
+import io.crate.exceptions.ConversionException;
 import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.expression.symbol.Literal;
@@ -31,50 +34,60 @@ public class CIDROperatorTest extends ScalarTestCase {
 
     @Test
     public void test_ipv4_operands_in_wrong_order() {
-        expectedException.expect(IllegalArgumentException.class);
-        assertEvaluate("'192.168.0.1/24' << '192.168.0.1'", false);
+        assertThatThrownBy(() -> {
+            assertEvaluate("'192.168.0.1/24' << '192.168.0.1'", false);
+        })
+            .isExactlyInstanceOf(ConversionException.class);
     }
 
     @Test
     public void test_ipv4_operands_in_wrong_order_from_query() {
-        expectedException.expect(IllegalArgumentException.class);
-        assertEvaluate("name << ip",
-                       false,
-                       Literal.of("192.168.0.1/24"), Literal.of("192.168.0.1"));
+        assertThatThrownBy(() -> {
+            assertEvaluate("name << ip",
+                    false,
+                    Literal.of("192.168.0.1/24"), Literal.of("192.168.0.1"));
+        })
+            .isExactlyInstanceOf(ConversionException.class);
     }
 
     @Test
     public void test_ipv6_operands_in_wrong_order() {
-        expectedException.expect(IllegalArgumentException.class);
-        assertEvaluate("'2001:db8::1/120' << '2001:db8:0:0:0:0:0:c8'::ip", false);
+        assertThatThrownBy(() -> {
+            assertEvaluate("'2001:db8::1/120' << '2001:db8:0:0:0:0:0:c8'::ip", false);
+        })
+            .isExactlyInstanceOf(ConversionException.class);
     }
 
     @Test
     public void test_ipv6_operands_in_wrong_order_from_query() {
-        expectedException.expect(IllegalArgumentException.class);
-        assertEvaluate("name << ip",
-                       false,
-                       Literal.of("2001:db8::1/120"), Literal.of("2001:db8:0:0:0:0:0:c8"));
+        assertThatThrownBy(() -> {
+            assertEvaluate("name << ip",
+                    false,
+                    Literal.of("2001:db8::1/120"), Literal.of("2001:db8:0:0:0:0:0:c8"));
+        })
+            .isExactlyInstanceOf(ConversionException.class);
     }
 
     @Test
     public void test_ipv4_both_operands_are_ips() {
-        expectedException.expect(IllegalArgumentException.class);
-        assertEvaluate("'192.168.0.1'::ip << '192.168.0.1'::ip", false);
+        assertThatThrownBy(() -> assertEvaluate("'192.168.0.1'::ip << '192.168.0.1'::ip", false))
+            .isExactlyInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     public void test_both_operands_are_ints() {
-        expectedException.expect(IllegalArgumentException.class);
-        assertEvaluate("1 << 2", false);
+        assertThatThrownBy(() -> assertEvaluate("1 << 2", false))
+            .isExactlyInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     public void test_both_operands_are_of_wrong_type() {
-        expectedException.expect(UnsupportedFunctionException.class);
-        expectedException.expectMessage("Unknown function: (1.2 << _map('cidr', '192.168.0.0/24'))," +
-                                        " no overload found for matching argument types: (double precision, object).");
-        assertEvaluate("1.2 << { cidr = '192.168.0.0/24'}", false);
+        assertThatThrownBy(() -> {
+            assertEvaluate("1.2 << { cidr = '192.168.0.0/24'}", false);
+        })
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
+            .hasMessageStartingWith("Unknown function: (1.2 << _map('cidr', '192.168.0.0/24'))," +
+                " no overload found for matching argument types: (double precision, object).");
     }
 
     @Test
@@ -93,19 +106,25 @@ public class CIDROperatorTest extends ScalarTestCase {
 
     @Test
     public void test_ipv4_both_operands_are_ips_from_query() {
-        expectedException.expect(IllegalArgumentException.class);
-        assertEvaluate("ip << ip ",
-                       false,
-                       Literal.of("192.168.0.0"),
-                       Literal.of("192.168.0.1"));
+        assertThatThrownBy(() -> {
+            assertEvaluate("ip << ip ",
+                    false,
+                    Literal.of("192.168.0.0"),
+                    Literal.of("192.168.0.1"));
+
+        })
+            .isExactlyInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     public void test_ipv6_both_operands_are_text_from_query() {
-        expectedException.expect(IllegalArgumentException.class);
-        assertEvaluate("name << name",
-                       true,
-                       Literal.of("2001:db8:0:0:0:0:0:c7/120"),
-                       Literal.of("2001:db8:0:0:0:0:0:c8/120"));
+        assertThatThrownBy(() -> {
+            assertEvaluate("name << name",
+                    true,
+                    Literal.of("2001:db8:0:0:0:0:0:c7/120"),
+                    Literal.of("2001:db8:0:0:0:0:0:c8/120"));
+
+        })
+            .isExactlyInstanceOf(ConversionException.class);
     }
 }

--- a/server/src/test/java/io/crate/expression/reference/sys/check/cluster/LuceneVersionChecksTest.java
+++ b/server/src/test/java/io/crate/expression/reference/sys/check/cluster/LuceneVersionChecksTest.java
@@ -22,6 +22,7 @@
 package io.crate.expression.reference.sys.check.cluster;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
@@ -37,8 +38,11 @@ public class LuceneVersionChecksTest extends ESTestCase {
 
     @Test
     public void testUpgradeRequiredInvalidArg() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("'invalidVersion' is not a valid Lucene version");
-        LuceneVersionChecks.isUpgradeRequired("invalidVersion");
+        assertThatThrownBy(() -> {
+            LuceneVersionChecks.isUpgradeRequired("invalidVersion");
+
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("'invalidVersion' is not a valid Lucene version");
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/ArrayCatFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayCatFunctionTest.java
@@ -23,6 +23,7 @@ package io.crate.expression.scalar;
 
 import static io.crate.testing.Asserts.isFunction;
 import static io.crate.testing.Asserts.isLiteral;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
 import java.util.function.Consumer;
@@ -56,26 +57,26 @@ public class ArrayCatFunctionTest extends ScalarTestCase {
 
     @Test
     public void testZeroArguments() throws Exception {
-        expectedException.expect(UnsupportedFunctionException.class);
-        expectedException.expectMessage("Unknown function: array_cat()." +
-                                        " Possible candidates: array_cat(array(E), array(E)):array(E)");
-        assertEvaluateNull("array_cat()");
+        assertThatThrownBy(() -> assertEvaluateNull("array_cat()"))
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
+            .hasMessageStartingWith("Unknown function: array_cat()." +
+                " Possible candidates: array_cat(array(E), array(E)):array(E)");
     }
 
     @Test
     public void testOneArgument() {
-        expectedException.expect(UnsupportedFunctionException.class);
-        expectedException.expectMessage("Unknown function: array_cat(_array(1))," +
-                                        " no overload found for matching argument types: (integer_array).");
-        assertEvaluateNull("array_cat([1])");
+        assertThatThrownBy(() -> assertEvaluateNull("array_cat([1])"))
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
+            .hasMessageStartingWith("Unknown function: array_cat(_array(1))," +
+                    " no overload found for matching argument types: (integer_array).");
     }
 
     @Test
     public void testThreeArguments() throws Exception {
-        expectedException.expect(UnsupportedFunctionException.class);
-        expectedException.expectMessage("Unknown function: array_cat(_array(1), _array(2), _array(3))," +
-                                        " no overload found for matching argument types: (integer_array, integer_array, integer_array).");
-        assertEvaluateNull("array_cat([1], [2], [3])");
+        assertThatThrownBy(() -> assertEvaluateNull("array_cat([1], [2], [3])"))
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
+            .hasMessageStartingWith("Unknown function: array_cat(_array(1), _array(2), _array(3))," +
+                    " no overload found for matching argument types: (integer_array, integer_array, integer_array).");
     }
 
     @Test
@@ -116,8 +117,12 @@ public class ArrayCatFunctionTest extends ScalarTestCase {
 
     @Test
     public void testEmptyArrays() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("One of the arguments of the `array_cat` function can be of undefined inner type, but not both");
-        assertNormalize("array_cat([], [])", (Consumer<Symbol>) null);
+        assertThatThrownBy(() -> {
+            assertNormalize("array_cat([], [])", (Consumer<Symbol>) null);
+
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage(
+                        "One of the arguments of the `array_cat` function can be of undefined inner type, but not both");
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/ArrayDifferenceFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayDifferenceFunctionTest.java
@@ -26,6 +26,7 @@ import static io.crate.testing.Asserts.isNotSameInstance;
 import static io.crate.testing.Asserts.isNull;
 import static io.crate.testing.Asserts.isSameInstance;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -91,18 +92,18 @@ public class ArrayDifferenceFunctionTest extends ScalarTestCase {
 
     @Test
     public void testZeroArguments() throws Exception {
-        expectedException.expect(UnsupportedFunctionException.class);
-        expectedException.expectMessage("Unknown function: array_difference()." +
-                                        " Possible candidates: array_difference(array(E), array(E)):array(E)");
-        assertNormalize("array_difference()", isNull());
+        assertThatThrownBy(() -> assertNormalize("array_difference()", isNull()))
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
+            .hasMessage("Unknown function: array_difference()." +
+                    " Possible candidates: array_difference(array(E), array(E)):array(E)");
     }
 
     @Test
     public void testOneArgument() {
-        expectedException.expect(UnsupportedFunctionException.class);
-        expectedException.expectMessage("Unknown function: array_difference(_array(1))," +
-                                        " no overload found for matching argument types: (integer_array).");
-        assertNormalize("array_difference([1])", isNull());
+        assertThatThrownBy(() -> assertNormalize("array_difference([1])", isNull()))
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
+            .hasMessageStartingWith("Unknown function: array_difference(_array(1))," +
+                " no overload found for matching argument types: (integer_array).");
     }
 
     @Test
@@ -125,8 +126,12 @@ public class ArrayDifferenceFunctionTest extends ScalarTestCase {
 
     @Test
     public void testEmptyArrays() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("One of the arguments of the `array_difference` function can be of undefined inner type, but not both");
-        assertNormalize("array_difference([], [])", isNull());
+        assertThatThrownBy(() -> {
+            assertNormalize("array_difference([], [])", isNull());
+
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage(
+                        "One of the arguments of the `array_difference` function can be of undefined inner type, but not both");
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/ArrayLowerFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayLowerFunctionTest.java
@@ -21,6 +21,8 @@
 
 package io.crate.expression.scalar;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import org.junit.Test;
 
 import io.crate.exceptions.UnsupportedFunctionException;
@@ -88,41 +90,40 @@ public class ArrayLowerFunctionTest extends ScalarTestCase {
 
     @Test
     public void testZeroArguments() {
-        expectedException.expect(UnsupportedFunctionException.class);
-        expectedException.expectMessage("Unknown function: array_lower()." +
-                                        " Possible candidates: array_lower(array(E), integer):integer");
-        assertEvaluateNull("array_lower()");
+        assertThatThrownBy(() -> assertEvaluateNull("array_lower()"))
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
+            .hasMessageStartingWith("Unknown function: array_lower()." +
+                    " Possible candidates: array_lower(array(E), integer):integer");
     }
 
     @Test
     public void testOneArgument() {
-        expectedException.expect(UnsupportedFunctionException.class);
-        expectedException.expectMessage("Unknown function: array_lower(_array(1))," +
-                                        " no overload found for matching argument types: (integer_array).");
-        assertEvaluateNull("array_lower([1])");
+        assertThatThrownBy(() -> assertEvaluateNull("array_lower([1])"))
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
+            .hasMessageStartingWith("Unknown function: array_lower(_array(1))," +
+                    " no overload found for matching argument types: (integer_array).");
     }
 
     @Test
     public void testThreeArguments() {
-        expectedException.expect(UnsupportedFunctionException.class);
-        expectedException.expectMessage("Unknown function: array_lower(_array(1), 2, _array(3))," +
-                                        " no overload found for matching argument types: (integer_array, integer, integer_array).");
-        assertEvaluateNull("array_lower([1], 2, [3])");
+        assertThatThrownBy(() -> assertEvaluateNull("array_lower([1], 2, [3])"))
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
+            .hasMessageStartingWith("Unknown function: array_lower(_array(1), 2, _array(3))," +
+                    " no overload found for matching argument types: (integer_array, integer, integer_array).");
     }
 
     @Test
     public void testSecondArgumentNotANumber() {
-        expectedException.expect(UnsupportedFunctionException.class);
-        expectedException.expectMessage("Unknown function: array_lower(_array(1), _array(2))," +
-                                        " no overload found for matching argument types: (integer_array, integer_array).");
-        assertEvaluateNull("array_lower([1], [2])");
+        assertThatThrownBy(() -> assertEvaluateNull("array_lower([1], [2])"))
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
+            .hasMessageStartingWith("Unknown function: array_lower(_array(1), _array(2))," +
+                    " no overload found for matching argument types: (integer_array, integer_array).");
     }
 
     @Test
     public void testFirstArgumentIsNull() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage(
-            "The inner type of the array argument `array_lower` function cannot be undefined");
-        assertEvaluateNull("array_lower(null, 1)");
+        assertThatThrownBy(() -> assertEvaluateNull("array_lower(null, 1)"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("The inner type of the array argument `array_lower` function cannot be undefined");
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/ArraySliceFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArraySliceFunctionTest.java
@@ -21,6 +21,8 @@
 
 package io.crate.expression.scalar;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.util.List;
 
 import org.junit.Test;
@@ -107,93 +109,110 @@ public class ArraySliceFunctionTest extends ScalarTestCase {
 
     @Test
     public void testFromIsNotAnInteger() {
-        expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast `'three'` of type `text` to type `integer`");
-        assertEvaluateNull("[1,2,3,4,5]['three':]");
+        assertThatThrownBy(() -> assertEvaluateNull("[1,2,3,4,5]['three':]"))
+            .isExactlyInstanceOf(ConversionException.class)
+            .hasMessage("Cannot cast `'three'` of type `text` to type `integer`");
     }
 
     @Test
     public void testToIsNotAnInteger() {
-        expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast `'three'` of type `text` to type `integer`");
-        assertEvaluateNull("[1,2,3,4,5][:'three']");
+        assertThatThrownBy(() -> assertEvaluateNull("[1,2,3,4,5][:'three']"))
+            .isExactlyInstanceOf(ConversionException.class)
+            .hasMessage("Cannot cast `'three'` of type `text` to type `integer`");
     }
 
     @Test
     public void testBaseIsNotAnArray() {
-        expectedException.expect(UnsupportedFunctionException.class);
-        expectedException.expectMessage("Unknown function: array_slice('not an array', 1, 3), no overload found for matching argument types");
-        assertEvaluateNull("'not an array'[1:3]");
+        assertThatThrownBy(() -> assertEvaluateNull("'not an array'[1:3]"))
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
+            .hasMessageStartingWith(
+                "Unknown function: array_slice('not an array', 1, 3), no overload found for matching argument types");
     }
 
     @Test
     public void testFromIsNegative() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Array index must be in range 1 to 2147483647");
-        assertEvaluateNull("[1,2,3,4,5][-1:]");
+        assertThatThrownBy(() -> assertEvaluateNull("[1,2,3,4,5][-1:]"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Array index must be in range 1 to 2147483647");
     }
 
     @Test
     public void testToIsNegative() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Array index must be in range 1 to 2147483647");
-        assertEvaluateNull("[1,2,3,4,5][:-1]");
+        assertThatThrownBy(() -> assertEvaluateNull("[1,2,3,4,5][:-1]"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Array index must be in range 1 to 2147483647");
     }
 
     @Test
     public void testFromIsBig() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Cannot cast `2147483648::bigint` of type `bigint` to type `integer`");
-        assertEvaluate("[1,2,3,4,5][2147483648:]", List.of());
+        assertThatThrownBy(() -> assertEvaluate("[1,2,3,4,5][2147483648:]", List.of()))
+            .isExactlyInstanceOf(ConversionException.class)
+            .hasMessage("Cannot cast `2147483648::bigint` of type `bigint` to type `integer`");
     }
 
     @Test
     public void testToIsBig() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Cannot cast `2147483648::bigint` of type `bigint` to type `integer`");
-        assertEvaluate("[1,2,3,4,5][:2147483648]", List.of(1, 2, 3, 4, 5));
+        assertThatThrownBy(() -> {
+            assertEvaluate("[1,2,3,4,5][:2147483648]", List.of(1, 2, 3, 4, 5));
+        })
+            .isExactlyInstanceOf(ConversionException.class)
+            .hasMessage("Cannot cast `2147483648::bigint` of type `bigint` to type `integer`");
     }
 
     @Test
     public void testFromIsBigExpression() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("integer overflow");
-        assertEvaluate("[1,2,3,4,5][2147483647+20:]", List.of());
+        assertThatThrownBy(() -> assertEvaluate("[1,2,3,4,5][2147483647+20:]", List.of()))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("integer overflow");
     }
 
     @Test
     public void testToIsBigExpression() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("integer overflow");
-        assertEvaluate("[1,2,3,4,5][:2147483647+20]", List.of(1, 2, 3, 4, 5));
+        assertThatThrownBy(() -> {
+            assertEvaluate("[1,2,3,4,5][:2147483647+20]", List.of(1, 2, 3, 4, 5));
+        })
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("integer overflow");
     }
 
     @Test
     public void testFromIsZero() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Array index must be in range 1 to 2147483647");
-        assertEvaluate("[1,2,3,4,5][0:]", List.of());
+        assertThatThrownBy(() -> {
+            assertEvaluate("[1,2,3,4,5][0:]", List.of());
+
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Array index must be in range 1 to 2147483647");
     }
 
     @Test
     public void testToIsZero() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Array index must be in range 1 to 2147483647");
-        assertEvaluate("[1,2,3,4,5][:0]", List.of());
+        assertThatThrownBy(() -> {
+            assertEvaluate("[1,2,3,4,5][:0]", List.of());
+
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Array index must be in range 1 to 2147483647");
     }
 
     @Test
     public void testFromIsZeroExpression() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Array index must be in range 1 to 2147483647");
-        assertEvaluate("[1,2,3,4,5][10-10:]", List.of());
+        assertThatThrownBy(() -> {
+            assertEvaluate("[1,2,3,4,5][10-10:]", List.of());
+
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Array index must be in range 1 to 2147483647");
     }
 
     @Test
     public void testToIsZeroExpression() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Array index must be in range 1 to 2147483647");
-        assertEvaluate("[1,2,3,4,5][:10-10]", List.of());
+        assertThatThrownBy(() -> {
+            assertEvaluate("[1,2,3,4,5][:10-10]", List.of());
+
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Array index must be in range 1 to 2147483647");
     }
 
 }

--- a/server/src/test/java/io/crate/expression/scalar/ArrayToStringFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayToStringFunctionTest.java
@@ -21,6 +21,8 @@
 
 package io.crate.expression.scalar;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import org.junit.Test;
 
 import io.crate.exceptions.UnsupportedFunctionException;
@@ -29,17 +31,17 @@ public class ArrayToStringFunctionTest extends ScalarTestCase {
 
     @Test
     public void testZeroArguments() {
-        expectedException.expect(UnsupportedFunctionException.class);
-        expectedException.expectMessage("Unknown function: array_to_string()");
-        assertEvaluateNull("array_to_string()");
+        assertThatThrownBy(() -> assertEvaluateNull("array_to_string()"))
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
+            .hasMessageStartingWith("Unknown function: array_to_string()");
     }
 
     @Test
     public void testOneArgument() {
-        expectedException.expect(UnsupportedFunctionException.class);
-        expectedException.expectMessage("Unknown function: array_to_string(_array(1, 2))," +
-                                        " no overload found for matching argument types: (integer_array).");
-        assertEvaluateNull("array_to_string([1, 2])");
+        assertThatThrownBy(() -> assertEvaluateNull("array_to_string([1, 2])"))
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
+            .hasMessageStartingWith("Unknown function: array_to_string(_array(1, 2))," +
+                " no overload found for matching argument types: (integer_array).");
     }
 
     @Test
@@ -56,10 +58,13 @@ public class ArrayToStringFunctionTest extends ScalarTestCase {
 
     @Test
     public void testNullArray() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage(
-            "The inner type of the array argument `array_to_string` function cannot be undefined");
-        assertEvaluateNull("array_to_string(null, ',')");
+        assertThatThrownBy(() -> {
+            assertEvaluateNull("array_to_string(null, ',')");
+
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage(
+                        "The inner type of the array argument `array_to_string` function cannot be undefined");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/ArrayUniqueFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayUniqueFunctionTest.java
@@ -24,6 +24,7 @@ package io.crate.expression.scalar;
 import static io.crate.testing.Asserts.isFunction;
 import static io.crate.testing.Asserts.isLiteral;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -81,9 +82,9 @@ public class ArrayUniqueFunctionTest extends ScalarTestCase {
 
     @Test
     public void testZeroArguments() throws Exception {
-        expectedException.expect(UnsupportedFunctionException.class);
-        expectedException.expectMessage("Unknown function: array_unique().");
-        assertEvaluateNull("array_unique()");
+        assertThatThrownBy(() -> assertEvaluateNull("array_unique()"))
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
+            .hasMessageStartingWith("Unknown function: array_unique().");
     }
 
     @Test
@@ -105,17 +106,17 @@ public class ArrayUniqueFunctionTest extends ScalarTestCase {
 
     @Test
     public void testConvertNonNumericStringToNumber() {
-        expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `integer`");
-        assertEvaluateNull("array_unique([10, 20], ['foo', 'bar'])");
+        assertThatThrownBy(() -> assertEvaluateNull("array_unique([10, 20], ['foo', 'bar'])"))
+            .isExactlyInstanceOf(ConversionException.class)
+            .hasMessage("Cannot cast `'foo'` of type `text` to type `integer`");
     }
 
     @Test
     public void testDifferentUnconvertableInnerTypes() throws Exception {
-        expectedException.expect(UnsupportedFunctionException.class);
-        expectedException.expectMessage("Unknown function: array_unique(_array(doc.users.geopoint), _array(true))," +
-                                        " no overload found for matching argument types: (geo_point_array, boolean_array).");
-        assertEvaluateNull("array_unique([geopoint], [true])");
+        assertThatThrownBy(() -> assertEvaluateNull("array_unique([geopoint], [true])"))
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
+            .hasMessageStartingWith("Unknown function: array_unique(_array(doc.users.geopoint), _array(true))," +
+                    " no overload found for matching argument types: (geo_point_array, boolean_array).");
     }
 
     @Test
@@ -130,17 +131,20 @@ public class ArrayUniqueFunctionTest extends ScalarTestCase {
 
     @Test
     public void testEmptyArrays() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("One of the arguments of the `array_unique` function can " +
-                                        "be of undefined inner type, but not both");
-        assertEvaluateNull("array_unique([], [])");
+        assertThatThrownBy(() -> assertEvaluateNull("array_unique([], [])"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("One of the arguments of the `array_unique` function can " +
+                    "be of undefined inner type, but not both");
     }
 
     @Test
     public void testEmptyArray() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage(
-            "When used with only one argument, the inner type of the array argument cannot be undefined");
-        assertEvaluateNull("array_unique([])");
+        assertThatThrownBy(() -> {
+            assertEvaluateNull("array_unique([])");
+
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage(
+                        "When used with only one argument, the inner type of the array argument cannot be undefined");
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/ArrayUpperFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayUpperFunctionTest.java
@@ -21,6 +21,8 @@
 
 package io.crate.expression.scalar;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import org.junit.Test;
 
 import io.crate.exceptions.UnsupportedFunctionException;
@@ -89,41 +91,41 @@ public class ArrayUpperFunctionTest extends ScalarTestCase {
 
     @Test
     public void testZeroArguments() {
-        expectedException.expect(UnsupportedFunctionException.class);
-        expectedException.expectMessage("Unknown function: array_upper()." +
-                                        " Possible candidates: array_upper(array(E), integer):integer");
-        assertEvaluateNull("array_upper()");
+        assertThatThrownBy(() -> assertEvaluateNull("array_upper()"))
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
+            .hasMessageStartingWith("Unknown function: array_upper()." +
+                " Possible candidates: array_upper(array(E), integer):integer");
     }
 
     @Test
     public void testOneArgument() {
-        expectedException.expect(UnsupportedFunctionException.class);
-        expectedException.expectMessage("Unknown function: array_upper(_array(1))," +
-                                        " no overload found for matching argument types: (integer_array).");
-        assertEvaluateNull("array_upper([1])");
+        assertThatThrownBy(() -> assertEvaluateNull("array_upper([1])"))
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
+            .hasMessageStartingWith("Unknown function: array_upper(_array(1))," +
+                    " no overload found for matching argument types: (integer_array).");
     }
 
     @Test
     public void testThreeArguments() {
-        expectedException.expect(UnsupportedFunctionException.class);
-        expectedException.expectMessage("Unknown function: array_upper(_array(1), 2, _array(3))," +
-                                        " no overload found for matching argument types: (integer_array, integer, integer_array).");
-        assertEvaluateNull("array_upper([1], 2, [3])");
+        assertThatThrownBy(() -> assertEvaluateNull("array_upper([1], 2, [3])"))
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
+            .hasMessageStartingWith("Unknown function: array_upper(_array(1), 2, _array(3))," +
+                " no overload found for matching argument types: (integer_array, integer, integer_array).");
     }
 
     @Test
     public void testSecondArgumentNotANumber() {
-        expectedException.expect(UnsupportedFunctionException.class);
-        expectedException.expectMessage("Unknown function: array_upper(_array(1), _array(2))," +
-                                        " no overload found for matching argument types: (integer_array, integer_array).");
-        assertEvaluateNull("array_upper([1], [2])");
+        assertThatThrownBy(() -> assertEvaluateNull("array_upper([1], [2])"))
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
+            .hasMessageStartingWith("Unknown function: array_upper(_array(1), _array(2))," +
+                " no overload found for matching argument types: (integer_array, integer_array).");
     }
 
     @Test
     public void testFirstArgumentIsNull() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage(
-            "The inner type of the array argument `array_upper` function cannot be undefined");
-        assertEvaluateNull("array_upper(null, 1)");
+        assertThatThrownBy(() -> assertEvaluateNull("array_upper(null, 1)"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage(
+                "The inner type of the array argument `array_upper` function cannot be undefined");
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/ConcatFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ConcatFunctionTest.java
@@ -24,6 +24,7 @@ package io.crate.expression.scalar;
 import static io.crate.testing.Asserts.isLiteral;
 import static io.crate.testing.Asserts.isNull;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 import java.util.Map;
@@ -42,10 +43,13 @@ public class ConcatFunctionTest extends ScalarTestCase {
 
     @Test
     public void testArgumentThatHasNoStringRepr() {
-        expectedException.expect(UnsupportedFunctionException.class);
-        expectedException.expectMessage("Unknown function: concat('foo', _array(1))," +
-                                        " no overload found for matching argument types: (text, integer_array).");
-        assertNormalize("concat('foo', [1])", isNull());
+        assertThatThrownBy(() -> {
+            assertNormalize("concat('foo', [1])", isNull());
+
+        })
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
+            .hasMessageStartingWith("Unknown function: concat('foo', _array(1))," +
+                    " no overload found for matching argument types: (text, integer_array).");
     }
 
 
@@ -91,18 +95,18 @@ public class ConcatFunctionTest extends ScalarTestCase {
 
     @Test
     public void testTwoArraysOfIncompatibleInnerTypes() {
-        expectedException.expect(UnsupportedFunctionException.class);
-        expectedException.expectMessage("Unknown function: concat(_array(1, 2), _array(_array(1, 2)))," +
-                                        " no overload found for matching argument types: (integer_array, integer_array_array).");
-        assertNormalize("concat([1, 2], [[1, 2]])", isNull());
+        assertThatThrownBy(() -> assertNormalize("concat([1, 2], [[1, 2]])", isNull()))
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
+            .hasMessageStartingWith("Unknown function: concat(_array(1, 2), _array(_array(1, 2)))," +
+                " no overload found for matching argument types: (integer_array, integer_array_array).");
     }
 
     @Test
     public void testTwoArraysOfUndefinedTypes() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage(
-            "One of the arguments of the `concat` function can be of undefined inner type, but not both");
-        assertNormalize("concat([], [])", isNull());
+        assertThatThrownBy(() -> assertNormalize("concat([], [])", isNull()))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageStartingWith(
+                "One of the arguments of the `concat` function can be of undefined inner type, but not both");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/ConcatWsFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ConcatWsFunctionTest.java
@@ -23,6 +23,7 @@ package io.crate.expression.scalar;
 
 import static io.crate.testing.Asserts.isLiteral;
 import static io.crate.testing.Asserts.isNull;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.Test;
 
@@ -67,12 +68,14 @@ public class ConcatWsFunctionTest extends ScalarTestCase {
 
     @Test
     public void testInvalidArrayArgument() {
-        expectedException.expect(UnsupportedFunctionException.class);
-        expectedException.expectMessage(
-            "Unknown function: concat_ws(',', 'foo', []), " +
-            "no overload found for matching argument types: (text, text, undefined_array). " +
-            "Possible candidates: concat_ws(text):text"
-        );
-        assertNormalize("concat_ws(',' , 'foo', [])", isNull());
+        assertThatThrownBy(() -> {
+            assertNormalize("concat_ws(',' , 'foo', [])", isNull());
+
+        })
+                .isExactlyInstanceOf(UnsupportedFunctionException.class)
+                .hasMessage(
+                        "Unknown function: concat_ws(',', 'foo', []), " +
+                                "no overload found for matching argument types: (text, text, undefined_array). " +
+                                "Possible candidates: concat_ws(text):text");
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/DateFormatFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/DateFormatFunctionTest.java
@@ -23,12 +23,14 @@ package io.crate.expression.scalar;
 
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.isLiteral;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Locale;
 import java.util.Map;
 
 import org.junit.Test;
 
+import io.crate.exceptions.ConversionException;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.types.DataTypes;
@@ -132,16 +134,16 @@ public class DateFormatFunctionTest extends ScalarTestCase {
 
     @Test
     public void testInvalidTimeZone() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("invalid time zone value 'wrong timezone'");
-        assertEvaluateNull("date_format('%d.%m.%Y', 'wrong timezone', 0)");
+        assertThatThrownBy(() -> assertEvaluateNull("date_format('%d.%m.%Y', 'wrong timezone', 0)"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("invalid time zone value 'wrong timezone'");
     }
 
     @Test
     public void testInvalidTimestamp() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Cannot cast `'NO TIMESTAMP'` of type `text` to type `timestamp with time zone`");
-        assertEvaluateNull("date_format('%d.%m.%Y', 'NO TIMESTAMP')");
+        assertThatThrownBy(() -> assertEvaluateNull("date_format('%d.%m.%Y', 'NO TIMESTAMP')"))
+            .isExactlyInstanceOf(ConversionException.class)
+            .hasMessage("Cannot cast `'NO TIMESTAMP'` of type `text` to type `timestamp with time zone`");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/DateTruncFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/DateTruncFunctionTest.java
@@ -25,6 +25,7 @@ import static io.crate.testing.Asserts.isLiteral;
 import static io.crate.testing.Asserts.isNotSameInstance;
 import static io.crate.testing.Asserts.isNull;
 import static io.crate.testing.Asserts.isSameInstance;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.Test;
 
@@ -34,7 +35,7 @@ import io.crate.types.DataTypes;
 public class DateTruncFunctionTest extends ScalarTestCase {
 
     // timestamp for Do Feb 25 12:38:01.123 UTC 1999
-    private static final Literal TIMESTAMP = Literal.of(DataTypes.TIMESTAMPZ, 919946281123L);
+    private static final Literal<Long> TIMESTAMP = Literal.of(DataTypes.TIMESTAMPZ, 919946281123L);
 
     @Test
     public void testDateTruncWithLongLiteral() throws Exception {
@@ -66,9 +67,12 @@ public class DateTruncFunctionTest extends ScalarTestCase {
 
     @Test
     public void testInvalidInterval() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("invalid interval 'invalid interval' for scalar 'date_trunc'");
-        assertNormalize("date_trunc('invalid interval', 919946281123)", isNull());
+        assertThatThrownBy(() -> {
+            assertNormalize("date_trunc('invalid interval', 919946281123)", isNull());
+
+        })
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("invalid interval 'invalid interval' for scalar 'date_trunc'");
     }
 
     @Test
@@ -124,9 +128,12 @@ public class DateTruncFunctionTest extends ScalarTestCase {
 
     @Test
     public void testInvalidTimeZone() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("invalid time zone value 'no time zone'");
-        assertNormalize("date_trunc('day', 'no time zone', 919946281123)", isNull());
+        assertThatThrownBy(() -> {
+            assertNormalize("date_trunc('day', 'no time zone', 919946281123)", isNull());
+
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("invalid time zone value 'no time zone'");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/StringToArrayFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/StringToArrayFunctionTest.java
@@ -23,6 +23,7 @@ package io.crate.expression.scalar;
 
 import static io.crate.testing.Asserts.isFunction;
 import static io.crate.testing.Asserts.isLiteral;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -38,17 +39,17 @@ public class StringToArrayFunctionTest extends ScalarTestCase {
 
     @Test
     public void testZeroArguments() {
-        expectedException.expect(UnsupportedFunctionException.class);
-        expectedException.expectMessage("Unknown function: string_to_array()");
-        assertEvaluateNull("string_to_array()");
+        assertThatThrownBy(() -> assertEvaluateNull("string_to_array()"))
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
+            .hasMessageStartingWith("Unknown function: string_to_array()");
     }
 
     @Test
     public void testOneArgument() {
-        expectedException.expect(UnsupportedFunctionException.class);
-        expectedException.expectMessage("Unknown function: string_to_array('xyz')," +
-                                        " no overload found for matching argument types: (text).");
-        assertEvaluateNull("string_to_array('xyz')");
+        assertThatThrownBy(() -> assertEvaluateNull("string_to_array('xyz')"))
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
+            .hasMessageStartingWith("Unknown function: string_to_array('xyz')," +
+                " no overload found for matching argument types: (text).");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/SubscriptObjectFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/SubscriptObjectFunctionTest.java
@@ -22,6 +22,7 @@
 package io.crate.expression.scalar;
 
 import static io.crate.testing.Asserts.isLiteral;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Map;
 
@@ -58,8 +59,11 @@ public class SubscriptObjectFunctionTest extends ScalarTestCase {
 
     @Test
     public void testSubscriptOnObjectLiteralWithNonExistingKey() throws Exception {
-        expectedException.expect(ColumnUnknownException.class);
-        assertEvaluate("subscript_obj(obj, 'y')", 10L, Literal.of(Map.of("x", 10L)));
+        assertThatThrownBy(() -> {
+            assertEvaluate("subscript_obj(obj, 'y')", 10L, Literal.of(Map.of("x", 10L)));
+
+        })
+                .isExactlyInstanceOf(ColumnUnknownException.class);
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/AbsFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/AbsFunctionTest.java
@@ -23,6 +23,7 @@ package io.crate.expression.scalar.arithmetic;
 
 import static io.crate.testing.Asserts.isFunction;
 import static io.crate.testing.Asserts.isLiteral;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.Test;
 
@@ -43,9 +44,12 @@ public class AbsFunctionTest extends ScalarTestCase {
 
     @Test
     public void testWrongType() throws Exception {
-        expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `byte`");
-        assertEvaluateNull("abs('foo')");
+        assertThatThrownBy(() -> {
+            assertEvaluateNull("abs('foo')");
+
+        })
+                .isExactlyInstanceOf(ConversionException.class)
+                .hasMessage("Cannot cast `'foo'` of type `text` to type `byte`");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/ArithmeticOverflowTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/ArithmeticOverflowTest.java
@@ -21,6 +21,8 @@
 
 package io.crate.expression.scalar.arithmetic;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import org.junit.Test;
 
 import io.crate.expression.scalar.ScalarTestCase;
@@ -30,85 +32,121 @@ public class ArithmeticOverflowTest extends ScalarTestCase {
 
     @Test
     public void test_integer_overflow() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("integer overflow");
-        assertEvaluateNull("2147483647::integer + 1::integer");
+        assertThatThrownBy(() -> {
+            assertEvaluateNull("2147483647::integer + 1::integer");
+
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("integer overflow");
     }
 
     @Test
     public void test_integer_overflow_from_table() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("integer overflow");
-        assertEvaluateNull("a + 1::integer", Literal.of(Integer.MAX_VALUE));
+        assertThatThrownBy(() -> {
+            assertEvaluateNull("a + 1::integer", Literal.of(Integer.MAX_VALUE));
+
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("integer overflow");
     }
 
     @Test
     public void test_integer_overflow_mul() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("integer overflow");
-        assertEvaluateNull("2147483647::integer * 2::integer");
+        assertThatThrownBy(() -> {
+            assertEvaluateNull("2147483647::integer * 2::integer");
+
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("integer overflow");
     }
 
     @Test
     public void test_integer_overflow_mul_from_table() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("integer overflow");
-        assertEvaluateNull("a * 2::integer", Literal.of(Integer.MAX_VALUE));
+        assertThatThrownBy(() -> {
+            assertEvaluateNull("a * 2::integer", Literal.of(Integer.MAX_VALUE));
+
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("integer overflow");
     }
 
     @Test
     public void test_integer_underflow() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("integer overflow");
-        assertEvaluateNull("-2147483647::integer - 2::integer");
+        assertThatThrownBy(() -> {
+            assertEvaluateNull("-2147483647::integer - 2::integer");
+
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("integer overflow");
     }
 
     @Test
     public void test_integer_underflow_from_table() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("integer overflow");
-        assertEvaluateNull("a - 1::integer", Literal.of(Integer.MIN_VALUE));
+        assertThatThrownBy(() -> {
+            assertEvaluateNull("a - 1::integer", Literal.of(Integer.MIN_VALUE));
+
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("integer overflow");
     }
 
     @Test
     public void test_long_overflow() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("long overflow");
-        assertEvaluateNull("9223372036854775807 + 1");
+        assertThatThrownBy(() -> {
+            assertEvaluateNull("9223372036854775807 + 1");
+
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("long overflow");
     }
 
     @Test
     public void test_long_overflow_from_table() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("long overflow");
-        assertEvaluateNull("x + 1", Literal.of(Long.MAX_VALUE));
+        assertThatThrownBy(() -> {
+            assertEvaluateNull("x + 1", Literal.of(Long.MAX_VALUE));
+
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("long overflow");
     }
 
     @Test
     public void test_long_overflow_mul() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("long overflow");
-        assertEvaluateNull("9223372036854775807 * 2");
+        assertThatThrownBy(() -> {
+            assertEvaluateNull("9223372036854775807 * 2");
+
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("long overflow");
     }
 
     @Test
     public void test_long_overflow_mul_from_table() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("long overflow");
-        assertEvaluateNull("x * 2", Literal.of(Long.MAX_VALUE));
+        assertThatThrownBy(() -> {
+            assertEvaluateNull("x * 2", Literal.of(Long.MAX_VALUE));
+
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("long overflow");
     }
 
     @Test
     public void test_long_underflow() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("long overflow");
-        assertEvaluateNull("-9223372036854775807 - 2");
+        assertThatThrownBy(() -> {
+            assertEvaluateNull("-9223372036854775807 - 2");
+
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("long overflow");
     }
 
     @Test
     public void test_long_underflow_from_table() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("long overflow");
-        assertEvaluateNull("x - 1", Literal.of(Long.MIN_VALUE));
+        assertThatThrownBy(() -> {
+            assertEvaluateNull("x - 1", Literal.of(Long.MIN_VALUE));
+
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("long overflow");
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/ArrayFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/ArrayFunctionTest.java
@@ -22,6 +22,7 @@
 package io.crate.expression.scalar.arithmetic;
 
 import static io.crate.testing.Asserts.isLiteral;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 
@@ -36,9 +37,12 @@ public class ArrayFunctionTest extends ScalarTestCase {
 
     @Test
     public void testTypeValidation() {
-        expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `integer`");
-        assertEvaluateNull("ARRAY[1, 'foo']");
+        assertThatThrownBy(() -> {
+            assertEvaluateNull("ARRAY[1, 'foo']");
+
+        })
+            .isExactlyInstanceOf(ConversionException.class)
+            .hasMessage("Cannot cast `'foo'` of type `text` to type `integer`");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/Ignore3vlFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/Ignore3vlFunctionTest.java
@@ -23,6 +23,7 @@ package io.crate.expression.scalar.arithmetic;
 
 import static io.crate.testing.Asserts.isFunction;
 import static io.crate.testing.Asserts.isLiteral;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.Test;
 
@@ -40,9 +41,12 @@ public class Ignore3vlFunctionTest extends ScalarTestCase {
 
     @Test
     public void testWrongType() {
-        expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `boolean`");
-        assertEvaluateNull("ignore3vl('foo')");
+        assertThatThrownBy(() -> {
+            assertEvaluateNull("ignore3vl('foo')");
+
+        })
+                .isExactlyInstanceOf(ConversionException.class)
+                .hasMessage("Cannot cast `'foo'` of type `text` to type `boolean`");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/LogFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/LogFunctionTest.java
@@ -21,9 +21,9 @@
 
 package io.crate.expression.scalar.arithmetic;
 
-
 import static io.crate.testing.Asserts.isLiteral;
 import static io.crate.testing.Asserts.isNull;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.Test;
 
@@ -86,9 +86,9 @@ public class LogFunctionTest extends ScalarTestCase {
 
     @Test
     public void testNormalizeString() throws Exception {
-        expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `double precision`");
-        assertNormalize("log('foo')", isNull());
+        assertThatThrownBy(() -> assertNormalize("log('foo')", isNull()))
+            .isExactlyInstanceOf(ConversionException.class)
+            .hasMessage("Cannot cast `'foo'` of type `text` to type `double precision`");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/MapFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/MapFunctionTest.java
@@ -21,6 +21,8 @@
 
 package io.crate.expression.scalar.arithmetic;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -34,10 +36,10 @@ public class MapFunctionTest extends ScalarTestCase {
 
     @Test
     public void testMapWithWrongNumOfArguments() {
-        expectedException.expect(UnsupportedFunctionException.class);
-        expectedException.expectMessage("Unknown function: _map('foo', 1, 'bar')," +
-                                        " no overload found for matching argument types: (text, integer, text).");
-        assertEvaluateNull("_map('foo', 1, 'bar')");
+        assertThatThrownBy(() -> assertEvaluateNull("_map('foo', 1, 'bar')"))
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
+            .hasMessageStartingWith("Unknown function: _map('foo', 1, 'bar')," +
+                " no overload found for matching argument types: (text, integer, text).");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/NegateFunctionsTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/NegateFunctionsTest.java
@@ -22,6 +22,7 @@
 package io.crate.expression.scalar.arithmetic;
 
 import static io.crate.testing.Asserts.isFunction;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.Matchers.nullValue;
 
 import java.math.BigDecimal;
@@ -42,10 +43,10 @@ public class NegateFunctionsTest extends ScalarTestCase {
 
     @Test
     public void testNegateOnStringResultsInError() {
-        expectedException.expect(UnsupportedFunctionException.class);
-        expectedException.expectMessage("Unknown function: - doc.users.name," +
-                                        " no overload found for matching argument types: (text).");
-        assertEvaluate("- name", nullValue(), Literal.of("foo"));
+        assertThatThrownBy(() -> assertEvaluate("- name", nullValue(), Literal.of("foo")))
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
+            .hasMessageStartingWith("Unknown function: - doc.users.name," +
+                    " no overload found for matching argument types: (text).");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/PowerFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/PowerFunctionTest.java
@@ -21,6 +21,8 @@
 
 package io.crate.expression.scalar.arithmetic;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import org.junit.Test;
 
 import io.crate.expression.scalar.ScalarTestCase;
@@ -64,8 +66,8 @@ public class PowerFunctionTest extends ScalarTestCase {
 
     @Test
     public void testInvalidNumberOfArguments() {
-        expectedException.expectMessage("Unknown function: power(2)," +
-                                        " no overload found for matching argument types: (integer).");
-        assertEvaluateNull("power(2)");
+        assertThatThrownBy(() -> assertEvaluateNull("power(2)"))
+            .hasMessageStartingWith("Unknown function: power(2)," +
+                    " no overload found for matching argument types: (integer).");
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/RoundFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/RoundFunctionTest.java
@@ -22,6 +22,7 @@
 package io.crate.expression.scalar.arithmetic;
 
 import static io.crate.testing.Asserts.isFunction;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.Test;
 
@@ -44,8 +45,11 @@ public class RoundFunctionTest extends ScalarTestCase {
 
     @Test
     public void testInvalidType() throws Exception {
-        expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `byte`");
-        assertEvaluateNull("round('foo')");
+        assertThatThrownBy(() -> {
+            assertEvaluateNull("round('foo')");
+
+        })
+                .isExactlyInstanceOf(ConversionException.class)
+                .hasMessage("Cannot cast `'foo'` of type `text` to type `byte`");
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/SquareRootFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/SquareRootFunctionTest.java
@@ -22,6 +22,7 @@
 package io.crate.expression.scalar.arithmetic;
 
 import static io.crate.testing.Asserts.isFunction;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.Test;
 
@@ -42,15 +43,15 @@ public class SquareRootFunctionTest extends ScalarTestCase {
 
     @Test
     public void testSmallerThanZero() {
-        expectedException.expectMessage("cannot take square root of a negative number");
-        assertEvaluateNull("sqrt(-25.0)");
+        assertThatThrownBy(() -> assertEvaluateNull("sqrt(-25.0)"))
+            .hasMessage("cannot take square root of a negative number");
     }
 
     @Test
     public void testInvalidType() {
-        expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast `'foo'` of type `text` to type `byte`");
-        assertEvaluateNull("sqrt('foo')");
+        assertThatThrownBy(() -> assertEvaluateNull("sqrt('foo')"))
+            .isExactlyInstanceOf(ConversionException.class)
+            .hasMessage("Cannot cast `'foo'` of type `text` to type `byte`");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/geo/AreaFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/geo/AreaFunctionTest.java
@@ -25,12 +25,14 @@ import static io.crate.expression.scalar.geo.AreaFunction.getArea;
 import static io.crate.testing.Asserts.isLiteral;
 import static io.crate.testing.Asserts.isNull;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Map;
 
 import org.junit.Test;
 import org.locationtech.spatial4j.shape.Shape;
 
+import io.crate.exceptions.ConversionException;
 import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.expression.symbol.Literal;
@@ -77,24 +79,24 @@ public class AreaFunctionTest extends ScalarTestCase {
 
     @Test
     public void testWithTooManyArguments() {
-        expectedException.expect(UnsupportedFunctionException.class);
-        expectedException.expectMessage(
-            "Unknown function: area(doc.users.geoshape, 'foo'), no overload found for matching argument types: (geo_shape, text). Possible candidates: area(geo_shape):double precision");
-        assertNormalize("area(geoShape, 'foo')", isNull());
+        assertThatThrownBy(() -> assertNormalize("area(geoShape, 'foo')", isNull()))
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
+            .hasMessage(
+                "Unknown function: area(doc.users.geoshape, 'foo'), no overload found for matching argument types: (geo_shape, text). Possible candidates: area(geo_shape):double precision");
     }
 
     @Test
     public void testResolveWithInvalidType() throws Exception {
-        expectedException.expect(UnsupportedFunctionException.class);
-        expectedException.expectMessage(
-            "Unknown function: area(1), no overload found for matching argument types: (integer). Possible candidates: area(geo_shape):double precision");
-        assertEvaluateNull("area(1)");
+        assertThatThrownBy(() -> assertEvaluateNull("area(1)"))
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
+            .hasMessage(
+                "Unknown function: area(1), no overload found for matching argument types: (integer). Possible candidates: area(geo_shape):double precision");
     }
 
     @Test
     public void testWithInvalidStringReferences() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Cannot cast `'POLYGON (foo)'` of type `text` to type `geo_shape`");
-        assertEvaluateNull("area('POLYGON (foo)')");
+        assertThatThrownBy(() -> assertEvaluateNull("area('POLYGON (foo)')"))
+            .isExactlyInstanceOf(ConversionException.class)
+            .hasMessage("Cannot cast `'POLYGON (foo)'` of type `text` to type `geo_shape`");
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/geo/DistanceFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/geo/DistanceFunctionTest.java
@@ -21,8 +21,9 @@
 
 package io.crate.expression.scalar.geo;
 
-import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.isLiteral;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.Test;
 import org.locationtech.spatial4j.context.jts.JtsSpatialContext;
@@ -38,18 +39,22 @@ public class DistanceFunctionTest extends ScalarTestCase {
 
     @Test
     public void testResolveWithTooManyArguments() throws Exception {
-        expectedException.expect(UnsupportedFunctionException.class);
-        expectedException.expectMessage("Unknown function: distance('POINT (10 20)', 'POINT (11 21)', 'foo')," +
-                                        " no overload found for matching argument types: (text, text, text).");
-        assertNormalize("distance('POINT (10 20)', 'POINT (11 21)', 'foo')", s -> assertThat(s).isNull());
+        assertThatThrownBy(() -> {
+            assertNormalize("distance('POINT (10 20)', 'POINT (11 21)', 'foo')", s -> assertThat(s).isNull());
+        })
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
+            .hasMessageStartingWith("Unknown function: distance('POINT (10 20)', 'POINT (11 21)', 'foo')," +
+                " no overload found for matching argument types: (text, text, text).");
     }
 
     @Test
     public void testResolveWithInvalidType() throws Exception {
-        expectedException.expect(UnsupportedFunctionException.class);
-        expectedException.expectMessage("Unknown function: distance(1, 'POINT (11 21)')," +
-                                        " no overload found for matching argument types: (integer, text).");
-        assertNormalize("distance(1, 'POINT (11 21)')", s -> assertThat(s).isNull());
+        assertThatThrownBy(() -> {
+            assertNormalize("distance(1, 'POINT (11 21)')", s -> assertThat(s).isNull());
+        })
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
+            .hasMessageStartingWith("Unknown function: distance(1, 'POINT (11 21)')," +
+                " no overload found for matching argument types: (integer, text).");
     }
 
     @Test
@@ -78,9 +83,12 @@ public class DistanceFunctionTest extends ScalarTestCase {
 
     @Test
     public void testWithInvalidReferences() {
-        expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast value `foo` to type `geo_point`");
-        assertEvaluateNull("distance(name, [10.04, 28.02])", Literal.of("foo"));
+        assertThatThrownBy(() -> {
+            assertEvaluateNull("distance(name, [10.04, 28.02])", Literal.of("foo"));
+
+        })
+                .isExactlyInstanceOf(ConversionException.class)
+                .hasMessage("Cannot cast value `foo` to type `geo_point`");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/geo/IntersectsFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/geo/IntersectsFunctionTest.java
@@ -24,9 +24,7 @@ package io.crate.expression.scalar.geo;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.isLiteral;
 import static io.crate.testing.TestingHelpers.jsonMap;
-import static org.hamcrest.Matchers.stringContainsInOrder;
-
-import java.util.Arrays;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.Test;
 
@@ -57,9 +55,13 @@ public class IntersectsFunctionTest extends ScalarTestCase {
 
     @Test
     public void testNormalizeFromInvalidLiteral() throws Exception {
-        expectedException.expect(ConversionException.class);
-        expectedException.expectMessage(stringContainsInOrder(Arrays.asList("Cannot cast ", "to type `geo_shape`")));
-        assertNormalize("intersects({type='LineString', coordinates=[0, 0]}, 'LINESTRING (0 2, 0 -2)')", s -> assertThat(s).isNull());
+        assertThatThrownBy(() -> {
+            assertNormalize("intersects({type='LineString', coordinates=[0, 0]}, 'LINESTRING (0 2, 0 -2)')",
+                    s -> assertThat(s).isNull());
+
+        })
+            .isExactlyInstanceOf(ConversionException.class)
+            .hasMessageContaining("to type `geo_shape`");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/geo/WithinFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/geo/WithinFunctionTest.java
@@ -23,6 +23,7 @@ package io.crate.expression.scalar.geo;
 
 import static io.crate.testing.Asserts.isFunction;
 import static io.crate.testing.Asserts.isLiteral;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 import java.util.Map;
@@ -139,18 +140,22 @@ public class WithinFunctionTest extends ScalarTestCase {
 
     @Test
     public void testFirstArgumentWithInvalidType() throws Exception {
-        expectedException.expect(UnsupportedFunctionException.class);
-        expectedException.expectMessage("Unknown function: within(INPUT(0), INPUT(0))," +
-                                        " no overload found for matching argument types: (bigint, geo_point).");
-        getFunction(FNAME, List.of(DataTypes.LONG, DataTypes.GEO_POINT));
+        assertThatThrownBy(() -> {
+            getFunction(FNAME, List.of(DataTypes.LONG, DataTypes.GEO_POINT));
+        })
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
+            .hasMessageStartingWith("Unknown function: within(INPUT(0), INPUT(0))," +
+                " no overload found for matching argument types: (bigint, geo_point).");
     }
 
     @Test
     public void testSecondArgumentWithInvalidType() throws Exception {
-        expectedException.expect(UnsupportedFunctionException.class);
-        expectedException.expectMessage("Unknown function: within(INPUT(0), INPUT(0))," +
-                                        " no overload found for matching argument types: (geo_point, bigint).");
-        getFunction(FNAME, List.of(DataTypes.GEO_POINT, DataTypes.LONG));
+        assertThatThrownBy(() -> {
+            getFunction(FNAME, List.of(DataTypes.GEO_POINT, DataTypes.LONG));
+        })
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
+            .hasMessageStartingWith("Unknown function: within(INPUT(0), INPUT(0))," +
+                " no overload found for matching argument types: (geo_point, bigint).");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/object/ObjectKeysFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/object/ObjectKeysFunctionTest.java
@@ -21,6 +21,8 @@
 
 package io.crate.expression.scalar.object;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.util.List;
 
 import org.junit.Test;
@@ -37,11 +39,14 @@ public class ObjectKeysFunctionTest extends ScalarTestCase {
 
     @Test
     public void test_array_input() {
-        expectedException.expect(UnsupportedFunctionException.class);
-        expectedException.expectMessage("Unknown function: object_keys(_array(1)), no overload found for" +
-                                        " matching argument types: (integer_array). Possible candidates:" +
-                                        " object_keys(object):array(text)");
-        assertEvaluateNull("object_keys([1])");
+        assertThatThrownBy(() -> {
+            assertEvaluateNull("object_keys([1])");
+
+        })
+                .isExactlyInstanceOf(UnsupportedFunctionException.class)
+                .hasMessage("Unknown function: object_keys(_array(1)), no overload found for" +
+                        " matching argument types: (integer_array). Possible candidates:" +
+                        " object_keys(object):array(text)");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/postgres/CurrentSettingFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/postgres/CurrentSettingFunctionTest.java
@@ -23,6 +23,7 @@ package io.crate.expression.scalar.postgres;
 
 import static io.crate.testing.Asserts.isFunction;
 import static io.crate.testing.Asserts.isLiteral;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.Test;
 
@@ -92,9 +93,11 @@ public class CurrentSettingFunctionTest extends ScalarTestCase {
 
     @Test
     public void testEvaluateNonExistingSettingSingleArgument() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Unrecognised Setting");
-        assertEvaluate("current_setting(name)", "", Literal.of("foo"));
+        assertThatThrownBy(() -> {
+            assertEvaluate("current_setting(name)", "", Literal.of("foo"));
+        })
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Unrecognised Setting: foo");
     }
 
     @Test
@@ -104,9 +107,11 @@ public class CurrentSettingFunctionTest extends ScalarTestCase {
 
     @Test
     public void testEvaluateNonExistingSettingWithMissingOKArgumentAsFalse() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Unrecognised Setting");
-        assertEvaluate("current_setting(name, false)", "", Literal.of("foo"));
+        assertThatThrownBy(() -> {
+            assertEvaluate("current_setting(name, false)", "", Literal.of("foo"));
+        })
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Unrecognised Setting: foo");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/postgres/PgBackendPidFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/postgres/PgBackendPidFunctionTest.java
@@ -22,6 +22,7 @@
 package io.crate.expression.scalar.postgres;
 
 import static io.crate.testing.Asserts.isLiteral;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.Test;
 
@@ -42,9 +43,9 @@ public class PgBackendPidFunctionTest extends ScalarTestCase {
 
     @Test
     public void testInvalidType() throws Exception {
-        expectedException.expectMessage("Unknown function: pg_backend_pid(NULL)," +
-                                        " no overload found for matching argument types: (undefined).");
-        sqlExpressions.asSymbol("pg_backend_pid(null)");
+        assertThatThrownBy(() -> sqlExpressions.asSymbol("pg_backend_pid(null)"))
+            .hasMessageStartingWith("Unknown function: pg_backend_pid(NULL)," +
+                " no overload found for matching argument types: (undefined).");
     }
 
 }

--- a/server/src/test/java/io/crate/expression/scalar/regex/RegexpReplaceFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/regex/RegexpReplaceFunctionTest.java
@@ -23,6 +23,7 @@ package io.crate.expression.scalar.regex;
 
 import static io.crate.testing.Asserts.isFunction;
 import static io.crate.testing.Asserts.isLiteral;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.Test;
 
@@ -76,23 +77,29 @@ public class RegexpReplaceFunctionTest extends ScalarTestCase {
 
     @Test
     public void testNormalizeSymbolWithInvalidFlags() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("The regular expression flag is unknown: n");
-        assertNormalize("regexp_replace('foobar', 'foo', 'bar', 'n')", isLiteral(""));
+        assertThatThrownBy(() -> {
+            assertNormalize("regexp_replace('foobar', 'foo', 'bar', 'n')", isLiteral(""));
+        })
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("The regular expression flag is unknown: n");
     }
 
     @Test
     public void testNormalizeSymbolWithInvalidNumberOfArguments() throws Exception {
-        expectedException.expect(UnsupportedFunctionException.class);
-        assertNormalize("regexp_replace('foobar')", isLiteral(""));
+        assertThatThrownBy(() -> {
+            assertNormalize("regexp_replace('foobar')", isLiteral(""));
+        })
+            .isExactlyInstanceOf(UnsupportedFunctionException.class);
     }
 
     @Test
     public void testNormalizeSymbolWithInvalidArgumentType() {
-        expectedException.expect(UnsupportedFunctionException.class);
-        expectedException.expectMessage("Unknown function: regexp_replace('foobar', '.*', _array(1, 2))," +
-                                        " no overload found for matching argument types: (text, text, integer_array).");
+        assertThatThrownBy(() -> {
+            assertNormalize("regexp_replace('foobar', '.*', [1,2])", isLiteral(""));
 
-        assertNormalize("regexp_replace('foobar', '.*', [1,2])", isLiteral(""));
+        })
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
+            .hasMessageStartingWith("Unknown function: regexp_replace('foobar', '.*', _array(1, 2))," +
+                " no overload found for matching argument types: (text, text, integer_array).");
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/string/ChrFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/string/ChrFunctionTest.java
@@ -21,8 +21,11 @@
 
 package io.crate.expression.scalar.string;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import org.junit.Test;
 
+import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.expression.scalar.ScalarTestCase;
 
 public class ChrFunctionTest extends ScalarTestCase {
@@ -34,30 +37,30 @@ public class ChrFunctionTest extends ScalarTestCase {
 
     @Test
     public void test_zero_value_throws_exception() throws Exception {
-        expectedException.expectMessage("null character not permitted");
-        expectedException.expect(IllegalArgumentException.class);
-        assertEvaluate("chr(0)", "");
+        assertThatThrownBy(() -> assertEvaluate("chr(0)", ""))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("null character not permitted");
     }
 
     @Test
     public void test_negative_number_throws_exception() throws Exception {
-        expectedException.expectMessage("requested character too large for encoding: -1");
-        expectedException.expect(IllegalArgumentException.class);
-        assertEvaluate("chr(-1)", "");
+        assertThatThrownBy(() -> assertEvaluate("chr(-1)", ""))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("requested character too large for encoding: -1");
     }
 
     @Test
     public void test_large_number_throws_exception() throws Exception {
-        expectedException.expectMessage("requested character too large for encoding: 1114112");
-        expectedException.expect(IllegalArgumentException.class);
-        assertEvaluate("chr(1114112)", "");
+        assertThatThrownBy(() -> assertEvaluate("chr(1114112)", ""))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("requested character too large for encoding: 1114112");
     }
 
     @Test
     public void test_empty_value_throws_exception() throws Exception {
-        expectedException.expectMessage("Unknown function: chr(). Possible candidates: chr(integer):text");
-        expectedException.expect(Exception.class);
-        assertEvaluate("chr()", "");
+        assertThatThrownBy(() -> assertEvaluate("chr()", ""))
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
+            .hasMessage("Unknown function: chr(). Possible candidates: chr(integer):text");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/string/EncodeDecodeFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/string/EncodeDecodeFunctionTest.java
@@ -21,6 +21,8 @@
 
 package io.crate.expression.scalar.string;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import org.junit.Test;
 
 import io.crate.expression.scalar.ScalarTestCase;
@@ -30,51 +32,72 @@ public class EncodeDecodeFunctionTest extends ScalarTestCase {
 
     @Test
     public void testInvalidBytea() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Illegal octal character b at index 4");
-        assertEvaluateNull("encode('123\\b\\t56', 'base64')");
+        assertThatThrownBy(() -> {
+            assertEvaluateNull("encode('123\\b\\t56', 'base64')");
+
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Illegal octal character b at index 4");
     }
 
     @Test
     public void testInvalidBased64() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Illegal base64 character 8");
-        assertEvaluateNull("decode(E'123\\b\\t56', 'base64')");
+        assertThatThrownBy(() -> {
+            assertEvaluateNull("decode(E'123\\b\\t56', 'base64')");
+
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Illegal base64 character 8");
     }
 
     @Test
     public void testInvalidBinaryEncodeToBase64() {
-        expectedException.expect(IllegalStateException.class);
-        expectedException.expectMessage("Illegal hexadecimal character h at index 3");
-        assertEvaluateNull("encode('\\xfh', 'base64')");
+        assertThatThrownBy(() -> {
+            assertEvaluateNull("encode('\\xfh', 'base64')");
+
+        })
+                .isExactlyInstanceOf(IllegalStateException.class)
+                .hasMessage("Illegal hexadecimal character h at index 3");
     }
 
     @Test
     public void testInvalidBinaryEncodeToHex() {
-        expectedException.expect(IllegalStateException.class);
-        expectedException.expectMessage("Illegal hexadecimal character h at index 3");
-        assertEvaluateNull("encode('\\xfh', 'hex')");
+        assertThatThrownBy(() -> {
+            assertEvaluateNull("encode('\\xfh', 'hex')");
+
+        })
+                .isExactlyInstanceOf(IllegalStateException.class)
+                .hasMessage("Illegal hexadecimal character h at index 3");
     }
 
     @Test
     public void testInvalidBinaryEncodeToEscape() {
-        expectedException.expect(IllegalStateException.class);
-        expectedException.expectMessage("Illegal hexadecimal character h at index 3");
-        assertEvaluateNull("encode('\\xfh', 'escape')");
+        assertThatThrownBy(() -> {
+            assertEvaluateNull("encode('\\xfh', 'escape')");
+
+        })
+                .isExactlyInstanceOf(IllegalStateException.class)
+                .hasMessage("Illegal hexadecimal character h at index 3");
     }
 
     @Test
     public void testInvalidBinaryDecodeFromHex1() {
-        expectedException.expect(IllegalStateException.class);
-        expectedException.expectMessage("Illegal hexadecimal character \\ at index 0");
-        assertEvaluateNull("decode('\\xff', 'hex')");
+        assertThatThrownBy(() -> {
+            assertEvaluateNull("decode('\\xff', 'hex')");
+
+        })
+                .isExactlyInstanceOf(IllegalStateException.class)
+                .hasMessage("Illegal hexadecimal character \\ at index 0");
     }
 
     @Test
     public void testInvalidBinaryDecodeFromHex2() {
-        expectedException.expect(IllegalStateException.class);
-        expectedException.expectMessage("Odd number of characters");
-        assertEvaluateNull("decode('ffa', 'hex')");
+        assertThatThrownBy(() -> {
+            assertEvaluateNull("decode('ffa', 'hex')");
+
+        })
+                .isExactlyInstanceOf(IllegalStateException.class)
+                .hasMessage("Odd number of characters");
     }
 
     @Test
@@ -89,16 +112,22 @@ public class EncodeDecodeFunctionTest extends ScalarTestCase {
 
     @Test
     public void testUnknownEncodeFormat() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Encoding format 'bad' is not supported");
-        assertEvaluateNull("encode('\\xff', 'bad')");
+        assertThatThrownBy(() -> {
+            assertEvaluateNull("encode('\\xff', 'bad')");
+
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Encoding format 'bad' is not supported");
     }
 
     @Test
     public void testUnknownDecodeFormat() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Encoding format 'bad' is not supported");
-        assertEvaluateNull("decode('FA==', 'bad')");
+        assertThatThrownBy(() -> {
+            assertEvaluateNull("decode('FA==', 'bad')");
+
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Encoding format 'bad' is not supported");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/string/QuoteIdentFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/string/QuoteIdentFunctionTest.java
@@ -24,6 +24,7 @@ package io.crate.expression.scalar.string;
 import static io.crate.testing.Asserts.isFunction;
 import static io.crate.testing.Asserts.isLiteral;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 
@@ -39,10 +40,13 @@ public class QuoteIdentFunctionTest extends ScalarTestCase {
 
     @Test
     public void testZeroArguments() {
-        expectedException.expect(UnsupportedFunctionException.class);
-        expectedException.expectMessage("Unknown function: quote_ident()." +
-                                        " Possible candidates: pg_catalog.quote_ident(text):text");
-        assertEvaluateNull("quote_ident()");
+        assertThatThrownBy(() -> {
+            assertEvaluateNull("quote_ident()");
+
+        })
+                .isExactlyInstanceOf(UnsupportedFunctionException.class)
+                .hasMessage("Unknown function: quote_ident()." +
+                        " Possible candidates: pg_catalog.quote_ident(text):text");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/string/StringPaddingFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/string/StringPaddingFunctionTest.java
@@ -21,6 +21,8 @@
 
 package io.crate.expression.scalar.string;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import org.junit.Test;
 
 import io.crate.expression.scalar.ScalarTestCase;
@@ -30,10 +32,13 @@ public class StringPaddingFunctionTest extends ScalarTestCase {
 
     @Test
     public void test_lpad_parameter_len_too_big() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("len argument exceeds predefined limit of 50000");
-        assertEvaluateNull("lpad('yes', 2000000, 'yes')");
-        assertEvaluateNull("lpad('yes', a, 'yes')",Literal.of(2000000));
+        assertThatThrownBy(() -> {
+            assertEvaluateNull("lpad('yes', 2000000, 'yes')");
+            assertEvaluateNull("lpad('yes', a, 'yes')", Literal.of(2000000));
+
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("len argument exceeds predefined limit of 50000");
     }
 
     @Test
@@ -96,10 +101,13 @@ public class StringPaddingFunctionTest extends ScalarTestCase {
 
     @Test
     public void test_rpad_parameter_len_too_big() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("len argument exceeds predefined limit of 50000");
-        assertEvaluateNull("rpad('yes', 2000000, 'yes')");
-        assertEvaluate("rpad('yes', a, 'yes')", Literal.of(2000000));
+        assertThatThrownBy(() -> {
+            assertEvaluateNull("rpad('yes', 2000000, 'yes')");
+            assertEvaluate("rpad('yes', a, 'yes')", Literal.of(2000000));
+
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("len argument exceeds predefined limit of 50000");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/string/StringSplitPartFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/string/StringSplitPartFunctionTest.java
@@ -21,6 +21,8 @@
 
 package io.crate.expression.scalar.string;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import org.junit.Test;
 
 import io.crate.expression.scalar.ScalarTestCase;
@@ -44,9 +46,12 @@ public class StringSplitPartFunctionTest extends ScalarTestCase {
 
     @Test
     public void split_part_index_smaller_one_throws_exception() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("index in split_part must be greater than zero");
-        assertEvaluate("split_part('abc~@~def~@~ghi', '~@~', 0)", "");
+        assertThatThrownBy(() -> {
+            assertEvaluate("split_part('abc~@~def~@~ghi', '~@~', 0)", "");
+
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("index in split_part must be greater than zero");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/timestamp/CurrentTimeFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/timestamp/CurrentTimeFunctionTest.java
@@ -22,6 +22,7 @@
 package io.crate.expression.scalar.timestamp;
 
 import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -74,9 +75,12 @@ public class CurrentTimeFunctionTest extends ScalarTestCase {
 
     @Test
     public void precision_larger_than_6_raises_exception() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("precision must be between [0..6]");
-        assertEvaluateNull("current_time(14)");
+        assertThatThrownBy(() -> {
+            assertEvaluateNull("current_time(14)");
+
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("precision must be between [0..6]");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/timestamp/CurrentTimestampFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/timestamp/CurrentTimestampFunctionTest.java
@@ -22,6 +22,7 @@
 package io.crate.expression.scalar.timestamp;
 
 import static io.crate.testing.Asserts.exactlyInstanceOf;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.After;
 import org.junit.Before;
@@ -72,9 +73,12 @@ public class CurrentTimestampFunctionTest extends ScalarTestCase {
 
     @Test
     public void precisionLargerThan3RaisesException() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Precision must be between 0 and 3");
-        assertEvaluateNull("current_timestamp(4)");
+        assertThatThrownBy(() -> {
+            assertEvaluateNull("current_timestamp(4)");
+
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Precision must be between 0 and 3");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/timestamp/TimezoneFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/timestamp/TimezoneFunctionTest.java
@@ -21,10 +21,13 @@
 
 package io.crate.expression.scalar.timestamp;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import io.crate.exceptions.ConversionException;
 import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.SystemClock;
@@ -56,31 +59,33 @@ public class TimezoneFunctionTest extends ScalarTestCase {
 
     @Test
     public void testEvaluateInvalidZoneIsBlanc() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("time zone \" \" not recognized");
-        assertEvaluateNull("timezone(' ', 257504400000)");
+        assertThatThrownBy(() -> assertEvaluateNull("timezone(' ', 257504400000)"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("time zone \" \" not recognized");
     }
 
     @Test
     public void testEvaluateInvalidZoneIsRandom() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("time zone \"Random/Location\" not recognized");
-        assertEvaluateNull("timezone('Random/Location', 257504400000)");
+        assertThatThrownBy(() -> assertEvaluateNull("timezone('Random/Location', 257504400000)"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("time zone \"Random/Location\" not recognized");
     }
 
     @Test
     public void testEvaluateInvalidZoneIsRandomNumeric() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("time zone \"+31:97\" not recognized");
-        assertEvaluateNull("timezone('+31:97', 257504400000)");
+        assertThatThrownBy(() -> assertEvaluateNull("timezone('+31:97', 257504400000)"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("time zone \"+31:97\" not recognized");
     }
 
     @Test
     public void testEvaluateInvalidTimestamp() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage(
-            "Cannot cast `'not_a_timestamp'` of type `text` to type `timestamp with time zone`");
-        assertEvaluateNull("timezone('Europe/Madrid', 'not_a_timestamp')");
+        assertThatThrownBy(() -> {
+            assertEvaluateNull("timezone('Europe/Madrid', 'not_a_timestamp')");
+        })
+            .isExactlyInstanceOf(ConversionException.class)
+            .hasMessage(
+                "Cannot cast `'not_a_timestamp'` of type `text` to type `timestamp with time zone`");
     }
 
     @Test
@@ -90,23 +95,32 @@ public class TimezoneFunctionTest extends ScalarTestCase {
 
     @Test
     public void testEvaluateInvalidZoneIsBlancFromColumn() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("time zone \" \" not recognized");
-        assertEvaluateNull("timezone(name, 257504400000)", Literal.of(" "));
+        assertThatThrownBy(() -> {
+            assertEvaluateNull("timezone(name, 257504400000)", Literal.of(" "));
+
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("time zone \" \" not recognized");
     }
 
     @Test
     public void testEvaluateInvalidZoneIsRandomFromColumn() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("time zone \"Random/Location\" not recognized");
-        assertEvaluateNull("timezone(name, 257504400000)", Literal.of("Random/Location"));
+        assertThatThrownBy(() -> {
+            assertEvaluateNull("timezone(name, 257504400000)", Literal.of("Random/Location"));
+
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("time zone \"Random/Location\" not recognized");
     }
 
     @Test
     public void testEvaluateInvalidZoneIsRandomNumericFromColumn() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("time zone \"+31:97\" not recognized");
-        assertEvaluateNull("timezone(name, 257504400000)", Literal.of("+31:97"));
+        assertThatThrownBy(() -> {
+            assertEvaluateNull("timezone(name, 257504400000)", Literal.of("+31:97"));
+
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("time zone \"+31:97\" not recognized");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/symbol/format/SymbolFormatterTest.java
+++ b/server/src/test/java/io/crate/expression/symbol/format/SymbolFormatterTest.java
@@ -22,6 +22,7 @@
 package io.crate.expression.symbol.format;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.IllegalFormatConversionException;
 import java.util.List;
@@ -54,8 +55,11 @@ public class SymbolFormatterTest extends ESTestCase {
 
     @Test
     public void testFormatInvalidEscape() throws Exception {
-        expectedException.expect(IllegalFormatConversionException.class);
-        expectedException.expectMessage("d != java.lang.String");
-        assertThat(Symbols.format("%d", Literal.of(42L))).isEqualTo("");
+        assertThatThrownBy(() -> {
+            assertThat(Symbols.format("%d", Literal.of(42L))).isEqualTo("");
+
+        })
+                .isExactlyInstanceOf(IllegalFormatConversionException.class)
+                .hasMessage("d != java.lang.String");
     }
 }

--- a/server/src/test/java/io/crate/expression/tablefunctions/GenerateSubscriptsTest.java
+++ b/server/src/test/java/io/crate/expression/tablefunctions/GenerateSubscriptsTest.java
@@ -21,6 +21,8 @@
 
 package io.crate.expression.tablefunctions;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import org.junit.Test;
 
 public class GenerateSubscriptsTest extends AbstractTableFunctionsTest {
@@ -65,9 +67,12 @@ public class GenerateSubscriptsTest extends AbstractTableFunctionsTest {
 
     @Test
     public void test_multidimensional_arrays_of_inconsistent_dimension_are_not_supported() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("nested arrays must have the same dimension within a level, offending level 2, position 3");
-        assertExecute("generate_subscripts([[[1],[2]], [[3],[4]], [[4]]], 3)", "1\n2\n3\n");
+        assertThatThrownBy(() -> {
+            assertExecute("generate_subscripts([[[1],[2]], [[3],[4]], [[4]]], 3)", "1\n2\n3\n");
+
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("nested arrays must have the same dimension within a level, offending level 2, position 3");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/tablefunctions/ValuesFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/tablefunctions/ValuesFunctionTest.java
@@ -22,6 +22,7 @@
 package io.crate.expression.tablefunctions;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 
@@ -106,10 +107,13 @@ public class ValuesFunctionTest extends AbstractTableFunctionsTest {
 
     @Test
     public void test_function_arguments_must_have_array_types() {
-        expectedException.expect(UnsupportedFunctionException.class);
-        expectedException.expectMessage("Unknown function: _values(200)," +
-                                        " no overload found for matching argument types: (integer).");
-        assertExecute("_values(200)", "");
+        assertThatThrownBy(() -> {
+            assertExecute("_values(200)", "");
+
+        })
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
+            .hasMessageStartingWith("Unknown function: _values(200)," +
+                    " no overload found for matching argument types: (integer).");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/udf/UserDefinedFunctionServiceTest.java
+++ b/server/src/test/java/io/crate/expression/udf/UserDefinedFunctionServiceTest.java
@@ -99,17 +99,22 @@ public class UserDefinedFunctionServiceTest extends UdfUnitTest {
 
     @Test
     public void testRemoveDoesNotExist() throws Exception {
-        expectedException.expect(UserDefinedFunctionUnknownException.class);
-        expectedException.expectMessage("Cannot resolve user defined function: 'doc.different()'");
-        UserDefinedFunctionsMetadata metadata = UserDefinedFunctionsMetadata.of(same1);
-        udfService.removeFunction(metadata, different.schema(), different.name(), different.argumentTypes(), false);
+        assertThatThrownBy(() -> {
+            UserDefinedFunctionsMetadata metadata = UserDefinedFunctionsMetadata.of(same1);
+            udfService.removeFunction(metadata, different.schema(), different.name(), different.argumentTypes(), false);
+
+        })
+                .isExactlyInstanceOf(UserDefinedFunctionUnknownException.class)
+                .hasMessage("Cannot resolve user defined function: 'doc.different()'");
     }
 
     @Test
     public void testReplaceIsFalse() throws Exception {
-        expectedException.expect(UserDefinedFunctionAlreadyExistsException.class);
-        expectedException.expectMessage("User defined Function 'doc.same()' already exists.");
-        udfService.putFunction(UserDefinedFunctionsMetadata.of(same1), same2, false);
+        assertThatThrownBy(() -> {
+            udfService.putFunction(UserDefinedFunctionsMetadata.of(same1), same2, false);
+        })
+            .isExactlyInstanceOf(UserDefinedFunctionAlreadyExistsException.class)
+            .hasMessage("User defined Function 'doc.same()' already exists.");
     }
 
     @Test

--- a/server/src/test/java/io/crate/metadata/settings/CrateSettingsTest.java
+++ b/server/src/test/java/io/crate/metadata/settings/CrateSettingsTest.java
@@ -22,6 +22,7 @@
 package io.crate.metadata.settings;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertThat;
 
@@ -75,10 +76,12 @@ public class CrateSettingsTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testIsNotRuntimeSetting() {
-        expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("Setting 'gateway.expected_nodes' cannot be set/reset at runtime");
+        assertThatThrownBy(() -> {
+            CrateSettings.checkIfRuntimeSetting(GatewayService.EXPECTED_NODES_SETTING.getKey());
 
-        CrateSettings.checkIfRuntimeSetting(GatewayService.EXPECTED_NODES_SETTING.getKey());
+        })
+            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .hasMessage("Setting 'gateway.expected_nodes' cannot be set/reset at runtime");
     }
 
     @Test

--- a/server/src/test/java/io/crate/planner/DeletePlannerTest.java
+++ b/server/src/test/java/io/crate/planner/DeletePlannerTest.java
@@ -104,9 +104,12 @@ public class DeletePlannerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testDeleteWhereVersionIsNullPredicate() throws Exception {
-        expectedException.expect(VersioningValidationException.class);
-        expectedException.expectMessage(VersioningValidationException.VERSION_COLUMN_USAGE_MSG);
-        e.plan("delete from users where _version is null");
+        assertThatThrownBy(() -> {
+            e.plan("delete from users where _version is null");
+
+        })
+                .isExactlyInstanceOf(VersioningValidationException.class)
+                .hasMessage(VersioningValidationException.VERSION_COLUMN_USAGE_MSG);
     }
 
     @Test

--- a/server/src/test/java/io/crate/planner/consumer/InsertFromSubQueryPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/consumer/InsertFromSubQueryPlannerTest.java
@@ -22,6 +22,7 @@
 package io.crate.planner.consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 
@@ -60,23 +61,30 @@ public class InsertFromSubQueryPlannerTest extends CrateDummyClusterServiceUnitT
     public void test_returning_for_insert_from_values_throw_error_with_4_1_nodes() throws Exception {
         // Make sure the former initialized cluster service is shutdown
         cleanup();
-        this.clusterService = createClusterService(additionalClusterSettings(), Metadata.EMPTY_METADATA, Version.V_4_1_0);
+        this.clusterService = createClusterService(additionalClusterSettings(), Metadata.EMPTY_METADATA,
+                Version.V_4_1_0);
         e = buildExecutor(clusterService);
-        expectedException.expect(UnsupportedFeatureException.class);
-        expectedException.expectMessage(InsertFromSubQueryPlanner.RETURNING_VERSION_ERROR_MSG);
-        e.plan("insert into users (id, name) values (1, 'bob') returning id");
+        assertThatThrownBy(() -> {
+            e.plan("insert into users (id, name) values (1, 'bob') returning id");
 
+        })
+                .isExactlyInstanceOf(UnsupportedFeatureException.class)
+                .hasMessage(InsertFromSubQueryPlanner.RETURNING_VERSION_ERROR_MSG);
     }
 
     @Test
     public void test_returning_for_insert_from_subquery_throw_error_with_4_1_nodes() throws Exception {
         // Make sure the former initialized cluster service is shutdown
         cleanup();
-        this.clusterService = createClusterService(additionalClusterSettings(), Metadata.EMPTY_METADATA, Version.V_4_1_0);
+        this.clusterService = createClusterService(additionalClusterSettings(), Metadata.EMPTY_METADATA,
+                Version.V_4_1_0);
         e = buildExecutor(clusterService);
-        expectedException.expect(UnsupportedFeatureException.class);
-        expectedException.expectMessage(InsertFromSubQueryPlanner.RETURNING_VERSION_ERROR_MSG);
-        e.plan("insert into users (id, name) select '1' as id, 'b' as name returning id");
+        assertThatThrownBy(() -> {
+            e.plan("insert into users (id, name) select '1' as id, 'b' as name returning id");
+
+        })
+                .isExactlyInstanceOf(UnsupportedFeatureException.class)
+                .hasMessage(InsertFromSubQueryPlanner.RETURNING_VERSION_ERROR_MSG);
     }
 
     @Test

--- a/server/src/test/java/io/crate/planner/node/ddl/ResetSettingsPlanTest.java
+++ b/server/src/test/java/io/crate/planner/node/ddl/ResetSettingsPlanTest.java
@@ -22,8 +22,8 @@
 package io.crate.planner.node.ddl;
 
 import static io.crate.planner.node.ddl.ResetSettingsPlan.buildSettingsFrom;
-import static org.assertj.core.api.Assertions.assertThat;
 import static io.crate.testing.TestingHelpers.createNodeContext;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Set;
@@ -88,12 +88,14 @@ public class ResetSettingsPlanTest extends ESTestCase {
 
     @Test
     public void testResetNonRuntimeSettingObject() {
-        expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("Setting 'gateway.recover_after_nodes' cannot be set/reset at runtime");
+        assertThatThrownBy(() -> {
+            Set<Symbol> settings = Set.of(Literal.of("gateway.recover_after_nodes"));
 
-        Set<Symbol> settings = Set.of(Literal.of("gateway.recover_after_nodes"));
+            buildSettingsFrom(settings, symbolEvaluator(Row.EMPTY));
 
-        buildSettingsFrom(settings, symbolEvaluator(Row.EMPTY));
+        })
+                .isExactlyInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("Setting 'gateway.recover_after_nodes' cannot be set/reset at runtime");
     }
 
     @Test
@@ -141,10 +143,12 @@ public class ResetSettingsPlanTest extends ESTestCase {
 
     @Test
     public void testUnsupportedSetting() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Setting 'unsupported_setting' is not supported");
+        assertThatThrownBy(() -> {
+            Set<Symbol> settings = Set.of(Literal.of("unsupported_setting"));
+            buildSettingsFrom(settings, symbolEvaluator(Row.EMPTY));
 
-        Set<Symbol> settings = Set.of(Literal.of("unsupported_setting"));
-        buildSettingsFrom(settings, symbolEvaluator(Row.EMPTY));
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Setting 'unsupported_setting' is not supported");
     }
 }

--- a/server/src/test/java/io/crate/planner/node/ddl/UpdateSettingsPlanTest.java
+++ b/server/src/test/java/io/crate/planner/node/ddl/UpdateSettingsPlanTest.java
@@ -24,8 +24,7 @@ package io.crate.planner.node.ddl;
 import static io.crate.planner.node.ddl.UpdateSettingsPlan.buildSettingsFrom;
 import static io.crate.testing.TestingHelpers.createNodeContext;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 import java.util.Map;
@@ -85,10 +84,8 @@ public class UpdateSettingsPlanTest extends ESTestCase {
             .put("stats.jobs_log_size", 25)
             .build();
 
-        assertThat(
-            buildSettingsFrom(settings, symbolEvaluator(new RowN(new Object[]{10, 25}))),
-            is(expected)
-        );
+        assertThat(buildSettingsFrom(settings, symbolEvaluator(new RowN(new Object[]{10, 25}))))
+            .isEqualTo(expected);
     }
 
     @Test
@@ -117,47 +114,51 @@ public class UpdateSettingsPlanTest extends ESTestCase {
 
     @Test
     public void testSetNonRuntimeSettingObject() {
-        expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("Setting 'gateway.recover_after_nodes' cannot be set/reset at runtime");
+        assertThatThrownBy(() -> {
+            List<Assignment<Symbol>> settings = List.of(
+                    new Assignment<>(Literal.of("gateway"), List.of(Literal.of(Map.of("recover_after_nodes", 3)))));
 
-        List<Assignment<Symbol>> settings = List.of(
-            new Assignment<>(Literal.of("gateway"), List.of(Literal.of(Map.of("recover_after_nodes", 3))))
-        );
+            buildSettingsFrom(settings, symbolEvaluator(Row.EMPTY));
 
-
-        buildSettingsFrom(settings, symbolEvaluator(Row.EMPTY));
+        })
+            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .hasMessage("Setting 'gateway.recover_after_nodes' cannot be set/reset at runtime");
     }
 
     @Test
     public void testSetNonRuntimeSetting() {
-        expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("Setting 'gateway.recover_after_time' cannot be set/reset at runtime");
+        assertThatThrownBy(() -> {
+            List<Assignment<Symbol>> settings = List.of(
+                    new Assignment<>(Literal.of("gateway.recover_after_time"), List.of(Literal.of("5m"))));
 
-        List<Assignment<Symbol>> settings = List.of(
-            new Assignment<>(Literal.of("gateway.recover_after_time"), List.of(Literal.of("5m"))
-            ));
+            buildSettingsFrom(settings, symbolEvaluator(Row.EMPTY));
 
-        buildSettingsFrom(settings, symbolEvaluator(Row.EMPTY));
+        })
+            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .hasMessage("Setting 'gateway.recover_after_time' cannot be set/reset at runtime");
     }
 
     @Test
     public void testUnsupportedSetting() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Setting 'unsupported_setting' is not supported");
+        assertThatThrownBy(() -> {
+            List<Assignment<Symbol>> settings = List.of(
+                    new Assignment<>(Literal.of("unsupported_setting"), List.of(Literal.of("foo"))));
 
-        List<Assignment<Symbol>> settings = List.of(
-            new Assignment<>(Literal.of("unsupported_setting"), List.of(Literal.of("foo"))
-            ));
+            buildSettingsFrom(settings, symbolEvaluator(Row.EMPTY));
 
-        buildSettingsFrom(settings, symbolEvaluator(Row.EMPTY));
+        })
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Setting 'unsupported_setting' is not supported");
     }
 
     @Test
     public void test_build_settings_with_null_value() {
-        List<Assignment<Symbol>> settings = List.of(new Assignment<>(Literal.of("cluster.routing.allocation.exclude._id"), Literal.NULL));
+        List<Assignment<Symbol>> settings = List
+                .of(new Assignment<>(Literal.of("cluster.routing.allocation.exclude._id"), Literal.NULL));
 
-        expectedException.expectMessage("Cannot set \"cluster.routing.allocation.exclude._id\" to `null`. Use `RESET [GLOBAL] \"cluster.routing.allocation.exclude._id\"` to reset a setting to its default value");
-        buildSettingsFrom(settings, symbolEvaluator(Row.EMPTY));
+        assertThatThrownBy(() -> buildSettingsFrom(settings, symbolEvaluator(Row.EMPTY)))
+            .hasMessage(
+                "Cannot set \"cluster.routing.allocation.exclude._id\" to `null`. Use `RESET [GLOBAL] \"cluster.routing.allocation.exclude._id\"` to reset a setting to its default value");
     }
 
     @Test

--- a/server/src/test/java/io/crate/planner/operators/SubQueryAndParamBinderTest.java
+++ b/server/src/test/java/io/crate/planner/operators/SubQueryAndParamBinderTest.java
@@ -21,6 +21,8 @@
 
 package io.crate.planner.operators;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.util.Map;
 
 import org.elasticsearch.test.ESTestCase;
@@ -37,7 +39,10 @@ public class SubQueryAndParamBinderTest extends ESTestCase {
         SubQueryAndParamBinder paramBinder = new SubQueryAndParamBinder(Row.EMPTY, SubQueryResults.EMPTY);
         Symbol symbol = new SqlExpressions(Map.of()).asSymbol("$1 > 10");
 
-        expectedException.expectMessage("The query contains a parameter placeholder $1, but there are only 0 parameter values");
-        paramBinder.apply(symbol);
+        assertThatThrownBy(() -> {
+            paramBinder.apply(symbol);
+
+        })
+                .hasMessage("The query contains a parameter placeholder $1, but there are only 0 parameter values");
     }
 }

--- a/server/src/test/java/io/crate/protocols/postgres/types/TimestampTypeTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/types/TimestampTypeTest.java
@@ -21,8 +21,9 @@
 
 package io.crate.protocols.postgres.types;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -60,8 +61,10 @@ public class TimestampTypeTest extends BasePGTypeTest<Long> {
 
     @Test
     public void testDecodeUTF8TextWithUnexpectedNumberOfFractionDigits() {
-        expectedException.expectMessage("Text '2016-06-28 00:00:00.0000000001+05:00' could not be parsed");
-        TimestampType.INSTANCE.decodeUTF8Text("2016-06-28 00:00:00.0000000001+05:00".getBytes(UTF_8));
+        assertThatThrownBy(() -> {
+            TimestampType.INSTANCE.decodeUTF8Text("2016-06-28 00:00:00.0000000001+05:00".getBytes(UTF_8));
+        })
+            .hasMessageStartingWith("Text '2016-06-28 00:00:00.0000000001+05:00' could not be parsed");
     }
 
     @Test

--- a/server/src/test/java/io/crate/protocols/postgres/types/TimestampZTypeTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/types/TimestampZTypeTest.java
@@ -21,8 +21,9 @@
 
 package io.crate.protocols.postgres.types;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -60,9 +61,12 @@ public class TimestampZTypeTest extends BasePGTypeTest<Long> {
 
     @Test
     public void testDecodeUTF8TextWithUnexpectedNumberOfFractionDigits() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Cannot parse more than 9 digits for fraction of a second");
-        TimestampZType.INSTANCE.decodeUTF8Text("2016-06-28 00:00:00.0000000001+05:00".getBytes(UTF_8));
+        assertThatThrownBy(() -> {
+            TimestampZType.INSTANCE.decodeUTF8Text("2016-06-28 00:00:00.0000000001+05:00".getBytes(UTF_8));
+
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Cannot parse more than 9 digits for fraction of a second");
     }
 
     @Test

--- a/server/src/test/java/io/crate/types/TimeTZParserTest.java
+++ b/server/src/test/java/io/crate/types/TimeTZParserTest.java
@@ -23,6 +23,7 @@ package io.crate.types;
 
 import static io.crate.types.TimeTZParser.parse;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -66,65 +67,96 @@ public class TimeTZParserTest extends ESTestCase {
 
     @Test
     public void test_parse_time_range_overflow() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Text '24:00:00.000001' could not be parsed: Invalid value for HourOfDay (valid values 0 - 23): 24");
-        parse("24:00:00.000001");
+        assertThatThrownBy(() -> {
+            parse("24:00:00.000001");
+
+        })
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage(
+                    "Text '24:00:00.000001' could not be parsed: Invalid value for HourOfDay (valid values 0 - 23): 24");
     }
 
     @Test
     public void test_parse_time_unsupported_literal_long() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Text '234' could not be parsed, unparsed text found at index 2");
-        parse("234");
+        assertThatThrownBy(() -> {
+            parse("234");
+
+        })
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Text '234' could not be parsed, unparsed text found at index 2");
     }
 
     @Test
     public void test_parse_time_unsupported_literal_floating_point() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Text '234.9999' could not be parsed, unparsed text found at index 2");
-        parse("234.9999");
+        assertThatThrownBy(() -> {
+            parse("234.9999");
+
+        })
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Text '234.9999' could not be parsed, unparsed text found at index 2");
     }
 
     @Test
     public void test_parse_time_out_of_range_hh() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Text '25' could not be parsed: Invalid value for HourOfDay (valid values 0 - 23): 25");
-        parse("25");
+        assertThatThrownBy(() -> {
+            parse("25");
+
+        })
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Text '25' could not be parsed: Invalid value for HourOfDay (valid values 0 - 23): 25");
     }
 
     @Test
     public void test_parse_time_out_of_range_hhmm() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Text '1778' could not be parsed: Invalid value for MinuteOfHour (valid values 0 - 59): 78");
-        parse("1778");
+        assertThatThrownBy(() -> {
+            parse("1778");
+
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage(
+                        "Text '1778' could not be parsed: Invalid value for MinuteOfHour (valid values 0 - 59): 78");
     }
 
     @Test
     public void test_parse_time_out_of_range_hhmmss() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Text '175978' could not be parsed: Invalid value for SecondOfMinute (valid values 0 - 59): 78");
-        parse("175978");
+        assertThatThrownBy(() -> {
+            parse("175978");
+
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage(
+                        "Text '175978' could not be parsed: Invalid value for SecondOfMinute (valid values 0 - 59): 78");
     }
 
     @Test
     public void test_parse_time_out_of_range_hh_floating_point() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Invalid value for HourOfDay (valid values 0 - 23): 25");
-        parse("25.999999");
+        assertThatThrownBy(() -> {
+            parse("25.999999");
+
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Invalid value for HourOfDay (valid values 0 - 23): 25");
     }
 
     @Test
     public void test_parse_time_out_of_range_hhmm_floating_point() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Invalid value for MinuteOfHour (valid values 0 - 59): 78");
-        parse("1778.999999");
+        assertThatThrownBy(() -> {
+            parse("1778.999999");
+
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Invalid value for MinuteOfHour (valid values 0 - 59): 78");
     }
 
     @Test
     public void test_parse_time_out_of_range_hhmmss_floating_point() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Text '175978.999999' could not be parsed: Invalid value for SecondOfMinute (valid values 0 - 59): 78");
-        parse("175978.999999");
+        assertThatThrownBy(() -> {
+            parse("175978.999999");
+
+        })
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage(
+                        "Text '175978.999999' could not be parsed: Invalid value for SecondOfMinute (valid values 0 - 59): 78");
     }
 
     @Test


### PR DESCRIPTION
Formatting might be a bit off in a couple of places as I tried to do this semi-automated with:

```
COMBY_M="$(cat <<"MATCH"
expectedException.expect(:[exc]);
expectedException.expectMessage(:[msg]);
:[after]
MATCH
)"
 COMBY_R="$(cat <<"REWRITE"
assertThatThrownBy(() -> {
    :[after]
})
.isExactlyInstanceOf(:[exc])
.hasMessage(:[msg]);

REWRITE
)"
  comby "$COMBY_M" "$COMBY_R" .java -in-place -match-newline-at-toplevel 
```