### PR TITLE
Test reference resolvers for types with index/column store off

### DIFF
--- a/server/src/test/java/io/crate/execution/dml/IndexerTest.java
+++ b/server/src/test/java/io/crate/execution/dml/IndexerTest.java
@@ -26,7 +26,6 @@ import static io.crate.types.GeoShapeType.Names.TREE_BKD;
 import static io.crate.types.GeoShapeType.Names.TREE_GEOHASH;
 import static io.crate.types.GeoShapeType.Names.TREE_LEGACY_QUADTREE;
 import static io.crate.types.GeoShapeType.Names.TREE_QUADTREE;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
 

--- a/server/src/test/java/io/crate/types/ArrayTypeTest.java
+++ b/server/src/test/java/io/crate/types/ArrayTypeTest.java
@@ -60,6 +60,41 @@ public class ArrayTypeTest extends DataTypeTestCase<List<Object>> {
         return new DataDef<>(type, type.getTypeSignature().toString(), DataTypeTesting.getDataGenerator(type));
     }
 
+    @Override
+    @SuppressWarnings("unchecked")
+    public void test_reference_resolver_docvalues_off() throws Exception {
+        DataType<Object> randomType = (DataType<Object>) DataTypeTesting.randomTypeExcluding(
+            Set.of(FloatVectorType.INSTANCE_ONE, ObjectType.UNTYPED, BitStringType.INSTANCE_ONE, IpType.INSTANCE, BooleanType.INSTANCE,
+                GeoPointType.INSTANCE, GeoShapeType.INSTANCE)
+        );
+        DataType<List<Object>> type = new ArrayType<>(randomType);
+        String definition = type.getTypeSignature().toString() + " STORAGE WITH (columnstore=false)";
+        doReferenceResolveTest(type, definition, DataTypeTesting.getDataGenerator(type).get());
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void test_reference_resolver_index_and_docvalues_off() throws Exception {
+        DataType<Object> randomType = (DataType<Object>) DataTypeTesting.randomTypeExcluding(
+            Set.of(FloatVectorType.INSTANCE_ONE, ObjectType.UNTYPED, BitStringType.INSTANCE_ONE, IpType.INSTANCE, BooleanType.INSTANCE,
+                GeoPointType.INSTANCE, GeoShapeType.INSTANCE)
+        );
+        DataType<List<Object>> type = new ArrayType<>(randomType);
+        String definition = type.getTypeSignature().toString() + " INDEX OFF STORAGE WITH (columnstore=false)";
+        doReferenceResolveTest(type, definition, DataTypeTesting.getDataGenerator(type).get());
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void test_reference_resolver_index_off() throws Exception {
+        DataType<Object> randomType = (DataType<Object>) DataTypeTesting.randomTypeExcluding(
+            Set.of(FloatVectorType.INSTANCE_ONE, ObjectType.UNTYPED, GeoPointType.INSTANCE, GeoShapeType.INSTANCE)
+        );
+        DataType<List<Object>> type = new ArrayType<>(randomType);
+        String definition = type.getTypeSignature().toString() + " INDEX OFF";
+        doReferenceResolveTest(type, definition, DataTypeTesting.getDataGenerator(type).get());
+    }
+
     @Test
     public void test_pg_string_array_literal_can_be_converted_to_values() {
         ArrayType<String> strArray = new ArrayType<>(DataTypes.STRING);

--- a/server/src/test/java/io/crate/types/BitStringTypeTest.java
+++ b/server/src/test/java/io/crate/types/BitStringTypeTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.types;
 
+import static com.carrotsearch.randomizedtesting.RandomizedTest.assumeFalse;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.function.Supplier;
@@ -76,5 +77,15 @@ public class BitStringTypeTest extends DataTypeTestCase<BitString> {
         BitStringType type = new BitStringType(4);
         BitString result = type.explicitCast(BitString.ofRawBits("111"), SESSION_SETTINGS);
         assertThat(result).isEqualTo(BitString.ofRawBits("1110"));
+    }
+
+    @Override
+    public void test_reference_resolver_docvalues_off() throws Exception {
+        assumeFalse("BitStringType cannot disable column store", true);
+    }
+
+    @Override
+    public void test_reference_resolver_index_and_docvalues_off() throws Exception {
+        assumeFalse("BitStringType cannot disable column store", true);
     }
 }

--- a/server/src/test/java/io/crate/types/BooleanTypeTest.java
+++ b/server/src/test/java/io/crate/types/BooleanTypeTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.types;
 
+import static com.carrotsearch.randomizedtesting.RandomizedTest.assumeFalse;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -93,5 +94,15 @@ public class BooleanTypeTest extends DataTypeTestCase<Boolean> {
         assertThatThrownBy(() -> BooleanType.INSTANCE.implicitCast(Map.of()))
             .isExactlyInstanceOf(ClassCastException.class)
             .hasMessage("Can't cast '{}' to boolean");
+    }
+
+    @Override
+    public void test_reference_resolver_docvalues_off() throws Exception {
+        assumeFalse("BooleanType cannot disable column store", true);
+    }
+
+    @Override
+    public void test_reference_resolver_index_and_docvalues_off() throws Exception {
+        assumeFalse("BooleanType cannot disable column store", true);
     }
 }

--- a/server/src/test/java/io/crate/types/GeoPointTypeTest.java
+++ b/server/src/test/java/io/crate/types/GeoPointTypeTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.types;
 
+import static com.carrotsearch.randomizedtesting.RandomizedTest.assumeFalse;
 import static io.crate.testing.Asserts.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -115,5 +116,20 @@ public class GeoPointTypeTest extends DataTypeTestCase<Point> {
         assertThatThrownBy(() -> DataTypes.GEO_POINT.implicitCast(new Double[]{-187.654, 123.456}))
             .isExactlyInstanceOf(IllegalArgumentException.class)
             .hasMessage("Failed to validate geo point [lon=-187.654000, lat=123.456000], not a valid location.");
+    }
+
+    @Override
+    public void test_reference_resolver_docvalues_off() throws Exception {
+        assumeFalse("GeoPointType cannot disable column store", true);
+    }
+
+    @Override
+    public void test_reference_resolver_index_and_docvalues_off() throws Exception {
+        assumeFalse("GeoPointType cannot disable column store", true);
+    }
+
+    @Override
+    public void test_reference_resolver_index_off() throws Exception {
+        assumeFalse("GeoPointType cannot disable index", true);
     }
 }

