### PR TITLE
Fixed most-specific function matching when some are equal specific

### DIFF
--- a/server/src/main/java/io/crate/metadata/Functions.java
+++ b/server/src/main/java/io/crate/metadata/Functions.java
@@ -421,21 +421,22 @@ public class Functions {
         List<ApplicableFunction> representatives = new ArrayList<>();
 
         for (ApplicableFunction current : candidates) {
-            boolean found = false;
-            for (int i = 0; i < representatives.size(); i++) {
-                ApplicableFunction representative = representatives.get(i);
+            boolean addCandidate = true;
+            var it = representatives.iterator();
+            while (it.hasNext()) {
+                ApplicableFunction representative = it.next();
+                if (representative.equals(current)) {
+                    continue;
+                }
                 if (isMoreSpecific.apply(current, representative)) {
-                    representatives.clear();
-                    representatives.add(current);
-                    found = true;
-                    break;
+                    it.remove();
+                    addCandidate = true;
                 } else if (isMoreSpecific.apply(representative, current)) {
-                    found = true;
-                    break;
+                    addCandidate = false;
                 }
             }
 
-            if (!found) {
+            if (addCandidate) {
                 representatives.add(current);
             }
         }


### PR DESCRIPTION
When multiple functions are already selected as equal specific, the next more specific candidate must only remove the one it was compared with.

This issue popped with by #13965 as it adds more variants for the same function.

