### PR TITLE
Rename Feature NULLABLE -> STRICTNULL, NON_NULLABLE -> NOTNULL

### DIFF
--- a/server/src/main/java/io/crate/expression/operator/AllOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/AllOperator.java
@@ -66,7 +66,7 @@ public final class AllOperator extends Operator<Object> {
                         TypeSignature.parse("array(E)"))
                     .returnType(Operator.RETURN_TYPE.getTypeSignature())
                     .typeVariableConstraints(typeVariable("E"))
-                    .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                    .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
                     .build(),
                 (signature, boundSignature) ->
                     new AllOperator(

--- a/server/src/main/java/io/crate/expression/operator/CIDROperator.java
+++ b/server/src/main/java/io/crate/expression/operator/CIDROperator.java
@@ -55,7 +55,7 @@ public final class CIDROperator {
                 .argumentTypes(DataTypes.IP.getTypeSignature(),
                     DataTypes.STRING.getTypeSignature())
                 .returnType(Operator.RETURN_TYPE.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
             ContainedWithinOperator::new
         );

--- a/server/src/main/java/io/crate/expression/operator/EqOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/EqOperator.java
@@ -76,7 +76,7 @@ public final class EqOperator extends Operator<Object> {
         .argumentTypes(TypeSignature.parse("E"),
             TypeSignature.parse("E"))
         .returnType(Operator.RETURN_TYPE.getTypeSignature())
-        .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+        .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
         .typeVariableConstraints(typeVariable("E"))
         .build();
 

--- a/server/src/main/java/io/crate/expression/operator/ExistsOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/ExistsOperator.java
@@ -42,7 +42,7 @@ public class ExistsOperator extends Operator<List<Object>> {
                 .argumentTypes(TypeSignature.parse("array(E)"))
                 .returnType(Operator.RETURN_TYPE.getTypeSignature())
                 .typeVariableConstraints(TypeVariableConstraint.typeVariable("E"))
-                .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
                 .build();
         builder.add(signature, ExistsOperator::new);
     }

--- a/server/src/main/java/io/crate/expression/operator/GtOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/GtOperator.java
@@ -38,7 +38,7 @@ public final class GtOperator {
                     .argumentTypes(supportedType.getTypeSignature(),
                         supportedType.getTypeSignature())
                     .returnType(Operator.RETURN_TYPE.getTypeSignature())
-                    .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                    .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                     .build(),
                 (signature, boundSignature) -> new CmpOperator(
                     signature,

--- a/server/src/main/java/io/crate/expression/operator/GteOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/GteOperator.java
@@ -38,7 +38,7 @@ public final class GteOperator {
                     .argumentTypes(supportedType.getTypeSignature(),
                         supportedType.getTypeSignature())
                     .returnType(Operator.RETURN_TYPE.getTypeSignature())
-                    .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                    .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                     .build(),
                 (signature, boundSignature) -> new CmpOperator(
                     signature,

--- a/server/src/main/java/io/crate/expression/operator/LikeOperators.java
+++ b/server/src/main/java/io/crate/expression/operator/LikeOperators.java
@@ -112,7 +112,7 @@ public class LikeOperators {
                 .argumentTypes(DataTypes.STRING.getTypeSignature(),
                     DataTypes.STRING.getTypeSignature())
                 .returnType(Operator.RETURN_TYPE.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
             (signature, boundSignature) ->
                 new LikeOperator(signature, boundSignature, LikeOperators::matches, CaseSensitivity.SENSITIVE)
@@ -122,7 +122,7 @@ public class LikeOperators {
                 .argumentTypes(DataTypes.STRING.getTypeSignature(),
                     DataTypes.STRING.getTypeSignature())
                 .returnType(Operator.RETURN_TYPE.getTypeSignature())
-                .features(Scalar.Feature.NULLABLE, Scalar.Feature.DETERMINISTIC)
+                .features(Scalar.Feature.STRICTNULL, Scalar.Feature.DETERMINISTIC)
                 .build(),
             (signature, boundSignature) ->
                 new LikeOperator(signature, boundSignature, LikeOperators::matches, CaseSensitivity.INSENSITIVE)
@@ -151,7 +151,7 @@ public class LikeOperators {
                 .argumentTypes(DataTypes.STRING.getTypeSignature(),
                     DataTypes.STRING_ARRAY.getTypeSignature())
                 .returnType(Operator.RETURN_TYPE.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
             (signature, boundSignature) ->
                 new AnyLikeOperator(
@@ -165,7 +165,7 @@ public class LikeOperators {
                 .argumentTypes(DataTypes.STRING.getTypeSignature(),
                     DataTypes.STRING_ARRAY.getTypeSignature())
                 .returnType(Operator.RETURN_TYPE.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
             (signature, boundSignature) ->
                 new AnyNotLikeOperator(
@@ -179,7 +179,7 @@ public class LikeOperators {
                 .argumentTypes(DataTypes.STRING.getTypeSignature(),
                     DataTypes.STRING_ARRAY.getTypeSignature())
                 .returnType(Operator.RETURN_TYPE.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
             (signature, boundSignature) ->
                 new AnyLikeOperator(
@@ -193,7 +193,7 @@ public class LikeOperators {
                 .argumentTypes(DataTypes.STRING.getTypeSignature(),
                     DataTypes.STRING_ARRAY.getTypeSignature())
                 .returnType(Operator.RETURN_TYPE.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
             (signature, boundSignature) ->
                 new AnyNotLikeOperator(

--- a/server/src/main/java/io/crate/expression/operator/LtOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/LtOperator.java
@@ -38,7 +38,7 @@ public final class LtOperator {
                     .argumentTypes(supportedType.getTypeSignature(),
                         supportedType.getTypeSignature())
                     .returnType(Operator.RETURN_TYPE.getTypeSignature())
-                    .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                    .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                     .build(),
                 (signature, boundSignature) ->
                     new CmpOperator(signature, boundSignature, cmpResult -> cmpResult < 0)

--- a/server/src/main/java/io/crate/expression/operator/LteOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/LteOperator.java
@@ -38,7 +38,7 @@ public final class LteOperator {
                     .argumentTypes(supportedType.getTypeSignature(),
                         supportedType.getTypeSignature())
                     .returnType(Operator.RETURN_TYPE.getTypeSignature())
-                    .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                    .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                     .build(),
                 (signature, boundSignature) -> new CmpOperator(
                     signature,

--- a/server/src/main/java/io/crate/expression/predicate/IsNullPredicate.java
+++ b/server/src/main/java/io/crate/expression/predicate/IsNullPredicate.java
@@ -68,7 +68,7 @@ public class IsNullPredicate<T> extends Scalar<Boolean, T> {
     public static final Signature SIGNATURE = Signature.builder(NAME, FunctionType.SCALAR)
         .argumentTypes(TypeSignature.parse("E"))
         .returnType(DataTypes.BOOLEAN.getTypeSignature())
-        .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+        .features(Feature.DETERMINISTIC, Feature.NOTNULL)
         .typeVariableConstraints(typeVariable("E"))
         .build();
 

--- a/server/src/main/java/io/crate/expression/predicate/MatchPredicate.java
+++ b/server/src/main/java/io/crate/expression/predicate/MatchPredicate.java
@@ -102,7 +102,7 @@ public class MatchPredicate implements FunctionImplementation, FunctionToQuery {
             DataTypes.STRING.getTypeSignature(),
             DataTypes.UNTYPED_OBJECT.getTypeSignature())
         .returnType(DataTypes.BOOLEAN.getTypeSignature())
-        .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NON_NULLABLE)
+        .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NOTNULL)
         .build();
 
     public static final Signature GEO_MATCH = Signature.builder(NAME, FunctionType.SCALAR)
@@ -111,7 +111,7 @@ public class MatchPredicate implements FunctionImplementation, FunctionToQuery {
             DataTypes.STRING.getTypeSignature(),
             DataTypes.UNTYPED_OBJECT.getTypeSignature())
         .returnType(DataTypes.BOOLEAN.getTypeSignature())
-        .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NON_NULLABLE)
+        .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NOTNULL)
         .build();
 
 

--- a/server/src/main/java/io/crate/expression/predicate/NotPredicate.java
+++ b/server/src/main/java/io/crate/expression/predicate/NotPredicate.java
@@ -61,7 +61,7 @@ public class NotPredicate extends Scalar<Boolean, Boolean> {
     public static final Signature SIGNATURE = Signature.builder(NAME, FunctionType.SCALAR)
         .argumentTypes(DataTypes.BOOLEAN.getTypeSignature())
         .returnType(DataTypes.BOOLEAN.getTypeSignature())
-        .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+        .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
         .build();
 
     public static void register(Functions.Builder builder) {
@@ -161,9 +161,9 @@ public class NotPredicate extends Scalar<Boolean, Boolean> {
                 return null;
             } else {
                 var signature = function.signature();
-                if (signature.hasFeature(Feature.NON_NULLABLE)) {
+                if (signature.hasFeature(Feature.NOTNULL)) {
                     context.isNullable = false;
-                } else if (!signature.hasFeature(Feature.NULLABLE)) {
+                } else if (!signature.hasFeature(Feature.STRICTNULL)) {
                     // default case
                     context.enforceThreeValuedLogic = true;
                     return null;

--- a/server/src/main/java/io/crate/expression/scalar/AgeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/AgeFunction.java
@@ -51,7 +51,7 @@ public class AgeFunction extends Scalar<Period, Object> {
             Signature.builder(NAME, FunctionType.SCALAR)
                 .argumentTypes(DataTypes.TIMESTAMP.getTypeSignature())
                 .returnType(DataTypes.INTERVAL.getTypeSignature())
-                .features(EnumSet.of(Feature.NULLABLE))
+                .features(EnumSet.of(Feature.STRICTNULL))
                 .build(),
             AgeFunction::new
         );
@@ -61,7 +61,7 @@ public class AgeFunction extends Scalar<Period, Object> {
                 .argumentTypes(DataTypes.TIMESTAMP.getTypeSignature(),
                     DataTypes.TIMESTAMP.getTypeSignature())
                 .returnType(DataTypes.INTERVAL.getTypeSignature())
-                .features(EnumSet.of(Feature.NULLABLE))
+                .features(EnumSet.of(Feature.STRICTNULL))
                 .build(),
             AgeFunction::new
         );

--- a/server/src/main/java/io/crate/expression/scalar/ArrayAppendFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayAppendFunction.java
@@ -49,7 +49,7 @@ public class ArrayAppendFunction extends Scalar<List<Object>, Object> {
                                 TypeSignature.parse("E"))
                         .returnType(TypeSignature.parse("array(E)"))
                         .typeVariableConstraints(typeVariable("E"))
-                        .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                        .features(Feature.DETERMINISTIC, Feature.NOTNULL)
                         .build(),
                 ArrayAppendFunction::new
         );

--- a/server/src/main/java/io/crate/expression/scalar/ArrayAvgFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayAvgFunction.java
@@ -91,7 +91,7 @@ public class ArrayAvgFunction {
             Signature.builder(NAME, FunctionType.SCALAR)
                 .argumentTypes(new ArrayType<>(DataTypes.NUMERIC).getTypeSignature())
                 .returnType(DataTypes.NUMERIC.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
             (signature, boundSignature) -> new UnaryScalar<>(
                 signature,
@@ -105,7 +105,7 @@ public class ArrayAvgFunction {
             Signature.builder(NAME, FunctionType.SCALAR)
                 .argumentTypes(new ArrayType<>(DataTypes.FLOAT).getTypeSignature())
                 .returnType(DataTypes.FLOAT.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
             (signature, boundSignature) -> new UnaryScalar<>(
                 signature,
@@ -119,7 +119,7 @@ public class ArrayAvgFunction {
             Signature.builder(NAME, FunctionType.SCALAR)
                 .argumentTypes(new ArrayType<>(DataTypes.DOUBLE).getTypeSignature())
                 .returnType(DataTypes.DOUBLE.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
             (signature, boundSignature) -> new UnaryScalar<>(
                 signature,
@@ -136,7 +136,7 @@ public class ArrayAvgFunction {
                     Signature.builder(NAME, FunctionType.SCALAR)
                         .argumentTypes(new ArrayType<>(supportedType).getTypeSignature())
                         .returnType(DataTypes.NUMERIC.getTypeSignature())
-                        .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                        .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                         .build(),
                     (signature, boundSignature) -> new UnaryScalar<>(
                         signature,

--- a/server/src/main/java/io/crate/expression/scalar/ArrayCatFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayCatFunction.java
@@ -48,7 +48,7 @@ public class ArrayCatFunction extends Scalar<List<Object>, List<Object>> {
                 .argumentTypes(TypeSignature.parse("array(E)"),
                     TypeSignature.parse("array(E)"))
                 .returnType(TypeSignature.parse("array(E)"))
-                .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                .features(Feature.DETERMINISTIC, Feature.NOTNULL)
                 .typeVariableConstraints(typeVariable("E"))
                 .build(),
             ArrayCatFunction::new

--- a/server/src/main/java/io/crate/expression/scalar/ArrayDifferenceFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayDifferenceFunction.java
@@ -57,7 +57,7 @@ class ArrayDifferenceFunction extends Scalar<List<Object>, List<Object>> {
                 .argumentTypes(TypeSignature.parse("array(E)"),
                     TypeSignature.parse("array(E)"))
                 .returnType(TypeSignature.parse("array(E)"))
-                .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
                 .typeVariableConstraints(typeVariable("E"))
                 .build(),
             (signature, boundSignature) ->

--- a/server/src/main/java/io/crate/expression/scalar/ArrayLowerFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayLowerFunction.java
@@ -49,7 +49,7 @@ class ArrayLowerFunction extends Scalar<Integer, Object> {
                 .argumentTypes(TypeSignature.parse("array(E)"),
                     DataTypes.INTEGER.getTypeSignature())
                 .returnType(DataTypes.INTEGER.getTypeSignature())
-                .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
                 .typeVariableConstraints(typeVariable("E"))
                 .build(),
             ArrayLowerFunction::new

--- a/server/src/main/java/io/crate/expression/scalar/ArrayMaxFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayMaxFunction.java
@@ -50,7 +50,7 @@ public class ArrayMaxFunction<T> extends Scalar<T, List<T>> {
             Signature.builder(NAME, FunctionType.SCALAR)
                 .argumentTypes(new ArrayType(DataTypes.NUMERIC).getTypeSignature())
                 .returnType(DataTypes.NUMERIC.getTypeSignature())
-                .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
                 .build(),
             ArrayMaxFunction::new
         );
@@ -60,7 +60,7 @@ public class ArrayMaxFunction<T> extends Scalar<T, List<T>> {
                 Signature.builder(NAME, FunctionType.SCALAR)
                     .argumentTypes(new ArrayType(supportedType).getTypeSignature())
                     .returnType(supportedType.getTypeSignature())
-                    .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                    .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
                     .build(),
                 ArrayMaxFunction::new
             );

--- a/server/src/main/java/io/crate/expression/scalar/ArrayMinFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayMinFunction.java
@@ -50,7 +50,7 @@ public class ArrayMinFunction<T> extends Scalar<T, List<T>> {
             Signature.builder(NAME, FunctionType.SCALAR)
                 .argumentTypes(new ArrayType(DataTypes.NUMERIC).getTypeSignature())
                 .returnType(DataTypes.NUMERIC.getTypeSignature())
-                .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
                 .build(),
             ArrayMinFunction::new
         );
@@ -60,7 +60,7 @@ public class ArrayMinFunction<T> extends Scalar<T, List<T>> {
                 Signature.builder(NAME, FunctionType.SCALAR)
                     .argumentTypes(new ArrayType(supportedType).getTypeSignature())
                     .returnType(supportedType.getTypeSignature())
-                    .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                    .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
                     .build(),
                 ArrayMinFunction::new
             );

--- a/server/src/main/java/io/crate/expression/scalar/ArrayPositionFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayPositionFunction.java
@@ -54,7 +54,7 @@ public class ArrayPositionFunction extends Scalar<Integer, List<Object>> {
                                 TypeSignature.parse("T"))
                         .returnType(DataTypes.INTEGER.getTypeSignature())
                         .typeVariableConstraints(typeVariable("T"))
-                        .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                        .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
                         .build(),
                 ArrayPositionFunction::new);
 
@@ -65,7 +65,7 @@ public class ArrayPositionFunction extends Scalar<Integer, List<Object>> {
                                 DataTypes.INTEGER.getTypeSignature())
                         .returnType(DataTypes.INTEGER.getTypeSignature())
                         .typeVariableConstraints(typeVariable("T"))
-                        .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                        .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
                         .build(),
                 ArrayPositionFunction::new);
     }

--- a/server/src/main/java/io/crate/expression/scalar/ArraySetFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArraySetFunction.java
@@ -51,7 +51,7 @@ public class ArraySetFunction extends Scalar<List<Object>, Object> {
                                 arrayESignature)
                         .returnType(arrayESignature)
                         .typeVariableConstraints(typeVariable("E"))
-                        .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                        .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
                         .build(),
                 ArraySetFunction::new
         );
@@ -62,7 +62,7 @@ public class ArraySetFunction extends Scalar<List<Object>, Object> {
                                 TypeSignature.parse("E"))
                         .returnType(arrayESignature)
                         .typeVariableConstraints(typeVariable("E"))
-                        .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                        .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
                         .build(),
                 SingleArraySetFunction::new
         );

--- a/server/src/main/java/io/crate/expression/scalar/ArraySliceFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArraySliceFunction.java
@@ -50,7 +50,7 @@ public class ArraySliceFunction extends Scalar<List<Object>, Object> {
                                 DataTypes.INTEGER.getTypeSignature())
                         .returnType(TypeSignature.parse("array(E)"))
                         .typeVariableConstraints(typeVariable("E"))
-                        .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                        .features(Feature.DETERMINISTIC, Feature.NOTNULL)
                         .build(),
                 ArraySliceFunction::new
         );

--- a/server/src/main/java/io/crate/expression/scalar/ArraySumFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArraySumFunction.java
@@ -50,7 +50,7 @@ public class ArraySumFunction<T extends Number, R extends Number> extends Scalar
         return Signature.builder(NAME, FunctionType.SCALAR)
             .argumentTypes(new ArrayType<>(elementType).getTypeSignature())
             .returnType(returnType.getTypeSignature())
-            .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+            .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
             .build();
     }
 

--- a/server/src/main/java/io/crate/expression/scalar/ArrayToStringFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayToStringFunction.java
@@ -51,7 +51,7 @@ class ArrayToStringFunction extends Scalar<String, Object> {
                     DataTypes.STRING.getTypeSignature())
                 .returnType(DataTypes.STRING.getTypeSignature())
                 .typeVariableConstraints(typeVariable("E"))
-                .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
                 .build(),
             ArrayToStringFunction::new
         );
@@ -62,7 +62,7 @@ class ArrayToStringFunction extends Scalar<String, Object> {
                     DataTypes.STRING.getTypeSignature())
                 .returnType(DataTypes.STRING.getTypeSignature())
                 .typeVariableConstraints(typeVariable("E"))
-                .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
                 .build(),
             ArrayToStringFunction::new
         );

--- a/server/src/main/java/io/crate/expression/scalar/ArrayUniqueFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayUniqueFunction.java
@@ -52,7 +52,7 @@ public class ArrayUniqueFunction extends Scalar<List<Object>, List<Object>> {
                 .argumentTypes(TypeSignature.parse("array(E)"))
                 .returnType(TypeSignature.parse("array(E)"))
                 .typeVariableConstraints(typeVariable("E"))
-                .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                .features(Feature.DETERMINISTIC, Feature.NOTNULL)
                 .build(),
             ArrayUniqueFunction::new
         );
@@ -61,7 +61,7 @@ public class ArrayUniqueFunction extends Scalar<List<Object>, List<Object>> {
                 .argumentTypes(TypeSignature.parse("array(E)"), TypeSignature.parse("array(E)"))
                 .returnType(TypeSignature.parse("array(E)"))
                 .typeVariableConstraints(typeVariable("E"))
-                .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                .features(Feature.DETERMINISTIC, Feature.NOTNULL)
                 .build(),
             ArrayUniqueFunction::new
         );

--- a/server/src/main/java/io/crate/expression/scalar/ArrayUnnestFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayUnnestFunction.java
@@ -52,7 +52,7 @@ public class ArrayUnnestFunction extends Scalar<List<Object>, List<List<Object>>
             .argumentTypes(TypeSignature.parse("array(array(E))"))
             .returnType(TypeSignature.parse("array(E)"))
             .typeVariableConstraints(typeVariable("E"))
-            .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+            .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
             .build();
 
     public static void register(Functions.Builder module) {

--- a/server/src/main/java/io/crate/expression/scalar/ArrayUpperFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayUpperFunction.java
@@ -73,7 +73,7 @@ public class ArrayUpperFunction extends Scalar<Integer, Object> {
                                     DataTypes.INTEGER.getTypeSignature())
                             .returnType(DataTypes.INTEGER.getTypeSignature())
                             .typeVariableConstraints(typeVariable("E"))
-                            .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                            .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
                             .build(),
                     ArrayUpperFunction::new
             );

--- a/server/src/main/java/io/crate/expression/scalar/CollectionAverageFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/CollectionAverageFunction.java
@@ -46,7 +46,7 @@ public class CollectionAverageFunction extends Scalar<Double, List<Object>> {
                         .argumentTypes(TypeSignature.parse("array(E)"))
                         .returnType(DataTypes.DOUBLE.getTypeSignature())
                         .typeVariableConstraints(typeVariable("E"))
-                        .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                        .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
                         .build(),
                 CollectionAverageFunction::new
         );

--- a/server/src/main/java/io/crate/expression/scalar/CollectionCountFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/CollectionCountFunction.java
@@ -46,7 +46,7 @@ public class CollectionCountFunction extends Scalar<Long, List<Object>> {
                         .argumentTypes(TypeSignature.parse("array(E)"))
                         .returnType(DataTypes.LONG.getTypeSignature())
                         .typeVariableConstraints(typeVariable("E"))
-                        .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                        .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
                         .build(),
                 CollectionCountFunction::new
         );

--- a/server/src/main/java/io/crate/expression/scalar/ConcatFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ConcatFunction.java
@@ -50,7 +50,7 @@ public abstract class ConcatFunction extends Scalar<String, String> {
                 .argumentTypes(DataTypes.STRING.getTypeSignature(),
                     DataTypes.STRING.getTypeSignature())
                 .returnType(DataTypes.STRING.getTypeSignature())
-                .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                .features(Feature.DETERMINISTIC, Feature.NOTNULL)
                 .build(),
             StringConcatFunction::new
         );
@@ -59,7 +59,7 @@ public abstract class ConcatFunction extends Scalar<String, String> {
             Signature.builder(NAME, FunctionType.SCALAR)
                 .argumentTypes(DataTypes.STRING.getTypeSignature())
                 .returnType(DataTypes.STRING.getTypeSignature())
-                .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                .features(Feature.DETERMINISTIC, Feature.NOTNULL)
                 .setVariableArity(true)
                 .build(),
             GenericConcatFunction::new
@@ -71,7 +71,7 @@ public abstract class ConcatFunction extends Scalar<String, String> {
                 .argumentTypes(TypeSignature.parse("array(E)"),
                     TypeSignature.parse("array(E)"))
                 .returnType(TypeSignature.parse("array(E)"))
-                .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                .features(Feature.DETERMINISTIC, Feature.NOTNULL)
                 .typeVariableConstraints(typeVariable("E"))
                 .build(),
             ArrayCatFunction::new
@@ -95,7 +95,7 @@ public abstract class ConcatFunction extends Scalar<String, String> {
                 .argumentTypes(DataTypes.STRING.getTypeSignature(),
                     DataTypes.STRING.getTypeSignature())
                 .returnType(DataTypes.STRING.getTypeSignature())
-                .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
                 .build(),
             (signature, boundSignature) -> new StringConcatFunction(signature, boundSignature, true)
         );
@@ -104,7 +104,7 @@ public abstract class ConcatFunction extends Scalar<String, String> {
                 .argumentTypes(TypeSignature.parse("array(E)"),
                     TypeSignature.parse("array(E)"))
                 .returnType(TypeSignature.parse("array(E)"))
-                .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                .features(Feature.DETERMINISTIC)
                 .typeVariableConstraints(typeVariable("E"))
                 .build(),
             ArrayCatFunction::new
@@ -114,7 +114,7 @@ public abstract class ConcatFunction extends Scalar<String, String> {
                 .argumentTypes(DataTypes.UNTYPED_OBJECT.getTypeSignature(),
                     DataTypes.UNTYPED_OBJECT.getTypeSignature())
                 .returnType(DataTypes.UNTYPED_OBJECT.getTypeSignature())
-                .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                .features(Feature.DETERMINISTIC)
                 .build(),
             ObjectMergeFunction::new
         );

--- a/server/src/main/java/io/crate/expression/scalar/CurrentDatabaseFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/CurrentDatabaseFunction.java
@@ -43,7 +43,7 @@ final class CurrentDatabaseFunction extends Scalar<String, Void> {
             Signature.builder(FQN, FunctionType.SCALAR)
                 .argumentTypes()
                 .returnType(DataTypes.STRING.getTypeSignature())
-                .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                .features(Feature.DETERMINISTIC, Feature.NOTNULL)
                 .build(),
             CurrentDatabaseFunction::new
         );

--- a/server/src/main/java/io/crate/expression/scalar/CurrentDateFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/CurrentDateFunction.java
@@ -42,7 +42,7 @@ public final class CurrentDateFunction extends Scalar<Long, String> {
                 Signature.builder(NAME, FunctionType.SCALAR)
                         .argumentTypes()
                         .returnType(DataTypes.DATE.getTypeSignature())
-                        .features(EnumSet.of(Feature.NON_NULLABLE))
+                        .features(EnumSet.of(Feature.NOTNULL))
                         .build(),
                 CurrentDateFunction::new
         );

--- a/server/src/main/java/io/crate/expression/scalar/DateBinFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/DateBinFunction.java
@@ -49,7 +49,7 @@ public class DateBinFunction extends Scalar<Long, Object> {
                                 DataTypes.TIMESTAMPZ.getTypeSignature(), // source
                                 DataTypes.TIMESTAMPZ.getTypeSignature())
                         .returnType(DataTypes.TIMESTAMPZ.getTypeSignature())
-                        .features(EnumSet.of(Feature.DETERMINISTIC, Feature.COMPARISON_REPLACEMENT, Feature.NULLABLE))
+                        .features(EnumSet.of(Feature.DETERMINISTIC, Feature.COMPARISON_REPLACEMENT, Feature.STRICTNULL))
                         .build(),
                 DateBinFunction::new);
 
@@ -59,7 +59,7 @@ public class DateBinFunction extends Scalar<Long, Object> {
                                 DataTypes.TIMESTAMP.getTypeSignature(), // source
                                 DataTypes.TIMESTAMP.getTypeSignature())
                         .returnType(DataTypes.TIMESTAMP.getTypeSignature())
-                        .features(EnumSet.of(Feature.DETERMINISTIC, Feature.COMPARISON_REPLACEMENT, Feature.NULLABLE))
+                        .features(EnumSet.of(Feature.DETERMINISTIC, Feature.COMPARISON_REPLACEMENT, Feature.STRICTNULL))
                         .build(),
                 DateBinFunction::new);
     }

--- a/server/src/main/java/io/crate/expression/scalar/ExtractFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/ExtractFunctions.java
@@ -84,7 +84,7 @@ public class ExtractFunctions {
                     Signature.builder(functionNameFrom(entry.extractField()), FunctionType.SCALAR)
                         .argumentTypes(argType.getTypeSignature())
                         .returnType(DataTypes.INTEGER.getTypeSignature())
-                        .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                        .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                         .build(),
                     (signature, boundSignature) ->
                         new UnaryScalar<Number, Long>(signature, boundSignature, argType, dtf::get)
@@ -95,7 +95,7 @@ public class ExtractFunctions {
                 Signature.builder(functionNameFrom(EPOCH), FunctionType.SCALAR)
                     .argumentTypes(argType.getTypeSignature())
                     .returnType(DataTypes.DOUBLE.getTypeSignature())
-                    .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                    .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                     .build(),
                 (signature, boundSignature) ->
                     new UnaryScalar<>(signature, boundSignature, argType, v -> (double) v / 1000)
@@ -119,7 +119,7 @@ public class ExtractFunctions {
                 Signature.builder(functionNameFrom(entry.extractField()), FunctionType.SCALAR)
                     .argumentTypes(DataTypes.INTERVAL.getTypeSignature())
                     .returnType(DataTypes.INTEGER.getTypeSignature())
-                    .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                    .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                     .build(),
                 (signature, boundSignature) ->
                     new UnaryScalar<Number, Period>(signature, boundSignature, DataTypes.INTERVAL, function::apply)
@@ -130,7 +130,7 @@ public class ExtractFunctions {
             Signature.builder(functionNameFrom(EPOCH), FunctionType.SCALAR)
                 .argumentTypes(DataTypes.INTERVAL.getTypeSignature())
                 .returnType(DataTypes.DOUBLE.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
             (signature, boundSignature) ->
                 new UnaryScalar<>(signature, boundSignature, DataTypes.INTERVAL, ExtractFunctions::toMillis)

--- a/server/src/main/java/io/crate/expression/scalar/FormatFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/FormatFunction.java
@@ -43,7 +43,7 @@ public class FormatFunction extends Scalar<String, Object> {
     public static final Signature SIGNATURE = Signature.builder(NAME, FunctionType.SCALAR)
         .argumentTypes(DataTypes.STRING.getTypeSignature(), TypeSignature.parse("E"))
         .returnType(DataTypes.STRING.getTypeSignature())
-        .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+        .features(Feature.DETERMINISTIC, Feature.NOTNULL)
         .typeVariableConstraints(typeVariableOfAnyType("E"))
         .setVariableArity(true)
         .build();

--- a/server/src/main/java/io/crate/expression/scalar/GenRandomTextUUIDFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/GenRandomTextUUIDFunction.java
@@ -44,7 +44,7 @@ public final class GenRandomTextUUIDFunction extends Scalar<String, Void> {
                 Signature.builder(NAME, FunctionType.SCALAR)
                         .argumentTypes()
                         .returnType(DataTypes.STRING.getTypeSignature())
-                        .features(EnumSet.of(Feature.NON_NULLABLE))
+                        .features(EnumSet.of(Feature.NOTNULL))
                         .build(),
                 GenRandomTextUUIDFunction::new
         );

--- a/server/src/main/java/io/crate/expression/scalar/HasDatabasePrivilegeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/HasDatabasePrivilegeFunction.java
@@ -22,7 +22,7 @@
 package io.crate.expression.scalar;
 
 import static io.crate.metadata.Scalar.Feature.DETERMINISTIC;
-import static io.crate.metadata.Scalar.Feature.NULLABLE;
+import static io.crate.metadata.Scalar.Feature.STRICTNULL;
 
 import java.util.Collection;
 import java.util.EnumSet;
@@ -128,7 +128,7 @@ public class HasDatabasePrivilegeFunction {
                     DataTypes.STRING.getTypeSignature(), // Database
                     DataTypes.STRING.getTypeSignature())
                 .returnType(DataTypes.BOOLEAN.getTypeSignature())
-                .features(EnumSet.of(DETERMINISTIC, NULLABLE))
+                .features(EnumSet.of(DETERMINISTIC, STRICTNULL))
                 .build(),
             (signature, boundSignature) -> new HasPrivilegeFunction(
                 signature,
@@ -146,7 +146,7 @@ public class HasDatabasePrivilegeFunction {
                     DataTypes.INTEGER.getTypeSignature(), // Database
                     DataTypes.STRING.getTypeSignature())
                 .returnType(DataTypes.BOOLEAN.getTypeSignature())
-                .features(EnumSet.of(DETERMINISTIC, NULLABLE))
+                .features(EnumSet.of(DETERMINISTIC, STRICTNULL))
                 .build(),
             (signature, boundSignature) -> new HasPrivilegeFunction(
                 signature,
@@ -164,7 +164,7 @@ public class HasDatabasePrivilegeFunction {
                     DataTypes.STRING.getTypeSignature(), // Database
                     DataTypes.STRING.getTypeSignature())
                 .returnType(DataTypes.BOOLEAN.getTypeSignature())
-                .features(EnumSet.of(DETERMINISTIC, NULLABLE))
+                .features(EnumSet.of(DETERMINISTIC, STRICTNULL))
                 .build(),
             (signature, boundSignature) -> new HasPrivilegeFunction(
                 signature,
@@ -182,7 +182,7 @@ public class HasDatabasePrivilegeFunction {
                     DataTypes.INTEGER.getTypeSignature(), // Database
                     DataTypes.STRING.getTypeSignature())
                 .returnType(DataTypes.BOOLEAN.getTypeSignature())
-                .features(EnumSet.of(DETERMINISTIC, NULLABLE))
+                .features(EnumSet.of(DETERMINISTIC, STRICTNULL))
                 .build(),
             (signature, boundSignature) -> new HasPrivilegeFunction(
                 signature,
@@ -199,7 +199,7 @@ public class HasDatabasePrivilegeFunction {
                     DataTypes.STRING.getTypeSignature(),  // Database
                     DataTypes.STRING.getTypeSignature())
                 .returnType(DataTypes.BOOLEAN.getTypeSignature())
-                .features(EnumSet.of(DETERMINISTIC, NULLABLE))
+                .features(EnumSet.of(DETERMINISTIC, STRICTNULL))
                 .build(),
             (signature, boundSignature) -> new HasPrivilegeFunction(
                 signature,
@@ -216,7 +216,7 @@ public class HasDatabasePrivilegeFunction {
                     DataTypes.INTEGER.getTypeSignature(), // Database
                     DataTypes.STRING.getTypeSignature())
                 .returnType(DataTypes.BOOLEAN.getTypeSignature())
-                .features(EnumSet.of(DETERMINISTIC, NULLABLE))
+                .features(EnumSet.of(DETERMINISTIC, STRICTNULL))
                 .build(),
             (signature, boundSignature) -> new HasPrivilegeFunction(
                 signature,

--- a/server/src/main/java/io/crate/expression/scalar/HasPrivilegeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/HasPrivilegeFunction.java
@@ -70,7 +70,7 @@ public class HasPrivilegeFunction extends Scalar<Boolean, Object> {
                                 CheckPrivilege checkPrivilege,
                                 ParsePermissions parsePermissions) {
         super(signature, boundSignature);
-        assert signature().hasFeature(Feature.NULLABLE) : "HasPrivilegeFunctions are nullable";
+        assert signature().hasFeature(Feature.STRICTNULL) : "HasPrivilegeFunctions are nullable";
         this.getUser = getUser;
         this.checkPrivilege = checkPrivilege;
         this.parsePermissions = parsePermissions;

--- a/server/src/main/java/io/crate/expression/scalar/HasSchemaPrivilegeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/HasSchemaPrivilegeFunction.java
@@ -22,7 +22,7 @@
 package io.crate.expression.scalar;
 
 import static io.crate.metadata.Scalar.Feature.DETERMINISTIC;
-import static io.crate.metadata.Scalar.Feature.NULLABLE;
+import static io.crate.metadata.Scalar.Feature.STRICTNULL;
 
 import java.util.Collection;
 import java.util.EnumSet;
@@ -105,7 +105,7 @@ public class HasSchemaPrivilegeFunction {
                     DataTypes.STRING.getTypeSignature(), // Schema
                     DataTypes.STRING.getTypeSignature())
                 .returnType(DataTypes.BOOLEAN.getTypeSignature())
-                .features(EnumSet.of(DETERMINISTIC, NULLABLE))
+                .features(EnumSet.of(DETERMINISTIC, STRICTNULL))
                 .build(),
             (signature, boundSignature) -> new HasPrivilegeFunction(
                 signature,
@@ -123,7 +123,7 @@ public class HasSchemaPrivilegeFunction {
                     DataTypes.INTEGER.getTypeSignature(), // Schema
                     DataTypes.STRING.getTypeSignature())
                 .returnType(DataTypes.BOOLEAN.getTypeSignature())
-                .features(EnumSet.of(DETERMINISTIC, NULLABLE))
+                .features(EnumSet.of(DETERMINISTIC, STRICTNULL))
                 .build(),
             (signature, boundSignature) -> new HasPrivilegeFunction(
                 signature,
@@ -141,7 +141,7 @@ public class HasSchemaPrivilegeFunction {
                     DataTypes.STRING.getTypeSignature(), // Schema
                     DataTypes.STRING.getTypeSignature())
                 .returnType(DataTypes.BOOLEAN.getTypeSignature())
-                .features(EnumSet.of(DETERMINISTIC, NULLABLE))
+                .features(EnumSet.of(DETERMINISTIC, STRICTNULL))
                 .build(),
             (signature, boundSignature) -> new HasPrivilegeFunction(
                 signature,
@@ -159,7 +159,7 @@ public class HasSchemaPrivilegeFunction {
                     DataTypes.INTEGER.getTypeSignature(), // Schema
                     DataTypes.STRING.getTypeSignature())
                 .returnType(DataTypes.BOOLEAN.getTypeSignature())
-                .features(EnumSet.of(DETERMINISTIC, NULLABLE))
+                .features(EnumSet.of(DETERMINISTIC, STRICTNULL))
                 .build(),
             (signature, boundSignature) -> new HasPrivilegeFunction(
                 signature,
@@ -177,7 +177,7 @@ public class HasSchemaPrivilegeFunction {
                     DataTypes.STRING.getTypeSignature(),  // Schema
                     DataTypes.STRING.getTypeSignature())
                 .returnType(DataTypes.BOOLEAN.getTypeSignature())
-                .features(EnumSet.of(DETERMINISTIC, NULLABLE))
+                .features(EnumSet.of(DETERMINISTIC, STRICTNULL))
                 .build(),
             (signature, boundSignature) -> new HasPrivilegeFunction(
                 signature,
@@ -195,7 +195,7 @@ public class HasSchemaPrivilegeFunction {
                     DataTypes.INTEGER.getTypeSignature(), // Schema
                     DataTypes.STRING.getTypeSignature())
                 .returnType(DataTypes.BOOLEAN.getTypeSignature())
-                .features(EnumSet.of(DETERMINISTIC, NULLABLE))
+                .features(EnumSet.of(DETERMINISTIC, STRICTNULL))
                 .build(),
             (signature, boundSignature) -> new HasPrivilegeFunction(
                 signature,

--- a/server/src/main/java/io/crate/expression/scalar/HasTablePrivilegeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/HasTablePrivilegeFunction.java
@@ -22,7 +22,7 @@
 package io.crate.expression.scalar;
 
 import static io.crate.metadata.Scalar.Feature.DETERMINISTIC;
-import static io.crate.metadata.Scalar.Feature.NULLABLE;
+import static io.crate.metadata.Scalar.Feature.STRICTNULL;
 
 import java.util.Collection;
 import java.util.EnumSet;
@@ -113,7 +113,7 @@ public class HasTablePrivilegeFunction {
                     DataTypes.STRING.getTypeSignature(), // Table
                     DataTypes.STRING.getTypeSignature())
                 .returnType(DataTypes.BOOLEAN.getTypeSignature())
-                .features(EnumSet.of(DETERMINISTIC, NULLABLE))
+                .features(EnumSet.of(DETERMINISTIC, STRICTNULL))
                 .build(),
             (signature, boundSignature) -> new HasPrivilegeFunction(
                 signature,
@@ -131,7 +131,7 @@ public class HasTablePrivilegeFunction {
                     DataTypes.INTEGER.getTypeSignature(), // Table
                     DataTypes.STRING.getTypeSignature())
                 .returnType(DataTypes.BOOLEAN.getTypeSignature())
-                .features(EnumSet.of(DETERMINISTIC, NULLABLE))
+                .features(EnumSet.of(DETERMINISTIC, STRICTNULL))
                 .build(),
             (signature, boundSignature) -> new HasPrivilegeFunction(
                 signature,
@@ -149,7 +149,7 @@ public class HasTablePrivilegeFunction {
                     DataTypes.STRING.getTypeSignature(), // Table
                     DataTypes.STRING.getTypeSignature())
                 .returnType(DataTypes.BOOLEAN.getTypeSignature())
-                .features(EnumSet.of(DETERMINISTIC, NULLABLE))
+                .features(EnumSet.of(DETERMINISTIC, STRICTNULL))
                 .build(),
             (signature, boundSignature) -> new HasPrivilegeFunction(
                 signature,
@@ -167,7 +167,7 @@ public class HasTablePrivilegeFunction {
                     DataTypes.INTEGER.getTypeSignature(), // Table
                     DataTypes.STRING.getTypeSignature())
                 .returnType(DataTypes.BOOLEAN.getTypeSignature())
-                .features(EnumSet.of(DETERMINISTIC, NULLABLE))
+                .features(EnumSet.of(DETERMINISTIC, STRICTNULL))
                 .build(),
             (signature, boundSignature) -> new HasPrivilegeFunction(
                 signature,
@@ -185,7 +185,7 @@ public class HasTablePrivilegeFunction {
                     DataTypes.STRING.getTypeSignature(),  // Table
                     DataTypes.STRING.getTypeSignature())
                 .returnType(DataTypes.BOOLEAN.getTypeSignature())
-                .features(EnumSet.of(DETERMINISTIC, NULLABLE))
+                .features(EnumSet.of(DETERMINISTIC, STRICTNULL))
                 .build(),
             (signature, boundSignature) -> new HasPrivilegeFunction(
                 signature,
@@ -203,7 +203,7 @@ public class HasTablePrivilegeFunction {
                     DataTypes.INTEGER.getTypeSignature(), // Table
                     DataTypes.STRING.getTypeSignature())
                 .returnType(DataTypes.BOOLEAN.getTypeSignature())
-                .features(EnumSet.of(DETERMINISTIC, NULLABLE))
+                .features(EnumSet.of(DETERMINISTIC, STRICTNULL))
                 .build(),
             (signature, boundSignature) -> new HasPrivilegeFunction(
                 signature,

--- a/server/src/main/java/io/crate/expression/scalar/Ignore3vlFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/Ignore3vlFunction.java
@@ -55,7 +55,7 @@ public class Ignore3vlFunction extends Scalar<Boolean, Boolean> {
     public static final Signature SIGNATURE = Signature.builder(NAME, FunctionType.SCALAR)
         .argumentTypes(DataTypes.BOOLEAN.getTypeSignature())
         .returnType(DataTypes.BOOLEAN.getTypeSignature())
-        .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+        .features(Feature.DETERMINISTIC, Feature.NOTNULL)
         .build();
 
     public static void register(Functions.Builder module) {

--- a/server/src/main/java/io/crate/expression/scalar/NullOrEmptyFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/NullOrEmptyFunction.java
@@ -57,7 +57,7 @@ public final class NullOrEmptyFunction extends Scalar<Boolean, Object> {
             Signature.builder("null_or_empty", FunctionType.SCALAR)
                 .argumentTypes(DataTypes.UNTYPED_OBJECT.getTypeSignature())
                 .returnType(DataTypes.BOOLEAN.getTypeSignature())
-                .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                .features(Feature.DETERMINISTIC, Feature.NOTNULL)
                 .build(),
             NullOrEmptyFunction::new
         );
@@ -66,7 +66,7 @@ public final class NullOrEmptyFunction extends Scalar<Boolean, Object> {
                 .argumentTypes(TypeSignature.parse("array(E)"))
                 .returnType(DataTypes.BOOLEAN.getTypeSignature())
                 .typeVariableConstraints(TypeVariableConstraint.typeVariableOfAnyType("E"))
-                .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                .features(Feature.DETERMINISTIC, Feature.NOTNULL)
                 .build(),
             NullOrEmptyFunction::new
         );

--- a/server/src/main/java/io/crate/expression/scalar/PiFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/PiFunction.java
@@ -40,7 +40,7 @@ public final class PiFunction extends Scalar<Double, Object> {
             Signature.builder(NAME, FunctionType.SCALAR)
                 .argumentTypes()
                 .returnType(DataTypes.DOUBLE.getTypeSignature())
-                .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                .features(Feature.DETERMINISTIC, Feature.NOTNULL)
                 .build(),
             PiFunction::new
         );

--- a/server/src/main/java/io/crate/expression/scalar/TripleScalar.java
+++ b/server/src/main/java/io/crate/expression/scalar/TripleScalar.java
@@ -45,7 +45,7 @@ public final class TripleScalar<R, T> extends Scalar<R, T> {
                         DataType<T> type,
                         ThreeParametersFunction<T, T, T, R> func) {
         super(signature, boundSignature);
-        assert signature.hasFeature(Feature.NULLABLE) : "A TriScalar is NULLABLE by definition";
+        assert signature.hasFeature(Feature.STRICTNULL) : "A TriScalar is NULLABLE by definition";
         assert boundSignature.argTypes().stream().allMatch(t -> t.id() == type.id()) :
             "All argument types of the bound signature must match the type argument";
         this.type = type;

--- a/server/src/main/java/io/crate/expression/scalar/UnaryScalar.java
+++ b/server/src/main/java/io/crate/expression/scalar/UnaryScalar.java
@@ -47,7 +47,7 @@ public class UnaryScalar<R, T> extends Scalar<R, T> {
                        DataType<T> type,
                        Function<T, R> func) {
         super(signature, boundSignature);
-        assert signature.hasFeature(Feature.NULLABLE) : "A UnaryScalar is NULLABLE by definition";
+        assert signature.hasFeature(Feature.STRICTNULL) : "A UnaryScalar is NULLABLE by definition";
         assert boundSignature.argTypes().get(0).id() == type.id() :
             "The bound argument type of the signature must match the type argument";
         this.type = type;

--- a/server/src/main/java/io/crate/expression/scalar/VectorSimilarityFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/VectorSimilarityFunction.java
@@ -40,7 +40,7 @@ public class VectorSimilarityFunction extends Scalar<Float, float[]> {
                 .argumentTypes(FloatVectorType.INSTANCE_ONE.getTypeSignature(),
                     FloatVectorType.INSTANCE_ONE.getTypeSignature())
                 .returnType(DataTypes.FLOAT.getTypeSignature())
-                .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
                 .build(),
             VectorSimilarityFunction::new
         );

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/AbsFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/AbsFunction.java
@@ -40,7 +40,7 @@ public final class AbsFunction {
                 Signature.builder(NAME, FunctionType.SCALAR)
                     .argumentTypes(typeSignature)
                     .returnType(typeSignature)
-                    .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                    .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                     .build(),
                 (signature, boundSignature) -> {
                     DataType<?> argType = boundSignature.argTypes().get(0);

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/ArithmeticFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/ArithmeticFunctions.java
@@ -50,7 +50,7 @@ public class ArithmeticFunctions {
 
     private enum Operations {
         ADD(
-            EnumSet.of(Feature.DETERMINISTIC, Feature.COMPARISON_REPLACEMENT, Feature.NULLABLE),
+            EnumSet.of(Feature.DETERMINISTIC, Feature.COMPARISON_REPLACEMENT, Feature.STRICTNULL),
             Math::addExact,
             Double::sum,
             Math::addExact,
@@ -58,7 +58,7 @@ public class ArithmeticFunctions {
             BigDecimal::add
         ),
         SUBTRACT(
-            EnumSet.of(Feature.DETERMINISTIC, Feature.NULLABLE),
+            EnumSet.of(Feature.DETERMINISTIC, Feature.STRICTNULL),
             Math::subtractExact,
                 (arg0, arg1) -> arg0 - arg1,
             Math::subtractExact,
@@ -66,7 +66,7 @@ public class ArithmeticFunctions {
             BigDecimal::subtract
         ),
         MULTIPLY(
-            EnumSet.of(Feature.DETERMINISTIC, Feature.NULLABLE),
+            EnumSet.of(Feature.DETERMINISTIC, Feature.STRICTNULL),
             Math::multiplyExact,
                 (arg0, arg1) -> arg0 * arg1,
             Math::multiplyExact,
@@ -74,7 +74,7 @@ public class ArithmeticFunctions {
             BigDecimal::multiply
         ),
         DIVIDE(
-            EnumSet.of(Feature.DETERMINISTIC, Feature.NULLABLE),
+            EnumSet.of(Feature.DETERMINISTIC, Feature.STRICTNULL),
                 (arg0, arg1) -> arg0 / arg1,
                 (arg0, arg1) -> arg0 / arg1,
                 (arg0, arg1) -> arg0 / arg1,
@@ -82,7 +82,7 @@ public class ArithmeticFunctions {
                 (arg0, arg1) -> arg0.divide(arg1, MathContext.DECIMAL64)
         ),
         MODULUS(
-            EnumSet.of(Feature.DETERMINISTIC, Feature.NULLABLE),
+            EnumSet.of(Feature.DETERMINISTIC, Feature.STRICTNULL),
                 (arg0, arg1) -> arg0 % arg1,
                 (arg0, arg1) -> arg0 % arg1,
                 (arg0, arg1) -> arg0 % arg1,
@@ -90,7 +90,7 @@ public class ArithmeticFunctions {
             BigDecimal::remainder
         ),
         MOD(
-            EnumSet.of(Feature.DETERMINISTIC, Feature.NULLABLE),
+            EnumSet.of(Feature.DETERMINISTIC, Feature.STRICTNULL),
                 (arg0, arg1) -> arg0 % arg1,
                 (arg0, arg1) -> arg0 % arg1,
                 (arg0, arg1) -> arg0 % arg1,
@@ -192,7 +192,7 @@ public class ArithmeticFunctions {
             Signature.builder(Names.POWER, FunctionType.SCALAR)
                 .argumentTypes(DataTypes.DOUBLE.getTypeSignature(), DataTypes.DOUBLE.getTypeSignature())
                 .returnType(DataTypes.DOUBLE.getTypeSignature())
-                .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
                 .build(),
             (signature, boundSignature) ->
                 new BinaryScalar<>(Math::pow, signature, boundSignature, DataTypes.DOUBLE)

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/ArrayFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/ArrayFunction.java
@@ -44,7 +44,7 @@ public class ArrayFunction extends Scalar<Object, Object> {
             .argumentTypes(TypeSignature.parse("E"))
             .returnType(TypeSignature.parse("array(E)"))
             .setVariableArity(true)
-            .features(Feature.NON_NULLABLE, Feature.DETERMINISTIC)
+            .features(Feature.NOTNULL, Feature.DETERMINISTIC)
             .build();
 
 

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/BinaryScalar.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/BinaryScalar.java
@@ -41,7 +41,7 @@ public final class BinaryScalar<T> extends Scalar<T, T> {
                         BoundSignature boundSignature,
                         DataType<T> type) {
         super(signature, boundSignature);
-        assert signature.hasFeature(Feature.NULLABLE) : "A BinaryScalar is NULLABLE by definition";
+        assert signature.hasFeature(Feature.STRICTNULL) : "A BinaryScalar is NULLABLE by definition";
         assert boundSignature.argTypes().stream().allMatch(t -> t.id() == type.id()) :
             "All bound argument types of the signature must match the type argument";
         this.func = func;

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/CeilFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/CeilFunction.java
@@ -46,7 +46,7 @@ public final class CeilFunction {
                     Signature.builder(name, FunctionType.SCALAR)
                         .argumentTypes(typeSignature)
                         .returnType(returnType.getTypeSignature())
-                        .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                        .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                         .build(),
                     (signature, boundSignature) ->
                         new UnaryScalar<>(

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/ExpFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/ExpFunction.java
@@ -39,7 +39,7 @@ public class ExpFunction {
             Signature.builder(NAME, FunctionType.SCALAR)
                 .argumentTypes(signature)
                 .returnType(signature)
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
             (declaredSignature, boundSignature) ->
                 new UnaryScalar<>(

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/FloorFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/FloorFunction.java
@@ -42,7 +42,7 @@ public final class FloorFunction {
                 Signature.builder(NAME, FunctionType.SCALAR)
                     .argumentTypes(typeSignature)
                     .returnType(returnType.getTypeSignature())
-                    .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                    .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                     .build(),
                 (signature, boundSignature) ->
                     new UnaryScalar<>(

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/IntervalArithmeticFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/IntervalArithmeticFunctions.java
@@ -45,7 +45,7 @@ public class IntervalArithmeticFunctions {
                 .argumentTypes(DataTypes.INTERVAL.getTypeSignature(),
                     DataTypes.INTERVAL.getTypeSignature())
                 .returnType(DataTypes.INTERVAL.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
             (signature, boundSignature) ->
                 new IntervalIntervalArithmeticScalar(Period::plus, signature, boundSignature)
@@ -55,7 +55,7 @@ public class IntervalArithmeticFunctions {
                 .argumentTypes(DataTypes.INTERVAL.getTypeSignature(),
                     DataTypes.INTERVAL.getTypeSignature())
                 .returnType(DataTypes.INTERVAL.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
             (signature, boundSignature) ->
                 new IntervalIntervalArithmeticScalar(Period::minus, signature, boundSignature)
@@ -65,7 +65,7 @@ public class IntervalArithmeticFunctions {
                 .argumentTypes(DataTypes.INTEGER.getTypeSignature(),
                     DataTypes.INTERVAL.getTypeSignature())
                 .returnType(DataTypes.INTERVAL.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
             MultiplyIntervalByIntegerScalar::new
         );
@@ -74,7 +74,7 @@ public class IntervalArithmeticFunctions {
                 .argumentTypes(DataTypes.INTERVAL.getTypeSignature(),
                     DataTypes.INTEGER.getTypeSignature())
                 .returnType(DataTypes.INTERVAL.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
             MultiplyIntervalByIntegerScalar::new
         );

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/LogFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/LogFunction.java
@@ -70,7 +70,7 @@ public abstract class LogFunction extends Scalar<Number, Number> {
                     .argumentTypes(DataTypes.DOUBLE.getTypeSignature(),
                         DataTypes.DOUBLE.getTypeSignature())
                     .returnType(TypeSignature.parse("double precision"))
-                    .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                    .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
                     .build(),
                 LogBaseFunction::new
             );
@@ -108,7 +108,7 @@ public abstract class LogFunction extends Scalar<Number, Number> {
                 Signature.builder(NAME, FunctionType.SCALAR)
                     .argumentTypes(DataTypes.DOUBLE.getTypeSignature())
                     .returnType(DataTypes.DOUBLE.getTypeSignature())
-                    .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                    .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
                     .build(),
                 Log10Function::new
             );
@@ -142,7 +142,7 @@ public abstract class LogFunction extends Scalar<Number, Number> {
                 Signature.builder(LnFunction.NAME, FunctionType.SCALAR)
                     .argumentTypes(DataTypes.DOUBLE.getTypeSignature())
                     .returnType(DataTypes.DOUBLE.getTypeSignature())
-                    .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                    .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
                     .build(),
                 LnFunction::new
             );

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/NegateFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/NegateFunctions.java
@@ -40,7 +40,7 @@ public final class NegateFunctions {
             Signature.builder(NAME, FunctionType.SCALAR)
                 .argumentTypes(TypeSignature.parse("double precision"))
                 .returnType(TypeSignature.parse("double precision"))
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .forbidCoercion()
                 .build(),
             (signature, boundSignature) ->
@@ -50,7 +50,7 @@ public final class NegateFunctions {
             Signature.builder(NAME, FunctionType.SCALAR)
                 .argumentTypes(DataTypes.FLOAT.getTypeSignature())
                 .returnType(DataTypes.FLOAT.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .forbidCoercion()
                 .build(),
             (signature, boundSignature) ->
@@ -60,7 +60,7 @@ public final class NegateFunctions {
             Signature.builder(NAME, FunctionType.SCALAR)
                 .argumentTypes(TypeSignature.parse("integer"))
                 .returnType(TypeSignature.parse("integer"))
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .forbidCoercion()
                 .build(),
             (signature, boundSignature) ->
@@ -70,7 +70,7 @@ public final class NegateFunctions {
             Signature.builder(NAME, FunctionType.SCALAR)
                 .argumentTypes(TypeSignature.parse("bigint"))
                 .returnType(TypeSignature.parse("bigint"))
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .forbidCoercion()
                 .build(),
             (signature, boundSignature) ->
@@ -80,7 +80,7 @@ public final class NegateFunctions {
             Signature.builder(NAME, FunctionType.SCALAR)
                 .argumentTypes(TypeSignature.parse("smallint"))
                 .returnType(TypeSignature.parse("smallint"))
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .forbidCoercion()
                 .build(),
             (signature, boundSignature) ->
@@ -90,7 +90,7 @@ public final class NegateFunctions {
             Signature.builder(NAME, FunctionType.SCALAR)
                 .argumentTypes(DataTypes.NUMERIC.getTypeSignature())
                 .returnType(DataTypes.NUMERIC.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .forbidCoercion()
                 .build(),
             (signature, boundSignature) ->

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/RadiansDegreesFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/RadiansDegreesFunctions.java
@@ -35,7 +35,7 @@ public class RadiansDegreesFunctions {
             Signature.builder("radians", FunctionType.SCALAR)
                 .argumentTypes(DataTypes.DOUBLE.getTypeSignature())
                 .returnType(DataTypes.DOUBLE.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
             (signature, boundSignature) ->
                 new UnaryScalar<>(signature, boundSignature, DataTypes.DOUBLE, Math::toRadians));
@@ -44,7 +44,7 @@ public class RadiansDegreesFunctions {
             Signature.builder("degrees", FunctionType.SCALAR)
                 .argumentTypes(DataTypes.DOUBLE.getTypeSignature())
                 .returnType(DataTypes.DOUBLE.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
             (signature, boundSignature) ->
                 new UnaryScalar<>(signature, boundSignature, DataTypes.DOUBLE, Math::toDegrees));

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/RandomFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/RandomFunction.java
@@ -46,7 +46,7 @@ public class RandomFunction extends Scalar<Double, Void> {
             Signature.builder(NAME, FunctionType.SCALAR)
                 .argumentTypes()
                 .returnType(DataTypes.DOUBLE.getTypeSignature())
-                .features(EnumSet.of(Feature.NON_NULLABLE))
+                .features(EnumSet.of(Feature.NOTNULL))
                 .build(),
             RandomFunction::new
         );

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/RoundFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/RoundFunction.java
@@ -42,7 +42,7 @@ public final class RoundFunction {
                 Signature.builder(NAME, FunctionType.SCALAR)
                     .argumentTypes(typeSignature)
                     .returnType(returnType.getTypeSignature())
-                    .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                    .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                     .build(),
                 (signature, boundSignature) -> {
                     if (returnType.equals(DataTypes.INTEGER)) {

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/SignFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/SignFunction.java
@@ -41,7 +41,7 @@ public class SignFunction {
             Signature.builder(NAME, FunctionType.SCALAR)
                 .argumentTypes(DataTypes.NUMERIC.getTypeSignature())
                 .returnType(DataTypes.NUMERIC.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
             (signature, boundSignature) -> {
                 DataType<?> argType = boundSignature.argTypes().getFirst();
@@ -59,7 +59,7 @@ public class SignFunction {
             Signature.builder(NAME, FunctionType.SCALAR)
                 .argumentTypes(DataTypes.DOUBLE.getTypeSignature())
                 .returnType(DataTypes.DOUBLE.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
             (signature, boundSignature) ->
                 new DoubleScalar(signature, boundSignature, Math::signum)

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/SquareRootFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/SquareRootFunction.java
@@ -39,7 +39,7 @@ public final class SquareRootFunction {
                 Signature.builder(NAME, FunctionType.SCALAR)
                     .argumentTypes(typeSignature)
                     .returnType(DataTypes.DOUBLE.getTypeSignature())
-                    .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                    .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                     .build(),
                 (signature, boundSignature) ->
                     new DoubleScalar(signature, boundSignature, SquareRootFunction::sqrt)

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/TrigonometricFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/TrigonometricFunctions.java
@@ -48,7 +48,7 @@ public final class TrigonometricFunctions {
                 .argumentTypes(DataTypes.DOUBLE.getTypeSignature(),
                     DataTypes.DOUBLE.getTypeSignature())
                 .returnType(DataTypes.DOUBLE.getTypeSignature())
-                .features(Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
             (signature, boundSignature) ->
                 new BinaryScalar<>(
@@ -65,7 +65,7 @@ public final class TrigonometricFunctions {
             Signature.builder(name, FunctionType.SCALAR)
                 .argumentTypes(DataTypes.DOUBLE.getTypeSignature())
                 .returnType(DataTypes.DOUBLE.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
             (signature, boundSignature) ->
                 new DoubleScalar(signature, boundSignature, func)

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/TruncFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/TruncFunction.java
@@ -52,7 +52,7 @@ public final class TruncFunction {
                 Signature.builder(NAME, FunctionType.SCALAR)
                     .argumentTypes(type.getTypeSignature())
                     .returnType(returnType.getTypeSignature())
-                    .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                    .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                     .forbidCoercion()
                     .build(),
                 (signature, boundSignature) ->
@@ -75,7 +75,7 @@ public final class TruncFunction {
                 .argumentTypes(DataTypes.DOUBLE.getTypeSignature(),
                     DataTypes.INTEGER.getTypeSignature())
                 .returnType(DataTypes.DOUBLE.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
             TruncFunction::createTruncWithMode
         );

--- a/server/src/main/java/io/crate/expression/scalar/bitwise/BitwiseFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/bitwise/BitwiseFunctions.java
@@ -58,7 +58,7 @@ public class BitwiseFunctions {
             .argumentTypes(typeSignature,
                 typeSignature)
             .returnType(typeSignature)
-            .features(Scalar.Feature.DETERMINISTIC, Feature.NULLABLE)
+            .features(Scalar.Feature.DETERMINISTIC, Feature.STRICTNULL)
             .build();
         module.add(scalar, (signature, boundSignature) -> new BinaryScalar<>(operator, signature, boundSignature, type));
     }

--- a/server/src/main/java/io/crate/expression/scalar/geo/AreaFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/geo/AreaFunction.java
@@ -61,7 +61,7 @@ public final class AreaFunction {
             Signature.builder(FUNCTION_NAME, FunctionType.SCALAR)
                 .argumentTypes(DataTypes.GEO_SHAPE.getTypeSignature())
                 .returnType(DataTypes.DOUBLE.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
             (signature, boundSignature) ->
                 new UnaryScalar<>(

--- a/server/src/main/java/io/crate/expression/scalar/geo/CoordinateFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/geo/CoordinateFunction.java
@@ -35,7 +35,7 @@ public final class CoordinateFunction {
             Signature.builder("latitude", FunctionType.SCALAR)
                 .argumentTypes(DataTypes.GEO_POINT.getTypeSignature())
                 .returnType(DataTypes.DOUBLE.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
             (signature, boundSignature) ->
                 new UnaryScalar<>(
@@ -49,7 +49,7 @@ public final class CoordinateFunction {
             Signature.builder("longitude", FunctionType.SCALAR)
                 .argumentTypes(DataTypes.GEO_POINT.getTypeSignature())
                 .returnType(DataTypes.DOUBLE.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
             (signature, boundSignature) ->
                 new UnaryScalar<>(

--- a/server/src/main/java/io/crate/expression/scalar/geo/DistanceFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/geo/DistanceFunction.java
@@ -64,7 +64,7 @@ public class DistanceFunction extends Scalar<Double, Point> {
                 .argumentTypes(DataTypes.GEO_POINT.getTypeSignature(),
                     DataTypes.GEO_POINT.getTypeSignature())
                 .returnType(DataTypes.DOUBLE.getTypeSignature())
-                .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
                 .build(),
             DistanceFunction::new
         );

--- a/server/src/main/java/io/crate/expression/scalar/geo/GeoHashFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/geo/GeoHashFunction.java
@@ -39,7 +39,7 @@ public final class GeoHashFunction {
             Signature.builder("geohash", FunctionType.SCALAR)
                 .argumentTypes(DataTypes.GEO_POINT.getTypeSignature())
                 .returnType(DataTypes.STRING.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
             (signature, boundSignature) ->
                 new UnaryScalar<>(

--- a/server/src/main/java/io/crate/expression/scalar/geo/IntersectsFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/geo/IntersectsFunction.java
@@ -47,7 +47,7 @@ public class IntersectsFunction extends Scalar<Boolean, Object> {
                 .argumentTypes(DataTypes.GEO_SHAPE.getTypeSignature(),
                     DataTypes.GEO_SHAPE.getTypeSignature())
                 .returnType(DataTypes.BOOLEAN.getTypeSignature())
-                .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
                 .build(),
             IntersectsFunction::new
         );

--- a/server/src/main/java/io/crate/expression/scalar/object/ObjectKeysFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/object/ObjectKeysFunction.java
@@ -37,7 +37,7 @@ public final class ObjectKeysFunction {
             Signature.builder("object_keys", FunctionType.SCALAR)
                 .argumentTypes(DataTypes.UNTYPED_OBJECT.getTypeSignature())
                 .returnType(DataTypes.STRING_ARRAY.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
             (signature, boundSignature) ->
                 new UnaryScalar<>(

--- a/server/src/main/java/io/crate/expression/scalar/postgres/PgBackendPidFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/postgres/PgBackendPidFunction.java
@@ -48,7 +48,7 @@ public class PgBackendPidFunction extends Scalar<Integer, Void> {
             Signature.builder(FQN, FunctionType.SCALAR)
                 .argumentTypes()
                 .returnType(DataTypes.INTEGER.getTypeSignature())
-                .features(EnumSet.of(Feature.NON_NULLABLE))
+                .features(EnumSet.of(Feature.NOTNULL))
                 .build(),
             PgBackendPidFunction::new
         );

--- a/server/src/main/java/io/crate/expression/scalar/postgres/PgGetUserByIdFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/postgres/PgGetUserByIdFunction.java
@@ -42,7 +42,7 @@ public class PgGetUserByIdFunction extends Scalar<String, Integer> {
             Signature.builder(name, FunctionType.SCALAR)
                 .argumentTypes(DataTypes.INTEGER.getTypeSignature())
                 .returnType(DataTypes.STRING.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
             PgGetUserByIdFunction::new
         );

--- a/server/src/main/java/io/crate/expression/scalar/postgres/PgPostmasterStartTime.java
+++ b/server/src/main/java/io/crate/expression/scalar/postgres/PgPostmasterStartTime.java
@@ -46,7 +46,7 @@ public final class PgPostmasterStartTime extends Scalar<Long, Void> {
             Signature.builder(FQN, FunctionType.SCALAR)
                 .argumentTypes()
                 .returnType(DataTypes.TIMESTAMPZ.getTypeSignature())
-                .features(EnumSet.of(Feature.NON_NULLABLE))
+                .features(EnumSet.of(Feature.NOTNULL))
                 .build(),
             PgPostmasterStartTime::new
         );

--- a/server/src/main/java/io/crate/expression/scalar/postgres/PgTableIsVisibleFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/postgres/PgTableIsVisibleFunction.java
@@ -54,7 +54,7 @@ public class PgTableIsVisibleFunction extends Scalar<Boolean, Integer> {
             Signature.builder(NAME, FunctionType.SCALAR)
                 .argumentTypes(DataTypes.INTEGER.getTypeSignature())
                 .returnType(DataTypes.BOOLEAN.getTypeSignature())
-                .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
                 .build(),
             PgTableIsVisibleFunction::new);
     }

--- a/server/src/main/java/io/crate/expression/scalar/string/AsciiFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/AsciiFunction.java
@@ -35,7 +35,7 @@ public final class AsciiFunction {
             Signature.builder("ascii", FunctionType.SCALAR)
                 .argumentTypes(DataTypes.STRING.getTypeSignature())
                 .returnType(DataTypes.INTEGER.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
             (signature, boundSignature) ->
                 new UnaryScalar<>(signature, boundSignature, DataTypes.STRING, AsciiFunction::ascii)

--- a/server/src/main/java/io/crate/expression/scalar/string/ChrFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/ChrFunction.java
@@ -38,7 +38,7 @@ public final class ChrFunction extends Scalar<String, Object> {
             Signature.builder("chr", FunctionType.SCALAR)
                 .argumentTypes(DataTypes.INTEGER.getTypeSignature())
                 .returnType(DataTypes.STRING.getTypeSignature())
-                .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
                 .build(),
             ChrFunction::new
         );

--- a/server/src/main/java/io/crate/expression/scalar/string/EncodeDecodeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/EncodeDecodeFunction.java
@@ -44,7 +44,7 @@ public class EncodeDecodeFunction {
                 .argumentTypes(DataTypes.STRING.getTypeSignature(),
                     DataTypes.STRING.getTypeSignature())
                 .returnType(DataTypes.STRING.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
             (signature, boundSignature) ->
                 new BinaryScalar<>(
@@ -59,7 +59,7 @@ public class EncodeDecodeFunction {
                 .argumentTypes(DataTypes.STRING.getTypeSignature(),
                     DataTypes.STRING.getTypeSignature())
                 .returnType(DataTypes.STRING.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
             (signature, boundSignature) ->
                 new BinaryScalar<>(

--- a/server/src/main/java/io/crate/expression/scalar/string/HashFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/HashFunctions.java
@@ -49,7 +49,7 @@ public final class HashFunctions {
             Signature.builder(name, FunctionType.SCALAR)
                 .argumentTypes(DataTypes.STRING.getTypeSignature())
                 .returnType(DataTypes.STRING.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
             (signature, boundSignature) ->
                 new UnaryScalar<>(signature, boundSignature, DataTypes.STRING, func)

--- a/server/src/main/java/io/crate/expression/scalar/string/InitCapFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/InitCapFunction.java
@@ -35,7 +35,7 @@ public final class InitCapFunction {
             Signature.builder("initcap", FunctionType.SCALAR)
                 .argumentTypes(DataTypes.STRING.getTypeSignature())
                 .returnType(DataTypes.STRING.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
             (signature, boundSignature) ->
                 new UnaryScalar<>(

--- a/server/src/main/java/io/crate/expression/scalar/string/LengthFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/LengthFunction.java
@@ -45,7 +45,7 @@ public final class LengthFunction {
             Signature.builder(name, FunctionType.SCALAR)
                 .argumentTypes(DataTypes.STRING.getTypeSignature())
                 .returnType(DataTypes.INTEGER.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
             (signature, boundSignature) -> new UnaryScalar<>(signature, boundSignature, DataTypes.STRING, func)
         );

--- a/server/src/main/java/io/crate/expression/scalar/string/ParseURIFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/ParseURIFunction.java
@@ -46,7 +46,7 @@ public final class ParseURIFunction extends Scalar<Object, String> {
             Signature.builder(NAME, FunctionType.SCALAR)
                 .argumentTypes(DataTypes.STRING.getTypeSignature())
                 .returnType(DataTypes.UNTYPED_OBJECT.getTypeSignature())
-                .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
                 .build(),
             ParseURIFunction::new
         );

--- a/server/src/main/java/io/crate/expression/scalar/string/ParseURLFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/ParseURLFunction.java
@@ -54,7 +54,7 @@ public final class ParseURLFunction extends Scalar<Object, String> {
             Signature.builder(NAME, FunctionType.SCALAR)
                 .argumentTypes(DataTypes.STRING.getTypeSignature())
                 .returnType(DataTypes.UNTYPED_OBJECT.getTypeSignature())
-                .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
                 .build(),
             ParseURLFunction::new
         );

--- a/server/src/main/java/io/crate/expression/scalar/string/QuoteIdentFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/QuoteIdentFunction.java
@@ -45,7 +45,7 @@ public final class QuoteIdentFunction {
             Signature.builder(FQNAME, FunctionType.SCALAR)
                 .argumentTypes(DataTypes.STRING.getTypeSignature())
                 .returnType(DataTypes.STRING.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
             (signature, boundSignature) ->
                 new UnaryScalar<>(

--- a/server/src/main/java/io/crate/expression/scalar/string/ReplaceFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/ReplaceFunction.java
@@ -40,7 +40,7 @@ public final class ReplaceFunction {
             Signature.builder(NAME, FunctionType.SCALAR)
                 .argumentTypes(DataTypes.STRING.getTypeSignature(), DataTypes.STRING.getTypeSignature(), DataTypes.STRING.getTypeSignature())
                 .returnType(DataTypes.STRING.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
             (signature, boundSignature) ->
                 new TripleScalar<>(

--- a/server/src/main/java/io/crate/expression/scalar/string/ReverseFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/ReverseFunction.java
@@ -37,7 +37,7 @@ public final class ReverseFunction {
             Signature.builder(NAME, FunctionType.SCALAR)
                 .argumentTypes(DataTypes.STRING.getTypeSignature())
                 .returnType(DataTypes.STRING.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
             (signature, boundSignature) -> {
                 return new UnaryScalar<>(

--- a/server/src/main/java/io/crate/expression/scalar/string/StringCaseFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/StringCaseFunction.java
@@ -37,7 +37,7 @@ public final class StringCaseFunction {
             Signature.builder("upper", FunctionType.SCALAR)
                 .argumentTypes(DataTypes.STRING.getTypeSignature())
                 .returnType(DataTypes.STRING.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
             (signature, boundSignature) ->
                 new UnaryScalar<>(
@@ -51,7 +51,7 @@ public final class StringCaseFunction {
             Signature.builder("lower", FunctionType.SCALAR)
                 .argumentTypes(DataTypes.STRING.getTypeSignature())
                 .returnType(DataTypes.STRING.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
             (signature, boundSignature) ->
                 new UnaryScalar<>(

--- a/server/src/main/java/io/crate/expression/scalar/string/StringPositionFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/StringPositionFunction.java
@@ -38,7 +38,7 @@ public final class StringPositionFunction extends Scalar<Integer , String> {
             Signature.builder("strpos", FunctionType.SCALAR)
                 .argumentTypes(DataTypes.STRING.getTypeSignature(), DataTypes.STRING.getTypeSignature())
                 .returnType(DataTypes.INTEGER.getTypeSignature())
-                .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
                 .build(),
             StringPositionFunction::new
         );

--- a/server/src/main/java/io/crate/expression/scalar/string/TrimFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/TrimFunctions.java
@@ -55,7 +55,7 @@ public final class TrimFunctions {
             Signature.builder(TRIM_NAME, FunctionType.SCALAR)
                 .argumentTypes(DataTypes.STRING.getTypeSignature())
                 .returnType(DataTypes.STRING.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
             (signature, boundSignature) ->
                 new OneCharTrimFunction(
@@ -69,7 +69,7 @@ public final class TrimFunctions {
             Signature.builder(TRIM_NAME, FunctionType.SCALAR)
                 .argumentTypes(DataTypes.STRING.getTypeSignature(), DataTypes.STRING.getTypeSignature(), DataTypes.STRING.getTypeSignature())
                 .returnType(DataTypes.STRING.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
             TrimFunction::new
         );
@@ -79,7 +79,7 @@ public final class TrimFunctions {
             Signature.builder(LTRIM_NAME, FunctionType.SCALAR)
                 .argumentTypes(DataTypes.STRING.getTypeSignature())
                 .returnType(DataTypes.STRING.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
             (signature, boundSignature) ->
                 new SideTrimFunction(
@@ -94,7 +94,7 @@ public final class TrimFunctions {
                 .argumentTypes(DataTypes.STRING.getTypeSignature(),
                     DataTypes.STRING.getTypeSignature())
                 .returnType(DataTypes.STRING.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
             (signature, boundSignature) ->
                 new SideTrimFunction(
@@ -109,7 +109,7 @@ public final class TrimFunctions {
             Signature.builder(RTRIM_NAME, FunctionType.SCALAR)
                 .argumentTypes(DataTypes.STRING.getTypeSignature())
                 .returnType(DataTypes.STRING.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
             (signature, boundSignature) ->
                 new SideTrimFunction(
@@ -124,7 +124,7 @@ public final class TrimFunctions {
                 .argumentTypes(DataTypes.STRING.getTypeSignature(),
                     DataTypes.STRING.getTypeSignature())
                 .returnType(DataTypes.STRING.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
             (signature, boundSignature) ->
                 new SideTrimFunction(
@@ -140,7 +140,7 @@ public final class TrimFunctions {
             Signature.builder(BTRIM_NAME, FunctionType.SCALAR)
                 .argumentTypes(DataTypes.STRING.getTypeSignature())
                 .returnType(DataTypes.STRING.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
             (signature, boundSignature) ->
                 new SideTrimFunction(
@@ -155,7 +155,7 @@ public final class TrimFunctions {
                 .argumentTypes(DataTypes.STRING.getTypeSignature(),
                     DataTypes.STRING.getTypeSignature())
                 .returnType(DataTypes.STRING.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
             (signature, boundSignature) ->
                 new SideTrimFunction(

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/CurrentSchemaFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/CurrentSchemaFunction.java
@@ -52,7 +52,7 @@ public class CurrentSchemaFunction extends Scalar<String, Object> {
             Signature.builder(FQN, FunctionType.SCALAR)
                     .argumentTypes()
                     .returnType(DataTypes.STRING.getTypeSignature())
-                    .features(EnumSet.of(Feature.NON_NULLABLE))
+                    .features(EnumSet.of(Feature.NOTNULL))
                     .build(),
             CurrentSchemaFunction::new
         );

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/CurrentSchemasFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/CurrentSchemasFunction.java
@@ -47,7 +47,7 @@ public class CurrentSchemasFunction extends Scalar<List<String>, Boolean> {
             Signature.builder(FQN, FunctionType.SCALAR)
                 .argumentTypes(DataTypes.BOOLEAN.getTypeSignature())
                 .returnType(DataTypes.STRING_ARRAY.getTypeSignature())
-                .features(EnumSet.of(Feature.NON_NULLABLE))
+                .features(EnumSet.of(Feature.NOTNULL))
                 .build(),
             CurrentSchemasFunction::new
         );

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/PgFunctionIsVisibleFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/PgFunctionIsVisibleFunction.java
@@ -40,7 +40,7 @@ public final class PgFunctionIsVisibleFunction extends Scalar<Boolean, Integer> 
             Signature.builder(NAME, FunctionType.SCALAR)
                 .argumentTypes(DataTypes.INTEGER.getTypeSignature())
                 .returnType(DataTypes.BOOLEAN.getTypeSignature())
-                .features(Feature.DETERMINISTIC, Feature.NULLABLE)
+                .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
                 .build(),
             PgFunctionIsVisibleFunction::new);
     }

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetSerialSequenceFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetSerialSequenceFunction.java
@@ -41,7 +41,7 @@ public class PgGetSerialSequenceFunction {
                 .argumentTypes(DataTypes.STRING.getTypeSignature(),
                     DataTypes.STRING.getTypeSignature())
                 .returnType(DataTypes.STRING.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
             (signature, boundSignature) -> new BinaryScalar<>(
                 (table, column) -> null,

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/PgTypeofFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/PgTypeofFunction.java
@@ -45,7 +45,7 @@ public final class PgTypeofFunction extends Scalar<String, Object> {
             Signature.builder(FQNAME, FunctionType.SCALAR)
                 .argumentTypes(TypeSignature.parse("E"))
                 .returnType(DataTypes.STRING.getTypeSignature())
-                .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                .features(Feature.DETERMINISTIC, Feature.NOTNULL)
                 .typeVariableConstraints(typeVariable("E"))
                 .build(),
             PgTypeofFunction::new

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/VersionFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/VersionFunction.java
@@ -50,7 +50,7 @@ public class VersionFunction extends Scalar<String, Void> {
             Signature.builder(FQN, FunctionType.SCALAR)
                 .argumentTypes()
                 .returnType(DataTypes.STRING.getTypeSignature())
-                .features(EnumSet.of(Feature.NON_NULLABLE))
+                .features(EnumSet.of(Feature.NOTNULL))
                 .build(),
             VersionFunction::new
         );

--- a/server/src/main/java/io/crate/expression/scalar/timestamp/CurrentTimeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/timestamp/CurrentTimeFunction.java
@@ -46,7 +46,7 @@ public class CurrentTimeFunction extends Scalar<TimeTZ, Integer> {
             Signature.builder(NAME, FunctionType.SCALAR)
                 .argumentTypes(DataTypes.INTEGER.getTypeSignature())
                 .returnType(DataTypes.TIMETZ.getTypeSignature())
-                .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                .features(Feature.DETERMINISTIC, Feature.NOTNULL)
                 .build(),
             CurrentTimeFunction::new
         );
@@ -54,7 +54,7 @@ public class CurrentTimeFunction extends Scalar<TimeTZ, Integer> {
             Signature.builder(NAME, FunctionType.SCALAR)
                 .argumentTypes()
                 .returnType(DataTypes.TIMETZ.getTypeSignature())
-                .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                .features(Feature.DETERMINISTIC, Feature.NOTNULL)
                 .build(),
             CurrentTimeFunction::new
         );

--- a/server/src/main/java/io/crate/expression/scalar/timestamp/CurrentTimestampFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/timestamp/CurrentTimestampFunction.java
@@ -46,7 +46,7 @@ public class CurrentTimestampFunction extends Scalar<Long, Integer> {
             Signature.builder(NAME, FunctionType.SCALAR)
                 .argumentTypes()
                 .returnType(DataTypes.TIMESTAMPZ.getTypeSignature())
-                .features(EnumSet.of(Feature.NON_NULLABLE))
+                .features(EnumSet.of(Feature.NOTNULL))
                 .build(),
             CurrentTimestampFunction::new
         );
@@ -54,7 +54,7 @@ public class CurrentTimestampFunction extends Scalar<Long, Integer> {
             Signature.builder(NAME, FunctionType.SCALAR)
                 .argumentTypes(DataTypes.INTEGER.getTypeSignature())
                 .returnType(DataTypes.TIMESTAMPZ.getTypeSignature())
-                .features(EnumSet.of(Feature.NON_NULLABLE))
+                .features(EnumSet.of(Feature.NOTNULL))
                 .build(),
             CurrentTimestampFunction::new
         );

--- a/server/src/main/java/io/crate/expression/scalar/timestamp/NowFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/timestamp/NowFunction.java
@@ -44,7 +44,7 @@ public final class NowFunction extends Scalar<Long, Object> {
             Signature.builder(NAME, FunctionType.SCALAR)
                 .argumentTypes()
                 .returnType(DataTypes.TIMESTAMPZ.getTypeSignature())
-                .features(EnumSet.of(Feature.NON_NULLABLE))
+                .features(EnumSet.of(Feature.NOTNULL))
                 .build(),
             NowFunction::new
         );

--- a/server/src/main/java/io/crate/expression/tablefunctions/EmptyRowTableFunction.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/EmptyRowTableFunction.java
@@ -47,7 +47,7 @@ public class EmptyRowTableFunction {
             Signature.builder(NAME, FunctionType.TABLE)
                 .argumentTypes()
                 .returnType(RowType.EMPTY.getTypeSignature())
-                .features(Scalar.Feature.NON_NULLABLE, Scalar.Feature.DETERMINISTIC)
+                .features(Scalar.Feature.NOTNULL, Scalar.Feature.DETERMINISTIC)
                 .build(),
             EmptyRowTableFunctionImplementation::new
         );

--- a/server/src/main/java/io/crate/expression/tablefunctions/GenerateSeries.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/GenerateSeries.java
@@ -73,7 +73,7 @@ public final class GenerateSeries<T extends Number> extends TableFunctionImpleme
                 .argumentTypes(DataTypes.LONG.getTypeSignature(),
                     DataTypes.LONG.getTypeSignature())
                 .returnType(DataTypes.LONG.getTypeSignature())
-                .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                .features(Feature.DETERMINISTIC, Feature.NOTNULL)
                 .build(),
             (signature, boundSignature) -> new GenerateSeries<>(
                 signature,
@@ -90,7 +90,7 @@ public final class GenerateSeries<T extends Number> extends TableFunctionImpleme
                 .argumentTypes(DataTypes.INTEGER.getTypeSignature(),
                     DataTypes.INTEGER.getTypeSignature())
                 .returnType(DataTypes.INTEGER.getTypeSignature())
-                .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                .features(Feature.DETERMINISTIC, Feature.NOTNULL)
                 .build(),
             (signature, boundSignature) -> new GenerateSeries<>(
                 signature,
@@ -110,7 +110,7 @@ public final class GenerateSeries<T extends Number> extends TableFunctionImpleme
                     DataTypes.LONG.getTypeSignature(),
                     DataTypes.LONG.getTypeSignature())
                 .returnType(DataTypes.LONG.getTypeSignature())
-                .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                .features(Feature.DETERMINISTIC, Feature.NOTNULL)
                 .build(),
             (signature, boundSignature) -> new GenerateSeries<>(
                 signature,
@@ -128,7 +128,7 @@ public final class GenerateSeries<T extends Number> extends TableFunctionImpleme
                     DataTypes.INTEGER.getTypeSignature(),
                     DataTypes.INTEGER.getTypeSignature())
                 .returnType(DataTypes.INTEGER.getTypeSignature())
-                .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                .features(Feature.DETERMINISTIC, Feature.NOTNULL)
                 .build(),
             (signature, boundSignature) -> new GenerateSeries<>(
                 signature,
@@ -149,7 +149,7 @@ public final class GenerateSeries<T extends Number> extends TableFunctionImpleme
                         supportedType.getTypeSignature(),
                         DataTypes.INTERVAL.getTypeSignature())
                     .returnType(supportedType.getTypeSignature())
-                    .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                    .features(Feature.DETERMINISTIC, Feature.NOTNULL)
                     .build(),
                 (signature, boundSignature) -> new GenerateSeriesIntervals(
                     signature,

--- a/server/src/main/java/io/crate/expression/tablefunctions/GenerateSubscripts.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/GenerateSubscripts.java
@@ -54,7 +54,7 @@ public final class GenerateSubscripts<T> extends TableFunctionImplementation<T> 
                 .argumentTypes(TypeSignature.parse("array(E)"),
                     INTEGER.getTypeSignature())
                 .returnType(INTEGER.getTypeSignature())
-                .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                .features(Feature.DETERMINISTIC, Feature.NOTNULL)
                 .typeVariableConstraints(typeVariable("E"))
                 .build(),
             GenerateSubscripts::new
@@ -65,7 +65,7 @@ public final class GenerateSubscripts<T> extends TableFunctionImplementation<T> 
                     INTEGER.getTypeSignature(),
                     DataTypes.BOOLEAN.getTypeSignature())
                 .returnType(INTEGER.getTypeSignature())
-                .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                .features(Feature.DETERMINISTIC, Feature.NOTNULL)
                 .typeVariableConstraints(typeVariable("E"))
                 .build(),
             GenerateSubscripts::new

--- a/server/src/main/java/io/crate/expression/tablefunctions/MatchesFunction.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/MatchesFunction.java
@@ -33,8 +33,8 @@ import java.util.regex.Pattern;
 
 import org.elasticsearch.common.settings.Settings;
 import org.jetbrains.annotations.Nullable;
-
 import org.jetbrains.annotations.VisibleForTesting;
+
 import io.crate.data.Input;
 import io.crate.data.Row;
 import io.crate.data.RowN;
@@ -70,7 +70,7 @@ public final class MatchesFunction extends TableFunctionImplementation<List<Obje
                 .argumentTypes(DataTypes.STRING.getTypeSignature(),
                     DataTypes.STRING.getTypeSignature())
                 .returnType(DataTypes.STRING_ARRAY.getTypeSignature())
-                .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                .features(Feature.DETERMINISTIC, Feature.NOTNULL)
                 .build(),
             (signature, boundSignature) -> new MatchesFunction(
                 signature,
@@ -84,7 +84,7 @@ public final class MatchesFunction extends TableFunctionImplementation<List<Obje
                     DataTypes.STRING.getTypeSignature(),
                     DataTypes.STRING.getTypeSignature())
                 .returnType(DataTypes.STRING_ARRAY.getTypeSignature())
-                .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                .features(Feature.DETERMINISTIC, Feature.NOTNULL)
                 .build(),
             (signature, boundSignature) -> new MatchesFunction(
                 signature,

--- a/server/src/main/java/io/crate/expression/tablefunctions/PgExpandArray.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/PgExpandArray.java
@@ -53,7 +53,7 @@ public final class PgExpandArray extends TableFunctionImplementation<List<Object
                 Signature.builder(FUNCTION_NAME, FunctionType.TABLE)
                         .argumentTypes(TypeSignature.parse("array(E)"))
                         .returnType(TypeSignature.parse("record(x E, n integer)"))
-                        .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                        .features(Feature.DETERMINISTIC, Feature.NOTNULL)
                         .typeVariableConstraints(typeVariable("E"))
                         .build(),
                 PgExpandArray::new

--- a/server/src/main/java/io/crate/expression/tablefunctions/PgGetKeywordsFunction.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/PgGetKeywordsFunction.java
@@ -57,7 +57,7 @@ public final class PgGetKeywordsFunction extends TableFunctionImplementation<Lis
             Signature.builder(FUNCTION_NAME, FunctionType.TABLE)
                 .argumentTypes()
                 .returnType(RETURN_TYPE.getTypeSignature())
-                .features(Feature.DETERMINISTIC, Feature.NON_NULLABLE)
+                .features(Feature.DETERMINISTIC, Feature.NOTNULL)
                 .build(),
             PgGetKeywordsFunction::new
         );

--- a/server/src/main/java/io/crate/expression/tablefunctions/UnnestFunction.java
+++ b/server/src/main/java/io/crate/expression/tablefunctions/UnnestFunction.java
@@ -58,7 +58,7 @@ public class UnnestFunction {
             Signature.builder(NAME, FunctionType.TABLE)
                 .argumentTypes(TypeSignature.parse("array(N)"))
                 .returnType(RowType.EMPTY.getTypeSignature())
-                .features(Scalar.Feature.NON_NULLABLE, Scalar.Feature.DETERMINISTIC)
+                .features(Scalar.Feature.NOTNULL, Scalar.Feature.DETERMINISTIC)
                 .typeVariableConstraints(typeVariableOfAnyType("N"))
                 .setVariableArity(true)
                 .build(),
@@ -90,7 +90,7 @@ public class UnnestFunction {
             Signature.builder(NAME, FunctionType.TABLE)
                 .argumentTypes()
                 .returnType(DataTypes.UNTYPED_OBJECT.getTypeSignature())
-                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NON_NULLABLE)
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NOTNULL)
                 .build(),
             (signature, boundSignature) -> new UnnestTableFunctionImplementation(
                 signature,

--- a/server/src/main/java/io/crate/metadata/Scalar.java
+++ b/server/src/main/java/io/crate/metadata/Scalar.java
@@ -220,13 +220,20 @@ public abstract class Scalar<ReturnType, InputType> implements FunctionImplement
          */
         COMPARISON_REPLACEMENT,
         LAZY_ATTRIBUTES,
+
         /**
-         * If this feature is set, the function will return for null argument(s) as result null.
-         */
-        NULLABLE,
+         * Function returns null if any argument is null.
+         * <p>
+         *
+         * Not set for functions that return null under special conditions - e.g. null only if all
+         * arguments are null
+         * </p>
+         **/
+        STRICTNULL,
+
         /**
-         * If this feature is set, the function will never return null.
-         */
-        NON_NULLABLE
+         * Function never returns null.
+         **/
+        NOTNULL
     }
 }

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgProcTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgProcTable.java
@@ -77,7 +77,7 @@ public final class PgProcTable {
         .add("prokind", STRING, x -> prokind(x.signature))
         .add("prosecdef", BOOLEAN, x -> null)
         .add("proleakproof", BOOLEAN, x -> null)
-        .add("proisstrict", BOOLEAN, x -> x.signature.hasFeature(Feature.NULLABLE))
+        .add("proisstrict", BOOLEAN, x -> x.signature.hasFeature(Feature.STRICTNULL))
         .add("proretset", BOOLEAN, x -> x.returnSetType)
         .add("provolatile", STRING, x -> null)
         .add("proparallel", STRING, x -> null)

--- a/server/src/test/java/io/crate/execution/engine/pipeline/MapRowUsingInputsTest.java
+++ b/server/src/test/java/io/crate/execution/engine/pipeline/MapRowUsingInputsTest.java
@@ -63,7 +63,7 @@ public class MapRowUsingInputsTest extends ESTestCase {
                 .argumentTypes(DataTypes.LONG.getTypeSignature(),
                     DataTypes.LONG.getTypeSignature())
                 .returnType(DataTypes.LONG.getTypeSignature())
-                .features(Feature.DETERMINISTIC, Feature.COMPARISON_REPLACEMENT, Scalar.Feature.NULLABLE)
+                .features(Feature.DETERMINISTIC, Feature.COMPARISON_REPLACEMENT, Scalar.Feature.STRICTNULL)
                 .build(),
             List.of(new InputColumn(0, DataTypes.LONG), Literal.of(2L)),
             DataTypes.LONG

--- a/server/src/test/java/io/crate/expression/InputFactoryTest.java
+++ b/server/src/test/java/io/crate/expression/InputFactoryTest.java
@@ -67,7 +67,7 @@ public class InputFactoryTest extends CrateDummyClusterServiceUnitTest {
                     .argumentTypes(DataTypes.INTEGER.getTypeSignature(),
                             DataTypes.INTEGER.getTypeSignature())
                     .returnType(DataTypes.INTEGER.getTypeSignature())
-                    .features(Feature.DETERMINISTIC, Feature.COMPARISON_REPLACEMENT, Scalar.Feature.NULLABLE)
+                    .features(Feature.DETERMINISTIC, Feature.COMPARISON_REPLACEMENT, Scalar.Feature.STRICTNULL)
                     .build(),
             List.of(new InputColumn(1, DataTypes.INTEGER), Literal.of(10)),
             DataTypes.INTEGER

--- a/server/src/test/java/io/crate/expression/scalar/ScalarNullabilityTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ScalarNullabilityTest.java
@@ -54,7 +54,7 @@ public class ScalarNullabilityTest {
     public void test_nullability_scalars_return_null_on_null_input() {
         var numberOfFunctionsToTested = 0;
         for (var signature : functions.signatures()) {
-            if (signature.hasFeature(Scalar.Feature.NULLABLE)) {
+            if (signature.hasFeature(Scalar.Feature.STRICTNULL)) {
                 // Using this::getDataType instead of signature.getArgumentDataTypes to handle generics as string
                 List<DataType<?>> argumentTypes = Lists.map(signature.getArgumentTypes(), this::getDataType);
                 var function = functions.getQualified(
@@ -79,7 +79,7 @@ public class ScalarNullabilityTest {
     public void test_non_nullability_scalars_return_not_null_on_null_input() {
         var numberOfFunctionsToTested = 0;
         for (var signature : functions.signatures()) {
-            if (signature.hasFeature(Scalar.Feature.NON_NULLABLE)) {
+            if (signature.hasFeature(Scalar.Feature.NOTNULL)) {
                 // Using this::getDataType instead of signature.getArgumentDataTypes to handle generics as string
                 List<DataType<?>> argumentTypes = Lists.map(signature.getArgumentTypes(), this::getDataType);
                 var function = functions.getQualified(

--- a/server/src/testFixtures/java/io/crate/expression/scalar/ScalarTestCase.java
+++ b/server/src/testFixtures/java/io/crate/expression/scalar/ScalarTestCase.java
@@ -257,7 +257,7 @@ public abstract class ScalarTestCase extends CrateDummyClusterServiceUnitTest {
 
         actualValue = scalar.evaluate(txnCtx, sqlExpressions.nodeCtx, arguments);
         assertThat((T) actualValue).satisfies(expectedValue);
-        if (scalar.signature().hasFeature(Scalar.Feature.NON_NULLABLE)) {
+        if (scalar.signature().hasFeature(Scalar.Feature.NOTNULL)) {
             assertThat(actualValue).isNotNull();
         }
     }


### PR DESCRIPTION
`NULLABLE` can be misleading as it doesn't indicate if a function can
return `null`, but rather indicates if it returns `null` if any argument
is null.

There are functions which are nullable but with different semantics
(e.g. all arguments must be null, or otherwise conditional)

This is similar to https://github.com/crate/crate/pull/16224
