### PR TITLE
Fix ARRAY_LENGTH scalar on array of nulls

### DIFF
--- a/server/src/main/java/io/crate/execution/dml/ArrayIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/ArrayIndexer.java
@@ -24,7 +24,6 @@ package io.crate.execution.dml;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -68,9 +67,7 @@ public class ArrayIndexer<T> implements ValueIndexer<List<T>> {
                     );
                 }
             }
-            if (values.stream().filter(Objects::nonNull).toList().isEmpty()) {
-                addField.accept(new IntField("_empty_null_arrays_" + storageIdent, values.size(), Field.Store.NO));
-            }
+            addField.accept(new IntField("_array_size_" + storageIdent, values.size(), Field.Store.NO));
         }
         xContentBuilder.endArray();
     }

--- a/server/src/main/java/io/crate/execution/dml/ArrayIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/ArrayIndexer.java
@@ -67,7 +67,12 @@ public class ArrayIndexer<T> implements ValueIndexer<List<T>> {
                     );
                 }
             }
+            // map '[]' to '_array_size_ = 0'
+            // map '[null]' to '_array_size_ = 1'
             addField.accept(new IntField("_array_size_" + storageIdent, values.size(), Field.Store.NO));
+        } else {
+            // map 'null' to '_array_size_ = -1'
+            addField.accept(new IntField("_array_size_" + storageIdent, -1, Field.Store.NO));
         }
         xContentBuilder.endArray();
     }

--- a/server/src/main/java/io/crate/expression/scalar/ArrayUpperFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayUpperFunction.java
@@ -56,6 +56,7 @@ import io.crate.metadata.functions.Signature;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
+import io.crate.types.IntEqQuery;
 import io.crate.types.ObjectType;
 import io.crate.types.TypeSignature;
 
