### PR TITLE
Remove normalize from RoutedCollectPhase

### DIFF
--- a/server/src/main/java/io/crate/execution/dsl/phases/RoutedCollectPhase.java
+++ b/server/src/main/java/io/crate/execution/dsl/phases/RoutedCollectPhase.java
@@ -27,25 +27,20 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
-import java.util.function.UnaryOperator;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import io.crate.analyze.OrderBy;
-import io.crate.common.collections.Lists;
 import io.crate.data.Paging;
 import io.crate.execution.dsl.projection.Projection;
-import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.expression.symbol.ScopedSymbol;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.Routing;
 import io.crate.metadata.RowGranularity;
-import io.crate.metadata.TransactionContext;
 import io.crate.planner.distribution.DistributionInfo;
 
 /**
@@ -234,40 +229,6 @@ public class RoutedCollectPhase extends AbstractProjectionsPhase implements Coll
 
         out.writeOptionalVInt(nodePageSizeHint);
         out.writeOptionalWriteable(orderBy);
-    }
-
-    /**
-     * normalizes the symbols of this node with the given normalizer
-     *
-     * @return a normalized node, if no changes occurred returns this
-     */
-    public RoutedCollectPhase normalize(EvaluatingNormalizer normalizer, @NotNull TransactionContext txnCtx) {
-        RoutedCollectPhase result = this;
-        UnaryOperator<Symbol> normalize = s -> normalizer.normalize(s, txnCtx);
-        List<Symbol> newToCollect = Lists.map(toCollect, normalize);
-        boolean changed = !newToCollect.equals(toCollect);
-        Symbol newWhereClause = normalizer.normalize(where, txnCtx);
-        OrderBy orderBy = this.orderBy;
-        if (orderBy != null) {
-            orderBy = orderBy.map(normalize);
-        }
-        changed = changed || newWhereClause != where || orderBy != this.orderBy;
-        if (changed) {
-            result = new RoutedCollectPhase(
-                jobId(),
-                phaseId(),
-                name(),
-                routing,
-                maxRowGranularity,
-                newToCollect,
-                projections,
-                newWhereClause,
-                distributionInfo
-            );
-            result.nodePageSizeHint(nodePageSizeHint);
-            result.orderBy(orderBy);
-        }
-        return result;
     }
 
     @Override

--- a/server/src/main/java/io/crate/execution/engine/collect/BlobShardCollectorProvider.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/BlobShardCollectorProvider.java
@@ -106,9 +106,8 @@ public class BlobShardCollectorProvider extends ShardCollectorProvider {
                                                    SharedShardContext sharedShardContext,
                                                    CollectTask collectTask,
                                                    boolean requiresRepeat) {
-        RoutedCollectPhase normalizedCollectPhase = collectPhase.normalize(shardNormalizer, collectTask.txnCtx());
         return new BlobOrderedDocCollector(
             blobShard.indexShard().shardId(),
-            getBlobRows(collectTask.txnCtx(), normalizedCollectPhase, requiresRepeat));
+            getBlobRows(collectTask.txnCtx(), collectPhase, requiresRepeat));
     }
 }

--- a/server/src/main/java/io/crate/execution/engine/collect/ShardCollectorProvider.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/ShardCollectorProvider.java
@@ -109,16 +109,15 @@ public abstract class ShardCollectorProvider {
                 "granularity must be DOC";
 
             boolean isOpenIndex = !indexShard.isClosed();
-            RoutedCollectPhase normalizedCollectNode = collectPhase.normalize(shardNormalizer, collectTask.txnCtx());
             if (isOpenIndex) {
-                BatchIterator<Row> fusedIterator = getProjectionFusedIterator(normalizedCollectNode, collectTask);
+                BatchIterator<Row> fusedIterator = getProjectionFusedIterator(collectPhase, collectTask);
                 if (fusedIterator != null) {
                     return fusedIterator;
                 }
             }
             final BatchIterator<Row> iterator;
-            if (isOpenIndex && WhereClause.canMatch(normalizedCollectNode.where())) {
-                iterator = getUnorderedIterator(normalizedCollectNode, requiresScroll, collectTask);
+            if (isOpenIndex && WhereClause.canMatch(collectPhase.where())) {
+                iterator = getUnorderedIterator(collectPhase, requiresScroll, collectTask);
             } else {
                 iterator = InMemoryBatchIterator.empty(SentinelRow.SENTINEL);
             }


### PR DESCRIPTION
Doing a normalize pass on the RoutedCollectPhase shouldn't be necessary:

- Normalize happens eagerly when expressions are created
- In some logical plan operators
- And again later when building Lucene queries (including some Lucene query specific optimization rules)
- Other source phases (ForeignCollect, PKLookup, TableFunction) don't have something like it

This may have been an artifact from the very early days where there was
the idea of making it possible to inline `sys.shard` expressions without
join.
