### PR TITLE
Replace lunasec.io link regarding log4j vulnerability with wikipedia link (backport #16208)

### DIFF
--- a/blackbox/requirements.txt
+++ b/blackbox/requirements.txt
@@ -14,8 +14,7 @@ minio>=5.0.0
 dnslib
 
 # Documentation
-sphinx>=3.5,<5
-docutils==0.16
+sphinx>=4.6
 sphinx-csv-filter>=0.2.0
 crate-docs-theme>=0.12.0
 

--- a/docs/appendices/release-notes/4.6.6.rst
+++ b/docs/appendices/release-notes/4.6.6.rst
@@ -35,7 +35,7 @@ Fixes
 =====
 
 - Updated ``log4j`` to 2.15.0 to fix a security vulnerability. See `Log4Shell
-  <https://www.lunasec.io/docs/blog/log4j-zero-day/>`_ for details.
+  <https://en.wikipedia.org/wiki/Log4Shell>`_ for details.
 
 - Fixed an issue that could result in an error if a client sent multiple
   statements in a single string using the PostgreSQL simple protocol mode.

--- a/docs/config/environment.rst
+++ b/docs/config/environment.rst
@@ -120,6 +120,6 @@ General
 
 
 .. _basic installation: https://crate.io/docs/crate/tutorials/en/latest/basic/
-.. _a CrateDB Linux package: https://crate.io/docs/crate/tutorials/en/latest/basic/index.html#linux
-.. _CrateDB on Docker: https://crate.io/docs/crate/tutorials/en/latest/basic/index.html#docker
+.. _a CrateDB Linux package: https://cratedb.com/docs/guide/install/
+.. _CrateDB on Docker: https://cratedb.com/docs/guide/install/container/
 .. _environment variables: https://en.wikipedia.org/wiki/Environment_variable

--- a/docs/config/logging.rst
+++ b/docs/config/logging.rst
@@ -166,8 +166,8 @@ garbage collection logging.
   If you have installed `a CrateDB Linux package`_, the default directory is
   ``/var/log/crate`` instead.
 
-.. _basic installation: https://crate.io/docs/crate/tutorials/en/latest/basic/
-.. _a CrateDB Linux package: https://crate.io/docs/crate/tutorials/en/latest/basic/index.html#linux
+.. _basic installation: https://cratedb.com/docs/guide/install/
+.. _a CrateDB Linux package: https://cratedb.com/docs/guide/install/
 
 .. _conf-logging-gc-log-size:
 

--- a/docs/general/dql/selects.rst
+++ b/docs/general/dql/selects.rst
@@ -1120,4 +1120,4 @@ in the ``HAVING`` clause, like in the result columns::
 .. _`3-valued logic`: https://en.wikipedia.org/wiki/Null_(SQL)#Comparisons_with_NULL_and_the_three-valued_logic_(3VL)
 .. _Lucene Regular Expressions: http://lucene.apache.org/core/4_9_0/core/org/apache/lucene/util/automaton/RegExp.html
 .. _PCRE: https://en.wikipedia.org/wiki/Perl_Compatible_Regular_Expressions
-.. _POSIX Extended Regular Expressions: http://en.wikipedia.org/wiki/Regular_expression#POSIX_extended
+.. _POSIX Extended Regular Expressions: http://en.wikipedia.org/wiki/Regular_expression#Metacharacters_in_POSIX_extended


### PR DESCRIPTION
## About
lunasec.io site seems to be down, I think it makes sense anyway to point to a wikipedia entry.

## Backport
- Original: GH-16208

## Notes
As found out previously, building docs on 4.8 might be broken. This PR intends to fix it.