### PR TITLE
Use null instead of optionals in optimizer rule patterns

### DIFF
--- a/server/src/main/java/io/crate/planner/optimizer/matcher/Pattern.java
+++ b/server/src/main/java/io/crate/planner/optimizer/matcher/Pattern.java
@@ -21,7 +21,6 @@
 
 package io.crate.planner.optimizer.matcher;
 
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
@@ -34,7 +33,7 @@ public abstract class Pattern<T> {
         return new TypeOfPattern<>(expectedClass);
     }
 
-    public <U, V> Pattern<T> with(Function<? super T, Optional<U>> getProperty, Pattern<V> propertyPattern) {
+    public <U, V> Pattern<T> with(Function<? super T, U> getProperty, Pattern<V> propertyPattern) {
         return new WithPattern<>(this, getProperty, propertyPattern);
     }
 

--- a/server/src/main/java/io/crate/planner/optimizer/matcher/Patterns.java
+++ b/server/src/main/java/io/crate/planner/optimizer/matcher/Patterns.java
@@ -21,19 +21,18 @@
 
 package io.crate.planner.optimizer.matcher;
 
-import io.crate.planner.operators.LogicalPlan;
-
-import java.util.Optional;
 import java.util.function.Function;
+
+import io.crate.planner.operators.LogicalPlan;
 
 public final class Patterns {
 
     private Patterns() {
     }
 
-    public static Function<LogicalPlan, Optional<LogicalPlan>> source() {
+    public static Function<LogicalPlan, LogicalPlan> source() {
         return plan -> plan.sources().size() == 1
-            ? Optional.of(plan.sources().get(0))
-            : Optional.empty();
+            ? plan.sources().get(0)
+            : null;
     }
 }

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveArrayLengthOnReferenceCastToLiteralCastInsideOperators.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveArrayLengthOnReferenceCastToLiteralCastInsideOperators.java
@@ -25,7 +25,6 @@ import static io.crate.expression.operator.Operators.COMPARISON_OPERATORS;
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 
 import java.util.List;
-import java.util.Optional;
 
 import io.crate.expression.scalar.ArrayUpperFunction;
 import io.crate.expression.symbol.Function;
@@ -50,9 +49,9 @@ public class MoveArrayLengthOnReferenceCastToLiteralCastInsideOperators implemen
         this.pattern = typeOf(Function.class)
             .with(f -> COMPARISON_OPERATORS.contains(f.name()))
             .with(f -> f.arguments().get(1).symbolType().isValueOrParameterSymbol())
-            .with(f -> Optional.of(f.arguments().get(0)), typeOf(Function.class).capturedAs(castCapture)
+            .with(f -> f.arguments().get(0), typeOf(Function.class).capturedAs(castCapture)
                 .with(f -> f.isCast())
-                .with(f -> Optional.of(f.arguments().get(0)), typeOf(Function.class)
+                .with(f -> f.arguments().get(0), typeOf(Function.class)
                     .with(f -> f.name().equals(ArrayUpperFunction.ARRAY_LENGTH)
                                || f.name().equals(ArrayUpperFunction.ARRAY_UPPER))
                     .with(f -> f.arguments().get(0).symbolType() == SymbolType.REFERENCE)

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveReferenceCastToLiteralCastOnAnyOperatorsWhenLeftIsReference.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveReferenceCastToLiteralCastOnAnyOperatorsWhenLeftIsReference.java
@@ -24,7 +24,6 @@ package io.crate.planner.optimizer.symbol.rule;
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 
 import java.util.List;
-import java.util.Optional;
 
 import io.crate.expression.operator.any.AnyOperator;
 import io.crate.expression.symbol.Function;
@@ -50,7 +49,7 @@ public class MoveReferenceCastToLiteralCastOnAnyOperatorsWhenLeftIsReference imp
         this.pattern = typeOf(Function.class)
             .with(f -> AnyOperator.OPERATOR_NAMES.contains(f.name()))
             .with(f -> f.arguments().get(1).symbolType().isValueOrParameterSymbol())
-            .with(f -> Optional.of(f.arguments().get(0)), typeOf(Function.class).capturedAs(castCapture)
+            .with(f -> f.arguments().get(0), typeOf(Function.class).capturedAs(castCapture)
                 .with(f -> f.isCast())
                 .with(f -> f.arguments().get(0).symbolType() == SymbolType.REFERENCE)
             );

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveReferenceCastToLiteralCastOnAnyOperatorsWhenRightIsReference.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveReferenceCastToLiteralCastOnAnyOperatorsWhenRightIsReference.java
@@ -24,7 +24,6 @@ package io.crate.planner.optimizer.symbol.rule;
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 
 import java.util.List;
-import java.util.Optional;
 
 import io.crate.expression.operator.any.AnyEqOperator;
 import io.crate.expression.operator.any.AnyNeqOperator;
@@ -52,7 +51,7 @@ public class MoveReferenceCastToLiteralCastOnAnyOperatorsWhenRightIsReference im
         this.pattern = typeOf(Function.class)
             .with(f -> AnyOperator.OPERATOR_NAMES.contains(f.name()))
             .with(f -> f.arguments().get(0).symbolType().isValueOrParameterSymbol())
-            .with(f -> Optional.of(f.arguments().get(1)), typeOf(Function.class).capturedAs(castCapture)
+            .with(f -> f.arguments().get(1), typeOf(Function.class).capturedAs(castCapture)
                 .with(f -> f.isCast())
                 .with(f -> f.arguments().get(0).symbolType() == SymbolType.REFERENCE)
             );

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveSubscriptOnReferenceCastToLiteralCastInsideOperators.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveSubscriptOnReferenceCastToLiteralCastInsideOperators.java
@@ -25,7 +25,6 @@ import static io.crate.expression.operator.Operators.COMPARISON_OPERATORS;
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 
 import java.util.List;
-import java.util.Optional;
 
 import io.crate.expression.scalar.SubscriptFunction;
 import io.crate.expression.symbol.Function;
@@ -50,9 +49,9 @@ public class MoveSubscriptOnReferenceCastToLiteralCastInsideOperators implements
         this.pattern = typeOf(Function.class)
             .with(f -> COMPARISON_OPERATORS.contains(f.name()))
             .with(f -> f.arguments().get(1).symbolType().isValueOrParameterSymbol())
-            .with(f -> Optional.of(f.arguments().get(0)), typeOf(Function.class).capturedAs(castCapture)
+            .with(f -> f.arguments().get(0), typeOf(Function.class).capturedAs(castCapture)
                 .with(f -> f.isCast())
-                .with(f -> Optional.of(f.arguments().get(0)), typeOf(Function.class)
+                .with(f -> f.arguments().get(0), typeOf(Function.class)
                     .with(f -> f.name().equals(SubscriptFunction.NAME))
                     .with(f -> f.arguments().get(0).symbolType() == SymbolType.REFERENCE)
                 )

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/rule/SimplifyEqualsOperationOnIdenticalReferences.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/rule/SimplifyEqualsOperationOnIdenticalReferences.java
@@ -25,7 +25,6 @@ package io.crate.planner.optimizer.symbol.rule;
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 
 import java.util.List;
-import java.util.Optional;
 
 import io.crate.expression.operator.EqOperator;
 import io.crate.expression.predicate.IsNullPredicate;
@@ -48,7 +47,7 @@ public class SimplifyEqualsOperationOnIdenticalReferences implements Rule<Functi
     public SimplifyEqualsOperationOnIdenticalReferences() {
         this.pattern = typeOf(Function.class)
             .with(f -> EqOperator.NAME.equals(f.name()))
-            .with(f -> Optional.of(f.arguments()), typeOf(List.class)
+            .with(f -> f.arguments(), typeOf(List.class)
                 .with(list -> list.get(0) instanceof Reference left &&
                               list.get(1) instanceof Reference right &&
                               left.equals(right))

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/rule/SwapCastsInComparisonOperators.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/rule/SwapCastsInComparisonOperators.java
@@ -25,7 +25,6 @@ import static io.crate.expression.operator.Operators.COMPARISON_OPERATORS;
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 
 import java.util.List;
-import java.util.Optional;
 
 import io.crate.expression.scalar.cast.CastMode;
 import io.crate.expression.scalar.cast.ImplicitCastFunction;
@@ -52,7 +51,7 @@ public class SwapCastsInComparisonOperators implements Rule<Function> {
         this.pattern = typeOf(Function.class)
             .with(f -> COMPARISON_OPERATORS.contains(f.name()))
             .with(f -> f.arguments().get(1).symbolType().isValueOrParameterSymbol())
-            .with(f -> Optional.of(f.arguments().get(0)), typeOf(Function.class).capturedAs(castCapture)
+            .with(f -> f.arguments().get(0), typeOf(Function.class).capturedAs(castCapture)
                 // We have to respect explicit casts, see https://github.com/crate/crate/issues/12135
                 .with(f -> f.name().equals(ImplicitCastFunction.NAME) || f.name().equals(TryCastFunction.NAME))
                 .with(f -> f.arguments().get(0).symbolType() == SymbolType.REFERENCE)

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/rule/SwapCastsInLikeOperators.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/rule/SwapCastsInLikeOperators.java
@@ -24,7 +24,6 @@ package io.crate.planner.optimizer.symbol.rule;
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 import io.crate.expression.operator.LikeOperators;
@@ -52,7 +51,7 @@ public class SwapCastsInLikeOperators implements Rule<Function> {
         this.pattern = typeOf(Function.class)
             .with(f -> LIKE_OPERATORS.contains(f.name()))
             .with(f -> f.arguments().get(1).symbolType().isValueOrParameterSymbol())
-            .with(f -> Optional.of(f.arguments().get(0)), typeOf(Function.class).capturedAs(castCapture)
+            .with(f -> f.arguments().get(0), typeOf(Function.class).capturedAs(castCapture)
                 .with(f -> f.isCast())
                 .with(f -> f.arguments().get(0) instanceof Reference ref && ref.valueType().id() == StringType.ID)
             );


### PR DESCRIPTION
Avoids some allocations during rule pattern matching - the null check
itself is contained within the `WithPattern` logic and it makes some of
the pattern definitions actually simpler.

![image](https://github.com/crate/crate/assets/38700/4bd5db32-52c0-4493-b732-cff1d0f2cc2a)

Popped up looking into https://github.com/crate/crate/issues/16178

