### PR TITLE
Increase timeout in testInsertIntoDynamicObjectColumnAddsAllColumnsToTemplate

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
@@ -24,6 +24,7 @@ package io.crate.integrationtests;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.randomAsciiLettersOfLength;
 import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -384,7 +385,7 @@ public class PartitionedTableConcurrentIntegrationTest extends IntegTestCase {
             }
             new Thread(() -> {
                 try {
-                    execute("insert into dyn_parted (id, bucket, data) values (?, ?, ?)", bulkArgs, TimeValue.timeValueSeconds(10));
+                    execute("insert into dyn_parted (id, bucket, data) values (?, ?, ?)", bulkArgs, TimeValue.timeValueSeconds(30));
                     numSuccessfulInserts.incrementAndGet();
                 } finally {
                     countDownLatch.countDown();


### PR DESCRIPTION
The test is flaky, failing with:

    Caused by: org.elasticsearch.ElasticsearchTimeoutException: java.util.concurrent.TimeoutException
        at __randomizedtesting.SeedInfo.seed([E7593F83351510E3]:0)
        at org.elasticsearch.common.util.concurrent.FutureUtils.get(FutureUtils.java:90)
        at org.elasticsearch.common.util.concurrent.FutureUtils.get(FutureUtils.java:74)
        at io.crate.testing.SQLTransportExecutor.executeBulk(SQLTransportExecutor.java:487)
        at io.crate.testing.SQLTransportExecutor.execBulk(SQLTransportExecutor.java:141)
        at org.elasticsearch.test.IntegTestCase.execute(IntegTestCase.java:1796)
        at io.crate.integrationtests.PartitionedTableConcurrentIntegrationTest.lambda$testInsertIntoDynamicObjectColumnAddsAllColumnsToTemplate$4(PartitionedTableConcurrentIntegrationTest.java:387)
        at java.base/java.lang.Thread.run(Thread.java:1570)
    Caused by: java.util.concurrent.TimeoutException
        at java.base/java.util.concurrent.CompletableFuture.timedGet(CompletableFuture.java:1960)
        at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2095)
        at org.elasticsearch.common.util.concurrent.FutureUtils.get(FutureUtils.java:88)
        ... 6 more

Looking at a scatter plot of the test run durations the gap between the
failure and a successful run is rather small, indicating that the
timeout is too short for the CI environment.

![image](https://github.com/crate/crate/assets/38700/31266821-f8ab-4811-aecd-a6e7a4c69c1b)
