### PR TITLE
Rename kind on signature to type

### DIFF
--- a/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -1225,7 +1225,7 @@ public class ExpressionAnalyzer {
         List<Symbol> castArguments = cast(arguments, boundSignature.argTypes());
         Function newFunction;
         if (windowDefinition == null) {
-            if (signature.getKind() == FunctionType.AGGREGATE) {
+            if (signature.getType() == FunctionType.AGGREGATE) {
                 context.indicateAggregates();
             } else if (filter != null) {
                 throw new UnsupportedOperationException(
@@ -1239,8 +1239,8 @@ public class ExpressionAnalyzer {
             }
             newFunction = new Function(signature, castArguments, boundSignature.returnType(), filter);
         } else {
-            if (signature.getKind() != FunctionType.WINDOW) {
-                if (signature.getKind() != FunctionType.AGGREGATE) {
+            if (signature.getType() != FunctionType.WINDOW) {
+                if (signature.getType() != FunctionType.AGGREGATE) {
                     throw new IllegalArgumentException(String.format(
                         Locale.ENGLISH,
                         "OVER clause was specified, but %s is neither a window nor an aggregate function.",

--- a/server/src/main/java/io/crate/analyze/validator/GroupBySymbolValidator.java
+++ b/server/src/main/java/io/crate/analyze/validator/GroupBySymbolValidator.java
@@ -42,7 +42,7 @@ public class GroupBySymbolValidator {
 
         @Override
         public Void visitFunction(Function function, Boolean insideScalar) {
-            switch (function.signature().getKind()) {
+            switch (function.signature().getType()) {
                 case SCALAR:
                     for (Symbol argument : function.arguments()) {
                         argument.accept(this, true);
@@ -57,7 +57,7 @@ public class GroupBySymbolValidator {
                     break;
                 default:
                     throw new UnsupportedOperationException(
-                        String.format(Locale.ENGLISH, "FunctionInfo.Type %s not handled", function.signature().getKind()));
+                        String.format(Locale.ENGLISH, "FunctionInfo.Type %s not handled", function.signature().getType()));
             }
             return null;
         }

--- a/server/src/main/java/io/crate/analyze/validator/HavingSymbolValidator.java
+++ b/server/src/main/java/io/crate/analyze/validator/HavingSymbolValidator.java
@@ -83,7 +83,7 @@ public class HavingSymbolValidator {
 
         @Override
         public Void visitFunction(Function function, HavingContext context) {
-            FunctionType type = function.signature().getKind();
+            FunctionType type = function.signature().getType();
             if (type == FunctionType.TABLE) {
                 throw new IllegalArgumentException("Table functions are not allowed in HAVING");
             } else if (type == FunctionType.AGGREGATE) {

--- a/server/src/main/java/io/crate/analyze/validator/SelectSymbolValidator.java
+++ b/server/src/main/java/io/crate/analyze/validator/SelectSymbolValidator.java
@@ -43,14 +43,14 @@ public class SelectSymbolValidator {
 
         @Override
         public Void visitFunction(Function symbol, Void context) {
-            switch (symbol.signature().getKind()) {
+            switch (symbol.signature().getType()) {
                 case SCALAR:
                 case AGGREGATE:
                 case TABLE:
                     break;
                 default:
                     throw new UnsupportedOperationException(String.format(Locale.ENGLISH,
-                        "FunctionInfo.Type %s not handled", symbol.signature().getKind()));
+                        "FunctionInfo.Type %s not handled", symbol.signature().getType()));
             }
             for (Symbol arg : symbol.arguments()) {
                 arg.accept(this, context);

--- a/server/src/main/java/io/crate/analyze/where/WhereClauseValidator.java
+++ b/server/src/main/java/io/crate/analyze/where/WhereClauseValidator.java
@@ -94,7 +94,7 @@ public final class WhereClauseValidator {
         @Override
         public Symbol visitFunction(Function function, Context context) {
             context.functions.push(function);
-            if (function.signature().getKind().equals(FunctionType.TABLE)) {
+            if (function.signature().getType().equals(FunctionType.TABLE)) {
                 throw new UnsupportedOperationException("Table functions are not allowed in WHERE");
             }
             continueTraversal(function, context);

--- a/server/src/main/java/io/crate/execution/dsl/projection/builder/ProjectionBuilder.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/builder/ProjectionBuilder.java
@@ -110,7 +110,7 @@ public class ProjectionBuilder {
                                                    UnaryOperator<Symbol> subQueryAndParamBinder) {
         ArrayList<Aggregation> aggregations = new ArrayList<>(functions.size());
         for (Function function : functions) {
-            assert function.signature().getKind() == FunctionType.AGGREGATE :
+            assert function.signature().getType() == FunctionType.AGGREGATE :
                     "function type must be " + FunctionType.AGGREGATE;
             AggregationFunction<?, ?> aggregationFunction = (AggregationFunction<?, ?>) nodeCtx.functions().getQualified(
                 function

--- a/server/src/main/java/io/crate/execution/dsl/projection/builder/SplitPointsBuilder.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/builder/SplitPointsBuilder.java
@@ -182,7 +182,7 @@ public final class SplitPointsBuilder extends DefaultTraversalSymbolVisitor<Spli
 
     @Override
     public Void visitFunction(Function function, Context context) {
-        FunctionType type = function.signature().getKind();
+        FunctionType type = function.signature().getType();
         switch (type) {
             case SCALAR:
                 super.visitFunction(function, context);

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/ArrayFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/ArrayFunction.java
@@ -44,8 +44,7 @@ public class ArrayFunction extends Scalar<Object, Object> {
             .argumentTypes(TypeSignature.parse("E"))
             .returnType(TypeSignature.parse("array(E)"))
             .setVariableArity(true)
-            .feature(Feature.NON_NULLABLE)
-            .feature(Feature.DETERMINISTIC)
+            .features(Feature.NON_NULLABLE, Feature.DETERMINISTIC)
             .build();
 
 

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/MapFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/MapFunction.java
@@ -59,7 +59,7 @@ public class MapFunction extends Scalar<Object, Object> {
             // This is *ok* as the returnType is currently not used directly, only for function description.
             .returnType(TypeSignature.parse("object(text, V)"))
             .variableArityGroup(List.of(TypeSignature.parse("text"), TypeSignature.parse("V")))
-            .feature(Feature.DETERMINISTIC)
+            .features(Feature.DETERMINISTIC)
             .build();
 
 

--- a/server/src/main/java/io/crate/expression/scalar/conditional/CaseFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/conditional/CaseFunction.java
@@ -72,7 +72,7 @@ public class CaseFunction extends Scalar<Object, Object> {
                 .argumentTypes(bool, t)
                 .returnType(t)
                 .variableArityGroup(List.of(bool, t))
-                .feature(Feature.DETERMINISTIC)
+                .features(Feature.DETERMINISTIC)
                 .build(),
             CaseFunction::new
         );

--- a/server/src/main/java/io/crate/expression/symbol/GroupAndAggregateSemantics.java
+++ b/server/src/main/java/io/crate/expression/symbol/GroupAndAggregateSemantics.java
@@ -57,7 +57,7 @@ public final class GroupAndAggregateSemantics {
                                 List<Symbol> groupBy) throws IllegalArgumentException {
         boolean containsAggregations = Symbols.any(
             outputSymbols,
-            x -> x instanceof Function fn && fn.signature().getKind() == FunctionType.AGGREGATE
+            x -> x instanceof Function fn && fn.signature().getType() == FunctionType.AGGREGATE
         );
         if (!containsAggregations && groupBy.isEmpty()) {
             return;
@@ -123,7 +123,7 @@ public final class GroupAndAggregateSemantics {
 
         @Override
         public Symbol visitFunction(Function function, List<Symbol> groupBy) {
-            switch (function.signature().getKind()) {
+            switch (function.signature().getType()) {
                 case SCALAR: {
                     /* valid:
                      *  SELECT 4 * x FROM tbl GROUP BY x
@@ -159,7 +159,7 @@ public final class GroupAndAggregateSemantics {
                     return null;
 
                 default:
-                    throw new IllegalStateException("Unexpected function type: " + function.signature().getKind());
+                    throw new IllegalStateException("Unexpected function type: " + function.signature().getType());
             }
         }
 

--- a/server/src/main/java/io/crate/expression/symbol/Symbol.java
+++ b/server/src/main/java/io/crate/expression/symbol/Symbol.java
@@ -126,7 +126,7 @@ public interface Symbol extends Writeable, Accountable {
      * Returns true if the tree contains the given function type
      */
     default boolean hasFunctionType(FunctionType type) {
-        return any(s -> s instanceof Function fn && fn.signature.getKind().equals(type));
+        return any(s -> s instanceof Function fn && fn.signature.getType().equals(type));
     }
 
     /**

--- a/server/src/main/java/io/crate/expression/symbol/WindowFunction.java
+++ b/server/src/main/java/io/crate/expression/symbol/WindowFunction.java
@@ -66,7 +66,7 @@ public class WindowFunction extends Function {
                           WindowDefinition windowDefinition,
                           @Nullable Boolean ignoreNulls) {
         super(signature, arguments, returnType, filter);
-        assert signature.getKind() == WINDOW || signature.getKind() == AGGREGATE :
+        assert signature.getType() == WINDOW || signature.getType() == AGGREGATE :
             "only window and aggregate functions are allowed to be modelled over a window";
         this.windowDefinition = windowDefinition;
         this.ignoreNulls = ignoreNulls;

--- a/server/src/main/java/io/crate/expression/tablefunctions/TableFunctionFactory.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/TableFunctionFactory.java
@@ -41,7 +41,7 @@ public class TableFunctionFactory {
 
     public static TableFunctionImplementation<?> from(FunctionImplementation functionImplementation) {
         TableFunctionImplementation<?> tableFunction;
-        switch (functionImplementation.signature().getKind()) {
+        switch (functionImplementation.signature().getType()) {
             case TABLE:
                 tableFunction = (TableFunctionImplementation<?>) functionImplementation;
                 break;

--- a/server/src/main/java/io/crate/expression/udf/UserDefinedFunctionService.java
+++ b/server/src/main/java/io/crate/expression/udf/UserDefinedFunctionService.java
@@ -225,12 +225,9 @@ public class UserDefinedFunctionService extends AbstractLifecycleComponent imple
     public FunctionProvider buildFunctionResolver(UserDefinedFunctionMetadata udf) {
         var functionName = new FunctionName(udf.schema(), udf.name());
         var signature = Signature.builder(functionName, FunctionType.SCALAR)
-                .argumentTypes(
-                Lists.map(
-                    udf.argumentTypes(),
-                    DataType::getTypeSignature))
+            .argumentTypes(Lists.map(udf.argumentTypes(), DataType::getTypeSignature))
             .returnType(udf.returnType().getTypeSignature())
-            .feature(Scalar.Feature.DETERMINISTIC)
+            .features(Scalar.Feature.DETERMINISTIC)
             .build();
 
         final Scalar<?, ?> scalar;

--- a/server/src/main/java/io/crate/metadata/functions/Signature.java
+++ b/server/src/main/java/io/crate/metadata/functions/Signature.java
@@ -37,7 +37,6 @@ import org.jetbrains.annotations.Nullable;
 
 import io.crate.common.collections.EnumSets;
 import io.crate.common.collections.Lists;
-import io.crate.common.collections.Sets;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.FunctionType;
 import io.crate.metadata.Scalar;
@@ -121,18 +120,18 @@ public final class Signature implements Writeable, Accountable {
             return this;
         }
 
-        public Builder feature(Scalar.Feature feature) {
-            this.features = Sets.concat(this.features, feature);
-            return this;
-        }
-
         public Builder features(Set<Scalar.Feature> features) {
-            this.features = Sets.union(this.features, features);
+            this.features = features;
             return this;
         }
 
         public Builder features(Scalar.Feature feature, Scalar.Feature ... rest) {
             this.features = EnumSet.of(feature, rest);
+            return this;
+        }
+
+        public Builder features(Scalar.Feature feature) {
+            this.features = EnumSet.of(feature);
             return this;
         }
 

--- a/server/src/main/java/io/crate/metadata/functions/Signature.java
+++ b/server/src/main/java/io/crate/metadata/functions/Signature.java
@@ -52,13 +52,13 @@ public final class Signature implements Writeable, Accountable {
     public static Builder builder(FunctionName name, FunctionType type) {
         return new Builder()
             .name(name)
-            .kind(type);
+            .type(type);
     }
 
     public static Builder builder(String name, FunctionType type) {
         return new Builder()
             .name(name)
-            .kind(type);
+            .type(type);
     }
 
     public static Builder builder(Signature signature) {
@@ -67,7 +67,7 @@ public final class Signature implements Writeable, Accountable {
 
     public static class Builder {
         private FunctionName name;
-        private FunctionType kind;
+        private FunctionType type;
         private List<TypeSignature> argumentTypes = Collections.emptyList();
         private TypeSignature returnType;
         private Set<Scalar.Feature> features = Set.of();
@@ -81,7 +81,7 @@ public final class Signature implements Writeable, Accountable {
 
         public Builder(Signature signature) {
             name = signature.getName();
-            kind = signature.getKind();
+            type = signature.getType();
             argumentTypes = signature.getArgumentTypes();
             returnType = signature.getReturnType();
             features = signature.getFeatures();
@@ -102,8 +102,8 @@ public final class Signature implements Writeable, Accountable {
             return this;
         }
 
-        public Builder kind(FunctionType kind) {
-            this.kind = kind;
+        public Builder type(FunctionType type) {
+            this.type = type;
             return this;
         }
 
@@ -163,11 +163,11 @@ public final class Signature implements Writeable, Accountable {
 
         public Signature build() {
             assert name != null : "Signature requires the 'name' to be set";
-            assert kind != null : "Signature requires the 'kind' to be set";
+            assert type != null : "Signature requires the 'type' to be set";
             assert returnType != null : "Signature requires the 'returnType' to be set";
             return new Signature(
                 name,
-                kind,
+                type,
                 typeVariableConstraints,
                 argumentTypes,
                 returnType,
@@ -208,7 +208,7 @@ public final class Signature implements Writeable, Accountable {
 
 
     private final FunctionName name;
-    private final FunctionType kind;
+    private final FunctionType type;
     private final List<TypeSignature> argumentTypes;
     private final TypeSignature returnType;
     private final Set<Scalar.Feature> features;
@@ -216,7 +216,7 @@ public final class Signature implements Writeable, Accountable {
     private final SignatureBindingInfo bindingInfo;
 
     private Signature(FunctionName name,
-                      FunctionType kind,
+                      FunctionType type,
                       List<TypeVariableConstraint> typeVariableConstraints,
                       List<TypeSignature> argumentTypes,
                       TypeSignature returnType,
@@ -225,7 +225,7 @@ public final class Signature implements Writeable, Accountable {
                       boolean variableArity,
                       boolean allowCoercion) {
         this.name = name;
-        this.kind = kind;
+        this.type = type;
         this.argumentTypes = argumentTypes;
         this.returnType = returnType;
         this.features = features;
@@ -239,7 +239,7 @@ public final class Signature implements Writeable, Accountable {
 
     public Signature(StreamInput in) throws IOException {
         name = new FunctionName(in);
-        kind = FunctionType.values()[in.readVInt()];
+        type = FunctionType.values()[in.readVInt()];
         int argsSize = in.readVInt();
         argumentTypes = new ArrayList<>(argsSize);
         for (int i = 0; i < argsSize; i++) {
@@ -263,8 +263,8 @@ public final class Signature implements Writeable, Accountable {
         return name;
     }
 
-    public FunctionType getKind() {
-        return kind;
+    public FunctionType getType() {
+        return type;
     }
 
     public List<TypeSignature> getArgumentTypes() {
@@ -299,7 +299,7 @@ public final class Signature implements Writeable, Accountable {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         name.writeTo(out);
-        out.writeVInt(kind.ordinal());
+        out.writeVInt(type.ordinal());
         out.writeVInt(argumentTypes.size());
         for (TypeSignature typeSignature : argumentTypes) {
             TypeSignature.toStream(typeSignature, out);
@@ -312,7 +312,7 @@ public final class Signature implements Writeable, Accountable {
     public boolean equals(Object o) {
         return o instanceof Signature signature &&
             name.equals(signature.name) &&
-            kind == signature.kind &&
+            type == signature.type &&
             argumentTypes.equals(signature.argumentTypes) &&
             returnType.equals(signature.returnType);
     }
@@ -320,7 +320,7 @@ public final class Signature implements Writeable, Accountable {
     @Override
     public int hashCode() {
         int result = name.hashCode();
-        result = 31 * result + kind.hashCode();
+        result = 31 * result + type.hashCode();
         result = 31 * result + argumentTypes.hashCode();
         result = 31 * result + returnType.hashCode();
         return result;
@@ -355,7 +355,7 @@ public final class Signature implements Writeable, Accountable {
         // FunctionIdent end
 
         DataTypes.toStream(returnType.createType(), out);
-        out.writeVInt(kind.ordinal());
+        out.writeVInt(type.ordinal());
         out.writeVInt(EnumSets.packToInt(features));
     }
 }

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgProcTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgProcTable.java
@@ -155,9 +155,9 @@ public final class PgProcTable {
     }
 
     private static String prokind(Signature signature) {
-        if (signature.getKind() == WINDOW) {
+        if (signature.getType() == WINDOW) {
             return "w";
-        } else if (signature.getKind() == AGGREGATE) {
+        } else if (signature.getType() == AGGREGATE) {
             return "a";
         } else return "f";
     }

--- a/server/src/main/java/io/crate/planner/consumer/OrderByWithAggregationValidator.java
+++ b/server/src/main/java/io/crate/planner/consumer/OrderByWithAggregationValidator.java
@@ -80,7 +80,7 @@ public class OrderByWithAggregationValidator {
             if (context.isDistinct) {
                 throw new UnsupportedOperationException(Symbols.format(INVALID_FIELD_IN_DISTINCT_TEMPLATE, symbol));
             }
-            switch (symbol.signature().getKind()) {
+            switch (symbol.signature().getType()) {
                 case AGGREGATE:
                     if (context.aggregateFunctionVisited == null) {
                         context.aggregateFunctionVisited = symbol;

--- a/server/src/main/java/io/crate/planner/operators/HashAggregate.java
+++ b/server/src/main/java/io/crate/planner/operators/HashAggregate.java
@@ -223,7 +223,7 @@ public class HashAggregate extends ForwardingLogicalPlan {
         @Override
         public Void visitFunction(Function symbol, OutputValidatorContext context) {
             context.insideAggregation =
-                context.insideAggregation || symbol.signature().getKind().equals(FunctionType.AGGREGATE);
+                context.insideAggregation || symbol.signature().getType().equals(FunctionType.AGGREGATE);
             for (Symbol argument : symbol.arguments()) {
                 argument.accept(this, context);
             }

--- a/server/src/main/java/io/crate/planner/operators/ProjectSet.java
+++ b/server/src/main/java/io/crate/planner/operators/ProjectSet.java
@@ -75,7 +75,7 @@ public class ProjectSet extends ForwardingLogicalPlan {
         while (true) {
             List<Function> childTableFunctions = tableFunctions.stream()
                 .flatMap(func -> func.arguments().stream())
-                .filter(arg -> arg instanceof Function fn && fn.signature().getKind() == FunctionType.TABLE)
+                .filter(arg -> arg instanceof Function fn && fn.signature().getType() == FunctionType.TABLE)
                 .map(x -> (Function) x)
                 .toList();
 
@@ -88,7 +88,7 @@ public class ProjectSet extends ForwardingLogicalPlan {
         LogicalPlan result = source;
         for (int i = nestedFunctions.size() - 1; i >= 0; i--) {
             List<Symbol> standalone = result.outputs().stream()
-                .filter(x -> !(x instanceof Function fn && fn.signature().getKind() == FunctionType.TABLE))
+                .filter(x -> !(x instanceof Function fn && fn.signature().getType() == FunctionType.TABLE))
                 .toList();
             result = new ProjectSet(result, nestedFunctions.get(i), standalone);
         }

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathProjectSet.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathProjectSet.java
@@ -87,6 +87,6 @@ public final class MoveFilterBeneathProjectSet implements Rule<Filter> {
 
     private static boolean isTableFunction(Symbol s) {
         return s instanceof io.crate.expression.symbol.Function &&
-               ((io.crate.expression.symbol.Function) s).signature().getKind() == FunctionType.TABLE;
+               ((io.crate.expression.symbol.Function) s).signature().getType() == FunctionType.TABLE;
     }
 }

--- a/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -175,7 +175,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         assertThat(relation.groupBy()).isEmpty();
         assertThat(relation.outputs()).hasSize(1);
         Function col1 = (Function) relation.outputs().getFirst();
-        assertThat(col1.signature().getKind()).isEqualTo(FunctionType.AGGREGATE);
+        assertThat(col1.signature().getType()).isEqualTo(FunctionType.AGGREGATE);
         assertThat(col1.name()).isEqualTo(AverageAggregation.NAME);
     }
 
@@ -230,7 +230,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
 
         Function whereClause = (Function) relation.where();
         assertThat(whereClause.name()).isEqualTo(OrOperator.NAME);
-        assertThat(whereClause.signature().getKind() == FunctionType.AGGREGATE).isFalse();
+        assertThat(whereClause.signature().getType() == FunctionType.AGGREGATE).isFalse();
 
         Function left = (Function) whereClause.arguments().getFirst();
         assertThat(left.name()).isEqualTo(EqOperator.NAME);
@@ -256,7 +256,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
             "or load['1'] = ? or name = ?");
         Function whereClause = (Function) relation.where();
         assertThat(whereClause.name()).isEqualTo(OrOperator.NAME);
-        assertThat(whereClause.signature().getKind() == FunctionType.AGGREGATE).isFalse();
+        assertThat(whereClause.signature().getType() == FunctionType.AGGREGATE).isFalse();
 
         Function function = (Function) whereClause.arguments().getFirst();
         assertThat(function.name()).isEqualTo(OrOperator.NAME);
@@ -545,7 +545,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         assertThat(symbol).isFunction("collect_set");
 
         Function collectSet = (Function) symbol;
-        assertThat(collectSet.signature().getKind()).isEqualTo(FunctionType.AGGREGATE);
+        assertThat(collectSet.signature().getType()).isEqualTo(FunctionType.AGGREGATE);
 
         assertThat(collectSet.arguments()).hasSize(1);
         assertThat(collectSet.arguments().getFirst()).isReference().hasName("load['1']");


### PR DESCRIPTION
It's confusing having `kind` being a `FunctionType` enum.


(Could also go the other route and rename `FunctionType` to `FunctionKind` ? I considered it for a moment because `type` is already used in a lot of places, but in the context of the signature the `type` needs qualification anyway as there are argument types, return type and function type, and `type` seems to fit better)