### PR TITLE
Remove ignoreAlias option from IndicesOptions

### DIFF
--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportRenameTableAction.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportRenameTableAction.java
@@ -111,7 +111,6 @@ public class TransportRenameTableAction extends TransportMasterNodeAction<Rename
                         true,
                         true,
                         false,
-                        true,
                         true
                     );
                     newIndexNames.set(IndexNameExpressionResolver.concreteIndexNames(

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportRenameTableAction.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportRenameTableAction.java
@@ -112,8 +112,7 @@ public class TransportRenameTableAction extends TransportMasterNodeAction<Rename
                         true,
                         false,
                         true,
-                        true,
-                        false
+                        true
                     );
                     newIndexNames.set(IndexNameExpressionResolver.concreteIndexNames(
                         updatedState.metadata(), openIndices, request.targetName().indexNameOrAlias()));

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/delete/DeleteIndexRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/delete/DeleteIndexRequest.java
@@ -35,7 +35,7 @@ public class DeleteIndexRequest extends AcknowledgedRequest<DeleteIndexRequest> 
 
     private String[] indices;
     // Delete index should work by default on both open and closed indices.
-    private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, true, true, true, false, false);
+    private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, true, true, true, false);
 
     /**
      * Constructs a new delete index request for the specified indices.

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/delete/DeleteIndexRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/delete/DeleteIndexRequest.java
@@ -19,35 +19,23 @@
 
 package org.elasticsearch.action.admin.indices.delete;
 
+import java.io.IOException;
+
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
-import java.io.IOException;
-
 
 /**
  * A request to delete an index.
  */
-public class DeleteIndexRequest extends AcknowledgedRequest<DeleteIndexRequest> implements IndicesRequest.Replaceable {
+public class DeleteIndexRequest extends AcknowledgedRequest<DeleteIndexRequest> implements IndicesRequest {
 
     private String[] indices;
     // Delete index should work by default on both open and closed indices.
-    private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, true, true, true, false, false, true);
-
-    public DeleteIndexRequest() {
-    }
-
-    /**
-     * Constructs a new delete index request for the specified index.
-     *
-     * @param index The index to delete. Use "_all" to delete all indices.
-     */
-    public DeleteIndexRequest(String index) {
-        this.indices = new String[]{index};
-    }
+    private IndicesOptions indicesOptions = IndicesOptions.fromOptions(false, true, true, true, false, false);
 
     /**
      * Constructs a new delete index request for the specified indices.
@@ -65,12 +53,6 @@ public class DeleteIndexRequest extends AcknowledgedRequest<DeleteIndexRequest> 
 
     public DeleteIndexRequest indicesOptions(IndicesOptions indicesOptions) {
         this.indicesOptions = indicesOptions;
-        return this;
-    }
-
-    @Override
-    public DeleteIndexRequest indices(String... indices) {
-        this.indices = indices;
         return this;
     }
 

--- a/server/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
+++ b/server/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
@@ -49,7 +49,6 @@ public class IndicesOptions implements ToXContentFragment {
     public enum Option {
         IGNORE_UNAVAILABLE,
         ALLOW_NO_INDICES,
-        FORBID_ALIASES_TO_MULTIPLE_INDICES,
         FORBID_CLOSED_INDICES;
 
         public static final EnumSet<Option> NONE = EnumSet.noneOf(Option.class);
@@ -68,7 +67,7 @@ public class IndicesOptions implements ToXContentFragment {
     public static final IndicesOptions STRICT_EXPAND_OPEN_FORBID_CLOSED =
         new IndicesOptions(EnumSet.of(Option.ALLOW_NO_INDICES, Option.FORBID_CLOSED_INDICES), EnumSet.of(WildcardStates.OPEN));
     public static final IndicesOptions STRICT_SINGLE_INDEX_NO_EXPAND_FORBID_CLOSED =
-        new IndicesOptions(EnumSet.of(Option.FORBID_ALIASES_TO_MULTIPLE_INDICES, Option.FORBID_CLOSED_INDICES),
+        new IndicesOptions(EnumSet.of(Option.FORBID_CLOSED_INDICES),
             EnumSet.noneOf(WildcardStates.class));
 
     private final EnumSet<Option> options;
@@ -122,15 +121,6 @@ public class IndicesOptions implements ToXContentFragment {
         return options.contains(Option.FORBID_CLOSED_INDICES);
     }
 
-    /**
-     * @return whether aliases pointing to multiple indices are allowed
-     */
-    public boolean allowAliasesToMultipleIndices() {
-        // true is default here, for bw comp we keep the first 16 values
-        // in the array same as before + the default value for the new flag
-        return options.contains(Option.FORBID_ALIASES_TO_MULTIPLE_INDICES) == false;
-    }
-
     public void writeIndicesOptions(StreamOutput out) throws IOException {
         out.writeEnumSet(options);
         out.writeEnumSet(expandWildcards);
@@ -149,7 +139,6 @@ public class IndicesOptions implements ToXContentFragment {
             allowNoIndices,
             expandToOpenIndices,
             expandToClosedIndices,
-            true,
             false
         );
     }
@@ -164,7 +153,6 @@ public class IndicesOptions implements ToXContentFragment {
             allowNoIndices,
             expandToOpenIndices,
             expandToClosedIndices,
-            defaultOptions.allowAliasesToMultipleIndices(),
             defaultOptions.forbidClosedIndices()
         );
     }
