### PR TITLE
Move PartitionInfo creation from PartitionInfos to DocTableInfo

### DIFF
--- a/server/src/main/java/io/crate/analyze/where/WhereClauseAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/where/WhereClauseAnalyzer.java
@@ -68,7 +68,7 @@ public class WhereClauseAnalyzer {
         if (!table.isPartitioned()) {
             return where;
         }
-        if (table.getPartitions(metadata).isEmpty()) {
+        if (table.getPartitionNames(metadata).isEmpty()) {
             return WhereClause.NO_MATCH;
         }
         PartitionResult partitionResult = resolvePartitions(where.queryOrFallback(), table, coordinatorTxnCtx, nodeCtx, metadata);
@@ -107,7 +107,7 @@ public class WhereClauseAnalyzer {
                                                     NodeContext nodeCtx,
                                                     Metadata metadata) {
         assert tableInfo.isPartitioned() : "table must be partitioned in order to resolve partitions";
-        assert !tableInfo.getPartitions(metadata).isEmpty() : "table must have at least one partition";
+        assert !tableInfo.getPartitionNames(metadata).isEmpty() : "table must have at least one partition";
 
         PartitionReferenceResolver partitionReferenceResolver = preparePartitionResolver(
             tableInfo.partitionedByColumns());
@@ -121,7 +121,7 @@ public class WhereClauseAnalyzer {
         Symbol normalized;
         Map<Symbol, List<Literal<?>>> queryPartitionMap = new HashMap<>();
 
-        for (PartitionName partitionName : tableInfo.getPartitions(metadata)) {
+        for (PartitionName partitionName : tableInfo.getPartitionNames(metadata)) {
             for (PartitionExpression partitionExpression : partitionReferenceResolver.expressions()) {
                 partitionExpression.setNextRow(partitionName);
             }
@@ -153,7 +153,7 @@ public class WhereClauseAnalyzer {
             return partitionResult == null
                 // if partitionResult is null we can't narrow the partitions and keep the full query + use all partitions
                 // the query will then be evaluated correctly within each partition to see whether it matches or not
-                ? new PartitionResult(query, Lists.map(tableInfo.getPartitions(metadata), PartitionName::asIndexName))
+                ? new PartitionResult(query, Lists.map(tableInfo.getPartitionNames(metadata), PartitionName::asIndexName))
                 : partitionResult;
         } else {
             return new PartitionResult(Literal.BOOLEAN_FALSE, Collections.emptyList());

--- a/server/src/main/java/io/crate/execution/engine/collect/sources/InformationSchemaIterables.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/sources/InformationSchemaIterables.java
@@ -172,7 +172,7 @@ public class InformationSchemaIterables implements ClusterStateListener {
             .flatMap(Function.identity())
             .iterator();
 
-        partitionInfos = new PartitionInfos(clusterService);
+        partitionInfos = new PartitionInfos(clusterService, schemas);
 
         referentialConstraints = emptyList();
         // these are initialized on a clusterState change

--- a/server/src/main/java/io/crate/expression/reference/sys/check/cluster/NumberOfPartitionsSysCheck.java
+++ b/server/src/main/java/io/crate/expression/reference/sys/check/cluster/NumberOfPartitionsSysCheck.java
@@ -21,17 +21,17 @@
 
 package io.crate.expression.reference.sys.check.cluster;
 
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Singleton;
+
+import io.crate.expression.reference.sys.check.AbstractSysCheck;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.doc.DocSchemaInfo;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.SchemaInfo;
-import io.crate.expression.reference.sys.check.AbstractSysCheck;
-
-import org.elasticsearch.cluster.metadata.Metadata;
-import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.inject.Singleton;
 
 @Singleton
 public class NumberOfPartitionsSysCheck extends AbstractSysCheck {
@@ -61,7 +61,7 @@ public class NumberOfPartitionsSysCheck extends AbstractSysCheck {
             }
             for (var table : docSchemaInfo.getTables()) {
                 DocTableInfo docTableInfo = (DocTableInfo) table;
-                if (docTableInfo.isPartitioned() && docTableInfo.getPartitions(metadata).size() > PARTITIONS_THRESHOLD) {
+                if (docTableInfo.isPartitioned() && docTableInfo.getPartitionNames(metadata).size() > PARTITIONS_THRESHOLD) {
                     return false;
                 }
             }

--- a/server/src/main/java/io/crate/metadata/PartitionInfos.java
+++ b/server/src/main/java/io/crate/metadata/PartitionInfos.java
@@ -21,100 +21,32 @@
 
 package io.crate.metadata;
 
-import java.util.HashMap;
 import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 import java.util.stream.StreamSupport;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.elasticsearch.cluster.metadata.IndexMetadata;
-import org.elasticsearch.cluster.metadata.IndexMetadata.State;
-import org.elasticsearch.cluster.metadata.MappingMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.settings.Settings;
 
-import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
-
-import io.crate.metadata.settings.NumberOfReplicas;
-import io.crate.types.DataType;
-import io.crate.types.DataTypes;
+import io.crate.metadata.doc.DocSchemaInfo;
+import io.crate.metadata.doc.DocTableInfo;
 
 public class PartitionInfos implements Iterable<PartitionInfo> {
 
     private final ClusterService clusterService;
-    private static final Logger LOGGER = LogManager.getLogger(PartitionInfos.class);
+    private final Schemas schemas;
 
-    public PartitionInfos(ClusterService clusterService) {
+    public PartitionInfos(ClusterService clusterService, Schemas schemas) {
         this.clusterService = clusterService;
+        this.schemas = schemas;
     }
 
     @Override
     public Iterator<PartitionInfo> iterator() {
-        // get a fresh one for each iteration
-        return StreamSupport.stream(clusterService.state().metadata().indices().spliterator(), false)
-            .filter(entry -> IndexParts.isPartitioned(entry.key))
-            .map(PartitionInfos::createPartitionInfo)
-            .filter(Objects::nonNull)
+        Metadata metadata = clusterService.state().metadata();
+        return StreamSupport.stream(schemas.spliterator(), false)
+            .filter(schemaInfo -> schemaInfo instanceof DocSchemaInfo)
+            .flatMap(docSchemaInfo -> StreamSupport.stream(docSchemaInfo.getTables().spliterator(), false))
+            .flatMap(docTable -> ((DocTableInfo) docTable).getPartitions(metadata).stream())
             .iterator();
-    }
-
-    private static PartitionInfo createPartitionInfo(ObjectObjectCursor<String, IndexMetadata> indexMetadataEntry) {
-        var indexName = indexMetadataEntry.key;
-        var indexMetadata = indexMetadataEntry.value;
-        PartitionName partitionName = PartitionName.fromIndexOrTemplate(indexName);
-        try {
-            MappingMetadata mappingMetadata = indexMetadata.mapping();
-            if (mappingMetadata == null) {
-                LOGGER.trace("Cannot resolve mapping definition of index {}", indexName);
-                return null;
-            }
-            Map<String, Object> mappingMap = mappingMetadata.sourceAsMap();
-            Map<String, Object> valuesMap = buildValuesMap(partitionName, mappingMap);
-            Settings settings = indexMetadata.getSettings();
-            String numberOfReplicas = NumberOfReplicas.getVirtualValue(settings);
-            return new PartitionInfo(
-                    partitionName,
-                    indexMetadata.getNumberOfShards(),
-                    numberOfReplicas,
-                    IndexMetadata.SETTING_INDEX_VERSION_CREATED.get(settings),
-                    settings.getAsVersion(IndexMetadata.SETTING_VERSION_UPGRADED, null),
-                    indexMetadata.getState() == State.CLOSE,
-                    valuesMap,
-                    settings);
-        } catch (Exception e) {
-            LOGGER.trace("error extracting partition infos from index " + indexMetadata, e);
-            return null; // must filter on null
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    private static Map<String, Object> buildValuesMap(PartitionName partitionName, Map<String, Object> mappingMetadata) throws Exception {
-        Map<String, Object> meta = (Map<String, Object>) mappingMetadata.get("_meta");
-        if (meta == null) {
-            return Map.of();
-        }
-        Object partitionedBy = meta.get("partitioned_by");
-        if (!(partitionedBy instanceof List)) {
-            return Map.of();
-        }
-
-        List<List<String>> partitionedByColumns = (List<List<String>>) partitionedBy;
-        assert partitionedByColumns.size() == partitionName.values().size()
-            : "partitionedByColumns size must match partitionName values size";
-        Map<String, Object> valuesByColumn = new HashMap<>();
-        for (int i = 0; i < partitionedByColumns.size(); i++) {
-            var columnAndType = partitionedByColumns.get(i);
-            assert columnAndType.size() == 2 : "_meta['partitioned_by'] mapping must contain (columnName, datatype) pairs";
-            String dottedColumnName = columnAndType.get(0);
-            String sqlFqn = ColumnIdent.fromPath(dottedColumnName).sqlFqn();
-            String typeName = columnAndType.get(1);
-            DataType<?> type = DataTypes.ofMappingName(typeName);
-            Object value = type.implicitCast(partitionName.values().get(i));
-            valuesByColumn.put(sqlFqn, value);
-        }
-        return valuesByColumn;
     }
 }

--- a/server/src/main/java/io/crate/metadata/PartitionName.java
+++ b/server/src/main/java/io/crate/metadata/PartitionName.java
@@ -71,7 +71,7 @@ public class PartitionName {
      */
     public static PartitionName ofAssignments(DocTableInfo table, List<Assignment<Object>> assignments, Metadata metadata) {
         PartitionName partitionName = ofAssignmentsUnsafe(table, assignments);
-        if (table.getPartitions(metadata).contains(partitionName) == false) {
+        if (table.getPartitionNames(metadata).contains(partitionName) == false) {
             throw new PartitionUnknownException(partitionName);
         }
         return partitionName;

--- a/server/src/main/java/io/crate/planner/WhereClauseOptimizer.java
+++ b/server/src/main/java/io/crate/planner/WhereClauseOptimizer.java
@@ -122,7 +122,7 @@ public final class WhereClauseOptimizer {
                 clusteredBy.add(binder.apply(clusteredByValue));
             }
             if (table.isPartitioned()) {
-                if (table.getPartitions(metadata).isEmpty()) {
+                if (table.getPartitionNames(metadata).isEmpty()) {
                     return WhereClause.NO_MATCH;
                 }
                 WhereClauseAnalyzer.PartitionResult partitionResult =

--- a/server/src/main/java/io/crate/planner/statement/DeletePlanner.java
+++ b/server/src/main/java/io/crate/planner/statement/DeletePlanner.java
@@ -103,7 +103,7 @@ public final class DeletePlanner {
             return new DeleteById(tableRel.tableInfo(), detailedQuery.docKeys().get());
         }
         if (table.isPartitioned() && query instanceof Input<?> input && DataTypes.BOOLEAN.sanitizeValue(input.value())) {
-            return new DeleteAllPartitions(Lists.map(table.getPartitions(context.clusterState().metadata()), PartitionName::asIndexName));
+            return new DeleteAllPartitions(Lists.map(table.getPartitionNames(context.clusterState().metadata()), PartitionName::asIndexName));
         }
 
         return new Delete(tableRel, detailedQuery);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -65,11 +65,11 @@ import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.rest.RestStatus;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import com.carrotsearch.hppc.cursors.ObjectCursor;
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 
-import org.jetbrains.annotations.VisibleForTesting;
 import io.crate.fdw.ForeignTablesMetadata;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
@@ -333,6 +333,9 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
         throw new IndexNotFoundException(index);
     }
 
+    /**
+     * @return indexName -> indexMetadata
+     **/
     public ImmutableOpenMap<String, IndexMetadata> indices() {
         return this.indices;
     }

--- a/server/src/test/java/io/crate/expression/reference/sys/check/cluster/SysChecksTest.java
+++ b/server/src/test/java/io/crate/expression/reference/sys/check/cluster/SysChecksTest.java
@@ -21,8 +21,8 @@
 
 package io.crate.expression.reference.sys.check.cluster;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static io.crate.testing.TestingHelpers.createNodeContext;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -67,7 +67,7 @@ public class SysChecksTest extends ESTestCase {
 
         List<PartitionName> partitionsFirst = buildPartitions(500);
         List<PartitionName> partitionsSecond = buildPartitions(100);
-        when(docTableInfo.getPartitions(any())).thenReturn(partitionsFirst, partitionsSecond);
+        when(docTableInfo.getPartitionNames(any())).thenReturn(partitionsFirst, partitionsSecond);
 
         assertThat(numberOfPartitionsSysCheck.id()).isEqualTo(2);
         assertThat(numberOfPartitionsSysCheck.severity()).isEqualTo(Severity.MEDIUM);
@@ -86,7 +86,7 @@ public class SysChecksTest extends ESTestCase {
         when(clusterService.state()).thenReturn(ClusterState.EMPTY_STATE);
         when(docSchemaInfo.getTables()).thenReturn(List.of(docTableInfo));
         when(docTableInfo.isPartitioned()).thenReturn(true);
-        when(docTableInfo.getPartitions(any())).thenReturn(partitions);
+        when(docTableInfo.getPartitionNames(any())).thenReturn(partitions);
 
         assertThat(numberOfPartitionsSysCheck.id()).isEqualTo(2);
         assertThat(numberOfPartitionsSysCheck.severity()).isEqualTo(Severity.MEDIUM);


### PR DESCRIPTION
`PartitionInfos` used `IndexMetadata.mapping()` to create the values for
the `PartitionInfo`.

Direct `.mapping()` access is problematic in the context of:

https://github.com/crate/crate/issues/11939
