### PR TITLE
Replace lunasec.io link regarding log4j vulnerability with wikipedia link

### DIFF
--- a/docs/appendices/release-notes/4.6.6.rst
+++ b/docs/appendices/release-notes/4.6.6.rst
@@ -35,7 +35,7 @@ Fixes
 =====
 
 - Updated ``log4j`` to 2.15.0 to fix a security vulnerability. See `Log4Shell
-  <https://www.lunasec.io/docs/blog/log4j-zero-day/>`_ for details.
+  <https://en.wikipedia.org/wiki/Log4Shell>`_ for details.
 
 - Fixed an issue that could result in an error if a client sent multiple
   statements in a single string using the PostgreSQL simple protocol mode.


### PR DESCRIPTION
## Problem
Link checker trips at [PR build run #9611188697](https://github.com/crate/crate/actions/runs/9611188697/job/26509257101?pr=16207).

- https://github.com/crate/crate/pull/16207

## Review
_Please adjust backport labels as you see fit._