### PR TITLE
Move methods from Symbols/SymbolVisitors to Symbol

### DIFF
--- a/server/src/main/java/io/crate/analyze/AnalyzedCreateTable.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedCreateTable.java
@@ -38,7 +38,6 @@ import io.crate.analyze.TableElementsAnalyzer.RefBuilder;
 import io.crate.common.collections.Lists;
 import io.crate.data.Row;
 import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.FulltextAnalyzerResolver;
 import io.crate.metadata.IndexReference;
@@ -148,7 +147,7 @@ public record AnalyzedCreateTable(
 
         Optional<ColumnIdent> optClusteredBy = clusteredBy
             .flatMap(ClusteredBy::column)
-            .map(Symbols::pathFromSymbol);
+            .map(Symbol::toColumn);
         optClusteredBy.ifPresent(c -> {
             if (!primaryKeys.isEmpty() && Reference.indexOf(primaryKeys, c) < 0) {
                 throw new IllegalArgumentException(

--- a/server/src/main/java/io/crate/analyze/AnalyzedInsertStatement.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedInsertStatement.java
@@ -41,8 +41,6 @@ import io.crate.execution.dsl.projection.builder.InputColumns;
 import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.SymbolVisitors;
-import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.GeneratedReference;
 import io.crate.metadata.Reference;
@@ -159,7 +157,7 @@ public class AnalyzedInsertStatement implements AnalyzedStatement {
                     }
                 }
 
-                if (SymbolVisitors.any(Symbols.IS_COLUMN, symbol)) {
+                if (symbol.any(Symbol.IS_COLUMN)) {
                     if (alwaysRequireColumn) {
                         throw new IllegalArgumentException(String.format(
                             Locale.ENGLISH,

--- a/server/src/main/java/io/crate/analyze/BoundCreateTable.java
+++ b/server/src/main/java/io/crate/analyze/BoundCreateTable.java
@@ -31,7 +31,6 @@ import com.carrotsearch.hppc.IntArrayList;
 
 import io.crate.common.collections.Lists;
 import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.Reference;
@@ -74,7 +73,7 @@ public record BoundCreateTable(
     }
 
     public static List<String> toPartitionMapping(Symbol symbol) {
-        String fqn = Symbols.pathFromSymbol(symbol).fqn();
+        String fqn = symbol.toColumn().fqn();
         String typeMappingName = DataTypes.esMappingNameFrom(symbol.valueType().id());
         return List.of(fqn, typeMappingName);
     }

--- a/server/src/main/java/io/crate/analyze/CreateTableAsAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/CreateTableAsAnalyzer.java
@@ -30,7 +30,7 @@ import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.RelationAnalyzer;
 import io.crate.analyze.relations.StatementAnalysisContext;
 import io.crate.common.collections.Lists;
-import io.crate.expression.symbol.Symbols;
+import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.table.Operation;
@@ -71,7 +71,7 @@ public final class CreateTableAsAnalyzer {
             new StatementAnalysisContext(paramTypeHints, Operation.READ, txnCtx));
 
         List<TableElement<Expression>> tableElements =
-            Lists.map(analyzedSourceQuery.outputs(), Symbols::toColumnDefinition);
+            Lists.map(analyzedSourceQuery.outputs(), Symbol::toColumnDefinition);
 
         CreateTable<Expression> createTable = new CreateTable<Expression>(
             createTableAs.name(),

--- a/server/src/main/java/io/crate/analyze/DropColumn.java
+++ b/server/src/main/java/io/crate/analyze/DropColumn.java
@@ -27,7 +27,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 
-import io.crate.expression.symbol.Symbols;
+import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.Reference;
 
 public record DropColumn(Reference ref, boolean ifExists) implements Writeable {
@@ -38,7 +38,7 @@ public record DropColumn(Reference ref, boolean ifExists) implements Writeable {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        Symbols.toStream(ref, out);
+        Symbol.toStream(ref, out);
         out.writeBoolean(ifExists);
     }
 }

--- a/server/src/main/java/io/crate/analyze/FrameBoundDefinition.java
+++ b/server/src/main/java/io/crate/analyze/FrameBoundDefinition.java
@@ -21,19 +21,19 @@
 
 package io.crate.analyze;
 
-import io.crate.expression.symbol.Literal;
-import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.Symbols;
-import io.crate.sql.tree.FrameBound;
-import io.crate.sql.tree.FrameBound.Type;
+import java.io.IOException;
+import java.util.Objects;
+import java.util.function.Function;
+
 import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 
-import java.io.IOException;
-import java.util.Objects;
-import java.util.function.Function;
+import io.crate.expression.symbol.Literal;
+import io.crate.expression.symbol.Symbol;
+import io.crate.sql.tree.FrameBound;
+import io.crate.sql.tree.FrameBound.Type;
 
 public class FrameBoundDefinition implements Writeable {
 
@@ -50,9 +50,9 @@ public class FrameBoundDefinition implements Writeable {
     public FrameBoundDefinition(StreamInput in) throws IOException {
         type = in.readEnum(FrameBound.Type.class);
         if (in.getVersion().onOrAfter(Version.V_4_1_0)) {
-            value = Symbols.fromStream(in);
+            value = Symbol.fromStream(in);
         } else {
-            Symbol val = Symbols.nullableFromStream(in);
+            Symbol val = Symbol.nullableFromStream(in);
             value = val == null ? Literal.NULL : val;
         }
     }
@@ -61,9 +61,9 @@ public class FrameBoundDefinition implements Writeable {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeEnum(type);
         if (out.getVersion().onOrAfter(Version.V_4_1_0)) {
-            Symbols.toStream(value, out);
+            Symbol.toStream(value, out);
         } else {
-            Symbols.nullableToStream(value, out);
+            Symbol.nullableToStream(value, out);
         }
     }
 

--- a/server/src/main/java/io/crate/analyze/GeneratedColumnExpander.java
+++ b/server/src/main/java/io/crate/analyze/GeneratedColumnExpander.java
@@ -47,8 +47,6 @@ import io.crate.expression.symbol.FunctionCopyVisitor;
 import io.crate.expression.symbol.RefReplacer;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolType;
-import io.crate.expression.symbol.SymbolVisitors;
-import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.GeneratedReference;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
@@ -133,7 +131,7 @@ public final class GeneratedColumnExpander {
                 Symbol otherSide = null;
                 for (int i = 0; i < function.arguments().size(); i++) {
                     Symbol arg = function.arguments().get(i);
-                    arg = Symbols.unwrapReferenceFromCast(arg);
+                    arg = arg.uncast();
                     if (arg instanceof Reference ref) {
                         reference = ref;
                     } else {
@@ -142,7 +140,7 @@ public final class GeneratedColumnExpander {
                 }
                 if (reference != null
                     && otherSide != null
-                    && !SymbolVisitors.any(Symbols.IS_GENERATED_COLUMN, otherSide)) {
+                    && !otherSide.any(s -> s instanceof GeneratedReference)) {
                     return addComparison(function, reference, otherSide, context);
                 }
             }
@@ -179,7 +177,7 @@ public final class GeneratedColumnExpander {
 
                 // Account for possible implicit cast
                 // which is added when return type of the generation expression doesn't match type of the generated column.
-                Symbol symbol = Symbols.unwrapReferenceFromCast(generatedReference.generatedExpression());
+                Symbol symbol = generatedReference.generatedExpression().uncast();
                 Function generatedFunction;
                 if (symbol instanceof Function fn) {
                     generatedFunction = fn;

--- a/server/src/main/java/io/crate/analyze/InsertAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/InsertAnalyzer.java
@@ -223,7 +223,7 @@ class InsertAnalyzer {
             }
         });
         for (Symbol conflictTarget : conflictTargets) {
-            if (!pkColumnIdents.contains(Symbols.pathFromSymbol(conflictTarget))) {
+            if (!pkColumnIdents.contains(conflictTarget.toColumn())) {
                 throw new IllegalArgumentException(
                     String.format(
                         Locale.ENGLISH,

--- a/server/src/main/java/io/crate/analyze/OrderBy.java
+++ b/server/src/main/java/io/crate/analyze/OrderBy.java
@@ -39,7 +39,6 @@ import org.jetbrains.annotations.Nullable;
 import io.crate.common.Booleans;
 import io.crate.common.collections.Lists;
 import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.Symbols;
 
 /**
  * <pre>
@@ -153,7 +152,7 @@ public class OrderBy implements Writeable {
         }
         orderBySymbols = new ArrayList<>(numOrderBy);
         for (int i = 0; i < numOrderBy; i++) {
-            orderBySymbols.add(Symbols.fromStream(in));
+            orderBySymbols.add(Symbol.fromStream(in));
         }
         nullsFirst = new boolean[numOrderBy];
         for (int i = 0; i < numOrderBy; i++) {
@@ -168,7 +167,7 @@ public class OrderBy implements Writeable {
             out.writeBoolean(reverseFlag);
         }
         for (Symbol symbol : orderBySymbols) {
-            Symbols.toStream(symbol, out);
+            Symbol.toStream(symbol, out);
         }
         for (boolean nullFirst : nullsFirst) {
             out.writeBoolean(nullFirst);

--- a/server/src/main/java/io/crate/analyze/QueriedSelectRelation.java
+++ b/server/src/main/java/io/crate/analyze/QueriedSelectRelation.java
@@ -35,7 +35,6 @@ import io.crate.exceptions.AmbiguousColumnException;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.expression.symbol.AliasSymbol;
 import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.table.Operation;
@@ -87,7 +86,7 @@ public class QueriedSelectRelation implements AnalyzedRelation {
     public Symbol getField(ColumnIdent column, Operation operation, boolean errorOnUnknownObjectKey) throws AmbiguousColumnException, ColumnUnknownException, UnsupportedOperationException {
         Symbol match = null;
         for (Symbol output : outputs()) {
-            ColumnIdent outputName = Symbols.pathFromSymbol(output);
+            ColumnIdent outputName = output.toColumn();
             if (outputName.equals(column)) {
                 if (match != null) {
                     throw new AmbiguousColumnException(column, output);
@@ -187,7 +186,7 @@ public class QueriedSelectRelation implements AnalyzedRelation {
     @Override
     public String toString() {
         return "SELECT "
-               + Lists.joinOn(", ", outputs(), x -> Symbols.pathFromSymbol(x).sqlFqn())
+               + Lists.joinOn(", ", outputs(), x -> x.toColumn().sqlFqn())
                + " FROM ("
                + Lists.joinOn(", ", from, x -> x.relationName().toString())
                + ')';

--- a/server/src/main/java/io/crate/analyze/UpdateAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/UpdateAnalyzer.java
@@ -21,8 +21,6 @@
 
 package io.crate.analyze;
 
-import static io.crate.expression.symbol.Symbols.unwrapReferenceFromCast;
-
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -226,7 +224,7 @@ public final class UpdateAnalyzer {
 
                     arraySetFunctionAllocator.put(targetCol, indexToUpdate, targetValue);
                     continue;
-                } else if (unwrapReferenceFromCast(baseCol) instanceof Reference targetCol) {
+                } else if (baseCol.uncast() instanceof Reference targetCol) {
                     rejectUpdatesToFieldsOfObjectArrays(tableInfo, targetCol, IS_OBJECT_ARRAY);
                 }
             }

--- a/server/src/main/java/io/crate/analyze/ViewAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/ViewAnalyzer.java
@@ -27,7 +27,6 @@ import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.RelationAnalyzer;
 import io.crate.exceptions.RelationUnknown;
 import io.crate.exceptions.RelationsUnknown;
-import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Schemas;
@@ -76,7 +75,7 @@ public final class ViewAnalyzer {
         // on an outdated cluster check, leading to a potential race condition.
         // The "masterOperation" which will update the clusterState will do a real-time verification
 
-        if (query.outputs().stream().map(f -> Symbols.pathFromSymbol(f).sqlFqn()).distinct().count() != query.outputs().size()) {
+        if (query.outputs().stream().map(f -> f.toColumn().sqlFqn()).distinct().count() != query.outputs().size()) {
             throw new IllegalArgumentException("Query in CREATE VIEW must not have duplicate column names");
         }
         return new CreateViewStmt(

--- a/server/src/main/java/io/crate/analyze/WhereClause.java
+++ b/server/src/main/java/io/crate/analyze/WhereClause.java
@@ -34,7 +34,6 @@ import io.crate.exceptions.VersioningValidationException;
 import io.crate.expression.operator.AndOperator;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.doc.DocSysColumns;
 
 public class WhereClause {
@@ -100,19 +99,19 @@ public class WhereClause {
     }
 
     public static void validateVersioningColumnsUsage(Symbol query) {
-        if (Symbols.containsColumn(query, DocSysColumns.SEQ_NO)) {
-            if (!Symbols.containsColumn(query, DocSysColumns.PRIMARY_TERM)) {
+        if (query.hasColumn(DocSysColumns.SEQ_NO)) {
+            if (!query.hasColumn(DocSysColumns.PRIMARY_TERM)) {
                 throw VersioningValidationException.seqNoAndPrimaryTermUsage();
             } else {
-                if (Symbols.containsColumn(query, DocSysColumns.VERSION)) {
+                if (query.hasColumn(DocSysColumns.VERSION)) {
                     throw VersioningValidationException.mixedVersioningMeachanismsUsage();
                 }
             }
-        } else if (Symbols.containsColumn(query, DocSysColumns.PRIMARY_TERM)) {
-            if (!Symbols.containsColumn(query, DocSysColumns.SEQ_NO)) {
+        } else if (query.hasColumn(DocSysColumns.PRIMARY_TERM)) {
+            if (!query.hasColumn(DocSysColumns.SEQ_NO)) {
                 throw VersioningValidationException.seqNoAndPrimaryTermUsage();
             } else {
-                if (Symbols.containsColumn(query, DocSysColumns.VERSION)) {
+                if (query.hasColumn(DocSysColumns.VERSION)) {
                     throw VersioningValidationException.mixedVersioningMeachanismsUsage();
                 }
             }
@@ -158,12 +157,13 @@ public class WhereClause {
     }
 
     public boolean hasVersions() {
-        return Symbols.containsColumn(query, DocSysColumns.VERSION);
+        return query != null && query.hasColumn(DocSysColumns.VERSION);
     }
 
     public boolean hasSeqNoAndPrimaryTerm() {
-        return Symbols.containsColumn(query, DocSysColumns.SEQ_NO) &&
-               Symbols.containsColumn(query, DocSysColumns.PRIMARY_TERM);
+        return query != null
+            && query.hasColumn(DocSysColumns.SEQ_NO)
+            && query.hasColumn(DocSysColumns.PRIMARY_TERM);
     }
 
     /**

--- a/server/src/main/java/io/crate/analyze/WindowDefinition.java
+++ b/server/src/main/java/io/crate/analyze/WindowDefinition.java
@@ -58,7 +58,7 @@ public class WindowDefinition implements Writeable {
     private final WindowFrameDefinition windowFrameDefinition;
 
     public WindowDefinition(StreamInput in) throws IOException {
-        partitions = Symbols.listFromStream(in);
+        partitions = Symbols.fromStream(in);
         orderBy = in.readOptionalWriteable(OrderBy::new);
         windowFrameDefinition = new WindowFrameDefinition(in);
     }
@@ -96,7 +96,7 @@ public class WindowDefinition implements Writeable {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeVInt(partitions.size());
         for (Symbol partition : partitions) {
-            Symbols.toStream(partition, out);
+            Symbol.toStream(partition, out);
         }
         out.writeOptionalWriteable(orderBy);
         windowFrameDefinition.writeTo(out);

--- a/server/src/main/java/io/crate/analyze/relations/AliasedAnalyzedRelation.java
+++ b/server/src/main/java/io/crate/analyze/relations/AliasedAnalyzedRelation.java
@@ -33,7 +33,6 @@ import io.crate.exceptions.AmbiguousColumnException;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.expression.symbol.ScopedSymbol;
 import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.Symbols;
 import io.crate.expression.symbol.VoidReference;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.ReferenceIdent;
@@ -67,7 +66,7 @@ public class AliasedAnalyzedRelation implements AnalyzedRelation, FieldResolver 
         this.scopedSymbols = new ArrayList<>(relation.outputs().size());
         for (int i = 0; i < relation.outputs().size(); i++) {
             Symbol childOutput = relation.outputs().get(i);
-            ColumnIdent childColumn = Symbols.pathFromSymbol(childOutput);
+            ColumnIdent childColumn = childOutput.toColumn();
             ColumnIdent columnAlias = childColumn;
             if (i < columnAliases.size()) {
                 columnAlias = ColumnIdent.of(columnAliases.get(i));
@@ -79,7 +78,7 @@ public class AliasedAnalyzedRelation implements AnalyzedRelation, FieldResolver 
         }
         for (int i = 0; i < relation.hiddenOutputs().size(); i++) {
             Symbol childOutput = relation.hiddenOutputs().get(i);
-            ColumnIdent childColumn = Symbols.pathFromSymbol(childOutput);
+            ColumnIdent childColumn = childOutput.toColumn();
             ColumnIdent columnAlias = childColumn;
             if (i + relation.outputs().size() < columnAliases.size()) {
                 columnAlias = ColumnIdent.of(columnAliases.get(i));

--- a/server/src/main/java/io/crate/analyze/relations/AnalyzedView.java
+++ b/server/src/main/java/io/crate/analyze/relations/AnalyzedView.java
@@ -21,22 +21,22 @@
 
 package io.crate.analyze.relations;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 import io.crate.exceptions.AmbiguousColumnException;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.expression.symbol.ScopedSymbol;
 import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.Symbols;
 import io.crate.expression.symbol.VoidReference;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.table.Operation;
 import io.crate.role.Role;
-
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.function.Consumer;
 
 /**
  * A view is a stored SELECT statement.
@@ -59,7 +59,7 @@ public final class AnalyzedView implements AnalyzedRelation, FieldResolver {
         ArrayList<Symbol> outputs = new ArrayList<>(childOutputs.size());
         for (int i = 0; i < childOutputs.size(); i++) {
             var output = childOutputs.get(i);
-            var column = Symbols.pathFromSymbol(output);
+            var column = output.toColumn();
             outputs.add(new ScopedSymbol(name, column, output.valueType()));
         }
         this.outputSymbols = List.copyOf(outputs);

--- a/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -182,7 +182,7 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
             expressionAnalyzer,
             expressionAnalysisContext);
         for (Symbol field : childRelationFields) {
-            selectAnalysis.add(Symbols.pathFromSymbol(field), field);
+            selectAnalysis.add(field.toColumn(), field);
         }
 
         var normalizer = EvaluatingNormalizer.functionOnlyNormalizer(
@@ -316,7 +316,7 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
 
             boolean joinColumnExistsInLeft = false;
             for (var leftOutput : leftOutputs) {
-                var columnIdent = Symbols.pathFromSymbol(leftOutput);
+                var columnIdent = leftOutput.toColumn();
                 if (columnIdent.name().equals(joinColumn)) {
                     joinColumnExistsInLeft = true;
                     if (lhsOutputs.put(joinColumn, leftOutput) != null) {
@@ -333,7 +333,7 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
 
             boolean joinColumnExistsInRight = false;
             for (Symbol rightOutput : rightOutputs) {
-                var columnIdent = Symbols.pathFromSymbol(rightOutput);
+                var columnIdent = rightOutput.toColumn();
                 if (columnIdent.name().equals(joinColumn)) {
                     joinColumnExistsInRight = true;
                     if (rhsOutputs.put(joinColumn, rightOutput) != null) {

--- a/server/src/main/java/io/crate/analyze/relations/TableFunctionRelation.java
+++ b/server/src/main/java/io/crate/analyze/relations/TableFunctionRelation.java
@@ -34,7 +34,6 @@ import io.crate.expression.scalar.SubscriptFunctions;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.ScopedSymbol;
 import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.Symbols;
 import io.crate.expression.symbol.format.Style;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.FunctionName;
@@ -89,14 +88,14 @@ public class TableFunctionRelation implements AnalyzedRelation, FieldResolver {
     @Override
     public Symbol getField(ColumnIdent column, Operation operation, boolean errorOnUnknownObjectKey) throws AmbiguousColumnException, ColumnUnknownException, UnsupportedOperationException {
         for (Symbol output : outputs) {
-            ColumnIdent outputColumn = Symbols.pathFromSymbol(output);
+            ColumnIdent outputColumn = output.toColumn();
             if (column.equals(outputColumn)) {
                 return output;
             }
         }
         ColumnIdent rootColumn = column.getRoot();
         for (Symbol output : outputs) {
-            ColumnIdent outputRoot = Symbols.pathFromSymbol(output).getRoot();
+            ColumnIdent outputRoot = output.toColumn().getRoot();
             if (output.valueType().id() == ObjectType.ID && rootColumn.equals(outputRoot)) {
                 return SubscriptFunctions.makeObjectSubscript(output, column);
             }

--- a/server/src/main/java/io/crate/analyze/relations/UnionSelect.java
+++ b/server/src/main/java/io/crate/analyze/relations/UnionSelect.java
@@ -26,15 +26,13 @@ import static io.crate.types.DataTypes.merge;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.jetbrains.annotations.NotNull;
-
 import org.elasticsearch.common.UUIDs;
+import org.jetbrains.annotations.NotNull;
 
 import io.crate.exceptions.AmbiguousColumnException;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.expression.symbol.ScopedSymbol;
 import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.table.Operation;
@@ -62,7 +60,7 @@ public class UnionSelect implements AnalyzedRelation {
             var l = leftOutputs.get(i);
             var r = rightOutputs.get(i);
             try {
-                outputs.add(new ScopedSymbol(name, Symbols.pathFromSymbol(l), merge(l.valueType(), r.valueType())));
+                outputs.add(new ScopedSymbol(name, l.toColumn(), merge(l.valueType(), r.valueType())));
             } catch (IllegalArgumentException e) {
                 throw new UnsupportedOperationException(
                     "Output columns at position " + (i + 1) +

--- a/server/src/main/java/io/crate/analyze/relations/select/SelectAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/relations/select/SelectAnalyzer.java
@@ -21,6 +21,10 @@
 
 package io.crate.analyze.relations.select;
 
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
 import io.crate.analyze.OutputNameFormatter;
 import io.crate.analyze.expressions.ExpressionAnalysisContext;
 import io.crate.analyze.expressions.ExpressionAnalyzer;
@@ -28,7 +32,6 @@ import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.validator.SelectSymbolValidator;
 import io.crate.expression.symbol.AliasSymbol;
 import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.RelationName;
 import io.crate.sql.tree.AllColumns;
@@ -36,10 +39,6 @@ import io.crate.sql.tree.DefaultTraversalVisitor;
 import io.crate.sql.tree.QualifiedName;
 import io.crate.sql.tree.SelectItem;
 import io.crate.sql.tree.SingleColumn;
-
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
 
 public class SelectAnalyzer {
 
@@ -115,9 +114,9 @@ public class SelectAnalyzer {
 
         private static void addAllFieldsFromRelation(SelectAnalysis context, AnalyzedRelation relation) {
             for (Symbol field : relation.outputs()) {
-                var columnIdent = Symbols.pathFromSymbol(field);
+                var columnIdent = field.toColumn();
                 if (!columnIdent.isSystemColumn()) {
-                    context.add(Symbols.pathFromSymbol(field), field);
+                    context.add(field.toColumn(), field);
                 }
             }
         }

--- a/server/src/main/java/io/crate/analyze/where/EqualityExtractor.java
+++ b/server/src/main/java/io/crate/analyze/where/EqualityExtractor.java
@@ -53,8 +53,6 @@ import io.crate.expression.symbol.MatchPredicate;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolType;
 import io.crate.expression.symbol.SymbolVisitor;
-import io.crate.expression.symbol.SymbolVisitors;
-import io.crate.expression.symbol.Symbols;
 import io.crate.expression.symbol.format.Style;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
@@ -433,7 +431,7 @@ public class EqualityExtractor {
 
             if (functionName.equals(EqOperator.NAME)) {
                 Symbol firstArg = arguments.get(0).accept(this, ctx);
-                if (firstArg instanceof Reference ref && SymbolVisitors.any(Symbols.IS_COLUMN, arguments.get(1)) == false) {
+                if (firstArg instanceof Reference ref && arguments.get(1).any(Symbol.IS_COLUMN) == false) {
                     Comparison comparison = ctx.comparisons.get(ref.column());
                     if (comparison != null) {
                         ctx.proxyBelow = true;

--- a/server/src/main/java/io/crate/execution/ddl/tables/RenameColumnRequest.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/RenameColumnRequest.java
@@ -28,7 +28,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.jetbrains.annotations.NotNull;
 
-import io.crate.expression.symbol.Symbols;
+import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
@@ -48,7 +48,7 @@ public class RenameColumnRequest extends AcknowledgedRequest<RenameColumnRequest
     public RenameColumnRequest(StreamInput in) throws IOException {
         super(in);
         this.relationName = new RelationName(in);
-        this.refToRename = (Reference) Symbols.fromStream(in);
+        this.refToRename = (Reference) Symbol.fromStream(in);
         this.newName = ColumnIdent.of(in);
     }
 
@@ -56,7 +56,7 @@ public class RenameColumnRequest extends AcknowledgedRequest<RenameColumnRequest
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         relationName.writeTo(out);
-        Symbols.toStream(refToRename, out);
+        Symbol.toStream(refToRename, out);
         newName.writeTo(out);
     }
 

--- a/server/src/main/java/io/crate/execution/dml/Indexer.java
+++ b/server/src/main/java/io/crate/execution/dml/Indexer.java
@@ -478,7 +478,7 @@ public class Indexer {
             Synthetic synthetic = new Synthetic(ref, input, valueIndexer);
             this.synthetics.put(column, synthetic);
 
-            if (!Symbols.isDeterministic(ref.defaultExpression())) {
+            if (!ref.defaultExpression().isDeterministic()) {
                 undeterministic.add(synthetic);
             }
         }
@@ -501,7 +501,7 @@ public class Indexer {
             Synthetic synthetic = new Synthetic(ref, input, valueIndexer);
             this.synthetics.put(ref.column(), synthetic);
 
-            if (!Symbols.isDeterministic(ref.generatedExpression())) {
+            if (!ref.isDeterministic()) {
                 undeterministic.add(synthetic);
             }
         }
@@ -647,11 +647,10 @@ public class Indexer {
     }
 
     private static void addGeneratedToVerify(Map<ColumnIdent, ColumnConstraint> columnConstraints,
-                                      DocTableInfo table,
-                                      Context<?> ctxForRefs,
-                                      Reference ref) {
-        if (ref instanceof GeneratedReference generated
-                && Symbols.isDeterministic(generated.generatedExpression())) {
+                                             DocTableInfo table,
+                                             Context<?> ctxForRefs,
+                                             Reference ref) {
+        if (ref instanceof GeneratedReference generated && generated.isDeterministic()) {
             Input<?> input = ctxForRefs.add(generated.generatedExpression());
             columnConstraints.put(ref.column(), new CheckGeneratedValue(input, generated));
         }

--- a/server/src/main/java/io/crate/execution/dml/ShardResponse.java
+++ b/server/src/main/java/io/crate/execution/dml/ShardResponse.java
@@ -179,7 +179,7 @@ public class ShardResponse extends ReplicationResponse implements WriteResponse 
             if (resultColumnsSize > 0) {
                 resultColumns = new Symbol[resultColumnsSize];
                 for (int i = 0; i < resultColumnsSize; i++) {
-                    Symbol symbol = Symbols.fromStream(in);
+                    Symbol symbol = Symbol.fromStream(in);
                     resultColumns[i] = symbol;
                 }
                 Streamer<?>[] resultRowStreamers = Symbols.streamerArray(resultColumns);
@@ -225,7 +225,7 @@ public class ShardResponse extends ReplicationResponse implements WriteResponse 
                 Streamer[] resultRowStreamers = Symbols.streamerArray(resultColumns);
                 out.writeVInt(resultColumns.length);
                 for (int i = 0; i < resultColumns.length; i++) {
-                    Symbols.toStream(resultColumns[i], out);
+                    Symbol.toStream(resultColumns[i], out);
                 }
                 out.writeVInt(resultRows.size());
                 int rowLength = resultRows.get(0).length;

--- a/server/src/main/java/io/crate/execution/dml/upsert/ShardUpsertRequest.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/ShardUpsertRequest.java
@@ -134,7 +134,7 @@ public final class ShardUpsertRequest extends ShardRequest<ShardUpsertRequest, S
             if (returnValuesSize > 0) {
                 returnValues = new Symbol[returnValuesSize];
                 for (int i = 0; i < returnValuesSize; i++) {
-                    returnValues[i] = Symbols.fromStream(in);
+                    returnValues[i] = Symbol.fromStream(in);
                 }
             }
         }
@@ -184,7 +184,7 @@ public final class ShardUpsertRequest extends ShardRequest<ShardUpsertRequest, S
             if (returnValues != null) {
                 out.writeVInt(returnValues.length);
                 for (Symbol returnValue : returnValues) {
-                    Symbols.toStream(returnValue, out);
+                    Symbol.toStream(returnValue, out);
                 }
             } else {
                 out.writeVInt(0);
@@ -414,7 +414,7 @@ public final class ShardUpsertRequest extends ShardRequest<ShardUpsertRequest, S
                 int assignmentsSize = in.readVInt();
                 updateAssignments = new Symbol[assignmentsSize];
                 for (int i = 0; i < assignmentsSize; i++) {
-                    updateAssignments[i] = Symbols.fromStream(in);
+                    updateAssignments[i] = Symbol.fromStream(in);
                 }
             }
 
@@ -453,7 +453,7 @@ public final class ShardUpsertRequest extends ShardRequest<ShardUpsertRequest, S
                 out.writeBoolean(true);
                 out.writeVInt(updateAssignments.length);
                 for (Symbol updateAssignment : updateAssignments) {
-                    Symbols.toStream(updateAssignment, out);
+                    Symbol.toStream(updateAssignment, out);
                 }
             } else {
                 out.writeBoolean(false);

--- a/server/src/main/java/io/crate/execution/dsl/phases/CountPhase.java
+++ b/server/src/main/java/io/crate/execution/dsl/phases/CountPhase.java
@@ -30,7 +30,6 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 
 import io.crate.Streamer;
 import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.Routing;
 import io.crate.planner.distribution.DistributionInfo;
 import io.crate.types.DataTypes;
@@ -105,7 +104,7 @@ public class CountPhase implements UpstreamPhase {
     public CountPhase(StreamInput in) throws IOException {
         executionPhaseId = in.readVInt();
         routing = new Routing(in);
-        where = Symbols.fromStream(in);
+        where = Symbol.fromStream(in);
         distributionInfo = new DistributionInfo(in);
     }
 
@@ -113,7 +112,7 @@ public class CountPhase implements UpstreamPhase {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeVInt(executionPhaseId);
         routing.writeTo(out);
-        Symbols.toStream(where, out);
+        Symbol.toStream(where, out);
         distributionInfo.writeTo(out);
     }
 

--- a/server/src/main/java/io/crate/execution/dsl/phases/FileUriCollectPhase.java
+++ b/server/src/main/java/io/crate/execution/dsl/phases/FileUriCollectPhase.java
@@ -21,23 +21,24 @@
 
 package io.crate.execution.dsl.phases;
 
-import io.crate.analyze.CopyFromParserProperties;
-import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.Symbols;
-import io.crate.planner.distribution.DistributionInfo;
-import io.crate.execution.dsl.projection.Projection;
-import org.elasticsearch.Version;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.settings.Settings;
-
-import org.jetbrains.annotations.Nullable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.settings.Settings;
+import org.jetbrains.annotations.Nullable;
+
+import io.crate.analyze.CopyFromParserProperties;
+import io.crate.execution.dsl.projection.Projection;
+import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.Symbols;
+import io.crate.planner.distribution.DistributionInfo;
 
 public class FileUriCollectPhase extends AbstractProjectionsPhase implements CollectPhase {
 
@@ -127,7 +128,7 @@ public class FileUriCollectPhase extends AbstractProjectionsPhase implements Col
         super(in);
         compression = in.readOptionalString();
         sharedStorage = in.readOptionalBoolean();
-        targetUri = Symbols.fromStream(in);
+        targetUri = Symbol.fromStream(in);
         int numNodes = in.readVInt();
         List<String> nodes = new ArrayList<>(numNodes);
         for (int i = 0; i < numNodes; i++) {
@@ -139,7 +140,7 @@ public class FileUriCollectPhase extends AbstractProjectionsPhase implements Col
         } else {
             targetColumns = List.of();
         }
-        toCollect = Symbols.listFromStream(in);
+        toCollect = Symbols.fromStream(in);
         inputFormat = InputFormat.values()[in.readVInt()];
         if (in.getVersion().onOrAfter(Version.V_4_4_0)) {
             parserProperties = new CopyFromParserProperties(in);
@@ -158,7 +159,7 @@ public class FileUriCollectPhase extends AbstractProjectionsPhase implements Col
         super.writeTo(out);
         out.writeOptionalString(compression);
         out.writeOptionalBoolean(sharedStorage);
-        Symbols.toStream(targetUri, out);
+        Symbol.toStream(targetUri, out);
         out.writeVInt(executionNodes.size());
         for (String node : executionNodes) {
             out.writeString(node);

--- a/server/src/main/java/io/crate/execution/dsl/phases/ForeignCollectPhase.java
+++ b/server/src/main/java/io/crate/execution/dsl/phases/ForeignCollectPhase.java
@@ -68,10 +68,10 @@ public class ForeignCollectPhase extends AbstractProjectionsPhase implements Col
         super(in);
         this.handlerNode = in.readString();
         this.relationName = new RelationName(in);
-        this.toCollect = Symbols.listFromStream(in);
+        this.toCollect = Symbols.fromStream(in);
         this.outputTypes = extractOutputTypes(toCollect, projections);
         this.distributionInfo = new DistributionInfo(in);
-        this.query = Symbols.fromStream(in);
+        this.query = Symbol.fromStream(in);
         if (in.getVersion().onOrAfter(Version.V_5_8_0)) {
             this.executeAs = in.readOptionalString();
         } else {
@@ -86,7 +86,7 @@ public class ForeignCollectPhase extends AbstractProjectionsPhase implements Col
         relationName.writeTo(out);
         Symbols.toStream(toCollect, out);
         distributionInfo.writeTo(out);
-        Symbols.toStream(query, out);
+        Symbol.toStream(query, out);
         if (out.getVersion().onOrAfter(Version.V_5_8_0)) {
             out.writeOptionalString(executeAs);
         }

--- a/server/src/main/java/io/crate/execution/dsl/phases/HashJoinPhase.java
+++ b/server/src/main/java/io/crate/execution/dsl/phases/HashJoinPhase.java
@@ -21,22 +21,22 @@
 
 package io.crate.execution.dsl.phases;
 
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.jetbrains.annotations.Nullable;
+
 import io.crate.execution.dsl.projection.Projection;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
 import io.crate.sql.tree.JoinType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
-
-import org.elasticsearch.Version;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
-
-import org.jetbrains.annotations.Nullable;
-import java.io.IOException;
-import java.util.Collection;
-import java.util.List;
-import java.util.UUID;
 
 public class HashJoinPhase extends JoinPhase {
 
@@ -82,8 +82,8 @@ public class HashJoinPhase extends JoinPhase {
     public HashJoinPhase(StreamInput in) throws IOException {
         super(in);
 
-        leftJoinConditionInputs = Symbols.listFromStream(in);
-        rightJoinConditionInputs = Symbols.listFromStream(in);
+        leftJoinConditionInputs = Symbols.fromStream(in);
+        rightJoinConditionInputs = Symbols.fromStream(in);
         leftOutputTypes = DataTypes.listFromStream(in);
 
         estimatedRowSizeForLeft = in.readZLong();

--- a/server/src/main/java/io/crate/execution/dsl/phases/PKLookupPhase.java
+++ b/server/src/main/java/io/crate/execution/dsl/phases/PKLookupPhase.java
@@ -21,19 +21,6 @@
 
 package io.crate.execution.dsl.phases;
 
-import io.crate.expression.symbol.ScopedSymbol;
-import io.crate.expression.symbol.SelectSymbol;
-import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.SymbolVisitors;
-import io.crate.expression.symbol.Symbols;
-import io.crate.metadata.ColumnIdent;
-import io.crate.planner.distribution.DistributionInfo;
-import io.crate.planner.operators.PKAndVersion;
-import io.crate.types.DataType;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.index.shard.ShardId;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -42,6 +29,19 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.shard.ShardId;
+
+import io.crate.expression.symbol.ScopedSymbol;
+import io.crate.expression.symbol.SelectSymbol;
+import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.Symbols;
+import io.crate.metadata.ColumnIdent;
+import io.crate.planner.distribution.DistributionInfo;
+import io.crate.planner.operators.PKAndVersion;
+import io.crate.types.DataType;
 
 public final class PKLookupPhase extends AbstractProjectionsPhase implements CollectPhase {
 
@@ -57,7 +57,7 @@ public final class PKLookupPhase extends AbstractProjectionsPhase implements Col
                          Map<String, Map<ShardId, List<PKAndVersion>>> idsByShardByNode) {
         super(jobId, phaseId, "pkLookup", Collections.emptyList());
         assert toCollect.stream().noneMatch(
-            st -> SymbolVisitors.any(s -> s instanceof ScopedSymbol || s instanceof SelectSymbol, st))
+            st -> st.any(s -> s instanceof ScopedSymbol || s instanceof SelectSymbol))
             : "toCollect must not contain any fields or selectSymbols: " + toCollect;
         this.partitionedByColumns = partitionedByColumns;
         this.toCollect = toCollect;
@@ -67,7 +67,7 @@ public final class PKLookupPhase extends AbstractProjectionsPhase implements Col
     public PKLookupPhase(StreamInput in) throws IOException {
         super(in);
         distInfo = new DistributionInfo(in);
-        toCollect = Symbols.listFromStream(in);
+        toCollect = Symbols.fromStream(in);
 
         int numNodes = in.readVInt();
         idsByShardByNode = new HashMap<>(numNodes);

--- a/server/src/main/java/io/crate/execution/dsl/phases/RoutedCollectPhase.java
+++ b/server/src/main/java/io/crate/execution/dsl/phases/RoutedCollectPhase.java
@@ -42,7 +42,6 @@ import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.expression.symbol.ScopedSymbol;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.SymbolVisitors;
 import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.Routing;
 import io.crate.metadata.RowGranularity;
@@ -78,9 +77,9 @@ public class RoutedCollectPhase extends AbstractProjectionsPhase implements Coll
                               DistributionInfo distributionInfo) {
         super(jobId, executionNodeId, name, projections);
         assert toCollect.stream().noneMatch(
-            st -> SymbolVisitors.any(s -> s instanceof ScopedSymbol || s instanceof SelectSymbol, st))
+            st -> st.any(s -> s instanceof ScopedSymbol || s instanceof SelectSymbol))
             : "toCollect must not contain any fields or selectSymbols: " + toCollect;
-        assert !SymbolVisitors.any(s -> s instanceof ScopedSymbol || s instanceof SelectSymbol, where)
+        assert !where.any(s -> s instanceof ScopedSymbol || s instanceof SelectSymbol)
             : "whereClause must not contain any fields or selectSymbols: " + where;
         assert routing != null : "routing must not be null";
 
@@ -174,7 +173,8 @@ public class RoutedCollectPhase extends AbstractProjectionsPhase implements Coll
     }
 
     public void orderBy(@Nullable OrderBy orderBy) {
-        assert orderBy == null || orderBy.orderBySymbols().stream().noneMatch(st -> SymbolVisitors.any(s -> s instanceof ScopedSymbol, st))
+        assert orderBy == null
+            || orderBy.orderBySymbols().stream().noneMatch(st -> st.any(s -> s instanceof ScopedSymbol))
             : "orderBy must not contain any fields: " + orderBy.orderBySymbols();
         this.orderBy = orderBy;
     }
@@ -208,12 +208,12 @@ public class RoutedCollectPhase extends AbstractProjectionsPhase implements Coll
         super(in);
         distributionInfo = new DistributionInfo(in);
 
-        toCollect = Symbols.listFromStream(in);
+        toCollect = Symbols.fromStream(in);
         maxRowGranularity = RowGranularity.fromStream(in);
 
         routing = new Routing(in);
 
-        where = Symbols.fromStream(in);
+        where = Symbol.fromStream(in);
 
         nodePageSizeHint = in.readOptionalVInt();
 
@@ -230,7 +230,7 @@ public class RoutedCollectPhase extends AbstractProjectionsPhase implements Coll
         RowGranularity.toStream(maxRowGranularity, out);
 
         routing.writeTo(out);
-        Symbols.toStream(where, out);
+        Symbol.toStream(where, out);
 
         out.writeOptionalVInt(nodePageSizeHint);
         out.writeOptionalWriteable(orderBy);

--- a/server/src/main/java/io/crate/execution/dsl/projection/AbstractIndexWriterProjection.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/AbstractIndexWriterProjection.java
@@ -29,8 +29,8 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.jetbrains.annotations.Nullable;
-
 import org.jetbrains.annotations.VisibleForTesting;
+
 import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
@@ -88,7 +88,7 @@ public abstract class AbstractIndexWriterProjection extends Projection {
         relationName = new RelationName(in);
 
         partitionIdent = in.readOptionalString();
-        idSymbols = Symbols.listFromStream(in);
+        idSymbols = Symbols.fromStream(in);
 
         int numPks = in.readVInt();
         primaryKeys = new ArrayList<>(numPks);
@@ -96,12 +96,8 @@ public abstract class AbstractIndexWriterProjection extends Projection {
             primaryKeys.add(ColumnIdent.of(in));
         }
 
-        partitionedBySymbols = Symbols.listFromStream(in);
-        if (in.readBoolean()) {
-            clusteredBySymbol = Symbols.fromStream(in);
-        } else {
-            clusteredBySymbol = null;
-        }
+        partitionedBySymbols = Symbols.fromStream(in);
+        clusteredBySymbol = Symbol.nullableFromStream(in);
         if (in.readBoolean()) {
             clusteredByColumn = ColumnIdent.of(in);
         }
@@ -206,12 +202,7 @@ public abstract class AbstractIndexWriterProjection extends Projection {
             primaryKey.writeTo(out);
         }
         Symbols.toStream(partitionedBySymbols, out);
-        if (clusteredBySymbol == null) {
-            out.writeBoolean(false);
-        } else {
-            out.writeBoolean(true);
-            Symbols.toStream(clusteredBySymbol, out);
-        }
+        Symbol.nullableToStream(clusteredBySymbol, out);
 
         if (clusteredByColumn == null) {
             out.writeBoolean(false);

--- a/server/src/main/java/io/crate/execution/dsl/projection/AggregationProjection.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/AggregationProjection.java
@@ -36,7 +36,6 @@ import io.crate.expression.symbol.AggregateMode;
 import io.crate.expression.symbol.Aggregation;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.SymbolVisitors;
 import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.RowGranularity;
 
@@ -53,7 +52,7 @@ public class AggregationProjection extends Projection {
         int size = in.readVInt();
         aggregations = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {
-            aggregations.add((Aggregation) Symbols.fromStream(in));
+            aggregations.add((Aggregation) Symbol.fromStream(in));
         }
         contextGranularity = RowGranularity.fromStream(in);
         mode = AggregateMode.readFrom(in);
@@ -62,7 +61,7 @@ public class AggregationProjection extends Projection {
     public AggregationProjection(List<Aggregation> aggregations, RowGranularity contextGranularity, AggregateMode mode) {
         assert aggregations != null : "aggregations must not be null";
         assert aggregations.stream().noneMatch(s ->
-            SymbolVisitors.any(Symbols.IS_COLUMN.or(x -> x instanceof SelectSymbol), s))
+            s.any(Symbol.IS_COLUMN.or(x -> x instanceof SelectSymbol)))
             : "Cannot operate on Reference, Field or SelectSymbol symbols: " + aggregations;
 
         this.contextGranularity = contextGranularity;

--- a/server/src/main/java/io/crate/execution/dsl/projection/DMLProjection.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/DMLProjection.java
@@ -21,17 +21,17 @@
 
 package io.crate.execution.dsl.projection;
 
-import io.crate.expression.symbol.InputColumn;
-import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.Symbols;
-import io.crate.metadata.RowGranularity;
-import io.crate.types.DataTypes;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
-
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import io.crate.expression.symbol.InputColumn;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.RowGranularity;
+import io.crate.types.DataTypes;
 
 public abstract class DMLProjection extends Projection {
 
@@ -46,7 +46,7 @@ public abstract class DMLProjection extends Projection {
     }
 
     DMLProjection(StreamInput in) throws IOException {
-        uidSymbol = Symbols.fromStream(in);
+        uidSymbol = Symbol.fromStream(in);
     }
 
     @Override
@@ -77,7 +77,7 @@ public abstract class DMLProjection extends Projection {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        Symbols.toStream(uidSymbol, out);
+        Symbol.toStream(uidSymbol, out);
     }
 
     @Override

--- a/server/src/main/java/io/crate/execution/dsl/projection/EvalProjection.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/EvalProjection.java
@@ -36,7 +36,6 @@ import io.crate.common.collections.MapBuilder;
 import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.SymbolVisitors;
 import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.RowGranularity;
 import io.crate.types.DataType;
@@ -74,14 +73,14 @@ public class EvalProjection extends Projection {
 
     public EvalProjection(List<Symbol> outputs, RowGranularity granularity) {
         assert outputs.stream().noneMatch(
-            s -> SymbolVisitors.any(Symbols.IS_COLUMN.or(x -> x instanceof SelectSymbol), s))
+            s -> s.any(Symbol.IS_COLUMN.or(x -> x instanceof SelectSymbol)))
             : "EvalProjection doesn't support Field, Reference or SelectSymbol symbols, got: " + outputs;
         this.outputs = outputs;
         this.granularity = granularity;
     }
 
     public EvalProjection(StreamInput in) throws IOException {
-        this.outputs = Symbols.listFromStream(in);
+        this.outputs = Symbols.fromStream(in);
         if (in.getVersion().onOrAfter(Version.V_4_5_3)) {
             this.granularity = RowGranularity.fromStream(in) ;
         } else {

--- a/server/src/main/java/io/crate/execution/dsl/projection/FetchProjection.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/FetchProjection.java
@@ -29,6 +29,7 @@ import java.util.TreeMap;
 
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.monitor.jvm.JvmInfo;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import com.carrotsearch.hppc.IntObjectHashMap;
 import com.carrotsearch.hppc.IntObjectMap;
@@ -36,14 +37,12 @@ import com.carrotsearch.hppc.IntSet;
 import com.carrotsearch.hppc.cursors.IntCursor;
 
 import io.crate.Streamer;
-import org.jetbrains.annotations.VisibleForTesting;
 import io.crate.common.collections.Lists;
 import io.crate.common.collections.MapBuilder;
 import io.crate.data.Paging;
 import io.crate.expression.symbol.ScopedSymbol;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.SymbolVisitors;
 import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.RelationName;
 import io.crate.planner.node.fetch.FetchSource;
@@ -72,7 +71,7 @@ public class FetchProjection extends Projection {
                            TreeMap<Integer, String> readerIndices,
                            Map<String, RelationName> indicesToIdents) {
         assert outputSymbols.stream().noneMatch(s ->
-            SymbolVisitors.any(x -> x instanceof ScopedSymbol || x instanceof SelectSymbol, s))
+            s.any(x -> x instanceof ScopedSymbol || x instanceof SelectSymbol))
             : "Cannot operate on Field or SelectSymbol symbols: " + outputSymbols;
         this.fetchPhaseId = fetchPhaseId;
         this.fetchSources = fetchSources;

--- a/server/src/main/java/io/crate/execution/dsl/projection/FilterProjection.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/FilterProjection.java
@@ -21,19 +21,19 @@
 
 package io.crate.execution.dsl.projection;
 
-import io.crate.common.collections.MapBuilder;
-import io.crate.expression.symbol.SelectSymbol;
-import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.SymbolVisitors;
-import io.crate.expression.symbol.Symbols;
-import io.crate.metadata.RowGranularity;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
-
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import io.crate.common.collections.MapBuilder;
+import io.crate.expression.symbol.SelectSymbol;
+import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.Symbols;
+import io.crate.metadata.RowGranularity;
 
 public class FilterProjection extends Projection {
 
@@ -42,18 +42,18 @@ public class FilterProjection extends Projection {
     private RowGranularity requiredGranularity = RowGranularity.CLUSTER;
 
     public FilterProjection(Symbol query, List<Symbol> outputs) {
-        assert !SymbolVisitors.any(Symbols.IS_COLUMN.or(s -> s instanceof SelectSymbol), query)
+        assert !query.any(Symbol.IS_COLUMN.or(s -> s instanceof SelectSymbol))
             : "FilterProjection cannot operate on Reference, Field or SelectSymbol symbols: " + query;
         assert outputs.stream().noneMatch(s ->
-            SymbolVisitors.any(Symbols.IS_COLUMN.or(x -> x instanceof SelectSymbol), s))
+            s.any(Symbol.IS_COLUMN.or(x -> x instanceof SelectSymbol)))
             : "Cannot operate on Reference, Field or SelectSymbol symbols: " + outputs;
         this.query = query;
         this.outputs = outputs;
     }
 
     public FilterProjection(StreamInput in) throws IOException {
-        query = Symbols.fromStream(in);
-        outputs = Symbols.listFromStream(in);
+        query = Symbol.fromStream(in);
+        outputs = Symbols.fromStream(in);
         requiredGranularity = RowGranularity.fromStream(in);
     }
 
@@ -97,7 +97,7 @@ public class FilterProjection extends Projection {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        Symbols.toStream(query, out);
+        Symbol.toStream(query, out);
         Symbols.toStream(outputs, out);
         RowGranularity.toStream(requiredGranularity, out);
     }

--- a/server/src/main/java/io/crate/execution/dsl/projection/GroupProjection.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/GroupProjection.java
@@ -36,7 +36,6 @@ import io.crate.expression.symbol.AggregateMode;
 import io.crate.expression.symbol.Aggregation;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.SymbolVisitors;
 import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.RowGranularity;
 
@@ -54,10 +53,10 @@ public class GroupProjection extends Projection {
                            AggregateMode mode,
                            RowGranularity requiredGranularity) {
         assert keys.stream().noneMatch(s ->
-            SymbolVisitors.any(Symbols.IS_COLUMN.or(x -> x instanceof SelectSymbol), s))
+            s.any(Symbol.IS_COLUMN.or(x -> x instanceof SelectSymbol)))
             : "Cannot operate on Reference, Field or SelectSymbol symbols: " + keys;
         assert values.stream().noneMatch(s ->
-            SymbolVisitors.any(Symbols.IS_COLUMN.or(x -> x instanceof SelectSymbol), s))
+            s.any(Symbol.IS_COLUMN.or(x -> x instanceof SelectSymbol)))
             : "Cannot operate on Reference, Field or SelectSymbol symbols: " + values;
         this.keys = keys;
         this.values = values;
@@ -67,11 +66,11 @@ public class GroupProjection extends Projection {
 
     public GroupProjection(StreamInput in) throws IOException {
         mode = AggregateMode.readFrom(in);
-        keys = Symbols.listFromStream(in);
+        keys = Symbols.fromStream(in);
         int size = in.readVInt();
         values = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {
-            values.add((Aggregation) Symbols.fromStream(in));
+            values.add((Aggregation) Symbol.fromStream(in));
         }
         requiredGranularity = RowGranularity.fromStream(in);
     }

--- a/server/src/main/java/io/crate/execution/dsl/projection/LimitAndOffsetProjection.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/LimitAndOffsetProjection.java
@@ -50,7 +50,7 @@ public class LimitAndOffsetProjection extends Projection {
     public LimitAndOffsetProjection(StreamInput in) throws IOException {
         offset = in.readVInt();
         limit = in.readVInt();
-        outputs = Symbols.listFromStream(in);
+        outputs = Symbols.fromStream(in);
     }
 
     @Override

--- a/server/src/main/java/io/crate/execution/dsl/projection/LimitDistinctProjection.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/LimitDistinctProjection.java
@@ -21,15 +21,15 @@
 
 package io.crate.execution.dsl.projection;
 
-import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.Symbols;
-import io.crate.metadata.RowGranularity;
+import java.io.IOException;
+import java.util.List;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
-import java.io.IOException;
-import java.util.List;
+import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.Symbols;
+import io.crate.metadata.RowGranularity;
 
 public class LimitDistinctProjection extends Projection {
 
@@ -45,7 +45,7 @@ public class LimitDistinctProjection extends Projection {
 
     public LimitDistinctProjection(StreamInput in) throws IOException {
         this.limit = in.readVInt();
-        this.outputs = Symbols.listFromStream(in);
+        this.outputs = Symbols.fromStream(in);
         this.granularity = RowGranularity.fromStream(in);
     }
 

--- a/server/src/main/java/io/crate/execution/dsl/projection/OrderedLimitAndOffsetProjection.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/OrderedLimitAndOffsetProjection.java
@@ -36,7 +36,6 @@ import io.crate.common.collections.Lists;
 import io.crate.common.collections.MapBuilder;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.SymbolVisitors;
 import io.crate.expression.symbol.Symbols;
 
 public class OrderedLimitAndOffsetProjection extends Projection {
@@ -54,9 +53,9 @@ public class OrderedLimitAndOffsetProjection extends Projection {
                                            List<Symbol> orderBy,
                                            boolean[] reverseFlags,
                                            boolean[] nullsFirst) {
-        assert outputs.stream().noneMatch(s -> SymbolVisitors.any(Symbols.IS_COLUMN.or(x -> x instanceof SelectSymbol), s))
+        assert outputs.stream().noneMatch(s -> s.any(Symbol.IS_COLUMN.or(x -> x instanceof SelectSymbol)))
             : "OrderedLimitAndOffsetProjection outputs cannot contain Field, Reference or SelectSymbol symbols: " + outputs;
-        assert orderBy.stream().noneMatch(s -> SymbolVisitors.any(Symbols.IS_COLUMN.or(x -> x instanceof SelectSymbol), s))
+        assert orderBy.stream().noneMatch(s -> s.any(Symbol.IS_COLUMN.or(x -> x instanceof SelectSymbol)))
             : "OrderedLimitAndOffsetProjection orderBy cannot contain Field, Reference or SelectSymbol symbols: " + orderBy;
         assert orderBy.size() == reverseFlags.length : "reverse flags length does not match orderBy items count";
         assert orderBy.size() == nullsFirst.length : "nullsFirst length does not match orderBy items count";
@@ -72,7 +71,7 @@ public class OrderedLimitAndOffsetProjection extends Projection {
     public OrderedLimitAndOffsetProjection(StreamInput in) throws IOException {
         limit = in.readVInt();
         offset = in.readVInt();
-        outputs = Symbols.listFromStream(in);
+        outputs = Symbols.fromStream(in);
         int numOrderBy = in.readVInt();
         if (numOrderBy == 0) {
             orderBy = Collections.emptyList();
@@ -83,7 +82,7 @@ public class OrderedLimitAndOffsetProjection extends Projection {
             reverseFlags = new boolean[numOrderBy];
             nullsFirst = new boolean[numOrderBy];
             for (int i = 0; i < numOrderBy; i++) {
-                orderBy.add(Symbols.fromStream(in));
+                orderBy.add(Symbol.fromStream(in));
                 reverseFlags[i] = in.readBoolean();
                 nullsFirst[i] = in.readBoolean();
             }
@@ -132,7 +131,7 @@ public class OrderedLimitAndOffsetProjection extends Projection {
         Symbols.toStream(outputs, out);
         out.writeVInt(orderBy.size());
         for (int i = 0; i < orderBy.size(); i++) {
-            Symbols.toStream(orderBy.get(i), out);
+            Symbol.toStream(orderBy.get(i), out);
             out.writeBoolean(reverseFlags[i]);
             out.writeBoolean(nullsFirst[i]);
         }

--- a/server/src/main/java/io/crate/execution/dsl/projection/ProjectSetProjection.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/ProjectSetProjection.java
@@ -38,9 +38,9 @@ public final class ProjectSetProjection extends Projection {
     private final List<Symbol> outputs;
 
     public ProjectSetProjection(List<Symbol> tableFunctionsWithInputs, List<Symbol> standaloneWithInputs) {
-        assert tableFunctionsWithInputs.stream().noneMatch(Symbols.IS_COLUMN)
+        assert tableFunctionsWithInputs.stream().noneMatch(Symbol.IS_COLUMN)
             : "Cannot operate on Reference or Field: " + tableFunctionsWithInputs;
-        assert standaloneWithInputs.stream().noneMatch(Symbols.IS_COLUMN)
+        assert standaloneWithInputs.stream().noneMatch(Symbol.IS_COLUMN)
             : "Cannot operate on Reference or Field: " + standaloneWithInputs;
         this.tableFunctionsWithInputs = tableFunctionsWithInputs;
         this.standaloneWithInputs = standaloneWithInputs;
@@ -48,8 +48,8 @@ public final class ProjectSetProjection extends Projection {
     }
 
     public ProjectSetProjection(StreamInput in) throws IOException {
-        tableFunctionsWithInputs = Symbols.listFromStream(in);
-        standaloneWithInputs = Symbols.listFromStream(in);
+        tableFunctionsWithInputs = Symbols.fromStream(in);
+        standaloneWithInputs = Symbols.fromStream(in);
         outputs = Lists.concat(tableFunctionsWithInputs, standaloneWithInputs);
     }
 

--- a/server/src/main/java/io/crate/execution/dsl/projection/SourceIndexWriterProjection.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/SourceIndexWriterProjection.java
@@ -92,7 +92,7 @@ public class SourceIndexWriterProjection extends AbstractIndexWriterProjection {
         }
         overwriteDuplicates = in.readBoolean();
         rawSourceReference = Reference.fromStream(in);
-        rawSourceSymbol = (InputColumn) Symbols.fromStream(in);
+        rawSourceSymbol = (InputColumn) Symbol.fromStream(in);
 
         if (version.before(Version.V_5_3_0)) {
             if (in.readBoolean()) {
@@ -112,7 +112,7 @@ public class SourceIndexWriterProjection extends AbstractIndexWriterProjection {
         } else {
             excludes = null;
         }
-        outputs = Symbols.listFromStream(in);
+        outputs = Symbols.fromStream(in);
         if (version.onOrAfter(Version.V_4_8_0) && version.before(Version.V_5_5_0)) {
             in.readBoolean(); // validation
         }
@@ -128,7 +128,7 @@ public class SourceIndexWriterProjection extends AbstractIndexWriterProjection {
         }
         out.writeBoolean(overwriteDuplicates);
         Reference.toStream(out, rawSourceReference);
-        Symbols.toStream(rawSourceSymbol, out);
+        Symbol.toStream(rawSourceSymbol, out);
 
         if (version.before(Version.V_5_3_0)) {
             // no includes

--- a/server/src/main/java/io/crate/execution/dsl/projection/SourceIndexWriterReturnSummaryProjection.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/SourceIndexWriterReturnSummaryProjection.java
@@ -33,7 +33,6 @@ import org.jetbrains.annotations.Nullable;
 
 import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
@@ -72,12 +71,12 @@ public class SourceIndexWriterReturnSummaryProjection extends SourceIndexWriterP
 
     SourceIndexWriterReturnSummaryProjection(StreamInput in) throws IOException {
         super(in);
-        sourceUri = (InputColumn) Symbols.fromStream(in);
-        sourceUriFailure = (InputColumn) Symbols.fromStream(in);
-        lineNumber = (InputColumn) Symbols.fromStream(in);
+        sourceUri = (InputColumn) Symbol.fromStream(in);
+        sourceUriFailure = (InputColumn) Symbol.fromStream(in);
+        lineNumber = (InputColumn) Symbol.fromStream(in);
         // From 4.7.2 we differentiate IO and non-io failure
         // as the former is supposed to happen only once and the latter can happen multiple times per URI.
-        sourceParsingFailure = in.getVersion().before(Version.V_4_7_1) ? null : (InputColumn) Symbols.fromStream(in);
+        sourceParsingFailure = in.getVersion().before(Version.V_4_7_1) ? null : (InputColumn) Symbol.fromStream(in);
     }
 
     public InputColumn sourceUri() {
@@ -105,11 +104,11 @@ public class SourceIndexWriterReturnSummaryProjection extends SourceIndexWriterP
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        Symbols.toStream(sourceUri, out);
-        Symbols.toStream(sourceUriFailure, out);
-        Symbols.toStream(lineNumber, out);
+        Symbol.toStream(sourceUri, out);
+        Symbol.toStream(sourceUriFailure, out);
+        Symbol.toStream(lineNumber, out);
         if (out.getVersion().after(Version.V_4_7_1)) {
-            Symbols.toStream(sourceParsingFailure, out);
+            Symbol.toStream(sourceParsingFailure, out);
         }
     }
 

--- a/server/src/main/java/io/crate/execution/dsl/projection/SysUpdateProjection.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/SysUpdateProjection.java
@@ -21,25 +21,24 @@
 
 package io.crate.execution.dsl.projection;
 
-import io.crate.expression.symbol.InputColumn;
-import io.crate.expression.symbol.SelectSymbol;
-import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.SymbolVisitors;
-import io.crate.expression.symbol.Symbols;
-import io.crate.metadata.Reference;
-import io.crate.metadata.RowGranularity;
-import io.crate.types.DataTypes;
-import org.elasticsearch.Version;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
-
-import org.jetbrains.annotations.Nullable;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.jetbrains.annotations.Nullable;
+
+import io.crate.expression.symbol.InputColumn;
+import io.crate.expression.symbol.SelectSymbol;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.Reference;
+import io.crate.metadata.RowGranularity;
+import io.crate.types.DataTypes;
 
 public class SysUpdateProjection extends Projection {
 
@@ -60,29 +59,29 @@ public class SysUpdateProjection extends Projection {
         this.uidSymbol = uidSymbol;
         this.assignments = assignments;
         this.returnValues = returnValues;
-        assert Arrays.stream(outputs).noneMatch(s -> SymbolVisitors.any(Symbols.IS_COLUMN.or(x -> x instanceof SelectSymbol), s))
+        assert Arrays.stream(outputs).noneMatch(s -> s.any(Symbol.IS_COLUMN.or(x -> x instanceof SelectSymbol)))
             : "Cannot operate on Reference, Field or SelectSymbol symbols: " + outputs;
         this.outputs = outputs;
     }
 
     public SysUpdateProjection(StreamInput in) throws IOException {
-        uidSymbol = Symbols.fromStream(in);
+        uidSymbol = Symbol.fromStream(in);
         int numAssignments = in.readVInt();
         assignments = new HashMap<>(numAssignments, 1.0f);
         for (int i = 0; i < numAssignments; i++) {
-            assignments.put(Reference.fromStream(in), Symbols.fromStream(in));
+            assignments.put(Reference.fromStream(in), Symbol.fromStream(in));
         }
         if (in.getVersion().onOrAfter(Version.V_4_2_0)) {
             int outputSize = in.readVInt();
             outputs = new Symbol[outputSize];
             for (int i = 0; i < outputSize; i++) {
-                outputs[i] = Symbols.fromStream(in);
+                outputs[i] = Symbol.fromStream(in);
             }
             int returnValuesSize = in.readVInt();
             if (returnValuesSize > 0) {
                 returnValues = new Symbol[returnValuesSize];
                 for (int i = 0; i < returnValuesSize; i++) {
-                    returnValues[i] = Symbols.fromStream(in);
+                    returnValues[i] = Symbol.fromStream(in);
                 }
             }
         } else {
@@ -118,22 +117,22 @@ public class SysUpdateProjection extends Projection {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        Symbols.toStream(uidSymbol, out);
+        Symbol.toStream(uidSymbol, out);
         out.writeVInt(assignments.size());
         for (Map.Entry<Reference, Symbol> e : assignments.entrySet()) {
             Reference.toStream(out, e.getKey());
-            Symbols.toStream(e.getValue(), out);
+            Symbol.toStream(e.getValue(), out);
         }
 
         if (out.getVersion().onOrAfter(Version.V_4_2_0)) {
             out.writeVInt(outputs.length);
             for (int i = 0; i < outputs.length; i++) {
-                Symbols.toStream(outputs[i], out);
+                Symbol.toStream(outputs[i], out);
             }
             if (returnValues != null) {
                 out.writeVInt(returnValues.length);
                 for (int i = 0; i < returnValues.length; i++) {
-                    Symbols.toStream(returnValues[i], out);
+                    Symbol.toStream(returnValues[i], out);
                 }
             } else {
                 out.writeVInt(0);

--- a/server/src/main/java/io/crate/execution/dsl/projection/WindowAggProjection.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/WindowAggProjection.java
@@ -50,9 +50,9 @@ public class WindowAggProjection extends Projection {
                                List<WindowFunction> windowFunctions,
                                List<Symbol> standaloneWithInputs) {
         this.windowFunctions = windowFunctions;
-        assert windowFunctions.stream().noneMatch(Symbols.IS_COLUMN)
+        assert windowFunctions.stream().noneMatch(Symbol.IS_COLUMN)
             : "Cannot operate on Reference or Field: " + windowFunctions;
-        assert standaloneWithInputs.stream().noneMatch(Symbols.IS_COLUMN)
+        assert standaloneWithInputs.stream().noneMatch(Symbol.IS_COLUMN)
             : "Cannot operate on Reference or Field: " + standaloneWithInputs;
         this.windowDefinition = windowDefinition;
         this.standaloneWithInputs = standaloneWithInputs;
@@ -63,23 +63,23 @@ public class WindowAggProjection extends Projection {
     @SuppressWarnings({"unchecked", "rawtypes"})
     WindowAggProjection(StreamInput in) throws IOException {
         windowDefinition = new WindowDefinition(in);
-        standaloneWithInputs = Symbols.listFromStream(in);
+        standaloneWithInputs = Symbols.fromStream(in);
 
         Version version = in.getVersion();
         if (version.onOrAfter(Version.V_4_2_1)) {
-            windowFunctions = (List<WindowFunction>) (List)Symbols.listFromStream(in);
+            windowFunctions = (List<WindowFunction>) (List)Symbols.fromStream(in);
         } else {
             boolean onOrAfter4_1_0 = version.onOrAfter(Version.V_4_1_0);
             int functionsCount = in.readVInt();
             windowFunctions = new ArrayList<>();
             for (int i = 0; i < functionsCount; i++) {
-                WindowFunction function = (WindowFunction) Symbols.fromStream(in);
+                WindowFunction function = (WindowFunction) Symbol.fromStream(in);
                 if (onOrAfter4_1_0) {
                     // used to be the filter
                     Symbols.fromStream(in);
                 }
                 // used to be the inputs (arguments of the window function)
-                Symbols.listFromStream(in);
+                Symbols.fromStream(in);
                 windowFunctions.add(function);
             }
         }
@@ -150,10 +150,10 @@ public class WindowAggProjection extends Projection {
             boolean onOrAfter4_1_0 = version.onOrAfter(Version.V_4_1_0);
             out.writeVInt(windowFunctions.size());
             for (var windowFunction : windowFunctions) {
-                Symbols.toStream(windowFunction, out);
+                Symbol.toStream(windowFunction, out);
                 if (onOrAfter4_1_0) {
                     Symbol filter = windowFunction.filter();
-                    Symbols.toStream(filter == null ? Literal.BOOLEAN_TRUE : filter, out);
+                    Symbol.toStream(filter == null ? Literal.BOOLEAN_TRUE : filter, out);
                 }
                 Symbols.toStream(windowFunction.arguments(), out);
             }

--- a/server/src/main/java/io/crate/execution/dsl/projection/builder/SplitPointsBuilder.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/builder/SplitPointsBuilder.java
@@ -37,7 +37,6 @@ import io.crate.expression.symbol.OuterColumn;
 import io.crate.expression.symbol.RefVisitor;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.Symbols;
 import io.crate.expression.symbol.WindowFunction;
 import io.crate.metadata.FunctionType;
 
@@ -174,7 +173,7 @@ public final class SplitPointsBuilder extends DefaultTraversalSymbolVisitor<Spli
         FieldsVisitor.visitFields(where, toCollect::add);
         ArrayList<Symbol> outputs = new ArrayList<>();
         for (var output : toCollect) {
-            if (Symbols.containsCorrelatedSubQuery(output)) {
+            if (output.any(Symbol.IS_CORRELATED_SUBQUERY)) {
                 outputs.addAll(extractColumns(output));
             } else {
                 outputs.add(output);

--- a/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
@@ -93,7 +93,7 @@ final class DocValuesGroupByOptimizedIterator {
                                           RoutedCollectPhase collectPhase,
                                           CollectTask collectTask) {
         if (Symbols.containsColumn(collectPhase.toCollect(), DocSysColumns.SCORE)
-            || Symbols.containsColumn(collectPhase.where(), DocSysColumns.SCORE)) {
+            || collectPhase.where().hasColumn(DocSysColumns.SCORE)) {
             return null;
         }
 

--- a/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
@@ -133,7 +133,7 @@ final class GroupByOptimizedIterator {
             return null;
         }
         if (Symbols.containsColumn(collectPhase.toCollect(), DocSysColumns.SCORE)
-            || Symbols.containsColumn(collectPhase.where(), DocSysColumns.SCORE)) {
+            || collectPhase.where().hasColumn(DocSysColumns.SCORE)) {
             // We could optimize this, but since it's assumed to be an uncommon case we fallback to generic group-by
             // to keep the optimized implementation a bit simpler
             return null;

--- a/server/src/main/java/io/crate/expression/eval/EvaluatingNormalizer.java
+++ b/server/src/main/java/io/crate/expression/eval/EvaluatingNormalizer.java
@@ -177,7 +177,7 @@ public class EvaluatingNormalizer {
                         } else {
                             TEXT_MATCH.writeAsFunctionInfo(out, TEXT_MATCH.getArgumentDataTypes());
                             if (out.getVersion().onOrAfter(Version.V_4_1_0)) {
-                                Symbols.nullableToStream(filter, out);
+                                Symbol.nullableToStream(filter, out);
                             }
                             Symbols.toStream(arguments, out);
                             if (out.getVersion().onOrAfter(Version.V_4_2_0)) {

--- a/server/src/main/java/io/crate/expression/symbol/Aggregation.java
+++ b/server/src/main/java/io/crate/expression/symbol/Aggregation.java
@@ -79,11 +79,11 @@ public final class Aggregation implements Symbol {
         }
         valueType = DataTypes.fromStream(in);
         if (in.getVersion().onOrAfter(Version.V_4_1_0)) {
-            filter = Symbols.fromStream(in);
+            filter = Symbol.fromStream(in);
         } else {
             filter = Literal.BOOLEAN_TRUE;
         }
-        inputs = Symbols.listFromStream(in);
+        inputs = Symbols.fromStream(in);
         if (in.getVersion().onOrAfter(Version.V_4_2_0)) {
             if (in.getVersion().before(Version.V_5_0_0)) {
                 in.readBoolean();
@@ -136,7 +136,7 @@ public final class Aggregation implements Symbol {
         }
         DataTypes.toStream(valueType, out);
         if (out.getVersion().onOrAfter(Version.V_4_1_0)) {
-            Symbols.toStream(filter, out);
+            Symbol.toStream(filter, out);
         }
         Symbols.toStream(inputs, out);
         if (out.getVersion().onOrAfter(Version.V_4_2_0)) {

--- a/server/src/main/java/io/crate/expression/symbol/FetchMarker.java
+++ b/server/src/main/java/io/crate/expression/symbol/FetchMarker.java
@@ -23,6 +23,7 @@ package io.crate.expression.symbol;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.function.Predicate;
 
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -63,6 +64,11 @@ public final class FetchMarker implements Symbol {
 
     public Reference fetchId() {
         return fetchId;
+    }
+
+    @Override
+    public boolean any(Predicate<? super Symbol> predicate) {
+        return predicate.test(this) || fetchId.any(predicate);
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/symbol/FetchReference.java
+++ b/server/src/main/java/io/crate/expression/symbol/FetchReference.java
@@ -22,6 +22,7 @@
 package io.crate.expression.symbol;
 
 import java.io.IOException;
+import java.util.function.Predicate;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -61,6 +62,16 @@ public class FetchReference implements Symbol {
 
     public Reference ref() {
         return ref;
+    }
+
+    @Override
+    public boolean isDeterministic() {
+        return fetchId.isDeterministic() && ref.isDeterministic();
+    }
+
+    @Override
+    public boolean any(Predicate<? super Symbol> predicate) {
+        return predicate.test(this) || fetchId.any(predicate) || ref.any(predicate);
     }
 
     public FetchReference(StreamInput in) throws IOException {

--- a/server/src/main/java/io/crate/expression/symbol/OuterColumn.java
+++ b/server/src/main/java/io/crate/expression/symbol/OuterColumn.java
@@ -22,6 +22,7 @@
 package io.crate.expression.symbol;
 
 import java.io.IOException;
+import java.util.function.Predicate;
 
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -62,6 +63,16 @@ public final class OuterColumn implements Symbol {
 
     public Symbol symbol() {
         return symbol;
+    }
+
+    @Override
+    public boolean isDeterministic() {
+        return symbol.isDeterministic();
+    }
+
+    @Override
+    public boolean any(Predicate<? super Symbol> predicate) {
+        return predicate.test(this) || symbol.any(predicate);
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/symbol/ScopedSymbol.java
+++ b/server/src/main/java/io/crate/expression/symbol/ScopedSymbol.java
@@ -21,14 +21,15 @@
 
 package io.crate.expression.symbol;
 
+import java.io.IOException;
+
+import org.elasticsearch.common.io.stream.StreamOutput;
+
 import io.crate.Constants;
 import io.crate.expression.symbol.format.Style;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.RelationName;
 import io.crate.types.DataType;
-import org.elasticsearch.common.io.stream.StreamOutput;
-
-import java.io.IOException;
 
 /**
  * A symbol that associates another symbol with a relation.
@@ -66,6 +67,11 @@ public final class ScopedSymbol implements Symbol {
     }
 
     public ColumnIdent column() {
+        return column;
+    }
+
+    @Override
+    public ColumnIdent toColumn() {
         return column;
     }
 

--- a/server/src/main/java/io/crate/expression/symbol/SelectSymbol.java
+++ b/server/src/main/java/io/crate/expression/symbol/SelectSymbol.java
@@ -59,7 +59,7 @@ public class SelectSymbol implements Symbol {
         this.resultType = resultType;
         boolean[] isCorrelatedArr = new boolean[] { false };
         relation.visitSymbols(symbolTree -> {
-            if (SymbolVisitors.any(s -> s instanceof OuterColumn, symbolTree)) {
+            if (symbolTree.any(s -> s instanceof OuterColumn)) {
                 isCorrelatedArr[0] = true;
             }
         });

--- a/server/src/main/java/io/crate/expression/symbol/Symbols.java
+++ b/server/src/main/java/io/crate/expression/symbol/Symbols.java
@@ -27,9 +27,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.function.Predicate;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.jetbrains.annotations.Nullable;
@@ -38,39 +36,12 @@ import io.crate.Streamer;
 import io.crate.common.collections.Lists;
 import io.crate.expression.symbol.format.Style;
 import io.crate.metadata.ColumnIdent;
-import io.crate.metadata.FunctionType;
-import io.crate.metadata.GeneratedReference;
 import io.crate.metadata.Reference;
-import io.crate.sql.tree.ColumnDefinition;
-import io.crate.sql.tree.ColumnPolicy;
-import io.crate.sql.tree.Expression;
 import io.crate.types.DataType;
 
 public final class Symbols {
 
-    private static final HasColumnVisitor HAS_COLUMN_VISITOR = new HasColumnVisitor();
-
-    public static final Predicate<Symbol> IS_COLUMN = s -> s instanceof ScopedSymbol || s instanceof Reference;
-    public static final Predicate<Symbol> IS_GENERATED_COLUMN = s -> s instanceof GeneratedReference;
-    public static final Predicate<Symbol> IS_CORRELATED_SUBQUERY = Symbols::isCorrelatedSubQuery;
-
     private Symbols() {}
-
-    public static boolean isCorrelatedSubQuery(Symbol symbol) {
-        return symbol instanceof SelectSymbol selectSymbol && selectSymbol.isCorrelated();
-    }
-
-    public static boolean containsCorrelatedSubQuery(Symbol symbol) {
-        return SymbolVisitors.any(IS_CORRELATED_SUBQUERY, symbol);
-    }
-
-    public static boolean isAggregate(Symbol s) {
-        return s instanceof Function fn && fn.signature().getKind() == FunctionType.AGGREGATE;
-    }
-
-    public static boolean isTableFunction(Symbol s) {
-        return s instanceof Function fn && fn.signature().getKind() == FunctionType.TABLE;
-    }
 
     public static List<DataType<?>> typeView(List<? extends Symbol> symbols) {
         return Lists.mapLazy(symbols, Symbol::valueType);
@@ -108,22 +79,11 @@ public final class Symbols {
     }
 
     /**
-     * returns true if the symbol contains the given columnIdent.
-     * If symbol is a Function the function tree will be traversed
-     */
-    public static boolean containsColumn(@Nullable Symbol symbol, ColumnIdent path) {
-        if (symbol == null) {
-            return false;
-        }
-        return symbol.accept(HAS_COLUMN_VISITOR, path);
-    }
-
-    /**
      * returns true if any of the symbols contains the given column
      */
     public static boolean containsColumn(Iterable<? extends Symbol> symbols, ColumnIdent path) {
         for (Symbol symbol : symbols) {
-            if (containsColumn(symbol, path)) {
+            if (symbol.hasColumn(path)) {
                 return true;
             }
         }
@@ -133,74 +93,14 @@ public final class Symbols {
     public static void toStream(Collection<? extends Symbol> symbols, StreamOutput out) throws IOException {
         out.writeVInt(symbols.size());
         for (Symbol symbol : symbols) {
-            toStream(symbol, out);
+            Symbol.toStream(symbol, out);
         }
     }
 
-    public static void nullableToStream(@Nullable Symbol symbol, StreamOutput out) throws IOException {
-        if (symbol == null) {
-            out.writeBoolean(false);
-        } else {
-            out.writeBoolean(true);
-            out.writeVInt(symbol.symbolType().ordinal());
-            symbol.writeTo(out);
-        }
+    public static List<Symbol> fromStream(StreamInput in) throws IOException {
+        return in.readList(Symbol::fromStream);
     }
 
-    public static void toStream(Symbol symbol, StreamOutput out) throws IOException {
-        if (out.getVersion().before(Version.V_4_2_0) && symbol instanceof AliasSymbol aliasSymbol) {
-            toStream(aliasSymbol.symbol(), out);
-        } else {
-            int ordinal = symbol.symbolType().ordinal();
-            out.writeVInt(ordinal);
-            symbol.writeTo(out);
-        }
-    }
-
-    public static List<Symbol> listFromStream(StreamInput in) throws IOException {
-        return in.readList(Symbols::fromStream);
-    }
-
-    @Nullable
-    public static Symbol nullableFromStream(StreamInput in) throws IOException {
-        boolean valuePresent = in.readBoolean();
-        if (!valuePresent) {
-            return null;
-        }
-        return fromStream(in);
-    }
-
-    public static Symbol fromStream(StreamInput in) throws IOException {
-        return SymbolType.VALUES.get(in.readVInt()).newInstance(in);
-    }
-
-    public static ColumnIdent pathFromSymbol(Symbol symbol) {
-        if (symbol instanceof AliasSymbol aliasSymbol) {
-            return ColumnIdent.of(aliasSymbol.alias());
-        } else if (symbol instanceof ScopedSymbol scopedSymbol) {
-            return scopedSymbol.column();
-        } else if (symbol instanceof Reference ref) {
-            return ref.column();
-        }
-        return ColumnIdent.of(symbol.toString(Style.UNQUALIFIED));
-    }
-
-    public static boolean isDeterministic(Symbol symbol) {
-        boolean[] isDeterministic = new boolean[] { true };
-        symbol.accept(new DefaultTraversalSymbolVisitor<boolean[], Void>() {
-
-            @Override
-            public Void visitFunction(io.crate.expression.symbol.Function func,
-                                      boolean[] isDeterministic) {
-                if (!func.signature().isDeterministic()) {
-                    isDeterministic[0] = false;
-                    return null;
-                }
-                return super.visitFunction(func, isDeterministic);
-            }
-        }, isDeterministic);
-        return isDeterministic[0];
-    }
 
     /**
      * format symbols in simple style and use the formatted symbols as {@link String#format(Locale, String, Object...)} arguments
@@ -217,57 +117,5 @@ public final class Symbols {
             }
         }
         return String.format(Locale.ENGLISH, messageTmpl, formattedSymbols);
-    }
-
-    public static Symbol unwrapReferenceFromCast(Symbol symbol) {
-        if (symbol instanceof Function fn && fn.isCast()) {
-            return fn.arguments().getFirst();
-        }
-        return symbol;
-    }
-
-    private static class HasColumnVisitor extends SymbolVisitor<ColumnIdent, Boolean> {
-
-        @Override
-        protected Boolean visitSymbol(Symbol symbol, ColumnIdent column) {
-            return false;
-        }
-
-        @Override
-        public Boolean visitFunction(Function symbol, ColumnIdent column) {
-            for (Symbol arg : symbol.arguments()) {
-                if (arg.accept(this, column)) {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        @Override
-        public Boolean visitFetchReference(FetchReference fetchReference, ColumnIdent column) {
-            if (((Symbol) fetchReference.fetchId()).accept(this, column)) {
-                return true;
-            }
-            return fetchReference.ref().accept(this, column);
-        }
-
-        @Override
-        public Boolean visitField(ScopedSymbol field, ColumnIdent column) {
-            return field.column().equals(column);
-        }
-
-        @Override
-        public Boolean visitReference(Reference symbol, ColumnIdent column) {
-            return column.equals(symbol.column());
-        }
-    }
-
-    public static ColumnDefinition<Expression> toColumnDefinition(Symbol symbol) {
-        return new ColumnDefinition<>(
-            pathFromSymbol(symbol).sqlFqn(), // allow ObjectTypes to return col name in subscript notation
-            symbol.valueType().toColumnType(
-                symbol instanceof Reference reference ? reference.columnPolicy() : ColumnPolicy.DYNAMIC,
-                null),
-            List.of());
     }
 }

--- a/server/src/main/java/io/crate/expression/udf/UserDefinedFunctionService.java
+++ b/server/src/main/java/io/crate/expression/udf/UserDefinedFunctionService.java
@@ -51,7 +51,6 @@ import io.crate.exceptions.UserDefinedFunctionAlreadyExistsException;
 import io.crate.exceptions.UserDefinedFunctionUnknownException;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.SymbolVisitors;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.FunctionProvider;
 import io.crate.metadata.FunctionType;
@@ -272,7 +271,7 @@ public class UserDefinedFunctionService extends AbstractLifecycleComponent imple
                 }
                 List<GeneratedReference> generatedColumns = docTable.generatedColumns();
                 for (var genColumn : generatedColumns) {
-                    if (SymbolVisitors.any(isFunction, genColumn.generatedExpression())) {
+                    if (genColumn.generatedExpression().any(isFunction)) {
                         throw new IllegalArgumentException(String.format(
                             Locale.ENGLISH,
                             "Cannot drop function '%s'. It is in use by column '%s' of table '%s'",

--- a/server/src/main/java/io/crate/fdw/JdbcForeignDataWrapper.java
+++ b/server/src/main/java/io/crate/fdw/JdbcForeignDataWrapper.java
@@ -52,7 +52,6 @@ import io.crate.expression.predicate.NotPredicate;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.RefVisitor;
 import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.SymbolVisitors;
 import io.crate.fdw.ServersMetadata.Server;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
@@ -190,9 +189,6 @@ final class JdbcForeignDataWrapper implements ForeignDataWrapper {
 
     @Override
     public boolean supportsQueryPushdown(Symbol query) {
-        return !SymbolVisitors.any(
-            x -> x instanceof Function fn && !SAFE_FUNCTIONS.contains(fn.name()),
-            query
-        );
+        return !query.any(x -> x instanceof Function fn && !SAFE_FUNCTIONS.contains(fn.name()));
     }
 }

--- a/server/src/main/java/io/crate/lucene/GenericFunctionQuery.java
+++ b/server/src/main/java/io/crate/lucene/GenericFunctionQuery.java
@@ -46,7 +46,6 @@ import io.crate.expression.InputCondition;
 import io.crate.expression.reference.doc.lucene.LuceneCollectorExpression;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.RefVisitor;
-import io.crate.expression.symbol.SymbolVisitors;
 
 /**
  * Query implementation which filters docIds by evaluating {@code condition} on each docId to verify if it matches.
@@ -70,12 +69,7 @@ public class GenericFunctionQuery extends Query {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        GenericFunctionQuery that = (GenericFunctionQuery) o;
-
-        return function.equals(that.function);
+        return o instanceof GenericFunctionQuery that && function.equals(that.function);
     }
 
     @Override
@@ -88,7 +82,7 @@ public class GenericFunctionQuery extends Query {
         return new Weight(this) {
             @Override
             public boolean isCacheable(LeafReaderContext ctx) {
-                if (SymbolVisitors.any(s -> s instanceof Function fn && !fn.signature().isDeterministic(), function)) {
+                if (!function.isDeterministic()) {
                     return false;
                 }
                 var fields = new ArrayList<String>();

--- a/server/src/main/java/io/crate/metadata/GeneratedReference.java
+++ b/server/src/main/java/io/crate/metadata/GeneratedReference.java
@@ -38,8 +38,6 @@ import io.crate.expression.symbol.RefVisitor;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolType;
 import io.crate.expression.symbol.SymbolVisitor;
-import io.crate.expression.symbol.SymbolVisitors;
-import io.crate.expression.symbol.Symbols;
 import io.crate.expression.symbol.format.Style;
 import io.crate.sql.tree.ColumnPolicy;
 import io.crate.types.DataType;
@@ -66,11 +64,11 @@ public final class GeneratedReference implements Reference {
         this.ref = ref;
         this.generatedExpression = generatedExpression;
         this.formattedGeneratedExpression = formattedGeneratedExpression;
-        if (SymbolVisitors.any(Symbols::isAggregate, generatedExpression)) {
+        if (generatedExpression.hasFunctionType(FunctionType.AGGREGATE)) {
             throw new UnsupportedOperationException(
                 "Aggregation functions are not allowed in generated columns: " + generatedExpression);
         }
-        if (SymbolVisitors.any(Symbols::isTableFunction, generatedExpression)) {
+        if (generatedExpression.hasFunctionType(FunctionType.TABLE)) {
             throw new UnsupportedOperationException(
                 "Cannot use table function in generated expression of column `" + ref.column().fqn() + "`");
         }
@@ -87,9 +85,9 @@ public final class GeneratedReference implements Reference {
         }
         formattedGeneratedExpression = in.readString();
         if (version.onOrAfter(Version.V_5_1_0) && version.onOrBefore(Version.V_5_6_0)) {
-            generatedExpression = Symbols.nullableFromStream(in);
+            generatedExpression = Symbol.nullableFromStream(in);
         } else {
-            generatedExpression = Symbols.fromStream(in);
+            generatedExpression = Symbol.fromStream(in);
         }
         int size = in.readVInt();
         referencedReferences = new ArrayList<>(size);
@@ -125,9 +123,9 @@ public final class GeneratedReference implements Reference {
         }
         out.writeString(formattedGeneratedExpression);
         if (version.onOrAfter(Version.V_5_1_0) && version.onOrBefore(Version.V_5_6_0)) {
-            Symbols.nullableToStream(generatedExpression, out);
+            Symbol.nullableToStream(generatedExpression, out);
         } else {
-            Symbols.toStream(generatedExpression, out);
+            Symbol.toStream(generatedExpression, out);
         }
 
         out.writeVInt(referencedReferences.size());
@@ -150,6 +148,11 @@ public final class GeneratedReference implements Reference {
 
     public List<Reference> referencedReferences() {
         return referencedReferences;
+    }
+
+    @Override
+    public boolean isDeterministic() {
+        return generatedExpression.isDeterministic();
     }
 
     @Override

--- a/server/src/main/java/io/crate/metadata/Reference.java
+++ b/server/src/main/java/io/crate/metadata/Reference.java
@@ -40,7 +40,9 @@ import org.jetbrains.annotations.Nullable;
 
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolType;
+import io.crate.sql.tree.ColumnDefinition;
 import io.crate.sql.tree.ColumnPolicy;
+import io.crate.sql.tree.Expression;
 import io.crate.types.DataType;
 
 public interface Reference extends Symbol {
@@ -63,6 +65,20 @@ public interface Reference extends Symbol {
     ReferenceIdent ident();
 
     ColumnIdent column();
+
+    @Override
+    default ColumnIdent toColumn() {
+        return column();
+    }
+
+    @Override
+    default ColumnDefinition<Expression> toColumnDefinition() {
+        return new ColumnDefinition<>(
+            toColumn().sqlFqn(), // allow ObjectTypes to return col name in subscript notation
+            valueType().toColumnType(columnPolicy(), null),
+            List.of()
+        );
+    }
 
     IndexType indexType();
 

--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
@@ -829,7 +829,7 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
         for (var constraint : checkConstraints) {
             boolean drop = false;
             for (var ref : toDrop) {
-                drop = Symbols.containsColumn(constraint.expression(), ref.column());
+                drop = constraint.expression().hasColumn(ref.column());
                 if (drop) {
                     break;
                 }

--- a/server/src/main/java/io/crate/metadata/view/ViewInfoFactory.java
+++ b/server/src/main/java/io/crate/metadata/view/ViewInfoFactory.java
@@ -31,7 +31,6 @@ import org.elasticsearch.cluster.ClusterState;
 import io.crate.analyze.ParamTypeHints;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.RelationAnalyzer;
-import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.Reference;
@@ -75,7 +74,7 @@ public class ViewInfoFactory {
             List<Reference> subColumns = new ArrayList<>();
             int position = 1;
             for (var field : relation.outputs()) {
-                ColumnIdent columnIdent = Symbols.pathFromSymbol(field);
+                ColumnIdent columnIdent = field.toColumn();
                 collectedColumns.add(
                     new SimpleReference(
                         new ReferenceIdent(ident, columnIdent.sqlFqn()),

--- a/server/src/main/java/io/crate/planner/WhereClauseOptimizer.java
+++ b/server/src/main/java/io/crate/planner/WhereClauseOptimizer.java
@@ -42,7 +42,6 @@ import io.crate.common.collections.Lists;
 import io.crate.data.Row;
 import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.NodeContext;
@@ -162,9 +161,9 @@ public final class WhereClauseOptimizer {
         }
         WhereClause.validateVersioningColumnsUsage(query);
 
-        boolean versionInQuery = Symbols.containsColumn(query, DocSysColumns.VERSION);
-        boolean sequenceVersioningInQuery = Symbols.containsColumn(query, DocSysColumns.SEQ_NO) &&
-                                            Symbols.containsColumn(query, DocSysColumns.PRIMARY_TERM);
+        boolean versionInQuery = query.hasColumn(DocSysColumns.VERSION);
+        boolean sequenceVersioningInQuery = query.hasColumn(DocSysColumns.SEQ_NO) &&
+                                            query.hasColumn(DocSysColumns.PRIMARY_TERM);
         List<ColumnIdent> pkCols = pkColsInclVersioning(table, versionInQuery, sequenceVersioningInQuery);
 
         EqualityExtractor eqExtractor = new EqualityExtractor(normalizer);

--- a/server/src/main/java/io/crate/planner/operators/Collect.java
+++ b/server/src/main/java/io/crate/planner/operators/Collect.java
@@ -56,7 +56,6 @@ import io.crate.expression.symbol.RefReplacer;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitors;
-import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.DocReferences;
 import io.crate.metadata.IndexType;
 import io.crate.metadata.Reference;
@@ -186,7 +185,7 @@ public class Collect implements LogicalPlan {
 
     private static boolean noLuceneSortSupport(OrderBy order) {
         for (Symbol sortKey : order.orderBySymbols()) {
-            if (SymbolVisitors.any(Collect::isPartitionColOrAnalyzed, sortKey)) {
+            if (sortKey.any(Collect::isPartitionColOrAnalyzed)) {
                 return true;
             }
         }
@@ -358,10 +357,10 @@ public class Collect implements LogicalPlan {
         FetchMarker fetchMarker = new FetchMarker(relation.relationName(), refsToFetch);
         for (int i = 0; i < outputs.size(); i++) {
             Symbol output = outputs.get(i);
-            if (Symbols.containsColumn(output, DocSysColumns.SCORE)) {
+            if (output.hasColumn(DocSysColumns.SCORE)) {
                 newOutputs.add(output);
                 replacedOutputs.put(output, output);
-            } else if (!SymbolVisitors.any(Symbols.IS_COLUMN, output)) {
+            } else if (!output.any(Symbol.IS_COLUMN)) {
                 newOutputs.add(output);
                 replacedOutputs.put(output, output);
             } else if (SymbolVisitors.any(output::equals, usedColumns)) {

--- a/server/src/main/java/io/crate/planner/operators/Eval.java
+++ b/server/src/main/java/io/crate/planner/operators/Eval.java
@@ -39,7 +39,6 @@ import io.crate.execution.dsl.projection.builder.InputColumns;
 import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
 import io.crate.expression.symbol.FetchMarker;
 import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.SymbolVisitors;
 import io.crate.planner.DependencyCarrier;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.Merge;
@@ -126,7 +125,7 @@ public final class Eval extends ForwardingLogicalPlan {
         }
         for (Symbol output : outputs) {
             newReplacedOutputs.put(output, mapToFetchStubs.apply(output));
-            if (SymbolVisitors.any(newSource.outputs()::contains, output)) {
+            if (output.any(newSource.outputs()::contains)) {
                 newOutputs.add(output);
             }
         }

--- a/server/src/main/java/io/crate/planner/operators/GroupHashAggregate.java
+++ b/server/src/main/java/io/crate/planner/operators/GroupHashAggregate.java
@@ -49,7 +49,6 @@ import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.ScopedSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitors;
-import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.doc.DocTableInfo;
@@ -114,7 +113,7 @@ public class GroupHashAggregate extends ForwardingLogicalPlan {
         this.outputs = Lists.concat(groupKeys, this.aggregates);
         this.groupKeys = groupKeys;
         for (Symbol key : groupKeys) {
-            if (Symbols.containsCorrelatedSubQuery(key)) {
+            if (key.any(Symbol.IS_CORRELATED_SUBQUERY)) {
                 throw new UnsupportedOperationException(
                     "Cannot use correlated subquery in GROUP BY clause");
             }

--- a/server/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
+++ b/server/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
@@ -43,7 +43,6 @@ import io.crate.common.collections.Lists;
 import io.crate.expression.operator.AndOperator;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.SymbolVisitors;
 import io.crate.metadata.RelationName;
 import io.crate.planner.SubqueryPlanner.SubQueries;
 import io.crate.sql.tree.JoinType;
@@ -310,7 +309,7 @@ public class JoinPlanBuilder {
         var remainder = new ArrayList<Symbol>(values.size());
         var correlatedSubQueries = new ArrayList<Symbol>(values.size());
         for (var symbol : values) {
-            if (SymbolVisitors.any(s -> s instanceof SelectSymbol x && x.isCorrelated(), symbol)) {
+            if (symbol.any(s -> s instanceof SelectSymbol x && x.isCorrelated())) {
                 correlatedSubQueries.add(symbol);
             } else {
                 remainder.add(symbol);

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -70,7 +70,6 @@ import io.crate.expression.symbol.ScopedSymbol;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.SelectSymbol.ResultType;
 import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.Symbols;
 import io.crate.fdw.ForeignDataWrapper;
 import io.crate.fdw.ForeignDataWrappers;
 import io.crate.fdw.ForeignTableRelation;
@@ -498,7 +497,7 @@ public class LogicalPlanner {
                 }
             );
             Symbol having = relation.having();
-            if (having != null && Symbols.containsCorrelatedSubQuery(having)) {
+            if (having != null && having.any(Symbol.IS_CORRELATED_SUBQUERY)) {
                 throw new UnsupportedOperationException("Cannot use correlated subquery in HAVING clause");
             }
             return MultiPhase.createIfNeeded(

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathGroupBy.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathGroupBy.java
@@ -31,8 +31,7 @@ import java.util.function.UnaryOperator;
 
 import io.crate.expression.operator.AndOperator;
 import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.SymbolVisitors;
-import io.crate.expression.symbol.Symbols;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
 import io.crate.planner.operators.Filter;
@@ -87,7 +86,7 @@ public final class MoveFilterBeneathGroupBy implements Rule<Filter> {
         ArrayList<Symbol> withAggregates = new ArrayList<>();
         ArrayList<Symbol> withoutAggregates = new ArrayList<>();
         for (Symbol part : parts) {
-            if (SymbolVisitors.any(Symbols::isAggregate, part)) {
+            if (part.hasFunctionType(FunctionType.AGGREGATE)) {
                 withAggregates.add(part);
             } else {
                 withoutAggregates.add(part);

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathProjectSet.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathProjectSet.java
@@ -32,7 +32,6 @@ import java.util.function.UnaryOperator;
 
 import io.crate.expression.operator.AndOperator;
 import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.SymbolVisitors;
 import io.crate.metadata.FunctionType;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
@@ -74,7 +73,7 @@ public final class MoveFilterBeneathProjectSet implements Rule<Filter> {
         ArrayList<Symbol> toPushDown = new ArrayList<>();
         ArrayList<Symbol> toKeep = new ArrayList<>();
         for (var part : queryParts) {
-            if (!SymbolVisitors.any(MoveFilterBeneathProjectSet::isTableFunction, part)
+            if (!part.any(MoveFilterBeneathProjectSet::isTableFunction)
                 && projectSet.standaloneOutputs().containsAll(extractColumns(part))) {
                 toPushDown.add(part);
             } else {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathWindowAgg.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathWindowAgg.java
@@ -34,7 +34,6 @@ import java.util.function.UnaryOperator;
 import io.crate.analyze.WindowDefinition;
 import io.crate.expression.operator.AndOperator;
 import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.SymbolVisitors;
 import io.crate.expression.symbol.WindowFunction;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
@@ -84,7 +83,7 @@ public final class MoveFilterBeneathWindowAgg implements Rule<Filter> {
         ArrayList<Symbol> windowPartitionedBasedFilters = new ArrayList<>();
 
         for (Symbol part : filterParts) {
-            if (SymbolVisitors.any(containsWindowFunction, part) == false
+            if (part.any(containsWindowFunction) == false
                 && windowDefinition.partitions().containsAll(extractColumns(part))) {
                 windowPartitionedBasedFilters.add(part);
             } else {

--- a/server/src/main/java/io/crate/planner/statement/DeletePlanner.java
+++ b/server/src/main/java/io/crate/planner/statement/DeletePlanner.java
@@ -52,7 +52,6 @@ import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.SymbolVisitors;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.Reference;
 import io.crate.metadata.Routing;
@@ -94,10 +93,7 @@ public final class DeletePlanner {
         Symbol query = detailedQuery.query();
         if (!detailedQuery.partitions().isEmpty()) {
             // deleting whole partitions is only valid if the query only contains filters based on partition-by cols
-            var hasNonPartitionReferences = SymbolVisitors.any(
-                s -> s instanceof Reference && table.partitionedByColumns().contains(s) == false,
-                query
-            );
+            var hasNonPartitionReferences = query.any(s -> s instanceof Reference && table.partitionedByColumns().contains(s) == false);
             if (hasNonPartitionReferences == false) {
                 return new DeletePartitions(table.ident(), detailedQuery.partitions());
             }

--- a/server/src/main/java/io/crate/protocols/postgres/Messages.java
+++ b/server/src/main/java/io/crate/protocols/postgres/Messages.java
@@ -35,7 +35,6 @@ import io.crate.auth.AccessControl;
 import io.crate.data.Row;
 import io.crate.exceptions.SQLExceptions;
 import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationInfo;
 import io.crate.metadata.pgcatalog.OidHash;
@@ -434,7 +433,7 @@ public class Messages {
         }
         int idx = 0;
         for (Symbol column : columns) {
-            byte[] nameBytes = Symbols.pathFromSymbol(column).sqlFqn().getBytes(StandardCharsets.UTF_8);
+            byte[] nameBytes = column.toColumn().sqlFqn().getBytes(StandardCharsets.UTF_8);
             length += nameBytes.length + 1;
             length += columnSize;
 

--- a/server/src/main/java/io/crate/rest/action/ResultToXContentBuilder.java
+++ b/server/src/main/java/io/crate/rest/action/ResultToXContentBuilder.java
@@ -21,15 +21,15 @@
 
 package io.crate.rest.action;
 
-import io.crate.data.Row;
-import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.Symbols;
-import io.crate.types.ArrayType;
-import io.crate.types.DataType;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-
 import java.io.IOException;
 import java.util.List;
+
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import io.crate.data.Row;
+import io.crate.expression.symbol.Symbol;
+import io.crate.types.ArrayType;
+import io.crate.types.DataType;
 
 class ResultToXContentBuilder {
 
@@ -58,7 +58,7 @@ class ResultToXContentBuilder {
     ResultToXContentBuilder cols(List<? extends Symbol> fields) throws IOException {
         builder.startArray(FIELDS.COLS);
         for (Symbol field : fields) {
-            builder.value(Symbols.pathFromSymbol(field).sqlFqn());
+            builder.value(field.toColumn().sqlFqn());
         }
         builder.endArray();
         return this;

--- a/server/src/test/java/io/crate/analyze/SelectFromViewAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectFromViewAnalyzerTest.java
@@ -36,7 +36,6 @@ import org.junit.Test;
 
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.AnalyzedView;
-import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.RelationName;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
@@ -70,15 +69,15 @@ public class SelectFromViewAnalyzerTest extends CrateDummyClusterServiceUnitTest
 
         relation = e.analyze("select crate.doc.v1.name from crate.doc.v1");
         Assertions.assertThat(relation.outputs()).hasSize(1);
-        Assertions.assertThat(Symbols.pathFromSymbol(relation.outputs().get(0)).fqn()).isEqualTo("name");
+        Assertions.assertThat(relation.outputs().get(0).toColumn().fqn()).isEqualTo("name");
 
         relation = e.analyze("select crate.doc.v1.name from v1");
         Assertions.assertThat(relation.outputs()).hasSize(1);
-        Assertions.assertThat(Symbols.pathFromSymbol(relation.outputs().get(0)).fqn()).isEqualTo("name");
+        Assertions.assertThat(relation.outputs().get(0).toColumn().fqn()).isEqualTo("name");
 
         relation = e.analyze("select v.name from crate.doc.v1 as v");
         Assertions.assertThat(relation.outputs()).hasSize(1);
-        Assertions.assertThat(Symbols.pathFromSymbol(relation.outputs().get(0)).fqn()).isEqualTo("name");
+        Assertions.assertThat(relation.outputs().get(0).toColumn().fqn()).isEqualTo("name");
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -32,6 +32,7 @@ import static io.crate.testing.Asserts.isLiteral;
 import static io.crate.testing.Asserts.isReference;
 import static io.crate.testing.Asserts.toCondition;
 import static org.assertj.core.api.Assertions.anyOf;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
@@ -179,7 +180,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     }
 
     private List<String> outputNames(AnalyzedRelation relation) {
-        return Lists.map(relation.outputs(), x -> Symbols.pathFromSymbol(x).sqlFqn());
+        return Lists.map(relation.outputs(), x -> x.toColumn().sqlFqn());
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/SymbolToColumnDefinitionConverterTest.java
+++ b/server/src/test/java/io/crate/analyze/SymbolToColumnDefinitionConverterTest.java
@@ -37,7 +37,7 @@ import org.junit.Test;
 
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.common.collections.Lists;
-import io.crate.expression.symbol.Symbols;
+import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.RelationName;
 import io.crate.sql.tree.ColumnDefinition;
 import io.crate.sql.tree.ColumnPolicy;
@@ -53,7 +53,7 @@ public class SymbolToColumnDefinitionConverterTest extends CrateDummyClusterServ
         var e = SQLExecutor.of(clusterService)
             .addTable(createTableStmt);
         AnalyzedRelation analyzedRelation = e.analyze("select * from tbl");
-        return Lists.map(analyzedRelation.outputs(), Symbols::toColumnDefinition);
+        return Lists.map(analyzedRelation.outputs(), Symbol::toColumnDefinition);
     }
 
     @Test
@@ -155,7 +155,7 @@ public class SymbolToColumnDefinitionConverterTest extends CrateDummyClusterServ
         AnalyzedRelation analyzedRelation = e.analyze(
             "select col_default_object from tbl"
         );
-        var actual = Lists.map(analyzedRelation.outputs(), Symbols::toColumnDefinition);
+        var actual = Lists.map(analyzedRelation.outputs(), Symbol::toColumnDefinition);
 
         assertThat(actual.get(0))
             .isColumnDefinition(
@@ -235,7 +235,7 @@ public class SymbolToColumnDefinitionConverterTest extends CrateDummyClusterServ
             "from tbl";
         var analyzedRelation = e.analyze(selectStmt);
         var actual =
-            Lists.map(Objects.requireNonNull(analyzedRelation.outputs()), Symbols::toColumnDefinition);
+            Lists.map(Objects.requireNonNull(analyzedRelation.outputs()), Symbol::toColumnDefinition);
 
         assertThat(actual).satisfiesExactlyInAnyOrder(
             c -> assertThat(c).isColumnDefinition(
@@ -334,7 +334,7 @@ public class SymbolToColumnDefinitionConverterTest extends CrateDummyClusterServ
             "from tbl";
         var analyzedRelation = e.analyze(selectStmt);
         var actual =
-            Lists.map(Objects.requireNonNull(analyzedRelation.outputs()), Symbols::toColumnDefinition);
+            Lists.map(Objects.requireNonNull(analyzedRelation.outputs()), Symbol::toColumnDefinition);
 
         assertThat(actual).satisfiesExactlyInAnyOrder(
             c -> assertThat(c).isColumnDefinition(
@@ -378,7 +378,7 @@ public class SymbolToColumnDefinitionConverterTest extends CrateDummyClusterServ
             "from tbl_view";
         var analyzedRelation = e.analyze(selectStmt);
         var actual =
-            Lists.map(Objects.requireNonNull(analyzedRelation.outputs()), Symbols::toColumnDefinition);
+            Lists.map(Objects.requireNonNull(analyzedRelation.outputs()), Symbol::toColumnDefinition);
 
         assertThat(actual).satisfiesExactlyInAnyOrder(
             c -> assertThat(c).isColumnDefinition(
@@ -423,7 +423,7 @@ public class SymbolToColumnDefinitionConverterTest extends CrateDummyClusterServ
             "   from tbl) as A";
         var analyzedRelation = e.analyze(selectStmt);
         var actual =
-            Lists.map(Objects.requireNonNull(analyzedRelation.outputs()), Symbols::toColumnDefinition);
+            Lists.map(Objects.requireNonNull(analyzedRelation.outputs()), Symbol::toColumnDefinition);
 
         assertThat(actual).satisfiesExactlyInAnyOrder(
             c -> assertThat(c).isColumnDefinition(
@@ -452,7 +452,7 @@ public class SymbolToColumnDefinitionConverterTest extends CrateDummyClusterServ
             "   cast(port['http']as boolean) from sys.nodes limit 1 ";
         var e = SQLExecutor.of(clusterService);
         var analyzedRelation = e.analyze(selectStmt);
-        var actual = Lists.map(Objects.requireNonNull(analyzedRelation.outputs()), Symbols::toColumnDefinition);
+        var actual = Lists.map(Objects.requireNonNull(analyzedRelation.outputs()), Symbol::toColumnDefinition);
 
         assertThat(actual).satisfiesExactlyInAnyOrder(
             c -> assertThat(c).isColumnDefinition(

--- a/server/src/test/java/io/crate/analyze/relations/GroupByScalarAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/relations/GroupByScalarAnalyzerTest.java
@@ -31,7 +31,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import io.crate.analyze.TableDefinitions;
-import io.crate.expression.symbol.Symbols;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 
@@ -57,18 +56,18 @@ public class GroupByScalarAnalyzerTest extends CrateDummyClusterServiceUnitTest 
     @Test
     public void testValidGroupByWithScalarAndMultipleColumns() throws Exception {
         AnalyzedRelation relation = executor.analyze("select id * other_id from users group by id, other_id");
-        assertThat(Symbols.pathFromSymbol(relation.outputs().get(0)).sqlFqn()).isEqualTo("(id * other_id)");
+        assertThat(relation.outputs().get(0).toColumn().sqlFqn()).isEqualTo("(id * other_id)");
     }
 
     @Test
     public void testValidGroupByWithScalar() throws Exception {
         AnalyzedRelation relation = executor.analyze("select id * 2 from users group by id");
-        assertThat(Symbols.pathFromSymbol(relation.outputs().get(0)).sqlFqn()).isEqualTo("(id * 2::bigint)");
+        assertThat(relation.outputs().get(0).toColumn().sqlFqn()).isEqualTo("(id * 2::bigint)");
     }
 
     @Test
     public void testValidGroupByWithMultipleScalarFunctions() throws Exception {
         AnalyzedRelation relation = executor.analyze("select abs(id * 2) from users group by id");
-        assertThat(Symbols.pathFromSymbol(relation.outputs().get(0)).sqlFqn()).isEqualTo("abs((id * 2::bigint))");
+        assertThat(relation.outputs().get(0).toColumn().sqlFqn()).isEqualTo("abs((id * 2::bigint))");
     }
 }

--- a/server/src/test/java/io/crate/analyze/relations/RelationAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/relations/RelationAnalyzerTest.java
@@ -24,6 +24,7 @@ package io.crate.analyze.relations;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.isFunction;
 import static io.crate.testing.Asserts.isLiteral;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
@@ -37,7 +38,6 @@ import io.crate.analyze.QueriedSelectRelation;
 import io.crate.exceptions.RelationValidationException;
 import io.crate.expression.scalar.SubscriptFunction;
 import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.Symbols;
 import io.crate.expression.tablefunctions.ValuesFunction;
 import io.crate.metadata.RelationName;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
@@ -89,7 +89,7 @@ public class RelationAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     public void testColumnNameFromArrayComparisonExpression() {
         AnalyzedRelation relation = executor.analyze("select 'foo' = any(partitioned_by) " +
                                                      "from information_schema.tables");
-        assertThat(Symbols.pathFromSymbol(relation.outputs().getFirst()).sqlFqn()).isEqualTo("('foo' = ANY(partitioned_by))");
+        assertThat(relation.outputs().getFirst().toColumn().sqlFqn()).isEqualTo("('foo' = ANY(partitioned_by))");
     }
 
     @Test
@@ -106,15 +106,15 @@ public class RelationAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
         relation = executor.analyze("select crate.doc.t1.a from crate.doc.t1");
         assertThat(relation.outputs()).hasSize(1);
-        assertThat(Symbols.pathFromSymbol(relation.outputs().getFirst()).fqn()).isEqualTo("a");
+        assertThat(relation.outputs().getFirst().toColumn().fqn()).isEqualTo("a");
 
         relation = executor.analyze("select crate.doc.t1.a from t1");
         assertThat(relation.outputs()).hasSize(1);
-        assertThat(Symbols.pathFromSymbol(relation.outputs().getFirst()).fqn()).isEqualTo("a");
+        assertThat(relation.outputs().getFirst().toColumn().fqn()).isEqualTo("a");
 
         relation = executor.analyze("select t.a from crate.doc.t1 as t");
         assertThat(relation.outputs()).hasSize(1);
-        assertThat(Symbols.pathFromSymbol(relation.outputs().getFirst()).fqn()).isEqualTo("a");
+        assertThat(relation.outputs().getFirst().toColumn().fqn()).isEqualTo("a");
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/symbol/AggregationTest.java
+++ b/server/src/test/java/io/crate/expression/symbol/AggregationTest.java
@@ -45,10 +45,10 @@ public class AggregationTest extends ESTestCase {
             Literal.BOOLEAN_FALSE
         );
         BytesStreamOutput output = new BytesStreamOutput();
-        Symbols.toStream(actual, output);
+        Symbol.toStream(actual, output);
 
         StreamInput input = output.bytes().streamInput();
-        Aggregation expected = (Aggregation) Symbols.fromStream(input);
+        Aggregation expected = (Aggregation) Symbol.fromStream(input);
 
         assertThat(expected.filter()).isEqualTo(Literal.BOOLEAN_FALSE);
         assertThat(expected).isEqualTo(actual);
@@ -63,12 +63,12 @@ public class AggregationTest extends ESTestCase {
         );
         BytesStreamOutput output = new BytesStreamOutput();
         output.setVersion(Version.V_4_0_0);
-        Symbols.toStream(actual, output);
+        Symbol.toStream(actual, output);
 
         StreamInput input = output.bytes().streamInput();
         input.setVersion(Version.V_4_0_0);
 
-        Aggregation expected = (Aggregation) Symbols.fromStream(input);
+        Aggregation expected = (Aggregation) Symbol.fromStream(input);
 
         assertThat(expected.filter()).isEqualTo(Literal.BOOLEAN_TRUE);
         assertThat(expected).isEqualTo(actual);

--- a/server/src/test/java/io/crate/expression/symbol/FetchMarkerTest.java
+++ b/server/src/test/java/io/crate/expression/symbol/FetchMarkerTest.java
@@ -41,10 +41,10 @@ public class FetchMarkerTest {
         FetchMarker fetchMarker = new FetchMarker(relationName, List.of());
 
         BytesStreamOutput out = new BytesStreamOutput();
-        Symbols.toStream(fetchMarker, out);
+        Symbol.toStream(fetchMarker, out);
 
         StreamInput in = out.bytes().streamInput();
-        Symbol symbol = Symbols.fromStream(in);
+        Symbol symbol = Symbol.fromStream(in);
         assertThat(symbol)
             .isReference()
             .hasColumnIdent(ColumnIdent.of("_fetchid"))

--- a/server/src/test/java/io/crate/expression/symbol/FunctionTest.java
+++ b/server/src/test/java/io/crate/expression/symbol/FunctionTest.java
@@ -62,10 +62,10 @@ public class FunctionTest extends ESTestCase {
         );
 
         BytesStreamOutput output = new BytesStreamOutput();
-        Symbols.toStream(fn, output);
+        Symbol.toStream(fn, output);
 
         StreamInput input = output.bytes().streamInput();
-        Function fn2 = (Function) Symbols.fromStream(input);
+        Function fn2 = (Function) Symbol.fromStream(input);
 
         assertThat(fn).isEqualTo(fn2);
     }
@@ -80,10 +80,10 @@ public class FunctionTest extends ESTestCase {
         );
 
         BytesStreamOutput output = new BytesStreamOutput();
-        Symbols.toStream(fn, output);
+        Symbol.toStream(fn, output);
 
         StreamInput input = output.bytes().streamInput();
-        Function fn2 = (Function) Symbols.fromStream(input);
+        Function fn2 = (Function) Symbol.fromStream(input);
 
         assertThat(fn2.filter()).isNotNull();
         assertThat(fn).isEqualTo(fn2);
@@ -99,11 +99,11 @@ public class FunctionTest extends ESTestCase {
 
         var output = new BytesStreamOutput();
         output.setVersion(Version.V_4_0_0);
-        Symbols.toStream(fn, output);
+        Symbol.toStream(fn, output);
 
         var input = output.bytes().streamInput();
         input.setVersion(Version.V_4_0_0);
-        Function fn2 = (Function) Symbols.fromStream(input);
+        Function fn2 = (Function) Symbol.fromStream(input);
 
         assertThat(fn2.filter()).isNull();
         assertThat(fn).isEqualTo(fn2);

--- a/server/src/test/java/io/crate/expression/symbol/SymbolsTest.java
+++ b/server/src/test/java/io/crate/expression/symbol/SymbolsTest.java
@@ -37,10 +37,10 @@ public class SymbolsTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testNullableSerializationOfNull() throws IOException {
         BytesStreamOutput output = new BytesStreamOutput();
-        Symbols.nullableToStream(null, output);
+        Symbol.nullableToStream(null, output);
 
         StreamInput input = output.bytes().streamInput();
-        Symbol symbol = Symbols.nullableFromStream(input);
+        Symbol symbol = Symbol.nullableFromStream(input);
 
         assertThat(symbol).isNull();
     }
@@ -49,10 +49,10 @@ public class SymbolsTest extends CrateDummyClusterServiceUnitTest {
     public void testNullableSerialization() throws IOException {
         Literal<Long> inputSymbol = Literal.of(42L);
         BytesStreamOutput output = new BytesStreamOutput();
-        Symbols.nullableToStream(inputSymbol, output);
+        Symbol.nullableToStream(inputSymbol, output);
 
         StreamInput inputStream = output.bytes().streamInput();
-        Symbol deserialisedSymbol = Symbols.nullableFromStream(inputStream);
+        Symbol deserialisedSymbol = Symbol.nullableFromStream(inputStream);
 
         assertThat(inputSymbol).isEqualTo(deserialisedSymbol);
         assertThat(inputSymbol.hashCode()).isEqualTo(deserialisedSymbol.hashCode());

--- a/server/src/test/java/io/crate/integrationtests/CorrelatedSubqueryITest.java
+++ b/server/src/test/java/io/crate/integrationtests/CorrelatedSubqueryITest.java
@@ -23,6 +23,7 @@ package io.crate.integrationtests;
 
 
 import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.sql.DriverManager;

--- a/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -24,6 +24,7 @@ package io.crate.integrationtests;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;

--- a/server/src/testFixtures/java/io/crate/testing/SQLTransportExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLTransportExecutor.java
@@ -78,7 +78,6 @@ import io.crate.data.Row;
 import io.crate.data.Row1;
 import io.crate.exceptions.SQLExceptions;
 import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.SearchPath;
 import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
 import io.crate.planner.optimizer.LoadedRules;
@@ -582,7 +581,7 @@ public class SQLTransportExecutor {
 
             for (int i = 0, outputFieldsSize = outputFields.size(); i < outputFieldsSize; i++) {
                 Symbol field = outputFields.get(i);
-                outputNames[i] = Symbols.pathFromSymbol(field).sqlFqn();
+                outputNames[i] = field.toColumn().sqlFqn();
                 outputTypes[i] = field.valueType();
             }
 


### PR DESCRIPTION
It was a bit unclear if something belongs to either Symbol, Symbols,
SymbolVisitors

This attempts to clarify it:

- Symbol: anything operating on a symbol node (either tree, or leaf)
- Symbols: anything operating on a collection of symbols (e.g. List of symbols)
- SymbolVisitors: going to be removed (this PR moves parts, but not all yet)
