### PR TITLE
Add maven cheetsheet file in dev docs

### DIFF
--- a/devs/docs/index.rst
+++ b/devs/docs/index.rst
@@ -13,3 +13,4 @@ Contents
 - `Release workflow <release.rst>`_
 - `Benchmarks <benchmarks.rst>`_
 - `Logging <logging.rst>`_
+- `Maven cheatsheet <maven.rst>`_

--- a/devs/docs/maven.rst
+++ b/devs/docs/maven.rst
@@ -1,0 +1,13 @@
+================
+Maven cheatsheet
+================
+
+To check new versions available for maven plugins::
+
+    $ ./mvnw versions:display-plugin-updates
+
+
+To check new versions available for library dependencies::
+
+    $ ./mvnw versions:display-dependency-updates
+


### PR DESCRIPTION
Add instructions to check for new versions for maven plugins and library dependencies.