@@ -208,7 +209,13 @@ public class ArrayUpperFunction extends Scalar<Integer, Object> {
                 return docValueCountOrGeneric(parent, context, arrayRef, valueCountIsMatch);
 
             case GtOperator.NAME:
-                return docValueCountOrGeneric(parent, context, arrayRef, valueCountIsMatch);
+                return new BooleanQuery.Builder()
+                    .setMinimumNumberShouldMatch(1)
+                    .add(docValueCountOrGeneric(parent, context, arrayRef, valueCountIsMatch), BooleanClause.Occur.SHOULD)
+                    .add(
+                        new IntEqQuery().rangeQuery("_empty_null_arrays_" + arrayRef.storageIdent(), cmpVal, null, false, false, true, true), BooleanClause.Occur.SHOULD
+                    ).build();
+                //return docValueCountOrGeneric(parent, context, arrayRef, valueCountIsMatch);
 
             case GteOperator.NAME:
                 if (cmpVal == 0) {

--- a/server/src/main/java/io/crate/expression/scalar/ArrayUpperFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayUpperFunction.java
@@ -209,12 +209,7 @@ public class ArrayUpperFunction extends Scalar<Integer, Object> {
                 return docValueCountOrGeneric(parent, context, arrayRef, valueCountIsMatch);
 
             case GtOperator.NAME:
-                return new BooleanQuery.Builder()
-                    .setMinimumNumberShouldMatch(1)
-                    .add(docValueCountOrGeneric(parent, context, arrayRef, valueCountIsMatch), BooleanClause.Occur.SHOULD)
-                    .add(
-                        new IntEqQuery().rangeQuery("_empty_null_arrays_" + arrayRef.storageIdent(), cmpVal, null, false, false, true, true), BooleanClause.Occur.SHOULD
-                    ).build();
+                return new IntEqQuery().rangeQuery("_array_size_" + arrayRef.storageIdent(), cmpVal, null, false, false, true, true);
                 //return docValueCountOrGeneric(parent, context, arrayRef, valueCountIsMatch);
 
             case GteOperator.NAME:

--- a/server/src/main/java/io/crate/types/ArrayType.java
+++ b/server/src/main/java/io/crate/types/ArrayType.java
@@ -99,7 +99,7 @@ public class ArrayType<T> extends DataType<List<T>> {
                 public ValueIndexer<T> valueIndexer(RelationName table, Reference ref,
                                                     Function<ColumnIdent, Reference> getRef) {
                     return new ArrayIndexer<>(
-                        innerStorage.valueIndexer(table, ref, getRef));
+                        innerStorage.valueIndexer(table, ref, getRef), ref.storageIdent());
                 }
             };
         }

--- a/server/src/test/java/io/crate/lucene/ArrayLengthQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/ArrayLengthQueryBuilderTest.java
@@ -41,9 +41,9 @@ public class ArrayLengthQueryBuilderTest extends LuceneQueryBuilderTest {
     }
 
     @Test
-    public void testArrayLengthGt0UsesExistsQuery() {
+    public void testArrayLengthGt0UsesNumTermsPerOrAndGenericFunction() {
         Query query = convert("array_length(y_array, 1) > 0");
-        assertThat(query).hasToString("FieldExistsQuery [field=y_array]");
+        assertThat(query).hasToString("(NumTermsPerDoc: y_array (array_length(y_array, 1) > 0))~1");
     }
 
     @Test
@@ -53,9 +53,9 @@ public class ArrayLengthQueryBuilderTest extends LuceneQueryBuilderTest {
     }
 
     @Test
-    public void testArrayLengthGte1UsesNumTermsPerDocQuery() {
+    public void testArrayLengthGte1UsesNumTermsPerOrAndGenericFunction() {
         Query query = convert("array_length(y_array, 1) >= 1");
-        assertThat(query).hasToString("NumTermsPerDoc: y_array");
+        assertThat(query).hasToString("(NumTermsPerDoc: y_array (array_length(y_array, 1) >= 1))~1");
     }
 
     @Test
@@ -89,7 +89,7 @@ public class ArrayLengthQueryBuilderTest extends LuceneQueryBuilderTest {
             () -> oid
         ).indexValues("int_array", List.of(), List.of(1)).build()) {
             Query query = tester.toQuery("array_length(int_array, 1) >= 1");
-            assertThat(query).hasToString(String.format("NumTermsPerDoc: %s", oid));
+            assertThat(query).hasToString(String.format("(NumTermsPerDoc: %s (array_length(int_array, 1) >= 1))~1", oid));
             Assertions.assertThat(tester.runQuery("int_array", "array_length(int_array, 1) >= 1"))
                 .containsExactly(List.of(1));
         }

--- a/server/src/test/java/io/crate/lucene/ArrayLengthQueryTest.java
+++ b/server/src/test/java/io/crate/lucene/ArrayLengthQueryTest.java
@@ -24,6 +24,7 @@ package io.crate.lucene;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
@@ -46,6 +47,24 @@ public class ArrayLengthQueryTest extends CrateDummyClusterServiceUnitTest {
 
     private QueryTester tester;
 
+    private static final List<Integer> ARRAY_WITH_ONE_NULL_ELEMENT;
+    private static final List<Integer> ARRAY_WITH_TWO_NULL_ELEMENT;
+    private static final List<Integer> ARRAY_WITH_THREE_NULL_ELEMENT;
+
+    static {
+        ARRAY_WITH_ONE_NULL_ELEMENT = new ArrayList<>();
+        ARRAY_WITH_ONE_NULL_ELEMENT.add(null);
+
+        ARRAY_WITH_TWO_NULL_ELEMENT = new ArrayList<>();
+        ARRAY_WITH_TWO_NULL_ELEMENT.add(null);
+        ARRAY_WITH_TWO_NULL_ELEMENT.add(null);
+
+        ARRAY_WITH_THREE_NULL_ELEMENT = new ArrayList<>();
+        ARRAY_WITH_THREE_NULL_ELEMENT.add(null);
+        ARRAY_WITH_THREE_NULL_ELEMENT.add(null);
+        ARRAY_WITH_THREE_NULL_ELEMENT.add(null);
+    }
+
     @Before
     public void setUpTester() throws Exception {
         QueryTester.Builder builder = new QueryTester.Builder(
@@ -65,7 +84,10 @@ public class ArrayLengthQueryTest extends CrateDummyClusterServiceUnitTest {
                 List.of(10, 10),
                 List.of(10, 20),
                 List.of(10, 10, 20),
-                List.of(10, 20, 30)
+                List.of(10, 20, 30),
+                ARRAY_WITH_ONE_NULL_ELEMENT,
+                ARRAY_WITH_TWO_NULL_ELEMENT,
+                ARRAY_WITH_THREE_NULL_ELEMENT
             )
             .build();
     }
@@ -84,7 +106,10 @@ public class ArrayLengthQueryTest extends CrateDummyClusterServiceUnitTest {
             List.of(10, 10),
             List.of(10, 20),
             List.of(10, 10, 20),
-            List.of(10, 20, 30)
+            List.of(10, 20, 30),
+            ARRAY_WITH_ONE_NULL_ELEMENT,
+            ARRAY_WITH_TWO_NULL_ELEMENT,
+            ARRAY_WITH_THREE_NULL_ELEMENT
         );
     }
 
@@ -98,7 +123,10 @@ public class ArrayLengthQueryTest extends CrateDummyClusterServiceUnitTest {
             List.of(10, 10),
             List.of(10, 20),
             List.of(10, 10, 20),
-            List.of(10, 20, 30)
+            List.of(10, 20, 30),
+            ARRAY_WITH_ONE_NULL_ELEMENT,
+            ARRAY_WITH_TWO_NULL_ELEMENT,
+            ARRAY_WITH_THREE_NULL_ELEMENT
         );
     }
 
@@ -109,7 +137,9 @@ public class ArrayLengthQueryTest extends CrateDummyClusterServiceUnitTest {
             List.of(10, 10),
             List.of(10, 20),
             List.of(10, 10, 20),
-            List.of(10, 20, 30)
+            List.of(10, 20, 30),
+            ARRAY_WITH_TWO_NULL_ELEMENT,
+            ARRAY_WITH_THREE_NULL_ELEMENT
         );
     }
 
@@ -122,7 +152,10 @@ public class ArrayLengthQueryTest extends CrateDummyClusterServiceUnitTest {
             List.of(10, 10),
             List.of(10, 20),
             List.of(10, 10, 20),
-            List.of(10, 20, 30)
+            List.of(10, 20, 30),
+            ARRAY_WITH_ONE_NULL_ELEMENT,
+            ARRAY_WITH_TWO_NULL_ELEMENT,
+            ARRAY_WITH_THREE_NULL_ELEMENT
         );
     }
 
