### PR TITLE
Format _array(...) as [...]

### DIFF
--- a/server/src/main/java/io/crate/expression/symbol/Function.java
+++ b/server/src/main/java/io/crate/expression/symbol/Function.java
@@ -370,6 +370,10 @@ public class Function implements Symbol, Cloneable {
                 }
                 break;
 
+            case ArrayFunction.NAME:
+                printArray(builder, style);
+                break;
+
             default:
                 if (AnyOperator.OPERATOR_NAMES.contains(name)) {
                     printAnyOperator(builder, style);
@@ -401,6 +405,19 @@ public class Function implements Symbol, Cloneable {
         builder.append(arguments.get(0).toString(style));
         builder.append(").");
         builder.append(arguments.get(1).toString(style));
+    }
+
+    private void printArray(StringBuilder builder, Style style) {
+        builder.append("[");
+        int size = arguments.size();
+        for (int i = 0; i < size; i++) {
+            Symbol arg = arguments.get(i);
+            builder.append(arg.toString(style));
+            if (i + 1 < size) {
+                builder.append(", ");
+            }
+        }
+        builder.append("]");
     }
 
     private void printAnyOperator(StringBuilder builder, Style style) {

--- a/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -325,7 +325,7 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     public void testAnyWithArrayOnBothSidesResultsInNiceErrorMessage() {
         assertThatThrownBy(() -> executor.analyze("select * from tarr where xs = ANY([10, 20])"))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: (doc.tarr.xs = ANY(_array(10, 20)))," +
+            .hasMessageStartingWith("Unknown function: (doc.tarr.xs = ANY([10, 20]))," +
                         " no overload found for matching argument types: (integer_array, integer_array).");
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/ArrayCatFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayCatFunctionTest.java
@@ -67,7 +67,7 @@ public class ArrayCatFunctionTest extends ScalarTestCase {
     public void testOneArgument() {
         assertThatThrownBy(() -> assertEvaluateNull("array_cat([1])"))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: array_cat(_array(1)), " +
+            .hasMessageStartingWith("Unknown function: array_cat([1]), " +
                                     "no overload found for matching argument types: (integer_array).");
     }
 
@@ -75,7 +75,7 @@ public class ArrayCatFunctionTest extends ScalarTestCase {
     public void testThreeArguments() throws Exception {
         assertThatThrownBy(() -> assertEvaluateNull("array_cat([1], [2], [3])"))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: array_cat(_array(1), _array(2), _array(3)), " +
+            .hasMessageStartingWith("Unknown function: array_cat([1], [2], [3]), " +
                     "no overload found for matching argument types: (integer_array, integer_array, integer_array).");
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/ArrayDifferenceFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayDifferenceFunctionTest.java
@@ -102,7 +102,7 @@ public class ArrayDifferenceFunctionTest extends ScalarTestCase {
     public void testOneArgument() {
         assertThatThrownBy(() -> assertNormalize("array_difference([1])", isNull()))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: array_difference(_array(1)), " +
+            .hasMessageStartingWith("Unknown function: array_difference([1]), " +
                                     "no overload found for matching argument types: (integer_array).");
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/ArrayLowerFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayLowerFunctionTest.java
@@ -100,7 +100,7 @@ public class ArrayLowerFunctionTest extends ScalarTestCase {
     public void testOneArgument() {
         assertThatThrownBy(() -> assertEvaluateNull("array_lower([1])"))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: array_lower(_array(1)), " +
+            .hasMessageStartingWith("Unknown function: array_lower([1]), " +
                                     "no overload found for matching argument types: (integer_array).");
     }
 
@@ -108,7 +108,7 @@ public class ArrayLowerFunctionTest extends ScalarTestCase {
     public void testThreeArguments() {
         assertThatThrownBy(() -> assertEvaluateNull("array_lower([1], 2, [3])"))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: array_lower(_array(1), 2, _array(3)), " +
+            .hasMessageStartingWith("Unknown function: array_lower([1], 2, [3]), " +
                     "no overload found for matching argument types: (integer_array, integer, integer_array).");
     }
 
@@ -116,7 +116,7 @@ public class ArrayLowerFunctionTest extends ScalarTestCase {
     public void testSecondArgumentNotANumber() {
         assertThatThrownBy(() -> assertEvaluateNull("array_lower([1], [2])"))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: array_lower(_array(1), _array(2)), " +
+            .hasMessageStartingWith("Unknown function: array_lower([1], [2]), " +
                     "no overload found for matching argument types: (integer_array, integer_array).");
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/ArrayToStringFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayToStringFunctionTest.java
@@ -40,7 +40,7 @@ public class ArrayToStringFunctionTest extends ScalarTestCase {
     public void testOneArgument() {
         assertThatThrownBy(() -> assertEvaluateNull("array_to_string([1, 2])"))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: array_to_string(_array(1, 2)), " +
+            .hasMessageStartingWith("Unknown function: array_to_string([1, 2]), " +
                                     "no overload found for matching argument types: (integer_array).");
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/ArrayUniqueFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayUniqueFunctionTest.java
@@ -115,7 +115,7 @@ public class ArrayUniqueFunctionTest extends ScalarTestCase {
     public void testDifferentUnconvertableInnerTypes() throws Exception {
         assertThatThrownBy(() -> assertEvaluateNull("array_unique([geopoint], [true])"))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: array_unique(_array(doc.users.geopoint), _array(true)), " +
+            .hasMessageStartingWith("Unknown function: array_unique([doc.users.geopoint], [true]), " +
                     "no overload found for matching argument types: (geo_point_array, boolean_array).");
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/ArrayUpperFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayUpperFunctionTest.java
@@ -101,7 +101,7 @@ public class ArrayUpperFunctionTest extends ScalarTestCase {
     public void testOneArgument() {
         assertThatThrownBy(() -> assertEvaluateNull("array_upper([1])"))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: array_upper(_array(1)), " +
+            .hasMessageStartingWith("Unknown function: array_upper([1]), " +
                                     "no overload found for matching argument types: (integer_array).");
     }
 
@@ -109,7 +109,7 @@ public class ArrayUpperFunctionTest extends ScalarTestCase {
     public void testThreeArguments() {
         assertThatThrownBy(() -> assertEvaluateNull("array_upper([1], 2, [3])"))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: array_upper(_array(1), 2, _array(3)), " +
+            .hasMessageStartingWith("Unknown function: array_upper([1], 2, [3]), " +
                 "no overload found for matching argument types: (integer_array, integer, integer_array).");
     }
 
@@ -117,7 +117,7 @@ public class ArrayUpperFunctionTest extends ScalarTestCase {
     public void testSecondArgumentNotANumber() {
         assertThatThrownBy(() -> assertEvaluateNull("array_upper([1], [2])"))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: array_upper(_array(1), _array(2)), " +
+            .hasMessageStartingWith("Unknown function: array_upper([1], [2]), " +
                 "no overload found for matching argument types: (integer_array, integer_array).");
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/ConcatFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ConcatFunctionTest.java
@@ -45,7 +45,7 @@ public class ConcatFunctionTest extends ScalarTestCase {
     public void testArgumentThatHasNoStringRepr() {
         assertThatThrownBy(() -> assertNormalize("concat('foo', [1])", isNull()))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: concat('foo', _array(1)), " +
+            .hasMessageStartingWith("Unknown function: concat('foo', [1]), " +
                                     "no overload found for matching argument types: (text, integer_array).");
     }
 
@@ -94,7 +94,7 @@ public class ConcatFunctionTest extends ScalarTestCase {
     public void testTwoArraysOfIncompatibleInnerTypes() {
         assertThatThrownBy(() -> assertNormalize("concat([1, 2], [[1, 2]])", isNull()))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: concat(_array(1, 2), _array(_array(1, 2))), " +
+            .hasMessageStartingWith("Unknown function: concat([1, 2], [[1, 2]]), " +
                 "no overload found for matching argument types: (integer_array, integer_array_array).");
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/object/ObjectKeysFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/object/ObjectKeysFunctionTest.java
@@ -41,7 +41,7 @@ public class ObjectKeysFunctionTest extends ScalarTestCase {
     public void test_array_input() {
         assertThatThrownBy(() -> assertEvaluateNull("object_keys([1])"))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessage("Unknown function: object_keys(_array(1)), no overload found for " +
+            .hasMessage("Unknown function: object_keys([1]), no overload found for " +
                         "matching argument types: (integer_array). Possible candidates: " +
                         "object_keys(object):array(text)");
     }

--- a/server/src/test/java/io/crate/expression/scalar/regex/RegexpReplaceFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/regex/RegexpReplaceFunctionTest.java
@@ -94,7 +94,7 @@ public class RegexpReplaceFunctionTest extends ScalarTestCase {
         assertThatThrownBy(() ->
                 assertNormalize("regexp_replace('foobar', '.*', [1,2])", isLiteral("")))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: regexp_replace('foobar', '.*', _array(1, 2)), " +
+            .hasMessageStartingWith("Unknown function: regexp_replace('foobar', '.*', [1, 2]), " +
                                     "no overload found for matching argument types: (text, text, integer_array).");
     }
 }

--- a/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -23,6 +23,7 @@ package io.crate.planner.operators;
 
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.MemoryLimits.assertMaxBytesAllocated;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.List;
@@ -644,8 +645,8 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(plan).isEqualTo(
             """
                 Rename[sumx, umaxx, minx, uavgx] AS vt
-                  └ Eval[sum(x) AS sumx, unnest(_array(max(x))) AS umaxx, min(x) AS minx, unnest(_array(avg(x))) AS uavgx]
-                    └ ProjectSet[unnest(_array(min(x))), unnest(_array(max(x))), unnest(_array(avg(x))), unnest(_array(sum(x))), sum(x), max(x), min(x), avg(x)]
+                  └ Eval[sum(x) AS sumx, unnest([max(x)]) AS umaxx, min(x) AS minx, unnest([avg(x)]) AS uavgx]
+                    └ ProjectSet[unnest([min(x)]), unnest([max(x)]), unnest([avg(x)]), unnest([sum(x)]), sum(x), max(x), min(x), avg(x)]
                       └ HashAggregate[min(x), max(x), avg(x), sum(x)]
                         └ Collect[doc.t1 | [x] | true]""");
     }


### PR DESCRIPTION
`_array` is an implementation detail but it got leaked to users in
various error messages which can be confusing as they didn't originally
use `_array` in a statement.

This adds a format implementation to ensure it prints as `[...]`
