### PR TITLE
Assert schema on TableInfo instead of IndexMetadata mapping in ColumnPolicyIntegrationTest

### DIFF
--- a/server/src/test/java/io/crate/analyze/AlterTableAddColumnAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/AlterTableAddColumnAnalyzerTest.java
@@ -221,9 +221,9 @@ public class AlterTableAddColumnAnalyzerTest extends CrateDummyClusterServiceUni
 
         var addColumnRequest = analyze("alter table t add column o1 object as (o2 object as (b int check (o1['o2']['b'] > 100)))");
         assertThat(addColumnRequest.references()).satisfiesExactly(
-            o1 -> assertThat(o1).isReference().hasName("o1"),
-            o1 -> assertThat(o1).isReference().hasName("o1['o2']"),
-            o1 -> assertThat(o1).isReference().hasName("o1['o2']['b']").hasType(DataTypes.INTEGER)
+            o1 -> assertThat(o1).hasName("o1"),
+            o1 -> assertThat(o1).hasName("o1['o2']"),
+            o1 -> assertThat(o1).hasName("o1['o2']['b']").hasType(DataTypes.INTEGER)
         );
         assertThat(addColumnRequest.checkConstraints()).containsValue("\"o1\"['o2']['b'] > 100");
     }

--- a/server/src/test/java/io/crate/analyze/AlterTableDropColumnAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/AlterTableDropColumnAnalyzerTest.java
@@ -54,7 +54,7 @@ public class AlterTableDropColumnAnalyzerTest extends CrateDummyClusterServiceUn
 
         AnalyzedAlterTableDropColumn d = e.analyze("ALTER TABLE t DROP COLUMN a");
         assertThat(d.columns()).satisfiesExactly(
-            dc -> assertThat(dc.ref()).isReference().hasName("a"));
+            dc -> assertThat(dc.ref()).hasName("a"));
     }
 
     @Test
@@ -65,8 +65,8 @@ public class AlterTableDropColumnAnalyzerTest extends CrateDummyClusterServiceUn
         AnalyzedAlterTableDropColumn d = e.analyze("ALTER TABLE t DROP COLUMN a, DROP b");
         assertThat(d.table().ident().name()).isEqualTo("t");
         assertThat(d.columns()).satisfiesExactly(
-            dc -> assertThat(dc.ref()).isReference().hasName("a"),
-            dc -> assertThat(dc.ref()).isReference().hasName("b"));
+            dc -> assertThat(dc.ref()).hasName("a"),
+            dc -> assertThat(dc.ref()).hasName("b"));
     }
 
     @Test
@@ -76,7 +76,7 @@ public class AlterTableDropColumnAnalyzerTest extends CrateDummyClusterServiceUn
 
         AnalyzedAlterTableDropColumn d = e.analyze("ALTER TABLE t DROP COLUMN b");
         assertThat(d.columns()).satisfiesExactly(
-            dc -> assertThat(dc.ref()).isReference().hasName("b"));
+            dc -> assertThat(dc.ref()).hasName("b"));
     }
 
     @Test
@@ -86,7 +86,7 @@ public class AlterTableDropColumnAnalyzerTest extends CrateDummyClusterServiceUn
 
         AnalyzedAlterTableDropColumn d = e.analyze("ALTER TABLE t DROP COLUMN b");
         assertThat(d.columns()).satisfiesExactly(
-            dc -> assertThat(dc.ref()).isReference().hasName("b"));
+            dc -> assertThat(dc.ref()).hasName("b"));
     }
 
     @Test
@@ -96,7 +96,7 @@ public class AlterTableDropColumnAnalyzerTest extends CrateDummyClusterServiceUn
 
         AnalyzedAlterTableDropColumn d = e.analyze("ALTER TABLE t DROP COLUMN b");
         assertThat(d.columns()).satisfiesExactly(
-            dc -> assertThat(dc.ref()).isReference().hasName("b"));
+            dc -> assertThat(dc.ref()).hasName("b"));
     }
 
     @Test
@@ -107,7 +107,7 @@ public class AlterTableDropColumnAnalyzerTest extends CrateDummyClusterServiceUn
 
         AnalyzedAlterTableDropColumn d = e.analyze("ALTER TABLE t DROP COLUMN o['oo']");
         assertThat(d.columns()).satisfiesExactly(
-            dc -> assertThat(dc.ref()).isReference().hasName("o['oo']"));
+            dc -> assertThat(dc.ref()).hasName("o['oo']"));
     }
 
     @Test
