### PR TITLE
Create symbol optimizer rules only once

### DIFF
--- a/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -1181,12 +1181,12 @@ public class ExpressionAnalyzer {
         return allocateFunction(functionName, arguments, null, context, coordinatorTxnCtx, nodeCtx);
     }
 
-    public static Symbol allocateFunction(String functionName,
-                                          List<Symbol> arguments,
-                                          @Nullable Symbol filter,
-                                          ExpressionAnalysisContext context,
-                                          TransactionContext txnCtx,
-                                          NodeContext nodeCtx) {
+    public static Function allocateFunction(String functionName,
+                                            List<Symbol> arguments,
+                                            @Nullable Symbol filter,
+                                            ExpressionAnalysisContext context,
+                                            TransactionContext txnCtx,
+                                            NodeContext nodeCtx) {
         return allocateBuiltinOrUdfFunction(
             null, functionName, arguments, filter, null, context, null, txnCtx, nodeCtx);
     }
@@ -1205,15 +1205,15 @@ public class ExpressionAnalyzer {
      * @param nodeCtx The {@link NodeContext} to normalize constant expressions.
      * @return The supplied {@link Function} or a {@link Literal} in case of constant folding.
      */
-    private static Symbol allocateBuiltinOrUdfFunction(@Nullable String schema,
-                                                       String functionName,
-                                                       List<Symbol> arguments,
-                                                       @Nullable Symbol filter,
-                                                       @Nullable Boolean ignoreNulls,
-                                                       ExpressionAnalysisContext context,
-                                                       @Nullable WindowDefinition windowDefinition,
-                                                       TransactionContext txnCtx,
-                                                       NodeContext nodeCtx) {
+    private static Function allocateBuiltinOrUdfFunction(@Nullable String schema,
+                                                         String functionName,
+                                                         List<Symbol> arguments,
+                                                         @Nullable Symbol filter,
+                                                         @Nullable Boolean ignoreNulls,
+                                                         ExpressionAnalysisContext context,
+                                                         @Nullable WindowDefinition windowDefinition,
+                                                         TransactionContext txnCtx,
+                                                         NodeContext nodeCtx) {
         FunctionImplementation funcImpl = nodeCtx.functions().get(
             schema,
             functionName,

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/FunctionLookup.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/FunctionLookup.java
@@ -21,11 +21,12 @@
 
 package io.crate.planner.optimizer.symbol;
 
-import io.crate.expression.symbol.Symbol;
-
 import java.util.List;
 
-public interface FunctionSymbolResolver {
+import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.Symbol;
 
-    Symbol apply(String name, List<Symbol> arguments);
+public interface FunctionLookup {
+
+    Function get(String name, List<Symbol> arguments);
 }

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/Optimizer.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/Optimizer.java
@@ -24,13 +24,11 @@ package io.crate.planner.optimizer.symbol;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
-import java.util.function.Function;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import io.crate.analyze.expressions.ExpressionAnalyzer;
-import io.crate.common.collections.Lists;
 import io.crate.exceptions.ConversionException;
 import io.crate.expression.symbol.AliasResolver;
 import io.crate.expression.symbol.FunctionCopyVisitor;
@@ -50,52 +48,44 @@ import io.crate.planner.optimizer.symbol.rule.SwapCastsInLikeOperators;
 
 public class Optimizer {
 
+    private static final Logger LOGGER = LogManager.getLogger(Optimizer.class);
+    private static final List<Rule<?>> RULES = List.of(
+        new SwapCastsInComparisonOperators(),
+        new SwapCastsInLikeOperators(),
+        new MoveReferenceCastToLiteralCastOnAnyOperatorsWhenRightIsReference(),
+        new MoveReferenceCastToLiteralCastOnAnyOperatorsWhenLeftIsReference(),
+        new MoveSubscriptOnReferenceCastToLiteralCastInsideOperators(),
+        new MoveArrayLengthOnReferenceCastToLiteralCastInsideOperators(),
+        new SimplifyEqualsOperationOnIdenticalReferences()
+    );
 
     public static Symbol optimizeCasts(Symbol query, PlannerContext plannerCtx) {
         return optimizeCasts(query, plannerCtx.transactionContext(), plannerCtx.nodeContext());
     }
 
     public static Symbol optimizeCasts(Symbol query, TransactionContext txnCtx, NodeContext nodeCtx) {
-        Optimizer optimizer = new Optimizer(
-            txnCtx,
-            nodeCtx,
-            List.of(
-                SwapCastsInComparisonOperators::new,
-                SwapCastsInLikeOperators::new,
-                MoveReferenceCastToLiteralCastOnAnyOperatorsWhenRightIsReference::new,
-                MoveReferenceCastToLiteralCastOnAnyOperatorsWhenLeftIsReference::new,
-                MoveSubscriptOnReferenceCastToLiteralCastInsideOperators::new,
-                MoveArrayLengthOnReferenceCastToLiteralCastInsideOperators::new,
-                SimplifyEqualsOperationOnIdenticalReferences::new
-            )
-        );
+        Optimizer optimizer = new Optimizer(txnCtx, nodeCtx);
         return optimizer.optimize(query);
     }
 
-    private static final Logger LOGGER = LogManager.getLogger(Optimizer.class);
-
-    private final List<Rule<?>> rules;
     private final NodeContext nodeCtx;
     private final Visitor visitor = new Visitor();
+    private FunctionLookup functionLookup;
 
-    public Optimizer(TransactionContext txnCtx,
-                     NodeContext nodeCtx,
-                     List<Function<FunctionSymbolResolver, Rule<?>>> rules) {
-        FunctionSymbolResolver functionResolver =
-            (f, args) -> {
-                try {
-                    return ExpressionAnalyzer.allocateFunction(
-                        f,
-                        args,
-                        null,
-                        null,
-                        txnCtx,
-                        nodeCtx);
-                } catch (ConversionException e) {
-                    return null;
-                }
-            };
-        this.rules = Lists.map(rules, r -> r.apply(functionResolver));
+    public Optimizer(TransactionContext txnCtx, NodeContext nodeCtx) {
+        functionLookup = (f, args) -> {
+            try {
+                return ExpressionAnalyzer.allocateFunction(
+                    f,
+                    args,
+                    null,
+                    null,
+                    txnCtx,
+                    nodeCtx);
+            } catch (ConversionException e) {
+                return null;
+            }
+        };
         this.nodeCtx = nodeCtx;
     }
 
@@ -111,7 +101,7 @@ public class Optimizer {
         int numIterations = 0;
         while (!done && numIterations < 10_000) {
             done = true;
-            for (Rule<?> rule : rules) {
+            for (Rule<?> rule : RULES) {
                 Symbol transformed = tryMatchAndApply(rule, node, nodeCtx);
                 if (transformed != null) {
                     if (isTraceEnabled) {
@@ -134,7 +124,7 @@ public class Optimizer {
             if (LOGGER.isTraceEnabled()) {
                 LOGGER.trace("Rule '{}' matched", rule.getClass().getSimpleName());
             }
-            return rule.apply(match.value(), match.captures(), nodeCtx, visitor.getParentFunction());
+            return rule.apply(match.value(), match.captures(), nodeCtx, functionLookup, visitor.getParentFunction());
         }
         return null;
     }
@@ -166,5 +156,4 @@ public class Optimizer {
             return parent;
         }
     }
-
 }

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/Rule.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/Rule.java
@@ -32,5 +32,9 @@ public interface Rule<T> {
 
     Pattern<T> pattern();
 
-    Symbol apply(T symbol, Captures captures, NodeContext nodeCtx, @Nullable Symbol parentNode);
+    Symbol apply(T symbol,
+                 Captures captures,
+                 NodeContext nodeCtx,
+                 FunctionLookup functionLookup,
+                 @Nullable Symbol parentNode);
 }

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveArrayLengthOnReferenceCastToLiteralCastInsideOperators.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveArrayLengthOnReferenceCastToLiteralCastInsideOperators.java
@@ -35,7 +35,7 @@ import io.crate.metadata.NodeContext;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.planner.optimizer.symbol.FunctionSymbolResolver;
+import io.crate.planner.optimizer.symbol.FunctionLookup;
 import io.crate.planner.optimizer.symbol.Rule;
 import io.crate.types.DataType;
 
@@ -44,10 +44,8 @@ public class MoveArrayLengthOnReferenceCastToLiteralCastInsideOperators implemen
 
     private final Capture<Function> castCapture;
     private final Pattern<Function> pattern;
-    private final FunctionSymbolResolver functionResolver;
 
-    public MoveArrayLengthOnReferenceCastToLiteralCastInsideOperators(FunctionSymbolResolver functionResolver) {
-        this.functionResolver = functionResolver;
+    public MoveArrayLengthOnReferenceCastToLiteralCastInsideOperators() {
         this.castCapture = new Capture<>();
         this.pattern = typeOf(Function.class)
             .with(f -> COMPARISON_OPERATORS.contains(f.name()))
@@ -71,13 +69,14 @@ public class MoveArrayLengthOnReferenceCastToLiteralCastInsideOperators implemen
     public Symbol apply(Function operator,
                         Captures captures,
                         NodeContext nodeCtx,
+                        FunctionLookup functionLookup,
                         Symbol parentNode) {
         var literalOrParam = operator.arguments().get(1);
         var castFunction = captures.get(castCapture);
         var function = castFunction.arguments().get(0);
         DataType<?> targetType = function.valueType();
 
-        return functionResolver.apply(
+        return functionLookup.get(
             operator.name(),
             List.of(function, literalOrParam.cast(targetType))
         );

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveReferenceCastToLiteralCastOnAnyOperatorsWhenRightIsReference.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveReferenceCastToLiteralCastOnAnyOperatorsWhenRightIsReference.java
@@ -36,7 +36,7 @@ import io.crate.metadata.NodeContext;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.planner.optimizer.symbol.FunctionSymbolResolver;
+import io.crate.planner.optimizer.symbol.FunctionLookup;
 import io.crate.planner.optimizer.symbol.Rule;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
@@ -46,10 +46,8 @@ public class MoveReferenceCastToLiteralCastOnAnyOperatorsWhenRightIsReference im
 
     private final Capture<Function> castCapture;
     private final Pattern<Function> pattern;
-    private final FunctionSymbolResolver functionResolver;
 
-    public MoveReferenceCastToLiteralCastOnAnyOperatorsWhenRightIsReference(FunctionSymbolResolver functionResolver) {
-        this.functionResolver = functionResolver;
+    public MoveReferenceCastToLiteralCastOnAnyOperatorsWhenRightIsReference() {
         this.castCapture = new Capture<>();
         this.pattern = typeOf(Function.class)
             .with(f -> AnyOperator.OPERATOR_NAMES.contains(f.name()))
@@ -69,6 +67,7 @@ public class MoveReferenceCastToLiteralCastOnAnyOperatorsWhenRightIsReference im
     public Symbol apply(Function operator,
                         Captures captures,
                         NodeContext nodeCtx,
+                        FunctionLookup functionLookup,
                         Symbol parentNode) {
         var literalOrParam = operator.arguments().get(0);
         var castFunction = captures.get(castCapture);
@@ -86,7 +85,7 @@ public class MoveReferenceCastToLiteralCastOnAnyOperatorsWhenRightIsReference im
             return null;
         }
 
-        return functionResolver.apply(
+        return functionLookup.get(
             operator.name(),
             List.of(literalOrParam.cast(targetType), reference)
         );

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/rule/SimplifyEqualsOperationOnIdenticalReferences.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/rule/SimplifyEqualsOperationOnIdenticalReferences.java
@@ -38,16 +38,14 @@ import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.planner.optimizer.symbol.FunctionSymbolResolver;
+import io.crate.planner.optimizer.symbol.FunctionLookup;
 import io.crate.planner.optimizer.symbol.Rule;
 
 public class SimplifyEqualsOperationOnIdenticalReferences implements Rule<Function> {
 
     private final Pattern<Function> pattern;
-    private final FunctionSymbolResolver functionSymbolResolver;
 
-    public SimplifyEqualsOperationOnIdenticalReferences(FunctionSymbolResolver functionResolver) {
-        this.functionSymbolResolver = functionResolver;
+    public SimplifyEqualsOperationOnIdenticalReferences() {
         this.pattern = typeOf(Function.class)
             .with(f -> EqOperator.NAME.equals(f.name()))
             .with(f -> Optional.of(f.arguments()), typeOf(List.class)
@@ -63,7 +61,7 @@ public class SimplifyEqualsOperationOnIdenticalReferences implements Rule<Functi
     }
 
     @Override
-    public Symbol apply(Function operator, Captures captures, NodeContext nodeCtx, Symbol parentNode) {
+    public Symbol apply(Function operator, Captures captures, NodeContext nodeCtx, FunctionLookup functionLookup, Symbol parentNode) {
         Reference ref = (Reference) operator.arguments().get(0);
         // if ref is not null or the parent node is ignore3vl
         if (ref.isNullable() == false || (parentNode != null && Ignore3vlFunction.NAME.equals(((Function) parentNode).name()))) {
@@ -73,14 +71,9 @@ public class SimplifyEqualsOperationOnIdenticalReferences implements Rule<Functi
         // if ref is nullable it is 3vl, but having no parent node makes it implicitly 2vl
         if (ref.isNullable() && parentNode == null) {
             // WHERE COL = COL  =>  WHERE COL IS NOT NULL
-            return functionSymbolResolver.apply(
+            return functionLookup.get(
                 NotPredicate.NAME,
-                List.of(
-                    functionSymbolResolver.apply(
-                        IsNullPredicate.NAME,
-                        List.of(ref)
-                    )
-                )
+                List.of(functionLookup.get(IsNullPredicate.NAME, List.of(ref)))
             );
         }
         return null;

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/rule/SwapCastsInComparisonOperators.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/rule/SwapCastsInComparisonOperators.java
@@ -37,7 +37,7 @@ import io.crate.metadata.NodeContext;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.planner.optimizer.symbol.FunctionSymbolResolver;
+import io.crate.planner.optimizer.symbol.FunctionLookup;
 import io.crate.planner.optimizer.symbol.Rule;
 import io.crate.types.DataType;
 
@@ -47,7 +47,7 @@ public class SwapCastsInComparisonOperators implements Rule<Function> {
     private final Capture<Function> castCapture;
     private final Pattern<Function> pattern;
 
-    public SwapCastsInComparisonOperators(FunctionSymbolResolver functionResolver) {
+    public SwapCastsInComparisonOperators() {
         this.castCapture = new Capture<>();
         this.pattern = typeOf(Function.class)
             .with(f -> COMPARISON_OPERATORS.contains(f.name()))
@@ -68,6 +68,7 @@ public class SwapCastsInComparisonOperators implements Rule<Function> {
     public Symbol apply(Function operator,
                         Captures captures,
                         NodeContext nodeCtx,
+                        FunctionLookup functionLookup,
                         Symbol parentNode) {
         var literalOrParam = operator.arguments().get(1);
         var castFunction = captures.get(castCapture);

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/rule/SwapCastsInLikeOperators.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/rule/SwapCastsInLikeOperators.java
@@ -36,7 +36,7 @@ import io.crate.metadata.Reference;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
-import io.crate.planner.optimizer.symbol.FunctionSymbolResolver;
+import io.crate.planner.optimizer.symbol.FunctionLookup;
 import io.crate.planner.optimizer.symbol.Rule;
 import io.crate.types.StringType;
 
@@ -47,7 +47,7 @@ public class SwapCastsInLikeOperators implements Rule<Function> {
     private final Capture<Function> castCapture;
     private final Pattern<Function> pattern;
 
-    public SwapCastsInLikeOperators(FunctionSymbolResolver functionResolver) {
+    public SwapCastsInLikeOperators() {
         this.castCapture = new Capture<>();
         this.pattern = typeOf(Function.class)
             .with(f -> LIKE_OPERATORS.contains(f.name()))
@@ -64,7 +64,7 @@ public class SwapCastsInLikeOperators implements Rule<Function> {
     }
 
     @Override
-    public Symbol apply(Function likeFunction, Captures captures, NodeContext nodeCtx, Symbol parentNode) {
+    public Symbol apply(Function likeFunction, Captures captures, NodeContext nodeCtx, FunctionLookup functionLookup, Symbol parentNode) {
         var literalOrParam = likeFunction.arguments().get(1);
         var castFunction = captures.get(castCapture);
         var reference = castFunction.arguments().get(0);


### PR DESCRIPTION
Popped up as surprising source of allocations during investigation of:

https://github.com/crate/crate/issues/16178

![image](https://github.com/crate/crate/assets/38700/0b08ddd7-d7b5-4280-9f45-b97e63c0dabe)

The overall impact is small, but was a low hanging fruit to change.
