### PR TITLE
Fix for incorrectly filtered empty arrays

### DIFF
--- a/docs/appendices/release-notes/5.9.0.rst
+++ b/docs/appendices/release-notes/5.9.0.rst
@@ -45,7 +45,13 @@ Version 5.9.0 - Unreleased
 Breaking Changes
 ================
 
-None
+- Fixed an issue that caused ``WHERE`` clause containing ``NOT`` operator on
+  an array type against a non-empty array to incorrectly filter empty arrays,
+  e.g.::
+
+      SELECT * FROM t WHERE a != [1];
+
+  It is a breaking change because the fix causes performance degradations.
 
 Deprecations
 ============

--- a/server/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
+++ b/server/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
@@ -104,7 +104,8 @@ public class LuceneQueryBuilder {
             queryCache,
             indexAnalyzers,
             indexName,
-            table.partitionedByColumns()
+            table.partitionedByColumns(),
+            query
         );
         ctx.query = eliminateNullsIfPossible(
             inverseSourceLookup(normalizer.normalize(query, txnCtx)),
@@ -128,6 +129,7 @@ public class LuceneQueryBuilder {
         private final IndexAnalyzers indexAnalyzers;
 
         final NodeContext nodeContext;
+        private final Symbol parentQuery;
 
         Context(DocTableInfo table,
                 TransactionContext txnCtx,
@@ -135,7 +137,8 @@ public class LuceneQueryBuilder {
                 QueryCache queryCache,
                 IndexAnalyzers indexAnalyzers,
                 String indexName,
-                List<Reference> partitionColumns) {
+                List<Reference> partitionColumns,
+                Symbol parentQuery) {
             this.table = table;
             this.nodeContext = nodeCtx;
             this.txnCtx = txnCtx;
@@ -148,6 +151,7 @@ public class LuceneQueryBuilder {
                 )
             );
             this.queryCache = queryCache;
+            this.parentQuery = parentQuery;
         }
 
         public Query query() {
@@ -208,6 +212,18 @@ public class LuceneQueryBuilder {
         @Nullable
         public Reference getRef(ColumnIdent column) {
             return table.getReadReference(column);
+        }
+
+        public TransactionContext transactionContext() {
+            return txnCtx;
+        }
+
+        public NodeContext nodeContext() {
+            return nodeContext;
+        }
+
+        public Symbol parentQuery() {
+            return parentQuery;
         }
     }
 

--- a/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -794,4 +794,11 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
         Query query = convert("(y % null != 1)");
         assertThat(query).hasToString("+(+*:* -((y % NULL) = 1)) #(NOT ((y % NULL) = 1))");
     }
+
+    @Test
+    public void test_neq_on_array() {
+        Query query = convert("(y_array != [1])");
+        // (+*:* -(y_array IS NULL)))~1) is required to make sure empty arrays are not filtered by the FieldExistsQuery
+        assertThat(query).hasToString("+(+*:* -(+y_array:{1} +(y_array = [1::bigint]))) +((FieldExistsQuery [field=y_array] (+*:* -(y_array IS NULL)))~1)");
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes:
```
cr> create table t (a int[]);
CREATE OK, 1 row affected (0.180 sec)
cr> insert into t values ([1]), ([]);
INSERT OK, 2 rows affected (0.049 sec)
cr> select * from t where a != [1];
+---+
| a |
+---+
+---+
-- expecting an '[]'
SELECT 0 rows in set (0.064 sec)

```

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