@@ -129,7 +129,6 @@ public class AlterTableDropColumnAnalyzerTest extends CrateDummyClusterServiceUn
         assertThat(d.table().ident().name()).isEqualTo("t");
         assertThat(d.columns()).satisfiesExactly(
             dc -> assertThat(dc.ref())
-                .isReference()
                 .hasColumnIdent(ColumnIdent.of("o", List.of("oo", "ooa")))
                 .hasTableIdent(d.table().ident())
                 .hasType(DataTypes.INTEGER)
@@ -189,19 +188,17 @@ public class AlterTableDropColumnAnalyzerTest extends CrateDummyClusterServiceUn
         AnalyzedAlterTableDropColumn d2 = e.analyze("ALTER TABLE t1 DROP COLUMN b, DROP IF EXISTS d");
         assertThat(d2.table().ident().name()).isEqualTo("t1");
         assertThat(d2.columns()).satisfiesExactly(
-            dc -> assertThat(dc.ref()).isReference().hasName("b"));
+            dc -> assertThat(dc.ref()).hasName("b"));
 
         AnalyzedAlterTableDropColumn d3 = e.analyze("ALTER TABLE t2 DROP COLUMN o['oa'], DROP COLUMN IF EXISTS o['ob'], " +
                          "DROP o['oo']['ooa'], DROP IF EXISTS o['oo']['ooc']");
         assertThat(d3.table().ident().name()).isEqualTo("t2");
         assertThat(d3.columns()).satisfiesExactly(
             dc -> assertThat(dc.ref())
-                .isReference()
                 .hasColumnIdent(ColumnIdent.of("o", "oa"))
                 .hasTableIdent(d3.table().ident())
                 .hasType(DataTypes.INTEGER),
             dc -> assertThat(dc.ref())
-                .isReference()
                 .hasColumnIdent(ColumnIdent.of("o", List.of("oo", "ooa")))
                 .hasTableIdent(d3.table().ident())
                 .hasType(DataTypes.INTEGER)

--- a/server/src/test/java/io/crate/analyze/AlterTableRenameColumnAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/AlterTableRenameColumnAnalyzerTest.java
@@ -49,7 +49,7 @@ public class AlterTableRenameColumnAnalyzerTest extends CrateDummyClusterService
             .addTable("create table t (a int)");
 
         AnalyzedAlterTableRenameColumn analyzed = e.analyze("alter table t rename column a to b");
-        assertThat(analyzed.refToRename()).isReference().hasName("a");
+        assertThat(analyzed.refToRename()).hasName("a");
         assertThat(analyzed.newName()).isEqualTo(ColumnIdent.of("b"));
         assertThat(analyzed.table()).isEqualTo(new RelationName("doc", "t"));
     }
@@ -60,7 +60,7 @@ public class AlterTableRenameColumnAnalyzerTest extends CrateDummyClusterService
             .addTable("create table t (o object as (o2 object as (o3 object)))");
 
         AnalyzedAlterTableRenameColumn analyzed = e.analyze("alter table t rename column o['o2']['o3'] to o['o2']['x']");
-        assertThat(analyzed.refToRename()).isReference().hasColumnIdent(ColumnIdent.of("o", List.of("o2", "o3")));
+        assertThat(analyzed.refToRename()).hasColumnIdent(ColumnIdent.of("o", List.of("o2", "o3")));
         assertThat(analyzed.newName()).isEqualTo(ColumnIdent.of("o", List.of("o2", "x")));
         assertThat(analyzed.table()).isEqualTo(new RelationName("doc", "t"));
     }
@@ -71,7 +71,7 @@ public class AlterTableRenameColumnAnalyzerTest extends CrateDummyClusterService
             .addTable("create table t (o object as (o2 object as (o3 object)))");
 
         AnalyzedAlterTableRenameColumn analyzed = e.analyze("alter table t rename column o['o2']['o3'] to o['o2']['x']");
-        assertThat(analyzed.refToRename()).isReference().hasColumnIdent(ColumnIdent.of("o", List.of("o2", "o3")));
+        assertThat(analyzed.refToRename()).hasColumnIdent(ColumnIdent.of("o", List.of("o2", "o3")));
         assertThat(analyzed.newName()).isEqualTo(ColumnIdent.of("o", List.of("o2", "x")));
         assertThat(analyzed.table()).isEqualTo(new RelationName("doc", "t"));
     }

--- a/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -26,6 +26,7 @@ import static io.crate.metadata.FulltextAnalyzerResolver.CustomType.ANALYZER;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_ROUTING_EXCLUDE_GROUP_SETTING;
 import static org.elasticsearch.index.engine.EngineConfig.INDEX_CODEC_SETTING;
