### PR TITLE
Extract cast signature definitions from Symbol to cast functions

### DIFF
--- a/server/src/main/java/io/crate/expression/scalar/cast/ExplicitCastFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/cast/ExplicitCastFunction.java
@@ -40,18 +40,15 @@ import io.crate.types.TypeSignature;
 public class ExplicitCastFunction extends Scalar<Object, Object> {
 
     public static final String NAME = "cast";
+    public static final Signature SIGNATURE = Signature.builder(NAME, FunctionType.SCALAR)
+        .argumentTypes(TypeSignature.parse("E"), TypeSignature.parse("V"))
+        .returnType(TypeSignature.parse("V"))
+        .features(Feature.DETERMINISTIC)
+        .typeVariableConstraints(typeVariable("E"), typeVariable("V"))
+        .build();
 
     public static void register(Functions.Builder module) {
-        module.add(
-            Signature.builder(NAME, FunctionType.SCALAR)
-                .argumentTypes(TypeSignature.parse("E"),
-                    TypeSignature.parse("V"))
-                .returnType(TypeSignature.parse("V"))
-                .features(Feature.DETERMINISTIC)
-                .typeVariableConstraints(typeVariable("E"), typeVariable("V"))
-                .build(),
-            ExplicitCastFunction::new
-        );
+        module.add(SIGNATURE, ExplicitCastFunction::new);
     }
 
     private final DataType<?> returnType;

--- a/server/src/main/java/io/crate/expression/scalar/cast/ImplicitCastFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/cast/ImplicitCastFunction.java
@@ -46,18 +46,15 @@ import io.crate.types.TypeSignature;
 public class ImplicitCastFunction extends Scalar<Object, Object> {
 
     public static final String NAME = "_cast";
+    public static final Signature SIGNATURE = Signature.builder(NAME, FunctionType.SCALAR)
+        .argumentTypes(TypeSignature.parse("E"), DataTypes.STRING.getTypeSignature())
+        .returnType(DataTypes.UNDEFINED.getTypeSignature())
+        .features(Feature.DETERMINISTIC)
+        .typeVariableConstraints(typeVariable("E"))
+        .build();
 
     public static void register(Functions.Builder module) {
-        module.add(
-            Signature.builder(NAME, FunctionType.SCALAR)
-                .argumentTypes(TypeSignature.parse("E"),
-                    DataTypes.STRING.getTypeSignature())
-                .returnType(DataTypes.UNDEFINED.getTypeSignature())
-                .features(Feature.DETERMINISTIC)
-                .typeVariableConstraints(typeVariable("E"))
-                .build(),
-            ImplicitCastFunction::new
-        );
+        module.add(SIGNATURE, ImplicitCastFunction::new);
     }
 
     @Nullable

--- a/server/src/main/java/io/crate/expression/scalar/cast/TryCastFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/cast/TryCastFunction.java
@@ -39,18 +39,15 @@ import io.crate.types.TypeSignature;
 public class TryCastFunction extends Scalar<Object, Object> {
 
     public static final String NAME = "try_cast";
+    public static final Signature SIGNATURE = Signature.builder(NAME, FunctionType.SCALAR)
+        .argumentTypes(TypeSignature.parse("E"), TypeSignature.parse("V"))
+        .returnType(TypeSignature.parse("V"))
+        .features(Feature.DETERMINISTIC)
+        .typeVariableConstraints(typeVariable("E"), typeVariable("V"))
+        .build();
 
     public static void register(Functions.Builder module) {
-        module.add(
-            Signature.builder(NAME, FunctionType.SCALAR)
-                .argumentTypes(TypeSignature.parse("E"),
-                    TypeSignature.parse("V"))
-                .returnType(TypeSignature.parse("V"))
-                .features(Feature.DETERMINISTIC)
-                .typeVariableConstraints(typeVariable("E"), typeVariable("V"))
-                .build(),
-            TryCastFunction::new
-        );
+        module.add(SIGNATURE, TryCastFunction::new);
     }
 
     private final DataType<?> returnType;


### PR DESCRIPTION
Avoids re-creating the signature instance on each cast and ensures the
definition is in one place instead of having it at two locations.
