### PR TITLE
Show in progress snapshots in sys.snapshots

### DIFF
--- a/docs/appendices/release-notes/5.7.3.rst
+++ b/docs/appendices/release-notes/5.7.3.rst
@@ -48,6 +48,9 @@ See the :ref:`version_5.7.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that caused snapshots in progress to not be shown in the
+  ``sys.snapshots`` table.
+
 - Fixed an issue that caused queries to incorrectly filter out rows when the
   ``WHERE`` clause contained :ref:`scalar-format_type` function under ``NOT`` or
   ``!=`` operators.

--- a/server/src/main/java/io/crate/expression/reference/sys/snapshot/SysSnapshots.java
+++ b/server/src/main/java/io/crate/expression/reference/sys/snapshot/SysSnapshots.java
@@ -31,8 +31,11 @@ import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.Version;
+import org.elasticsearch.cluster.SnapshotsInProgress;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.repositories.IndexId;
 import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.repositories.Repository;
 import org.elasticsearch.snapshots.SnapshotException;
@@ -40,6 +43,8 @@ import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.snapshots.SnapshotInfo;
 import org.elasticsearch.snapshots.SnapshotShardFailure;
 import org.elasticsearch.snapshots.SnapshotState;
+import org.elasticsearch.snapshots.SnapshotsService;
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
 
 import io.crate.common.collections.Lists;
@@ -53,15 +58,17 @@ public class SysSnapshots {
 
     private static final Logger LOGGER = LogManager.getLogger(SysSnapshots.class);
     private final Supplier<Collection<Repository>> getRepositories;
+    private final ClusterService clusterService;
 
     @Inject
-    public SysSnapshots(RepositoriesService repositoriesService) {
-        this(repositoriesService::getRepositoriesList);
+    public SysSnapshots(RepositoriesService repositoriesService, ClusterService clusterService) {
+        this(repositoriesService::getRepositoriesList, clusterService);
     }
 
     @VisibleForTesting
-    SysSnapshots(Supplier<Collection<Repository>> getRepositories) {
+    SysSnapshots(Supplier<Collection<Repository>> getRepositories, ClusterService clusterService) {
         this.getRepositories = getRepositories;
+        this.clusterService = clusterService;
     }
 
     public CompletableFuture<Iterable<SysSnapshot>> currentSnapshots() {
@@ -77,6 +84,11 @@ public class SysSnapshots {
                     return CompletableFutures.allSuccessfulAsList(snapshots);
                 });
             sysSnapshots.add(futureSnapshots);
+
+            // Add snapshots in progress in this repository.
+            final SnapshotsInProgress snapshotsInProgress = clusterService.state().custom(SnapshotsInProgress.TYPE);
+            List<SysSnapshot> inProgressSnapshots = snapshotsInProgress(snapshotsInProgress, repository.getMetadata().name());
+            sysSnapshots.add(CompletableFuture.completedFuture(inProgressSnapshots));
         }
         return CompletableFutures.allSuccessfulAsList(sysSnapshots).thenApply(data -> {
             ArrayList<SysSnapshot> result = new ArrayList<>();
@@ -102,6 +114,22 @@ public class SysSnapshots {
             version == null ? null : version.toString(),
             snapshotInfo.state().name(),
             Lists.map(snapshotInfo.shardFailures(), SnapshotShardFailure::toString)
+        );
+    }
+
+    private static SysSnapshot toSysSnapshot(String repositoryName,
+                                             SnapshotsInProgress.Entry entry,
+                                             List<String> partedTables) {
+        return new SysSnapshot(
+            entry.snapshot().getSnapshotId().getName(),
+            repositoryName,
+            entry.indices().stream().map(IndexId::getName).toList(),
+            partedTables,
+            entry.startTime(),
+            0L,
+            Version.CURRENT.toString(),
+            SnapshotState.IN_PROGRESS.name(),
+            Collections.emptyList()
         );
     }
 
@@ -134,5 +162,27 @@ public class SysSnapshots {
                 }
                 throw Exceptions.toRuntimeException(err);
             });
+    }
+
+    /**
+     * Returns a list of currently running snapshots from repository sorted by snapshot creation date
+     *
+     * @param snapshotsInProgress snapshots in progress in the cluster state
+     * @param repositoryName repository to check running snapshots
+     * @return list of snapshots
+     */
+    public static List<SysSnapshot> snapshotsInProgress(@Nullable SnapshotsInProgress snapshotsInProgress,
+                                                        String repositoryName) {
+        List<SysSnapshot> sysSnapshots = new ArrayList<>();
+        List<SnapshotsInProgress.Entry> entries =
+            SnapshotsService.currentSnapshots(snapshotsInProgress, repositoryName, Collections.emptyList());
+        for (SnapshotsInProgress.Entry entry : entries) {
+            List<String> partedTables = new ArrayList<>();
+            for (var template : entry.templates()) {
+                partedTables.add(RelationName.fqnFromIndexName(template));
+            }
+            sysSnapshots.add(SysSnapshots.toSysSnapshot(repositoryName, entry, partedTables));
+        }
+        return sysSnapshots;
     }
 }


### PR DESCRIPTION
This is also a pre-requisite for `GetSnapshotRequest` removal. 
Spot the issue when tried to replace it with SQL.

`testRetryPostingSnapshotStatusMessages` passes with this change if I use SQL.

Note, that SQL slightly diverged from `GetSnapshotRequest` behaviour. 
I noticed that `entry.templates` field is not used in ES to resolve indices, only to finalize snapshot. 

We had an issue with empty partitioned tables (see https://github.com/crate/crate/commit/76886ba7159b194e7cf6cdf396b9f81a0fe2e84a), so I replicated the fix here. 
See second commit.