@@ -913,8 +914,8 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
         Reference ftRef = columns.get(ft);
         assertThat(ftRef).isExactlyInstanceOf(IndexReference.class);
         assertThat(((IndexReference) ftRef).columns()).satisfiesExactly(
-            x -> assertThat(x).isReference().hasName("title"),
-            x -> assertThat(x).isReference().hasName("name")
+            x -> assertThat(x).hasName("title"),
+            x -> assertThat(x).hasName("name")
         );
     }
 
@@ -1544,7 +1545,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
         ColumnIdent o2b = ColumnIdent.of("o1", List.of("o2", "b"));
         Map<ColumnIdent, Reference> columns = createTable.columns();
         assertThat(columns).containsKey(o2b);
-        assertThat(columns.get(o2b)).isReference().hasName("o1['o2']['b']").hasType(DataTypes.INTEGER);
+        assertThat(columns.get(o2b)).hasName("o1['o2']['b']").hasType(DataTypes.INTEGER);
         assertThat(createTable.checks()).hasSize(1);
         AnalyzedCheck check = createTable.checks().values().iterator().next();
         assertThat(check.check()).isSQL("(doc.t.o1['o2']['b'] > 100)");
@@ -1882,7 +1883,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
         Map<ColumnIdent, Reference> columns = createTable.columns();
         assertThat(columns).containsKeys(x);
         Reference xRef = columns.get(x);
-        assertThat(xRef).isReference().hasName("x").hasType(new ArrayType<>(new ArrayType<>(DataTypes.INTEGER)));
+        assertThat(xRef).hasName("x").hasType(new ArrayType<>(new ArrayType<>(DataTypes.INTEGER)));
     }
 
 

--- a/server/src/test/java/io/crate/analyze/InsertAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/InsertAnalyzerTest.java
@@ -225,7 +225,7 @@ public class InsertAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(statement.onDuplicateKeyAssignments()).hasSize(1);
 
         for (var entry : statement.onDuplicateKeyAssignments().entrySet()) {
-            assertThat(entry.getKey()).isReference().hasName("name");
+            assertThat(entry.getKey()).hasName("name");
             assertThat(entry.getValue()).isLiteral("Arthur", StringType.INSTANCE);
         }
     }
@@ -240,7 +240,7 @@ public class InsertAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(statement.onDuplicateKeyAssignments()).hasSize(1);
 
         for (var entry : statement.onDuplicateKeyAssignments().entrySet()) {
-            assertThat(entry.getKey()).isReference().hasName("name");
+            assertThat(entry.getKey()).hasName("name");
             assertThat(entry.getValue()).isExactlyInstanceOf(ParameterSymbol.class);
         }
     }
