### PR TITLE
Unary/Binary/TripleScalar implementations do not need to be STRICTNULL

### DIFF
--- a/server/src/main/java/io/crate/expression/scalar/ArrayAvgFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayAvgFunction.java
@@ -91,7 +91,7 @@ public class ArrayAvgFunction {
             Signature.builder(NAME, FunctionType.SCALAR)
                 .argumentTypes(new ArrayType<>(DataTypes.NUMERIC).getTypeSignature())
                 .returnType(DataTypes.NUMERIC.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
+                .features(Scalar.Feature.DETERMINISTIC)
                 .build(),
             (signature, boundSignature) -> new UnaryScalar<>(
                 signature,
@@ -105,7 +105,7 @@ public class ArrayAvgFunction {
             Signature.builder(NAME, FunctionType.SCALAR)
                 .argumentTypes(new ArrayType<>(DataTypes.FLOAT).getTypeSignature())
                 .returnType(DataTypes.FLOAT.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
+                .features(Scalar.Feature.DETERMINISTIC)
                 .build(),
             (signature, boundSignature) -> new UnaryScalar<>(
                 signature,
@@ -119,7 +119,7 @@ public class ArrayAvgFunction {
             Signature.builder(NAME, FunctionType.SCALAR)
                 .argumentTypes(new ArrayType<>(DataTypes.DOUBLE).getTypeSignature())
                 .returnType(DataTypes.DOUBLE.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
+                .features(Scalar.Feature.DETERMINISTIC)
                 .build(),
             (signature, boundSignature) -> new UnaryScalar<>(
                 signature,
@@ -136,7 +136,7 @@ public class ArrayAvgFunction {
                     Signature.builder(NAME, FunctionType.SCALAR)
                         .argumentTypes(new ArrayType<>(supportedType).getTypeSignature())
                         .returnType(DataTypes.NUMERIC.getTypeSignature())
-                        .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
+                        .features(Scalar.Feature.DETERMINISTIC)
                         .build(),
                     (signature, boundSignature) -> new UnaryScalar<>(
                         signature,

--- a/server/src/main/java/io/crate/expression/scalar/TripleScalar.java
+++ b/server/src/main/java/io/crate/expression/scalar/TripleScalar.java
@@ -45,7 +45,6 @@ public final class TripleScalar<R, T> extends Scalar<R, T> {
                         DataType<T> type,
                         ThreeParametersFunction<T, T, T, R> func) {
         super(signature, boundSignature);
-        assert signature.hasFeature(Feature.STRICTNULL) : "A TriScalar is NULLABLE by definition";
         assert boundSignature.argTypes().stream().allMatch(t -> t.id() == type.id()) :
             "All argument types of the bound signature must match the type argument";
         this.type = type;

--- a/server/src/main/java/io/crate/expression/scalar/UnaryScalar.java
+++ b/server/src/main/java/io/crate/expression/scalar/UnaryScalar.java
@@ -47,7 +47,6 @@ public class UnaryScalar<R, T> extends Scalar<R, T> {
                        DataType<T> type,
                        Function<T, R> func) {
         super(signature, boundSignature);
-        assert signature.hasFeature(Feature.STRICTNULL) : "A UnaryScalar is NULLABLE by definition";
         assert boundSignature.argTypes().get(0).id() == type.id() :
             "The bound argument type of the signature must match the type argument";
         this.type = type;

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/BinaryScalar.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/BinaryScalar.java
@@ -41,7 +41,6 @@ public final class BinaryScalar<T> extends Scalar<T, T> {
                         BoundSignature boundSignature,
                         DataType<T> type) {
         super(signature, boundSignature);
-        assert signature.hasFeature(Feature.STRICTNULL) : "A BinaryScalar is NULLABLE by definition";
         assert boundSignature.argTypes().stream().allMatch(t -> t.id() == type.id()) :
             "All bound argument types of the signature must match the type argument";
         this.func = func;

--- a/server/src/test/java/io/crate/execution/engine/pipeline/MapRowUsingInputsTest.java
+++ b/server/src/test/java/io/crate/execution/engine/pipeline/MapRowUsingInputsTest.java
@@ -42,7 +42,6 @@ import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.FunctionType;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.Scalar.Feature;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -63,7 +62,7 @@ public class MapRowUsingInputsTest extends ESTestCase {
                 .argumentTypes(DataTypes.LONG.getTypeSignature(),
                     DataTypes.LONG.getTypeSignature())
                 .returnType(DataTypes.LONG.getTypeSignature())
-                .features(Feature.DETERMINISTIC, Feature.COMPARISON_REPLACEMENT, Scalar.Feature.STRICTNULL)
+                .features(Feature.DETERMINISTIC, Feature.COMPARISON_REPLACEMENT)
                 .build(),
             List.of(new InputColumn(0, DataTypes.LONG), Literal.of(2L)),
             DataTypes.LONG

--- a/server/src/test/java/io/crate/expression/InputFactoryTest.java
+++ b/server/src/test/java/io/crate/expression/InputFactoryTest.java
@@ -48,7 +48,6 @@ import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionType;
 import io.crate.metadata.RelationName;
-import io.crate.metadata.Scalar;
 import io.crate.metadata.Scalar.Feature;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
@@ -67,7 +66,7 @@ public class InputFactoryTest extends CrateDummyClusterServiceUnitTest {
                     .argumentTypes(DataTypes.INTEGER.getTypeSignature(),
                             DataTypes.INTEGER.getTypeSignature())
                     .returnType(DataTypes.INTEGER.getTypeSignature())
-                    .features(Feature.DETERMINISTIC, Feature.COMPARISON_REPLACEMENT, Scalar.Feature.STRICTNULL)
+                    .features(Feature.DETERMINISTIC, Feature.COMPARISON_REPLACEMENT)
                     .build(),
             List.of(new InputColumn(1, DataTypes.INTEGER), Literal.of(10)),
             DataTypes.INTEGER


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
The definition of `NULLABLE` is clear from https://github.com/crate/crate/pull/16181. A function is `nullable` if `null -> null` AND no other inputs result in nulls. Hence revisiting https://github.com/crate/crate/pull/15452 and reverting several lines.


## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