@@ -131,7 +164,8 @@ public class ArrayLengthQueryTest extends CrateDummyClusterServiceUnitTest {
         List<Object> rows = tester.runQuery("xs", "array_length(xs, 1) > 2");
         assertThat(rows).containsExactlyInAnyOrder(
             List.of(10, 10, 20),
-            List.of(10, 20, 30)
+            List.of(10, 20, 30),
+            ARRAY_WITH_THREE_NULL_ELEMENT
         );
     }
 
@@ -142,7 +176,9 @@ public class ArrayLengthQueryTest extends CrateDummyClusterServiceUnitTest {
             List.of(10, 10),
             List.of(10, 20),
             List.of(10, 10, 20),
-            List.of(10, 20, 30)
+            List.of(10, 20, 30),
+            ARRAY_WITH_TWO_NULL_ELEMENT,
+            ARRAY_WITH_THREE_NULL_ELEMENT
         );
     }
 
@@ -171,7 +207,8 @@ public class ArrayLengthQueryTest extends CrateDummyClusterServiceUnitTest {
         List<Object> rows = tester.runQuery("xs", "array_length(xs, 1) <= 1");
         assertThat(rows).containsExactlyInAnyOrder(
             List.of(10),
-            List.of(20)
+            List.of(20),
+            ARRAY_WITH_ONE_NULL_ELEMENT
         );
     }
 
@@ -184,7 +221,10 @@ public class ArrayLengthQueryTest extends CrateDummyClusterServiceUnitTest {
             List.of(10, 10),
             List.of(10, 20),
             List.of(10, 10, 20),
-            List.of(10, 20, 30)
+            List.of(10, 20, 30),
+            ARRAY_WITH_ONE_NULL_ELEMENT,
+            ARRAY_WITH_TWO_NULL_ELEMENT,
+            ARRAY_WITH_THREE_NULL_ELEMENT
         );
     }
 
@@ -195,7 +235,9 @@ public class ArrayLengthQueryTest extends CrateDummyClusterServiceUnitTest {
             List.of(10),
             List.of(20),
             List.of(10, 10),
-            List.of(10, 20)
+            List.of(10, 20),
+            ARRAY_WITH_ONE_NULL_ELEMENT,
+            ARRAY_WITH_TWO_NULL_ELEMENT
         );
     }
 
@@ -204,7 +246,8 @@ public class ArrayLengthQueryTest extends CrateDummyClusterServiceUnitTest {
         List<Object> rows = tester.runQuery("xs", "array_length(xs, 1) = 1");
         assertThat(rows).containsExactlyInAnyOrder(
             List.of(10),
-            List.of(20)
+            List.of(20),
+            ARRAY_WITH_ONE_NULL_ELEMENT
         );
     }
 
@@ -213,7 +256,8 @@ public class ArrayLengthQueryTest extends CrateDummyClusterServiceUnitTest {
         List<Object> rows = tester.runQuery("xs", "array_length(xs, 1) = 2");
         assertThat(rows).containsExactlyInAnyOrder(
             List.of(10, 10),
-            List.of(10, 20)
+            List.of(10, 20),
+            ARRAY_WITH_TWO_NULL_ELEMENT
         );
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
See below for buggy scenarios from `master`:
```
cr> create table t (a int[]);                                                                                                                                         
cr> insert into t values (null), ([]), ([null]), ([null, null]), ([null, null, null]);                                                                                

cr> select * from t where array_length(a,1) > 0;                                                                                                                      
+---+
| a |
+---+
+---+
=> expect [null], [null, null], [null, null, null]

cr> select * from t where array_length(a,1) >= 0;                                                                                                                     
+---+
| a |
+---+
+---+
=> expect [null], [null, null], [null, null, null]

cr> select * from t where array_length(a,1) >= 1;                                                                                                                     
+---+
| a |
+---+
+---+
=> expect [null], [null, null], [null, null, null]

cr> select * from t where array_length(a,1) = 1;                                                                                                                      
+---+
| a |
+---+
+---+
=> expect [null]

cr> select * from t where array_length(a,1) = 2;                                                                                                                      
+---+
| a |
+---+
+---+
=> expect [null, null]
```

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