@@ -254,7 +254,7 @@ public class InsertAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(statement.onDuplicateKeyAssignments()).hasSize(1);
 
         for (var entry : statement.onDuplicateKeyAssignments().entrySet()) {
-            assertThat(entry.getKey()).isReference().hasName("name");
+            assertThat(entry.getKey()).hasName("name");
             assertThat(entry.getValue()).isFunction(SubstrFunction.NAME);
             Function function = (Function) entry.getValue();
             assertThat(function.arguments().get(0)).isExactlyInstanceOf(InputColumn.class);

--- a/server/src/test/java/io/crate/execution/ddl/tables/AddColumnTaskTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/tables/AddColumnTaskTest.java
@@ -253,7 +253,7 @@ public class AddColumnTaskTest extends CrateDummyClusterServiceUnitTest {
         ClusterState newState = addColumnTask.execute(state, request);
         DocTableInfo newTable = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
         Reference addedColumn = newTable.getReference(newColumn1.column());
-        assertThat(addedColumn).isReference().hasType(new ArrayType<>(new ArrayType<>(DataTypes.LONG)));
+        assertThat(addedColumn).hasType(new ArrayType<>(new ArrayType<>(DataTypes.LONG)));
     }
 
     @Test
@@ -287,7 +287,7 @@ public class AddColumnTaskTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo newTable = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
 
         Reference addedColumn = newTable.getReference(colToAdd.column());
-        assertThat(addedColumn).isReference().hasOid(COLUMN_OID_UNASSIGNED);
+        assertThat(addedColumn).hasOid(COLUMN_OID_UNASSIGNED);
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/ddl/tables/DropColumnTaskTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/tables/DropColumnTaskTest.java
@@ -77,7 +77,7 @@ public class DropColumnTaskTest extends CrateDummyClusterServiceUnitTest {
         assertThat(newTable.getReference(colToDrop.column())).isNull();
         assertThat(newTable.columns()).hasSize(2);
         assertThat(newTable.droppedColumns()).satisfiesExactly(
-            x -> assertThat(x).isReference()
+            x -> assertThat(x)
                 .hasName("_dropped_2")
                 .hasPosition(2)
         );

--- a/server/src/test/java/io/crate/execution/ddl/tables/RenameColumnTaskTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/tables/RenameColumnTaskTest.java
@@ -62,7 +62,7 @@ public class RenameColumnTaskTest extends CrateDummyClusterServiceUnitTest {
         ClusterState newState = renameColumnTask.execute(clusterService.state(), request);
         DocTableInfo newTable = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
         assertThat(newTable.getReference(refToRename.column())).isNull();
-        assertThat(newTable.getReference(newName)).isReference().hasName(newName.sqlFqn());
+        assertThat(newTable.getReference(newName)).hasName(newName.sqlFqn());
     }
 
     @Test
@@ -82,7 +82,7 @@ public class RenameColumnTaskTest extends CrateDummyClusterServiceUnitTest {
         ClusterState newState = renameColumnTask.execute(clusterService.state(), request);
         tbl = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
         assertThat(tbl.getReference(refToRename1.column())).isNull();
-        assertThat(tbl.getReference(newName1)).isReference().hasName(newName1.sqlFqn());
+        assertThat(tbl.getReference(newName1)).hasName(newName1.sqlFqn());
 
         Reference refToRename2 = tbl.getReference(ColumnIdent.of("p", List.of("o2")));
         var newName2 = ColumnIdent.of("p", List.of("p2"));
@@ -90,7 +90,7 @@ public class RenameColumnTaskTest extends CrateDummyClusterServiceUnitTest {
         newState = renameColumnTask.execute(newState, request);
         tbl = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
         assertThat(tbl.getReference(refToRename2.column())).isNull();
-        assertThat(tbl.getReference(newName2)).isReference().hasName(newName2.sqlFqn());
+        assertThat(tbl.getReference(newName2)).hasName(newName2.sqlFqn());
 
         Reference refToRename3 = tbl.getReference(ColumnIdent.of("p", List.of("p2", "x")));
         var newName3 = ColumnIdent.of("p", List.of("p2", "y"));
@@ -98,7 +98,7 @@ public class RenameColumnTaskTest extends CrateDummyClusterServiceUnitTest {
         newState = renameColumnTask.execute(newState, request);
         tbl = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
         assertThat(tbl.getReference(refToRename3.column())).isNull();
-        assertThat(tbl.getReference(newName3)).isReference().hasName(newName3.sqlFqn());
+        assertThat(tbl.getReference(newName3)).hasName(newName3.sqlFqn());
     }
 
     @Test
@@ -120,7 +120,7 @@ public class RenameColumnTaskTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo newTable = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
         assertThat(newTable.getReference(refToRename.column())).isNull();
         assertThat(newTable.partitionedBy()).doesNotContain(refToRename.column());
-        assertThat(newTable.getReference(newName)).isReference().hasName(newName.name());
+        assertThat(newTable.getReference(newName)).hasName(newName.name());
         assertThat(newTable.partitionedBy()).doesNotContain(refToRename.column()).contains(newName);
 
         // alter table tbl rename column o to p;
@@ -133,7 +133,7 @@ public class RenameColumnTaskTest extends CrateDummyClusterServiceUnitTest {
         newState = renameColumnTask.execute(newState, request);
         newTable = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
         assertThat(newTable.getReference(oldNameOfChild)).isNull();
-        assertThat(newTable.getReference(newName)).isReference().hasName(newNameOfChild.name());
+        assertThat(newTable.getReference(newName)).hasName(newNameOfChild.name());
         assertThat(newTable.partitionedBy()).doesNotContain(oldNameOfChild).contains(newNameOfChild);
     }
 
@@ -154,7 +154,7 @@ public class RenameColumnTaskTest extends CrateDummyClusterServiceUnitTest {
         var oldPkCol = ColumnIdent.of("o", List.of("o2", "o3", "x"));
         var newPkCol = ColumnIdent.of("o", List.of("p2", "o3", "x"));
         assertThat(newTable.getReference(refToRename.column())).isNull();
-        assertThat(newTable.getReference(newName)).isReference().hasName(newName.sqlFqn());
+        assertThat(newTable.getReference(newName)).hasName(newName.sqlFqn());
         assertThat(newTable.primaryKey()).doesNotContain(oldPkCol).contains(newPkCol);
     }
 
@@ -283,7 +283,7 @@ public class RenameColumnTaskTest extends CrateDummyClusterServiceUnitTest {
 
         var renamedIndexColumn = tbl.indexColumn(ColumnIdent.of("i2"));
         assertThat(renamedIndexColumn.columns()).hasSize(1);
-        assertThat(renamedIndexColumn.columns().getFirst()).isReference().hasName("x2");
+        assertThat(renamedIndexColumn.columns().getFirst()).hasName("x2");
         assertThat(renamedIndexColumn.column()).isEqualTo(ColumnIdent.of("i2"));
     }
 }

--- a/server/src/test/java/io/crate/execution/dml/IndexerTest.java
+++ b/server/src/test/java/io/crate/execution/dml/IndexerTest.java
@@ -26,6 +26,7 @@ import static io.crate.types.GeoShapeType.Names.TREE_BKD;
 import static io.crate.types.GeoShapeType.Names.TREE_GEOHASH;
 import static io.crate.types.GeoShapeType.Names.TREE_LEGACY_QUADTREE;
 import static io.crate.types.GeoShapeType.Names.TREE_QUADTREE;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
 
@@ -207,10 +208,10 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
 
         assertThat(newColumns)
             .satisfiesExactly(
-                col1 -> assertThat(col1).isReference().hasName("o['obj']"),
-                col2 -> assertThat(col2).isReference()
+                col1 -> assertThat(col1).hasName("o['obj']"),
+                col2 -> assertThat(col2)
                     .hasName("o['obj']['y']"),
-                col3 -> assertThat(col3).isReference()
+                col3 -> assertThat(col3)
                     .hasName("o['obj']['z']")
             );
 
@@ -264,7 +265,6 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(newColumns)
             .satisfiesExactly(
                 col1 -> assertThat(col1)
-                    .isReference()
                     .hasName("o['xs']")
                     .hasType(new ArrayType<>(DataTypes.LONG))
             );
@@ -553,7 +553,6 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         List<Reference> newColumns = indexer.collectSchemaUpdates(item(Map.of("x", 10, "y", 20)));
         assertThat(newColumns).satisfiesExactly(
             r -> assertThat(r)
-                .isReference()
                 .hasName("o['y']")
                 .hasType(DataTypes.LONG)
         );
@@ -743,12 +742,10 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         ParsedDocument doc = indexer.index(item);
         assertThat(newColumns).satisfiesExactly(
             x -> assertThat(x)
-                .isReference()
                 .hasName("y")
                 .hasType(DataTypes.STRING)
                 .hasPosition(-1),
             x -> assertThat(x)
-                .isReference()
                 .hasName("z")
                 .hasType(DataTypes.LONG)
                 .hasPosition(-2)
@@ -1068,7 +1065,6 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         ParsedDocument doc = indexer.index(item);
         assertThat(newColumns).satisfiesExactly(
             column -> assertThat(column)
-                .isReference()
                 .hasName("y")
                 .hasType(new ArrayType<>(new ArrayType<>(DataTypes.LONG)))
         );

--- a/server/src/test/java/io/crate/execution/dml/upsert/UpdateToInsertTest.java
+++ b/server/src/test/java/io/crate/execution/dml/upsert/UpdateToInsertTest.java
@@ -201,8 +201,8 @@ public class UpdateToInsertTest extends CrateDummyClusterServiceUnitTest {
             new Object[] {}
         );
         assertThat(updateToInsert.columns()).satisfiesExactly(
-            c -> assertThat(c).isReference().hasName("x"),
-            c -> assertThat(c).isReference().hasName("y")
+            c -> assertThat(c).hasName("x"),
+            c -> assertThat(c).hasName("y")
         );
         assertThat(item.insertValues())
             .containsExactly(1, 2);
@@ -264,9 +264,9 @@ public class UpdateToInsertTest extends CrateDummyClusterServiceUnitTest {
         assertThat(updateToInsert.columns())
             .as("Start References of columns() must match insertColumns")
             .satisfiesExactly(
-                x -> assertThat(x).isReference().hasName("z"),
-                x -> assertThat(x).isReference().hasName("x"),
-                x -> assertThat(x).isReference().hasName("y")
+                x -> assertThat(x).hasName("z"),
+                x -> assertThat(x).hasName("x"),
+                x -> assertThat(x).hasName("y")
             );
 
         Map<String, Object> source = Map.of("x", 1, "y", 2, "z", 3);
@@ -303,9 +303,9 @@ public class UpdateToInsertTest extends CrateDummyClusterServiceUnitTest {
         assertThat(updateToInsert.columns())
             .as("Start References of columns() must match insertColumns")
             .satisfiesExactly(
-                    x -> assertThat(x).isReference().hasName("z"),
-                    x -> assertThat(x).isReference().hasName("x"),
-                    x -> assertThat(x).isReference().hasName("y")
+                    x -> assertThat(x).hasName("z"),
+                    x -> assertThat(x).hasName("x"),
+                    x -> assertThat(x).hasName("y")
             );
 
         Map<String, Object> source = Map.of("x", 1, "y", Map.of("a", 2), "z", 3);
@@ -354,8 +354,8 @@ public class UpdateToInsertTest extends CrateDummyClusterServiceUnitTest {
             new Object[] { 1, 20 }
         );
         assertThat(updateToInsert.columns()).satisfiesExactly(
-            x -> assertThat(x).isReference().hasName("x"),
-            x -> assertThat(x).isReference().hasName("z")
+            x -> assertThat(x).hasName("x"),
+            x -> assertThat(x).hasName("z")
         );
         assertThat(item.pkValues()).containsExactly("1", "2");
         assertThat(item.insertValues()).containsExactly(1, 20);

--- a/server/src/test/java/io/crate/integrationtests/ColumnPolicyIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ColumnPolicyIntegrationTest.java
@@ -27,7 +27,6 @@ import static io.crate.testing.Asserts.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Paths;
 import java.util.List;
@@ -37,8 +36,6 @@ import org.elasticsearch.test.IntegTestCase;
 import org.junit.Test;
 
 import io.crate.metadata.ColumnIdent;
-import io.crate.metadata.NodeContext;
-import io.crate.metadata.RelationName;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.planner.optimizer.rule.MergeFilterAndCollect;
 import io.crate.planner.optimizer.rule.OptimizeCollectWhereClauseAccess;
@@ -54,20 +51,6 @@ public class ColumnPolicyIntegrationTest extends IntegTestCase {
     private String copyFilePath = Paths.get(getClass().getResource("/essetup/data/copy").toURI()).toUri().toString();
 
     public ColumnPolicyIntegrationTest() throws URISyntaxException {
-    }
-
-    private DocTableInfo getTable(RelationName name) {
-        return cluster().getInstance(NodeContext.class)
-            .schemas()
-            .getTableInfo(name);
-    }
-
-    private DocTableInfo getTable(String table) throws IOException {
-        return getTable(new RelationName(sqlExecutor.getCurrentSchema(), table));
-    }
-
-    private DocTableInfo getTable(String schema, String table) throws IOException {
-        return getTable(new RelationName(schema, table));
     }
 
     @Test

--- a/server/src/test/java/io/crate/metadata/SystemTableTest.java
+++ b/server/src/test/java/io/crate/metadata/SystemTableTest.java
@@ -23,6 +23,7 @@ package io.crate.metadata;
 
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.isReference;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.Map;
@@ -47,7 +48,7 @@ public class SystemTableTest {
 
         assertThat(table.columns()).satisfiesExactly(isReference("obj_a"));
         assertThat(table.getReference(ColumnIdent.of("obj_a", List.of("obj_b", "x"))))
-            .isReference().hasName("obj_a['obj_b']['x']");
+            .hasName("obj_a['obj_b']['x']");
 
         var x = table.expressions().get(ColumnIdent.of("obj_a", List.of("obj_b", "x"))).create();
         x.setNextRow(null);
@@ -83,7 +84,7 @@ public class SystemTableTest {
                 .add("y", DataTypes.INTEGER, point -> point.y)
             .endObjectArray()
             .build();
-        assertThat(table.getReference(ColumnIdent.of("points"))).isReference().hasName("points");
+        assertThat(table.getReference(ColumnIdent.of("points"))).hasName("points");
         var points = table.expressions().get(ColumnIdent.of("points")).create();
         points.setNextRow(null);
         assertThat(points.value()).isEqualTo(
@@ -91,7 +92,6 @@ public class SystemTableTest {
                 Map.of("x", 10, "y", 20),
                 Map.of("x", 30, "y", 40)));
         assertThat(table.getReference(ColumnIdent.of("points", "x")))
-            .isReference()
             .hasName("points['x']")
             .hasType(new ArrayType<>(DataTypes.INTEGER));
         var xs = table.expressions().get(ColumnIdent.of("points", "x")).create();

--- a/server/src/test/java/io/crate/metadata/doc/DocIndexMetadataTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocIndexMetadataTest.java
@@ -26,6 +26,7 @@ import static io.crate.testing.Asserts.isLiteral;
 import static io.crate.testing.Asserts.isReference;
 import static io.crate.testing.TestingHelpers.createNodeContext;
 import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
@@ -1711,7 +1712,7 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
         assertThat(table.indexColumns()).hasSize(1);
         IndexReference ref = table.indexColumns().iterator().next();
         assertThat(ref.columns()).satisfiesExactly(
-            x -> assertThat(x).isReference().hasName("description")
+            x -> assertThat(x).hasName("description")
         );
     }
 

--- a/server/src/test/java/io/crate/metadata/doc/DocTableInfoTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocTableInfoTest.java
@@ -327,12 +327,12 @@ public class DocTableInfoTest extends CrateDummyClusterServiceUnitTest {
         Reference yref = table1.getReference(ColumnIdent.of("y"));
         DocTableInfo table2 = table1.dropColumns(List.of(new DropColumn(xref, true)));
         assertThat(table2.droppedColumns()).satisfiesExactlyInAnyOrder(
-            x -> assertThat(x).isReference().hasName("x")
+            x -> assertThat(x).hasName("x")
         );
         DocTableInfo table3 = table2.dropColumns(List.of(new DropColumn(yref, true)));
         assertThat(table3.droppedColumns()).satisfiesExactlyInAnyOrder(
-            x -> assertThat(x).isReference().hasName("x"),
-            x -> assertThat(x).isReference().hasName("y")
+            x -> assertThat(x).hasName("x"),
+            x -> assertThat(x).hasName("y")
         );
     }
 
@@ -359,7 +359,8 @@ public class DocTableInfoTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo tbl2 = docTableInfoFactory.create(tbl.ident(), builder.build());
 
         Reference description = tbl2.getReference(ColumnIdent.of("description"));
-        assertThat(description).isIndexReference()
+        assertThat(description)
+            .isExactlyInstanceOf(IndexReference.class)
             .hasName("description")
             .hasAnalyzer("simple");
 
@@ -367,7 +368,7 @@ public class DocTableInfoTest extends CrateDummyClusterServiceUnitTest {
         assertThat(indexColumn).isNotNull();
         assertThat(indexColumn.analyzer()).isEqualTo("standard");
         assertThat(indexColumn.columns()).satisfiesExactly(
-            x -> assertThat(x).isReference().hasName("name")
+            x -> assertThat(x).hasName("name")
         );
     }
 
@@ -393,17 +394,17 @@ public class DocTableInfoTest extends CrateDummyClusterServiceUnitTest {
             new IntArrayList(),
             Map.of());
         assertThat(table2.columns()).satisfiesExactly(
-            x -> assertThat(x).isReference()
+            x -> assertThat(x)
                 .hasName("x")
                 .hasType(DataTypes.INTEGER)
                 .hasPosition(1)
                 .isSameAs(xref),
-            x -> assertThat(x).isReference()
+            x -> assertThat(x)
                 .hasName("point")
                 .hasPosition(2)
                 .hasType(pointRef.valueType())
                 .isSameAs(pointRef),
-            x -> assertThat(x).isReference()
+            x -> assertThat(x)
                 .hasName("y")
                 .hasPosition(4)
                 .hasType(DataTypes.LONG)
@@ -497,15 +498,12 @@ public class DocTableInfoTest extends CrateDummyClusterServiceUnitTest {
             .setInnerType("a1", DataTypes.INTEGER).build();
 
         assertThat(newTable.getReference(ColumnIdent.of("o", List.of("o", "o"))))
-            .isReference()
             .hasName("o['o']['o']")
             .hasType(oooType);
         assertThat(newTable.getReference(ColumnIdent.of("o", List.of("o"))))
-            .isReference()
             .hasName("o['o']")
             .hasType(ooType);
         assertThat(newTable.getReference(ColumnIdent.of("o")))
-            .isReference()
             .hasName("o")
             .hasType(oType);
     }
@@ -535,11 +533,9 @@ public class DocTableInfoTest extends CrateDummyClusterServiceUnitTest {
         assertThat(newTable.getReference(dropCol2)).isNull();
         assertThat(newTable.getReference(dropCol3)).isNull();
         assertThat(newTable.getReference(ColumnIdent.of("o", List.of("o"))))
-            .isReference()
             .hasName("o['o']")
             .hasType(ooType);
         assertThat(newTable.getReference(ColumnIdent.of("o")))
-            .isReference()
             .hasName("o")
             .hasType(oType);
     }
@@ -567,11 +563,10 @@ public class DocTableInfoTest extends CrateDummyClusterServiceUnitTest {
 
         assertThat(table.getReference(ooo)).isNull();
         assertThat(table.getReference(ooo2))
-            .isReference()
             .hasName("o['o']['o2']")
             .hasType(ooo2Type);
-        assertThat(table.getReference(oo)).isReference().hasName("o['o']")
+        assertThat(table.getReference(oo)).hasName("o['o']")
             .hasType(ooType);
-        assertThat(table.getReference(o)).isReference().hasName("o").hasType(oType);
+        assertThat(table.getReference(o)).hasName("o").hasType(oType);
     }
 }

--- a/server/src/testFixtures/java/io/crate/testing/Asserts.java
+++ b/server/src/testFixtures/java/io/crate/testing/Asserts.java
@@ -43,6 +43,7 @@ import io.crate.data.Input;
 import io.crate.execution.dsl.projection.Projection;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.table.TableInfo;
@@ -64,6 +65,10 @@ public class Asserts extends Assertions {
 
     public static SymbolAssert assertThat(Symbol actual) {
         return new SymbolAssert(actual);
+    }
+
+    public static ReferenceAssert assertThat(Reference reference) {
+        return new ReferenceAssert(reference);
     }
 
     public static SymbolsAssert<? extends Symbol> assertList(List<? extends Symbol> actual) {

--- a/server/src/testFixtures/java/io/crate/testing/ReferenceAssert.java
+++ b/server/src/testFixtures/java/io/crate/testing/ReferenceAssert.java
@@ -23,15 +23,18 @@ package io.crate.testing;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.assertj.core.api.AbstractAssert;
+import java.util.function.Consumer;
 
+import org.assertj.core.api.AbstractObjectAssert;
+
+import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.IndexReference;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 import io.crate.types.DataType;
 
-public class ReferenceAssert extends AbstractAssert<ReferenceAssert, Reference> {
+public class ReferenceAssert extends AbstractObjectAssert<ReferenceAssert, Reference> {
 
     public ReferenceAssert(Reference reference) {
         super(reference, ReferenceAssert.class);
@@ -79,10 +82,23 @@ public class ReferenceAssert extends AbstractAssert<ReferenceAssert, Reference> 
         return this;
     }
 
+    public ReferenceAssert hasDefault(Symbol expectedDefault) {
+        assertThat(actual.defaultExpression())
+            .as("defaultExpression")
+            .isEqualTo(expectedDefault);
+        return this;
+    }
+
     public ReferenceAssert hasAnalyzer(String analyzer) {
         isExactlyInstanceOf(IndexReference.class);
         assertThat(((IndexReference) actual).analyzer()).isEqualTo(analyzer);
         return this;
     }
 
+    @SafeVarargs
+    public final ReferenceAssert hasSourceColumnsSatisfying(Consumer<? super Reference> ... assertions) {
+        isExactlyInstanceOf(IndexReference.class);
+        assertThat(((IndexReference) actual).columns()).satisfiesExactly(assertions);
+        return this;
+    }
 }

--- a/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
@@ -181,6 +181,7 @@ import io.crate.metadata.RelationName;
 import io.crate.metadata.RoutingProvider;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.SearchPath;
+import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.settings.CoordinatorSessionSettings;
 import io.crate.metadata.settings.SessionSettings;
 import io.crate.planner.DependencyCarrier;
@@ -1848,24 +1849,18 @@ public abstract class IntegTestCase extends ESTestCase {
         }
     }
 
-    /**
-     * Get all mappings from an index as JSON String
-     *
-     * @param index the name of the index
-     * @return the index mapping as String
-     * @throws IOException
-     */
-    protected Map<String, Object> getIndexMapping(String index) throws IOException {
-        ClusterStateRequest request = new ClusterStateRequest()
-            .routingTable(false)
-            .nodes(false)
-            .metadata(true)
-            .indices(index);
-        ClusterStateResponse response = FutureUtils.get(client().admin().cluster().state(request));
+    public DocTableInfo getTable(RelationName name) {
+        return cluster().getCurrentMasterNodeInstance(NodeContext.class)
+            .schemas()
+            .getTableInfo(name);
+    }
 
-        Metadata metadata = response.getState().metadata();
-        IndexMetadata indexMetadata = metadata.iterator().next();
-        return indexMetadata.mapping().sourceAsMap();
+    public DocTableInfo getTable(String table) throws IOException {
+        return getTable(new RelationName(sqlExecutor.getCurrentSchema(), table));
+    }
+
+    public DocTableInfo getTable(String schema, String table) throws IOException {
+        return getTable(new RelationName(schema, table));
     }
 
     public void assertFunctionIsCreatedOnAll(String schema, String name, List<DataType<?>> argTypes) throws Exception {


### PR DESCRIPTION
Relates to https://github.com/crate/crate/issues/11939
