### PR TITLE
Fix `!= <array>` for unfiltered nulls and missing array of nulls

### DIFF
--- a/docs/appendices/release-notes/5.9.0.rst
+++ b/docs/appendices/release-notes/5.9.0.rst
@@ -59,6 +59,15 @@ Breaking Changes
   regressions on tables created before 5.9.0. For tables created on and after
   5.9.0, the fix has positive impact on the performance.
 
+- Fixed an issue that caused ``WHERE`` clause containing ``NOT`` operator on
+  an array type against an empty array to incorrectly filter array of nulls. It
+  is a breaking change because the fix causes performance degradations.
+
+- Fixed an issue that caused ``WHERE`` clause containing ``NOT`` operator on
+  an array type without doc-values against a non-empty array to incorrectly
+  un-filter null rows. It is a breaking change because the fix causes
+  performance degradations.
+
 - Changed the return value of the concat operator to return a ``NULL`` literal
   instead of an empty string when any of the operand is ``NULL``.
 

--- a/server/src/main/java/io/crate/expression/operator/any/AnyNeqOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/any/AnyNeqOperator.java
@@ -73,7 +73,7 @@ public final class AnyNeqOperator extends AnyOperator<Object> {
             }
             andBuilder.add(fromPrimitive, BooleanClause.Occur.MUST);
         }
-        Query exists = IsNullPredicate.refExistsQuery(probe, context, false);
+        Query exists = IsNullPredicate.refExistsQuery(probe, context);
         return new BooleanQuery.Builder()
             .add(Queries.not(andBuilder.build()), Occur.MUST)
             .add(exists, Occur.FILTER)

--- a/server/src/main/java/io/crate/expression/predicate/NotPredicate.java
+++ b/server/src/main/java/io/crate/expression/predicate/NotPredicate.java
@@ -204,7 +204,7 @@ public class NotPredicate extends Scalar<Boolean, Boolean> {
                 if (!ref.isNullable()) {
                     return new MatchAllDocsQuery();
                 }
-                return IsNullPredicate.refExistsQuery(ref, context, true);
+                return IsNullPredicate.refExistsQuery(ref, context);
             }
         }
 
@@ -229,10 +229,16 @@ public class NotPredicate extends Scalar<Boolean, Boolean> {
                 // result set of the query
                 var refExistsQuery = IsNullPredicate.refExistsQuery(
                     nullableRef,
-                    context,
-                    countEmptyArrays(context.parentQuery(), nullableRef, context));
+                    context
+                );
                 if (refExistsQuery != null) {
                     builder.add(refExistsQuery, BooleanClause.Occur.MUST);
+                } else {
+                    // fall back
+                    return new BooleanQuery.Builder()
+                        .add(notX, Occur.MUST)
+                        .add(LuceneQueryBuilder.genericFunctionFilter(input, context), Occur.FILTER)
+                        .build();
                 }
             }
             return builder.build();

--- a/server/src/main/java/io/crate/expression/scalar/NullOrEmptyFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/NullOrEmptyFunction.java
@@ -110,7 +110,7 @@ public final class NullOrEmptyFunction extends Scalar<Boolean, Object> {
                 if (childRef == null) {
                     return null;
                 }
-                Query refExistsQuery = IsNullPredicate.refExistsQuery(childRef, context, true);
+                Query refExistsQuery = IsNullPredicate.refExistsQuery(childRef, context);
                 if (refExistsQuery == null) {
                     return null;
                 }

--- a/server/src/test/java/io/crate/expression/predicate/IsNullPredicateTest.java
+++ b/server/src/test/java/io/crate/expression/predicate/IsNullPredicateTest.java
@@ -76,7 +76,7 @@ public class IsNullPredicateTest extends ScalarTestCase {
                 1,
                 null
             );
-            Query refExistsQuery = IsNullPredicate.refExistsQuery(ref, context, true);
+            Query refExistsQuery = IsNullPredicate.refExistsQuery(ref, context);
             assertThat(refExistsQuery).isNull();
         }
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes:
```
cr> show create table t;
+-----------------------------------------------------+
| SHOW CREATE TABLE doc.t                             |
+-----------------------------------------------------+
| CREATE TABLE IF NOT EXISTS "doc"."t" (              |
|    "a" ARRAY(INTEGER)                               |
| )                                                   |
| CLUSTERED INTO 4 SHARDS                             |

cr> select * from t;
+--------+
| a      |
+--------+
| [null] |
| NULL   |
| [1]    |
| []     |
+--------+

cr> select * from t where a != [];
+-----+
| a   |
+-----+
| [1] | -- missing [null]
+-----+
```


```
cr> show create table t5;
+-----------------------------------------------------+
| SHOW CREATE TABLE doc.t5                            |
+-----------------------------------------------------+
| CREATE TABLE IF NOT EXISTS "doc"."t5" (             |
|    "a" ARRAY(INTEGER) STORAGE WITH (                |
|       columnstore = false                           |
|    )                                                |
| )                                                   |
| CLUSTERED INTO 4 SHARDS                             |

cr> select * from t5;
+--------+
| a      |
+--------+
| []     |
| NULL   |
| [1]    |
| [null] |
+--------+

cr> select * from t5 where a != [1];
+--------+
| a      |
+--------+
| []     |
| NULL   | -- unfiltered
| [null] |
+--------+
```

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
