### PR TITLE
Undeprecate bytesAsInt and SUPPORTS_V6

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/network/NetworkService.java
+++ b/server/src/main/java/org/elasticsearch/common/network/NetworkService.java
@@ -19,12 +19,6 @@
 
 package org.elasticsearch.common.network;
 
-import org.elasticsearch.common.settings.Setting;
-import org.elasticsearch.common.settings.Setting.Property;
-import org.elasticsearch.common.unit.ByteSizeValue;
-import io.crate.common.unit.TimeValue;
-import io.crate.types.DataTypes;
-
 import java.io.IOException;
 import java.net.InetAddress;
 import java.util.ArrayList;
@@ -35,6 +29,13 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Setting.Property;
+import org.elasticsearch.common.unit.ByteSizeValue;
+
+import io.crate.common.unit.TimeValue;
+import io.crate.types.DataTypes;
 
 public final class NetworkService {
 
@@ -130,7 +131,6 @@ public final class NetworkService {
      *                     such as _local_ (see the documentation). if it is null, it will fall back to _local_
      * @return single internet address
      */
-    // TODO: needs to be InetAddress[]
     public InetAddress resolvePublishHostAddresses(String[] publishHosts) throws IOException {
         if (publishHosts == null || publishHosts.length == 0) {
             for (CustomNameResolver customNameResolver : customNameResolvers) {

--- a/server/src/main/java/org/elasticsearch/common/network/NetworkUtils.java
+++ b/server/src/main/java/org/elasticsearch/common/network/NetworkUtils.java
@@ -19,9 +19,6 @@
 
 package org.elasticsearch.common.network;
 
-import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.Constants;
-
 import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetAddress;
@@ -34,6 +31,9 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.Constants;
 
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.Constants;
@@ -52,17 +52,13 @@ public abstract class NetworkUtils {
      * By default we bind to any addresses on an interface/name, unless restricted by :ipv4 etc.
      * This property is unrelated to that, this is about what we *publish*. Today the code pretty much
      * expects one address so this is used for the sort order.
-     * @deprecated transition mechanism only
      */
-    @Deprecated
     static final boolean PREFER_V6 = Boolean.parseBoolean(System.getProperty("java.net.preferIPv6Addresses", "false"));
 
     /**
      * True if we can bind to a v6 address. Its silly, but for *binding* we have a need to know
      * if the stack works. this can prevent scary noise on IPv4-only hosts.
-     * @deprecated transition mechanism only, do not use
      */
-    @Deprecated
     public static final boolean SUPPORTS_V6;
 
     static {
@@ -110,20 +106,14 @@ public abstract class NetworkUtils {
 
     /**
      * Sorts addresses by order of preference. This is used to pick the first one for publishing
-     * @deprecated remove this when multihoming is really correct
      */
-    @Deprecated
-    // only public because of silly multicast
     public static void sortAddresses(List<InetAddress> list) {
-        Collections.sort(list, new Comparator<InetAddress>() {
-            @Override
-            public int compare(InetAddress left, InetAddress right) {
-                int cmp = Integer.compare(sortKey(left, PREFER_V6), sortKey(right, PREFER_V6));
-                if (cmp == 0) {
-                    cmp = new BytesRef(left.getAddress()).compareTo(new BytesRef(right.getAddress()));
-                }
-                return cmp;
+        list.sort((left, right) -> {
+            int cmp = Integer.compare(sortKey(left, PREFER_V6), sortKey(right, PREFER_V6));
+            if (cmp == 0) {
+                cmp = new BytesRef(left.getAddress()).compareTo(new BytesRef(right.getAddress()));
             }
+            return cmp;
         });
     }
 

--- a/server/src/main/java/org/elasticsearch/common/unit/ByteSizeValue.java
+++ b/server/src/main/java/org/elasticsearch/common/unit/ByteSizeValue.java
@@ -19,16 +19,16 @@
 
 package org.elasticsearch.common.unit;
 
+import java.io.IOException;
+import java.util.Locale;
+import java.util.Objects;
+
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
-import java.io.IOException;
-import java.util.Locale;
-import java.util.Objects;
-
-public class ByteSizeValue implements Comparable<ByteSizeValue>, ToXContentFragment {
+public final class ByteSizeValue implements Comparable<ByteSizeValue>, ToXContentFragment {
 
     public static final ByteSizeValue ZERO = new ByteSizeValue(0, ByteSizeUnit.BYTES);
 
@@ -51,17 +51,12 @@ public class ByteSizeValue implements Comparable<ByteSizeValue>, ToXContentFragm
         this.unit = unit;
     }
 
-    // For testing
-    long getSize() {
-        return size;
-    }
-
-    // For testing
-    ByteSizeUnit getUnit() {
-        return unit;
-    }
-
-    @Deprecated
+    /**
+     * Returns the size as int.
+     * You should use {@link #getBytes()} instead if possible.
+     *
+     * @throws IllegalArgumentException if the value exceeds {@link Integer#MAX_VALUE}
+     */
     public int bytesAsInt() {
         long bytes = getBytes();
         if (bytes > Integer.MAX_VALUE) {
@@ -72,26 +67,6 @@ public class ByteSizeValue implements Comparable<ByteSizeValue>, ToXContentFragm
 
     public long getBytes() {
         return unit.toBytes(size);
-    }
-
-    public long getKb() {
-        return unit.toKB(size);
-    }
-
-    public long getMb() {
-        return unit.toMB(size);
-    }
-
-    public long getGb() {
-        return unit.toGB(size);
-    }
-
-    public long getTb() {
-        return unit.toTB(size);
-    }
-
-    public long getPb() {
-        return unit.toPB(size);
     }
 
     public double getMbFrac() {
@@ -213,14 +188,7 @@ public class ByteSizeValue implements Comparable<ByteSizeValue>, ToXContentFragm
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-
-        return compareTo((ByteSizeValue) o) == 0;
+        return o instanceof ByteSizeValue other && compareTo(other) == 0;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/shard/PrimaryReplicaSyncer.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/PrimaryReplicaSyncer.java
@@ -19,6 +19,12 @@
 
 package org.elasticsearch.index.shard;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
@@ -29,18 +35,13 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
-import io.crate.common.io.IOUtils;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.seqno.SequenceNumbers;
 import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.transport.TransportService;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
+import io.crate.common.io.IOUtils;
 
 public class PrimaryReplicaSyncer {
 
@@ -63,7 +64,7 @@ public class PrimaryReplicaSyncer {
     }
 
     void setChunkSize(ByteSizeValue chunkSize) { // only settable for tests
-        if (chunkSize.bytesAsInt() <= 0) {
+        if (chunkSize.getBytes() <= 0) {
             throw new IllegalArgumentException("chunkSize must be > 0");
         }
         this.chunkSize = chunkSize;


### PR DESCRIPTION
There's no real effort trying to get rid of these deprecations and they
aren't really harmful.
