### PR TITLE
Forbid both balance.index and balance.shard factors to be set to 0

### DIFF
--- a/app/src/main/dist/config/crate.yml
+++ b/app/src/main/dist/config/crate.yml
@@ -528,6 +528,10 @@ auth:
 # node (float).
 #cluster.routing.allocation.balance.index: 0.5f
 
+## Note that cluster.routing.allocation.balance.shard & cluster.routing.allocation.balance.index
+## cannot be both set to 0.0f
+
+
 # Defines a weight factor for the number of primaries of a specific index
 # allocated on a node (float).
 #cluster.routing.allocation.balance.primary: 0.05f

--- a/docs/appendices/release-notes/5.7.3.rst
+++ b/docs/appendices/release-notes/5.7.3.rst
@@ -48,6 +48,12 @@ See the :ref:`version_5.7.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Added check to forbid setting both
+  :ref:`cluster.routing.allocation.balance.shard` and
+  :ref:`cluster.routing.allocation.balance.index` to `0.0f` as this could
+  lead, if both settings are set as ``persistent``, to a cluster not being able
+  to start up.
+
 - Fixed an issue that resulted in ``ColumnUnknownException`` errors when using a
   subscript expression on a ``object(ignored)`` column of a foreign table
   despite having set :ref:`error_on_unknown_object_key

--- a/docs/config/cluster.rst
+++ b/docs/config/cluster.rst
@@ -705,6 +705,12 @@ each node closer together.
   <gloss-shard-allocation>` on a node (float). Raising this raises the tendency
   to equalize the number of shards across all nodes in the cluster.
 
+.. NOTE::
+
+    :ref:`cluster.routing.allocation.balance.shard` and
+    :ref:`cluster.routing.allocation.balance.index` cannot be both set to
+    ``0.0f``.
+
 .. _cluster.routing.allocation.balance.index:
 
 **cluster.routing.allocation.balance.index**
@@ -715,6 +721,12 @@ each node closer together.
   <gloss-shard-allocation>` on a specific node (float). Increasing this value
   raises the tendency to equalize the number of shards per index across all
   nodes in the cluster.
+
+.. NOTE::
+
+    :ref:`cluster.routing.allocation.balance.shard` and
+    :ref:`cluster.routing.allocation.balance.index` cannot be both set to
+    ``0.0f``.
 
 .. _cluster.routing.allocation.balance.threshold:
 

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -19,6 +19,9 @@
 
 package org.elasticsearch.common.settings;
 
+import static org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator.INDEX_BALANCE_FACTOR_SETTING;
+import static org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator.SHARD_BALANCE_FACTOR_SETTING;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -138,6 +141,17 @@ public final class ClusterSettings extends AbstractScopedSettings {
 
     public List<Setting<?>> maskedSettings() {
         return maskedSettings;
+    }
+
+    @Override
+    public synchronized Settings validateUpdate(Settings settings) {
+        Settings updatedSettings = super.validateUpdate(settings);
+        if (INDEX_BALANCE_FACTOR_SETTING.get(updatedSettings) + SHARD_BALANCE_FACTOR_SETTING.get(updatedSettings) == 0.0f) {
+            throw new IllegalArgumentException(
+                "[" + INDEX_BALANCE_FACTOR_SETTING.getKey() + "] and [" + SHARD_BALANCE_FACTOR_SETTING.getKey() +
+                "] cannot both be set to 0.0");
+        }
+        return updatedSettings;
     }
 
     private static final class LoggingSettingUpdater implements SettingUpdater<Settings> {

--- a/server/src/test/java/org/elasticsearch/common/settings/ScopedSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/ScopedSettingsTests.java
@@ -23,6 +23,8 @@ package org.elasticsearch.common.settings;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
+import static org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator.INDEX_BALANCE_FACTOR_SETTING;
+import static org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator.SHARD_BALANCE_FACTOR_SETTING;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -439,12 +441,38 @@ public class ScopedSettingsTests extends ESTestCase {
         assertThat(consumer2.get()).isEqualTo(0);
         assertThat(aC.get()).isEqualTo(0);
         assertThat(bC.get()).isEqualTo(0);
-        try {
-            service.validateUpdate(Settings.builder().put("foo.bar", 2).put("foo.bar.baz", -15).build());
-            fail("invalid value");
-        } catch (IllegalArgumentException ex) {
-            assertThat(ex.getMessage()).isEqualTo("illegal value can't update [foo.bar.baz] from [1] to [-15]");
-        }
+        assertThatThrownBy(() ->
+            service.validateUpdate(Settings.builder().put("foo.bar", 2).put("foo.bar.baz", -15).build()))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("illegal value can't update [foo.bar.baz] from [1] to [-15]");
+
+        assertThatThrownBy(() ->
+            service.validateUpdate(Settings.builder()
+                .put(INDEX_BALANCE_FACTOR_SETTING.getKey(), 0.0f)
+                .put(SHARD_BALANCE_FACTOR_SETTING.getKey(), 0.0f)
+                .build()))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("[cluster.routing.allocation.balance.index] and [cluster.routing.allocation.balance.shard] " +
+                        "cannot both be set to 0.0");
+
+        AbstractScopedSettings serviceBalanceFactor1 = new ClusterSettings(Settings.builder()
+                .put(INDEX_BALANCE_FACTOR_SETTING.getKey(), 0.0f).build(), Set.of());
+        assertThatThrownBy(() ->
+            serviceBalanceFactor1.validateUpdate(Settings.builder()
+                .put(SHARD_BALANCE_FACTOR_SETTING.getKey(), 0.0f)
+                .build()))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("[cluster.routing.allocation.balance.index] and [cluster.routing.allocation.balance.shard] " +
+                "cannot both be set to 0.0");
+        AbstractScopedSettings serviceBalanceFactor2 = new ClusterSettings(Settings.builder()
+            .put(SHARD_BALANCE_FACTOR_SETTING.getKey(), 0.0f).build(), Set.of());
+        assertThatThrownBy(() ->
+            serviceBalanceFactor2.validateUpdate(Settings.builder()
+                .put(INDEX_BALANCE_FACTOR_SETTING.getKey(), 0.0f)
+                .build()))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("[cluster.routing.allocation.balance.index] and [cluster.routing.allocation.balance.shard] " +
+                "cannot both be set to 0.0");
 
         assertThat(consumer.get()).isEqualTo(0);
         assertThat(consumer2.get()).isEqualTo(0);


### PR DESCRIPTION
Add a validation so that both settings cannot be set to 0 (no matter if they are set transient, persistent or a combination of the two).

Fixes: #15914
