### PR TITLE
Fix `!= <array>` to fail to filter nulls when the inner types have no doc values

### DIFF
--- a/docs/appendices/release-notes/5.8.0.rst
+++ b/docs/appendices/release-notes/5.8.0.rst
@@ -68,6 +68,13 @@ Breaking Changes
   .. NOTE:: If the number of routing shards equals the number of shard,
             increasing the number of shards will not be supported.
 
+- Fixed an issue that caused ``WHERE`` clause containing ``NOT`` operator on
+  an array type with the inner type that has the
+  :ref:`columnstore <ddl-storage-columnstore>` disabled to not filter null rows
+  .
+
+  .. NOTE:: This is a breaking change because it causes performance degradations.
+
 Deprecations
 ============
 

--- a/server/src/main/java/io/crate/expression/predicate/IsNullPredicate.java
+++ b/server/src/main/java/io/crate/expression/predicate/IsNullPredicate.java
@@ -130,7 +130,9 @@ public class IsNullPredicate<T> extends Scalar<Boolean, T> {
                         .add(Queries.not(isNullFuncToQuery(ref, context)), Occur.SHOULD)
                         .build();
                 } else {
-                    return null;
+                    return new BooleanQuery.Builder()
+                        .add(Queries.not(isNullFuncToQuery(ref, context)), Occur.MUST)
+                        .build();
                 }
             }
             // An empty array has no dimension, array_length([]) = NULL, thus we don't count [] as existing.

--- a/server/src/main/java/io/crate/expression/predicate/NotPredicate.java
+++ b/server/src/main/java/io/crate/expression/predicate/NotPredicate.java
@@ -233,6 +233,12 @@ public class NotPredicate extends Scalar<Boolean, Boolean> {
                     countEmptyArrays(context.parentQuery(), nullableRef, context));
                 if (refExistsQuery != null) {
                     builder.add(refExistsQuery, BooleanClause.Occur.MUST);
+                } else {
+                    // fall back to less efficient query
+                    return new BooleanQuery.Builder()
+                        .add(notX, Occur.MUST)
+                        .add(LuceneQueryBuilder.genericFunctionFilter(input, context), Occur.FILTER)
+                        .build();
                 }
             }
             return builder.build();

--- a/server/src/test/java/io/crate/expression/predicate/FieldExistsQueryTest.java
+++ b/server/src/test/java/io/crate/expression/predicate/FieldExistsQueryTest.java
@@ -38,6 +38,7 @@ import io.crate.sql.tree.ColumnPolicy;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.DataTypeTesting;
 import io.crate.testing.QueryTester;
+import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.FloatVectorType;
@@ -248,6 +249,41 @@ public class FieldExistsQueryTest extends CrateDummyClusterServiceUnitTest {
                 assertThat(queryTester.toQuery("x is null").toString())
                     .as(type.getName() + " indexes field_names")
                     .isEqualTo("+*:* -ConstantScore(_field_names:x)");
+            }
+        }
+    }
+
+    @Test
+    public void test_is_null_on_arrays_without_doc_values() throws Exception {
+        for (var type : DataTypeTesting.ALL_STORED_TYPES_EXCEPT_ARRAYS) {
+            if (type instanceof FloatVectorType) {
+                continue;
+            }
+            type = new ArrayType<>(type);
+            StorageSupport<?> storageSupport = type.storageSupport();
+            if (storageSupport == null || !storageSupport.supportsDocValuesOff()) {
+                continue;
+            }
+            Supplier<?> dataGenerator = DataTypeTesting.getDataGenerator(type);
+            Object val1 = dataGenerator.get();
+            var extendedType = DataTypeTesting.extendedType(type, val1);
+            String typeDefinition = SqlFormatter.formatSql(extendedType.toColumnType(ColumnPolicy.STRICT, null));
+            String stmt = "create table tbl (id int primary key, x " + typeDefinition + " storage with (columnstore = false))";
+            QueryTester.Builder builder = new QueryTester.Builder(
+                THREAD_POOL,
+                clusterService,
+                Version.CURRENT,
+                stmt
+            );
+            builder.indexValue("x", val1);
+            builder.indexValue("x", null);
+            try (var queryTester = builder.build()) {
+                assertThat(queryTester.runQuery("x", "x is null"))
+                    .containsExactly(new Object[] { null });
+
+                assertThat(queryTester.toQuery("x is null").toString())
+                    .as(type.getName() + " indexes field_names")
+                    .isEqualTo("+*:* -(+(+*:* -(x IS NULL)))");
             }
         }
     }

--- a/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -364,10 +364,10 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
     public void testIsNullOnObjectArray() throws Exception {
         Query isNull = convert("o_array IS NULL");
         assertThat(isNull).hasToString(
-            "(o_array IS NULL)");
+            "+*:* -(+(+*:* -(o_array IS NULL)))");
         Query isNotNull = convert("o_array IS NOT NULL");
         assertThat(isNotNull).hasToString(
-            "(NOT (o_array IS NULL))");
+            "+(+*:* -(o_array IS NULL))");
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes:

**- scenario 1:**
```
create table t4 (g geo_shape[]);
insert into t4 values ([]), (null), ([null]), (['POLYGON ((5 5, 10 5, 10 10, 5 10, 5 5))']);

-- master:
cr> select * from t4 where g != [];
+----------------------------------------------------------------------------------------------------------+
| g                                                                                                        |
+----------------------------------------------------------------------------------------------------------+
| [{"coordinates": [[[5.0, 5.0], [5.0, 10.0], [10.0, 10.0], [10.0, 5.0], [5.0, 5.0]]], "type": "Polygon"}] |
| NULL                                                                                                     |
| [null]                                                                                                   |
+----------------------------------------------------------------------------------------------------------+

-- after fix:
cr> select * from t4 where g != [];
+----------------------------------------------------------------------------------------------------------+
| g                                                                                                        |
+----------------------------------------------------------------------------------------------------------+
| [{"coordinates": [[[5.0, 5.0], [5.0, 10.0], [10.0, 10.0], [10.0, 5.0], [5.0, 5.0]]], "type": "Polygon"}] |
| [null]                                                                                                   |
+----------------------------------------------------------------------------------------------------------+
```
**- scenario 2:**
```
create table t5 (a int[] storage with (columnstore ='false'));
insert into t5 values ([]), (null), ([null]), ([1]);

-- master:
cr> select * from t5 where a != [];
+--------+
| a      |
+--------+
| [1]    |
| NULL   |
| [null] |
+--------+

-- after fix:
cr> select * from t5 where a != [];
+--------+
| a      |
+--------+
| [1]    |
| [null] |
+--------+
```



## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
