### PR TITLE
Remove `with*` functions on Signature

### DIFF
--- a/benchmarks/src/main/java/io/crate/data/join/RowsBatchIteratorBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/data/join/RowsBatchIteratorBenchmark.java
@@ -56,6 +56,7 @@ import io.crate.execution.engine.collect.RowCollectExpression;
 import io.crate.execution.engine.join.HashInnerJoinBatchIterator;
 import io.crate.execution.engine.window.WindowFunction;
 import io.crate.execution.engine.window.WindowFunctionBatchIterator;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
@@ -86,12 +87,12 @@ public class RowsBatchIteratorBenchmark {
             .toList();
         Functions functions = Functions.load(Settings.EMPTY, new SessionSettingRegistry(Set.of()));
         lastValueIntFunction = (WindowFunction) functions.getQualified(
-            Signature.window(
-                    LAST_VALUE_NAME,
-                    TypeSignature.parse("E"),
-                    TypeSignature.parse("E")
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withTypeVariableConstraints(typeVariable("E")),
+            Signature.builder(LAST_VALUE_NAME, FunctionType.WINDOW)
+                .argumentTypes(TypeSignature.parse("E"))
+                .returnType(TypeSignature.parse("E"))
+                .features(Scalar.Feature.DETERMINISTIC)
+                .typeVariableConstraints(typeVariable("E"))
+                .build(),
             List.of(DataTypes.INTEGER),
             DataTypes.INTEGER
         );

--- a/benchmarks/src/main/java/io/crate/execution/engine/aggregation/AggregateCollectorBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/execution/engine/aggregation/AggregateCollectorBenchmark.java
@@ -48,6 +48,7 @@ import io.crate.execution.engine.collect.RowCollectExpression;
 import io.crate.expression.symbol.AggregateMode;
 import io.crate.expression.symbol.Literal;
 import io.crate.memory.OnHeapMemoryManager;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
@@ -70,11 +71,11 @@ public class AggregateCollectorBenchmark {
         RowCollectExpression inExpr0 = new RowCollectExpression(0);
         Functions functions = Functions.load(Settings.EMPTY, new SessionSettingRegistry(Set.of()));
         SumAggregation<?> sumAggregation = (SumAggregation<?>) functions.getQualified(
-            Signature.aggregate(
-                    SumAggregation.NAME,
-                    DataTypes.INTEGER.getTypeSignature(),
-                    DataTypes.LONG.getTypeSignature())
-                .withFeature(Scalar.Feature.DETERMINISTIC),
+            Signature.builder(SumAggregation.NAME, FunctionType.AGGREGATE)
+                .argumentTypes(DataTypes.INTEGER.getTypeSignature())
+                .returnType(DataTypes.LONG.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC)
+                .build(),
             List.of(DataTypes.INTEGER),
             DataTypes.INTEGER
         );

--- a/benchmarks/src/main/java/io/crate/execution/engine/aggregation/GroupingLongCollectorBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/execution/engine/aggregation/GroupingLongCollectorBenchmark.java
@@ -71,6 +71,7 @@ import io.crate.expression.symbol.AggregateMode;
 import io.crate.expression.symbol.Literal;
 import io.crate.memory.MemoryManager;
 import io.crate.memory.OnHeapMemoryManager;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
@@ -97,13 +98,13 @@ public class GroupingLongCollectorBenchmark {
                  new IndexWriter(new ByteBuffersDirectory(), new IndexWriterConfig(new StandardAnalyzer()))) {
             Functions functions = Functions.load(Settings.EMPTY, new SessionSettingRegistry(Set.of()));
             SumAggregation<?> sumAgg = (SumAggregation<?>) functions.getQualified(
-                Signature.aggregate(
-                        SumAggregation.NAME,
-                        DataTypes.INTEGER.getTypeSignature(),
-                        DataTypes.LONG.getTypeSignature())
-                    .withFeature(Scalar.Feature.DETERMINISTIC),
-                List.of(DataTypes.INTEGER),
-                DataTypes.INTEGER
+                    Signature.builder(SumAggregation.NAME, FunctionType.AGGREGATE)
+                            .argumentTypes(DataTypes.INTEGER.getTypeSignature())
+                            .returnType(DataTypes.LONG.getTypeSignature())
+                            .features(Scalar.Feature.DETERMINISTIC)
+                            .build(),
+                    List.of(DataTypes.INTEGER),
+                    DataTypes.INTEGER
             );
             var memoryManager = new OnHeapMemoryManager(bytes -> {
             });

--- a/benchmarks/src/main/java/io/crate/execution/engine/aggregation/GroupingStringCollectorBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/execution/engine/aggregation/GroupingStringCollectorBenchmark.java
@@ -54,6 +54,7 @@ import io.crate.execution.engine.collect.RowCollectExpression;
 import io.crate.expression.symbol.AggregateMode;
 import io.crate.expression.symbol.Literal;
 import io.crate.memory.OnHeapMemoryManager;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
@@ -93,13 +94,13 @@ public class GroupingStringCollectorBenchmark {
         CollectExpression[] collectExpressions = new CollectExpression[]{keyInput};
 
         MinimumAggregation minAgg = (MinimumAggregation) functions.getQualified(
-            Signature.aggregate(
-                    MinimumAggregation.NAME,
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature())
-                .withFeature(Scalar.Feature.DETERMINISTIC),
-            List.of(DataTypes.STRING),
-            DataTypes.STRING
+                Signature.builder(MinimumAggregation.NAME, FunctionType.AGGREGATE)
+                        .argumentTypes(DataTypes.STRING.getTypeSignature())
+                        .returnType(DataTypes.STRING.getTypeSignature())
+                        .features(Scalar.Feature.DETERMINISTIC)
+                        .build(),
+                List.of(DataTypes.STRING),
+                DataTypes.STRING
         );
 
         return GroupingCollector.singleKey(

--- a/benchmarks/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationBenchmark.java
@@ -56,6 +56,7 @@ import io.crate.expression.symbol.AggregateMode;
 import io.crate.expression.symbol.Literal;
 import io.crate.memory.OffHeapMemoryManager;
 import io.crate.memory.OnHeapMemoryManager;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
@@ -85,13 +86,13 @@ public class HyperLogLogDistinctAggregationBenchmark {
         final RowCollectExpression inExpr0 = new RowCollectExpression(0);
         Functions functions = Functions.load(Settings.EMPTY, new SessionSettingRegistry(Set.of()));
         final HyperLogLogDistinctAggregation hllAggregation = (HyperLogLogDistinctAggregation) functions.getQualified(
-            Signature.aggregate(
-                    HyperLogLogDistinctAggregation.NAME,
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.LONG.getTypeSignature())
-                .withFeature(Scalar.Feature.DETERMINISTIC),
-            List.of(DataTypes.STRING),
-            DataTypes.STRING
+                Signature.builder(HyperLogLogDistinctAggregation.NAME, FunctionType.AGGREGATE)
+                        .argumentTypes(DataTypes.STRING.getTypeSignature())
+                        .returnType(DataTypes.LONG.getTypeSignature())
+                        .features(Scalar.Feature.DETERMINISTIC)
+                        .build(),
+                List.of(DataTypes.STRING),
+                DataTypes.STRING
         );
         onHeapMemoryManager = new OnHeapMemoryManager(bytes -> {});
         offHeapMemoryManager = new OffHeapMemoryManager();

--- a/benchmarks/src/main/java/io/crate/operation/aggregation/IntervalAggregationBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/operation/aggregation/IntervalAggregationBenchmark.java
@@ -56,6 +56,7 @@ import io.crate.execution.engine.collect.RowCollectExpression;
 import io.crate.expression.symbol.AggregateMode;
 import io.crate.expression.symbol.Literal;
 import io.crate.memory.OnHeapMemoryManager;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
@@ -92,23 +93,23 @@ public class IntervalAggregationBenchmark {
         Functions functions = Functions.load(Settings.EMPTY, new SessionSettingRegistry(Set.of()));
 
         final IntervalSumAggregation intervalSumAggregation = (IntervalSumAggregation) functions.getQualified(
-            Signature.aggregate(
-                    IntervalSumAggregation.NAME,
-                    DataTypes.INTERVAL.getTypeSignature(),
-                    DataTypes.INTERVAL.getTypeSignature())
-                .withFeature(Scalar.Feature.DETERMINISTIC),
-            List.of(DataTypes.INTERVAL),
+                Signature.builder(IntervalSumAggregation.NAME, FunctionType.AGGREGATE)
+                        .argumentTypes(DataTypes.INTERVAL.getTypeSignature())
+                        .returnType(DataTypes.INTERVAL.getTypeSignature())
+                        .features(Scalar.Feature.DETERMINISTIC)
+                        .build(),
+                List.of(DataTypes.INTERVAL),
                 DataTypes.INTERVAL
-            );
+        );
 
         final IntervalAverageAggregation intervalAvgAggregation = (IntervalAverageAggregation) functions.getQualified(
-            Signature.aggregate(
-                    AverageAggregation.NAME,
-                    DataTypes.INTERVAL.getTypeSignature(),
-                    DataTypes.INTERVAL.getTypeSignature())
-                .withFeature(Scalar.Feature.DETERMINISTIC),
-            List.of(DataTypes.INTERVAL),
-            DataTypes.INTERVAL
+                Signature.builder(AverageAggregation.NAME, FunctionType.AGGREGATE)
+                        .argumentTypes(DataTypes.INTERVAL.getTypeSignature())
+                        .returnType(DataTypes.INTERVAL.getTypeSignature())
+                        .features(Scalar.Feature.DETERMINISTIC)
+                        .build(),
+                List.of(DataTypes.INTERVAL),
+                DataTypes.INTERVAL
         );
 
         onHeapMemoryManager = new OnHeapMemoryManager(bytes -> {});

--- a/extensions/functions/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregation.java
+++ b/extensions/functions/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregation.java
@@ -55,6 +55,7 @@ import io.crate.execution.engine.aggregation.impl.templates.SortedNumericDocValu
 import io.crate.expression.reference.doc.lucene.LuceneReferenceResolver;
 import io.crate.expression.symbol.Literal;
 import io.crate.memory.MemoryManager;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
 import io.crate.metadata.Scalar;
@@ -86,21 +87,21 @@ public class HyperLogLogDistinctAggregation extends AggregationFunction<HyperLog
     public static void register(Functions.Builder builder) {
         for (var supportedType : DataTypes.PRIMITIVE_TYPES) {
             builder.add(
-                Signature.aggregate(
-                    NAME,
-                    supportedType.getTypeSignature(),
-                    DataTypes.LONG.getTypeSignature())
-                    .withFeature(Scalar.Feature.DETERMINISTIC),
+                Signature.builder(NAME, FunctionType.AGGREGATE)
+                    .argumentTypes(supportedType.getTypeSignature())
+                    .returnType(DataTypes.LONG.getTypeSignature())
+                    .features(Scalar.Feature.DETERMINISTIC)
+                    .build(),
                 (signature, boundSignature) ->
                     new HyperLogLogDistinctAggregation(signature, boundSignature, supportedType)
             );
             builder.add(
-                Signature.aggregate(
-                    NAME,
-                    supportedType.getTypeSignature(),
-                    DataTypes.INTEGER.getTypeSignature(),
-                    DataTypes.LONG.getTypeSignature())
-                    .withFeature(Scalar.Feature.DETERMINISTIC),
+                Signature.builder(NAME, FunctionType.AGGREGATE)
+                    .argumentTypes(supportedType.getTypeSignature(),
+                        DataTypes.INTEGER.getTypeSignature())
+                    .returnType(DataTypes.LONG.getTypeSignature())
+                    .features(Scalar.Feature.DETERMINISTIC)
+                    .build(),
                 (signature, boundSignature) ->
                     new HyperLogLogDistinctAggregation(signature, boundSignature, supportedType)
             );

--- a/extensions/functions/src/main/java/io/crate/window/NthValueFunctions.java
+++ b/extensions/functions/src/main/java/io/crate/window/NthValueFunctions.java
@@ -35,6 +35,7 @@ import io.crate.data.RowN;
 import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.execution.engine.window.WindowFrameState;
 import io.crate.execution.engine.window.WindowFunction;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.BoundSignature;
@@ -162,12 +163,12 @@ public class NthValueFunctions implements WindowFunction {
 
     public static void register(Functions.Builder builder) {
         builder.add(
-            Signature.window(
-                    FIRST_VALUE_NAME,
-                    TypeSignature.parse("E"),
-                    TypeSignature.parse("E")
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withTypeVariableConstraints(typeVariable("E")),
+            Signature.builder(FIRST_VALUE_NAME, FunctionType.WINDOW)
+                .argumentTypes(TypeSignature.parse("E"))
+                .returnType(TypeSignature.parse("E"))
+                .features(Scalar.Feature.DETERMINISTIC)
+                .typeVariableConstraints(typeVariable("E"))
+                .build(),
             (signature, boundSignature) ->
                 new NthValueFunctions(
                     signature,
@@ -177,12 +178,12 @@ public class NthValueFunctions implements WindowFunction {
         );
 
         builder.add(
-            Signature.window(
-                    LAST_VALUE_NAME,
-                    TypeSignature.parse("E"),
-                    TypeSignature.parse("E")
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withTypeVariableConstraints(typeVariable("E")),
+            Signature.builder(LAST_VALUE_NAME, FunctionType.WINDOW)
+                .argumentTypes(TypeSignature.parse("E"))
+                .returnType(TypeSignature.parse("E"))
+                .features(Scalar.Feature.DETERMINISTIC)
+                .typeVariableConstraints(typeVariable("E"))
+                .build(),
             (signature, boundSignature) ->
                 new NthValueFunctions(
                     signature,
@@ -192,13 +193,13 @@ public class NthValueFunctions implements WindowFunction {
         );
 
         builder.add(
-            Signature.window(
-                    NTH_VALUE_NAME,
-                    TypeSignature.parse("E"),
-                    DataTypes.INTEGER.getTypeSignature(),
-                    TypeSignature.parse("E")
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withTypeVariableConstraints(typeVariable("E")),
+            Signature.builder(NTH_VALUE_NAME, FunctionType.WINDOW)
+                .argumentTypes(TypeSignature.parse("E"),
+                    DataTypes.INTEGER.getTypeSignature())
+                .returnType(TypeSignature.parse("E"))
+                .features(Scalar.Feature.DETERMINISTIC)
+                .typeVariableConstraints(typeVariable("E"))
+                .build(),
             (signature, boundSignature) ->
                 new NthValueFunctions(
                     signature,

--- a/extensions/functions/src/main/java/io/crate/window/OffsetValueFunctions.java
+++ b/extensions/functions/src/main/java/io/crate/window/OffsetValueFunctions.java
@@ -36,6 +36,7 @@ import io.crate.data.UnsafeArrayRow;
 import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.execution.engine.window.WindowFrameState;
 import io.crate.execution.engine.window.WindowFunction;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.BoundSignature;
@@ -263,95 +264,95 @@ public class OffsetValueFunctions implements WindowFunction {
 
     public static void register(Functions.Builder builder) {
         builder.add(
-            Signature.window(
-                    LEAD_NAME,
-                    TypeSignature.parse("E"),
-                    TypeSignature.parse("E")
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withTypeVariableConstraints(typeVariable("E")),
-            (signature, boundSignature) ->
-                new OffsetValueFunctions(
-                    signature,
-                    boundSignature,
-                    LEAD_DEFAULT_OFFSET
-                )
+                Signature.builder(LEAD_NAME, FunctionType.WINDOW)
+                        .argumentTypes(TypeSignature.parse("E"))
+                        .returnType(TypeSignature.parse("E"))
+                        .features(Scalar.Feature.DETERMINISTIC)
+                        .typeVariableConstraints(typeVariable("E"))
+                        .build(),
+                (signature, boundSignature) ->
+                        new OffsetValueFunctions(
+                                signature,
+                                boundSignature,
+                                LEAD_DEFAULT_OFFSET
+                        )
         );
         builder.add(
-            Signature.window(
-                    LEAD_NAME,
-                    TypeSignature.parse("E"),
-                    DataTypes.INTEGER.getTypeSignature(),
-                    TypeSignature.parse("E")
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withTypeVariableConstraints(typeVariable("E")),
-            (signature, boundSignature) ->
-                new OffsetValueFunctions(
-                    signature,
-                    boundSignature,
-                    LEAD_DEFAULT_OFFSET
-                )
+                Signature.builder(LEAD_NAME, FunctionType.WINDOW)
+                        .argumentTypes(TypeSignature.parse("E"),
+                                DataTypes.INTEGER.getTypeSignature())
+                        .returnType(TypeSignature.parse("E"))
+                        .features(Scalar.Feature.DETERMINISTIC)
+                        .typeVariableConstraints(typeVariable("E"))
+                        .build(),
+                (signature, boundSignature) ->
+                        new OffsetValueFunctions(
+                                signature,
+                                boundSignature,
+                                LEAD_DEFAULT_OFFSET
+                        )
         );
         builder.add(
-            Signature.window(
-                    LEAD_NAME,
-                    TypeSignature.parse("E"),
-                    DataTypes.INTEGER.getTypeSignature(),
-                    TypeSignature.parse("E"),
-                    TypeSignature.parse("E")
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withTypeVariableConstraints(typeVariable("E")),
-            (signature, boundSignature) ->
-                new OffsetValueFunctions(
-                    signature,
-                    boundSignature,
-                    LEAD_DEFAULT_OFFSET
-                )
+                Signature.builder(LEAD_NAME, FunctionType.WINDOW)
+                        .argumentTypes(TypeSignature.parse("E"),
+                                DataTypes.INTEGER.getTypeSignature(),
+                                TypeSignature.parse("E"))
+                        .returnType(TypeSignature.parse("E"))
+                        .features(Scalar.Feature.DETERMINISTIC)
+                        .typeVariableConstraints(typeVariable("E"))
+                        .build(),
+                (signature, boundSignature) ->
+                        new OffsetValueFunctions(
+                                signature,
+                                boundSignature,
+                                LEAD_DEFAULT_OFFSET
+                        )
         );
 
         builder.add(
-            Signature.window(
-                    LAG_NAME,
-                    TypeSignature.parse("E"),
-                    TypeSignature.parse("E")
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withTypeVariableConstraints(typeVariable("E")),
-            (signature, boundSignature) ->
-                new OffsetValueFunctions(
-                    signature,
-                    boundSignature,
-                    LAG_DEFAULT_OFFSET
-                )
+                Signature.builder(LAG_NAME, FunctionType.WINDOW)
+                        .argumentTypes(TypeSignature.parse("E"))
+                        .returnType(TypeSignature.parse("E"))
+                        .features(Scalar.Feature.DETERMINISTIC)
+                        .typeVariableConstraints(typeVariable("E"))
+                        .build(),
+                (signature, boundSignature) ->
+                        new OffsetValueFunctions(
+                                signature,
+                                boundSignature,
+                                LAG_DEFAULT_OFFSET
+                        )
         );
         builder.add(
-            Signature.window(
-                    LAG_NAME,
-                    TypeSignature.parse("E"),
-                    DataTypes.INTEGER.getTypeSignature(),
-                    TypeSignature.parse("E")
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withTypeVariableConstraints(typeVariable("E")),
-            (signature, boundSignature) ->
-                new OffsetValueFunctions(
-                    signature,
-                    boundSignature,
-                    LAG_DEFAULT_OFFSET
-                )
+                Signature.builder(LAG_NAME, FunctionType.WINDOW)
+                        .argumentTypes(TypeSignature.parse("E"),
+                                DataTypes.INTEGER.getTypeSignature())
+                        .returnType(TypeSignature.parse("E"))
+                        .features(Scalar.Feature.DETERMINISTIC)
+                        .typeVariableConstraints(typeVariable("E"))
+                        .build(),
+                (signature, boundSignature) ->
+                        new OffsetValueFunctions(
+                                signature,
+                                boundSignature,
+                                LAG_DEFAULT_OFFSET
+                        )
         );
         builder.add(
-            Signature.window(
-                    LAG_NAME,
-                    TypeSignature.parse("E"),
-                    DataTypes.INTEGER.getTypeSignature(),
-                    TypeSignature.parse("E"),
-                    TypeSignature.parse("E")
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withTypeVariableConstraints(typeVariable("E")),
-            (signature, boundSignature) ->
-                new OffsetValueFunctions(
-                    signature,
-                    boundSignature,
-                    LAG_DEFAULT_OFFSET
-                )
+                Signature.builder(LAG_NAME, FunctionType.WINDOW)
+                        .argumentTypes(TypeSignature.parse("E"),
+                                DataTypes.INTEGER.getTypeSignature(),
+                                TypeSignature.parse("E"))
+                        .returnType(TypeSignature.parse("E"))
+                        .features(Scalar.Feature.DETERMINISTIC)
+                        .typeVariableConstraints(typeVariable("E"))
+                        .build(),
+                (signature, boundSignature) ->
+                        new OffsetValueFunctions(
+                                signature,
+                                boundSignature,
+                                LAG_DEFAULT_OFFSET
+                        )
         );
     }
 }

--- a/extensions/functions/src/main/java/io/crate/window/RankFunctions.java
+++ b/extensions/functions/src/main/java/io/crate/window/RankFunctions.java
@@ -32,6 +32,7 @@ import io.crate.data.Row;
 import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.execution.engine.window.WindowFrameState;
 import io.crate.execution.engine.window.WindowFunction;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.BoundSignature;
@@ -92,10 +93,11 @@ public class RankFunctions implements WindowFunction {
 
     public static void register(Functions.Builder builder) {
         builder.add(
-            Signature.window(
-                RANK_NAME,
-                DataTypes.INTEGER.getTypeSignature()
-                ).withFeature(Scalar.Feature.DETERMINISTIC),
+            Signature.builder(RANK_NAME, FunctionType.WINDOW)
+                .argumentTypes()
+                .returnType(DataTypes.INTEGER.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC)
+                .build(),
             (signature, boundSignature) ->
                 new RankFunctions(
                     signature,
@@ -105,10 +107,11 @@ public class RankFunctions implements WindowFunction {
         );
 
         builder.add(
-            Signature.window(
-                DENSE_RANK_NAME,
-                DataTypes.INTEGER.getTypeSignature()
-            ).withFeature(Scalar.Feature.DETERMINISTIC),
+            Signature.builder(DENSE_RANK_NAME, FunctionType.WINDOW)
+                .argumentTypes()
+                .returnType(DataTypes.INTEGER.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC)
+                .build(),
             (signature, boundSignature) ->
                 new RankFunctions(
                     signature,

--- a/extensions/functions/src/test/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationTest.java
+++ b/extensions/functions/src/test/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationTest.java
@@ -42,6 +42,7 @@ import io.crate.Streamer;
 import io.crate.execution.engine.aggregation.impl.HyperLogLogPlusPlus;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.FunctionImplementation;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.SearchPath;
 import io.crate.metadata.functions.Signature;
@@ -58,26 +59,26 @@ public class HyperLogLogDistinctAggregationTest extends AggregationTestCase {
 
     private Object executeAggregation(DataType<?> argumentType, Object[][] data) throws Exception {
         return executeAggregation(
-            Signature.aggregate(
-                    HyperLogLogDistinctAggregation.NAME,
-                    argumentType.getTypeSignature(),
-                    DataTypes.LONG.getTypeSignature())
-                .withFeature(Scalar.Feature.DETERMINISTIC),
-            data,
-            List.of()
+                Signature.builder(HyperLogLogDistinctAggregation.NAME, FunctionType.AGGREGATE)
+                        .argumentTypes(argumentType.getTypeSignature())
+                        .returnType(DataTypes.LONG.getTypeSignature())
+                        .features(Scalar.Feature.DETERMINISTIC)
+                        .build(),
+                data,
+                List.of()
         );
     }
 
     private Object executeAggregationWithPrecision(DataType<?> argumentType, Object[][] data, List<Literal<?>> optionalParams) throws Exception {
         return executeAggregation(
-            Signature.aggregate(
-                    HyperLogLogDistinctAggregation.NAME,
-                    argumentType.getTypeSignature(),
-                    DataTypes.INTEGER.getTypeSignature(),
-                    DataTypes.LONG.getTypeSignature())
-                .withFeature(Scalar.Feature.DETERMINISTIC),
-            data,
-            optionalParams
+                Signature.builder(HyperLogLogDistinctAggregation.NAME, FunctionType.AGGREGATE)
+                        .argumentTypes(argumentType.getTypeSignature(),
+                                DataTypes.INTEGER.getTypeSignature())
+                        .returnType(DataTypes.LONG.getTypeSignature())
+                        .features(Scalar.Feature.DETERMINISTIC)
+                        .build(),
+                data,
+                optionalParams
         );
     }
 

--- a/server/src/main/java/io/crate/analyze/where/EqualityExtractor.java
+++ b/server/src/main/java/io/crate/analyze/where/EqualityExtractor.java
@@ -55,6 +55,7 @@ import io.crate.expression.symbol.SymbolType;
 import io.crate.expression.symbol.SymbolVisitor;
 import io.crate.expression.symbol.format.Style;
 import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Reference;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
@@ -66,8 +67,11 @@ public class EqualityExtractor {
 
     private static final int MAX_ITERATIONS = 10_000;
     private static final Function NULL_MARKER = new Function(
-        Signature.scalar("null_marker", DataTypes.UNDEFINED.getTypeSignature())
-            .withFeature(Scalar.Feature.DETERMINISTIC),
+        Signature.builder("null_marker", FunctionType.SCALAR)
+            .argumentTypes()
+            .returnType(DataTypes.UNDEFINED.getTypeSignature())
+            .features(Scalar.Feature.DETERMINISTIC)
+            .build(),
         List.of(),
         DataTypes.UNDEFINED
     );

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregation.java
@@ -45,6 +45,7 @@ import io.crate.execution.engine.aggregation.DocValueAggregator;
 import io.crate.expression.reference.doc.lucene.LuceneReferenceResolver;
 import io.crate.expression.symbol.Literal;
 import io.crate.memory.MemoryManager;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
 import io.crate.metadata.Scalar;
@@ -76,15 +77,21 @@ public class ArbitraryAggregation extends AggregationFunction<Object, Object> {
     public static void register(Functions.Builder builder) {
         TypeSignature T = TypeSignature.parse("T");
         builder.add(
-            Signature.aggregate(NAME, T, T)
-                .withFeature(Scalar.Feature.DETERMINISTIC)
-                .withTypeVariableConstraints(TypeVariableConstraint.typeVariableOfAnyType("T")),
+                Signature.builder(NAME, FunctionType.AGGREGATE)
+                        .argumentTypes(T)
+                        .returnType(T)
+                        .features(Scalar.Feature.DETERMINISTIC)
+                        .typeVariableConstraints(TypeVariableConstraint.typeVariableOfAnyType("T"))
+                        .build(),
             ArbitraryAggregation::new
         );
         builder.add(
-            Signature.aggregate(ALIAS, T, T)
-                .withFeature(Scalar.Feature.DETERMINISTIC)
-                .withTypeVariableConstraints(TypeVariableConstraint.typeVariableOfAnyType("T")),
+                Signature.builder(ALIAS, FunctionType.AGGREGATE)
+                        .argumentTypes(T)
+                        .returnType(T)
+                        .features(Scalar.Feature.DETERMINISTIC)
+                        .typeVariableConstraints(TypeVariableConstraint.typeVariableOfAnyType("T"))
+                        .build(),
             ArbitraryAggregation::new
         );
     }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/ArrayAgg.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/ArrayAgg.java
@@ -33,6 +33,7 @@ import io.crate.data.Input;
 import io.crate.data.breaker.RamAccounting;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.memory.MemoryManager;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.BoundSignature;
@@ -43,13 +44,12 @@ import io.crate.types.TypeSignature;
 public final class ArrayAgg extends AggregationFunction<List<Object>, List<Object>> {
 
     public static final String NAME = "array_agg";
-    public static final Signature SIGNATURE =
-        Signature.aggregate(
-                NAME,
-                TypeSignature.parse("E"),
-                TypeSignature.parse("array(E)"))
-            .withFeature(Scalar.Feature.DETERMINISTIC)
-            .withTypeVariableConstraints(typeVariable("E"));
+    public static final Signature SIGNATURE = Signature.builder(NAME, FunctionType.AGGREGATE)
+        .argumentTypes(TypeSignature.parse("E"))
+        .returnType(TypeSignature.parse("array(E)"))
+        .features(Scalar.Feature.DETERMINISTIC)
+        .typeVariableConstraints(typeVariable("E"))
+        .build();
 
 
     public static void register(Functions.Builder builder) {

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/CmpByAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/CmpByAggregation.java
@@ -44,6 +44,7 @@ import io.crate.expression.reference.doc.lucene.LuceneCollectorExpression;
 import io.crate.expression.reference.doc.lucene.LuceneReferenceResolver;
 import io.crate.expression.symbol.Literal;
 import io.crate.memory.MemoryManager;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
 import io.crate.metadata.Scalar;
@@ -108,29 +109,23 @@ public final class CmpByAggregation extends AggregationFunction<CmpByAggregation
         var variableConstraintA = TypeVariableConstraint.typeVariableOfAnyType("A");
         var variableConstraintB = TypeVariableConstraint.typeVariableOfAnyType("B");
         builder.add(
-            Signature.aggregate(
-                    MAX_BY,
-                    returnValueType,
-                    cmpType,
-                    returnValueType)
-                .withFeature(Scalar.Feature.DETERMINISTIC)
-                .withTypeVariableConstraints(
-                    variableConstraintA,
-                    variableConstraintB
-                ),
+            Signature.builder(MAX_BY, FunctionType.AGGREGATE)
+                .argumentTypes(returnValueType,
+                        cmpType)
+                .returnType(returnValueType)
+                .features(Scalar.Feature.DETERMINISTIC)
+                .typeVariableConstraints(variableConstraintA, variableConstraintB)
+                .build(),
             (signature, boundSignature) -> new CmpByAggregation(1, signature, boundSignature)
         );
         builder.add(
-            Signature.aggregate(
-                MIN_BY,
-                returnValueType,
-                    cmpType,
-                    returnValueType)
-                .withFeature(Scalar.Feature.DETERMINISTIC)
-                .withTypeVariableConstraints(
-                    variableConstraintA,
-                    variableConstraintB
-                ),
+            Signature.builder(MIN_BY, FunctionType.AGGREGATE)
+                .argumentTypes(returnValueType,
+                        cmpType)
+                .returnType(returnValueType)
+                .features(Scalar.Feature.DETERMINISTIC)
+                .typeVariableConstraints(variableConstraintA, variableConstraintB)
+                .build(),
             (signature, boundSignature) -> new CmpByAggregation(-1, signature, boundSignature)
         );
     }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregation.java
@@ -35,6 +35,7 @@ import io.crate.data.Input;
 import io.crate.data.breaker.RamAccounting;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.memory.MemoryManager;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.BoundSignature;
@@ -58,12 +59,12 @@ public class CollectSetAggregation extends AggregationFunction<Map<Object, Objec
         for (DataType<?> supportedType : DataTypes.PRIMITIVE_TYPES) {
             var returnType = new ArrayType<>(supportedType);
             builder.add(
-                Signature.aggregate(
-                        NAME,
-                        supportedType.getTypeSignature(),
-                        returnType.getTypeSignature())
-                    .withFeature(Scalar.Feature.DETERMINISTIC),
-                CollectSetAggregation::new
+                    Signature.builder(NAME, FunctionType.AGGREGATE)
+                            .argumentTypes(supportedType.getTypeSignature())
+                            .returnType(returnType.getTypeSignature())
+                            .features(Scalar.Feature.DETERMINISTIC)
+                            .build(),
+                    CollectSetAggregation::new
             );
         }
     }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/CountAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/CountAggregation.java
@@ -44,6 +44,7 @@ import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.memory.MemoryManager;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
@@ -73,16 +74,19 @@ public class CountAggregation extends AggregationFunction<MutableLong, Long> {
 
     public static final String NAME = "count";
     public static final Signature SIGNATURE =
-        Signature.aggregate(
-                NAME,
-                TypeSignature.parse("V"),
-                DataTypes.LONG.getTypeSignature())
-            .withFeature(Scalar.Feature.DETERMINISTIC)
-            .withTypeVariableConstraints(typeVariable("V"));
+            Signature.builder(NAME, FunctionType.AGGREGATE)
+                    .argumentTypes(TypeSignature.parse("V"))
+                    .returnType(DataTypes.LONG.getTypeSignature())
+                    .features(Scalar.Feature.DETERMINISTIC)
+                    .typeVariableConstraints(typeVariable("V"))
+                    .build();
 
     public static final Signature COUNT_STAR_SIGNATURE =
-        Signature.aggregate(NAME, DataTypes.LONG.getTypeSignature())
-            .withFeature(Scalar.Feature.DETERMINISTIC);
+            Signature.builder(NAME, FunctionType.AGGREGATE)
+                    .argumentTypes()
+                    .returnType(DataTypes.LONG.getTypeSignature())
+                    .features(Scalar.Feature.DETERMINISTIC)
+                    .build();
 
     static {
         DataTypes.register(CountAggregation.LongStateType.ID, in -> CountAggregation.LongStateType.INSTANCE);

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregation.java
@@ -45,6 +45,7 @@ import io.crate.execution.engine.aggregation.impl.templates.SortedNumericDocValu
 import io.crate.expression.reference.doc.lucene.LuceneReferenceResolver;
 import io.crate.expression.symbol.Literal;
 import io.crate.memory.MemoryManager;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
 import io.crate.metadata.Scalar;
@@ -76,12 +77,12 @@ public class GeometricMeanAggregation extends AggregationFunction<GeometricMeanA
     public static void register(Functions.Builder builder) {
         for (var supportedType : SUPPORTED_TYPES) {
             builder.add(
-                Signature.aggregate(
-                        NAME,
-                        supportedType.getTypeSignature(),
-                        DataTypes.DOUBLE.getTypeSignature())
-                    .withFeature(Scalar.Feature.DETERMINISTIC),
-                GeometricMeanAggregation::new
+                    Signature.builder(NAME, FunctionType.AGGREGATE)
+                            .argumentTypes(supportedType.getTypeSignature())
+                            .returnType(DataTypes.DOUBLE.getTypeSignature())
+                            .features(Scalar.Feature.DETERMINISTIC)
+                            .build(),
+                    GeometricMeanAggregation::new
             );
         }
     }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/IntervalSumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/IntervalSumAggregation.java
@@ -31,6 +31,7 @@ import io.crate.data.Input;
 import io.crate.data.breaker.RamAccounting;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.memory.MemoryManager;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.BoundSignature;
@@ -44,12 +45,12 @@ public class IntervalSumAggregation extends AggregationFunction<Period, Period> 
 
     public static void register(Functions.Builder builder) {
         builder.add(
-            Signature.aggregate(
-                    NAME,
-                    DataTypes.INTERVAL.getTypeSignature(),
-                    DataTypes.INTERVAL.getTypeSignature())
-                .withFeature(Scalar.Feature.DETERMINISTIC),
-            IntervalSumAggregation::new
+                Signature.builder(NAME, FunctionType.AGGREGATE)
+                        .argumentTypes(DataTypes.INTERVAL.getTypeSignature())
+                        .returnType(DataTypes.INTERVAL.getTypeSignature())
+                        .features(Scalar.Feature.DETERMINISTIC)
+                        .build(),
+                IntervalSumAggregation::new
         );
     }
 

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
@@ -42,6 +42,7 @@ import io.crate.execution.engine.aggregation.DocValueAggregator;
 import io.crate.expression.reference.doc.lucene.LuceneReferenceResolver;
 import io.crate.expression.symbol.Literal;
 import io.crate.memory.MemoryManager;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
 import io.crate.metadata.Scalar;
@@ -67,15 +68,15 @@ public abstract class MaximumAggregation extends AggregationFunction<Object, Obj
         for (var supportedType : DataTypes.PRIMITIVE_TYPES) {
             var fixedWidthType = supportedType instanceof FixedWidthType;
             builder.add(
-                Signature.aggregate(
-                        NAME,
-                        supportedType.getTypeSignature(),
-                        supportedType.getTypeSignature())
-                    .withFeature(Scalar.Feature.DETERMINISTIC),
-                (signature, boundSignature) ->
-                    fixedWidthType
-                        ? new FixedMaximumAggregation(signature, boundSignature)
-                        : new VariableMaximumAggregation(signature, boundSignature)
+                    Signature.builder(NAME, FunctionType.AGGREGATE)
+                            .argumentTypes(supportedType.getTypeSignature())
+                            .returnType(supportedType.getTypeSignature())
+                            .features(Scalar.Feature.DETERMINISTIC)
+                            .build(),
+                    (signature, boundSignature) ->
+                            fixedWidthType
+                                    ? new FixedMaximumAggregation(signature, boundSignature)
+                                    : new VariableMaximumAggregation(signature, boundSignature)
             );
         }
     }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/MinimumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/MinimumAggregation.java
@@ -42,6 +42,7 @@ import io.crate.execution.engine.aggregation.DocValueAggregator;
 import io.crate.expression.reference.doc.lucene.LuceneReferenceResolver;
 import io.crate.expression.symbol.Literal;
 import io.crate.memory.MemoryManager;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
 import io.crate.metadata.Scalar;
@@ -67,15 +68,15 @@ public abstract class MinimumAggregation extends AggregationFunction<Object, Obj
         for (var supportedType : DataTypes.PRIMITIVE_TYPES) {
             var fixedWidthType = supportedType instanceof FixedWidthType;
             builder.add(
-                Signature.aggregate(
-                        NAME,
-                        supportedType.getTypeSignature(),
-                        supportedType.getTypeSignature())
-                    .withFeature(Scalar.Feature.DETERMINISTIC),
-                (signature, boundSignature) ->
-                    fixedWidthType
-                        ? new FixedMinimumAggregation(signature, boundSignature)
-                        : new VariableMinimumAggregation(signature, boundSignature)
+                    Signature.builder(NAME, FunctionType.AGGREGATE)
+                            .argumentTypes(supportedType.getTypeSignature())
+                            .returnType(supportedType.getTypeSignature())
+                            .features(Scalar.Feature.DETERMINISTIC)
+                            .build(),
+                    (signature, boundSignature) ->
+                            fixedWidthType
+                                    ? new FixedMinimumAggregation(signature, boundSignature)
+                                    : new VariableMinimumAggregation(signature, boundSignature)
             );
         }
     }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/NumericSumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/NumericSumAggregation.java
@@ -43,6 +43,7 @@ import io.crate.execution.engine.aggregation.impl.util.OverflowAwareMutableLong;
 import io.crate.expression.reference.doc.lucene.LuceneReferenceResolver;
 import io.crate.expression.symbol.Literal;
 import io.crate.memory.MemoryManager;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
 import io.crate.metadata.Scalar;
@@ -62,11 +63,11 @@ import io.crate.types.ShortType;
 public class NumericSumAggregation extends AggregationFunction<BigDecimal, BigDecimal> {
 
     public static final String NAME = "sum";
-    public static final Signature SIGNATURE = Signature.aggregate(
-            NAME,
-            DataTypes.NUMERIC.getTypeSignature(),
-            DataTypes.NUMERIC.getTypeSignature())
-        .withFeature(Scalar.Feature.DETERMINISTIC);
+    public static final Signature SIGNATURE = Signature.builder(NAME, FunctionType.AGGREGATE)
+            .argumentTypes(DataTypes.NUMERIC.getTypeSignature())
+            .returnType(DataTypes.NUMERIC.getTypeSignature())
+            .features(Scalar.Feature.DETERMINISTIC)
+            .build();
     private static final long INIT_BIG_DECIMAL_SIZE = NumericType.size(BigDecimal.ZERO);
 
     public static void register(Functions.Builder builder) {

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/PercentileAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/PercentileAggregation.java
@@ -32,6 +32,7 @@ import io.crate.data.Input;
 import io.crate.data.breaker.RamAccounting;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.memory.MemoryManager;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.BoundSignature;
@@ -51,22 +52,22 @@ class PercentileAggregation extends AggregationFunction<TDigestState, Object> {
     public static void register(Functions.Builder builder) {
         for (var supportedType : DataTypes.NUMERIC_PRIMITIVE_TYPES) {
             builder.add(
-                Signature.aggregate(
-                        NAME,
-                        supportedType.getTypeSignature(),
-                        DataTypes.DOUBLE.getTypeSignature(),
-                        DataTypes.DOUBLE.getTypeSignature())
-                    .withFeature(Scalar.Feature.DETERMINISTIC),
-                PercentileAggregation::new
+                    Signature.builder(NAME, FunctionType.AGGREGATE)
+                            .argumentTypes(supportedType.getTypeSignature(),
+                                    DataTypes.DOUBLE.getTypeSignature())
+                            .returnType(DataTypes.DOUBLE.getTypeSignature())
+                            .features(Scalar.Feature.DETERMINISTIC)
+                            .build(),
+                    PercentileAggregation::new
             );
             builder.add(
-                Signature.aggregate(
-                        NAME,
-                        supportedType.getTypeSignature(),
-                        DataTypes.DOUBLE_ARRAY.getTypeSignature(),
-                        DataTypes.DOUBLE_ARRAY.getTypeSignature())
-                    .withFeature(Scalar.Feature.DETERMINISTIC),
-                PercentileAggregation::new
+                    Signature.builder(NAME, FunctionType.AGGREGATE)
+                            .argumentTypes(supportedType.getTypeSignature(),
+                                    DataTypes.DOUBLE_ARRAY.getTypeSignature())
+                            .returnType(DataTypes.DOUBLE_ARRAY.getTypeSignature())
+                            .features(Scalar.Feature.DETERMINISTIC)
+                            .build(),
+                    PercentileAggregation::new
             );
         }
     }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationAggregation.java
@@ -42,6 +42,7 @@ import io.crate.execution.engine.aggregation.statistics.StandardDeviation;
 import io.crate.expression.reference.doc.lucene.LuceneReferenceResolver;
 import io.crate.expression.symbol.Literal;
 import io.crate.memory.MemoryManager;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
 import io.crate.metadata.Scalar;
@@ -73,12 +74,12 @@ public class StandardDeviationAggregation extends AggregationFunction<StandardDe
     public static void register(Functions.Builder builder) {
         for (var supportedType : SUPPORTED_TYPES) {
             builder.add(
-                Signature.aggregate(
-                    NAME,
-                    supportedType.getTypeSignature(),
-                    DataTypes.DOUBLE.getTypeSignature()
-                ).withFeature(Scalar.Feature.DETERMINISTIC),
-                StandardDeviationAggregation::new
+                    Signature.builder(NAME, FunctionType.AGGREGATE)
+                            .argumentTypes(supportedType.getTypeSignature())
+                            .returnType(DataTypes.DOUBLE.getTypeSignature())
+                            .features(Scalar.Feature.DETERMINISTIC)
+                            .build(),
+                    StandardDeviationAggregation::new
             );
         }
     }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/StringAgg.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/StringAgg.java
@@ -37,6 +37,7 @@ import io.crate.data.Input;
 import io.crate.data.breaker.RamAccounting;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.memory.MemoryManager;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.BoundSignature;
@@ -52,12 +53,12 @@ public final class StringAgg extends AggregationFunction<StringAgg.StringAggStat
 
     private static final String NAME = "string_agg";
     public static final Signature SIGNATURE =
-        Signature.aggregate(
-                NAME,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature())
-            .withFeature(Scalar.Feature.DETERMINISTIC);
+            Signature.builder(NAME, FunctionType.AGGREGATE)
+                    .argumentTypes(DataTypes.STRING.getTypeSignature(),
+                            DataTypes.STRING.getTypeSignature())
+                    .returnType(DataTypes.STRING.getTypeSignature())
+                    .features(Scalar.Feature.DETERMINISTIC)
+                    .build();
 
 
     private static final int LIST_ENTRY_OVERHEAD = 32;

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/SumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/SumAggregation.java
@@ -47,6 +47,7 @@ import io.crate.expression.reference.doc.lucene.LuceneReferenceResolver;
 import io.crate.expression.symbol.Literal;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.FunctionProvider.FunctionFactory;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
 import io.crate.metadata.Scalar;
@@ -71,31 +72,31 @@ public class SumAggregation<T extends Number> extends AggregationFunction<T, T> 
         BinaryOperator<Long> sub = Math::subtractExact;
 
         builder.add(
-            Signature.aggregate(
-                    NAME,
-                    DataTypes.FLOAT.getTypeSignature(),
-                    DataTypes.FLOAT.getTypeSignature())
-                .withFeature(Scalar.Feature.DETERMINISTIC),
-            getSumAggregationForFloatFactory()
+                Signature.builder(NAME, FunctionType.AGGREGATE)
+                        .argumentTypes(DataTypes.FLOAT.getTypeSignature())
+                        .returnType(DataTypes.FLOAT.getTypeSignature())
+                        .features(Scalar.Feature.DETERMINISTIC)
+                        .build(),
+                getSumAggregationForFloatFactory()
         );
         builder.add(
-            Signature.aggregate(
-                    NAME,
-                    DataTypes.DOUBLE.getTypeSignature(),
-                    DataTypes.DOUBLE.getTypeSignature())
-                .withFeature(Scalar.Feature.DETERMINISTIC),
-            getSumAggregationForDoubleFactory()
+                Signature.builder(NAME, FunctionType.AGGREGATE)
+                        .argumentTypes(DataTypes.DOUBLE.getTypeSignature())
+                        .returnType(DataTypes.DOUBLE.getTypeSignature())
+                        .features(Scalar.Feature.DETERMINISTIC)
+                        .build(),
+                getSumAggregationForDoubleFactory()
         );
 
         for (var supportedType : List.of(DataTypes.BYTE, DataTypes.SHORT, DataTypes.INTEGER, DataTypes.LONG)) {
             builder.add(
-                Signature.aggregate(
-                        NAME,
-                        supportedType.getTypeSignature(),
-                        DataTypes.LONG.getTypeSignature())
-                    .withFeature(Scalar.Feature.DETERMINISTIC),
-                (signature, boundSignature) ->
-                    new SumAggregation<>(DataTypes.LONG, add, sub, signature, boundSignature)
+                    Signature.builder(NAME, FunctionType.AGGREGATE)
+                            .argumentTypes(supportedType.getTypeSignature())
+                            .returnType(DataTypes.LONG.getTypeSignature())
+                            .features(Scalar.Feature.DETERMINISTIC)
+                            .build(),
+                    (signature, boundSignature) ->
+                            new SumAggregation<>(DataTypes.LONG, add, sub, signature, boundSignature)
             );
         }
     }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
@@ -42,6 +42,7 @@ import io.crate.execution.engine.aggregation.statistics.Variance;
 import io.crate.expression.reference.doc.lucene.LuceneReferenceResolver;
 import io.crate.expression.symbol.Literal;
 import io.crate.memory.MemoryManager;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
 import io.crate.metadata.Scalar;
@@ -73,12 +74,12 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
     public static void register(Functions.Builder builder) {
         for (var supportedType : SUPPORTED_TYPES) {
             builder.add(
-                Signature.aggregate(
-                        NAME,
-                        supportedType.getTypeSignature(),
-                        DataTypes.DOUBLE.getTypeSignature())
-                    .withFeature(Scalar.Feature.DETERMINISTIC),
-                VarianceAggregation::new
+                    Signature.builder(NAME, FunctionType.AGGREGATE)
+                            .argumentTypes(supportedType.getTypeSignature())
+                            .returnType(DataTypes.DOUBLE.getTypeSignature())
+                            .features(Scalar.Feature.DETERMINISTIC)
+                            .build(),
+                    VarianceAggregation::new
             );
         }
     }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/AverageAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/AverageAggregation.java
@@ -44,6 +44,7 @@ import io.crate.execution.engine.aggregation.impl.util.KahanSummationForDouble;
 import io.crate.expression.reference.doc.lucene.LuceneReferenceResolver;
 import io.crate.expression.symbol.Literal;
 import io.crate.memory.MemoryManager;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
 import io.crate.metadata.Scalar;
@@ -79,14 +80,14 @@ public class AverageAggregation extends AggregationFunction<AverageAggregation.A
         for (var functionName : NAMES) {
             for (var supportedType : SUPPORTED_TYPES) {
                 builder.add(
-                    Signature.aggregate(
-                            functionName,
-                            supportedType.getTypeSignature(),
-                            DataTypes.DOUBLE.getTypeSignature())
-                        .withFeature(Scalar.Feature.DETERMINISTIC),
-                    (signature, boundSignature) ->
-                        new AverageAggregation(signature, boundSignature,
-                            supportedType.id() != DataTypes.FLOAT.id() && supportedType.id() != DataTypes.DOUBLE.id())
+                        Signature.builder(functionName, FunctionType.AGGREGATE)
+                                .argumentTypes(supportedType.getTypeSignature())
+                                .returnType(DataTypes.DOUBLE.getTypeSignature())
+                                .features(Scalar.Feature.DETERMINISTIC)
+                                .build(),
+                        (signature, boundSignature) ->
+                                new AverageAggregation(signature, boundSignature,
+                                        supportedType.id() != DataTypes.FLOAT.id() && supportedType.id() != DataTypes.DOUBLE.id())
                 );
             }
         }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/IntervalAverageAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/IntervalAverageAggregation.java
@@ -48,6 +48,7 @@ import io.crate.data.breaker.RamAccounting;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.execution.engine.aggregation.impl.util.OverflowAwareMutableLong;
 import io.crate.memory.MemoryManager;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.BoundSignature;
@@ -68,12 +69,12 @@ public class IntervalAverageAggregation extends AggregationFunction<IntervalAver
     public static void register(Functions.Builder builder) {
         for (var functionName : NAMES) {
             builder.add(
-                Signature.aggregate(
-                        functionName,
-                        DataTypes.INTERVAL.getTypeSignature(),
-                        DataTypes.INTERVAL.getTypeSignature())
-                    .withFeature(Scalar.Feature.DETERMINISTIC),
-                IntervalAverageAggregation::new
+                    Signature.builder(functionName, FunctionType.AGGREGATE)
+                            .argumentTypes(DataTypes.INTERVAL.getTypeSignature())
+                            .returnType(DataTypes.INTERVAL.getTypeSignature())
+                            .features(Scalar.Feature.DETERMINISTIC)
+                            .build(),
+                    IntervalAverageAggregation::new
             );
         }
     }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/numeric/NumericAverageAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/numeric/NumericAverageAggregation.java
@@ -46,6 +46,7 @@ import io.crate.expression.reference.doc.lucene.LuceneReferenceResolver;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbols;
 import io.crate.memory.MemoryManager;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
 import io.crate.metadata.Scalar;
@@ -71,12 +72,12 @@ public class NumericAverageAggregation extends AggregationFunction<NumericAverag
     public static void register(Functions.Builder builder) {
         for (var functionName : NAMES) {
             builder.add(
-                Signature.aggregate(
-                        functionName,
-                        DataTypes.NUMERIC.getTypeSignature(),
-                        DataTypes.NUMERIC.getTypeSignature())
-                    .withFeature(Scalar.Feature.DETERMINISTIC),
-                NumericAverageAggregation::new
+                    Signature.builder(functionName, FunctionType.AGGREGATE)
+                            .argumentTypes(DataTypes.NUMERIC.getTypeSignature())
+                            .returnType(DataTypes.NUMERIC.getTypeSignature())
+                            .features(Scalar.Feature.DETERMINISTIC)
+                            .build(),
+                    NumericAverageAggregation::new
             );
         }
     }

--- a/server/src/main/java/io/crate/execution/engine/window/RowNumberWindowFunction.java
+++ b/server/src/main/java/io/crate/execution/engine/window/RowNumberWindowFunction.java
@@ -29,6 +29,7 @@ import org.jetbrains.annotations.Nullable;
 import io.crate.data.Input;
 import io.crate.data.Row;
 import io.crate.execution.engine.collect.CollectExpression;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.BoundSignature;
@@ -41,11 +42,12 @@ public class RowNumberWindowFunction implements WindowFunction {
 
     public static void register(Functions.Builder builder) {
         builder.add(
-            Signature.window(
-                NAME,
-                DataTypes.INTEGER.getTypeSignature()
-            ).withFeature(Scalar.Feature.DETERMINISTIC),
-            RowNumberWindowFunction::new
+                Signature.builder(NAME, FunctionType.WINDOW)
+                        .argumentTypes()
+                        .returnType(DataTypes.INTEGER.getTypeSignature())
+                        .features(Scalar.Feature.DETERMINISTIC)
+                        .build(),
+                RowNumberWindowFunction::new
         );
     }
 

--- a/server/src/main/java/io/crate/expression/operator/AllOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/AllOperator.java
@@ -27,6 +27,7 @@ import java.util.Collection;
 import java.util.function.IntPredicate;
 
 import io.crate.data.Input;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
@@ -60,14 +61,13 @@ public final class AllOperator extends Operator<Object> {
     public static void register(Functions.Builder builder) {
         for (var type : Type.values()) {
             builder.add(
-                Signature.scalar(
-                        type.fullQualifiedName,
-                        TypeSignature.parse("E"),
-                        TypeSignature.parse("array(E)"),
-                        Operator.RETURN_TYPE.getTypeSignature()
-                    ).withTypeVariableConstraints(typeVariable("E"))
-                    .withFeature(Feature.DETERMINISTIC)
-                    .withFeature(Feature.NULLABLE),
+                Signature.builder(type.fullQualifiedName, FunctionType.SCALAR)
+                    .argumentTypes(TypeSignature.parse("E"),
+                        TypeSignature.parse("array(E)"))
+                    .returnType(Operator.RETURN_TYPE.getTypeSignature())
+                    .typeVariableConstraints(typeVariable("E"))
+                    .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                    .build(),
                 (signature, boundSignature) ->
                     new AllOperator(
                         signature,

--- a/server/src/main/java/io/crate/expression/operator/AndOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/AndOperator.java
@@ -35,6 +35,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitor;
 import io.crate.lucene.LuceneQueryBuilder.Context;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
@@ -46,12 +47,12 @@ import io.crate.types.DataTypes;
 public class AndOperator extends Operator<Boolean> {
 
     public static final String NAME = "op_and";
-    public static final Signature SIGNATURE = Signature.scalar(
-        NAME,
-        DataTypes.BOOLEAN.getTypeSignature(),
-        DataTypes.BOOLEAN.getTypeSignature(),
-        DataTypes.BOOLEAN.getTypeSignature()
-    ).withFeature(Feature.DETERMINISTIC);
+    public static final Signature SIGNATURE = Signature.builder(NAME, FunctionType.SCALAR)
+        .argumentTypes(DataTypes.BOOLEAN.getTypeSignature(),
+            DataTypes.BOOLEAN.getTypeSignature())
+        .returnType(DataTypes.BOOLEAN.getTypeSignature())
+        .features(Feature.DETERMINISTIC)
+        .build();
 
     public static void register(Functions.Builder builder) {
         builder.add(SIGNATURE, AndOperator::new);

--- a/server/src/main/java/io/crate/expression/operator/CIDROperator.java
+++ b/server/src/main/java/io/crate/expression/operator/CIDROperator.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.network.InetAddresses;
 
 import io.crate.data.Input;
 import io.crate.expression.symbol.Literal;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.IndexType;
 import io.crate.metadata.NodeContext;
@@ -50,13 +51,12 @@ public final class CIDROperator {
 
     public static void register(Functions.Builder builder) {
         builder.add(
-            Signature.scalar(
-                    CONTAINED_WITHIN,
-                    DataTypes.IP.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature(),
-                    Operator.RETURN_TYPE.getTypeSignature())
-                .withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder(CONTAINED_WITHIN, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.IP.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature())
+                .returnType(Operator.RETURN_TYPE.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .build(),
             ContainedWithinOperator::new
         );
     }

--- a/server/src/main/java/io/crate/expression/operator/EqOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/EqOperator.java
@@ -50,6 +50,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.lucene.LuceneQueryBuilder.Context;
 import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.IndexType;
 import io.crate.metadata.NodeContext;
@@ -71,14 +72,13 @@ public final class EqOperator extends Operator<Object> {
 
     public static final String NAME = "op_=";
 
-    public static final Signature SIGNATURE = Signature.scalar(
-            NAME,
-            TypeSignature.parse("E"),
-            TypeSignature.parse("E"),
-            Operator.RETURN_TYPE.getTypeSignature())
-        .withFeature(Feature.DETERMINISTIC)
-        .withFeature(Feature.NULLABLE)
-        .withTypeVariableConstraints(typeVariable("E"));
+    public static final Signature SIGNATURE = Signature.builder(NAME, FunctionType.SCALAR)
+        .argumentTypes(TypeSignature.parse("E"),
+            TypeSignature.parse("E"))
+        .returnType(Operator.RETURN_TYPE.getTypeSignature())
+        .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+        .typeVariableConstraints(typeVariable("E"))
+        .build();
 
     public static void register(Functions.Builder builder) {
         builder.add(SIGNATURE, EqOperator::new);

--- a/server/src/main/java/io/crate/expression/operator/ExistsOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/ExistsOperator.java
@@ -24,6 +24,7 @@ package io.crate.expression.operator;
 import java.util.List;
 
 import io.crate.data.Input;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
@@ -37,13 +38,12 @@ public class ExistsOperator extends Operator<List<Object>> {
     public static final String NAME = "_exists";
 
     public static void register(Functions.Builder builder) {
-        Signature signature = Signature.scalar(
-                NAME,
-                TypeSignature.parse("array(E)"),
-                Operator.RETURN_TYPE.getTypeSignature()
-            ).withTypeVariableConstraints(TypeVariableConstraint.typeVariable("E"))
-            .withFeature(Feature.DETERMINISTIC)
-            .withFeature(Feature.NULLABLE);
+        Signature signature = Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(TypeSignature.parse("array(E)"))
+                .returnType(Operator.RETURN_TYPE.getTypeSignature())
+                .typeVariableConstraints(TypeVariableConstraint.typeVariable("E"))
+                .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                .build();
         builder.add(signature, ExistsOperator::new);
     }
 

--- a/server/src/main/java/io/crate/expression/operator/GtOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/GtOperator.java
@@ -21,6 +21,7 @@
 
 package io.crate.expression.operator;
 
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
@@ -33,13 +34,12 @@ public final class GtOperator {
     public static void register(Functions.Builder builder) {
         for (var supportedType : DataTypes.PRIMITIVE_TYPES) {
             builder.add(
-                Signature.scalar(
-                        NAME,
-                        supportedType.getTypeSignature(),
-                        supportedType.getTypeSignature(),
-                        Operator.RETURN_TYPE.getTypeSignature())
-                    .withFeature(Scalar.Feature.DETERMINISTIC)
-                    .withFeature(Scalar.Feature.NULLABLE),
+                Signature.builder(NAME, FunctionType.SCALAR)
+                    .argumentTypes(supportedType.getTypeSignature(),
+                        supportedType.getTypeSignature())
+                    .returnType(Operator.RETURN_TYPE.getTypeSignature())
+                    .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                    .build(),
                 (signature, boundSignature) -> new CmpOperator(
                     signature,
                     boundSignature,

--- a/server/src/main/java/io/crate/expression/operator/GteOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/GteOperator.java
@@ -21,6 +21,7 @@
 
 package io.crate.expression.operator;
 
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
@@ -33,13 +34,12 @@ public final class GteOperator {
     public static void register(Functions.Builder builder) {
         for (var supportedType : DataTypes.PRIMITIVE_TYPES) {
             builder.add(
-                Signature.scalar(
-                        NAME,
-                        supportedType.getTypeSignature(),
-                        supportedType.getTypeSignature(),
-                        Operator.RETURN_TYPE.getTypeSignature())
-                    .withFeature(Scalar.Feature.DETERMINISTIC)
-                    .withFeature(Scalar.Feature.NULLABLE),
+                Signature.builder(NAME, FunctionType.SCALAR)
+                    .argumentTypes(supportedType.getTypeSignature(),
+                        supportedType.getTypeSignature())
+                    .returnType(Operator.RETURN_TYPE.getTypeSignature())
+                    .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                    .build(),
                 (signature, boundSignature) -> new CmpOperator(
                     signature,
                     boundSignature,

--- a/server/src/main/java/io/crate/expression/operator/LikeOperators.java
+++ b/server/src/main/java/io/crate/expression/operator/LikeOperators.java
@@ -32,6 +32,7 @@ import io.crate.expression.operator.any.AnyLikeOperator;
 import io.crate.expression.operator.any.AnyNotLikeOperator;
 import io.crate.expression.operator.any.AnyOperator;
 import io.crate.lucene.match.CrateRegexQuery;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
@@ -107,58 +108,51 @@ public class LikeOperators {
 
     public static void register(Functions.Builder builder) {
         builder.add(
-            Signature.scalar(
-                    OP_LIKE,
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature(),
-                    Operator.RETURN_TYPE.getTypeSignature()
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder(OP_LIKE, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature())
+                .returnType(Operator.RETURN_TYPE.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .build(),
             (signature, boundSignature) ->
                 new LikeOperator(signature, boundSignature, LikeOperators::matches, CaseSensitivity.SENSITIVE)
         );
         builder.add(
-            Signature.scalar(
-                    OP_ILIKE,
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature(),
-                    Operator.RETURN_TYPE.getTypeSignature()
-                ).withFeature(Scalar.Feature.NULLABLE)
-                .withFeature(Scalar.Feature.DETERMINISTIC),
+            Signature.builder(OP_ILIKE, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature())
+                .returnType(Operator.RETURN_TYPE.getTypeSignature())
+                .features(Scalar.Feature.NULLABLE, Scalar.Feature.DETERMINISTIC)
+                .build(),
             (signature, boundSignature) ->
                 new LikeOperator(signature, boundSignature, LikeOperators::matches, CaseSensitivity.INSENSITIVE)
         );
 
         builder.add(
-            Signature.scalar(
-                OP_LIKE,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature(),
-                Operator.RETURN_TYPE.getTypeSignature()
-            ).withFeature(Scalar.Feature.DETERMINISTIC),
+            Signature.builder(OP_LIKE, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(), DataTypes.STRING.getTypeSignature(), DataTypes.STRING.getTypeSignature())
+                .returnType(Operator.RETURN_TYPE.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC)
+                .build(),
             (signature, boundSignature) ->
                 new LikeOperator(signature, boundSignature, LikeOperators::matches, CaseSensitivity.SENSITIVE)
         );
         builder.add(
-            Signature.scalar(
-                OP_ILIKE,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature(),
-                Operator.RETURN_TYPE.getTypeSignature()
-            ).withFeature(Scalar.Feature.DETERMINISTIC),
+            Signature.builder(OP_ILIKE, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(), DataTypes.STRING.getTypeSignature(), DataTypes.STRING.getTypeSignature())
+                .returnType(Operator.RETURN_TYPE.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC)
+                .build(),
             (signature, boundSignature) ->
                 new LikeOperator(signature, boundSignature, LikeOperators::matches, CaseSensitivity.INSENSITIVE)
         );
         builder.add(
-            Signature.scalar(
-                    ANY_LIKE,
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.STRING_ARRAY.getTypeSignature(),
-                    Operator.RETURN_TYPE.getTypeSignature()
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder(ANY_LIKE, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING_ARRAY.getTypeSignature())
+                .returnType(Operator.RETURN_TYPE.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .build(),
             (signature, boundSignature) ->
                 new AnyLikeOperator(
                     signature,
@@ -167,13 +161,12 @@ public class LikeOperators {
                 )
         );
         builder.add(
-            Signature.scalar(
-                    ANY_NOT_LIKE,
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.STRING_ARRAY.getTypeSignature(),
-                    Operator.RETURN_TYPE.getTypeSignature()
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder(ANY_NOT_LIKE, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING_ARRAY.getTypeSignature())
+                .returnType(Operator.RETURN_TYPE.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .build(),
             (signature, boundSignature) ->
                 new AnyNotLikeOperator(
                     signature,
@@ -182,13 +175,12 @@ public class LikeOperators {
                 )
         );
         builder.add(
-            Signature.scalar(
-                    ANY_ILIKE,
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.STRING_ARRAY.getTypeSignature(),
-                    Operator.RETURN_TYPE.getTypeSignature()
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder(ANY_ILIKE, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING_ARRAY.getTypeSignature())
+                .returnType(Operator.RETURN_TYPE.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .build(),
             (signature, boundSignature) ->
                 new AnyLikeOperator(
                     signature,
@@ -197,13 +189,12 @@ public class LikeOperators {
                 )
         );
         builder.add(
-            Signature.scalar(
-                    ANY_NOT_ILIKE,
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.STRING_ARRAY.getTypeSignature(),
-                    Operator.RETURN_TYPE.getTypeSignature()
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder(ANY_NOT_ILIKE, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING_ARRAY.getTypeSignature())
+                .returnType(Operator.RETURN_TYPE.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .build(),
             (signature, boundSignature) ->
                 new AnyNotLikeOperator(
                     signature,

--- a/server/src/main/java/io/crate/expression/operator/LtOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/LtOperator.java
@@ -21,6 +21,7 @@
 
 package io.crate.expression.operator;
 
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
@@ -33,13 +34,12 @@ public final class LtOperator {
     public static void register(Functions.Builder builder) {
         for (var supportedType : DataTypes.PRIMITIVE_TYPES) {
             builder.add(
-                Signature.scalar(
-                        NAME,
-                        supportedType.getTypeSignature(),
-                        supportedType.getTypeSignature(),
-                        Operator.RETURN_TYPE.getTypeSignature()
-                    ).withFeature(Scalar.Feature.DETERMINISTIC)
-                    .withFeature(Scalar.Feature.NULLABLE),
+                Signature.builder(NAME, FunctionType.SCALAR)
+                    .argumentTypes(supportedType.getTypeSignature(),
+                        supportedType.getTypeSignature())
+                    .returnType(Operator.RETURN_TYPE.getTypeSignature())
+                    .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                    .build(),
                 (signature, boundSignature) ->
                     new CmpOperator(signature, boundSignature, cmpResult -> cmpResult < 0)
             );

--- a/server/src/main/java/io/crate/expression/operator/LteOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/LteOperator.java
@@ -21,6 +21,7 @@
 
 package io.crate.expression.operator;
 
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
@@ -33,13 +34,12 @@ public final class LteOperator {
     public static void register(Functions.Builder builder) {
         for (var supportedType : DataTypes.PRIMITIVE_TYPES) {
             builder.add(
-                Signature.scalar(
-                        NAME,
-                        supportedType.getTypeSignature(),
-                        supportedType.getTypeSignature(),
-                        Operator.RETURN_TYPE.getTypeSignature()
-                    ).withFeature(Scalar.Feature.DETERMINISTIC)
-                    .withFeature(Scalar.Feature.NULLABLE),
+                Signature.builder(NAME, FunctionType.SCALAR)
+                    .argumentTypes(supportedType.getTypeSignature(),
+                        supportedType.getTypeSignature())
+                    .returnType(Operator.RETURN_TYPE.getTypeSignature())
+                    .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                    .build(),
                 (signature, boundSignature) -> new CmpOperator(
                     signature,
                     boundSignature,

--- a/server/src/main/java/io/crate/expression/operator/OrOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/OrOperator.java
@@ -30,6 +30,7 @@ import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.lucene.LuceneQueryBuilder.Context;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
@@ -41,12 +42,12 @@ public class OrOperator extends Operator<Boolean> {
 
     public static final String NAME = "op_or";
 
-    public static final Signature SIGNATURE = Signature.scalar(
-        NAME,
-        DataTypes.BOOLEAN.getTypeSignature(),
-        DataTypes.BOOLEAN.getTypeSignature(),
-        DataTypes.BOOLEAN.getTypeSignature()
-    ).withFeature(Feature.DETERMINISTIC);
+    public static final Signature SIGNATURE = Signature.builder(NAME, FunctionType.SCALAR)
+        .argumentTypes(DataTypes.BOOLEAN.getTypeSignature(),
+            DataTypes.BOOLEAN.getTypeSignature())
+        .returnType(DataTypes.BOOLEAN.getTypeSignature())
+        .features(Feature.DETERMINISTIC)
+        .build();
 
 
     public static void register(Functions.Builder builder) {

--- a/server/src/main/java/io/crate/expression/operator/RegexpMatchCaseInsensitiveOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/RegexpMatchCaseInsensitiveOperator.java
@@ -29,6 +29,7 @@ import org.apache.lucene.search.Query;
 import io.crate.data.Input;
 import io.crate.expression.symbol.Literal;
 import io.crate.lucene.match.CrateRegexQuery;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
@@ -44,12 +45,12 @@ public class RegexpMatchCaseInsensitiveOperator extends Operator<String> {
 
     public static void register(Functions.Builder builder) {
         builder.add(
-            Signature.scalar(
-                NAME,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature(),
-                Operator.RETURN_TYPE.getTypeSignature()
-            ).withFeature(Feature.DETERMINISTIC),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature())
+                .returnType(Operator.RETURN_TYPE.getTypeSignature())
+                .features(Feature.DETERMINISTIC)
+                .build(),
             RegexpMatchCaseInsensitiveOperator::new
         );
     }

--- a/server/src/main/java/io/crate/expression/operator/RegexpMatchOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/RegexpMatchOperator.java
@@ -36,6 +36,7 @@ import io.crate.data.Input;
 import io.crate.expression.RegexpFlags;
 import io.crate.expression.symbol.Literal;
 import io.crate.lucene.match.CrateRegexQuery;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
@@ -51,12 +52,12 @@ public class RegexpMatchOperator extends Operator<String> {
 
     public static void register(Functions.Builder builder) {
         builder.add(
-            Signature.scalar(
-                NAME,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature(),
-                Operator.RETURN_TYPE.getTypeSignature()
-            ).withFeature(Feature.DETERMINISTIC),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature())
+                .returnType(Operator.RETURN_TYPE.getTypeSignature())
+                .features(Feature.DETERMINISTIC)
+                .build(),
             RegexpMatchOperator::new
         );
     }

--- a/server/src/main/java/io/crate/expression/operator/any/AnyOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/any/AnyOperator.java
@@ -36,6 +36,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.lucene.LuceneQueryBuilder.Context;
 import io.crate.metadata.FunctionProvider.FunctionFactory;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
@@ -94,13 +95,13 @@ public abstract sealed class AnyOperator extends Operator<Object>
 
     private static void reg(Functions.Builder builder, String name, FunctionFactory operatorFactory) {
         builder.add(
-            Signature.scalar(
-                    name,
-                    TypeSignature.parse("E"),
-                    TypeSignature.parse("array(E)"),
-                    Operator.RETURN_TYPE.getTypeSignature()
-                ).withTypeVariableConstraints(TypeVariableConstraint.typeVariable("E"))
-                .withFeature(Feature.DETERMINISTIC),
+            Signature.builder(name, FunctionType.SCALAR)
+                .argumentTypes(TypeSignature.parse("E"),
+                    TypeSignature.parse("array(E)"))
+                .returnType(Operator.RETURN_TYPE.getTypeSignature())
+                .features(Feature.DETERMINISTIC)
+                .typeVariableConstraints(TypeVariableConstraint.typeVariable("E"))
+                .build(),
             operatorFactory
         );
     }

--- a/server/src/main/java/io/crate/expression/predicate/IsNullPredicate.java
+++ b/server/src/main/java/io/crate/expression/predicate/IsNullPredicate.java
@@ -44,6 +44,7 @@ import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.lucene.LuceneQueryBuilder.Context;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.IndexType;
 import io.crate.metadata.NodeContext;
@@ -64,13 +65,12 @@ import io.crate.types.TypeSignature;
 public class IsNullPredicate<T> extends Scalar<Boolean, T> {
 
     public static final String NAME = "op_isnull";
-    public static final Signature SIGNATURE = Signature.scalar(
-            NAME,
-            TypeSignature.parse("E"),
-            DataTypes.BOOLEAN.getTypeSignature()
-        ).withFeature(Feature.DETERMINISTIC)
-        .withFeature(Feature.NON_NULLABLE)
-        .withTypeVariableConstraints(typeVariable("E"));
+    public static final Signature SIGNATURE = Signature.builder(NAME, FunctionType.SCALAR)
+        .argumentTypes(TypeSignature.parse("E"))
+        .returnType(DataTypes.BOOLEAN.getTypeSignature())
+        .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+        .typeVariableConstraints(typeVariable("E"))
+        .build();
 
     public static void register(Functions.Builder builder) {
         builder.add(

--- a/server/src/main/java/io/crate/expression/predicate/MatchPredicate.java
+++ b/server/src/main/java/io/crate/expression/predicate/MatchPredicate.java
@@ -68,6 +68,7 @@ import io.crate.lucene.LuceneQueryBuilder.Context;
 import io.crate.lucene.match.OptionParser;
 import io.crate.lucene.match.ParsedOptions;
 import io.crate.metadata.FunctionImplementation;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.GeoReference;
 import io.crate.metadata.Reference;
@@ -95,25 +96,23 @@ public class MatchPredicate implements FunctionImplementation, FunctionToQuery {
      * 3. match_type - string (nullable)
      * 4. match_type options - object mapping option name to value (Object) (nullable)
      */
-    public static final Signature TEXT_MATCH = Signature.scalar(
-            NAME,
-            DataTypes.UNTYPED_OBJECT.getTypeSignature(),
+    public static final Signature TEXT_MATCH = Signature.builder(NAME, FunctionType.SCALAR)
+        .argumentTypes(DataTypes.UNTYPED_OBJECT.getTypeSignature(),
             DataTypes.STRING.getTypeSignature(),
             DataTypes.STRING.getTypeSignature(),
-            DataTypes.UNTYPED_OBJECT.getTypeSignature(),
-            DataTypes.BOOLEAN.getTypeSignature()
-        ).withFeature(Scalar.Feature.DETERMINISTIC)
-        .withFeature(Scalar.Feature.NON_NULLABLE);
+            DataTypes.UNTYPED_OBJECT.getTypeSignature())
+        .returnType(DataTypes.BOOLEAN.getTypeSignature())
+        .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NON_NULLABLE)
+        .build();
 
-    public static final Signature GEO_MATCH = Signature.scalar(
-            NAME,
-            DataTypes.UNTYPED_OBJECT.getTypeSignature(),
+    public static final Signature GEO_MATCH = Signature.builder(NAME, FunctionType.SCALAR)
+        .argumentTypes(DataTypes.UNTYPED_OBJECT.getTypeSignature(),
             DataTypes.GEO_SHAPE.getTypeSignature(),
             DataTypes.STRING.getTypeSignature(),
-            DataTypes.UNTYPED_OBJECT.getTypeSignature(),
-            DataTypes.BOOLEAN.getTypeSignature()
-        ).withFeature(Scalar.Feature.DETERMINISTIC)
-        .withFeature(Scalar.Feature.NON_NULLABLE);
+            DataTypes.UNTYPED_OBJECT.getTypeSignature())
+        .returnType(DataTypes.BOOLEAN.getTypeSignature())
+        .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NON_NULLABLE)
+        .build();
 
 
     public static void register(Functions.Builder builder) {

--- a/server/src/main/java/io/crate/expression/predicate/NotPredicate.java
+++ b/server/src/main/java/io/crate/expression/predicate/NotPredicate.java
@@ -40,6 +40,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitor;
 import io.crate.lucene.LuceneQueryBuilder;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
@@ -53,12 +54,11 @@ import io.crate.types.DataTypes;
 public class NotPredicate extends Scalar<Boolean, Boolean> {
 
     public static final String NAME = "op_not";
-    public static final Signature SIGNATURE = Signature.scalar(
-            NAME,
-            DataTypes.BOOLEAN.getTypeSignature(),
-            DataTypes.BOOLEAN.getTypeSignature())
-        .withFeature(Feature.DETERMINISTIC)
-        .withFeature(Feature.NULLABLE);
+    public static final Signature SIGNATURE = Signature.builder(NAME, FunctionType.SCALAR)
+        .argumentTypes(DataTypes.BOOLEAN.getTypeSignature())
+        .returnType(DataTypes.BOOLEAN.getTypeSignature())
+        .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+        .build();
 
     public static void register(Functions.Builder builder) {
         builder.add(SIGNATURE, NotPredicate::new);

--- a/server/src/main/java/io/crate/expression/scalar/AgeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/AgeFunction.java
@@ -22,7 +22,6 @@
 
 package io.crate.expression.scalar;
 
-import static io.crate.metadata.functions.Signature.scalar;
 
 import java.util.EnumSet;
 
@@ -33,6 +32,7 @@ import org.joda.time.PeriodType;
 
 import io.crate.data.Input;
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -48,21 +48,21 @@ public class AgeFunction extends Scalar<Period, Object> {
 
     public static void register(Functions.Builder builder) {
         builder.add(
-            scalar(
-                NAME,
-                DataTypes.TIMESTAMP.getTypeSignature(),
-                DataTypes.INTERVAL.getTypeSignature()
-            ).withFeatures(EnumSet.of(Feature.NULLABLE)),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.TIMESTAMP.getTypeSignature())
+                .returnType(DataTypes.INTERVAL.getTypeSignature())
+                .features(EnumSet.of(Feature.NULLABLE))
+                .build(),
             AgeFunction::new
         );
 
         builder.add(
-            scalar(
-                NAME,
-                DataTypes.TIMESTAMP.getTypeSignature(),
-                DataTypes.TIMESTAMP.getTypeSignature(),
-                DataTypes.INTERVAL.getTypeSignature()
-            ).withFeatures(EnumSet.of(Feature.NULLABLE)),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.TIMESTAMP.getTypeSignature(),
+                    DataTypes.TIMESTAMP.getTypeSignature())
+                .returnType(DataTypes.INTERVAL.getTypeSignature())
+                .features(EnumSet.of(Feature.NULLABLE))
+                .build(),
             AgeFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/ArrayAppendFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayAppendFunction.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import io.crate.data.Input;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -43,15 +44,14 @@ public class ArrayAppendFunction extends Scalar<List<Object>, Object> {
 
     public static void register(Functions.Builder builder) {
         builder.add(
-            Signature.scalar(
-                    NAME,
-                    TypeSignature.parse("array(E)"),
-                    TypeSignature.parse("E"),
-                    TypeSignature.parse("array(E)")
-                ).withTypeVariableConstraints(typeVariable("E"))
-                .withFeature(Feature.DETERMINISTIC)
-                .withFeature(Feature.NON_NULLABLE),
-            ArrayAppendFunction::new
+                Signature.builder(NAME, FunctionType.SCALAR)
+                        .argumentTypes(TypeSignature.parse("array(E)"),
+                                TypeSignature.parse("E"))
+                        .returnType(TypeSignature.parse("array(E)"))
+                        .typeVariableConstraints(typeVariable("E"))
+                        .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                        .build(),
+                ArrayAppendFunction::new
         );
     }
 

--- a/server/src/main/java/io/crate/expression/scalar/ArrayAvgFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayAvgFunction.java
@@ -30,6 +30,7 @@ import java.util.Objects;
 import org.jetbrains.annotations.Nullable;
 
 import io.crate.expression.scalar.array.ArraySummationFunctions;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
@@ -87,12 +88,11 @@ public class ArrayAvgFunction {
         // https://www.postgresql.org/docs/13/functions-aggregate.html
 
         builder.add(
-            Signature.scalar(
-                    NAME,
-                    new ArrayType<>(DataTypes.NUMERIC).getTypeSignature(),
-                    DataTypes.NUMERIC.getTypeSignature()
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(new ArrayType<>(DataTypes.NUMERIC).getTypeSignature())
+                .returnType(DataTypes.NUMERIC.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .build(),
             (signature, boundSignature) -> new UnaryScalar<>(
                 signature,
                 boundSignature,
@@ -102,12 +102,11 @@ public class ArrayAvgFunction {
         );
 
         builder.add(
-            Signature.scalar(
-                    NAME,
-                    new ArrayType<>(DataTypes.FLOAT).getTypeSignature(),
-                    DataTypes.FLOAT.getTypeSignature()
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(new ArrayType<>(DataTypes.FLOAT).getTypeSignature())
+                .returnType(DataTypes.FLOAT.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .build(),
             (signature, boundSignature) -> new UnaryScalar<>(
                 signature,
                 boundSignature,
@@ -117,12 +116,11 @@ public class ArrayAvgFunction {
         );
 
         builder.add(
-            Signature.scalar(
-                    NAME,
-                    new ArrayType<>(DataTypes.DOUBLE).getTypeSignature(),
-                    DataTypes.DOUBLE.getTypeSignature()
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(new ArrayType<>(DataTypes.DOUBLE).getTypeSignature())
+                .returnType(DataTypes.DOUBLE.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .build(),
             (signature, boundSignature) -> new UnaryScalar<>(
                 signature,
                 boundSignature,
@@ -135,12 +133,11 @@ public class ArrayAvgFunction {
         for (var supportedType : DataTypes.NUMERIC_PRIMITIVE_TYPES) {
             if (supportedType != DataTypes.FLOAT && supportedType != DataTypes.DOUBLE) {
                 builder.add(
-                    Signature.scalar(
-                            NAME,
-                            new ArrayType<>(supportedType).getTypeSignature(),
-                            DataTypes.NUMERIC.getTypeSignature()
-                        ).withFeature(Scalar.Feature.DETERMINISTIC)
-                        .withFeature(Scalar.Feature.NULLABLE),
+                    Signature.builder(NAME, FunctionType.SCALAR)
+                        .argumentTypes(new ArrayType<>(supportedType).getTypeSignature())
+                        .returnType(DataTypes.NUMERIC.getTypeSignature())
+                        .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                        .build(),
                     (signature, boundSignature) -> new UnaryScalar<>(
                         signature,
                         boundSignature,

--- a/server/src/main/java/io/crate/expression/scalar/ArrayCatFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayCatFunction.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import io.crate.data.Input;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -44,14 +45,13 @@ public class ArrayCatFunction extends Scalar<List<Object>, List<Object>> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                    NAME,
-                    TypeSignature.parse("array(E)"),
-                    TypeSignature.parse("array(E)"),
-                    TypeSignature.parse("array(E)")
-                ).withFeature(Feature.DETERMINISTIC)
-                .withFeature(Feature.NON_NULLABLE)
-                .withTypeVariableConstraints(typeVariable("E")),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(TypeSignature.parse("array(E)"),
+                    TypeSignature.parse("array(E)"))
+                .returnType(TypeSignature.parse("array(E)"))
+                .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                .typeVariableConstraints(typeVariable("E"))
+                .build(),
             ArrayCatFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/ArrayDifferenceFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayDifferenceFunction.java
@@ -35,6 +35,7 @@ import org.jetbrains.annotations.Nullable;
 
 import io.crate.data.Input;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -52,14 +53,13 @@ class ArrayDifferenceFunction extends Scalar<List<Object>, List<Object>> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                    NAME,
-                    TypeSignature.parse("array(E)"),
-                    TypeSignature.parse("array(E)"),
-                    TypeSignature.parse("array(E)")
-                ).withFeature(Feature.DETERMINISTIC)
-                .withTypeVariableConstraints(typeVariable("E"))
-                .withFeature(Feature.NULLABLE),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(TypeSignature.parse("array(E)"),
+                    TypeSignature.parse("array(E)"))
+                .returnType(TypeSignature.parse("array(E)"))
+                .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                .typeVariableConstraints(typeVariable("E"))
+                .build(),
             (signature, boundSignature) ->
                 new ArrayDifferenceFunction(
                     signature,

--- a/server/src/main/java/io/crate/expression/scalar/ArrayLowerFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayLowerFunction.java
@@ -29,6 +29,7 @@ import java.util.List;
 import org.jetbrains.annotations.Nullable;
 
 import io.crate.data.Input;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -44,14 +45,13 @@ class ArrayLowerFunction extends Scalar<Integer, Object> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                    NAME,
-                    TypeSignature.parse("array(E)"),
-                    DataTypes.INTEGER.getTypeSignature(),
-                    DataTypes.INTEGER.getTypeSignature()
-                ).withFeature(Feature.DETERMINISTIC)
-                .withTypeVariableConstraints(typeVariable("E"))
-                .withFeature(Feature.NULLABLE),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(TypeSignature.parse("array(E)"),
+                    DataTypes.INTEGER.getTypeSignature())
+                .returnType(DataTypes.INTEGER.getTypeSignature())
+                .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                .typeVariableConstraints(typeVariable("E"))
+                .build(),
             ArrayLowerFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/ArrayMaxFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayMaxFunction.java
@@ -27,6 +27,7 @@ import static io.crate.expression.scalar.array.ArrayArgumentValidators.ensureInn
 import java.util.List;
 
 import io.crate.data.Input;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -46,23 +47,21 @@ public class ArrayMaxFunction<T> extends Scalar<T, List<T>> {
     public static void register(Functions.Builder module) {
 
         module.add(
-            Signature.scalar(
-                    NAME,
-                    new ArrayType(DataTypes.NUMERIC).getTypeSignature(),
-                    DataTypes.NUMERIC.getTypeSignature()
-                ).withFeature(Feature.DETERMINISTIC)
-                .withFeature(Feature.NULLABLE),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(new ArrayType(DataTypes.NUMERIC).getTypeSignature())
+                .returnType(DataTypes.NUMERIC.getTypeSignature())
+                .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                .build(),
             ArrayMaxFunction::new
         );
 
         for (var supportedType : DataTypes.PRIMITIVE_TYPES) {
             module.add(
-                Signature.scalar(
-                    NAME,
-                    new ArrayType(supportedType).getTypeSignature(),
-                    supportedType.getTypeSignature()
-                ).withFeature(Feature.DETERMINISTIC)
-                .withFeature(Feature.NULLABLE),
+                Signature.builder(NAME, FunctionType.SCALAR)
+                    .argumentTypes(new ArrayType(supportedType).getTypeSignature())
+                    .returnType(supportedType.getTypeSignature())
+                    .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                    .build(),
                 ArrayMaxFunction::new
             );
         }

--- a/server/src/main/java/io/crate/expression/scalar/ArrayMinFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayMinFunction.java
@@ -27,6 +27,7 @@ import static io.crate.expression.scalar.array.ArrayArgumentValidators.ensureInn
 import java.util.List;
 
 import io.crate.data.Input;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -46,23 +47,21 @@ public class ArrayMinFunction<T> extends Scalar<T, List<T>> {
     public static void register(Functions.Builder module) {
 
         module.add(
-            Signature.scalar(
-                    NAME,
-                    new ArrayType(DataTypes.NUMERIC).getTypeSignature(),
-                    DataTypes.NUMERIC.getTypeSignature()
-                ).withFeature(Feature.DETERMINISTIC)
-                .withFeature(Feature.NULLABLE),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(new ArrayType(DataTypes.NUMERIC).getTypeSignature())
+                .returnType(DataTypes.NUMERIC.getTypeSignature())
+                .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                .build(),
             ArrayMinFunction::new
         );
 
         for (var supportedType : DataTypes.PRIMITIVE_TYPES) {
             module.add(
-                Signature.scalar(
-                        NAME,
-                        new ArrayType(supportedType).getTypeSignature(),
-                        supportedType.getTypeSignature()
-                    ).withFeature(Feature.DETERMINISTIC)
-                    .withFeature(Feature.NULLABLE),
+                Signature.builder(NAME, FunctionType.SCALAR)
+                    .argumentTypes(new ArrayType(supportedType).getTypeSignature())
+                    .returnType(supportedType.getTypeSignature())
+                    .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                    .build(),
                 ArrayMinFunction::new
             );
         }

--- a/server/src/main/java/io/crate/expression/scalar/ArrayPositionFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayPositionFunction.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Objects;
 
 import io.crate.data.Input;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -48,25 +49,25 @@ public class ArrayPositionFunction extends Scalar<Integer, List<Object>> {
 
     public static void register(Functions.Builder builder) {
         builder.add(
-            Signature.scalar(NAME,
-                    TypeSignature.parse("array(T)"),
-                    TypeSignature.parse("T"),
-                    DataTypes.INTEGER.getTypeSignature()
-                ).withTypeVariableConstraints(typeVariable("T"))
-                .withFeature(Feature.DETERMINISTIC)
-                .withFeature(Feature.NULLABLE),
-            ArrayPositionFunction::new);
+                Signature.builder(NAME, FunctionType.SCALAR)
+                        .argumentTypes(TypeSignature.parse("array(T)"),
+                                TypeSignature.parse("T"))
+                        .returnType(DataTypes.INTEGER.getTypeSignature())
+                        .typeVariableConstraints(typeVariable("T"))
+                        .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                        .build(),
+                ArrayPositionFunction::new);
 
         builder.add(
-            Signature.scalar(NAME,
-                    TypeSignature.parse("array(T)"),
-                    TypeSignature.parse("T"),
-                    DataTypes.INTEGER.getTypeSignature(),
-                    DataTypes.INTEGER.getTypeSignature()
-                ).withTypeVariableConstraints(typeVariable("T"))
-                .withFeature(Feature.DETERMINISTIC)
-                .withFeature(Feature.NULLABLE),
-            ArrayPositionFunction::new);
+                Signature.builder(NAME, FunctionType.SCALAR)
+                        .argumentTypes(TypeSignature.parse("array(T)"),
+                                TypeSignature.parse("T"),
+                                DataTypes.INTEGER.getTypeSignature())
+                        .returnType(DataTypes.INTEGER.getTypeSignature())
+                        .typeVariableConstraints(typeVariable("T"))
+                        .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                        .build(),
+                ArrayPositionFunction::new);
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/scalar/ArraySetFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArraySetFunction.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import io.crate.data.Input;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -44,28 +45,26 @@ public class ArraySetFunction extends Scalar<List<Object>, Object> {
     public static void register(Functions.Builder module) {
         TypeSignature arrayESignature = TypeSignature.parse("array(E)");
         module.add(
-            Signature.scalar(
-                    NAME,
-                    arrayESignature,
-                    new ArrayType<>(DataTypes.INTEGER).getTypeSignature(),
-                    arrayESignature,
-                    arrayESignature
-                ).withTypeVariableConstraints(typeVariable("E"))
-                .withFeature(Feature.DETERMINISTIC)
-                .withFeature(Feature.NULLABLE),
-            ArraySetFunction::new
+                Signature.builder(NAME, FunctionType.SCALAR)
+                        .argumentTypes(arrayESignature,
+                                new ArrayType<>(DataTypes.INTEGER).getTypeSignature(),
+                                arrayESignature)
+                        .returnType(arrayESignature)
+                        .typeVariableConstraints(typeVariable("E"))
+                        .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                        .build(),
+                ArraySetFunction::new
         );
         module.add(
-            Signature.scalar(
-                    NAME,
-                    arrayESignature,
-                    DataTypes.INTEGER.getTypeSignature(),
-                    TypeSignature.parse("E"),
-                    arrayESignature
-                ).withTypeVariableConstraints(typeVariable("E"))
-                .withFeature(Feature.DETERMINISTIC)
-                .withFeature(Feature.NULLABLE),
-            SingleArraySetFunction::new
+                Signature.builder(NAME, FunctionType.SCALAR)
+                        .argumentTypes(arrayESignature,
+                                DataTypes.INTEGER.getTypeSignature(),
+                                TypeSignature.parse("E"))
+                        .returnType(arrayESignature)
+                        .typeVariableConstraints(typeVariable("E"))
+                        .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                        .build(),
+                SingleArraySetFunction::new
         );
     }
 

--- a/server/src/main/java/io/crate/expression/scalar/ArraySliceFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArraySliceFunction.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import io.crate.data.Input;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -43,16 +44,15 @@ public class ArraySliceFunction extends Scalar<List<Object>, Object> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                    NAME,
-                    TypeSignature.parse("array(E)"),
-                    DataTypes.INTEGER.getTypeSignature(),
-                    DataTypes.INTEGER.getTypeSignature(),
-                    TypeSignature.parse("array(E)")
-                ).withTypeVariableConstraints(typeVariable("E"))
-                .withFeature(Feature.DETERMINISTIC)
-                .withFeature(Feature.NON_NULLABLE),
-            ArraySliceFunction::new
+                Signature.builder(NAME, FunctionType.SCALAR)
+                        .argumentTypes(TypeSignature.parse("array(E)"),
+                                DataTypes.INTEGER.getTypeSignature(),
+                                DataTypes.INTEGER.getTypeSignature())
+                        .returnType(TypeSignature.parse("array(E)"))
+                        .typeVariableConstraints(typeVariable("E"))
+                        .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                        .build(),
+                ArraySliceFunction::new
         );
     }
 

--- a/server/src/main/java/io/crate/expression/scalar/ArraySumFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArraySumFunction.java
@@ -29,6 +29,7 @@ import java.util.function.Function;
 
 import io.crate.data.Input;
 import io.crate.expression.scalar.array.ArraySummationFunctions;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -46,12 +47,11 @@ public class ArraySumFunction<T extends Number, R extends Number> extends Scalar
     private final Function<List<T>, R> sum;
 
     private static <T, U> Signature signature(DataType<T> elementType, DataType<U> returnType) {
-        return Signature.scalar(
-                NAME,
-                new ArrayType<>(elementType).getTypeSignature(),
-                returnType.getTypeSignature()
-            ).withFeature(Feature.DETERMINISTIC)
-            .withFeature(Feature.NULLABLE);
+        return Signature.builder(NAME, FunctionType.SCALAR)
+            .argumentTypes(new ArrayType<>(elementType).getTypeSignature())
+            .returnType(returnType.getTypeSignature())
+            .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+            .build();
     }
 
     public static void register(Functions.Builder builder) {

--- a/server/src/main/java/io/crate/expression/scalar/ArrayToStringFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayToStringFunction.java
@@ -29,6 +29,7 @@ import java.util.StringJoiner;
 
 import io.crate.data.Input;
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -45,26 +46,24 @@ class ArrayToStringFunction extends Scalar<String, Object> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                    FQN,
-                    TypeSignature.parse("array(E)"),
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature()
-                ).withTypeVariableConstraints(typeVariable("E"))
-                .withFeature(Feature.DETERMINISTIC)
-                .withFeature(Feature.NULLABLE),
+            Signature.builder(FQN, FunctionType.SCALAR)
+                .argumentTypes(TypeSignature.parse("array(E)"),
+                    DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .typeVariableConstraints(typeVariable("E"))
+                .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                .build(),
             ArrayToStringFunction::new
         );
         module.add(
-            Signature.scalar(
-                    FQN,
-                    TypeSignature.parse("array(E)"),
+            Signature.builder(FQN, FunctionType.SCALAR)
+                .argumentTypes(TypeSignature.parse("array(E)"),
                     DataTypes.STRING.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature()
-                ).withTypeVariableConstraints(typeVariable("E"))
-                .withFeature(Feature.DETERMINISTIC)
-                .withFeature(Feature.NULLABLE),
+                    DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .typeVariableConstraints(typeVariable("E"))
+                .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                .build(),
             ArrayToStringFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/ArrayUniqueFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayUniqueFunction.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Set;
 
 import io.crate.data.Input;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -47,24 +48,21 @@ public class ArrayUniqueFunction extends Scalar<List<Object>, List<Object>> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                    NAME,
-                    TypeSignature.parse("array(E)"),
-                    TypeSignature.parse("array(E)")
-                ).withTypeVariableConstraints(typeVariable("E"))
-                .withFeature(Feature.DETERMINISTIC)
-                .withFeature(Feature.NON_NULLABLE),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(TypeSignature.parse("array(E)"))
+                .returnType(TypeSignature.parse("array(E)"))
+                .typeVariableConstraints(typeVariable("E"))
+                .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                .build(),
             ArrayUniqueFunction::new
         );
         module.add(
-            Signature.scalar(
-                    NAME,
-                    TypeSignature.parse("array(E)"),
-                    TypeSignature.parse("array(E)"),
-                    TypeSignature.parse("array(E)")
-                ).withTypeVariableConstraints(typeVariable("E"))
-                .withFeature(Feature.DETERMINISTIC)
-                .withFeature(Feature.NON_NULLABLE),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(TypeSignature.parse("array(E)"), TypeSignature.parse("array(E)"))
+                .returnType(TypeSignature.parse("array(E)"))
+                .typeVariableConstraints(typeVariable("E"))
+                .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                .build(),
             ArrayUniqueFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/ArrayUnnestFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayUnnestFunction.java
@@ -29,6 +29,7 @@ import java.util.List;
 import io.crate.data.Input;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -47,13 +48,12 @@ import io.crate.types.TypeSignature;
 public class ArrayUnnestFunction extends Scalar<List<Object>, List<List<Object>>> {
 
     public static final String NAME = "array_unnest";
-    public static final Signature SIGNATURE = Signature.scalar(
-            NAME,
-            TypeSignature.parse("array(array(E))"),
-            TypeSignature.parse("array(E)")
-        ).withTypeVariableConstraints(typeVariable("E"))
-        .withFeature(Feature.DETERMINISTIC)
-        .withFeature(Feature.NULLABLE);
+    public static final Signature SIGNATURE = Signature.builder(NAME, FunctionType.SCALAR)
+            .argumentTypes(TypeSignature.parse("array(array(E))"))
+            .returnType(TypeSignature.parse("array(E)"))
+            .typeVariableConstraints(typeVariable("E"))
+            .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+            .build();
 
     public static void register(Functions.Builder module) {
         module.add(SIGNATURE, ArrayUnnestFunction::new);

--- a/server/src/main/java/io/crate/expression/scalar/ArrayUpperFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayUpperFunction.java
@@ -46,6 +46,7 @@ import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
 import io.crate.lucene.LuceneQueryBuilder;
 import io.crate.lucene.LuceneQueryBuilder.Context;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
@@ -67,15 +68,14 @@ public class ArrayUpperFunction extends Scalar<Integer, Object> {
     public static void register(Functions.Builder module) {
         for (var name : List.of(ARRAY_UPPER, ARRAY_LENGTH)) {
             module.add(
-                Signature.scalar(
-                        name,
-                        TypeSignature.parse("array(E)"),
-                        DataTypes.INTEGER.getTypeSignature(),
-                        DataTypes.INTEGER.getTypeSignature()
-                    ).withTypeVariableConstraints(typeVariable("E"))
-                    .withFeature(Feature.DETERMINISTIC)
-                    .withFeature(Feature.NULLABLE),
-                ArrayUpperFunction::new
+                    Signature.builder(name, FunctionType.SCALAR)
+                            .argumentTypes(TypeSignature.parse("array(E)"),
+                                    DataTypes.INTEGER.getTypeSignature())
+                            .returnType(DataTypes.INTEGER.getTypeSignature())
+                            .typeVariableConstraints(typeVariable("E"))
+                            .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                            .build(),
+                    ArrayUpperFunction::new
             );
         }
     }

--- a/server/src/main/java/io/crate/expression/scalar/CollectionAverageFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/CollectionAverageFunction.java
@@ -26,6 +26,7 @@ import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
 import java.util.List;
 
 import io.crate.data.Input;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -41,14 +42,13 @@ public class CollectionAverageFunction extends Scalar<Double, List<Object>> {
 
     public static void register(Functions.Builder builder) {
         builder.add(
-            Signature.scalar(
-                    NAME,
-                    TypeSignature.parse("array(E)"),
-                    DataTypes.DOUBLE.getTypeSignature()
-                ).withTypeVariableConstraints(typeVariable("E"))
-                .withFeature(Feature.DETERMINISTIC)
-                .withFeature(Feature.NULLABLE),
-            CollectionAverageFunction::new
+                Signature.builder(NAME, FunctionType.SCALAR)
+                        .argumentTypes(TypeSignature.parse("array(E)"))
+                        .returnType(DataTypes.DOUBLE.getTypeSignature())
+                        .typeVariableConstraints(typeVariable("E"))
+                        .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                        .build(),
+                CollectionAverageFunction::new
         );
     }
 

--- a/server/src/main/java/io/crate/expression/scalar/CollectionCountFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/CollectionCountFunction.java
@@ -26,6 +26,7 @@ import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
 import java.util.List;
 
 import io.crate.data.Input;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -41,14 +42,13 @@ public class CollectionCountFunction extends Scalar<Long, List<Object>> {
 
     public static void register(Functions.Builder builder) {
         builder.add(
-            Signature.scalar(
-                    NAME,
-                    TypeSignature.parse("array(E)"),
-                    DataTypes.LONG.getTypeSignature()
-                ).withTypeVariableConstraints(typeVariable("E"))
-                .withFeature(Feature.DETERMINISTIC)
-                .withFeature(Feature.NULLABLE),
-            CollectionCountFunction::new
+                Signature.builder(NAME, FunctionType.SCALAR)
+                        .argumentTypes(TypeSignature.parse("array(E)"))
+                        .returnType(DataTypes.LONG.getTypeSignature())
+                        .typeVariableConstraints(typeVariable("E"))
+                        .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                        .build(),
+                CollectionCountFunction::new
         );
     }
 

--- a/server/src/main/java/io/crate/expression/scalar/ConcatFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ConcatFunction.java
@@ -28,6 +28,7 @@ import io.crate.expression.scalar.object.ObjectMergeFunction;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -43,47 +44,44 @@ public abstract class ConcatFunction extends Scalar<String, String> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                NAME,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Feature.DETERMINISTIC)
-            .withFeature(Feature.NON_NULLABLE),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                .build(),
             StringConcatFunction::new
         );
 
         module.add(
-            Signature.scalar(
-                NAME,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Feature.DETERMINISTIC)
-            .withFeature(Feature.NON_NULLABLE)
-            .withVariableArity(),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                .setVariableArity(true)
+                .build(),
             GenericConcatFunction::new
         );
 
         // concat(array[], array[]) -> same as `array_cat(...)`
         module.add(
-            Signature.scalar(
-                NAME,
-                TypeSignature.parse("array(E)"),
-                TypeSignature.parse("array(E)"),
-                TypeSignature.parse("array(E)")
-            ).withFeature(Feature.DETERMINISTIC)
-            .withFeature(Feature.NON_NULLABLE)
-            .withTypeVariableConstraints(typeVariable("E")),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(TypeSignature.parse("array(E)"),
+                    TypeSignature.parse("array(E)"))
+                .returnType(TypeSignature.parse("array(E)"))
+                .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                .typeVariableConstraints(typeVariable("E"))
+                .build(),
             ArrayCatFunction::new
         );
 
         module.add(
-            Signature.scalar(
-                NAME,
-                DataTypes.UNTYPED_OBJECT.getTypeSignature(),
-                DataTypes.UNTYPED_OBJECT.getTypeSignature(),
-                DataTypes.UNTYPED_OBJECT.getTypeSignature()
-            ).withFeature(Feature.DETERMINISTIC),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.UNTYPED_OBJECT.getTypeSignature(),
+                    DataTypes.UNTYPED_OBJECT.getTypeSignature())
+                .returnType(DataTypes.UNTYPED_OBJECT.getTypeSignature())
+                .features(Feature.DETERMINISTIC)
+                .build(),
             ObjectMergeFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/ConcatWsFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ConcatWsFunction.java
@@ -22,6 +22,7 @@
 package io.crate.expression.scalar;
 
 import io.crate.data.Input;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -35,12 +36,12 @@ public class ConcatWsFunction extends Scalar<String, String> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                NAME,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Feature.DETERMINISTIC)
-            .withVariableArity(),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Feature.DETERMINISTIC)
+                .setVariableArity(true)
+                .build(),
             ConcatWsFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/CurrentDatabaseFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/CurrentDatabaseFunction.java
@@ -24,6 +24,7 @@ package io.crate.expression.scalar;
 import io.crate.Constants;
 import io.crate.data.Input;
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -39,11 +40,11 @@ final class CurrentDatabaseFunction extends Scalar<String, Void> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                    FQN,
-                    DataTypes.STRING.getTypeSignature()
-                ).withFeature(Feature.DETERMINISTIC)
-                .withFeature(Feature.NON_NULLABLE),
+            Signature.builder(FQN, FunctionType.SCALAR)
+                .argumentTypes()
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                .build(),
             CurrentDatabaseFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/CurrentDateFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/CurrentDateFunction.java
@@ -24,6 +24,7 @@ package io.crate.expression.scalar;
 import java.util.EnumSet;
 
 import io.crate.data.Input;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -38,11 +39,12 @@ public final class CurrentDateFunction extends Scalar<Long, String> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                    NAME,
-                    DataTypes.DATE.getTypeSignature()
-                ).withFeatures(EnumSet.of(Feature.NON_NULLABLE)),
-            CurrentDateFunction::new
+                Signature.builder(NAME, FunctionType.SCALAR)
+                        .argumentTypes()
+                        .returnType(DataTypes.DATE.getTypeSignature())
+                        .features(EnumSet.of(Feature.NON_NULLABLE))
+                        .build(),
+                CurrentDateFunction::new
         );
     }
 

--- a/server/src/main/java/io/crate/expression/scalar/DateBinFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/DateBinFunction.java
@@ -28,6 +28,7 @@ import org.joda.time.Period;
 
 import io.crate.data.Input;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -43,24 +44,24 @@ public class DateBinFunction extends Scalar<Long, Object> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                NAME,
-                DataTypes.INTERVAL.getTypeSignature(),
-                DataTypes.TIMESTAMPZ.getTypeSignature(), // source
-                DataTypes.TIMESTAMPZ.getTypeSignature(), // origin
-                DataTypes.TIMESTAMPZ.getTypeSignature()
-            ).withFeatures(EnumSet.of(Feature.DETERMINISTIC, Feature.COMPARISON_REPLACEMENT, Feature.NULLABLE)),
-            DateBinFunction::new);
+                Signature.builder(NAME, FunctionType.SCALAR)
+                        .argumentTypes(DataTypes.INTERVAL.getTypeSignature(),
+                                DataTypes.TIMESTAMPZ.getTypeSignature(), // source
+                                DataTypes.TIMESTAMPZ.getTypeSignature())
+                        .returnType(DataTypes.TIMESTAMPZ.getTypeSignature())
+                        .features(EnumSet.of(Feature.DETERMINISTIC, Feature.COMPARISON_REPLACEMENT, Feature.NULLABLE))
+                        .build(),
+                DateBinFunction::new);
 
         module.add(
-            Signature.scalar(
-                NAME,
-                DataTypes.INTERVAL.getTypeSignature(),
-                DataTypes.TIMESTAMP.getTypeSignature(), // source
-                DataTypes.TIMESTAMP.getTypeSignature(), // origin
-                DataTypes.TIMESTAMP.getTypeSignature()
-            ).withFeatures(EnumSet.of(Feature.DETERMINISTIC, Feature.COMPARISON_REPLACEMENT, Feature.NULLABLE)),
-            DateBinFunction::new);
+                Signature.builder(NAME, FunctionType.SCALAR)
+                        .argumentTypes(DataTypes.INTERVAL.getTypeSignature(),
+                                DataTypes.TIMESTAMP.getTypeSignature(), // source
+                                DataTypes.TIMESTAMP.getTypeSignature())
+                        .returnType(DataTypes.TIMESTAMP.getTypeSignature())
+                        .features(EnumSet.of(Feature.DETERMINISTIC, Feature.COMPARISON_REPLACEMENT, Feature.NULLABLE))
+                        .build(),
+                DateBinFunction::new);
     }
 
     private DateBinFunction(Signature signature, BoundSignature boundSignature) {

--- a/server/src/main/java/io/crate/expression/scalar/DateFormatFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/DateFormatFunction.java
@@ -27,6 +27,7 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
 import io.crate.data.Input;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -47,34 +48,32 @@ public class DateFormatFunction extends Scalar<String, Object> {
         for (DataType<?> dataType : supportedTimestampTypes) {
             // without format
             module.add(
-                Signature.scalar(
-                    NAME,
-                    dataType.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature()
-                ).withFeature(Feature.DETERMINISTIC),
+                Signature.builder(NAME, FunctionType.SCALAR)
+                    .argumentTypes(dataType.getTypeSignature())
+                    .returnType(DataTypes.STRING.getTypeSignature())
+                    .features(Feature.DETERMINISTIC)
+                    .build(),
                 DateFormatFunction::new
             );
 
             // with format
             module.add(
-                Signature.scalar(
-                    NAME,
-                    DataTypes.STRING.getTypeSignature(),
-                    dataType.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature()
-                ).withFeature(Feature.DETERMINISTIC),
+                Signature.builder(NAME, FunctionType.SCALAR)
+                    .argumentTypes(DataTypes.STRING.getTypeSignature(),
+                        dataType.getTypeSignature())
+                    .returnType(DataTypes.STRING.getTypeSignature())
+                    .features(Feature.DETERMINISTIC)
+                    .build(),
                 DateFormatFunction::new
             );
 
             // time zone aware variant
             module.add(
-                Signature.scalar(
-                    NAME,
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature(),
-                    dataType.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature()
-                ).withFeature(Feature.DETERMINISTIC),
+                Signature.builder(NAME, FunctionType.SCALAR)
+                    .argumentTypes(DataTypes.STRING.getTypeSignature(), DataTypes.STRING.getTypeSignature(), dataType.getTypeSignature())
+                    .returnType(DataTypes.STRING.getTypeSignature())
+                    .features(Feature.DETERMINISTIC)
+                    .build(),
                 DateFormatFunction::new
             );
         }

--- a/server/src/main/java/io/crate/expression/scalar/DateTruncFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/DateTruncFunction.java
@@ -35,6 +35,7 @@ import io.crate.data.Input;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -44,6 +45,7 @@ import io.crate.metadata.functions.Signature;
 import io.crate.role.Roles;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
+import io.crate.types.TypeSignature;
 
 public class DateTruncFunction extends Scalar<Long, Object> {
 
@@ -65,26 +67,25 @@ public class DateTruncFunction extends Scalar<Long, Object> {
     public static void register(Functions.Builder module) {
         List<DataType<?>> supportedTimestampTypes = List.of(
             DataTypes.TIMESTAMP, DataTypes.TIMESTAMPZ, DataTypes.LONG);
+
+        TypeSignature stringType = DataTypes.STRING.getTypeSignature();
         for (DataType<?> dataType : supportedTimestampTypes) {
             module.add(
-                Signature.scalar(
-                    NAME,
-                    DataTypes.STRING.getTypeSignature(),
-                    dataType.getTypeSignature(),
-                    DataTypes.TIMESTAMPZ.getTypeSignature()
-                ).withFeatures(Scalar.DETERMINISTIC_AND_COMPARISON_REPLACEMENT),
+                Signature.builder(NAME, FunctionType.SCALAR)
+                    .argumentTypes(stringType, dataType.getTypeSignature())
+                    .returnType(DataTypes.TIMESTAMPZ.getTypeSignature())
+                    .features(Scalar.DETERMINISTIC_AND_COMPARISON_REPLACEMENT)
+                    .build(),
                 DateTruncFunction::new
             );
 
             // time zone aware variant
             module.add(
-                Signature.scalar(
-                    NAME,
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature(),
-                    dataType.getTypeSignature(),
-                    DataTypes.TIMESTAMPZ.getTypeSignature()
-                ).withFeatures(Scalar.DETERMINISTIC_AND_COMPARISON_REPLACEMENT),
+                Signature.builder(NAME, FunctionType.SCALAR)
+                    .argumentTypes(stringType, stringType, dataType.getTypeSignature())
+                    .returnType(DataTypes.TIMESTAMPZ.getTypeSignature())
+                    .features(Scalar.DETERMINISTIC_AND_COMPARISON_REPLACEMENT)
+                    .build(),
                 DateTruncFunction::new
             );
         }

--- a/server/src/main/java/io/crate/expression/scalar/ExtractFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/ExtractFunctions.java
@@ -45,6 +45,7 @@ import org.joda.time.DurationFieldType;
 import org.joda.time.Period;
 import org.joda.time.chrono.ISOChronology;
 
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
@@ -80,24 +81,22 @@ public class ExtractFunctions {
             for (var entry : fieldsMapWithIntReturn) {
                 final DateTimeField dtf = entry.dtf();
                 module.add(
-                    Signature.scalar(
-                            functionNameFrom(entry.extractField()),
-                            argType.getTypeSignature(),
-                            DataTypes.INTEGER.getTypeSignature()
-                        ).withFeature(Scalar.Feature.DETERMINISTIC)
-                        .withFeature(Scalar.Feature.NULLABLE),
+                    Signature.builder(functionNameFrom(entry.extractField()), FunctionType.SCALAR)
+                        .argumentTypes(argType.getTypeSignature())
+                        .returnType(DataTypes.INTEGER.getTypeSignature())
+                        .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                        .build(),
                     (signature, boundSignature) ->
                         new UnaryScalar<Number, Long>(signature, boundSignature, argType, dtf::get)
                 );
             }
             // extract(epoch from ...) is different as is returns a `double precision`
             module.add(
-                Signature.scalar(
-                        functionNameFrom(EPOCH),
-                        argType.getTypeSignature(),
-                        DataTypes.DOUBLE.getTypeSignature()
-                    ).withFeature(Scalar.Feature.DETERMINISTIC)
-                    .withFeature(Scalar.Feature.NULLABLE),
+                Signature.builder(functionNameFrom(EPOCH), FunctionType.SCALAR)
+                    .argumentTypes(argType.getTypeSignature())
+                    .returnType(DataTypes.DOUBLE.getTypeSignature())
+                    .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                    .build(),
                 (signature, boundSignature) ->
                     new UnaryScalar<>(signature, boundSignature, argType, v -> (double) v / 1000)
             );
@@ -117,24 +116,22 @@ public class ExtractFunctions {
         for (var entry : intervalFieldsMapWithIntReturn) {
             final Function<Period, Integer> function = entry.function();
             module.add(
-                Signature.scalar(
-                        functionNameFrom(entry.extractField()),
-                        DataTypes.INTERVAL.getTypeSignature(),
-                        DataTypes.INTEGER.getTypeSignature()
-                    ).withFeature(Scalar.Feature.DETERMINISTIC)
-                    .withFeature(Scalar.Feature.NULLABLE),
+                Signature.builder(functionNameFrom(entry.extractField()), FunctionType.SCALAR)
+                    .argumentTypes(DataTypes.INTERVAL.getTypeSignature())
+                    .returnType(DataTypes.INTEGER.getTypeSignature())
+                    .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                    .build(),
                 (signature, boundSignature) ->
                     new UnaryScalar<Number, Period>(signature, boundSignature, DataTypes.INTERVAL, function::apply)
             );
         }
         // extract(epoch from ...) is different as is returns a `double precision`
         module.add(
-            Signature.scalar(
-                    functionNameFrom(EPOCH),
-                    DataTypes.INTERVAL.getTypeSignature(),
-                    DataTypes.DOUBLE.getTypeSignature()
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder(functionNameFrom(EPOCH), FunctionType.SCALAR)
+                .argumentTypes(DataTypes.INTERVAL.getTypeSignature())
+                .returnType(DataTypes.DOUBLE.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .build(),
             (signature, boundSignature) ->
                 new UnaryScalar<>(signature, boundSignature, DataTypes.INTERVAL, ExtractFunctions::toMillis)
         );

--- a/server/src/main/java/io/crate/expression/scalar/FormatFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/FormatFunction.java
@@ -26,6 +26,7 @@ import static io.crate.metadata.functions.TypeVariableConstraint.typeVariableOfA
 import java.util.Locale;
 
 import io.crate.data.Input;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -39,17 +40,13 @@ public class FormatFunction extends Scalar<String, Object> {
 
     public static final String NAME = "format";
 
-    public static final Signature SIGNATURE =
-        Signature.scalar(
-                NAME,
-                DataTypes.STRING.getTypeSignature(),
-                TypeSignature.parse("E"),
-                DataTypes.STRING.getTypeSignature()
-            )
-            .withFeature(Feature.DETERMINISTIC)
-            .withFeature(Feature.NON_NULLABLE)
-            .withTypeVariableConstraints(typeVariableOfAnyType("E"))
-            .withVariableArity();
+    public static final Signature SIGNATURE = Signature.builder(NAME, FunctionType.SCALAR)
+        .argumentTypes(DataTypes.STRING.getTypeSignature(), TypeSignature.parse("E"))
+        .returnType(DataTypes.STRING.getTypeSignature())
+        .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+        .typeVariableConstraints(typeVariableOfAnyType("E"))
+        .setVariableArity(true)
+        .build();
 
 
     public static void register(Functions.Builder module) {

--- a/server/src/main/java/io/crate/expression/scalar/GenRandomTextUUIDFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/GenRandomTextUUIDFunction.java
@@ -26,6 +26,7 @@ import java.util.EnumSet;
 import org.elasticsearch.common.UUIDs;
 
 import io.crate.data.Input;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -40,11 +41,12 @@ public final class GenRandomTextUUIDFunction extends Scalar<String, Void> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                    NAME,
-                    DataTypes.STRING.getTypeSignature()
-                ).withFeatures(EnumSet.of(Feature.NON_NULLABLE)),
-            GenRandomTextUUIDFunction::new
+                Signature.builder(NAME, FunctionType.SCALAR)
+                        .argumentTypes()
+                        .returnType(DataTypes.STRING.getTypeSignature())
+                        .features(EnumSet.of(Feature.NON_NULLABLE))
+                        .build(),
+                GenRandomTextUUIDFunction::new
         );
     }
 

--- a/server/src/main/java/io/crate/expression/scalar/HasDatabasePrivilegeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/HasDatabasePrivilegeFunction.java
@@ -31,6 +31,7 @@ import java.util.Locale;
 
 import io.crate.Constants;
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.functions.Signature;
@@ -122,12 +123,13 @@ public class HasDatabasePrivilegeFunction {
     public static void register(Functions.Builder module) {
         // Signature without user, takes user from session.
         module.add(
-            Signature.scalar(
-                NAME,
-                DataTypes.STRING.getTypeSignature(), // Database
-                DataTypes.STRING.getTypeSignature(), // Privilege
-                DataTypes.BOOLEAN.getTypeSignature()
-            ).withFeatures(EnumSet.of(DETERMINISTIC, NULLABLE)),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(
+                    DataTypes.STRING.getTypeSignature(), // Database
+                    DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.BOOLEAN.getTypeSignature())
+                .features(EnumSet.of(DETERMINISTIC, NULLABLE))
+                .build(),
             (signature, boundSignature) -> new HasPrivilegeFunction(
                 signature,
                 boundSignature,
@@ -139,12 +141,13 @@ public class HasDatabasePrivilegeFunction {
 
         // Signature without user, takes user from session.
         module.add(
-            Signature.scalar(
-                NAME,
-                DataTypes.INTEGER.getTypeSignature(), // Database
-                DataTypes.STRING.getTypeSignature(),  // Privilege
-                DataTypes.BOOLEAN.getTypeSignature()
-            ).withFeatures(EnumSet.of(DETERMINISTIC, NULLABLE)),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(
+                    DataTypes.INTEGER.getTypeSignature(), // Database
+                    DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.BOOLEAN.getTypeSignature())
+                .features(EnumSet.of(DETERMINISTIC, NULLABLE))
+                .build(),
             (signature, boundSignature) -> new HasPrivilegeFunction(
                 signature,
                 boundSignature,
@@ -155,13 +158,14 @@ public class HasDatabasePrivilegeFunction {
         );
 
         module.add(
-            Signature.scalar(
-                NAME,
-                DataTypes.STRING.getTypeSignature(), // User
-                DataTypes.STRING.getTypeSignature(), // Database
-                DataTypes.STRING.getTypeSignature(), // Privilege
-                DataTypes.BOOLEAN.getTypeSignature()
-            ).withFeatures(EnumSet.of(DETERMINISTIC, NULLABLE)),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(
+                    DataTypes.STRING.getTypeSignature(), // User
+                    DataTypes.STRING.getTypeSignature(), // Database
+                    DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.BOOLEAN.getTypeSignature())
+                .features(EnumSet.of(DETERMINISTIC, NULLABLE))
+                .build(),
             (signature, boundSignature) -> new HasPrivilegeFunction(
                 signature,
                 boundSignature,
@@ -172,13 +176,14 @@ public class HasDatabasePrivilegeFunction {
         );
 
         module.add(
-            Signature.scalar(
-                NAME,
-                DataTypes.STRING.getTypeSignature(),  // User
-                DataTypes.INTEGER.getTypeSignature(), // Database
-                DataTypes.STRING.getTypeSignature(),  // Privilege
-                DataTypes.BOOLEAN.getTypeSignature()
-            ).withFeatures(EnumSet.of(DETERMINISTIC, NULLABLE)),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(
+                    DataTypes.STRING.getTypeSignature(),  // User
+                    DataTypes.INTEGER.getTypeSignature(), // Database
+                    DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.BOOLEAN.getTypeSignature())
+                .features(EnumSet.of(DETERMINISTIC, NULLABLE))
+                .build(),
             (signature, boundSignature) -> new HasPrivilegeFunction(
                 signature,
                 boundSignature,
@@ -189,13 +194,13 @@ public class HasDatabasePrivilegeFunction {
         );
 
         module.add(
-            Signature.scalar(
-                NAME,
-                DataTypes.INTEGER.getTypeSignature(), // User
-                DataTypes.STRING.getTypeSignature(),  // Database
-                DataTypes.STRING.getTypeSignature(),  // Privilege
-                DataTypes.BOOLEAN.getTypeSignature()
-            ).withFeatures(EnumSet.of(DETERMINISTIC, NULLABLE)),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.INTEGER.getTypeSignature(), // User
+                    DataTypes.STRING.getTypeSignature(),  // Database
+                    DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.BOOLEAN.getTypeSignature())
+                .features(EnumSet.of(DETERMINISTIC, NULLABLE))
+                .build(),
             (signature, boundSignature) -> new HasPrivilegeFunction(
                 signature,
                 boundSignature,
@@ -206,13 +211,13 @@ public class HasDatabasePrivilegeFunction {
         );
 
         module.add(
-            Signature.scalar(
-                NAME,
-                DataTypes.INTEGER.getTypeSignature(), // User
-                DataTypes.INTEGER.getTypeSignature(), // Database
-                DataTypes.STRING.getTypeSignature(),  // Privilege
-                DataTypes.BOOLEAN.getTypeSignature()
-            ).withFeatures(EnumSet.of(DETERMINISTIC, NULLABLE)),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.INTEGER.getTypeSignature(), // User
+                    DataTypes.INTEGER.getTypeSignature(), // Database
+                    DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.BOOLEAN.getTypeSignature())
+                .features(EnumSet.of(DETERMINISTIC, NULLABLE))
+                .build(),
             (signature, boundSignature) -> new HasPrivilegeFunction(
                 signature,
                 boundSignature,

--- a/server/src/main/java/io/crate/expression/scalar/HasSchemaPrivilegeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/HasSchemaPrivilegeFunction.java
@@ -30,6 +30,7 @@ import java.util.HashSet;
 import java.util.Locale;
 
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.functions.Signature;
@@ -99,12 +100,13 @@ public class HasSchemaPrivilegeFunction {
     public static void register(Functions.Builder module) {
         // Signature without user, takes user from session.
         module.add(
-            Signature.scalar(
-                NAME,
-                DataTypes.STRING.getTypeSignature(), // Schema
-                DataTypes.STRING.getTypeSignature(), // Privilege
-                DataTypes.BOOLEAN.getTypeSignature()
-            ).withFeatures(EnumSet.of(DETERMINISTIC, NULLABLE)),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(
+                    DataTypes.STRING.getTypeSignature(), // Schema
+                    DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.BOOLEAN.getTypeSignature())
+                .features(EnumSet.of(DETERMINISTIC, NULLABLE))
+                .build(),
             (signature, boundSignature) -> new HasPrivilegeFunction(
                 signature,
                 boundSignature,
@@ -116,12 +118,13 @@ public class HasSchemaPrivilegeFunction {
 
         // Signature without user, takes user from session.
         module.add(
-            Signature.scalar(
-                NAME,
-                DataTypes.INTEGER.getTypeSignature(), // Schema
-                DataTypes.STRING.getTypeSignature(),  // Privilege
-                DataTypes.BOOLEAN.getTypeSignature()
-            ).withFeatures(EnumSet.of(DETERMINISTIC, NULLABLE)),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(
+                    DataTypes.INTEGER.getTypeSignature(), // Schema
+                    DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.BOOLEAN.getTypeSignature())
+                .features(EnumSet.of(DETERMINISTIC, NULLABLE))
+                .build(),
             (signature, boundSignature) -> new HasPrivilegeFunction(
                 signature,
                 boundSignature,
@@ -132,13 +135,14 @@ public class HasSchemaPrivilegeFunction {
         );
 
         module.add(
-            Signature.scalar(
-                NAME,
-                DataTypes.STRING.getTypeSignature(), // User
-                DataTypes.STRING.getTypeSignature(), // Schema
-                DataTypes.STRING.getTypeSignature(), // Privilege
-                DataTypes.BOOLEAN.getTypeSignature()
-            ).withFeatures(EnumSet.of(DETERMINISTIC, NULLABLE)),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(
+                    DataTypes.STRING.getTypeSignature(), // User
+                    DataTypes.STRING.getTypeSignature(), // Schema
+                    DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.BOOLEAN.getTypeSignature())
+                .features(EnumSet.of(DETERMINISTIC, NULLABLE))
+                .build(),
             (signature, boundSignature) -> new HasPrivilegeFunction(
                 signature,
                 boundSignature,
@@ -149,13 +153,14 @@ public class HasSchemaPrivilegeFunction {
         );
 
         module.add(
-            Signature.scalar(
-                NAME,
-                DataTypes.STRING.getTypeSignature(),  // User
-                DataTypes.INTEGER.getTypeSignature(), // Schema
-                DataTypes.STRING.getTypeSignature(),  // Privilege
-                DataTypes.BOOLEAN.getTypeSignature()
-            ).withFeatures(EnumSet.of(DETERMINISTIC, NULLABLE)),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(
+                    DataTypes.STRING.getTypeSignature(),  // User
+                    DataTypes.INTEGER.getTypeSignature(), // Schema
+                    DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.BOOLEAN.getTypeSignature())
+                .features(EnumSet.of(DETERMINISTIC, NULLABLE))
+                .build(),
             (signature, boundSignature) -> new HasPrivilegeFunction(
                 signature,
                 boundSignature,
@@ -166,13 +171,14 @@ public class HasSchemaPrivilegeFunction {
         );
 
         module.add(
-            Signature.scalar(
-                NAME,
-                DataTypes.INTEGER.getTypeSignature(), // User
-                DataTypes.STRING.getTypeSignature(),  // Schema
-                DataTypes.STRING.getTypeSignature(),  // Privilege
-                DataTypes.BOOLEAN.getTypeSignature()
-            ).withFeatures(EnumSet.of(DETERMINISTIC, NULLABLE)),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(
+                    DataTypes.INTEGER.getTypeSignature(), // User
+                    DataTypes.STRING.getTypeSignature(),  // Schema
+                    DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.BOOLEAN.getTypeSignature())
+                .features(EnumSet.of(DETERMINISTIC, NULLABLE))
+                .build(),
             (signature, boundSignature) -> new HasPrivilegeFunction(
                 signature,
                 boundSignature,
@@ -183,13 +189,14 @@ public class HasSchemaPrivilegeFunction {
         );
 
         module.add(
-            Signature.scalar(
-                NAME,
-                DataTypes.INTEGER.getTypeSignature(), // User
-                DataTypes.INTEGER.getTypeSignature(), // Schema
-                DataTypes.STRING.getTypeSignature(),  // Privilege
-                DataTypes.BOOLEAN.getTypeSignature()
-            ).withFeatures(EnumSet.of(DETERMINISTIC, NULLABLE)),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(
+                    DataTypes.INTEGER.getTypeSignature(), // User
+                    DataTypes.INTEGER.getTypeSignature(), // Schema
+                    DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.BOOLEAN.getTypeSignature())
+                .features(EnumSet.of(DETERMINISTIC, NULLABLE))
+                .build(),
             (signature, boundSignature) -> new HasPrivilegeFunction(
                 signature,
                 boundSignature,

--- a/server/src/main/java/io/crate/expression/scalar/HasTablePrivilegeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/HasTablePrivilegeFunction.java
@@ -30,6 +30,7 @@ import java.util.HashSet;
 import java.util.Locale;
 
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Schemas;
@@ -107,12 +108,13 @@ public class HasTablePrivilegeFunction {
     public static void register(Functions.Builder module) {
         // Signature without user, takes user from session.
         module.add(
-            Signature.scalar(
-                NAME,
-                DataTypes.STRING.getTypeSignature(), // Table
-                DataTypes.STRING.getTypeSignature(), // Privilege
-                DataTypes.BOOLEAN.getTypeSignature()
-            ).withFeatures(EnumSet.of(DETERMINISTIC, NULLABLE)),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(
+                    DataTypes.STRING.getTypeSignature(), // Table
+                    DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.BOOLEAN.getTypeSignature())
+                .features(EnumSet.of(DETERMINISTIC, NULLABLE))
+                .build(),
             (signature, boundSignature) -> new HasPrivilegeFunction(
                 signature,
                 boundSignature,
@@ -124,12 +126,13 @@ public class HasTablePrivilegeFunction {
 
         // Signature without user, takes user from session.
         module.add(
-            Signature.scalar(
-                NAME,
-                DataTypes.INTEGER.getTypeSignature(), // Table
-                DataTypes.STRING.getTypeSignature(),  // Privilege
-                DataTypes.BOOLEAN.getTypeSignature()
-            ).withFeatures(EnumSet.of(DETERMINISTIC, NULLABLE)),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(
+                    DataTypes.INTEGER.getTypeSignature(), // Table
+                    DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.BOOLEAN.getTypeSignature())
+                .features(EnumSet.of(DETERMINISTIC, NULLABLE))
+                .build(),
             (signature, boundSignature) -> new HasPrivilegeFunction(
                 signature,
                 boundSignature,
@@ -140,13 +143,14 @@ public class HasTablePrivilegeFunction {
         );
 
         module.add(
-            Signature.scalar(
-                NAME,
-                DataTypes.STRING.getTypeSignature(), // User
-                DataTypes.STRING.getTypeSignature(), // Table
-                DataTypes.STRING.getTypeSignature(), // Privilege
-                DataTypes.BOOLEAN.getTypeSignature()
-            ).withFeatures(EnumSet.of(DETERMINISTIC, NULLABLE)),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(
+                    DataTypes.STRING.getTypeSignature(), // User
+                    DataTypes.STRING.getTypeSignature(), // Table
+                    DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.BOOLEAN.getTypeSignature())
+                .features(EnumSet.of(DETERMINISTIC, NULLABLE))
+                .build(),
             (signature, boundSignature) -> new HasPrivilegeFunction(
                 signature,
                 boundSignature,
@@ -157,13 +161,14 @@ public class HasTablePrivilegeFunction {
         );
 
         module.add(
-            Signature.scalar(
-                NAME,
-                DataTypes.STRING.getTypeSignature(),  // User
-                DataTypes.INTEGER.getTypeSignature(), // Table
-                DataTypes.STRING.getTypeSignature(),  // Privilege
-                DataTypes.BOOLEAN.getTypeSignature()
-            ).withFeatures(EnumSet.of(DETERMINISTIC, NULLABLE)),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(
+                    DataTypes.STRING.getTypeSignature(),  // User
+                    DataTypes.INTEGER.getTypeSignature(), // Table
+                    DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.BOOLEAN.getTypeSignature())
+                .features(EnumSet.of(DETERMINISTIC, NULLABLE))
+                .build(),
             (signature, boundSignature) -> new HasPrivilegeFunction(
                 signature,
                 boundSignature,
@@ -174,13 +179,14 @@ public class HasTablePrivilegeFunction {
         );
 
         module.add(
-            Signature.scalar(
-                NAME,
-                DataTypes.INTEGER.getTypeSignature(), // User
-                DataTypes.STRING.getTypeSignature(),  // Table
-                DataTypes.STRING.getTypeSignature(),  // Privilege
-                DataTypes.BOOLEAN.getTypeSignature()
-            ).withFeatures(EnumSet.of(DETERMINISTIC, NULLABLE)),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(
+                    DataTypes.INTEGER.getTypeSignature(), // User
+                    DataTypes.STRING.getTypeSignature(),  // Table
+                    DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.BOOLEAN.getTypeSignature())
+                .features(EnumSet.of(DETERMINISTIC, NULLABLE))
+                .build(),
             (signature, boundSignature) -> new HasPrivilegeFunction(
                 signature,
                 boundSignature,
@@ -191,13 +197,14 @@ public class HasTablePrivilegeFunction {
         );
 
         module.add(
-            Signature.scalar(
-                NAME,
-                DataTypes.INTEGER.getTypeSignature(), // User
-                DataTypes.INTEGER.getTypeSignature(), // Table
-                DataTypes.STRING.getTypeSignature(),  // Privilege
-                DataTypes.BOOLEAN.getTypeSignature()
-            ).withFeatures(EnumSet.of(DETERMINISTIC, NULLABLE)),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(
+                    DataTypes.INTEGER.getTypeSignature(), // User
+                    DataTypes.INTEGER.getTypeSignature(), // Table
+                    DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.BOOLEAN.getTypeSignature())
+                .features(EnumSet.of(DETERMINISTIC, NULLABLE))
+                .build(),
             (signature, boundSignature) -> new HasPrivilegeFunction(
                 signature,
                 boundSignature,

--- a/server/src/main/java/io/crate/expression/scalar/Ignore3vlFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/Ignore3vlFunction.java
@@ -29,6 +29,7 @@ import io.crate.data.Input;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
 import io.crate.lucene.LuceneQueryBuilder.Context;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -51,12 +52,11 @@ import io.crate.types.DataTypes;
 public class Ignore3vlFunction extends Scalar<Boolean, Boolean> {
 
     public static final String NAME = "ignore3vl";
-    public static final Signature SIGNATURE = Signature.scalar(
-            NAME,
-            DataTypes.BOOLEAN.getTypeSignature(),
-            DataTypes.BOOLEAN.getTypeSignature()
-        ).withFeature(Feature.DETERMINISTIC)
-        .withFeature(Feature.NON_NULLABLE);
+    public static final Signature SIGNATURE = Signature.builder(NAME, FunctionType.SCALAR)
+        .argumentTypes(DataTypes.BOOLEAN.getTypeSignature())
+        .returnType(DataTypes.BOOLEAN.getTypeSignature())
+        .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+        .build();
 
     public static void register(Functions.Builder module) {
         module.add(

--- a/server/src/main/java/io/crate/expression/scalar/KnnMatch.java
+++ b/server/src/main/java/io/crate/expression/scalar/KnnMatch.java
@@ -33,6 +33,7 @@ import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.lucene.LuceneQueryBuilder.Context;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
@@ -48,13 +49,11 @@ public class KnnMatch extends Scalar<Boolean, Object> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                "knn_match",
-                TypeSignature.parse(FloatVectorType.NAME),
-                TypeSignature.parse(FloatVectorType.NAME),
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.BOOLEAN.getTypeSignature()
-            ).withFeature(Feature.DETERMINISTIC),
+            Signature.builder("knn_match", FunctionType.SCALAR)
+                .argumentTypes(TypeSignature.parse(FloatVectorType.NAME), TypeSignature.parse(FloatVectorType.NAME), DataTypes.INTEGER.getTypeSignature())
+                .returnType(DataTypes.BOOLEAN.getTypeSignature())
+                .features(Feature.DETERMINISTIC)
+                .build(),
             KnnMatch::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/NullOrEmptyFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/NullOrEmptyFunction.java
@@ -35,6 +35,7 @@ import io.crate.expression.predicate.IsNullPredicate;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
 import io.crate.lucene.LuceneQueryBuilder.Context;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
@@ -53,22 +54,20 @@ public final class NullOrEmptyFunction extends Scalar<Boolean, Object> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                    "null_or_empty",
-                    DataTypes.UNTYPED_OBJECT.getTypeSignature(),
-                    DataTypes.BOOLEAN.getTypeSignature())
-                .withFeature(Feature.DETERMINISTIC)
-                .withFeature(Feature.NON_NULLABLE),
+            Signature.builder("null_or_empty", FunctionType.SCALAR)
+                .argumentTypes(DataTypes.UNTYPED_OBJECT.getTypeSignature())
+                .returnType(DataTypes.BOOLEAN.getTypeSignature())
+                .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                .build(),
             NullOrEmptyFunction::new
         );
         module.add(
-            Signature.scalar(
-                    "null_or_empty",
-                    TypeSignature.parse("array(E)"),
-                    DataTypes.BOOLEAN.getTypeSignature()
-                ).withTypeVariableConstraints(TypeVariableConstraint.typeVariableOfAnyType("E"))
-                .withFeature(Feature.DETERMINISTIC)
-                .withFeature(Feature.NON_NULLABLE),
+            Signature.builder("null_or_empty", FunctionType.SCALAR)
+                .argumentTypes(TypeSignature.parse("array(E)"))
+                .returnType(DataTypes.BOOLEAN.getTypeSignature())
+                .typeVariableConstraints(TypeVariableConstraint.typeVariableOfAnyType("E"))
+                .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                .build(),
             NullOrEmptyFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/PiFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/PiFunction.java
@@ -22,6 +22,7 @@
 package io.crate.expression.scalar;
 
 import io.crate.data.Input;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -36,11 +37,11 @@ public final class PiFunction extends Scalar<Double, Object> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                NAME,
-                DataTypes.DOUBLE.getTypeSignature()
-            ).withFeature(Feature.DETERMINISTIC)
-            .withFeature(Feature.NON_NULLABLE),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes()
+                .returnType(DataTypes.DOUBLE.getTypeSignature())
+                .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                .build(),
             PiFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/StringToArrayFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/StringToArrayFunction.java
@@ -30,6 +30,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import io.crate.data.Input;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -44,22 +45,20 @@ public class StringToArrayFunction extends Scalar<List<String>, String> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                NAME,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING_ARRAY.getTypeSignature()
-            ).withFeature(Feature.DETERMINISTIC),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.STRING_ARRAY.getTypeSignature())
+                .features(Feature.DETERMINISTIC)
+                .build(),
             StringToArrayFunction::new
         );
         module.add(
-            Signature.scalar(
-                NAME,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING_ARRAY.getTypeSignature()
-            ).withFeature(Feature.DETERMINISTIC),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(), DataTypes.STRING.getTypeSignature(), DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.STRING_ARRAY.getTypeSignature())
+                .features(Feature.DETERMINISTIC)
+                .build(),
             StringToArrayFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/SubscriptFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/SubscriptFunction.java
@@ -45,6 +45,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.lucene.LuceneQueryBuilder;
 import io.crate.lucene.LuceneQueryBuilder.Context;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.IndexType;
 import io.crate.metadata.NodeContext;
@@ -80,13 +81,13 @@ public class SubscriptFunction extends Scalar<Object, Object> {
 
         // subscript(array(object)), text) -> array(undefined)
         module.add(
-            Signature.scalar(
-                    NAME,
-                    TypeSignature.parse("array(object)"),
-                    DataTypes.STRING.getTypeSignature(),
-                    TypeSignature.parse("array(undefined)")
-                ).withFeature(Feature.DETERMINISTIC)
-                .withForbiddenCoercion(),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(TypeSignature.parse("array(object)"),
+                    DataTypes.STRING.getTypeSignature())
+                .returnType(TypeSignature.parse("array(undefined)"))
+                .features(Feature.DETERMINISTIC)
+                .forbidCoercion()
+                .build(),
             (signature, boundSignature) ->
                 new SubscriptFunction(
                     signature,
@@ -96,14 +97,13 @@ public class SubscriptFunction extends Scalar<Object, Object> {
         );
         // subscript(array(any)), integer) -> any
         module.add(
-            Signature
-                .scalar(
-                    NAME,
-                    TypeSignature.parse("array(E)"),
-                    DataTypes.INTEGER.getTypeSignature(),
-                    TypeSignature.parse("E"))
-                .withFeature(Feature.DETERMINISTIC)
-                .withTypeVariableConstraints(typeVariable("E")),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(TypeSignature.parse("array(E)"),
+                    DataTypes.INTEGER.getTypeSignature())
+                .returnType(TypeSignature.parse("E"))
+                .features(Feature.DETERMINISTIC)
+                .typeVariableConstraints(typeVariable("E"))
+                .build(),
             (signature, boundSignature) ->
                 new SubscriptFunction(
                     signature,
@@ -113,13 +113,13 @@ public class SubscriptFunction extends Scalar<Object, Object> {
         );
         // subscript(object(text, element), text) -> undefined
         module.add(
-            Signature.scalar(
-                    NAME,
-                    DataTypes.UNTYPED_OBJECT.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.UNDEFINED.getTypeSignature()
-                ).withFeature(Feature.DETERMINISTIC)
-                .withForbiddenCoercion(),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.UNTYPED_OBJECT.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.UNDEFINED.getTypeSignature())
+                .features(Feature.DETERMINISTIC)
+                .forbidCoercion()
+                .build(),
             (signature, boundSignature) ->
                 new SubscriptFunction(
                     signature,
@@ -135,13 +135,13 @@ public class SubscriptFunction extends Scalar<Object, Object> {
         // returns the undefined type. Therefore, the second subscript function
         // must be resolved for the `subscript(undefined, text)` signature.
         module.add(
-            Signature.scalar(
-                    NAME,
-                    DataTypes.UNDEFINED.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.UNDEFINED.getTypeSignature()
-                ).withFeature(Feature.DETERMINISTIC)
-                .withForbiddenCoercion(),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.UNDEFINED.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.UNDEFINED.getTypeSignature())
+                .features(Feature.DETERMINISTIC)
+                .forbidCoercion()
+                .build(),
             (signature, boundSignature) ->
                 new SubscriptFunction(
                     signature,

--- a/server/src/main/java/io/crate/expression/scalar/SubscriptObjectFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/SubscriptObjectFunction.java
@@ -31,6 +31,7 @@ import io.crate.data.Input;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -48,14 +49,13 @@ public class SubscriptObjectFunction extends Scalar<Object, Map<String, Object>>
 
     public static final String NAME = "subscript_obj";
 
-    public static final Signature SIGNATURE = Signature
-        .scalar(
-            NAME,
-            DataTypes.UNTYPED_OBJECT.getTypeSignature(),
-            DataTypes.STRING.getTypeSignature(),
-            DataTypes.UNDEFINED.getTypeSignature())
-        .withFeature(Feature.DETERMINISTIC)
-        .withVariableArity();
+    public static final Signature SIGNATURE = Signature.builder(NAME, FunctionType.SCALAR)
+        .argumentTypes(DataTypes.UNTYPED_OBJECT.getTypeSignature(),
+            DataTypes.STRING.getTypeSignature())
+        .returnType(DataTypes.UNDEFINED.getTypeSignature())
+        .features(Feature.DETERMINISTIC)
+        .setVariableArity(true)
+        .build();
 
     public static void register(Functions.Builder module) {
         module.add(

--- a/server/src/main/java/io/crate/expression/scalar/SubscriptRecordFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/SubscriptRecordFunction.java
@@ -23,6 +23,7 @@ package io.crate.expression.scalar;
 
 import io.crate.data.Input;
 import io.crate.data.Row;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -35,12 +36,12 @@ import io.crate.types.RowType;
 public final class SubscriptRecordFunction extends Scalar<Object, Object> {
 
     public static final String NAME = "_subscript_record";
-    public static final Signature SIGNATURE = Signature.scalar(
-        NAME,
-        RowType.EMPTY.getTypeSignature(),
-        DataTypes.STRING.getTypeSignature(),
-        DataTypes.UNDEFINED.getTypeSignature()
-    ).withFeature(Feature.DETERMINISTIC);
+    public static final Signature SIGNATURE = Signature.builder(NAME, FunctionType.SCALAR)
+        .argumentTypes(RowType.EMPTY.getTypeSignature(),
+            DataTypes.STRING.getTypeSignature())
+        .returnType(DataTypes.UNDEFINED.getTypeSignature())
+        .features(Feature.DETERMINISTIC)
+        .build();
 
     public static void register(Functions.Builder module) {
         module.add(

--- a/server/src/main/java/io/crate/expression/scalar/SubstrFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/SubstrFunction.java
@@ -26,10 +26,11 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.jetbrains.annotations.NotNull;
-
 import org.jetbrains.annotations.VisibleForTesting;
+
 import io.crate.data.Input;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -50,15 +51,27 @@ public class SubstrFunction extends Scalar<String, Object> {
         TypeSignature intType = DataTypes.INTEGER.getTypeSignature();
         for (var name : List.of(NAME, ALIAS)) {
             builder.add(
-                Signature.scalar(name, stringType, intType, stringType).withFeature(Feature.DETERMINISTIC),
+                Signature.builder(name, FunctionType.SCALAR)
+                    .argumentTypes(stringType, intType)
+                    .returnType(stringType)
+                    .features(Feature.DETERMINISTIC)
+                    .build(),
                 SubstrFunction::new
             );
             builder.add(
-                Signature.scalar(name, stringType, intType, intType, stringType).withFeature(Feature.DETERMINISTIC),
+                Signature.builder(name, FunctionType.SCALAR)
+                    .argumentTypes(stringType, intType, intType)
+                    .returnType(stringType)
+                    .features(Feature.DETERMINISTIC)
+                    .build(),
                 SubstrFunction::new
             );
             builder.add(
-                Signature.scalar(name, stringType, stringType, stringType).withFeature(Feature.DETERMINISTIC),
+                Signature.builder(name, FunctionType.SCALAR)
+                    .argumentTypes(stringType, stringType)
+                    .returnType(stringType)
+                    .features(Feature.DETERMINISTIC)
+                    .build(),
                 SubstrExtractFunction::new
             );
         }

--- a/server/src/main/java/io/crate/expression/scalar/VectorSimilarityFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/VectorSimilarityFunction.java
@@ -22,6 +22,7 @@
 package io.crate.expression.scalar;
 
 import io.crate.data.Input;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -35,13 +36,12 @@ public class VectorSimilarityFunction extends Scalar<Float, float[]> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                    "vector_similarity",
-                    FloatVectorType.INSTANCE_ONE.getTypeSignature(),
-                    FloatVectorType.INSTANCE_ONE.getTypeSignature(),
-                    DataTypes.FLOAT.getTypeSignature()
-                ).withFeature(Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder("vector_similarity", FunctionType.SCALAR)
+                .argumentTypes(FloatVectorType.INSTANCE_ONE.getTypeSignature(),
+                    FloatVectorType.INSTANCE_ONE.getTypeSignature())
+                .returnType(DataTypes.FLOAT.getTypeSignature())
+                .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                .build(),
             VectorSimilarityFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/AbsFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/AbsFunction.java
@@ -21,11 +21,11 @@
 
 package io.crate.expression.scalar.arithmetic;
 
-import static io.crate.metadata.functions.Signature.scalar;
-
 import io.crate.expression.scalar.UnaryScalar;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.functions.Signature;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 
@@ -37,9 +37,11 @@ public final class AbsFunction {
         for (var type : DataTypes.NUMERIC_PRIMITIVE_TYPES) {
             var typeSignature = type.getTypeSignature();
             builder.add(
-                scalar(NAME, typeSignature, typeSignature)
-                    .withFeature(Scalar.Feature.DETERMINISTIC)
-                    .withFeature(Scalar.Feature.NULLABLE),
+                Signature.builder(NAME, FunctionType.SCALAR)
+                    .argumentTypes(typeSignature)
+                    .returnType(typeSignature)
+                    .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                    .build(),
                 (signature, boundSignature) -> {
                     DataType<?> argType = boundSignature.argTypes().get(0);
                     return new UnaryScalar<>(

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/ArrayFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/ArrayFunction.java
@@ -39,9 +39,7 @@ public class ArrayFunction extends Scalar<Object, Object> {
 
     public static final String NAME = "_array";
     public static final Signature SIGNATURE =
-        Signature.builder()
-            .name(NAME)
-            .kind(FunctionType.SCALAR)
+        Signature.builder(NAME, FunctionType.SCALAR)
             .typeVariableConstraints(typeVariable("E"))
             .argumentTypes(TypeSignature.parse("E"))
             .returnType(TypeSignature.parse("array(E)"))

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/CeilFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/CeilFunction.java
@@ -21,13 +21,13 @@
 
 package io.crate.expression.scalar.arithmetic;
 
-import static io.crate.metadata.functions.Signature.scalar;
-
 import java.util.List;
 
 import io.crate.expression.scalar.UnaryScalar;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.functions.Signature;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 
@@ -43,9 +43,11 @@ public final class CeilFunction {
             assert returnType != null : "Could not get integral type of " + type;
             for (var name : List.of(CEIL, CEILING)) {
                 module.add(
-                    scalar(name, typeSignature, returnType.getTypeSignature())
-                        .withFeature(Scalar.Feature.DETERMINISTIC)
-                        .withFeature(Scalar.Feature.NULLABLE),
+                    Signature.builder(name, FunctionType.SCALAR)
+                        .argumentTypes(typeSignature)
+                        .returnType(returnType.getTypeSignature())
+                        .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                        .build(),
                     (signature, boundSignature) ->
                         new UnaryScalar<>(
                             signature,

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/ExpFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/ExpFunction.java
@@ -21,11 +21,11 @@
 
 package io.crate.expression.scalar.arithmetic;
 
-import static io.crate.metadata.functions.Signature.scalar;
-
 import io.crate.expression.scalar.UnaryScalar;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
 public class ExpFunction {
@@ -36,9 +36,11 @@ public class ExpFunction {
         var type = DataTypes.DOUBLE;
         var signature = type.getTypeSignature();
         module.add(
-            scalar(NAME, signature, signature)
-                .withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(signature)
+                .returnType(signature)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .build(),
             (declaredSignature, boundSignature) ->
                 new UnaryScalar<>(
                     declaredSignature,

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/FloorFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/FloorFunction.java
@@ -21,11 +21,11 @@
 
 package io.crate.expression.scalar.arithmetic;
 
-import static io.crate.metadata.functions.Signature.scalar;
-
 import io.crate.expression.scalar.UnaryScalar;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.functions.Signature;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 
@@ -39,9 +39,11 @@ public final class FloorFunction {
             DataType<?> returnType = DataTypes.getIntegralReturnType(type);
             assert returnType != null : "Could not get integral type of " + type;
             module.add(
-                scalar(NAME, typeSignature, returnType.getTypeSignature())
-                    .withFeature(Scalar.Feature.DETERMINISTIC)
-                    .withFeature(Scalar.Feature.NULLABLE),
+                Signature.builder(NAME, FunctionType.SCALAR)
+                    .argumentTypes(typeSignature)
+                    .returnType(returnType.getTypeSignature())
+                    .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                    .build(),
                 (signature, boundSignature) ->
                     new UnaryScalar<>(
                         signature,

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/IntervalArithmeticFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/IntervalArithmeticFunctions.java
@@ -27,6 +27,7 @@ import org.joda.time.Period;
 import org.joda.time.PeriodType;
 
 import io.crate.data.Input;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -40,45 +41,41 @@ public class IntervalArithmeticFunctions {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                    ArithmeticFunctions.Names.ADD,
-                    DataTypes.INTERVAL.getTypeSignature(),
-                    DataTypes.INTERVAL.getTypeSignature(),
-                    DataTypes.INTERVAL.getTypeSignature()
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder(ArithmeticFunctions.Names.ADD, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.INTERVAL.getTypeSignature(),
+                    DataTypes.INTERVAL.getTypeSignature())
+                .returnType(DataTypes.INTERVAL.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .build(),
             (signature, boundSignature) ->
                 new IntervalIntervalArithmeticScalar(Period::plus, signature, boundSignature)
         );
         module.add(
-            Signature.scalar(
-                    ArithmeticFunctions.Names.SUBTRACT,
-                    DataTypes.INTERVAL.getTypeSignature(),
-                    DataTypes.INTERVAL.getTypeSignature(),
-                    DataTypes.INTERVAL.getTypeSignature()
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder(ArithmeticFunctions.Names.SUBTRACT, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.INTERVAL.getTypeSignature(),
+                    DataTypes.INTERVAL.getTypeSignature())
+                .returnType(DataTypes.INTERVAL.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .build(),
             (signature, boundSignature) ->
                 new IntervalIntervalArithmeticScalar(Period::minus, signature, boundSignature)
         );
         module.add(
-                Signature.scalar(
-                        ArithmeticFunctions.Names.MULTIPLY,
-                        DataTypes.INTEGER.getTypeSignature(),
-                        DataTypes.INTERVAL.getTypeSignature(),
-                        DataTypes.INTERVAL.getTypeSignature()
-                    ).withFeature(Scalar.Feature.DETERMINISTIC)
-                    .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder(ArithmeticFunctions.Names.MULTIPLY, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.INTEGER.getTypeSignature(),
+                    DataTypes.INTERVAL.getTypeSignature())
+                .returnType(DataTypes.INTERVAL.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .build(),
             MultiplyIntervalByIntegerScalar::new
         );
         module.add(
-                Signature.scalar(
-                        ArithmeticFunctions.Names.MULTIPLY,
-                        DataTypes.INTERVAL.getTypeSignature(),
-                        DataTypes.INTEGER.getTypeSignature(),
-                        DataTypes.INTERVAL.getTypeSignature()
-                    ).withFeature(Scalar.Feature.DETERMINISTIC)
-                    .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder(ArithmeticFunctions.Names.MULTIPLY, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.INTERVAL.getTypeSignature(),
+                    DataTypes.INTEGER.getTypeSignature())
+                .returnType(DataTypes.INTERVAL.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .build(),
             MultiplyIntervalByIntegerScalar::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/IntervalTimestampArithmeticScalar.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/IntervalTimestampArithmeticScalar.java
@@ -29,6 +29,7 @@ import org.joda.time.DateTimeZone;
 import org.joda.time.Period;
 
 import io.crate.data.Input;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -44,13 +45,13 @@ public class IntervalTimestampArithmeticScalar extends Scalar<Long, Object> impl
     public static void register(Functions.Builder module) {
         for (var timestampType : List.of(DataTypes.TIMESTAMP, DataTypes.TIMESTAMPZ)) {
             module.add(
-                Signature.scalar(
-                        ArithmeticFunctions.Names.ADD,
-                        DataTypes.INTERVAL.getTypeSignature(),
-                        timestampType.getTypeSignature(),
-                        timestampType.getTypeSignature()
-                    ).withFeature(Feature.DETERMINISTIC)
-                    .withForbiddenCoercion(),
+                Signature.builder(ArithmeticFunctions.Names.ADD, FunctionType.SCALAR)
+                    .argumentTypes(DataTypes.INTERVAL.getTypeSignature(),
+                        timestampType.getTypeSignature())
+                    .returnType(timestampType.getTypeSignature())
+                    .features(Feature.DETERMINISTIC)
+                    .forbidCoercion()
+                    .build(),
                 (signature, boundSignature) ->
                     new IntervalTimestampArithmeticScalar(
                         "+",
@@ -81,13 +82,13 @@ public class IntervalTimestampArithmeticScalar extends Scalar<Long, Object> impl
     }
 
     public static Signature signatureFor(DataType<?> timestampType, String name) {
-        return Signature.scalar(
-                name,
-                timestampType.getTypeSignature(),
-                DataTypes.INTERVAL.getTypeSignature(),
-                timestampType.getTypeSignature()
-            ).withFeature(Feature.DETERMINISTIC)
-            .withForbiddenCoercion();
+        return Signature.builder(name, FunctionType.SCALAR)
+            .argumentTypes(timestampType.getTypeSignature(),
+                DataTypes.INTERVAL.getTypeSignature())
+            .returnType(timestampType.getTypeSignature())
+            .features(Feature.DETERMINISTIC)
+            .forbidCoercion()
+            .build();
     }
 
     private final BiFunction<DateTime, Period, DateTime> operation;

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/LogFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/LogFunction.java
@@ -21,9 +21,8 @@
 
 package io.crate.expression.scalar.arithmetic;
 
-import static io.crate.metadata.functions.Signature.scalar;
-
 import io.crate.data.Input;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -67,13 +66,12 @@ public abstract class LogFunction extends Scalar<Number, Number> {
         static void registerLogBaseFunctions(Functions.Builder builder) {
             // log(valueType, baseType) : double
             builder.add(
-                scalar(
-                    NAME,
-                    DataTypes.DOUBLE.getTypeSignature(),
-                    DataTypes.DOUBLE.getTypeSignature(),
-                    TypeSignature.parse("double precision"))
-                    .withFeature(Feature.DETERMINISTIC)
-                    .withFeature(Feature.NULLABLE),
+                Signature.builder(NAME, FunctionType.SCALAR)
+                    .argumentTypes(DataTypes.DOUBLE.getTypeSignature(),
+                        DataTypes.DOUBLE.getTypeSignature())
+                    .returnType(TypeSignature.parse("double precision"))
+                    .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                    .build(),
                 LogBaseFunction::new
             );
         }
@@ -107,12 +105,11 @@ public abstract class LogFunction extends Scalar<Number, Number> {
         static void registerLog10Functions(Functions.Builder builder) {
             // log(double) : double
             builder.add(
-                scalar(
-                    NAME,
-                    DataTypes.DOUBLE.getTypeSignature(),
-                    DataTypes.DOUBLE.getTypeSignature())
-                    .withFeature(Feature.DETERMINISTIC)
-                    .withFeature(Feature.NULLABLE),
+                Signature.builder(NAME, FunctionType.SCALAR)
+                    .argumentTypes(DataTypes.DOUBLE.getTypeSignature())
+                    .returnType(DataTypes.DOUBLE.getTypeSignature())
+                    .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                    .build(),
                 Log10Function::new
             );
         }
@@ -142,12 +139,11 @@ public abstract class LogFunction extends Scalar<Number, Number> {
         static void registerLnFunctions(Functions.Builder builder) {
             // ln(double) : double
             builder.add(
-                scalar(
-                    LnFunction.NAME,
-                    DataTypes.DOUBLE.getTypeSignature(),
-                    DataTypes.DOUBLE.getTypeSignature())
-                    .withFeature(Feature.DETERMINISTIC)
-                    .withFeature(Feature.NULLABLE),
+                Signature.builder(LnFunction.NAME, FunctionType.SCALAR)
+                    .argumentTypes(DataTypes.DOUBLE.getTypeSignature())
+                    .returnType(DataTypes.DOUBLE.getTypeSignature())
+                    .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                    .build(),
                 LnFunction::new
             );
         }

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/MapFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/MapFunction.java
@@ -51,10 +51,8 @@ public class MapFunction extends Scalar<Object, Object> {
     public static final String NAME = "_map";
 
     public static final Signature SIGNATURE =
-        Signature.builder()
-            .name(new FunctionName(null, NAME))
-            .kind(FunctionType.SCALAR)
-            .typeVariableConstraints(List.of(typeVariableOfAnyType("V")))
+            Signature.builder(new FunctionName(null, NAME), FunctionType.SCALAR)
+                    .typeVariableConstraints(List.of(typeVariableOfAnyType("V")))
             .argumentTypes(TypeSignature.parse("text"), TypeSignature.parse("V"))
             // This is not 100% correct because each variadic `V` is type independent, resulting in a return type
             // of e.g. `object(text, int, text, geo_point, ...)`.

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/NegateFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/NegateFunctions.java
@@ -24,6 +24,7 @@ package io.crate.expression.scalar.arithmetic;
 import java.math.BigDecimal;
 
 import io.crate.expression.scalar.UnaryScalar;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
@@ -36,68 +37,62 @@ public final class NegateFunctions {
 
     public static void register(Functions.Builder builder) {
         builder.add(
-            Signature.scalar(
-                    NAME,
-                    TypeSignature.parse("double precision"),
-                    TypeSignature.parse("double precision")
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE)
-                .withForbiddenCoercion(),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(TypeSignature.parse("double precision"))
+                .returnType(TypeSignature.parse("double precision"))
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .forbidCoercion()
+                .build(),
             (signature, boundSignature) ->
                 new UnaryScalar<>(signature, boundSignature, DataTypes.DOUBLE, x -> x * -1)
         );
         builder.add(
-            Signature.scalar(
-                    NAME,
-                    DataTypes.FLOAT.getTypeSignature(),
-                    DataTypes.FLOAT.getTypeSignature()
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE)
-                .withForbiddenCoercion(),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.FLOAT.getTypeSignature())
+                .returnType(DataTypes.FLOAT.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .forbidCoercion()
+                .build(),
             (signature, boundSignature) ->
                 new UnaryScalar<>(signature, boundSignature, DataTypes.FLOAT, x -> x * -1)
         );
         builder.add(
-            Signature.scalar(
-                    NAME,
-                    TypeSignature.parse("integer"),
-                    TypeSignature.parse("integer")
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE)
-                .withForbiddenCoercion(),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(TypeSignature.parse("integer"))
+                .returnType(TypeSignature.parse("integer"))
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .forbidCoercion()
+                .build(),
             (signature, boundSignature) ->
                 new UnaryScalar<>(signature, boundSignature, DataTypes.INTEGER, x -> x * -1)
         );
         builder.add(
-            Signature.scalar(
-                    NAME,
-                    TypeSignature.parse("bigint"),
-                    TypeSignature.parse("bigint")
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE)
-                .withForbiddenCoercion(),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(TypeSignature.parse("bigint"))
+                .returnType(TypeSignature.parse("bigint"))
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .forbidCoercion()
+                .build(),
             (signature, boundSignature) ->
                 new UnaryScalar<>(signature, boundSignature, DataTypes.LONG, x -> x * -1)
         );
         builder.add(
-            Signature.scalar(
-                    NAME,
-                    TypeSignature.parse("smallint"),
-                    TypeSignature.parse("smallint")
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE)
-                .withForbiddenCoercion(),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(TypeSignature.parse("smallint"))
+                .returnType(TypeSignature.parse("smallint"))
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .forbidCoercion()
+                .build(),
             (signature, boundSignature) ->
                 new UnaryScalar<>(signature, boundSignature, DataTypes.SHORT, x -> (short) (x * -1))
         );
         builder.add(
-            Signature.scalar(
-                    NAME,
-                    DataTypes.NUMERIC.getTypeSignature(),
-                    DataTypes.NUMERIC.getTypeSignature()
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE)
-                .withForbiddenCoercion(),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.NUMERIC.getTypeSignature())
+                .returnType(DataTypes.NUMERIC.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .forbidCoercion()
+                .build(),
             (signature, boundSignature) ->
                 new UnaryScalar<>(signature, boundSignature, DataTypes.NUMERIC, BigDecimal::negate)
         );

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/RadiansDegreesFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/RadiansDegreesFunctions.java
@@ -21,33 +21,31 @@
 
 package io.crate.expression.scalar.arithmetic;
 
-import static io.crate.metadata.functions.Signature.scalar;
-
 import io.crate.expression.scalar.UnaryScalar;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
 public class RadiansDegreesFunctions {
 
     public static void register(Functions.Builder module) {
         module.add(
-            scalar(
-                "radians",
-                DataTypes.DOUBLE.getTypeSignature(),
-                DataTypes.DOUBLE.getTypeSignature()
-            ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder("radians", FunctionType.SCALAR)
+                .argumentTypes(DataTypes.DOUBLE.getTypeSignature())
+                .returnType(DataTypes.DOUBLE.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .build(),
             (signature, boundSignature) ->
                 new UnaryScalar<>(signature, boundSignature, DataTypes.DOUBLE, Math::toRadians));
 
         module.add(
-            scalar(
-                "degrees",
-                DataTypes.DOUBLE.getTypeSignature(),
-                DataTypes.DOUBLE.getTypeSignature()
-            ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder("degrees", FunctionType.SCALAR)
+                .argumentTypes(DataTypes.DOUBLE.getTypeSignature())
+                .returnType(DataTypes.DOUBLE.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .build(),
             (signature, boundSignature) ->
                 new UnaryScalar<>(signature, boundSignature, DataTypes.DOUBLE, Math::toDegrees));
     }

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/RandomFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/RandomFunction.java
@@ -22,14 +22,13 @@
 package io.crate.expression.scalar.arithmetic;
 
 
-import static io.crate.metadata.functions.Signature.scalar;
-
 import java.util.EnumSet;
 import java.util.Random;
 
 import io.crate.data.Input;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -44,10 +43,11 @@ public class RandomFunction extends Scalar<Double, Void> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            scalar(
-                NAME,
-                DataTypes.DOUBLE.getTypeSignature()
-            ).withFeatures(EnumSet.of(Feature.NON_NULLABLE)),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes()
+                .returnType(DataTypes.DOUBLE.getTypeSignature())
+                .features(EnumSet.of(Feature.NON_NULLABLE))
+                .build(),
             RandomFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/RoundFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/RoundFunction.java
@@ -21,11 +21,11 @@
 
 package io.crate.expression.scalar.arithmetic;
 
-import static io.crate.metadata.functions.Signature.scalar;
-
 import io.crate.expression.scalar.UnaryScalar;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.functions.Signature;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 
@@ -39,9 +39,11 @@ public final class RoundFunction {
             DataType<?> returnType = DataTypes.getIntegralReturnType(type);
             assert returnType != null : "Could not get integral type of " + type;
             module.add(
-                scalar(NAME, typeSignature, returnType.getTypeSignature())
-                    .withFeature(Scalar.Feature.DETERMINISTIC)
-                    .withFeature(Scalar.Feature.NULLABLE),
+                Signature.builder(NAME, FunctionType.SCALAR)
+                    .argumentTypes(typeSignature)
+                    .returnType(returnType.getTypeSignature())
+                    .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                    .build(),
                 (signature, boundSignature) -> {
                     if (returnType.equals(DataTypes.INTEGER)) {
                         return new UnaryScalar<>(

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/SignFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/SignFunction.java
@@ -21,14 +21,14 @@
 
 package io.crate.expression.scalar.arithmetic;
 
-import static io.crate.metadata.functions.Signature.scalar;
-
 import java.math.BigDecimal;
 
 import io.crate.expression.scalar.DoubleScalar;
 import io.crate.expression.scalar.UnaryScalar;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.functions.Signature;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 
@@ -38,9 +38,11 @@ public class SignFunction {
 
     public static void register(Functions.Builder builder) {
         builder.add(
-            scalar(NAME, DataTypes.NUMERIC.getTypeSignature(), DataTypes.NUMERIC.getTypeSignature())
-                .withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.NUMERIC.getTypeSignature())
+                .returnType(DataTypes.NUMERIC.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .build(),
             (signature, boundSignature) -> {
                 DataType<?> argType = boundSignature.argTypes().getFirst();
                 return new UnaryScalar<>(
@@ -54,9 +56,11 @@ public class SignFunction {
 
 
         builder.add(
-            scalar(NAME, DataTypes.DOUBLE.getTypeSignature(), DataTypes.DOUBLE.getTypeSignature())
-                .withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.DOUBLE.getTypeSignature())
+                .returnType(DataTypes.DOUBLE.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .build(),
             (signature, boundSignature) ->
                 new DoubleScalar(signature, boundSignature, Math::signum)
         );

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/SquareRootFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/SquareRootFunction.java
@@ -21,11 +21,11 @@
 
 package io.crate.expression.scalar.arithmetic;
 
-import static io.crate.metadata.functions.Signature.scalar;
-
 import io.crate.expression.scalar.DoubleScalar;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
 public final class SquareRootFunction {
@@ -36,9 +36,11 @@ public final class SquareRootFunction {
         for (var type : DataTypes.NUMERIC_PRIMITIVE_TYPES) {
             var typeSignature = type.getTypeSignature();
             module.add(
-                scalar(NAME, typeSignature, DataTypes.DOUBLE.getTypeSignature())
-                    .withFeature(Scalar.Feature.DETERMINISTIC)
-                    .withFeature(Scalar.Feature.NULLABLE),
+                Signature.builder(NAME, FunctionType.SCALAR)
+                    .argumentTypes(typeSignature)
+                    .returnType(DataTypes.DOUBLE.getTypeSignature())
+                    .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                    .build(),
                 (signature, boundSignature) ->
                     new DoubleScalar(signature, boundSignature, SquareRootFunction::sqrt)
             );

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/SubtractTimestampScalar.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/SubtractTimestampScalar.java
@@ -27,6 +27,7 @@ import org.joda.time.Period;
 import org.joda.time.PeriodType;
 
 import io.crate.data.Input;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -40,12 +41,12 @@ public class SubtractTimestampScalar extends Scalar<Period, Object> {
     public static void register(Functions.Builder module) {
         for (var timestampType : List.of(DataTypes.TIMESTAMP, DataTypes.TIMESTAMPZ)) {
             module.add(
-                Signature.scalar(
-                    ArithmeticFunctions.Names.SUBTRACT,
-                    timestampType.getTypeSignature(),
-                    timestampType.getTypeSignature(),
-                    DataTypes.INTERVAL.getTypeSignature()
-                ).withFeature(Feature.DETERMINISTIC),
+                Signature.builder(ArithmeticFunctions.Names.SUBTRACT, FunctionType.SCALAR)
+                    .argumentTypes(timestampType.getTypeSignature(),
+                        timestampType.getTypeSignature())
+                    .returnType(DataTypes.INTERVAL.getTypeSignature())
+                    .features(Feature.DETERMINISTIC)
+                    .build(),
                 SubtractTimestampScalar::new
             );
         }

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/TrigonometricFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/TrigonometricFunctions.java
@@ -21,13 +21,14 @@
 
 package io.crate.expression.scalar.arithmetic;
 
-import static io.crate.metadata.functions.Signature.scalar;
-
 import java.util.function.DoubleUnaryOperator;
 
 import io.crate.expression.scalar.DoubleScalar;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.Scalar.Feature;
+import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 import io.crate.types.DoubleType;
 
@@ -43,13 +44,12 @@ public final class TrigonometricFunctions {
         register(builder, "atan", x -> Math.atan(x));
 
         builder.add(
-            scalar(
-                "atan2",
-                DataTypes.DOUBLE.getTypeSignature(),
-                DataTypes.DOUBLE.getTypeSignature(),
-                DataTypes.DOUBLE.getTypeSignature())
-                .withFeatures(Scalar.DETERMINISTIC_ONLY)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder("atan2", FunctionType.SCALAR)
+                .argumentTypes(DataTypes.DOUBLE.getTypeSignature(),
+                    DataTypes.DOUBLE.getTypeSignature())
+                .returnType(DataTypes.DOUBLE.getTypeSignature())
+                .features(Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .build(),
             (signature, boundSignature) ->
                 new BinaryScalar<>(
                     Math::atan2,
@@ -62,12 +62,11 @@ public final class TrigonometricFunctions {
 
     private static void register(Functions.Builder builder, String name, DoubleUnaryOperator func) {
         builder.add(
-            scalar(
-                name,
-                DataTypes.DOUBLE.getTypeSignature(),
-                DataTypes.DOUBLE.getTypeSignature()
-            ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder(name, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.DOUBLE.getTypeSignature())
+                .returnType(DataTypes.DOUBLE.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .build(),
             (signature, boundSignature) ->
                 new DoubleScalar(signature, boundSignature, func)
         );

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/TruncFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/TruncFunction.java
@@ -21,14 +21,13 @@
 
 package io.crate.expression.scalar.arithmetic;
 
-import static io.crate.metadata.functions.Signature.scalar;
-
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.function.UnaryOperator;
 
 import io.crate.data.Input;
 import io.crate.expression.scalar.UnaryScalar;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -50,13 +49,12 @@ public final class TruncFunction {
 
             // trunc(number)
             module.add(
-                Signature.scalar(
-                        NAME,
-                        type.getTypeSignature(),
-                        returnType.getTypeSignature()
-                    ).withFeature(Scalar.Feature.DETERMINISTIC)
-                    .withForbiddenCoercion()
-                    .withFeature(Scalar.Feature.NULLABLE),
+                Signature.builder(NAME, FunctionType.SCALAR)
+                    .argumentTypes(type.getTypeSignature())
+                    .returnType(returnType.getTypeSignature())
+                    .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                    .forbidCoercion()
+                    .build(),
                 (signature, boundSignature) ->
                     new UnaryScalar<>(
                         signature,
@@ -73,13 +71,12 @@ public final class TruncFunction {
         }
         // trunc(number, mode)
         module.add(
-            scalar(
-                NAME,
-                DataTypes.DOUBLE.getTypeSignature(),
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.DOUBLE.getTypeSignature()
-            ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.DOUBLE.getTypeSignature(),
+                    DataTypes.INTEGER.getTypeSignature())
+                .returnType(DataTypes.DOUBLE.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .build(),
             TruncFunction::createTruncWithMode
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/bitwise/BitwiseFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/bitwise/BitwiseFunctions.java
@@ -31,8 +31,10 @@ import java.util.function.BinaryOperator;
 
 import io.crate.common.TriConsumer;
 import io.crate.expression.scalar.arithmetic.BinaryScalar;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.Scalar.Feature;
 import io.crate.metadata.functions.Signature;
 import io.crate.sql.tree.BitString;
 import io.crate.types.BitStringType;
@@ -52,14 +54,12 @@ public class BitwiseFunctions {
                                      DataType<T> type,
                                      BinaryOperator<T> operator) {
         TypeSignature typeSignature = type.getTypeSignature();
-        Signature scalar = Signature.scalar(
-                name.toLowerCase(Locale.ENGLISH),
-                typeSignature,
-                typeSignature,
-                typeSignature
-            ).withFeature(Scalar.Feature.DETERMINISTIC)
-            .withFeatures(Scalar.DETERMINISTIC_ONLY)
-            .withFeature(Scalar.Feature.NULLABLE);
+        Signature scalar = Signature.builder(name.toLowerCase(Locale.ENGLISH), FunctionType.SCALAR)
+            .argumentTypes(typeSignature,
+                typeSignature)
+            .returnType(typeSignature)
+            .features(Scalar.Feature.DETERMINISTIC, Feature.NULLABLE)
+            .build();
         module.add(scalar, (signature, boundSignature) -> new BinaryScalar<>(operator, signature, boundSignature, type));
     }
 

--- a/server/src/main/java/io/crate/expression/scalar/cast/ExplicitCastFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/cast/ExplicitCastFunction.java
@@ -27,6 +27,7 @@ import io.crate.data.Input;
 import io.crate.exceptions.ConversionException;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -42,14 +43,13 @@ public class ExplicitCastFunction extends Scalar<Object, Object> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature
-                .scalar(
-                    NAME,
-                    TypeSignature.parse("E"),
-                    TypeSignature.parse("V"),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(TypeSignature.parse("E"),
                     TypeSignature.parse("V"))
-                .withFeature(Feature.DETERMINISTIC)
-                .withTypeVariableConstraints(typeVariable("E"), typeVariable("V")),
+                .returnType(TypeSignature.parse("V"))
+                .features(Feature.DETERMINISTIC)
+                .typeVariableConstraints(typeVariable("E"), typeVariable("V"))
+                .build(),
             ExplicitCastFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/cast/ImplicitCastFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/cast/ImplicitCastFunction.java
@@ -31,6 +31,7 @@ import io.crate.data.Input;
 import io.crate.exceptions.ConversionException;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -48,13 +49,13 @@ public class ImplicitCastFunction extends Scalar<Object, Object> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                    NAME,
-                    TypeSignature.parse("E"),
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.UNDEFINED.getTypeSignature()
-                ).withFeature(Feature.DETERMINISTIC)
-                .withTypeVariableConstraints(typeVariable("E")),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(TypeSignature.parse("E"),
+                    DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.UNDEFINED.getTypeSignature())
+                .features(Feature.DETERMINISTIC)
+                .typeVariableConstraints(typeVariable("E"))
+                .build(),
             ImplicitCastFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/cast/TryCastFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/cast/TryCastFunction.java
@@ -26,6 +26,7 @@ import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
 import io.crate.data.Input;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -41,14 +42,13 @@ public class TryCastFunction extends Scalar<Object, Object> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature
-                .scalar(
-                    NAME,
-                    TypeSignature.parse("E"),
-                    TypeSignature.parse("V"),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(TypeSignature.parse("E"),
                     TypeSignature.parse("V"))
-                .withFeature(Feature.DETERMINISTIC)
-                .withTypeVariableConstraints(typeVariable("E"), typeVariable("V")),
+                .returnType(TypeSignature.parse("V"))
+                .features(Feature.DETERMINISTIC)
+                .typeVariableConstraints(typeVariable("E"), typeVariable("V"))
+                .build(),
             TryCastFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/conditional/CaseFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/conditional/CaseFunction.java
@@ -67,9 +67,7 @@ public class CaseFunction extends Scalar<Object, Object> {
         TypeSignature t = TypeSignature.parse("T");
         TypeSignature bool = TypeSignature.parse("boolean");
         module.add(
-            Signature.builder()
-                .name(new FunctionName(null, NAME))
-                .kind(FunctionType.SCALAR)
+            Signature.builder(new FunctionName(null, NAME), FunctionType.SCALAR)
                 .typeVariableConstraints(typeVariable("T"))
                 .argumentTypes(bool, t)
                 .returnType(t)

--- a/server/src/main/java/io/crate/expression/scalar/conditional/CoalesceFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/conditional/CoalesceFunction.java
@@ -24,6 +24,7 @@ package io.crate.expression.scalar.conditional;
 import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
 
 import io.crate.data.Input;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -38,14 +39,13 @@ public class CoalesceFunction extends Scalar<Object, Object> {
     // which fixes a bug : https://github.com/crate/crate/issues/15232
     public static void register(Functions.Builder module) {
         module.add(
-            Signature
-                .scalar(
-                    NAME,
-                    TypeSignature.parse("E"),
-                    TypeSignature.parse("E"))
-                .withFeature(Feature.DETERMINISTIC)
-                .withVariableArity()
-                .withTypeVariableConstraints(typeVariable("E")),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(TypeSignature.parse("E"))
+                .returnType(TypeSignature.parse("E"))
+                .features(Feature.DETERMINISTIC)
+                .setVariableArity(true)
+                .typeVariableConstraints(typeVariable("E"))
+                .build(),
             CoalesceFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/conditional/GreatestFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/conditional/GreatestFunction.java
@@ -23,6 +23,7 @@ package io.crate.expression.scalar.conditional;
 
 import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
 
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
@@ -35,14 +36,13 @@ public class GreatestFunction extends ConditionalCompareFunction {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature
-                .scalar(
-                    NAME,
-                    TypeSignature.parse("E"),
-                    TypeSignature.parse("E"))
-                .withFeature(Feature.DETERMINISTIC)
-                .withVariableArity()
-                .withTypeVariableConstraints(typeVariable("E")),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(TypeSignature.parse("E"))
+                .returnType(TypeSignature.parse("E"))
+                .features(Feature.DETERMINISTIC)
+                .setVariableArity(true)
+                .typeVariableConstraints(typeVariable("E"))
+                .build(),
             GreatestFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/conditional/IfFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/conditional/IfFunction.java
@@ -24,6 +24,7 @@ package io.crate.expression.scalar.conditional;
 import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
 
 import io.crate.data.Input;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -55,25 +56,23 @@ public class IfFunction extends Scalar<Object, Object> {
     public static void register(Functions.Builder module) {
         // if (condition, result)
         module.add(
-            Signature.scalar(
-                    NAME,
-                    DataTypes.BOOLEAN.getTypeSignature(),
-                    TypeSignature.parse("E"),
-                    TypeSignature.parse("E")
-                ).withFeature(Feature.DETERMINISTIC)
-                .withTypeVariableConstraints(typeVariable("E")),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.BOOLEAN.getTypeSignature(),
+                    TypeSignature.parse("E"))
+                .returnType(TypeSignature.parse("E"))
+                .features(Feature.DETERMINISTIC)
+                .typeVariableConstraints(typeVariable("E"))
+                .build(),
             IfFunction::new
         );
         // if (condition, result, default)
         module.add(
-            Signature.scalar(
-                    NAME,
-                    DataTypes.BOOLEAN.getTypeSignature(),
-                    TypeSignature.parse("E"),
-                    TypeSignature.parse("E"),
-                    TypeSignature.parse("E")
-                ).withFeature(Feature.DETERMINISTIC)
-                .withTypeVariableConstraints(typeVariable("E")),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.BOOLEAN.getTypeSignature(), TypeSignature.parse("E"), TypeSignature.parse("E"))
+                .returnType(TypeSignature.parse("E"))
+                .features(Feature.DETERMINISTIC)
+                .typeVariableConstraints(typeVariable("E"))
+                .build(),
             IfFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/conditional/LeastFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/conditional/LeastFunction.java
@@ -23,6 +23,7 @@ package io.crate.expression.scalar.conditional;
 
 import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
 
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
@@ -35,14 +36,13 @@ public class LeastFunction extends ConditionalCompareFunction {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature
-                .scalar(
-                    NAME,
-                    TypeSignature.parse("E"),
-                    TypeSignature.parse("E"))
-                .withFeature(Feature.DETERMINISTIC)
-                .withVariableArity()
-                .withTypeVariableConstraints(typeVariable("E")),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(TypeSignature.parse("E"))
+                .returnType(TypeSignature.parse("E"))
+                .features(Feature.DETERMINISTIC)
+                .setVariableArity(true)
+                .typeVariableConstraints(typeVariable("E"))
+                .build(),
             LeastFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/conditional/NullIfFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/conditional/NullIfFunction.java
@@ -24,6 +24,7 @@ package io.crate.expression.scalar.conditional;
 import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
 
 import io.crate.data.Input;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -36,13 +37,13 @@ public class NullIfFunction extends Scalar<Object, Object> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                    NAME,
-                    TypeSignature.parse("E"),
-                    TypeSignature.parse("E"),
-                    TypeSignature.parse("E")
-                ).withFeature(Feature.DETERMINISTIC)
-                .withTypeVariableConstraints(typeVariable("E")),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(TypeSignature.parse("E"),
+                    TypeSignature.parse("E"))
+                .returnType(TypeSignature.parse("E"))
+                .features(Feature.DETERMINISTIC)
+                .typeVariableConstraints(typeVariable("E"))
+                .build(),
             NullIfFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/formatting/ToCharFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/formatting/ToCharFunction.java
@@ -32,6 +32,7 @@ import org.joda.time.Period;
 
 import io.crate.data.Input;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -51,12 +52,12 @@ public class ToCharFunction extends Scalar<String, Object> {
         List.of(DataTypes.TIMESTAMP, DataTypes.TIMESTAMPZ).stream()
             .forEach(type -> {
                 module.add(
-                    Signature.scalar(
-                        NAME,
-                        type.getTypeSignature(),
-                        DataTypes.STRING.getTypeSignature(),
-                        DataTypes.STRING.getTypeSignature()
-                    ).withFeature(Feature.DETERMINISTIC),
+                    Signature.builder(NAME, FunctionType.SCALAR)
+                        .argumentTypes(type.getTypeSignature(),
+                            DataTypes.STRING.getTypeSignature())
+                        .returnType(DataTypes.STRING.getTypeSignature())
+                        .features(Feature.DETERMINISTIC)
+                        .build(),
                     (signature, boundSignature) ->
                         new ToCharFunction(
                             signature,
@@ -67,12 +68,12 @@ public class ToCharFunction extends Scalar<String, Object> {
             });
 
         module.add(
-            Signature.scalar(
-                NAME,
-                DataTypes.INTERVAL.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Feature.DETERMINISTIC),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.INTERVAL.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Feature.DETERMINISTIC)
+                .build(),
             (signature, boundSignature) ->
                 new ToCharFunction(
                     signature,

--- a/server/src/main/java/io/crate/expression/scalar/geo/AreaFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/geo/AreaFunction.java
@@ -21,8 +21,6 @@
 
 package io.crate.expression.scalar.geo;
 
-import static io.crate.metadata.functions.Signature.scalar;
-
 import java.util.Map;
 
 import org.locationtech.spatial4j.context.jts.JtsSpatialContext;
@@ -31,8 +29,10 @@ import org.locationtech.spatial4j.shape.Shape;
 import io.crate.expression.scalar.ScalarFunctions;
 import io.crate.expression.scalar.UnaryScalar;
 import io.crate.geo.GeoJSONUtils;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 import io.crate.types.GeoShapeType;
 
@@ -58,12 +58,11 @@ public final class AreaFunction {
      */
     public static void register(Functions.Builder builder) {
         builder.add(
-            scalar(
-                FUNCTION_NAME,
-                DataTypes.GEO_SHAPE.getTypeSignature(),
-                DataTypes.DOUBLE.getTypeSignature()
-            ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder(FUNCTION_NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.GEO_SHAPE.getTypeSignature())
+                .returnType(DataTypes.DOUBLE.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .build(),
             (signature, boundSignature) ->
                 new UnaryScalar<>(
                     signature,

--- a/server/src/main/java/io/crate/expression/scalar/geo/CoordinateFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/geo/CoordinateFunction.java
@@ -21,23 +21,22 @@
 
 package io.crate.expression.scalar.geo;
 
-import static io.crate.metadata.functions.Signature.scalar;
-
 import io.crate.expression.scalar.UnaryScalar;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
 public final class CoordinateFunction {
 
     public static void register(Functions.Builder module) {
         module.add(
-            scalar(
-                "latitude",
-                DataTypes.GEO_POINT.getTypeSignature(),
-                DataTypes.DOUBLE.getTypeSignature()
-            ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder("latitude", FunctionType.SCALAR)
+                .argumentTypes(DataTypes.GEO_POINT.getTypeSignature())
+                .returnType(DataTypes.DOUBLE.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .build(),
             (signature, boundSignature) ->
                 new UnaryScalar<>(
                     signature,
@@ -47,12 +46,11 @@ public final class CoordinateFunction {
                 )
         );
         module.add(
-            scalar(
-                "longitude",
-                DataTypes.GEO_POINT.getTypeSignature(),
-                DataTypes.DOUBLE.getTypeSignature()
-            ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder("longitude", FunctionType.SCALAR)
+                .argumentTypes(DataTypes.GEO_POINT.getTypeSignature())
+                .returnType(DataTypes.DOUBLE.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .build(),
             (signature, boundSignature) ->
                 new UnaryScalar<>(
                     signature,

--- a/server/src/main/java/io/crate/expression/scalar/geo/DistanceFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/geo/DistanceFunction.java
@@ -21,8 +21,6 @@
 
 package io.crate.expression.scalar.geo;
 
-import static io.crate.metadata.functions.Signature.scalar;
-
 import java.util.Arrays;
 import java.util.List;
 
@@ -46,6 +44,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.lucene.LuceneQueryBuilder;
 import io.crate.lucene.LuceneQueryBuilder.Context;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
@@ -61,13 +60,12 @@ public class DistanceFunction extends Scalar<Double, Point> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            scalar(
-                NAME,
-                DataTypes.GEO_POINT.getTypeSignature(),
-                DataTypes.GEO_POINT.getTypeSignature(),
-                DataTypes.DOUBLE.getTypeSignature()
-            ).withFeature(Feature.DETERMINISTIC)
-                .withFeature(Feature.NULLABLE),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.GEO_POINT.getTypeSignature(),
+                    DataTypes.GEO_POINT.getTypeSignature())
+                .returnType(DataTypes.DOUBLE.getTypeSignature())
+                .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                .build(),
             DistanceFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/geo/GeoHashFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/geo/GeoHashFunction.java
@@ -21,14 +21,14 @@
 
 package io.crate.expression.scalar.geo;
 
-import static io.crate.metadata.functions.Signature.scalar;
-
 import org.elasticsearch.common.geo.GeoHashUtils;
 import org.locationtech.spatial4j.shape.Point;
 
 import io.crate.expression.scalar.UnaryScalar;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 import io.crate.types.GeoPointType;
 
@@ -36,12 +36,11 @@ public final class GeoHashFunction {
 
     public static void register(Functions.Builder module) {
         module.add(
-            scalar(
-                "geohash",
-                DataTypes.GEO_POINT.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder("geohash", FunctionType.SCALAR)
+                .argumentTypes(DataTypes.GEO_POINT.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .build(),
             (signature, boundSignature) ->
                 new UnaryScalar<>(
                     signature,

--- a/server/src/main/java/io/crate/expression/scalar/geo/IntersectsFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/geo/IntersectsFunction.java
@@ -21,8 +21,6 @@
 
 package io.crate.expression.scalar.geo;
 
-import static io.crate.metadata.functions.Signature.scalar;
-
 import org.locationtech.spatial4j.shape.Shape;
 
 import io.crate.data.Input;
@@ -30,6 +28,7 @@ import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.geo.GeoJSONUtils;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -44,13 +43,12 @@ public class IntersectsFunction extends Scalar<Boolean, Object> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            scalar(
-                NAME,
-                DataTypes.GEO_SHAPE.getTypeSignature(),
-                DataTypes.GEO_SHAPE.getTypeSignature(),
-                DataTypes.BOOLEAN.getTypeSignature()
-            ).withFeature(Feature.DETERMINISTIC)
-                .withFeature(Feature.NULLABLE),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.GEO_SHAPE.getTypeSignature(),
+                    DataTypes.GEO_SHAPE.getTypeSignature())
+                .returnType(DataTypes.BOOLEAN.getTypeSignature())
+                .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                .build(),
             IntersectsFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/geo/WithinFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/geo/WithinFunction.java
@@ -48,6 +48,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.geo.GeoJSONUtils;
 import io.crate.lucene.LuceneQueryBuilder.Context;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
@@ -63,12 +64,12 @@ public class WithinFunction extends Scalar<Boolean, Object> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                NAME,
-                DataTypes.GEO_SHAPE.getTypeSignature(),
-                DataTypes.GEO_SHAPE.getTypeSignature(),
-                DataTypes.BOOLEAN.getTypeSignature()
-            ).withFeature(Feature.DETERMINISTIC),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.GEO_SHAPE.getTypeSignature(),
+                    DataTypes.GEO_SHAPE.getTypeSignature())
+                .returnType(DataTypes.BOOLEAN.getTypeSignature())
+                .features(Feature.DETERMINISTIC)
+                .build(),
             WithinFunction::new
         );
         // Needed to avoid casts on references of `geo_point` and thus to avoid generic function filter on lucene.
@@ -76,13 +77,13 @@ public class WithinFunction extends Scalar<Boolean, Object> {
         // the other signature
         for (var type : List.of(DataTypes.GEO_SHAPE, DataTypes.STRING, DataTypes.UNTYPED_OBJECT, DataTypes.UNDEFINED)) {
             module.add(
-                Signature.scalar(
-                    NAME,
-                    DataTypes.GEO_POINT.getTypeSignature(),
-                    type.getTypeSignature(),
-                    DataTypes.BOOLEAN.getTypeSignature()
-                ).withFeature(Feature.DETERMINISTIC)
-                    .withForbiddenCoercion(),
+                Signature.builder(NAME, FunctionType.SCALAR)
+                    .argumentTypes(DataTypes.GEO_POINT.getTypeSignature(),
+                        type.getTypeSignature())
+                    .returnType(DataTypes.BOOLEAN.getTypeSignature())
+                    .features(Feature.DETERMINISTIC)
+                    .forbidCoercion()
+                    .build(),
                 WithinFunction::new
             );
         }

--- a/server/src/main/java/io/crate/expression/scalar/object/ObjectKeysFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/object/ObjectKeysFunction.java
@@ -24,6 +24,7 @@ package io.crate.expression.scalar.object;
 import java.util.ArrayList;
 
 import io.crate.expression.scalar.UnaryScalar;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
@@ -33,19 +34,18 @@ public final class ObjectKeysFunction {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                "object_keys",
-                DataTypes.UNTYPED_OBJECT.getTypeSignature(),
-                DataTypes.STRING_ARRAY.getTypeSignature()
-            ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder("object_keys", FunctionType.SCALAR)
+                .argumentTypes(DataTypes.UNTYPED_OBJECT.getTypeSignature())
+                .returnType(DataTypes.STRING_ARRAY.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .build(),
             (signature, boundSignature) ->
-            new UnaryScalar<>(
-                signature,
-                boundSignature,
-                DataTypes.UNTYPED_OBJECT,
-                obj -> new ArrayList<>(obj.keySet())
-            )
+                new UnaryScalar<>(
+                    signature,
+                    boundSignature,
+                    DataTypes.UNTYPED_OBJECT,
+                    obj -> new ArrayList<>(obj.keySet())
+                )
         );
     }
 }

--- a/server/src/main/java/io/crate/expression/scalar/postgres/CurrentSettingFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/postgres/CurrentSettingFunction.java
@@ -21,10 +21,10 @@
 
 package io.crate.expression.scalar.postgres;
 
-import static io.crate.metadata.functions.Signature.scalar;
 
 import io.crate.data.Input;
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -43,11 +43,11 @@ public class CurrentSettingFunction extends Scalar<String, Object> {
 
     public static void register(Functions.Builder builder, SessionSettingRegistry sessionSettingRegistry) {
         builder.add(
-            scalar(
-                FQN,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Feature.DETERMINISTIC),
+            Signature.builder(FQN, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Feature.DETERMINISTIC)
+                .build(),
             (signature, boundSignature) ->
                 new CurrentSettingFunction(
                     signature,
@@ -57,12 +57,12 @@ public class CurrentSettingFunction extends Scalar<String, Object> {
         );
 
         builder.add(
-            scalar(
-                FQN,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.BOOLEAN.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Feature.DETERMINISTIC),
+            Signature.builder(FQN, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(),
+                    DataTypes.BOOLEAN.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Feature.DETERMINISTIC)
+                .build(),
             (signature, boundSignature) ->
                 new CurrentSettingFunction(
                     signature,

--- a/server/src/main/java/io/crate/expression/scalar/postgres/PgBackendPidFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/postgres/PgBackendPidFunction.java
@@ -21,8 +21,6 @@
 
 package io.crate.expression.scalar.postgres;
 
-import static io.crate.metadata.functions.Signature.scalar;
-
 import java.util.EnumSet;
 
 import io.crate.data.Input;
@@ -30,6 +28,7 @@ import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -46,10 +45,11 @@ public class PgBackendPidFunction extends Scalar<Integer, Void> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            scalar(
-                FQN,
-                DataTypes.INTEGER.getTypeSignature()
-            ).withFeatures(EnumSet.of(Feature.NON_NULLABLE)),
+            Signature.builder(FQN, FunctionType.SCALAR)
+                .argumentTypes()
+                .returnType(DataTypes.INTEGER.getTypeSignature())
+                .features(EnumSet.of(Feature.NON_NULLABLE))
+                .build(),
             PgBackendPidFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/postgres/PgEncodingToCharFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/postgres/PgEncodingToCharFunction.java
@@ -21,10 +21,9 @@
 
 package io.crate.expression.scalar.postgres;
 
-import static io.crate.metadata.functions.Signature.scalar;
-
 import io.crate.data.Input;
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -40,12 +39,12 @@ public class PgEncodingToCharFunction extends Scalar<String, Integer> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            scalar(
-                FQN,
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Feature.DETERMINISTIC),
-            PgEncodingToCharFunction:: new
+            Signature.builder(FQN, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.INTEGER.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Feature.DETERMINISTIC)
+                .build(),
+            PgEncodingToCharFunction::new
         );
     }
 

--- a/server/src/main/java/io/crate/expression/scalar/postgres/PgGetUserByIdFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/postgres/PgGetUserByIdFunction.java
@@ -21,13 +21,14 @@
 
 package io.crate.expression.scalar.postgres;
 
-import static io.crate.metadata.functions.Signature.scalar;
 import static io.crate.role.Role.CRATE_USER;
 
 import io.crate.expression.scalar.UnaryScalar;
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.functions.Signature;
 import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
 import io.crate.types.DataTypes;
 
@@ -36,12 +37,11 @@ public class PgGetUserByIdFunction {
     public static void register(Functions.Builder builder) {
         var name = new FunctionName(PgCatalogSchemaInfo.NAME, "pg_get_userbyid");
         builder.add(
-            scalar(
-                name,
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder(name, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.INTEGER.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .build(),
             (signature, boundSignature) ->
                 new UnaryScalar<>(
                     signature,

--- a/server/src/main/java/io/crate/expression/scalar/postgres/PgPostmasterStartTime.java
+++ b/server/src/main/java/io/crate/expression/scalar/postgres/PgPostmasterStartTime.java
@@ -26,6 +26,7 @@ import java.util.EnumSet;
 
 import io.crate.data.Input;
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -42,10 +43,11 @@ public final class PgPostmasterStartTime extends Scalar<Long, Void> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                FQN,
-                DataTypes.TIMESTAMPZ.getTypeSignature()
-            ).withFeatures(EnumSet.of(Feature.NON_NULLABLE)),
+            Signature.builder(FQN, FunctionType.SCALAR)
+                .argumentTypes()
+                .returnType(DataTypes.TIMESTAMPZ.getTypeSignature())
+                .features(EnumSet.of(Feature.NON_NULLABLE))
+                .build(),
             PgPostmasterStartTime::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/postgres/PgTableIsVisibleFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/postgres/PgTableIsVisibleFunction.java
@@ -27,6 +27,7 @@ import io.crate.data.Input;
 import io.crate.exceptions.RelationUnknown;
 import io.crate.expression.scalar.HasTablePrivilegeFunction;
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.RelationName;
@@ -50,12 +51,11 @@ public class PgTableIsVisibleFunction extends Scalar<Boolean, Integer> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                    NAME,
-                    DataTypes.INTEGER.getTypeSignature(),
-                    DataTypes.BOOLEAN.getTypeSignature()
-                ).withFeature(Feature.DETERMINISTIC)
-                .withFeature(Feature.NULLABLE),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.INTEGER.getTypeSignature())
+                .returnType(DataTypes.BOOLEAN.getTypeSignature())
+                .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                .build(),
             PgTableIsVisibleFunction::new);
     }
 

--- a/server/src/main/java/io/crate/expression/scalar/regex/RegexpReplaceFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/regex/RegexpReplaceFunction.java
@@ -33,6 +33,7 @@ import org.jetbrains.annotations.Nullable;
 import io.crate.data.Input;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -48,24 +49,22 @@ public final class RegexpReplaceFunction extends Scalar<String, String> {
 
     public static void register(Functions.Builder builder) {
         builder.add(
-            Signature.scalar(
-                NAME,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Feature.DETERMINISTIC),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(), DataTypes.STRING.getTypeSignature(), DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Feature.DETERMINISTIC)
+                .build(),
             RegexpReplaceFunction::new
         );
         builder.add(
-            Signature.scalar(
-                NAME,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Feature.DETERMINISTIC),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Feature.DETERMINISTIC)
+                .build(),
             RegexpReplaceFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/string/AsciiFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/AsciiFunction.java
@@ -22,6 +22,7 @@
 package io.crate.expression.scalar.string;
 
 import io.crate.expression.scalar.UnaryScalar;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
@@ -31,12 +32,11 @@ public final class AsciiFunction {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                    "ascii",
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.INTEGER.getTypeSignature()
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder("ascii", FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.INTEGER.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .build(),
             (signature, boundSignature) ->
                 new UnaryScalar<>(signature, boundSignature, DataTypes.STRING, AsciiFunction::ascii)
         );

--- a/server/src/main/java/io/crate/expression/scalar/string/ChrFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/ChrFunction.java
@@ -22,6 +22,7 @@
 package io.crate.expression.scalar.string;
 
 import io.crate.data.Input;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -34,12 +35,11 @@ public final class ChrFunction extends Scalar<String, Object> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                    "chr",
-                    DataTypes.INTEGER.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature()
-                ).withFeature(Feature.DETERMINISTIC)
-                .withFeature(Feature.NULLABLE),
+            Signature.builder("chr", FunctionType.SCALAR)
+                .argumentTypes(DataTypes.INTEGER.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                .build(),
             ChrFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/string/EncodeDecodeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/EncodeDecodeFunction.java
@@ -30,6 +30,7 @@ import java.util.function.UnaryOperator;
 import io.crate.common.Hex;
 import io.crate.common.Octal;
 import io.crate.expression.scalar.arithmetic.BinaryScalar;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
@@ -39,13 +40,12 @@ public class EncodeDecodeFunction {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                    "encode",
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature()
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder("encode", FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .build(),
             (signature, boundSignature) ->
                 new BinaryScalar<>(
                     new Encode(),
@@ -55,19 +55,18 @@ public class EncodeDecodeFunction {
                 )
         );
         module.add(
-            Signature.scalar(
-                    "decode",
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature()
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder("decode", FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .build(),
             (signature, boundSignature) ->
                 new BinaryScalar<>(
-                        new Decode(),
-                        signature,
-                        boundSignature,
-                        DataTypes.STRING
+                    new Decode(),
+                    signature,
+                    boundSignature,
+                    DataTypes.STRING
                 )
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/string/HashFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/HashFunctions.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.hash.MessageDigests;
 
 import io.crate.common.Hex;
 import io.crate.expression.scalar.UnaryScalar;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
@@ -45,12 +46,11 @@ public final class HashFunctions {
 
     private static void register(Functions.Builder builder, String name, UnaryOperator<String> func) {
         builder.add(
-            Signature.scalar(
-                    name,
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature()
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder(name, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .build(),
             (signature, boundSignature) ->
                 new UnaryScalar<>(signature, boundSignature, DataTypes.STRING, func)
         );

--- a/server/src/main/java/io/crate/expression/scalar/string/InitCapFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/InitCapFunction.java
@@ -22,6 +22,7 @@
 package io.crate.expression.scalar.string;
 
 import io.crate.expression.scalar.UnaryScalar;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
@@ -31,12 +32,11 @@ public final class InitCapFunction {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                    "initcap",
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature()
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder("initcap", FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .build(),
             (signature, boundSignature) ->
                 new UnaryScalar<>(
                     signature,

--- a/server/src/main/java/io/crate/expression/scalar/string/LengthFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/LengthFunction.java
@@ -25,6 +25,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.function.Function;
 
 import io.crate.expression.scalar.UnaryScalar;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
@@ -41,12 +42,11 @@ public final class LengthFunction {
 
     private static void register(Functions.Builder builder, String name, Function<String, Integer> func) {
         builder.add(
-            Signature.scalar(
-                    name,
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.INTEGER.getTypeSignature()
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder(name, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.INTEGER.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .build(),
             (signature, boundSignature) -> new UnaryScalar<>(signature, boundSignature, DataTypes.STRING, func)
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/string/ParseURIFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/ParseURIFunction.java
@@ -28,6 +28,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import io.crate.data.Input;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -42,12 +43,11 @@ public final class ParseURIFunction extends Scalar<Object, String> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                    NAME,
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.UNTYPED_OBJECT.getTypeSignature()
-                ).withFeature(Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.UNTYPED_OBJECT.getTypeSignature())
+                .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                .build(),
             ParseURIFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/string/ParseURLFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/ParseURLFunction.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import org.elasticsearch.common.Strings;
 
 import io.crate.data.Input;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -50,12 +51,11 @@ public final class ParseURLFunction extends Scalar<Object, String> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                    NAME,
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.UNTYPED_OBJECT.getTypeSignature()
-                ).withFeature(Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.UNTYPED_OBJECT.getTypeSignature())
+                .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                .build(),
             ParseURLFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/string/QuoteIdentFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/QuoteIdentFunction.java
@@ -24,8 +24,10 @@ package io.crate.expression.scalar.string;
 import static io.crate.sql.Identifiers.isKeyWord;
 
 import org.jetbrains.annotations.VisibleForTesting;
+
 import io.crate.expression.scalar.UnaryScalar;
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
@@ -40,12 +42,11 @@ public final class QuoteIdentFunction {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                    FQNAME,
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature()
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder(FQNAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .build(),
             (signature, boundSignature) ->
                 new UnaryScalar<>(
                     signature,

--- a/server/src/main/java/io/crate/expression/scalar/string/ReplaceFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/ReplaceFunction.java
@@ -24,6 +24,7 @@ package io.crate.expression.scalar.string;
 import org.elasticsearch.common.Strings;
 
 import io.crate.expression.scalar.TripleScalar;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
@@ -36,14 +37,11 @@ public final class ReplaceFunction {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                    NAME,
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature()
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(), DataTypes.STRING.getTypeSignature(), DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .build(),
             (signature, boundSignature) ->
                 new TripleScalar<>(
                     signature,

--- a/server/src/main/java/io/crate/expression/scalar/string/ReverseFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/ReverseFunction.java
@@ -22,6 +22,7 @@
 package io.crate.expression.scalar.string;
 
 import io.crate.expression.scalar.UnaryScalar;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
@@ -33,12 +34,11 @@ public final class ReverseFunction {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                    NAME,
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature()
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .build(),
             (signature, boundSignature) -> {
                 return new UnaryScalar<>(
                     signature,

--- a/server/src/main/java/io/crate/expression/scalar/string/StringCaseFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/StringCaseFunction.java
@@ -24,6 +24,7 @@ package io.crate.expression.scalar.string;
 import java.util.Locale;
 
 import io.crate.expression.scalar.UnaryScalar;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
@@ -33,12 +34,11 @@ public final class StringCaseFunction {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                    "upper",
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature()
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder("upper", FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .build(),
             (signature, boundSignature) ->
                 new UnaryScalar<>(
                     signature,
@@ -48,12 +48,11 @@ public final class StringCaseFunction {
                 )
         );
         module.add(
-            Signature.scalar(
-                    "lower",
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature()
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder("lower", FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .build(),
             (signature, boundSignature) ->
                 new UnaryScalar<>(
                     signature,

--- a/server/src/main/java/io/crate/expression/scalar/string/StringLeftRightFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/StringLeftRightFunction.java
@@ -25,6 +25,7 @@ import java.util.Locale;
 import java.util.function.BiFunction;
 
 import io.crate.data.Input;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -37,22 +38,22 @@ public class StringLeftRightFunction extends Scalar<String, Object> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                "left",
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Feature.DETERMINISTIC),
+            Signature.builder("left", FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(),
+                    DataTypes.INTEGER.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Feature.DETERMINISTIC)
+                .build(),
             (signature, boundSignature) ->
                 new StringLeftRightFunction(signature, boundSignature, StringLeftRightFunction::left)
         );
         module.add(
-            Signature.scalar(
-                "right",
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Feature.DETERMINISTIC),
+            Signature.builder("right", FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(),
+                    DataTypes.INTEGER.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Feature.DETERMINISTIC)
+                .build(),
             (signature, boundSignature) ->
                 new StringLeftRightFunction(signature, boundSignature, StringLeftRightFunction::right)
         );

--- a/server/src/main/java/io/crate/expression/scalar/string/StringPaddingFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/StringPaddingFunction.java
@@ -25,6 +25,7 @@ import java.util.Locale;
 
 import io.crate.data.Input;
 import io.crate.expression.scalar.ThreeParametersFunction;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -43,12 +44,12 @@ public class StringPaddingFunction extends Scalar<String, Object> {
     public static void register(Functions.Builder module) {
         // lpad(string1, len)
         module.add(
-            Signature.scalar(
-                LNAME,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Feature.DETERMINISTIC),
+            Signature.builder(LNAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(),
+                    DataTypes.INTEGER.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Feature.DETERMINISTIC)
+                .build(),
             (signature, boundSignature) ->
                 new StringPaddingFunction(
                     signature,
@@ -58,13 +59,11 @@ public class StringPaddingFunction extends Scalar<String, Object> {
         );
         // lpad(string1, len, string2)
         module.add(
-            Signature.scalar(
-                LNAME,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Feature.DETERMINISTIC),
+            Signature.builder(LNAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(), DataTypes.INTEGER.getTypeSignature(), DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Feature.DETERMINISTIC)
+                .build(),
             (signature, boundSignature) ->
                 new StringPaddingFunction(
                     signature,
@@ -74,12 +73,12 @@ public class StringPaddingFunction extends Scalar<String, Object> {
         );
         // rpad(string1, len)
         module.add(
-            Signature.scalar(
-                RNAME,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Feature.DETERMINISTIC),
+            Signature.builder(RNAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(),
+                    DataTypes.INTEGER.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Feature.DETERMINISTIC)
+                .build(),
             (signature, boundSignature) ->
                 new StringPaddingFunction(
                     signature,
@@ -89,13 +88,11 @@ public class StringPaddingFunction extends Scalar<String, Object> {
         );
         // rpad(string1, len, string2)
         module.add(
-            Signature.scalar(
-                RNAME,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Feature.DETERMINISTIC),
+            Signature.builder(RNAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(), DataTypes.INTEGER.getTypeSignature(), DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Feature.DETERMINISTIC)
+                .build(),
             (signature, boundSignature) ->
                 new StringPaddingFunction(
                     signature,

--- a/server/src/main/java/io/crate/expression/scalar/string/StringPositionFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/StringPositionFunction.java
@@ -21,9 +21,8 @@
 
 package io.crate.expression.scalar.string;
 
-import java.util.EnumSet;
-
 import io.crate.data.Input;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -36,12 +35,11 @@ public final class StringPositionFunction extends Scalar<Integer , String> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                "strpos",
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.INTEGER.getTypeSignature()
-            ).withFeatures(EnumSet.of(Feature.DETERMINISTIC, Feature.NULLABLE)),
+            Signature.builder("strpos", FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(), DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.INTEGER.getTypeSignature())
+                .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                .build(),
             StringPositionFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/string/StringRepeatFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/StringRepeatFunction.java
@@ -22,6 +22,7 @@
 package io.crate.expression.scalar.string;
 
 import io.crate.data.Input;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -34,12 +35,12 @@ public final class StringRepeatFunction extends Scalar<String, Object> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                "repeat",
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Feature.DETERMINISTIC),
+            Signature.builder("repeat", FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(),
+                    DataTypes.INTEGER.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Feature.DETERMINISTIC)
+                .build(),
             StringRepeatFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/string/StringSplitPartFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/StringSplitPartFunction.java
@@ -22,6 +22,7 @@
 package io.crate.expression.scalar.string;
 
 import io.crate.data.Input;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -39,13 +40,11 @@ public final class StringSplitPartFunction extends Scalar<String, Object> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                "split_part",
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Feature.DETERMINISTIC),
+            Signature.builder("split_part", FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(), DataTypes.STRING.getTypeSignature(), DataTypes.INTEGER.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Feature.DETERMINISTIC)
+                .build(),
             StringSplitPartFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/string/TranslateFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/TranslateFunction.java
@@ -27,6 +27,7 @@ import java.util.Map;
 
 import io.crate.data.Input;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -42,13 +43,11 @@ public class TranslateFunction extends Scalar<String, String> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                    "translate",
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature())
-                .withFeature(Feature.DETERMINISTIC),
+            Signature.builder("translate", FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(), DataTypes.STRING.getTypeSignature(), DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Feature.DETERMINISTIC)
+                .build(),
             TranslateFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/string/TrimFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/TrimFunctions.java
@@ -28,6 +28,7 @@ import java.util.function.BinaryOperator;
 import io.crate.common.StringUtils;
 import io.crate.data.Input;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -51,12 +52,11 @@ public final class TrimFunctions {
     public static void register(Functions.Builder module) {
         // trim(text)
         module.add(
-            Signature.scalar(
-                    TRIM_NAME,
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature()
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder(TRIM_NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .build(),
             (signature, boundSignature) ->
                 new OneCharTrimFunction(
                     signature,
@@ -66,25 +66,21 @@ public final class TrimFunctions {
         );
         // trim(MODE trimmingText from text)
         module.add(
-            Signature.scalar(
-                    TRIM_NAME,
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature()
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder(TRIM_NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(), DataTypes.STRING.getTypeSignature(), DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .build(),
             TrimFunction::new
         );
 
         // ltrim(text)
         module.add(
-            Signature.scalar(
-                    LTRIM_NAME,
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature()
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder(LTRIM_NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .build(),
             (signature, boundSignature) ->
                 new SideTrimFunction(
                     signature,
@@ -94,13 +90,12 @@ public final class TrimFunctions {
         );
         // ltrim(text, trimmingText)
         module.add(
-            Signature.scalar(
-                    LTRIM_NAME,
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature()
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder(LTRIM_NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .build(),
             (signature, boundSignature) ->
                 new SideTrimFunction(
                     signature,
@@ -111,12 +106,11 @@ public final class TrimFunctions {
 
         // rtrim(text)
         module.add(
-            Signature.scalar(
-                    RTRIM_NAME,
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature()
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder(RTRIM_NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .build(),
             (signature, boundSignature) ->
                 new SideTrimFunction(
                     signature,
@@ -126,13 +120,12 @@ public final class TrimFunctions {
         );
         // rtrim(text, trimmingText)
         module.add(
-            Signature.scalar(
-                    RTRIM_NAME,
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature()
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder(RTRIM_NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .build(),
             (signature, boundSignature) ->
                 new SideTrimFunction(
                     signature,
@@ -144,12 +137,11 @@ public final class TrimFunctions {
 
         // btrim(text)
         module.add(
-            Signature.scalar(
-                    BTRIM_NAME,
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature()
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder(BTRIM_NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .build(),
             (signature, boundSignature) ->
                 new SideTrimFunction(
                     signature,
@@ -159,13 +151,12 @@ public final class TrimFunctions {
         );
         // btrim(text, trimmingText)
         module.add(
-            Signature.scalar(
-                    BTRIM_NAME,
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature()
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder(BTRIM_NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .build(),
             (signature, boundSignature) ->
                 new SideTrimFunction(
                     signature,

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/ColDescriptionFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/ColDescriptionFunction.java
@@ -23,6 +23,7 @@ package io.crate.expression.scalar.systeminformation;
 
 import io.crate.data.Input;
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -39,12 +40,12 @@ public final class ColDescriptionFunction extends Scalar<String, Object> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                FQN,
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Feature.DETERMINISTIC),
+            Signature.builder(FQN, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.INTEGER.getTypeSignature(),
+                    DataTypes.INTEGER.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Feature.DETERMINISTIC)
+                .build(),
             ColDescriptionFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/CurrentSchemaFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/CurrentSchemaFunction.java
@@ -30,6 +30,7 @@ import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -48,10 +49,11 @@ public class CurrentSchemaFunction extends Scalar<String, Object> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                FQN,
-                DataTypes.STRING.getTypeSignature()
-            ).withFeatures(EnumSet.of(Feature.NON_NULLABLE)),
+            Signature.builder(FQN, FunctionType.SCALAR)
+                    .argumentTypes()
+                    .returnType(DataTypes.STRING.getTypeSignature())
+                    .features(EnumSet.of(Feature.NON_NULLABLE))
+                    .build(),
             CurrentSchemaFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/CurrentSchemasFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/CurrentSchemasFunction.java
@@ -27,6 +27,7 @@ import java.util.List;
 
 import io.crate.data.Input;
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -43,11 +44,11 @@ public class CurrentSchemasFunction extends Scalar<List<String>, Boolean> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                FQN,
-                DataTypes.BOOLEAN.getTypeSignature(),
-                DataTypes.STRING_ARRAY.getTypeSignature()
-            ).withFeatures(EnumSet.of(Feature.NON_NULLABLE)),
+            Signature.builder(FQN, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.BOOLEAN.getTypeSignature())
+                .returnType(DataTypes.STRING_ARRAY.getTypeSignature())
+                .features(EnumSet.of(Feature.NON_NULLABLE))
+                .build(),
             CurrentSchemasFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/FormatTypeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/FormatTypeFunction.java
@@ -23,6 +23,7 @@ package io.crate.expression.scalar.systeminformation;
 
 import io.crate.data.Input;
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -41,12 +42,12 @@ public final class FormatTypeFunction extends Scalar<String, Object> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                    FQN,
-                    DataTypes.INTEGER.getTypeSignature(),
-                    DataTypes.INTEGER.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature()
-                ).withFeature(Feature.DETERMINISTIC),
+            Signature.builder(FQN, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.INTEGER.getTypeSignature(),
+                    DataTypes.INTEGER.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Feature.DETERMINISTIC)
+                .build(),
             FormatTypeFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/ObjDescriptionFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/ObjDescriptionFunction.java
@@ -23,6 +23,7 @@ package io.crate.expression.scalar.systeminformation;
 
 import io.crate.data.Input;
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -39,12 +40,12 @@ public final class ObjDescriptionFunction extends Scalar<String, Object> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                FQN,
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Feature.DETERMINISTIC),
+            Signature.builder(FQN, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.INTEGER.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Feature.DETERMINISTIC)
+                .build(),
             ObjDescriptionFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/PgFunctionIsVisibleFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/PgFunctionIsVisibleFunction.java
@@ -22,6 +22,7 @@
 package io.crate.expression.scalar.systeminformation;
 
 import io.crate.data.Input;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -36,12 +37,11 @@ public final class PgFunctionIsVisibleFunction extends Scalar<Boolean, Integer> 
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                    NAME,
-                    DataTypes.INTEGER.getTypeSignature(),
-                    DataTypes.BOOLEAN.getTypeSignature()
-                ).withFeature(Feature.DETERMINISTIC)
-                .withFeature(Feature.NULLABLE),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.INTEGER.getTypeSignature())
+                .returnType(DataTypes.BOOLEAN.getTypeSignature())
+                .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                .build(),
             PgFunctionIsVisibleFunction::new);
     }
 

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetExpr.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetExpr.java
@@ -23,6 +23,7 @@ package io.crate.expression.scalar.systeminformation;
 
 import io.crate.data.Input;
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -39,22 +40,20 @@ public class PgGetExpr extends Scalar<String, Object> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                FQN,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Feature.DETERMINISTIC),
+            Signature.builder(FQN, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(),
+                    DataTypes.INTEGER.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Feature.DETERMINISTIC)
+                .build(),
             PgGetExpr::new
         );
         module.add(
-            Signature.scalar(
-                FQN,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.BOOLEAN.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Feature.DETERMINISTIC),
+            Signature.builder(FQN, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(), DataTypes.INTEGER.getTypeSignature(), DataTypes.BOOLEAN.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Feature.DETERMINISTIC)
+                .build(),
             PgGetExpr::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetFunctionResultFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetFunctionResultFunction.java
@@ -23,6 +23,7 @@ package io.crate.expression.scalar.systeminformation;
 
 import io.crate.data.Input;
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -39,11 +40,11 @@ public final class PgGetFunctionResultFunction extends Scalar<String, Integer> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                FQN,
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Feature.DETERMINISTIC),
+            Signature.builder(FQN, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.INTEGER.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Feature.DETERMINISTIC)
+                .build(),
             PgGetFunctionResultFunction::new);
     }
 

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetPartkeydefFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetPartkeydefFunction.java
@@ -23,6 +23,7 @@ package io.crate.expression.scalar.systeminformation;
 
 import io.crate.data.Input;
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -39,11 +40,11 @@ public class PgGetPartkeydefFunction extends Scalar<String, Integer> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                FQN,
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Feature.DETERMINISTIC),
+            Signature.builder(FQN, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.INTEGER.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Feature.DETERMINISTIC)
+                .build(),
             PgGetPartkeydefFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetSerialSequenceFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetSerialSequenceFunction.java
@@ -23,6 +23,7 @@ package io.crate.expression.scalar.systeminformation;
 
 import io.crate.expression.scalar.arithmetic.BinaryScalar;
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
@@ -36,19 +37,18 @@ public class PgGetSerialSequenceFunction {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                    FQN,
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature()
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder(FQN, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .build(),
             (signature, boundSignature) -> new BinaryScalar<>(
-                        (table,column) -> null,
-                        signature,
-                        boundSignature,
-                        DataTypes.STRING
-                )
+                (table, column) -> null,
+                signature,
+                boundSignature,
+                DataTypes.STRING
+            )
         );
     }
 }

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/PgTypeofFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/PgTypeofFunction.java
@@ -25,6 +25,7 @@ import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
 
 import io.crate.data.Input;
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -41,13 +42,12 @@ public final class PgTypeofFunction extends Scalar<String, Object> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                    FQNAME,
-                    TypeSignature.parse("E"),
-                    DataTypes.STRING.getTypeSignature()
-                ).withFeature(Feature.DETERMINISTIC)
-                .withTypeVariableConstraints(typeVariable("E"))
-                .withFeature(Feature.NON_NULLABLE),
+            Signature.builder(FQNAME, FunctionType.SCALAR)
+                .argumentTypes(TypeSignature.parse("E"))
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                .typeVariableConstraints(typeVariable("E"))
+                .build(),
             PgTypeofFunction::new
         );
 

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/VersionFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/VersionFunction.java
@@ -29,6 +29,7 @@ import org.elasticsearch.Version;
 
 import io.crate.data.Input;
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -46,10 +47,11 @@ public class VersionFunction extends Scalar<String, Void> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                FQN,
-                DataTypes.STRING.getTypeSignature()
-            ).withFeatures(EnumSet.of(Feature.NON_NULLABLE)),
+            Signature.builder(FQN, FunctionType.SCALAR)
+                .argumentTypes()
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(EnumSet.of(Feature.NON_NULLABLE))
+                .build(),
             VersionFunction::new
         );
 

--- a/server/src/main/java/io/crate/expression/scalar/timestamp/CurrentTimeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/timestamp/CurrentTimeFunction.java
@@ -26,6 +26,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Locale;
 
 import io.crate.data.Input;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -42,20 +43,19 @@ public class CurrentTimeFunction extends Scalar<TimeTZ, Integer> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                    NAME,
-                    DataTypes.INTEGER.getTypeSignature(),
-                    DataTypes.TIMETZ.getTypeSignature()
-                ).withFeature(Feature.DETERMINISTIC)
-                .withFeature(Feature.NON_NULLABLE),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.INTEGER.getTypeSignature())
+                .returnType(DataTypes.TIMETZ.getTypeSignature())
+                .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                .build(),
             CurrentTimeFunction::new
         );
         module.add(
-            Signature.scalar(
-                    NAME,
-                    DataTypes.TIMETZ.getTypeSignature()
-                ).withFeature(Feature.DETERMINISTIC)
-                .withFeature(Feature.NON_NULLABLE),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes()
+                .returnType(DataTypes.TIMETZ.getTypeSignature())
+                .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                .build(),
             CurrentTimeFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/timestamp/CurrentTimestampFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/timestamp/CurrentTimestampFunction.java
@@ -27,6 +27,7 @@ import java.util.EnumSet;
 import java.util.Locale;
 
 import io.crate.data.Input;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -42,18 +43,19 @@ public class CurrentTimestampFunction extends Scalar<Long, Integer> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                    NAME,
-                    DataTypes.TIMESTAMPZ.getTypeSignature()
-                ).withFeatures(EnumSet.of(Feature.NON_NULLABLE)),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes()
+                .returnType(DataTypes.TIMESTAMPZ.getTypeSignature())
+                .features(EnumSet.of(Feature.NON_NULLABLE))
+                .build(),
             CurrentTimestampFunction::new
         );
         module.add(
-            Signature.scalar(
-                    NAME,
-                    DataTypes.INTEGER.getTypeSignature(),
-                    DataTypes.TIMESTAMPZ.getTypeSignature()
-                ).withFeatures(EnumSet.of(Feature.NON_NULLABLE)),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.INTEGER.getTypeSignature())
+                .returnType(DataTypes.TIMESTAMPZ.getTypeSignature())
+                .features(EnumSet.of(Feature.NON_NULLABLE))
+                .build(),
             CurrentTimestampFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/timestamp/NowFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/timestamp/NowFunction.java
@@ -26,6 +26,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.EnumSet;
 
 import io.crate.data.Input;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -40,10 +41,11 @@ public final class NowFunction extends Scalar<Long, Object> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                    NAME,
-                    DataTypes.TIMESTAMPZ.getTypeSignature()
-                ).withFeatures(EnumSet.of(Feature.NON_NULLABLE)),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes()
+                .returnType(DataTypes.TIMESTAMPZ.getTypeSignature())
+                .features(EnumSet.of(Feature.NON_NULLABLE))
+                .build(),
             NowFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/scalar/timestamp/TimezoneFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/timestamp/TimezoneFunction.java
@@ -28,6 +28,7 @@ import java.time.ZonedDateTime;
 import java.util.Locale;
 
 import io.crate.data.Input;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -45,30 +46,30 @@ public class TimezoneFunction extends Scalar<Long, Object> {
 
     public static void register(Functions.Builder module) {
         module.add(
-            Signature.scalar(
-                NAME,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.TIMESTAMPZ.getTypeSignature(),
-                DataTypes.TIMESTAMP.getTypeSignature()
-            ).withFeature(Feature.DETERMINISTIC),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(),
+                    DataTypes.TIMESTAMPZ.getTypeSignature())
+                .returnType(DataTypes.TIMESTAMP.getTypeSignature())
+                .features(Feature.DETERMINISTIC)
+                .build(),
             TimezoneFunction::new
         );
         module.add(
-            Signature.scalar(
-                NAME,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.TIMESTAMP.getTypeSignature(),
-                DataTypes.TIMESTAMPZ.getTypeSignature()
-            ).withFeature(Feature.DETERMINISTIC),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(),
+                    DataTypes.TIMESTAMP.getTypeSignature())
+                .returnType(DataTypes.TIMESTAMPZ.getTypeSignature())
+                .features(Feature.DETERMINISTIC)
+                .build(),
             TimezoneFunction::new
         );
         module.add(
-            Signature.scalar(
-                NAME,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.LONG.getTypeSignature(),
-                DataTypes.TIMESTAMPZ.getTypeSignature()
-            ).withFeature(Feature.DETERMINISTIC),
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(),
+                    DataTypes.LONG.getTypeSignature())
+                .returnType(DataTypes.TIMESTAMPZ.getTypeSignature())
+                .features(Feature.DETERMINISTIC)
+                .build(),
             TimezoneFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/symbol/Symbol.java
+++ b/server/src/main/java/io/crate/expression/symbol/Symbol.java
@@ -245,16 +245,14 @@ public interface Symbol extends Writeable, Accountable {
                 ? TryCastFunction.NAME
                 : ExplicitCastFunction.NAME;
             return new Function(
-                Signature
-                    .scalar(
-                        name,
-                        TypeSignature.parse("E"),
-                        TypeSignature.parse("V"),
-                        TypeSignature.parse("V")
-                    ).withTypeVariableConstraints(
-                        TypeVariableConstraint.typeVariable("E"),
+                Signature.builder(name, FunctionType.SCALAR)
+                    .argumentTypes(TypeSignature.parse("E"),
+                        TypeSignature.parse("V"))
+                    .returnType(TypeSignature.parse("V"))
+                    .features(Scalar.Feature.DETERMINISTIC)
+                    .typeVariableConstraints(TypeVariableConstraint.typeVariable("E"),
                         TypeVariableConstraint.typeVariable("V"))
-                    .withFeature(Scalar.Feature.DETERMINISTIC),
+                    .build(),
                 // a literal with a NULL value is passed as an argument
                 // to match the method signature
                 List.of(sourceSymbol, Literal.of(targetType, null)),
@@ -262,14 +260,13 @@ public interface Symbol extends Writeable, Accountable {
             );
         } else {
             return new Function(
-                Signature
-                    .scalar(
-                        ImplicitCastFunction.NAME,
-                        TypeSignature.parse("E"),
-                        DataTypes.STRING.getTypeSignature(),
-                        DataTypes.UNDEFINED.getTypeSignature())
-                    .withFeature(Scalar.Feature.DETERMINISTIC)
-                    .withTypeVariableConstraints(TypeVariableConstraint.typeVariable("E")),
+                Signature.builder(ImplicitCastFunction.NAME, FunctionType.SCALAR)
+                    .argumentTypes(TypeSignature.parse("E"),
+                        DataTypes.STRING.getTypeSignature())
+                    .returnType(DataTypes.UNDEFINED.getTypeSignature())
+                    .features(Scalar.Feature.DETERMINISTIC)
+                    .typeVariableConstraints(TypeVariableConstraint.typeVariable("E"))
+                    .build(),
                 List.of(
                     sourceSymbol,
                     Literal.of(targetType.getTypeSignature().toString())

--- a/server/src/main/java/io/crate/expression/tablefunctions/EmptyRowTableFunction.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/EmptyRowTableFunction.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import io.crate.data.Input;
 import io.crate.data.Row;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -43,9 +44,11 @@ public class EmptyRowTableFunction {
 
     public static void register(Functions.Builder builder) {
         builder.add(
-            Signature.table(NAME, RowType.EMPTY.getTypeSignature())
-                .withFeature(Scalar.Feature.NON_NULLABLE)
-                .withFeature(Scalar.Feature.DETERMINISTIC),
+            Signature.builder(NAME, FunctionType.TABLE)
+                .argumentTypes()
+                .returnType(RowType.EMPTY.getTypeSignature())
+                .features(Scalar.Feature.NON_NULLABLE, Scalar.Feature.DETERMINISTIC)
+                .build(),
             EmptyRowTableFunctionImplementation::new
         );
     }

--- a/server/src/main/java/io/crate/expression/tablefunctions/GenerateSeries.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/GenerateSeries.java
@@ -35,6 +35,7 @@ import io.crate.data.Input;
 import io.crate.data.Row;
 import io.crate.legacy.LegacySettings;
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
@@ -68,13 +69,12 @@ public final class GenerateSeries<T extends Number> extends TableFunctionImpleme
 
         // without step
         builder.add(
-            Signature.table(
-                    NAME,
-                    DataTypes.LONG.getTypeSignature(),
-                    DataTypes.LONG.getTypeSignature(),
-                    DataTypes.LONG.getTypeSignature()
-                ).withFeature(Feature.DETERMINISTIC)
-                .withFeature(Feature.NON_NULLABLE),
+            Signature.builder(NAME, FunctionType.TABLE)
+                .argumentTypes(DataTypes.LONG.getTypeSignature(),
+                    DataTypes.LONG.getTypeSignature())
+                .returnType(DataTypes.LONG.getTypeSignature())
+                .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                .build(),
             (signature, boundSignature) -> new GenerateSeries<>(
                 signature,
                 boundSignature,
@@ -86,13 +86,12 @@ public final class GenerateSeries<T extends Number> extends TableFunctionImpleme
                 new RowType(List.of(boundSignature.argTypes().get(0)), fieldNames))
         );
         builder.add(
-            Signature.table(
-                    NAME,
-                    DataTypes.INTEGER.getTypeSignature(),
-                    DataTypes.INTEGER.getTypeSignature(),
-                    DataTypes.INTEGER.getTypeSignature()
-                ).withFeature(Feature.DETERMINISTIC)
-                .withFeature(Feature.NON_NULLABLE),
+            Signature.builder(NAME, FunctionType.TABLE)
+                .argumentTypes(DataTypes.INTEGER.getTypeSignature(),
+                    DataTypes.INTEGER.getTypeSignature())
+                .returnType(DataTypes.INTEGER.getTypeSignature())
+                .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                .build(),
             (signature, boundSignature) -> new GenerateSeries<>(
                 signature,
                 boundSignature,
@@ -106,14 +105,13 @@ public final class GenerateSeries<T extends Number> extends TableFunctionImpleme
 
         // with step
         builder.add(
-            Signature.table(
-                    NAME,
+            Signature.builder(NAME, FunctionType.TABLE)
+                .argumentTypes(DataTypes.LONG.getTypeSignature(),
                     DataTypes.LONG.getTypeSignature(),
-                    DataTypes.LONG.getTypeSignature(),
-                    DataTypes.LONG.getTypeSignature(),
-                    DataTypes.LONG.getTypeSignature()
-                ).withFeature(Feature.DETERMINISTIC)
-                .withFeature(Feature.NON_NULLABLE),
+                    DataTypes.LONG.getTypeSignature())
+                .returnType(DataTypes.LONG.getTypeSignature())
+                .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                .build(),
             (signature, boundSignature) -> new GenerateSeries<>(
                 signature,
                 boundSignature,
@@ -125,14 +123,13 @@ public final class GenerateSeries<T extends Number> extends TableFunctionImpleme
                 new RowType(List.of(boundSignature.argTypes().get(0)), fieldNames))
         );
         builder.add(
-            Signature.table(
-                    NAME,
+            Signature.builder(NAME, FunctionType.TABLE)
+                .argumentTypes(DataTypes.INTEGER.getTypeSignature(),
                     DataTypes.INTEGER.getTypeSignature(),
-                    DataTypes.INTEGER.getTypeSignature(),
-                    DataTypes.INTEGER.getTypeSignature(),
-                    DataTypes.INTEGER.getTypeSignature()
-                ).withFeature(Feature.DETERMINISTIC)
-                .withFeature(Feature.NON_NULLABLE),
+                    DataTypes.INTEGER.getTypeSignature())
+                .returnType(DataTypes.INTEGER.getTypeSignature())
+                .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                .build(),
             (signature, boundSignature) -> new GenerateSeries<>(
                 signature,
                 boundSignature,
@@ -147,31 +144,30 @@ public final class GenerateSeries<T extends Number> extends TableFunctionImpleme
         // generate_series(ts, ts, interval)
         for (var supportedType : List.of(DataTypes.TIMESTAMP, DataTypes.TIMESTAMPZ)) {
             builder.add(
-                Signature.table(
-                        NAME,
+                Signature.builder(NAME, FunctionType.TABLE)
+                    .argumentTypes(supportedType.getTypeSignature(),
                         supportedType.getTypeSignature(),
-                        supportedType.getTypeSignature(),
-                        DataTypes.INTERVAL.getTypeSignature(),
-                        supportedType.getTypeSignature()
-                    ).withFeature(Feature.DETERMINISTIC)
-                    .withFeature(Feature.NON_NULLABLE),
+                        DataTypes.INTERVAL.getTypeSignature())
+                    .returnType(supportedType.getTypeSignature())
+                    .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                    .build(),
                 (signature, boundSignature) -> new GenerateSeriesIntervals(
                     signature,
                     boundSignature,
                     new RowType(List.of(boundSignature.argTypes().get(0)), fieldNames))
             );
             builder.add(
-                Signature.table(
-                    NAME,
-                    supportedType.getTypeSignature(),
-                    supportedType.getTypeSignature(),
-                    supportedType.getTypeSignature()
-                ).withFeature(Feature.DETERMINISTIC),
+                Signature.builder(NAME, FunctionType.TABLE)
+                    .argumentTypes(supportedType.getTypeSignature(),
+                        supportedType.getTypeSignature())
+                    .returnType(supportedType.getTypeSignature())
+                    .features(Feature.DETERMINISTIC)
+                    .build(),
                 (signature, boundSignature) -> {
                     throw new IllegalArgumentException(
                         "generate_series(start, stop) has type `" + boundSignature.argTypes().get(0).getName() +
-                        "` for start, but requires long/int values for start and stop, " +
-                        "or if used with timestamps, it requires a third argument for the step (interval)");
+                            "` for start, but requires long/int values for start and stop, " +
+                            "or if used with timestamps, it requires a third argument for the step (interval)");
                 }
             );
         }

--- a/server/src/main/java/io/crate/expression/tablefunctions/GenerateSubscripts.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/GenerateSubscripts.java
@@ -30,6 +30,7 @@ import java.util.Locale;
 import io.crate.data.Input;
 import io.crate.data.Row;
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
@@ -49,26 +50,24 @@ public final class GenerateSubscripts<T> extends TableFunctionImplementation<T> 
 
     public static void register(Functions.Builder builder) {
         builder.add(
-            Signature.table(
-                    NAME,
-                    TypeSignature.parse("array(E)"),
-                    DataTypes.INTEGER.getTypeSignature(),
-                    DataTypes.INTEGER.getTypeSignature()
-                ).withTypeVariableConstraints(typeVariable("E"))
-                .withFeature(Feature.DETERMINISTIC)
-                .withFeature(Feature.NON_NULLABLE),
+            Signature.builder(NAME, FunctionType.TABLE)
+                .argumentTypes(TypeSignature.parse("array(E)"),
+                    INTEGER.getTypeSignature())
+                .returnType(INTEGER.getTypeSignature())
+                .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                .typeVariableConstraints(typeVariable("E"))
+                .build(),
             GenerateSubscripts::new
         );
         builder.add(
-            Signature.table(
-                    NAME,
-                    TypeSignature.parse("array(E)"),
-                    DataTypes.INTEGER.getTypeSignature(),
-                    DataTypes.BOOLEAN.getTypeSignature(),
-                    DataTypes.INTEGER.getTypeSignature()
-                ).withTypeVariableConstraints(typeVariable("E"))
-                .withFeature(Feature.DETERMINISTIC)
-                .withFeature(Feature.NON_NULLABLE),
+            Signature.builder(NAME, FunctionType.TABLE)
+                .argumentTypes(TypeSignature.parse("array(E)"),
+                    INTEGER.getTypeSignature(),
+                    DataTypes.BOOLEAN.getTypeSignature())
+                .returnType(INTEGER.getTypeSignature())
+                .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                .typeVariableConstraints(typeVariable("E"))
+                .build(),
             GenerateSubscripts::new
         );
     }

--- a/server/src/main/java/io/crate/expression/tablefunctions/MatchesFunction.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/MatchesFunction.java
@@ -42,6 +42,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolType;
 import io.crate.legacy.LegacySettings;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -65,13 +66,12 @@ public final class MatchesFunction extends TableFunctionImplementation<List<Obje
             LegacySettings.LEGACY_TABLE_FUNCTION_COLUMN_NAMING.get(settings) ? LEGACY_ROW_TYPE : ROW_TYPE;
 
         builder.add(
-            Signature.table(
-                    NAME,
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.STRING_ARRAY.getTypeSignature()
-                ).withFeature(Feature.DETERMINISTIC)
-                .withFeature(Feature.NON_NULLABLE),
+            Signature.builder(NAME, FunctionType.TABLE)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.STRING_ARRAY.getTypeSignature())
+                .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                .build(),
             (signature, boundSignature) -> new MatchesFunction(
                 signature,
                 boundSignature,
@@ -79,14 +79,13 @@ public final class MatchesFunction extends TableFunctionImplementation<List<Obje
             )
         );
         builder.add(
-            Signature.table(
-                    NAME,
+            Signature.builder(NAME, FunctionType.TABLE)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(),
                     DataTypes.STRING.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.STRING.getTypeSignature(),
-                    DataTypes.STRING_ARRAY.getTypeSignature()
-                ).withFeature(Feature.DETERMINISTIC)
-                .withFeature(Feature.NON_NULLABLE),
+                    DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.STRING_ARRAY.getTypeSignature())
+                .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                .build(),
             (signature, boundSignature) -> new MatchesFunction(
                 signature,
                 boundSignature,

--- a/server/src/main/java/io/crate/expression/tablefunctions/PgExpandArray.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/PgExpandArray.java
@@ -30,6 +30,7 @@ import io.crate.data.Input;
 import io.crate.data.Row;
 import io.crate.data.RowN;
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
@@ -49,14 +50,13 @@ public final class PgExpandArray extends TableFunctionImplementation<List<Object
 
     public static void register(Functions.Builder builder) {
         builder.add(
-            Signature.table(
-                    FUNCTION_NAME,
-                    TypeSignature.parse("array(E)"),
-                    TypeSignature.parse("record(x E, n integer)")
-                ).withTypeVariableConstraints(typeVariable("E"))
-                .withFeature(Feature.DETERMINISTIC)
-                .withFeature(Feature.NON_NULLABLE),
-            PgExpandArray::new
+                Signature.builder(FUNCTION_NAME, FunctionType.TABLE)
+                        .argumentTypes(TypeSignature.parse("array(E)"))
+                        .returnType(TypeSignature.parse("record(x E, n integer)"))
+                        .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                        .typeVariableConstraints(typeVariable("E"))
+                        .build(),
+                PgExpandArray::new
         );
     }
 

--- a/server/src/main/java/io/crate/expression/tablefunctions/PgGetKeywordsFunction.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/PgGetKeywordsFunction.java
@@ -31,6 +31,7 @@ import io.crate.data.Input;
 import io.crate.data.Row;
 import io.crate.data.RowN;
 import io.crate.metadata.FunctionName;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.TransactionContext;
@@ -53,11 +54,11 @@ public final class PgGetKeywordsFunction extends TableFunctionImplementation<Lis
     public static void register(Functions.Builder builder) {
 
         builder.add(
-            Signature.table(
-                    FUNCTION_NAME,
-                    RETURN_TYPE.getTypeSignature()
-                ).withFeature(Feature.DETERMINISTIC)
-                .withFeature(Feature.NON_NULLABLE),
+            Signature.builder(FUNCTION_NAME, FunctionType.TABLE)
+                .argumentTypes()
+                .returnType(RETURN_TYPE.getTypeSignature())
+                .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                .build(),
             PgGetKeywordsFunction::new
         );
     }

--- a/server/src/main/java/io/crate/expression/tablefunctions/TableFunctionFactory.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/TableFunctionFactory.java
@@ -24,11 +24,11 @@ package io.crate.expression.tablefunctions;
 import java.util.List;
 import java.util.Locale;
 
-import io.crate.common.collections.Lists;
 import io.crate.data.Input;
 import io.crate.data.Row;
 import io.crate.data.Row1;
 import io.crate.metadata.FunctionImplementation;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
@@ -36,7 +36,6 @@ import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 import io.crate.metadata.tablefunctions.TableFunctionImplementation;
 import io.crate.types.RowType;
-import io.crate.types.TypeSignature;
 
 public class TableFunctionFactory {
 
@@ -76,17 +75,15 @@ public class TableFunctionFactory {
 
         private ScalarTableFunctionImplementation(Scalar<?, T> functionImplementation) {
             super(
-                Signature.table(
-                    functionImplementation.signature().getName(),
-                    Lists.concat(
-                        functionImplementation.signature().getArgumentTypes(),
-                        functionImplementation.signature().getReturnType()
-                    ).toArray(new TypeSignature[0])
-                ).withFeature(Feature.DETERMINISTIC),
-                new BoundSignature(
-                    functionImplementation.boundSignature().argTypes(),
-                    functionImplementation.boundSignature().returnType()
-                )
+                    Signature.builder(functionImplementation.signature().getName(), FunctionType.TABLE)
+                            .argumentTypes(functionImplementation.signature().getArgumentTypes())
+                            .returnType(functionImplementation.signature().getReturnType())
+                            .features(Feature.DETERMINISTIC)
+                            .build(),
+                    new BoundSignature(
+                            functionImplementation.boundSignature().argTypes(),
+                            functionImplementation.boundSignature().returnType()
+                    )
             );
             this.functionImplementation = functionImplementation;
             var boundReturnType = functionImplementation.boundSignature().returnType();

--- a/server/src/main/java/io/crate/expression/tablefunctions/UnnestFunction.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/UnnestFunction.java
@@ -35,6 +35,7 @@ import io.crate.common.collections.Lists;
 import io.crate.data.Input;
 import io.crate.data.Row;
 import io.crate.legacy.LegacySettings;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -54,16 +55,13 @@ public class UnnestFunction {
 
     public static void register(Functions.Builder builder, Settings settings) {
         builder.add(
-            Signature
-                .table(
-                    NAME,
-                    TypeSignature.parse("array(N)"),
-                    RowType.EMPTY.getTypeSignature()
-                )
-                .withTypeVariableConstraints(typeVariableOfAnyType("N"))
-                .withFeature(Scalar.Feature.NON_NULLABLE)
-                .withFeature(Scalar.Feature.DETERMINISTIC)
-                .withVariableArity(),
+            Signature.builder(NAME, FunctionType.TABLE)
+                .argumentTypes(TypeSignature.parse("array(N)"))
+                .returnType(RowType.EMPTY.getTypeSignature())
+                .features(Scalar.Feature.NON_NULLABLE, Scalar.Feature.DETERMINISTIC)
+                .typeVariableConstraints(typeVariableOfAnyType("N"))
+                .setVariableArity(true)
+                .build(),
             (signature, boundSignature) -> {
                 List<DataType<?>> fieldTypes = Lists.map(boundSignature.argTypes(), ArrayType::unnest);
                 Boolean useLegacyName = LegacySettings.LEGACY_TABLE_FUNCTION_COLUMN_NAMING.get(settings);
@@ -89,11 +87,11 @@ public class UnnestFunction {
         );
         // unnest() to keep it compatible with previous versions
         builder.add(
-            Signature.table(
-                    NAME,
-                    DataTypes.UNTYPED_OBJECT.getTypeSignature()
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withFeature(Scalar.Feature.NON_NULLABLE),
+            Signature.builder(NAME, FunctionType.TABLE)
+                .argumentTypes()
+                .returnType(DataTypes.UNTYPED_OBJECT.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NON_NULLABLE)
+                .build(),
             (signature, boundSignature) -> new UnnestTableFunctionImplementation(
                 signature,
                 boundSignature,

--- a/server/src/main/java/io/crate/expression/tablefunctions/ValuesFunction.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/ValuesFunction.java
@@ -30,9 +30,10 @@ import java.util.List;
 
 import io.crate.data.Input;
 import io.crate.data.Row;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
-import io.crate.metadata.Scalar;
+import io.crate.metadata.Scalar.Feature;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
@@ -46,14 +47,13 @@ public class ValuesFunction {
 
     public static final String NAME = "_values";
 
-    public static final Signature SIGNATURE = Signature
-        .table(
-            NAME,
-            TypeSignature.parse("array(E)"),
-            RowType.EMPTY.getTypeSignature())
-        .withTypeVariableConstraints(typeVariableOfAnyType("E"))
-        .withFeature(Scalar.Feature.DETERMINISTIC)
-        .withVariableArity();
+    public static final Signature SIGNATURE = Signature.builder(NAME, FunctionType.TABLE)
+        .argumentTypes(TypeSignature.parse("array(E)"))
+        .returnType(RowType.EMPTY.getTypeSignature())
+        .typeVariableConstraints(typeVariableOfAnyType("E"))
+        .features(Feature.DETERMINISTIC)
+        .setVariableArity(true)
+        .build();
 
     public static void register(Functions.Builder builder) {
         builder.add(SIGNATURE, ValuesTableFunctionImplementation::of);

--- a/server/src/main/java/io/crate/expression/udf/UserDefinedFunctionService.java
+++ b/server/src/main/java/io/crate/expression/udf/UserDefinedFunctionService.java
@@ -224,10 +224,8 @@ public class UserDefinedFunctionService extends AbstractLifecycleComponent imple
     @Nullable
     public FunctionProvider buildFunctionResolver(UserDefinedFunctionMetadata udf) {
         var functionName = new FunctionName(udf.schema(), udf.name());
-        var signature = Signature.builder()
-            .name(functionName)
-            .kind(FunctionType.SCALAR)
-            .argumentTypes(
+        var signature = Signature.builder(functionName, FunctionType.SCALAR)
+                .argumentTypes(
                 Lists.map(
                     udf.argumentTypes(),
                     DataType::getTypeSignature))

--- a/server/src/main/java/io/crate/metadata/Functions.java
+++ b/server/src/main/java/io/crate/metadata/Functions.java
@@ -337,11 +337,9 @@ public class Functions {
                                      List<FunctionProvider> candidates) {
         List<DataType<?>> argumentTypes = Symbols.typeView(arguments);
         var function = new io.crate.expression.symbol.Function(
-            Signature.builder()
-                .name(new FunctionName(suppliedSchema, name))
+            Signature.builder(new FunctionName(suppliedSchema, name), FunctionType.SCALAR)
                 .argumentTypes(Lists.map(argumentTypes, DataType::getTypeSignature))
                 .returnType(DataTypes.UNDEFINED.getTypeSignature())
-                .kind(FunctionType.SCALAR)
                 .build(),
             arguments,
             DataTypes.UNDEFINED

--- a/server/src/main/java/io/crate/role/scalar/UserFunction.java
+++ b/server/src/main/java/io/crate/role/scalar/UserFunction.java
@@ -27,6 +27,7 @@ import io.crate.data.Input;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
@@ -42,17 +43,15 @@ public class UserFunction extends Scalar<String, Object> {
 
     public static void register(Functions.Builder builder) {
         builder.add(
-            Signature.scalar(
-                CURRENT_USER_FUNCTION_NAME,
-                DataTypes.STRING.getTypeSignature()
-            ),
+            Signature.builder(CURRENT_USER_FUNCTION_NAME, FunctionType.SCALAR)
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .build(),
             UserFunction::new
         );
         builder.add(
-            Signature.scalar(
-                SESSION_USER_FUNCTION_NAME,
-                DataTypes.STRING.getTypeSignature()
-            ),
+            Signature.builder(SESSION_USER_FUNCTION_NAME, FunctionType.SCALAR)
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .build(),
             UserFunction::new
         );
     }

--- a/server/src/main/java/io/crate/types/Regproc.java
+++ b/server/src/main/java/io/crate/types/Regproc.java
@@ -21,12 +21,14 @@
 
 package io.crate.types;
 
+import java.util.Objects;
+
+import org.jetbrains.annotations.NotNull;
+
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.metadata.pgcatalog.OidHash;
-
-import org.jetbrains.annotations.NotNull;
-import java.util.Objects;
 
 public class Regproc {
 
@@ -37,7 +39,11 @@ public class Regproc {
 
     public static Regproc of(@NotNull String name) {
         return new Regproc(
-            OidHash.functionOid(Signature.scalar(name, DataTypes.UNDEFINED.getTypeSignature()).withFeature(Scalar.Feature.DETERMINISTIC)),
+            OidHash.functionOid(Signature.builder(name, FunctionType.SCALAR)
+                    .argumentTypes()
+                    .returnType(DataTypes.UNDEFINED.getTypeSignature())
+                    .features(Scalar.Feature.DETERMINISTIC)
+                    .build()),
             name
         );
     }
@@ -57,7 +63,11 @@ public class Regproc {
     }
 
     public Signature asDummySignature() {
-        return Signature.scalar(name, DataTypes.UNDEFINED.getTypeSignature()).withFeature(Scalar.Feature.DETERMINISTIC);
+        return Signature.builder(name, FunctionType.SCALAR)
+                .argumentTypes()
+                .returnType(DataTypes.UNDEFINED.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC)
+                .build();
     }
 
     public int oid() {

--- a/server/src/test/java/io/crate/execution/dsl/projection/WindowAggProjectionSerialisationTest.java
+++ b/server/src/test/java/io/crate/execution/dsl/projection/WindowAggProjectionSerialisationTest.java
@@ -40,6 +40,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.WindowFunction;
 import io.crate.metadata.FunctionImplementation;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
@@ -132,13 +133,13 @@ public class WindowAggProjectionSerialisationTest {
 
     private FunctionImplementation getSumFunction() {
         return functions.getQualified(
-            Signature.aggregate(
-                    SumAggregation.NAME,
-                    DataTypes.LONG.getTypeSignature(),
-                    DataTypes.LONG.getTypeSignature())
-                .withFeature(Scalar.Feature.DETERMINISTIC),
-            List.of(DataTypes.LONG),
-            DataTypes.LONG
+                Signature.builder(SumAggregation.NAME, FunctionType.AGGREGATE)
+                        .argumentTypes(DataTypes.LONG.getTypeSignature())
+                        .returnType(DataTypes.LONG.getTypeSignature())
+                        .features(Scalar.Feature.DETERMINISTIC)
+                        .build(),
+                List.of(DataTypes.LONG),
+                DataTypes.LONG
         );
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregationTest.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import org.junit.Test;
 
 import io.crate.expression.symbol.Literal;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.SearchPath;
 import io.crate.metadata.functions.Signature;
@@ -40,13 +41,13 @@ public class ArbitraryAggregationTest extends AggregationTestCase {
 
     private Object executeAggregation(DataType<?> argumentType, Object[][] data) throws Exception {
         return executeAggregation(
-            Signature.aggregate(
-                    ArbitraryAggregation.NAME,
-                    argumentType.getTypeSignature(),
-                    argumentType.getTypeSignature())
-                .withFeature(Scalar.Feature.DETERMINISTIC),
-            data,
-            List.of()
+                Signature.builder(ArbitraryAggregation.NAME, FunctionType.AGGREGATE)
+                        .argumentTypes(argumentType.getTypeSignature())
+                        .returnType(argumentType.getTypeSignature())
+                        .features(Scalar.Feature.DETERMINISTIC)
+                        .build(),
+                data,
+                List.of()
         );
     }
 
@@ -137,11 +138,11 @@ public class ArbitraryAggregationTest extends AggregationTestCase {
 
     @Test
     public void test_can_use_any_value_as_name() throws Exception {
-        Signature aggregate = Signature.aggregate(
-            "any_value",
-            DataTypes.INTEGER.getTypeSignature(),
-            DataTypes.INTEGER.getTypeSignature()
-        ).withFeature(Scalar.Feature.DETERMINISTIC);
+        Signature aggregate = Signature.builder("any_value", FunctionType.AGGREGATE)
+                .argumentTypes(DataTypes.INTEGER.getTypeSignature())
+                .returnType(DataTypes.INTEGER.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC)
+                .build();
         Object result = executeAggregation(aggregate, new Object[][] { new Object[] { 1 } }, List.of());
         assertThat(result).isEqualTo(1);
     }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/AverageAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/AverageAggregationTest.java
@@ -39,6 +39,7 @@ import io.crate.execution.engine.aggregation.impl.average.AverageAggregation;
 import io.crate.execution.engine.aggregation.impl.average.numeric.NumericAverageState;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.FunctionImplementation;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.SearchPath;
 import io.crate.metadata.functions.Signature;
@@ -49,33 +50,33 @@ import io.crate.types.NumericType;
 
 public class AverageAggregationTest extends AggregationTestCase {
 
-    private static final Signature NUMERIC_AVG_SIGNATURE = Signature.aggregate(
-        AverageAggregation.NAME,
-        DataTypes.NUMERIC.getTypeSignature(),
-        DataTypes.NUMERIC.getTypeSignature()
-    ).withFeature(Scalar.Feature.DETERMINISTIC);
+    private static final Signature NUMERIC_AVG_SIGNATURE = Signature.builder(AverageAggregation.NAME, FunctionType.AGGREGATE)
+            .argumentTypes(DataTypes.NUMERIC.getTypeSignature())
+            .returnType(DataTypes.NUMERIC.getTypeSignature())
+            .features(Scalar.Feature.DETERMINISTIC)
+            .build();
 
     private Object executeAvgAgg(DataType<?> argumentType, Object[][] data) throws Exception {
         return executeAggregation(
-            Signature.aggregate(
-                AverageAggregation.NAME,
-                argumentType.getTypeSignature(),
-                DataTypes.DOUBLE.getTypeSignature()
-            ).withFeature(Scalar.Feature.DETERMINISTIC),
-            data,
-            List.of()
+                Signature.builder(AverageAggregation.NAME, FunctionType.AGGREGATE)
+                        .argumentTypes(argumentType.getTypeSignature())
+                        .returnType(DataTypes.DOUBLE.getTypeSignature())
+                        .features(Scalar.Feature.DETERMINISTIC)
+                        .build(),
+                data,
+                List.of()
         );
     }
 
     private Object executeIntervalAvgAgg(Object[][] data) throws Exception {
         return executeAggregation(
-            Signature.aggregate(
-                AverageAggregation.NAME,
-                DataTypes.INTERVAL.getTypeSignature(),
-                DataTypes.INTERVAL.getTypeSignature()
-            ).withFeature(Scalar.Feature.DETERMINISTIC),
-            data,
-            List.of()
+                Signature.builder(AverageAggregation.NAME, FunctionType.AGGREGATE)
+                        .argumentTypes(DataTypes.INTERVAL.getTypeSignature())
+                        .returnType(DataTypes.INTERVAL.getTypeSignature())
+                        .features(Scalar.Feature.DETERMINISTIC)
+                        .build(),
+                data,
+                List.of()
         );
     }
 

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/CmpByAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/CmpByAggregationTest.java
@@ -29,6 +29,7 @@ import java.util.Map;
 
 import org.junit.Test;
 
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.operation.aggregation.AggregationTestCase;
@@ -38,12 +39,12 @@ public class CmpByAggregationTest extends AggregationTestCase {
 
     @Test
     public void test_max_by() throws Exception {
-        Signature signature = Signature.aggregate(
-            "max_by",
-            DataTypes.STRING.getTypeSignature(),
-            DataTypes.INTEGER.getTypeSignature(),
-            DataTypes.STRING.getTypeSignature()
-        ).withFeature(Scalar.Feature.DETERMINISTIC);
+        Signature signature = Signature.builder("max_by", FunctionType.AGGREGATE)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(),
+                        DataTypes.INTEGER.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC)
+                .build();
         Object result = executeAggregation(
             signature,
             new Object[][] {
@@ -59,12 +60,12 @@ public class CmpByAggregationTest extends AggregationTestCase {
     @Test
     public void test_cmp_by_returns_null_if_all_search_fields_are_null() throws Exception {
         for (String func : List.of("max_by", "min_by")) {
-            Signature signature = Signature.aggregate(
-                func,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Scalar.Feature.DETERMINISTIC);
+            Signature signature = Signature.builder(func, FunctionType.AGGREGATE)
+                    .argumentTypes(DataTypes.STRING.getTypeSignature(),
+                            DataTypes.INTEGER.getTypeSignature())
+                    .returnType(DataTypes.STRING.getTypeSignature())
+                    .features(Scalar.Feature.DETERMINISTIC)
+                    .build();
             Object result = executeAggregation(
                 signature,
                 new Object[][] {
@@ -81,12 +82,12 @@ public class CmpByAggregationTest extends AggregationTestCase {
     @Test
     public void test_cmp_by_returns_null_if_all_return_fields_are_null() throws Exception {
         for (String func : List.of("max_by", "min_by")) {
-            Signature signature = Signature.aggregate(
-                func,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Scalar.Feature.DETERMINISTIC);
+            Signature signature = Signature.builder(func, FunctionType.AGGREGATE)
+                    .argumentTypes(DataTypes.STRING.getTypeSignature(),
+                            DataTypes.INTEGER.getTypeSignature())
+                    .returnType(DataTypes.STRING.getTypeSignature())
+                    .features(Scalar.Feature.DETERMINISTIC)
+                    .build();
             Object result = executeAggregation(
                 signature,
                 new Object[][] {
@@ -102,12 +103,12 @@ public class CmpByAggregationTest extends AggregationTestCase {
 
     @Test
     public void test_max_by_returns_null_if_return_field_of_max_search_field_is_null() throws Exception {
-        Signature signature = Signature.aggregate(
-            "max_by",
-            DataTypes.STRING.getTypeSignature(),
-            DataTypes.INTEGER.getTypeSignature(),
-            DataTypes.STRING.getTypeSignature()
-        ).withFeature(Scalar.Feature.DETERMINISTIC);
+        Signature signature = Signature.builder("max_by", FunctionType.AGGREGATE)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(),
+                        DataTypes.INTEGER.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC)
+                .build();
         Object result = executeAggregation(
             signature,
             new Object[][] {
@@ -123,12 +124,12 @@ public class CmpByAggregationTest extends AggregationTestCase {
     @Test
     public void test_cmp_by_result_is_nondeterministic_on_ties() throws Exception {
         for (String func : List.of("max_by", "min_by")) {
-            Signature signature = Signature.aggregate(
-                func,
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Scalar.Feature.DETERMINISTIC);
+            Signature signature = Signature.builder(func, FunctionType.AGGREGATE)
+                    .argumentTypes(DataTypes.STRING.getTypeSignature(),
+                            DataTypes.INTEGER.getTypeSignature())
+                    .returnType(DataTypes.STRING.getTypeSignature())
+                    .features(Scalar.Feature.DETERMINISTIC)
+                    .build();
             Object result = executeAggregation(
                 signature,
                 new Object[][] {
@@ -144,12 +145,12 @@ public class CmpByAggregationTest extends AggregationTestCase {
 
     @Test
     public void test_min_by() throws Exception {
-        Signature signature = Signature.aggregate(
-            "min_by",
-            DataTypes.STRING.getTypeSignature(),
-            DataTypes.INTEGER.getTypeSignature(),
-            DataTypes.STRING.getTypeSignature()
-        ).withFeature(Scalar.Feature.DETERMINISTIC);
+        Signature signature = Signature.builder("min_by", FunctionType.AGGREGATE)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(),
+                        DataTypes.INTEGER.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC)
+                .build();
         Object result = executeAggregation(
             signature,
             new Object[][] {
@@ -165,12 +166,12 @@ public class CmpByAggregationTest extends AggregationTestCase {
 
     @Test
     public void test_cannot_use_max_by_on_non_comparable_types() throws Exception {
-        Signature signature = Signature.aggregate(
-            "max_by",
-            DataTypes.STRING.getTypeSignature(),
-            DataTypes.UNTYPED_OBJECT.getTypeSignature(),
-            DataTypes.STRING.getTypeSignature()
-        ).withFeature(Scalar.Feature.DETERMINISTIC);
+        Signature signature = Signature.builder("max_by", FunctionType.AGGREGATE)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(),
+                        DataTypes.UNTYPED_OBJECT.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC)
+                .build();
         assertThatThrownBy(() -> executeAggregation(
             signature,
             new Object[][] {
@@ -184,12 +185,12 @@ public class CmpByAggregationTest extends AggregationTestCase {
 
     @Test
     public void test_min_by_does_not_overflow_on_MIN_VALUE() throws Exception {
-        Signature signature = Signature.aggregate(
-            "min_by",
-            DataTypes.STRING.getTypeSignature(),
-            DataTypes.LONG.getTypeSignature(),
-            DataTypes.STRING.getTypeSignature()
-        ).withFeature(Scalar.Feature.DETERMINISTIC);
+        Signature signature = Signature.builder("min_by", FunctionType.AGGREGATE)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(),
+                        DataTypes.LONG.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC)
+                .build();
         Object result = executeAggregation(
             signature,
             new Object[][] {

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregationTest.java
@@ -33,6 +33,7 @@ import io.crate.data.Input;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.FunctionImplementation;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.SearchPath;
 import io.crate.metadata.functions.Signature;
@@ -45,13 +46,13 @@ public class CollectSetAggregationTest extends AggregationTestCase {
 
     private Object executeAggregation(DataType<?> argumentType, Object[][] data) throws Exception {
         return executeAggregation(
-            Signature.aggregate(
-                "collect_set",
-                argumentType.getTypeSignature(),
-                new ArrayType<>(argumentType).getTypeSignature()
-            ).withFeature(Scalar.Feature.DETERMINISTIC),
-            data,
-            List.of()
+                Signature.builder("collect_set", FunctionType.AGGREGATE)
+                        .argumentTypes(argumentType.getTypeSignature())
+                        .returnType(new ArrayType<>(argumentType).getTypeSignature())
+                        .features(Scalar.Feature.DETERMINISTIC)
+                        .build(),
+                data,
+                List.of()
         );
     }
 

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregationTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.FunctionImplementation;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.SearchPath;
 import io.crate.metadata.functions.Signature;
@@ -43,13 +44,13 @@ public class GeometricMeanAggregationTest extends AggregationTestCase {
 
     private Object executeAggregation(DataType<?> argumentType, Object[][] data) throws Exception {
         return executeAggregation(
-            Signature.aggregate(
-                GeometricMeanAggregation.NAME,
-                argumentType.getTypeSignature(),
-                DataTypes.DOUBLE.getTypeSignature()
-            ).withFeature(Scalar.Feature.DETERMINISTIC),
-            data,
-            List.of()
+                Signature.builder(GeometricMeanAggregation.NAME, FunctionType.AGGREGATE)
+                        .argumentTypes(argumentType.getTypeSignature())
+                        .returnType(DataTypes.DOUBLE.getTypeSignature())
+                        .features(Scalar.Feature.DETERMINISTIC)
+                        .build(),
+                data,
+                List.of()
         );
     }
 

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/MaximumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/MaximumAggregationTest.java
@@ -30,6 +30,7 @@ import org.joda.time.Period;
 import org.junit.Test;
 
 import io.crate.exceptions.UnsupportedFunctionException;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.operation.aggregation.AggregationTestCase;
@@ -40,13 +41,13 @@ public class MaximumAggregationTest extends AggregationTestCase {
 
     private Object executeAggregation(DataType<?> argumentType, Object[][] data) throws Exception {
         return executeAggregation(
-            Signature.aggregate(
-                "max",
-                argumentType.getTypeSignature(),
-                argumentType.getTypeSignature()
-            ).withFeature(Scalar.Feature.DETERMINISTIC),
-            data,
-            List.of()
+                Signature.builder("max", FunctionType.AGGREGATE)
+                        .argumentTypes(argumentType.getTypeSignature())
+                        .returnType(argumentType.getTypeSignature())
+                        .features(Scalar.Feature.DETERMINISTIC)
+                        .build(),
+                data,
+                List.of()
         );
     }
 

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/MinimumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/MinimumAggregationTest.java
@@ -30,6 +30,7 @@ import org.joda.time.Period;
 import org.junit.Test;
 
 import io.crate.exceptions.UnsupportedFunctionException;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.operation.aggregation.AggregationTestCase;
@@ -40,13 +41,13 @@ public class MinimumAggregationTest extends AggregationTestCase {
 
     private Object executeAggregation(DataType<?> argumentType, Object[][] data) throws Exception {
         return executeAggregation(
-            Signature.aggregate(
-                MinimumAggregation.NAME,
-                argumentType.getTypeSignature(),
-                argumentType.getTypeSignature()
-            ).withFeature(Scalar.Feature.DETERMINISTIC),
-            data,
-            List.of()
+                Signature.builder(MinimumAggregation.NAME, FunctionType.AGGREGATE)
+                        .argumentTypes(argumentType.getTypeSignature())
+                        .returnType(argumentType.getTypeSignature())
+                        .features(Scalar.Feature.DETERMINISTIC)
+                        .build(),
+                data,
+                List.of()
         );
     }
 

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/PercentileAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/PercentileAggregationTest.java
@@ -36,6 +36,7 @@ import io.crate.data.breaker.RamAccounting;
 import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.expression.symbol.Literal;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.operation.aggregation.AggregationTestCase;
@@ -47,27 +48,27 @@ public class PercentileAggregationTest extends AggregationTestCase {
 
     private Object execSingleFractionPercentile(DataType<?> argumentType, Object[][] rows) throws Exception {
         return executeAggregation(
-            Signature.aggregate(
-                PercentileAggregation.NAME,
-                argumentType.getTypeSignature(),
-                DataTypes.DOUBLE.getTypeSignature(),
-                DataTypes.DOUBLE.getTypeSignature()
-            ).withFeature(Scalar.Feature.DETERMINISTIC),
-            rows,
-            List.of()
+                Signature.builder(PercentileAggregation.NAME, FunctionType.AGGREGATE)
+                        .argumentTypes(argumentType.getTypeSignature(),
+                                DataTypes.DOUBLE.getTypeSignature())
+                        .returnType(DataTypes.DOUBLE.getTypeSignature())
+                        .features(Scalar.Feature.DETERMINISTIC)
+                        .build(),
+                rows,
+                List.of()
         );
     }
 
     private Object execArrayFractionPercentile(DataType<?> argumentType, Object[][] rows) throws Exception {
         return executeAggregation(
-            Signature.aggregate(
-                PercentileAggregation.NAME,
-                argumentType.getTypeSignature(),
-                DataTypes.DOUBLE_ARRAY.getTypeSignature(),
-                DataTypes.DOUBLE_ARRAY.getTypeSignature()
-            ).withFeature(Scalar.Feature.DETERMINISTIC),
-            rows,
-            List.of()
+                Signature.builder(PercentileAggregation.NAME, FunctionType.AGGREGATE)
+                        .argumentTypes(argumentType.getTypeSignature(),
+                                DataTypes.DOUBLE_ARRAY.getTypeSignature())
+                        .returnType(DataTypes.DOUBLE_ARRAY.getTypeSignature())
+                        .features(Scalar.Feature.DETERMINISTIC)
+                        .build(),
+                rows,
+                List.of()
         );
     }
 
@@ -77,24 +78,24 @@ public class PercentileAggregationTest extends AggregationTestCase {
     @Before
     public void initFunctions() throws Exception {
         singleArgPercentile = (PercentileAggregation) nodeCtx.functions().getQualified(
-            Signature.aggregate(
-                PercentileAggregation.NAME,
-                DataTypes.DOUBLE.getTypeSignature(),
-                DataTypes.DOUBLE.getTypeSignature(),
-                DataTypes.DOUBLE.getTypeSignature()
-            ).withFeature(Scalar.Feature.DETERMINISTIC),
-            List.of(DataTypes.DOUBLE, DataTypes.DOUBLE),
-            DataTypes.DOUBLE
+                Signature.builder(PercentileAggregation.NAME, FunctionType.AGGREGATE)
+                        .argumentTypes(DataTypes.DOUBLE.getTypeSignature(),
+                                DataTypes.DOUBLE.getTypeSignature())
+                        .returnType(DataTypes.DOUBLE.getTypeSignature())
+                        .features(Scalar.Feature.DETERMINISTIC)
+                        .build(),
+                List.of(DataTypes.DOUBLE, DataTypes.DOUBLE),
+                DataTypes.DOUBLE
         );
         arraysPercentile = (PercentileAggregation) nodeCtx.functions().getQualified(
-            Signature.aggregate(
-                PercentileAggregation.NAME,
-                DataTypes.DOUBLE.getTypeSignature(),
-                DataTypes.DOUBLE_ARRAY.getTypeSignature(),
-                DataTypes.DOUBLE_ARRAY.getTypeSignature()
-            ).withFeature(Scalar.Feature.DETERMINISTIC),
-            List.of(DataTypes.DOUBLE, DataTypes.DOUBLE_ARRAY),
-            DataTypes.DOUBLE_ARRAY
+                Signature.builder(PercentileAggregation.NAME, FunctionType.AGGREGATE)
+                        .argumentTypes(DataTypes.DOUBLE.getTypeSignature(),
+                                DataTypes.DOUBLE_ARRAY.getTypeSignature())
+                        .returnType(DataTypes.DOUBLE_ARRAY.getTypeSignature())
+                        .features(Scalar.Feature.DETERMINISTIC)
+                        .build(),
+                List.of(DataTypes.DOUBLE, DataTypes.DOUBLE_ARRAY),
+                DataTypes.DOUBLE_ARRAY
         );
     }
 
@@ -230,14 +231,14 @@ public class PercentileAggregationTest extends AggregationTestCase {
     @Test
     public void testSingleItemFractionsArgumentResultsInArrayResult() {
         var impl = (AggregationFunction<Object, ?>) nodeCtx.functions().getQualified(
-            Signature.aggregate(
-                PercentileAggregation.NAME,
-                DataTypes.LONG.getTypeSignature(),
-                DataTypes.DOUBLE_ARRAY.getTypeSignature(),
-                DataTypes.DOUBLE_ARRAY.getTypeSignature()
-            ).withFeature(Scalar.Feature.DETERMINISTIC),
-            List.of(DataTypes.LONG, DataTypes.DOUBLE_ARRAY),
-            DataTypes.DOUBLE_ARRAY
+                Signature.builder(PercentileAggregation.NAME, FunctionType.AGGREGATE)
+                        .argumentTypes(DataTypes.LONG.getTypeSignature(),
+                                DataTypes.DOUBLE_ARRAY.getTypeSignature())
+                        .returnType(DataTypes.DOUBLE_ARRAY.getTypeSignature())
+                        .features(Scalar.Feature.DETERMINISTIC)
+                        .build(),
+                List.of(DataTypes.LONG, DataTypes.DOUBLE_ARRAY),
+                DataTypes.DOUBLE_ARRAY
         );
 
         RamAccounting ramAccounting = RamAccounting.NO_ACCOUNTING;
@@ -254,14 +255,14 @@ public class PercentileAggregationTest extends AggregationTestCase {
     @Test
     public void test_percentile_accounts_memory_for_tdigeststate() throws Exception {
         var impl = (AggregationFunction<Object, ?>) nodeCtx.functions().getQualified(
-            Signature.aggregate(
-                PercentileAggregation.NAME,
-                DataTypes.LONG.getTypeSignature(),
-                DataTypes.DOUBLE_ARRAY.getTypeSignature(),
-                DataTypes.DOUBLE_ARRAY.getTypeSignature()
-            ).withFeature(Scalar.Feature.DETERMINISTIC),
-            List.of(DataTypes.LONG, DataTypes.DOUBLE_ARRAY),
-            DataTypes.DOUBLE_ARRAY
+                Signature.builder(PercentileAggregation.NAME, FunctionType.AGGREGATE)
+                        .argumentTypes(DataTypes.LONG.getTypeSignature(),
+                                DataTypes.DOUBLE_ARRAY.getTypeSignature())
+                        .returnType(DataTypes.DOUBLE_ARRAY.getTypeSignature())
+                        .features(Scalar.Feature.DETERMINISTIC)
+                        .build(),
+                List.of(DataTypes.LONG, DataTypes.DOUBLE_ARRAY),
+                DataTypes.DOUBLE_ARRAY
         );
         RamAccounting ramAccounting = new PlainRamAccounting();
         Object state = impl.newState(ramAccounting, Version.CURRENT, Version.CURRENT, memoryManager);

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/StdDevAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/StdDevAggregationTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.FunctionImplementation;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.SearchPath;
 import io.crate.metadata.functions.Signature;
@@ -43,13 +44,13 @@ public class StdDevAggregationTest extends AggregationTestCase {
 
     private Object executeAggregation(DataType<?> argumentType, Object[][] data) throws Exception {
         return executeAggregation(
-            Signature.aggregate(
-                "stddev",
-                argumentType.getTypeSignature(),
-                DataTypes.DOUBLE.getTypeSignature()
-            ).withFeature(Scalar.Feature.DETERMINISTIC),
-            data,
-            List.of()
+                Signature.builder("stddev", FunctionType.AGGREGATE)
+                        .argumentTypes(argumentType.getTypeSignature())
+                        .returnType(DataTypes.DOUBLE.getTypeSignature())
+                        .features(Scalar.Feature.DETERMINISTIC)
+                        .build(),
+                data,
+                List.of()
         );
     }
 

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/SumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/SumAggregationTest.java
@@ -35,6 +35,7 @@ import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.FunctionImplementation;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.SearchPath;
 import io.crate.metadata.functions.Signature;
@@ -49,13 +50,13 @@ public class SumAggregationTest extends AggregationTestCase {
                                       DataType<?> returnType,
                                       Object[][] data) throws Exception {
         return executeAggregation(
-            Signature.aggregate(
-                SumAggregation.NAME,
-                argumentType.getTypeSignature(),
-                returnType.getTypeSignature()
-            ).withFeature(Scalar.Feature.DETERMINISTIC),
-            data,
-            List.of()
+                Signature.builder(SumAggregation.NAME, FunctionType.AGGREGATE)
+                        .argumentTypes(argumentType.getTypeSignature())
+                        .returnType(returnType.getTypeSignature())
+                        .features(Scalar.Feature.DETERMINISTIC)
+                        .build(),
+                data,
+                List.of()
         );
     }
 
@@ -114,11 +115,11 @@ public class SumAggregationTest extends AggregationTestCase {
     @Test
     public void testFloatSummationWithoutLosingPrecision() throws Exception {
         Object[][] rows = new Object[][] { { 0.8f }, { 0.4f }, { 0.2f } };
-        Signature signature = Signature.aggregate(
-            SumAggregation.NAME,
-            DataTypes.FLOAT.getTypeSignature(),
-            DataTypes.FLOAT.getTypeSignature()
-        ).withFeature(Scalar.Feature.DETERMINISTIC);
+        Signature signature = Signature.builder(SumAggregation.NAME, FunctionType.AGGREGATE)
+                .argumentTypes(DataTypes.FLOAT.getTypeSignature())
+                .returnType(DataTypes.FLOAT.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC)
+                .build();
         Object result = executeAggregation(
             signature,
             signature.getArgumentDataTypes(),
@@ -172,13 +173,13 @@ public class SumAggregationTest extends AggregationTestCase {
     public void testInterval() {
         assertThat(execPartialAggregationWithoutDocValues(
                 (IntervalSumAggregation) nodeCtx.functions().getQualified(
-                    Signature.aggregate(
-                            IntervalSumAggregation.NAME,
-                            DataTypes.INTERVAL.getTypeSignature(),
-                            DataTypes.INTERVAL.getTypeSignature())
-                        .withFeature(Scalar.Feature.DETERMINISTIC),
-                    List.of(DataTypes.INTERVAL),
-                    DataTypes.INTERVAL
+                        Signature.builder(IntervalSumAggregation.NAME, FunctionType.AGGREGATE)
+                                .argumentTypes(DataTypes.INTERVAL.getTypeSignature())
+                                .returnType(DataTypes.INTERVAL.getTypeSignature())
+                                .features(Scalar.Feature.DETERMINISTIC)
+                                .build(),
+                        List.of(DataTypes.INTERVAL),
+                        DataTypes.INTERVAL
                 ),
                 new Object[][]{
                     {Period.days(6).withHours(12).withSeconds(10)},

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/VarianceAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/VarianceAggregationTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 
 import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.expression.symbol.Literal;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.SearchPath;
 import io.crate.metadata.functions.Signature;
@@ -41,13 +42,13 @@ public class VarianceAggregationTest extends AggregationTestCase {
 
     private Object executeAggregation(DataType<?> argumentType, Object[][] data) throws Exception {
         return executeAggregation(
-            Signature.aggregate(
-                VarianceAggregation.NAME,
-                argumentType.getTypeSignature(),
-                DataTypes.DOUBLE.getTypeSignature()
-            ).withFeature(Scalar.Feature.DETERMINISTIC),
-            data,
-            List.of()
+                Signature.builder(VarianceAggregation.NAME, FunctionType.AGGREGATE)
+                        .argumentTypes(argumentType.getTypeSignature())
+                        .returnType(DataTypes.DOUBLE.getTypeSignature())
+                        .features(Scalar.Feature.DETERMINISTIC)
+                        .build(),
+                data,
+                List.of()
         );
     }
 

--- a/server/src/test/java/io/crate/execution/engine/collect/DocValuesAggregatesTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/DocValuesAggregatesTest.java
@@ -41,6 +41,7 @@ import io.crate.expression.reference.doc.lucene.LuceneReferenceResolver;
 import io.crate.expression.symbol.Aggregation;
 import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Literal;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
@@ -119,13 +120,13 @@ public class DocValuesAggregatesTest extends CrateDummyClusterServiceUnitTest {
             functions,
             mock(LuceneReferenceResolver.class),
             List.of(new Aggregation(
-                Signature.aggregate(
-                    SumAggregation.NAME,
-                    DataTypes.LONG.getTypeSignature(),
-                    DataTypes.LONG.getTypeSignature()
-                ).withFeature(Scalar.Feature.DETERMINISTIC),
-                DataTypes.LONG,
-                List.of(Literal.of(1L)))
+                    Signature.builder(SumAggregation.NAME, FunctionType.AGGREGATE)
+                            .argumentTypes(DataTypes.LONG.getTypeSignature())
+                            .returnType(DataTypes.LONG.getTypeSignature())
+                            .features(Scalar.Feature.DETERMINISTIC)
+                            .build(),
+                    DataTypes.LONG,
+                    List.of(Literal.of(1L)))
             ),
             Collections.emptyList(),
             table
@@ -214,13 +215,13 @@ public class DocValuesAggregatesTest extends CrateDummyClusterServiceUnitTest {
 
     private static Aggregation longSumAggregation(int inputCol) {
         return new Aggregation(
-            Signature.aggregate(
-                SumAggregation.NAME,
-                DataTypes.LONG.getTypeSignature(),
-                DataTypes.LONG.getTypeSignature()
-            ).withFeature(Scalar.Feature.DETERMINISTIC),
-            DataTypes.LONG,
-            List.of(new InputColumn(inputCol, DataTypes.LONG))
+                Signature.builder(SumAggregation.NAME, FunctionType.AGGREGATE)
+                        .argumentTypes(DataTypes.LONG.getTypeSignature())
+                        .returnType(DataTypes.LONG.getTypeSignature())
+                        .features(Scalar.Feature.DETERMINISTIC)
+                        .build(),
+                DataTypes.LONG,
+                List.of(new InputColumn(inputCol, DataTypes.LONG))
         );
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIteratorTest.java
@@ -70,6 +70,7 @@ import io.crate.expression.reference.doc.lucene.LuceneReferenceResolver;
 import io.crate.expression.symbol.AggregateMode;
 import io.crate.expression.symbol.InputColumn;
 import io.crate.lucene.LuceneQueryBuilder;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.IndexType;
 import io.crate.metadata.Reference;
@@ -116,11 +117,10 @@ public class DocValuesGroupByOptimizedIteratorTest extends CrateDummyClusterServ
     @Test
     public void test_group_by_doc_values_optimized_iterator_for_single_numeric_key() throws Exception {
         SumAggregation<?> sumAggregation = (SumAggregation<?>) functions.getQualified(
-            Signature.aggregate(
-                SumAggregation.NAME,
-                DataTypes.LONG.getTypeSignature(),
-                DataTypes.LONG.getTypeSignature()
-            ),
+            Signature.builder(SumAggregation.NAME, FunctionType.AGGREGATE)
+                .argumentTypes(DataTypes.LONG.getTypeSignature())
+                .returnType(DataTypes.LONG.getTypeSignature())
+                .build(),
             List.of(DataTypes.LONG),
             DataTypes.LONG
         );
@@ -177,11 +177,10 @@ public class DocValuesGroupByOptimizedIteratorTest extends CrateDummyClusterServ
     @Test
     public void test_group_by_doc_values_optimized_iterator_for_many_keys() throws Exception {
         SumAggregation<?> sumAggregation = (SumAggregation<?>) functions.getQualified(
-            Signature.aggregate(
-                SumAggregation.NAME,
-                DataTypes.LONG.getTypeSignature(),
-                DataTypes.LONG.getTypeSignature()
-            ),
+            Signature.builder(SumAggregation.NAME, FunctionType.AGGREGATE)
+                .argumentTypes(DataTypes.LONG.getTypeSignature())
+                .returnType(DataTypes.LONG.getTypeSignature())
+                .build(),
             List.of(DataTypes.LONG),
             DataTypes.LONG
         );

--- a/server/src/test/java/io/crate/execution/engine/pipeline/MapRowUsingInputsTest.java
+++ b/server/src/test/java/io/crate/execution/engine/pipeline/MapRowUsingInputsTest.java
@@ -41,7 +41,9 @@ import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Literal;
 import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.Scalar.Feature;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
@@ -57,14 +59,12 @@ public class MapRowUsingInputsTest extends ESTestCase {
         InputFactory inputFactory = new InputFactory(createNodeContext());
         InputFactory.Context<CollectExpression<Row, ?>> ctx = inputFactory.ctxForInputColumns(txnCtx);
         var addFunction = new Function(
-            Signature.scalar(
-                    ArithmeticFunctions.Names.ADD,
-                    DataTypes.LONG.getTypeSignature(),
-                    DataTypes.LONG.getTypeSignature(),
-                    DataTypes.LONG.getTypeSignature()
-                )
-                .withFeatures(Scalar.DETERMINISTIC_AND_COMPARISON_REPLACEMENT)
-                .withFeature(Scalar.Feature.NULLABLE),
+            Signature.builder(ArithmeticFunctions.Names.ADD, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.LONG.getTypeSignature(),
+                    DataTypes.LONG.getTypeSignature())
+                .returnType(DataTypes.LONG.getTypeSignature())
+                .features(Feature.DETERMINISTIC, Feature.COMPARISON_REPLACEMENT, Scalar.Feature.NULLABLE)
+                .build(),
             List.of(new InputColumn(0, DataTypes.LONG), Literal.of(2L)),
             DataTypes.LONG
         );

--- a/server/src/test/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitorTest.java
@@ -77,6 +77,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.memory.OnHeapMemoryManager;
 import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.Scalar;
@@ -114,11 +115,11 @@ public class ProjectionToProjectorVisitorTest extends CrateDummyClusterServiceUn
         );
         memoryManager = new OnHeapMemoryManager(usedBytes -> {});
 
-        avgSignature = Signature.aggregate(
-            "avg",
-            DataTypes.INTEGER.getTypeSignature(),
-            DataTypes.DOUBLE.getTypeSignature()
-        ).withFeature(Scalar.Feature.DETERMINISTIC);
+        avgSignature = Signature.builder("avg", FunctionType.AGGREGATE)
+                .argumentTypes(DataTypes.INTEGER.getTypeSignature())
+                .returnType(DataTypes.DOUBLE.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC)
+                .build();
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/engine/window/WindowBatchIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/window/WindowBatchIteratorTest.java
@@ -53,6 +53,7 @@ import io.crate.data.testing.TestingBatchIterators;
 import io.crate.data.testing.TestingRowConsumer;
 import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.execution.engine.sort.OrderingByPosition;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
@@ -400,7 +401,11 @@ public class WindowBatchIteratorTest {
 
             @Override
             public Signature signature() {
-                return Signature.window("first_cell_value", DataTypes.INTEGER.getTypeSignature()).withFeature(Scalar.Feature.DETERMINISTIC);
+                return Signature.builder("first_cell_value", FunctionType.WINDOW)
+                        .argumentTypes()
+                        .returnType(DataTypes.INTEGER.getTypeSignature())
+                        .features(Scalar.Feature.DETERMINISTIC)
+                        .build();
             }
 
             @Override
@@ -424,7 +429,11 @@ public class WindowBatchIteratorTest {
 
             @Override
             public Signature signature() {
-                return Signature.window("a_frame_bounded_window_function", DataTypes.INTEGER.getTypeSignature()).withFeature(Scalar.Feature.DETERMINISTIC);
+                return Signature.builder("a_frame_bounded_window_function", FunctionType.WINDOW)
+                        .argumentTypes()
+                        .returnType(DataTypes.INTEGER.getTypeSignature())
+                        .features(Scalar.Feature.DETERMINISTIC)
+                        .build();
             }
 
             @Override
@@ -449,7 +458,11 @@ public class WindowBatchIteratorTest {
 
             @Override
             public Signature signature() {
-                return Signature.window("row_number", DataTypes.INTEGER.getTypeSignature()).withFeature(Scalar.Feature.DETERMINISTIC);
+                return Signature.builder("row_number", FunctionType.WINDOW)
+                        .argumentTypes()
+                        .returnType(DataTypes.INTEGER.getTypeSignature())
+                        .features(Scalar.Feature.DETERMINISTIC)
+                        .build();
             }
 
             @Override

--- a/server/src/test/java/io/crate/expression/InputFactoryTest.java
+++ b/server/src/test/java/io/crate/expression/InputFactoryTest.java
@@ -47,8 +47,10 @@ import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.FunctionImplementation;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.Scalar.Feature;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.Signature;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
@@ -62,16 +64,14 @@ public class InputFactoryTest extends CrateDummyClusterServiceUnitTest {
     private InputFactory factory;
     private TransactionContext txnCtx = CoordinatorTxnCtx.systemTransactionContext();
     private Function add = new Function(
-        Signature.scalar(
-                ArithmeticFunctions.Names.ADD,
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.INTEGER.getTypeSignature()
-            )
-            .withFeatures(Scalar.DETERMINISTIC_AND_COMPARISON_REPLACEMENT)
-            .withFeature(Scalar.Feature.NULLABLE),
-        List.of(new InputColumn(1, DataTypes.INTEGER), Literal.of(10)),
-        DataTypes.INTEGER
+            Signature.builder(ArithmeticFunctions.Names.ADD, FunctionType.SCALAR)
+                    .argumentTypes(DataTypes.INTEGER.getTypeSignature(),
+                            DataTypes.INTEGER.getTypeSignature())
+                    .returnType(DataTypes.INTEGER.getTypeSignature())
+                    .features(Feature.DETERMINISTIC, Feature.COMPARISON_REPLACEMENT, Scalar.Feature.NULLABLE)
+                    .build(),
+            List.of(new InputColumn(1, DataTypes.INTEGER), Literal.of(10)),
+            DataTypes.INTEGER
     );
 
     @Before

--- a/server/src/test/java/io/crate/expression/scalar/cast/CastFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/cast/CastFunctionTest.java
@@ -47,6 +47,7 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.format.Style;
 import io.crate.geo.GeoJSONUtils;
 import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.ArrayType;
@@ -246,13 +247,13 @@ public class CastFunctionTest extends ScalarTestCase {
             .setInnerType("field", DataTypes.STRING)
             .build();
 
-        var signature = Signature.scalar(
-                ExplicitCastFunction.NAME,
-                TypeSignature.parse("E"),
-                TypeSignature.parse("V"),
-                TypeSignature.parse("V")
-            ).withFeature(Scalar.Feature.DETERMINISTIC)
-            .withTypeVariableConstraints(typeVariable("E"), typeVariable("V"));
+        var signature = Signature.builder(ExplicitCastFunction.NAME, FunctionType.SCALAR)
+            .argumentTypes(TypeSignature.parse("E"),
+                TypeSignature.parse("V"))
+            .returnType(TypeSignature.parse("V"))
+            .features(Scalar.Feature.DETERMINISTIC)
+            .typeVariableConstraints(typeVariable("E"), typeVariable("V"))
+            .build();
         var functionImpl = sqlExpressions.nodeCtx.functions().getQualified(
             signature,
             List.of(DataTypes.UNTYPED_OBJECT, returnType),

--- a/server/src/test/java/io/crate/expression/symbol/FunctionTest.java
+++ b/server/src/test/java/io/crate/expression/symbol/FunctionTest.java
@@ -35,6 +35,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
 
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.testing.TestingHelpers;
@@ -45,12 +46,11 @@ public class FunctionTest extends ESTestCase {
 
     private DataType<?> returnType = TestingHelpers.randomPrimitiveType();
 
-    private Signature signature = Signature.scalar(
-            randomAsciiLettersOfLength(10),
-            DataTypes.BOOLEAN.getTypeSignature(),
-            returnType.getTypeSignature()
-        ).withFeature(Scalar.Feature.DETERMINISTIC)
-        .withFeatures(randomFeatures());
+    private Signature signature = Signature.builder(randomAsciiLettersOfLength(10), FunctionType.SCALAR)
+        .argumentTypes(DataTypes.BOOLEAN.getTypeSignature())
+        .returnType(returnType.getTypeSignature())
+        .features(EnumSet.of(Scalar.Feature.DETERMINISTIC, randomFeatures().toArray(Scalar.Feature[]::new)))
+        .build();
 
 
     @Test

--- a/server/src/test/java/io/crate/expression/symbol/WindowFunctionSerializationTest.java
+++ b/server/src/test/java/io/crate/expression/symbol/WindowFunctionSerializationTest.java
@@ -37,6 +37,7 @@ import org.junit.Test;
 import io.crate.analyze.WindowDefinition;
 import io.crate.execution.engine.aggregation.impl.SumAggregation;
 import io.crate.metadata.FunctionImplementation;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
@@ -49,13 +50,13 @@ public class WindowFunctionSerializationTest {
 
     private FunctionImplementation dummyFunction =
         functions.getQualified(
-            Signature.aggregate(
-                    SumAggregation.NAME,
-                    DataTypes.FLOAT.getTypeSignature(),
-                    DataTypes.FLOAT.getTypeSignature())
-                .withFeature(Scalar.Feature.DETERMINISTIC),
-            List.of(DataTypes.FLOAT),
-            DataTypes.FLOAT
+                Signature.builder(SumAggregation.NAME, FunctionType.AGGREGATE)
+                        .argumentTypes(DataTypes.FLOAT.getTypeSignature())
+                        .returnType(DataTypes.FLOAT.getTypeSignature())
+                        .features(Scalar.Feature.DETERMINISTIC)
+                        .build(),
+                List.of(DataTypes.FLOAT),
+                DataTypes.FLOAT
         );
 
     private WindowFunction windowFunctionWithIgnoreNullsSetToTrue =

--- a/server/src/test/java/io/crate/expression/symbol/format/SymbolFormatterTest.java
+++ b/server/src/test/java/io/crate/expression/symbol/format/SymbolFormatterTest.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbols;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
@@ -42,12 +43,12 @@ public class SymbolFormatterTest extends ESTestCase {
     @Test
     public void testFormat() throws Exception {
         Function f = new Function(
-            Signature.scalar(
-                "foo",
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.UNDEFINED.getTypeSignature(),
-                DataTypes.DOUBLE.getTypeSignature()
-            ).withFeature(Scalar.Feature.DETERMINISTIC),
+            Signature.builder("foo", FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(),
+                    DataTypes.UNDEFINED.getTypeSignature())
+                .returnType(DataTypes.DOUBLE.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC)
+                .build(),
             List.of(Literal.of("bar"), Literal.of(3.4)),
             DataTypes.DOUBLE
         );

--- a/server/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
+++ b/server/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
@@ -43,6 +43,7 @@ import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.VoidReference;
 import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RelationName;
@@ -136,11 +137,11 @@ public class SymbolPrinterTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testFormatAggregation() {
-        Signature signature = Signature.aggregate(
-            "agg",
-            DataTypes.INTEGER.getTypeSignature(),
-            DataTypes.LONG.getTypeSignature()
-        ).withFeature(Scalar.Feature.DETERMINISTIC);
+        Signature signature = Signature.builder("agg", FunctionType.AGGREGATE)
+                .argumentTypes(DataTypes.INTEGER.getTypeSignature())
+                .returnType(DataTypes.LONG.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC)
+                .build();
         Aggregation a = new Aggregation(
             signature,
             DataTypes.LONG,

--- a/server/src/test/java/io/crate/integrationtests/UserDefinedFunctionsIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/UserDefinedFunctionsIntegrationTest.java
@@ -266,9 +266,7 @@ public class UserDefinedFunctionsIntegrationTest extends IntegTestCase {
     @Test
     public void test_pg_function_is_visible() throws Exception {
         Signature signature = Signature
-            .builder()
-            .kind(FunctionType.SCALAR)
-            .name(new FunctionName(Schemas.DOC_SCHEMA_NAME, "my_func"))
+            .builder(new FunctionName(Schemas.DOC_SCHEMA_NAME, "my_func"), FunctionType.SCALAR)
             .argumentTypes(
                 TypeSignature.parse("array(array(integer))"),
                 TypeSignature.parse("integer"),
@@ -294,10 +292,7 @@ public class UserDefinedFunctionsIntegrationTest extends IntegTestCase {
     public void test_pg_get_function_result() throws Exception {
         TypeSignature returnTypeSig = TypeSignature.parse("array(array(integer))");
         String returnType = returnTypeSig.toString();
-        Signature signature = Signature
-            .builder()
-            .kind(FunctionType.SCALAR)
-            .name(new FunctionName(Schemas.DOC_SCHEMA_NAME, "make_2d_array"))
+        Signature signature = Signature.builder(new FunctionName(Schemas.DOC_SCHEMA_NAME, "make_2d_array"), FunctionType.SCALAR)
             .argumentTypes(DataTypes.INTEGER.getTypeSignature())
             .returnType(returnTypeSig)
             .build();
@@ -318,11 +313,7 @@ public class UserDefinedFunctionsIntegrationTest extends IntegTestCase {
 
     @Test
     public void test_pg_function_is_visible_when_oid_is_retrieved_from_column() throws Exception {
-        Signature signature = Signature
-            .builder()
-            .kind(FunctionType.SCALAR)
-            .name(new FunctionName(null, CurrentTimeFunction.NAME))
-            .argumentTypes()
+        Signature signature = Signature.builder(new FunctionName(null, CurrentTimeFunction.NAME), FunctionType.SCALAR)
             .returnType(DataTypes.TIMETZ.getTypeSignature())
             .build();
         int functionOid = OidHash.functionOid(signature);

--- a/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -56,18 +56,19 @@ import io.crate.expression.symbol.AliasSymbol;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.lucene.match.CrateRegexQuery;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.doc.DocSchemaInfo;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.functions.Signature;
+import io.crate.role.Role;
 import io.crate.testing.QueryTester;
 import io.crate.testing.SQLExecutor;
 import io.crate.testing.SqlExpressions;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.TypeSignature;
-import io.crate.role.Role;
 
 public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
 
@@ -619,12 +620,12 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
         // Testing expression: f(col as alias) = 'foo'
         AliasSymbol alias = new AliasSymbol("aliased", createReference("arr", DataTypes.INTEGER_ARRAY));
         var innerFunction = new Function(
-            Signature.scalar(
-                "array_length",
-                TypeSignature.parse("array(E)"),
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.INTEGER.getTypeSignature()
-            ).withFeature(Scalar.Feature.DETERMINISTIC),
+            Signature.builder("array_length", FunctionType.SCALAR)
+                .argumentTypes(TypeSignature.parse("array(E)"),
+                    DataTypes.INTEGER.getTypeSignature())
+                .returnType(DataTypes.INTEGER.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC)
+                .build(),
             List.of(alias, Literal.of(1)), // 1 is a dummy argument for dimension.
             DataTypes.INTEGER
         );

--- a/server/src/test/java/io/crate/metadata/FunctionsTest.java
+++ b/server/src/test/java/io/crate/metadata/FunctionsTest.java
@@ -82,11 +82,11 @@ public class FunctionsTest extends ESTestCase {
     @Test
     public void test_signature_matches_exact() {
         functionsBuilder.add(
-            Signature.scalar(
-                "foo",
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Scalar.Feature.DETERMINISTIC),
+            Signature.builder("foo", FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC)
+                .build(),
             (signature, args) -> new DummyFunction(signature));
         var impl = resolve("foo", List.of(Literal.of("hoschi")));
         assertThat(impl.boundSignature().argTypes()).containsExactly(DataTypes.STRING);
@@ -95,11 +95,11 @@ public class FunctionsTest extends ESTestCase {
     @Test
     public void test_signature_matches_with_coercion() {
         functionsBuilder.add(
-            Signature.scalar(
-                "foo",
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature()
-            ).withFeature(Scalar.Feature.DETERMINISTIC),
+            Signature.builder("foo", FunctionType.SCALAR)
+                .argumentTypes(DataTypes.INTEGER.getTypeSignature())
+                .returnType(DataTypes.STRING.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC)
+                .build(),
             (signature, args) -> new DummyFunction(signature));
         var impl = resolve("foo", List.of(Literal.of(1L)));
         assertThat(impl.boundSignature().argTypes()).containsExactly(DataTypes.INTEGER);
@@ -108,18 +108,18 @@ public class FunctionsTest extends ESTestCase {
     @Test
     public void test_signature_matches_with_coercion_and_precedence() {
         functionsBuilder.add(
-            Signature.scalar(
-                "foo",
-                DataTypes.DOUBLE.getTypeSignature(),
-                DataTypes.DOUBLE.getTypeSignature()
-            ).withFeature(Scalar.Feature.DETERMINISTIC),
+            Signature.builder("foo", FunctionType.SCALAR)
+                .argumentTypes(DataTypes.DOUBLE.getTypeSignature())
+                .returnType(DataTypes.DOUBLE.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC)
+                .build(),
             (signature, args) -> new DummyFunction(signature));
         functionsBuilder.add(
-            Signature.scalar(
-                "foo",
-                DataTypes.FLOAT.getTypeSignature(),
-                DataTypes.FLOAT.getTypeSignature()
-            ).withFeature(Scalar.Feature.DETERMINISTIC),
+            Signature.builder("foo", FunctionType.SCALAR)
+                .argumentTypes(DataTypes.FLOAT.getTypeSignature())
+                .returnType(DataTypes.FLOAT.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC)
+                .build(),
             (signature, args) -> new DummyFunction(signature));
 
         var impl = resolve("foo", List.of(Literal.of(1L)));
@@ -131,19 +131,19 @@ public class FunctionsTest extends ESTestCase {
     @Test
     public void test_multiple_signature_matches_with_same_return_type_results_in_first_selected() {
         functionsBuilder.add(
-            Signature.scalar(
-                "foo",
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.INTEGER.getTypeSignature()
-            ).withFeature(Scalar.Feature.DETERMINISTIC),
+            Signature.builder("foo", FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.INTEGER.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC)
+                .build(),
             (signature, args) -> new DummyFunction(signature));
         functionsBuilder.add(
-            Signature.scalar(
-                    "foo",
-                    TypeSignature.parse("array(E)"),
-                    DataTypes.INTEGER.getTypeSignature()
-                ).withFeature(Scalar.Feature.DETERMINISTIC)
-                .withTypeVariableConstraints(typeVariable("E")),
+            Signature.builder("foo", FunctionType.SCALAR)
+                .argumentTypes(TypeSignature.parse("array(E)"))
+                .returnType(DataTypes.INTEGER.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC)
+                .typeVariableConstraints(typeVariable("E"))
+                .build(),
             (signature, args) -> new DummyFunction(signature));
 
         var impl = resolve("foo", List.of(Literal.of(DataTypes.UNDEFINED, null)));
@@ -153,18 +153,18 @@ public class FunctionsTest extends ESTestCase {
     @Test
     public void test_checks_built_in_and_udf_per_search_path_schema() throws Exception {
         functionsBuilder.add(
-            Signature.scalar(
-                new FunctionName("schema1", "foo"),
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.INTEGER.getTypeSignature()
-            ).withFeature(Scalar.Feature.DETERMINISTIC),
+            Signature.builder(new FunctionName("schema1", "foo"), FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.INTEGER.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC)
+                .build(),
             (signature, args) -> new DummyFunction(signature));
         Functions functions = functionsBuilder.build();
-        Signature signature = Signature.scalar(
-            new FunctionName("schema2", "foo"),
-            DataTypes.STRING.getTypeSignature(),
-            DataTypes.INTEGER.getTypeSignature()
-        ).withFeature(Scalar.Feature.DETERMINISTIC);
+        Signature signature = Signature.builder(new FunctionName("schema2", "foo"), FunctionType.SCALAR)
+            .argumentTypes(DataTypes.STRING.getTypeSignature())
+            .returnType(DataTypes.INTEGER.getTypeSignature())
+            .features(Scalar.Feature.DETERMINISTIC)
+            .build();
         functions.setUDFs(
             Map.of(
                 new FunctionName("schema2", "foo"),
@@ -180,19 +180,19 @@ public class FunctionsTest extends ESTestCase {
     @Test
     public void test_multiple_signature_matches_with_undefined_arguments_only_result_in_first_selected() {
         functionsBuilder.add(
-            Signature.scalar(
-                "foo",
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.INTEGER.getTypeSignature()
-            ).withFeature(Scalar.Feature.DETERMINISTIC),
+            Signature.builder("foo", FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.INTEGER.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC)
+                .build(),
             (signature, args) -> new DummyFunction(signature));
         functionsBuilder.add(
-            Signature.scalar(
-                    "foo",
-                    TypeSignature.parse("array(E)"),
-                    TypeSignature.parse("array(E)")
-                ).withTypeVariableConstraints(typeVariable("E"))
-                .withFeature(Scalar.Feature.DETERMINISTIC),
+            Signature.builder("foo", FunctionType.SCALAR)
+                .argumentTypes(TypeSignature.parse("array(E)"))
+                .returnType(TypeSignature.parse("array(E)"))
+                .features(Scalar.Feature.DETERMINISTIC)
+                .typeVariableConstraints(typeVariable("E"))
+                .build(),
             (signature, args) -> new DummyFunction(signature));
 
         var impl = resolve("foo", List.of(Literal.of(DataTypes.UNDEFINED, null)));
@@ -204,28 +204,28 @@ public class FunctionsTest extends ESTestCase {
         // We had a regression where this worked for 2 signatures (1 matching, 1 not matching)
         // but not with multiple not matching signatures. So lets use at least 2 not matching.
         functionsBuilder.add(
-            Signature.scalar(
-                "foo",
-                DataTypes.BOOLEAN.getTypeSignature(),
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.INTEGER.getTypeSignature()
-            ).withFeature(Scalar.Feature.DETERMINISTIC),
+            Signature.builder("foo", FunctionType.SCALAR)
+                .argumentTypes(DataTypes.BOOLEAN.getTypeSignature(),
+                    DataTypes.STRING.getTypeSignature())
+                .returnType(DataTypes.INTEGER.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC)
+                .build(),
             (signature, args) -> new DummyFunction(signature));
         functionsBuilder.add(
-            Signature.scalar(
-                "foo",
-                DataTypes.STRING.getTypeSignature(),
-                DataTypes.SHORT.getTypeSignature(),
-                DataTypes.INTEGER.getTypeSignature()
-            ).withFeature(Scalar.Feature.DETERMINISTIC),
+            Signature.builder("foo", FunctionType.SCALAR)
+                .argumentTypes(DataTypes.STRING.getTypeSignature(),
+                    DataTypes.SHORT.getTypeSignature())
+                .returnType(DataTypes.INTEGER.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC)
+                .build(),
             (signature, args) -> new DummyFunction(signature));
         functionsBuilder.add(
-            Signature.scalar(
-                "foo",
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.INTEGER.getTypeSignature(),
-                DataTypes.INTEGER.getTypeSignature()
-            ).withFeature(Scalar.Feature.DETERMINISTIC),
+            Signature.builder("foo", FunctionType.SCALAR)
+                .argumentTypes(DataTypes.INTEGER.getTypeSignature(),
+                    DataTypes.INTEGER.getTypeSignature())
+                .returnType(DataTypes.INTEGER.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC)
+                .build(),
             (signature, args) -> new DummyFunction(signature));
 
         var impl = resolve("foo", List.of(Literal.of(1), Literal.of(1L)));
@@ -234,11 +234,11 @@ public class FunctionsTest extends ESTestCase {
 
     @Test
     public void test_bwc_get_qualified_function_without_signature() {
-        var signature = Signature.scalar(
-            "foo",
-            DataTypes.STRING.getTypeSignature(),
-            DataTypes.INTEGER.getTypeSignature()
-        ).withFeature(Scalar.Feature.DETERMINISTIC);
+        var signature = Signature.builder("foo", FunctionType.SCALAR)
+            .argumentTypes(DataTypes.STRING.getTypeSignature())
+            .returnType(DataTypes.INTEGER.getTypeSignature())
+            .features(Scalar.Feature.DETERMINISTIC)
+            .build();
         var dummyFunction = new DummyFunction(signature);
 
         functionsBuilder.add(signature, (s, args) -> dummyFunction);
@@ -251,11 +251,11 @@ public class FunctionsTest extends ESTestCase {
 
     @Test
     public void test_bwc_get_qualified_aggregation_without_signature() {
-        var signature = Signature.scalar(
-            "foo",
-            DataTypes.STRING.getTypeSignature(),
-            DataTypes.INTEGER.getTypeSignature()
-        ).withFeature(Scalar.Feature.DETERMINISTIC);
+        var signature = Signature.builder("foo", FunctionType.SCALAR)
+            .argumentTypes(DataTypes.STRING.getTypeSignature())
+            .returnType(DataTypes.INTEGER.getTypeSignature())
+            .features(Scalar.Feature.DETERMINISTIC)
+            .build();
         var dummyFunction = new DummyFunction(signature);
 
         functionsBuilder.add(signature, (s, args) -> dummyFunction);
@@ -288,17 +288,19 @@ public class FunctionsTest extends ESTestCase {
                 List.of(),
                 List.of(
                     new FunctionProvider(
-                        Signature.scalar(new FunctionName("foo", "bar"),
-                                        DataTypes.STRING.getTypeSignature(),
-                                        DataTypes.STRING.getTypeSignature())
-                            .withFeature(Scalar.Feature.DETERMINISTIC),
+                        Signature.builder(new FunctionName("foo", "bar"), FunctionType.SCALAR)
+                            .argumentTypes(DataTypes.STRING.getTypeSignature())
+                            .returnType(DataTypes.STRING.getTypeSignature())
+                            .features(Scalar.Feature.DETERMINISTIC)
+                            .build(),
                         ((signature, dataTypes) -> null)
                     ),
                     new FunctionProvider(
-                        Signature.scalar(new FunctionName("foo", "bar"),
-                                        DataTypes.DOUBLE.getTypeSignature(),
-                                        DataTypes.DOUBLE.getTypeSignature())
-                            .withFeature(Scalar.Feature.DETERMINISTIC),
+                        Signature.builder(new FunctionName("foo", "bar"), FunctionType.SCALAR)
+                            .argumentTypes(DataTypes.DOUBLE.getTypeSignature())
+                            .returnType(DataTypes.DOUBLE.getTypeSignature())
+                            .features(Scalar.Feature.DETERMINISTIC)
+                            .build(),
                         ((signature, dataTypes) -> null)
                     )
                 )
@@ -317,17 +319,19 @@ public class FunctionsTest extends ESTestCase {
                 List.of(Literal.of(1), Literal.of(2)),
                 List.of(
                     new FunctionProvider(
-                        Signature.scalar(new FunctionName("foo", "bar"),
-                                        DataTypes.STRING.getTypeSignature(),
-                                        DataTypes.STRING.getTypeSignature())
-                            .withFeature(Scalar.Feature.DETERMINISTIC),
+                        Signature.builder(new FunctionName("foo", "bar"), FunctionType.SCALAR)
+                            .argumentTypes(DataTypes.STRING.getTypeSignature())
+                            .returnType(DataTypes.STRING.getTypeSignature())
+                            .features(Scalar.Feature.DETERMINISTIC)
+                            .build(),
                         ((signature, dataTypes) -> null)
                     ),
                     new FunctionProvider(
-                        Signature.scalar(new FunctionName("foo", "bar"),
-                                        DataTypes.DOUBLE.getTypeSignature(),
-                                        DataTypes.DOUBLE.getTypeSignature())
-                            .withFeature(Scalar.Feature.DETERMINISTIC),
+                        Signature.builder(new FunctionName("foo", "bar"), FunctionType.SCALAR)
+                            .argumentTypes(DataTypes.DOUBLE.getTypeSignature())
+                            .returnType(DataTypes.DOUBLE.getTypeSignature())
+                            .features(Scalar.Feature.DETERMINISTIC)
+                            .build(),
                         ((signature, dataTypes) -> null)
                     )
                 )

--- a/server/src/test/java/io/crate/metadata/functions/SignatureBinderTest.java
+++ b/server/src/test/java/io/crate/metadata/functions/SignatureBinderTest.java
@@ -51,9 +51,7 @@ import io.crate.types.TypeSignature;
 public class SignatureBinderTest extends ESTestCase {
 
     private static Signature.Builder functionSignature() {
-        return Signature.builder()
-            .name("function")
-            .kind(SCALAR);
+        return Signature.builder("function", SCALAR);
     }
 
     @Test

--- a/server/src/test/java/io/crate/metadata/functions/SignatureTest.java
+++ b/server/src/test/java/io/crate/metadata/functions/SignatureTest.java
@@ -43,10 +43,8 @@ public class SignatureTest {
             .setInnerType("x", DataTypes.INTEGER)
             .build();
 
-        var signature = Signature.builder()
-            .name("foo")
-            .kind(FunctionType.SCALAR)
-            .argumentTypes(
+        var signature = Signature.builder("foo", FunctionType.SCALAR)
+                .argumentTypes(
                 TypeSignature.parse("E"),
                 DataTypes.INTEGER.getTypeSignature(),
                 objectType.getTypeSignature()

--- a/server/src/test/java/io/crate/planner/operators/FetchRewriteTest.java
+++ b/server/src/test/java/io/crate/planner/operators/FetchRewriteTest.java
@@ -43,6 +43,7 @@ import io.crate.expression.symbol.AliasSymbol;
 import io.crate.expression.symbol.FetchStub;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Scalar;
@@ -68,12 +69,12 @@ public class FetchRewriteTest extends CrateDummyClusterServiceUnitTest {
             collect,
             List.of(
                 new Function(
-                    Signature.scalar(
-                        "add",
-                        DataTypes.INTEGER.getTypeSignature(),
-                        DataTypes.INTEGER.getTypeSignature(),
-                        DataTypes.INTEGER.getTypeSignature()
-                    ).withFeature(Scalar.Feature.DETERMINISTIC),
+                    Signature.builder("add", FunctionType.SCALAR)
+                        .argumentTypes(DataTypes.INTEGER.getTypeSignature(),
+                            DataTypes.INTEGER.getTypeSignature())
+                        .returnType(DataTypes.INTEGER.getTypeSignature())
+                        .features(Scalar.Feature.DETERMINISTIC)
+                        .build(),
                     List.of(x, x),
                     DataTypes.INTEGER
                 )

--- a/server/src/testFixtures/java/io/crate/testing/SleepScalarFunction.java
+++ b/server/src/testFixtures/java/io/crate/testing/SleepScalarFunction.java
@@ -22,6 +22,7 @@
 package io.crate.testing;
 
 import io.crate.data.Input;
+import io.crate.metadata.FunctionType;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
@@ -34,11 +35,10 @@ public class SleepScalarFunction extends Scalar<Boolean, Long> {
 
     public static final String NAME = "sleep";
 
-    public static final Signature SIGNATURE = Signature.scalar(
-        NAME,
-        DataTypes.LONG.getTypeSignature(),
-        DataTypes.BOOLEAN.getTypeSignature()
-    );
+    public static final Signature SIGNATURE = Signature.builder(NAME, FunctionType.SCALAR)
+        .argumentTypes(DataTypes.LONG.getTypeSignature())
+        .returnType(DataTypes.BOOLEAN.getTypeSignature())
+        .build();
 
     public SleepScalarFunction(Signature signature, BoundSignature boundSignature) {
         super(signature, boundSignature);


### PR DESCRIPTION
Alternative to https://github.com/crate/crate/pull/16270 which
immediately replaces the `with` calls by going through `builder()`

The functions are pretty much only used when creating a signature in
which case it is cheaper to stick to modifying the builder.

We should have:

- Create builder once
- Set all properties
- Create Signature once

Instead of

- Create builder
- Create Signature
- Re-create builder and signature again per .with call

Most of the refactors were IntelliJ structural replacements with query
and replacements like:

    io.crate.metadata.functions.Signature.scalar($name$, $types$, $returnType$)
            .withTypeVariableConstraints($typeVariables$)
            .withFeature($feat1$)
            .withFeature($feat2$)

    Signature.builder($name$, FunctionType.SCALAR)
            .argumentTypes($types$)
            .returnType($returnType$)
            .typeVariableConstraints($typeVariables$)
            .features($feat1$, $feat2$)
            .build()