--- a/server/src/test/java/io/crate/types/GeoShapeTypeTest.java
+++ b/server/src/test/java/io/crate/types/GeoShapeTypeTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.types;
 
+import static com.carrotsearch.randomizedtesting.RandomizedTest.assumeFalse;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -180,6 +181,21 @@ public class GeoShapeTypeTest extends DataTypeTestCase<Map<String, Object>> {
             Map<String, Object> map = type.sanitizeValue(shape);
             GeoJSONUtils.validateGeoJson(map);
         }
+    }
+
+    @Override
+    public void test_reference_resolver_docvalues_off() throws Exception {
+        assumeFalse("GeoShapeType cannot disable column store", true);
+    }
+
+    @Override
+    public void test_reference_resolver_index_and_docvalues_off() throws Exception {
+        assumeFalse("GeoShapeType cannot disable column store", true);
+    }
+
+    @Override
+    public void test_reference_resolver_index_off() throws Exception {
+        assumeFalse("GeoShapeType cannot disable index", true);
     }
 }
 

--- a/server/src/test/java/io/crate/types/IpTypeTest.java
+++ b/server/src/test/java/io/crate/types/IpTypeTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.types;
 
+import static com.carrotsearch.randomizedtesting.RandomizedTest.assumeFalse;
 import static io.crate.testing.Asserts.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -51,5 +52,15 @@ public class IpTypeTest extends DataTypeTestCase<String> {
         assertThatThrownBy(() -> IpType.INSTANCE.implicitCast(Long.MIN_VALUE))
             .isExactlyInstanceOf(IllegalArgumentException.class)
             .hasMessage("Failed to convert long value: -9223372036854775808 to ipv4 address");
+    }
+
+    @Override
+    public void test_reference_resolver_docvalues_off() throws Exception {
+        assumeFalse("IpType cannot disable column store", true);
+    }
+
+    @Override
+    public void test_reference_resolver_index_and_docvalues_off() throws Exception {
+        assumeFalse("IpType cannot disable column store", true);
     }
 }

