### PR TITLE
Add topk aggregation

### DIFF
--- a/docs/appendices/release-notes/5.9.0.rst
+++ b/docs/appendices/release-notes/5.9.0.rst
@@ -92,6 +92,9 @@ None
 Scalar and Aggregation Functions
 --------------------------------
 
+- Added :ref:`topk aggregation function <aggregation-topk>` which computes
+  the k most frequent argument values and their frequencies.
+
 - Changed :ref:`pg_get_userbyid <scalar-pg_get_userbyid>` to return the matching
   user or ``unknown`` instead of always ``crate``.
 

--- a/docs/general/builtins/aggregation.rst
+++ b/docs/general/builtins/aggregation.rst
@@ -825,6 +825,33 @@ Example::
     executions of the aggregate function on the same data produce slightly
     differing results.
 
+.. _aggregation-topk:
+
+``topk(column, k)``
+-------------------
+
+The ``topk`` aggregate function computes an approximation of the most frequent
+values and their frequencies of a specific column. The result is an array of
+objects containing the most common values and their frequencies ordered by
+frequency. The k parameter is an optional parameter which defines how many
+elements should be returned which defaults to 8. The maximum limit for k is
+10000.
+
+Internally the ``topk``
+aggregate function use an implementation of the
+`Efficient Computation of Frequent and Top-k Elements in Data Streams`_
+algorithm.
+
+Example::
+
+    cr> select topk(country, 3) from sys.summits;
+    +--------------------------------------------------------------------------------------------------------+
+    | topk(country, 3)                                                                                       |
+    +--------------------------------------------------------------------------------------------------------+
+    | [{"frequency": 436, "item": "IT"}, {"frequency": 401, "item": "AT"}, {"frequency": 320, "item": "CH"}] |
+    +--------------------------------------------------------------------------------------------------------+
+    SELECT 1 row in set (... sec)
+
 
 .. _aggregation-limitations:
 
@@ -845,3 +872,4 @@ Limitations
 .. _Standard Deviation: https://en.wikipedia.org/wiki/Standard_deviation
 .. _TDigest: https://github.com/tdunning/t-digest/blob/master/docs/t-digest-paper/histo.pdf
 .. _Variance: https://en.wikipedia.org/wiki/Variance
+.. _Efficient Computation of Frequent and Top-k Elements in Data Streams: https://www.cs.ucsb.edu/sites/default/files/documents/2005-23.pdf

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/Aggregations.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/Aggregations.java
@@ -57,5 +57,6 @@ public class Aggregations implements FunctionsProvider {
         VarianceAggregation.register(builder);
         GeometricMeanAggregation.register(builder);
         StandardDeviationAggregation.register(builder);
+        TopKAggregation.register(builder);
     }
 }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/TopKAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/TopKAggregation.java