@@ -173,7 +161,6 @@ public class IndicesOptions implements ToXContentFragment {
                                              boolean allowNoIndices,
                                              boolean expandToOpenIndices,
                                              boolean expandToClosedIndices,
-                                             boolean allowAliasesToMultipleIndices,
                                              boolean forbidClosedIndices) {
         final Set<Option> opts = new HashSet<>();
         final Set<WildcardStates> wildcards = new HashSet<>();
@@ -189,9 +176,6 @@ public class IndicesOptions implements ToXContentFragment {
         }
         if (expandToClosedIndices) {
             wildcards.add(WildcardStates.CLOSED);
-        }
-        if (allowAliasesToMultipleIndices == false) {
-            opts.add(Option.FORBID_ALIASES_TO_MULTIPLE_INDICES);
         }
         if (forbidClosedIndices) {
             opts.add(Option.FORBID_CLOSED_INDICES);
@@ -288,7 +272,6 @@ public class IndicesOptions implements ToXContentFragment {
                 ", allow_no_indices=" + allowNoIndices() +
                 ", expand_wildcards_open=" + expandWildcardsOpen() +
                 ", expand_wildcards_closed=" + expandWildcardsClosed() +
-                ", allow_aliases_to_multiple_indices=" + allowAliasesToMultipleIndices() +
                 ", forbid_closed_indices=" + forbidClosedIndices() +
                 ']';
     }

--- a/server/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
+++ b/server/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
@@ -48,7 +48,6 @@ public class IndicesOptions implements ToXContentFragment {
 
     public enum Option {
         IGNORE_UNAVAILABLE,
-        IGNORE_ALIASES,
         ALLOW_NO_INDICES,
         FORBID_ALIASES_TO_MULTIPLE_INDICES,
         FORBID_CLOSED_INDICES;
@@ -132,13 +131,6 @@ public class IndicesOptions implements ToXContentFragment {
         return options.contains(Option.FORBID_ALIASES_TO_MULTIPLE_INDICES) == false;
     }
 
-    /**
-     * @return whether aliases should be ignored (when resolving a wildcard)
-     */
-    public boolean ignoreAliases() {
-        return options.contains(Option.IGNORE_ALIASES);
-    }
-
     public void writeIndicesOptions(StreamOutput out) throws IOException {
         out.writeEnumSet(options);
         out.writeEnumSet(expandWildcards);
@@ -158,7 +150,6 @@ public class IndicesOptions implements ToXContentFragment {
             expandToOpenIndices,
             expandToClosedIndices,
             true,
-            false,
             false
         );
     }
@@ -174,8 +165,7 @@ public class IndicesOptions implements ToXContentFragment {
             expandToOpenIndices,
             expandToClosedIndices,
             defaultOptions.allowAliasesToMultipleIndices(),
-            defaultOptions.forbidClosedIndices(),
-            defaultOptions.ignoreAliases()
+            defaultOptions.forbidClosedIndices()
         );
     }
 
@@ -184,8 +174,7 @@ public class IndicesOptions implements ToXContentFragment {
                                              boolean expandToOpenIndices,
                                              boolean expandToClosedIndices,
                                              boolean allowAliasesToMultipleIndices,
-                                             boolean forbidClosedIndices,
-                                             boolean ignoreAliases) {
+                                             boolean forbidClosedIndices) {
         final Set<Option> opts = new HashSet<>();
         final Set<WildcardStates> wildcards = new HashSet<>();
 
@@ -206,9 +195,6 @@ public class IndicesOptions implements ToXContentFragment {
         }
         if (forbidClosedIndices) {
             opts.add(Option.FORBID_CLOSED_INDICES);
-        }
-        if (ignoreAliases) {
-            opts.add(Option.IGNORE_ALIASES);
         }
 
         return new IndicesOptions(opts, wildcards);
@@ -304,7 +290,6 @@ public class IndicesOptions implements ToXContentFragment {
                 ", expand_wildcards_closed=" + expandWildcardsClosed() +
                 ", allow_aliases_to_multiple_indices=" + allowAliasesToMultipleIndices() +
                 ", forbid_closed_indices=" + forbidClosedIndices() +
-                ", ignore_aliases=" + ignoreAliases() +
                 ']';
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -127,16 +127,6 @@ public class IndexNameExpressionResolver {
                     continue;
                 }
             }
-            if (aliasOrIndex.getIndices().size() > 1 && !options.allowAliasesToMultipleIndices()) {
-                String[] indexNames = new String[aliasOrIndex.getIndices().size()];
-                int i = 0;
-                for (IndexMetadata indexMetadata : aliasOrIndex.getIndices()) {
-                    indexNames[i++] = indexMetadata.getIndex().getName();
-                }
-                throw new IllegalArgumentException("Alias [" + expression + "] has more than one indices associated with it [" +
-                    Arrays.toString(indexNames) + "], can't execute a single index op");
-            }
-
             for (IndexMetadata index : aliasOrIndex.getIndices()) {
                 if (index.getState() == IndexMetadata.State.CLOSE) {
                     if (failClosed) {


### PR DESCRIPTION
Not required by CrateDB as we have a very specific use for aliases
(partitioned tables)

Relates to https://github.com/crate/crate/issues/11939
Trying to isolate/remove alias usages
