### PR TITLE
Fixed nullability for `format_type` scalar

### DIFF
--- a/docs/appendices/release-notes/5.7.3.rst
+++ b/docs/appendices/release-notes/5.7.3.rst
@@ -48,6 +48,10 @@ See the :ref:`version_5.7.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that caused queries to incorrectly filter out rows when the
+  ``WHERE`` clause contained :ref:`scalar-format_type` function under ``NOT`` or
+  ``!=`` operators.
+
 - Fixed an issue that resulted in an ``unsupported ExecutionNode`` error if
   joining a foreign table with another table that's sharded across many nodes.
 

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/FormatTypeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/FormatTypeFunction.java
@@ -46,8 +46,7 @@ public final class FormatTypeFunction extends Scalar<String, Object> {
                     DataTypes.INTEGER.getTypeSignature(),
                     DataTypes.INTEGER.getTypeSignature(),
                     DataTypes.STRING.getTypeSignature()
-                ).withFeature(Feature.DETERMINISTIC)
-                .withFeature(Feature.NULLABLE),
+                ).withFeature(Feature.DETERMINISTIC),
             FormatTypeFunction::new
         );
     }

--- a/server/src/test/java/io/crate/lucene/ThreeValuedLogicQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/ThreeValuedLogicQueryBuilderTest.java
@@ -129,4 +129,10 @@ public class ThreeValuedLogicQueryBuilderTest extends LuceneQueryBuilderTest {
         assertThat(convert("NOT (has_table_privilege(name, 'select'))"))
             .hasToString("+(+*:* -pg_catalog.has_table_privilege(name, 'select')) +FieldExistsQuery [field=name]");
     }
+
+    @Test
+    public void test_negated_format_type_with_three_valued_logic() {
+        assertThat(convert("NOT pg_catalog.format_type(x, null)")).hasToString(
+            "+(+*:* -pg_catalog.format_type(x, NULL)) #(NOT pg_catalog.format_type(x, NULL))");
+    }
 }


### PR DESCRIPTION
The 2nd argument is ignored, so even if it's `null` the function can return `???` as a result (only based on the 1st argument.

Fixes: #16225