@@ -1,0 +1,288 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.engine.aggregation.impl;
+
+
+import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.datasketches.frequencies.ErrorType;
+import org.apache.datasketches.frequencies.ItemsSketch;
+import org.apache.datasketches.memory.Memory;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.jetbrains.annotations.Nullable;
+
+import com.carrotsearch.hppc.RamUsageEstimator;
+
+import io.crate.Streamer;
+import io.crate.data.Input;
+import io.crate.data.breaker.RamAccounting;
+import io.crate.execution.engine.aggregation.AggregationFunction;
+import io.crate.memory.MemoryManager;
+import io.crate.metadata.FunctionType;
+import io.crate.metadata.Functions;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.functions.BoundSignature;
+import io.crate.metadata.functions.Signature;
+import io.crate.statistics.SketchStreamer;
+import io.crate.types.ArrayType;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+import io.crate.types.TypeSignature;
+
+public class TopKAggregation extends AggregationFunction<TopKAggregation.State, List<Object>> {
+
+    public static final String NAME = "topk";
+
+    static final Signature DEFAULT_SIGNATURE =
+        Signature.builder(NAME, FunctionType.AGGREGATE)
+            .argumentTypes(TypeSignature.parse("V"))
+            .returnType(new ArrayType<>(DataTypes.UNTYPED_OBJECT).getTypeSignature())
+            .features(Scalar.Feature.DETERMINISTIC)
+            .typeVariableConstraints(typeVariable("V"))
+            .build();
+
+    static final Signature PARAMETER_SIGNATURE =
+        Signature.builder(NAME, FunctionType.AGGREGATE)
+            .argumentTypes(TypeSignature.parse("V"),
+                DataTypes.INTEGER.getTypeSignature())
+            .returnType(new ArrayType<>(DataTypes.UNTYPED_OBJECT).getTypeSignature())
+            .features(Scalar.Feature.DETERMINISTIC)
+            .typeVariableConstraints(typeVariable("V"))
+            .build();
+
+    static {
+        DataTypes.register(StateType.ID, StateType::new);
+    }
+
+    public static void register(Functions.Builder builder) {
+        builder.add(
+            DEFAULT_SIGNATURE,
+            TopKAggregation::new
+        );
+
+        builder.add(
+            PARAMETER_SIGNATURE,
+            TopKAggregation::new
+        );
+    }
+
+    private final Signature signature;
+    private final BoundSignature boundSignature;
+
+    private static final int DEFAULT_MAP_SIZE = 32;
+    private static final int DEFAULT_LIMIT = 8;
+    private static final int MAX_LIMIT = 10_000;
+
+    private TopKAggregation(Signature signature, BoundSignature boundSignature) {
+        this.signature = signature;
+        this.boundSignature = boundSignature;
+    }
+
+    @Override
+    public Signature signature() {
+        return signature;
+    }
+
+    @Override
+    public BoundSignature boundSignature() {
+        return boundSignature;
+    }
+
+
+    @Nullable
+    @Override
+    public State newState(RamAccounting ramAccounting,
+                          Version indexVersionCreated,
+                          Version minNodeInCluster,
+                          MemoryManager memoryManager) {
+        return State.EMPTY;
+    }
+
+    @Override
+    public State iterate(RamAccounting ramAccounting,
+                         MemoryManager memoryManager,
+                         State state,
+                         Input<?>... args) throws CircuitBreakingException {
+        Object value = args[0].value();
+        if (state instanceof Empty) {
+            if (args.length == 2) {
+                // We have a limit provided by the user
+                Integer limit = (Integer) args[1].value();
+                if (limit <= 0 || limit > MAX_LIMIT) {
+                    throw new IllegalArgumentException(
+                        "Limit parameter for topk must be between 0 and 10_000. Got: " + limit);
+                }
+                int maxMapSize = maxMapSize(limit);
+                ramAccounting.addBytes(calculateRamUsage(maxMapSize));
+                state = new TopKState(new ItemsSketch<>(maxMapSize), limit);
+
+            } else if (args.length == 1) {
+                // We don't have a limit provided, let's go with the default values
+                ramAccounting.addBytes(calculateRamUsage(DEFAULT_MAP_SIZE));
+                state = new TopKState(new ItemsSketch<>(DEFAULT_MAP_SIZE), DEFAULT_LIMIT);
+            }
+            ramAccounting.addBytes(RamUsageEstimator.shallowSizeOf(state));
+        }
+        if (state instanceof TopKState topKState) {
+            topKState.itemsSketch.update(value);
+        }
+        return state;
+    }
+
+    private static int maxMapSize(int x) {
+        // max map size should be 4 * the limit based on the power of 2 to avoid errors
+        return (int) Math.pow(2, Math.ceil(Math.log(x) / Math.log(2))) * 4;
+    }
+
+    private static long calculateRamUsage(long maxMapSize) {
+        // The internal memory space usage of item sketch will never exceed 18 * maxMapSize bytes, plus a small
+        // constant number of additional bytes.
+        // https://datasketches.apache.org/docs/Frequency/FrequentItemsOverview.html
+        return maxMapSize * 18L;
+    }
+
+    @Override
+    public State reduce(RamAccounting ramAccounting, State state1, State state2) {
+        if (state1 instanceof TopKState t1 && state2 instanceof TopKState t2) {
+            return new TopKState(t1.itemsSketch.merge(t2.itemsSketch), t1.limit);
+        } else if (state1 instanceof Empty) {
+            return state2;
+        } else {
+            return state1;
+        }
+    }
+
+    @Override
+    public List<Object> terminatePartial(RamAccounting ramAccounting, State state) {
+        if (state instanceof TopKState topKState) {
+            ItemsSketch.Row<Object>[] frequentItems = topKState.itemsSketch.getFrequentItems(ErrorType.NO_FALSE_NEGATIVES);
+            int limit = Math.min(frequentItems.length, topKState.limit);
+            var result = new ArrayList<>(limit);
+            for (int i = 0; i < limit; i++) {
+                var item = frequentItems[i];
+                result.add(Map.of("item", item.getItem(), "frequency", item.getEstimate()));
+            }
+            return result;
+        }
+        return List.of();
+    }
+
+    public DataType<?> partialType() {
+        return new StateType(boundSignature.argTypes().getFirst());
+    }
+
+    sealed interface State {
+        State EMPTY = new Empty();
+    }
+
+    record Empty() implements State { }
+
+    record TopKState(ItemsSketch<Object> itemsSketch, int limit) implements State { }
+
+    static final class StateType extends DataType<State> implements Streamer<State> {
+
+        public static final int ID = 4232;
+        private final DataType<?> innerType;
+
+        public StateType(DataType<?> innerType) {
+            this.innerType = innerType;
+        }
+
+        public StateType(StreamInput streamInput) throws IOException {
+            this.innerType = DataTypes.fromStream(streamInput);
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            DataTypes.toStream(innerType, out);
+        }
+
+        @Override
+        public int id() {
+            return ID;
+        }
+
+        @Override
+        public Precedence precedence() {
+            return Precedence.CUSTOM;
+        }
+
+        @Override
+        public String getName() {
+            return "topk_state";
+        }
+
+        @Override
+        public Streamer<State> streamer() {
+            return this;
+        }
+
+        @Override
+        public State sanitizeValue(Object value) {
+            return (State) value;
+        }
+
+        @Override
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        public State readValueFrom(StreamInput in) throws IOException {
+            if (in.readBoolean()) {
+                return State.EMPTY;
+            } else {
+                int limit = in.readInt();
+                SketchStreamer streamer = new SketchStreamer(innerType.streamer());
+                return new TopKState(ItemsSketch.getInstance(Memory.wrap(in.readByteArray()), streamer), limit);
+            }
+        }
+
+        @Override
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        public void writeValueTo(StreamOutput out, State state) throws IOException {
+            if (state instanceof Empty) {
+                out.writeBoolean(true);
+            } else if (state instanceof TopKState topkState) {
+                out.writeBoolean(false);
+                out.writeInt(topkState.limit);
+                SketchStreamer streamer = new SketchStreamer(innerType.streamer());
+                out.writeByteArray(topkState.itemsSketch.toByteArray(streamer));
+            }
+        }
+
+        @Override
+        public long valueBytes(State value) {
+            throw new UnsupportedOperationException("valueSize is not implemented for TopKStateType");
+        }
+
+        @Override
+        public int compare(State s1, State s2) {
+            return 0;
+        }
+    }
+
+}

