### PR TITLE
tests: Fix assertion for testSelectGroupByIncludingUnassignedShards

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/ShardStatsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ShardStatsTest.java
@@ -76,7 +76,7 @@ public class ShardStatsTest extends IntegTestCase {
                 "group by state, \"primary\" order by state desc");
         assertThat(response.rowCount()).isGreaterThanOrEqualTo(2L);
         assertThat(response.cols().length).isEqualTo(3);
-        assertThat((Long) response.rows()[0][0]).isLessThanOrEqualTo(5L);
+        assertThat((Long) response.rows()[0][0]).isGreaterThanOrEqualTo(5L);
         assertThat(response.rows()[0][1]).isEqualTo("UNASSIGNED");
         assertThat(response.rows()[0][2]).isEqualTo(false);
     }


### PR DESCRIPTION
It was accidentally changed to `lessThanOrEqual` instead of `greaterThanOrEqual` with: #16210

Follows: a219fc34717ae5c9b177c946dcbdbf3f1cd16b57