--- a/server/src/test/java/io/crate/types/NestedArrayTypeTest.java
+++ b/server/src/test/java/io/crate/types/NestedArrayTypeTest.java
@@ -65,6 +65,41 @@ public class NestedArrayTypeTest extends DataTypeTestCase<List<List<Object>>> {
         return new ArrayType<>(new ArrayType<>(randomType));
     }
 
+    @Override
+    @SuppressWarnings("unchecked")
+    public void test_reference_resolver_docvalues_off() throws Exception {
+        DataType<Object> randomType = (DataType<Object>) DataTypeTesting.randomTypeExcluding(
+            Set.of(FloatVectorType.INSTANCE_ONE, ObjectType.UNTYPED, BitStringType.INSTANCE_ONE, IpType.INSTANCE, BooleanType.INSTANCE,
+                GeoPointType.INSTANCE, GeoShapeType.INSTANCE)
+        );
+        DataType<List<List<Object>>> type = new ArrayType<>(new ArrayType<>(randomType));
+        String definition = type.getTypeSignature().toString() + " STORAGE WITH (columnstore=false)";
+        doReferenceResolveTest(type, definition, DataTypeTesting.getDataGenerator(type).get());
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void test_reference_resolver_index_and_docvalues_off() throws Exception {
+        DataType<Object> randomType = (DataType<Object>) DataTypeTesting.randomTypeExcluding(
+            Set.of(FloatVectorType.INSTANCE_ONE, ObjectType.UNTYPED, BitStringType.INSTANCE_ONE, IpType.INSTANCE, BooleanType.INSTANCE,
+                GeoPointType.INSTANCE, GeoShapeType.INSTANCE)
+        );
+        DataType<List<List<Object>>> type = new ArrayType<>(new ArrayType<>(randomType));
+        String definition = type.getTypeSignature().toString() + " INDEX OFF STORAGE WITH (columnstore=false)";
+        doReferenceResolveTest(type, definition, DataTypeTesting.getDataGenerator(type).get());
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void test_reference_resolver_index_off() throws Exception {
+        DataType<Object> randomType = (DataType<Object>) DataTypeTesting.randomTypeExcluding(
+            Set.of(FloatVectorType.INSTANCE_ONE, ObjectType.UNTYPED, GeoPointType.INSTANCE, GeoShapeType.INSTANCE)
+        );
+        DataType<List<List<Object>>> type = new ArrayType<>(new ArrayType<>(randomType));
+        String definition = type.getTypeSignature().toString() + " INDEX OFF";
+        doReferenceResolveTest(type, definition, DataTypeTesting.getDataGenerator(type).get());
+    }
+
     @Test
     public void test_index_structure() throws IOException {
         // create a table with a nested array

--- a/server/src/test/java/io/crate/types/ObjectTypeTest.java
+++ b/server/src/test/java/io/crate/types/ObjectTypeTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.types;
 
+import static com.carrotsearch.randomizedtesting.RandomizedTest.assumeFalse;
 import static io.crate.testing.Asserts.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -207,5 +208,20 @@ public class ObjectTypeTest extends DataTypeTestCase<Map<String, Object>> {
         assertThatThrownBy(() -> ObjectType.UNTYPED.implicitCast("foo"))
             .isExactlyInstanceOf(ConversionException.class)
             .hasMessage("Cannot cast value `foo` to type `object`");
+    }
+
+    @Override
+    public void test_reference_resolver_docvalues_off() throws Exception {
+        assumeFalse("ObjectType cannot disable column store", true);
+    }
+
+    @Override
+    public void test_reference_resolver_index_and_docvalues_off() throws Exception {
+        assumeFalse("ObjectType cannot disable column store", true);
+    }
+
+    @Override
+    public void test_reference_resolver_index_off() throws Exception {
+        assumeFalse("ObjectType cannot disable index", true);
     }
 }


### PR DESCRIPTION
This adds a specific test for all data types that support different storage options,
to ensure that any option combination still allows us to resolve the values at fetch
time.