### PR TITLE
Optimize IndexParts.toIndexName

### DIFF
--- a/server/src/main/java/io/crate/metadata/IndexParts.java
+++ b/server/src/main/java/io/crate/metadata/IndexParts.java
@@ -131,19 +131,16 @@ public class IndexParts {
      * Encodes the given parts to a CrateDB index name.
      */
     public static String toIndexName(String schema, String table, @Nullable String partitionIdent) {
-        StringBuilder stringBuilder = new StringBuilder();
-        final boolean isPartitioned = partitionIdent != null;
-        if (!schema.equals(Schemas.DOC_SCHEMA_NAME)) {
-            stringBuilder.append(schema).append(".");
+        if (partitionIdent == null) {
+            if (schema.equals(Schemas.DOC_SCHEMA_NAME)) {
+                return table;
+            }
+            return schema + "." + table;
         }
-        if (isPartitioned) {
-            stringBuilder.append(PARTITIONED_TABLE_PART);
+        if (schema.equals(Schemas.DOC_SCHEMA_NAME)) {
+            return IndexParts.PARTITIONED_TABLE_PART + table + "." + partitionIdent;
         }
-        stringBuilder.append(table);
-        if (isPartitioned) {
-            stringBuilder.append(".").append(partitionIdent);
-        }
-        return stringBuilder.toString();
+        return schema + "." + IndexParts.PARTITIONED_TABLE_PART + table + "." + partitionIdent;
     }
 
     /**


### PR DESCRIPTION
Pretty minor micro optimization:

    Benchmark                                                       Mode  Cnt   Score   Error  Units
    IndexPartsBenchmark.measure_new_toIndexName_custom_partitioned  avgt    6   5.037 ± 0.012  ns/op
    IndexPartsBenchmark.measure_new_toIndexName_doc_partitioned     avgt    6   4.666 ± 0.006  ns/op
    IndexPartsBenchmark.measure_old_toIndexName_custom_partitioned  avgt    6  17.318 ± 0.048  ns/op
    IndexPartsBenchmark.measure_old_toIndexName_doc_partitioned     avgt    6  21.452 ± 0.074  ns/op
