### PR TITLE
Allow subscript access on `object(ignored)` on foreign tables

### DIFF
--- a/docs/appendices/release-notes/5.7.3.rst
+++ b/docs/appendices/release-notes/5.7.3.rst
@@ -48,6 +48,11 @@ See the :ref:`version_5.7.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that resulted in ``ColumnUnknownException`` errors when using a
+  subscript expression on a ``object(ignored)`` column of a foreign table
+  despite having set :ref:`error_on_unknown_object_key
+  <conf-session-error_on_unknown_object_key>` to false.
+
 - Fixed an issue that caused snapshots in progress to not be shown in the
   ``sys.snapshots`` table.
 

--- a/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -120,6 +120,7 @@ import io.crate.sql.tree.BitString;
 import io.crate.sql.tree.BitwiseExpression;
 import io.crate.sql.tree.BooleanLiteral;
 import io.crate.sql.tree.Cast;
+import io.crate.sql.tree.ColumnPolicy;
 import io.crate.sql.tree.ComparisonExpression;
 import io.crate.sql.tree.CurrentTime;
 import io.crate.sql.tree.DoubleLiteral;
@@ -729,7 +730,7 @@ public class ExpressionAnalyzer {
                     List.of(),
                     operation,
                     context.errorOnUnknownObjectKey());
-                if (base instanceof Reference) {
+                if (base instanceof Reference ref && ref.columnPolicy() != ColumnPolicy.IGNORED) {
                     throw e;
                 }
                 return allocateFunction(

--- a/server/src/test/java/io/crate/fdw/ForeignDataWrapperPlannerTest.java
+++ b/server/src/test/java/io/crate/fdw/ForeignDataWrapperPlannerTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.fdw;
 
+import static io.crate.testing.Asserts.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -29,6 +30,7 @@ import java.util.List;
 import org.elasticsearch.common.settings.Settings;
 import org.junit.Test;
 
+import io.crate.analyze.QueriedSelectRelation;
 import io.crate.exceptions.OperationOnInaccessibleRelationException;
 import io.crate.planner.CreateForeignTablePlan;
 import io.crate.planner.CreateServerPlan;
@@ -140,5 +142,31 @@ public class ForeignDataWrapperPlannerTest extends CrateDummyClusterServiceUnitT
         assertThatThrownBy(() -> e.plan("create publication pub1 for table doc.tbl"))
             .isExactlyInstanceOf(OperationOnInaccessibleRelationException.class)
             .hasMessage("The relation \"doc.tbl\" doesn't support or allow CREATE PUBLICATION operations");
+    }
+
+    @Test
+    public void test_subscript_on_ignored_object_leads_to_functioncall() throws Exception {
+        // Remote end could be any database - CrateDB, PostgreSQL, etc, we don't know up-front
+        //
+        // Using `subscript(o, 'x')` as function instead of (Dynamic)Reference is
+        // general and works in any case, but it bypasses push-down/optimizations of
+        // `o['x']` if the remote is CrateDB
+        //
+        // Compromise: Allow `subscript(o, 'x')`, but only on `object(ignored)`.
+        // It's a bit worse than native access on CrateDB (it fetches the full object),
+        // but it at least makes no difference regarding tablescan/index-lookup as the
+        // data is not indexed
+
+        Settings options = Settings.builder()
+            .put("url", "jdbc:postgresql://localhost:5432/")
+            .build();
+        var e = SQLExecutor.of(clusterService)
+            .addServer("pg", "jdbc", "crate", options)
+            .addForeignTable("create foreign table tbl (o object(ignored)) server pg options (schema_name 'doc')");
+
+        QueriedSelectRelation relation = e.analyze("select o['x'] from tbl");
+        assertThat(relation.outputs()).satisfiesExactly(
+            x -> assertThat(x).isFunction("subscript")
+        );
     }
 }


### PR DESCRIPTION
Closes https://github.com/crate/crate/issues/16203

Alternative to https://github.com/crate/crate/pull/16207

Instead of returning `(Dynamic)Reference`, this allows the expression
analyzer to create a `subscript` function call if the `base` of a
subscript expressin has a column policy `ignored`.

Note that there will still be a runtime error if the key is missing in a
record. Solving that will be part of
https://github.com/crate/crate/issues/14828