--- a/server/src/main/java/io/crate/statistics/SketchStreamer.java
+++ b/server/src/main/java/io/crate/statistics/SketchStreamer.java
@@ -35,7 +35,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 
 import io.crate.Streamer;
 
-class SketchStreamer<T> extends ArrayOfItemsSerDe<T> {
+public class SketchStreamer<T> extends ArrayOfItemsSerDe<T> {
 
     private final Streamer<T> streamer;
 

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/TopKAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/TopKAggregationTest.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.engine.aggregation.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import io.crate.operation.aggregation.AggregationTestCase;
+import io.crate.types.DataTypes;
+
+public class TopKAggregationTest extends AggregationTestCase {
+
+
+    @Test
+    public void test_top_k_longs() throws Exception {
+        var result = executeAggregation(
+            TopKAggregation.PARAMETER_SIGNATURE,
+            List.of(DataTypes.LONG),
+            DataTypes.UNTYPED_OBJECT,
+            new Object[][]{
+                new Long[]{1L},
+                new Long[]{2L},
+                new Long[]{2L},
+                new Long[]{3L},
+                new Long[]{3L},
+                new Long[]{3L},
+            },
+            true,
+            List.of()
+        );
+
+        assertThat(result)
+            .isEqualTo(
+                List.of(
+                    Map.of("item", 3L, "frequency", 3L),
+                    Map.of("item", 2L, "frequency", 2L),
+                    Map.of("item", 1L, "frequency", 1L)
+                )
+            );
+    }
+
+    @Test
+    public void test_top_k_longs_with_limit() throws Exception {
+        int limit = 2;
+        var result = executeAggregation(
+            TopKAggregation.PARAMETER_SIGNATURE,
+            List.of(DataTypes.LONG, DataTypes.LONG),
+            DataTypes.UNTYPED_OBJECT,
+            new Object[][]{
+                new Object[]{1L, limit},
+                new Object[]{2L, limit},
+                new Object[]{2L, limit},
+                new Object[]{3L, limit},
+                new Object[]{3L, limit},
+                new Object[]{3L, limit},
+            },
+            true,
+            List.of()
+        );
+
+        assertThat(result)
+            .isEqualTo(
+                List.of(
+                    Map.of("item", 3L, "frequency", 3L),
+                    Map.of("item", 2L, "frequency", 2L)
+                )
+            );
+    }
+
+    @Test
+    public void test_top_K_strings() throws Exception {
+        var result = executeAggregation(
+            TopKAggregation.PARAMETER_SIGNATURE,
+            List.of(DataTypes.STRING),
+            DataTypes.UNTYPED_OBJECT,
+            new Object[][]{
+                new String[]{"1"},
+                new String[]{"2"},
+                new String[]{"2"},
+                new String[]{"3"},
+                new String[]{"3"},
+                new String[]{"3"}
+            },
+            true,
+            List.of()
+        );
+        assertThat(result)
+            .isEqualTo(
+                List.of(
+                    Map.of("item", "3", "frequency", 3L),
+                    Map.of("item", "2", "frequency", 2L),
+                    Map.of("item", "1", "frequency", 1L)
+                )
+            );
+    }
+
+    @Test
+    public void test_top_K_boolean() throws Exception {
+        var result = executeAggregation(
+            TopKAggregation.PARAMETER_SIGNATURE,
+            List.of(DataTypes.BOOLEAN),
+            DataTypes.UNTYPED_OBJECT,
+            new Object[][]{
+                new Boolean[]{true},
+                new Boolean[]{true},
+                new Boolean[]{true},
+                new Boolean[]{false},
+                new Boolean[]{false},
+
+            },
+            true,
+            List.of()
+        );
+        assertThat(result)
+            .isEqualTo(
+                List.of(
+                    Map.of("item", true, "frequency", 3L),
+                    Map.of("item", false, "frequency", 2L)
+                )
+            );
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This adds a top-k aggregation scalar function which computes the k most frequent argument values and their frequencies. This is a generic implementation which fully works. 

There are at least two possible improvements as follow-ups possible:

- DocValueAggregator implementation to take advance of the column-store
- Custom numeric implementation, because there is a special Long version of `ItemsSketch` available 


Resolves https://github.com/crate/crate/issues/15000


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
