### PR TITLE
Don't evaluate second arg if first is null in BinaryScalar

### DIFF
--- a/server/src/main/java/io/crate/expression/scalar/BinaryScalar.java
+++ b/server/src/main/java/io/crate/expression/scalar/BinaryScalar.java
@@ -19,7 +19,7 @@
  * software solely pursuant to the terms of the relevant commercial agreement.
  */
 
-package io.crate.expression.scalar.arithmetic;
+package io.crate.expression.scalar;
 
 import java.util.function.BinaryOperator;
 
@@ -51,11 +51,10 @@ public final class BinaryScalar<T> extends Scalar<T, T> {
     @Override
     public T evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<T>[] args) {
         T arg0Value = type.sanitizeValue(args[0].value());
-        T arg1Value = type.sanitizeValue(args[1].value());
-
         if (arg0Value == null) {
             return null;
         }
+        T arg1Value = type.sanitizeValue(args[1].value());
         if (arg1Value == null) {
             return null;
         }

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/ArithmeticFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/ArithmeticFunctions.java
@@ -29,6 +29,7 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.function.BinaryOperator;
 
+import io.crate.expression.scalar.BinaryScalar;
 import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/TrigonometricFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/TrigonometricFunctions.java
@@ -23,6 +23,7 @@ package io.crate.expression.scalar.arithmetic;
 
 import java.util.function.DoubleUnaryOperator;
 
+import io.crate.expression.scalar.BinaryScalar;
 import io.crate.expression.scalar.DoubleScalar;
 import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;

--- a/server/src/main/java/io/crate/expression/scalar/bitwise/BitwiseFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/bitwise/BitwiseFunctions.java
@@ -30,7 +30,7 @@ import java.util.Locale;
 import java.util.function.BinaryOperator;
 
 import io.crate.common.TriConsumer;
-import io.crate.expression.scalar.arithmetic.BinaryScalar;
+import io.crate.expression.scalar.BinaryScalar;
 import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;

--- a/server/src/main/java/io/crate/expression/scalar/string/EncodeDecodeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/EncodeDecodeFunction.java
@@ -29,7 +29,7 @@ import java.util.function.UnaryOperator;
 
 import io.crate.common.Hex;
 import io.crate.common.Octal;
-import io.crate.expression.scalar.arithmetic.BinaryScalar;
+import io.crate.expression.scalar.BinaryScalar;
 import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;

--- a/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetSerialSequenceFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/systeminformation/PgGetSerialSequenceFunction.java
@@ -21,7 +21,7 @@
 
 package io.crate.expression.scalar.systeminformation;
 
-import io.crate.expression.scalar.arithmetic.BinaryScalar;
+import io.crate.expression.scalar.BinaryScalar;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;

--- a/server/src/main/java/io/crate/metadata/Scalar.java
+++ b/server/src/main/java/io/crate/metadata/Scalar.java
@@ -56,7 +56,7 @@ import io.crate.role.Roles;
  *
  * <ul>
  *     <li>{@link io.crate.expression.scalar.UnaryScalar}</li>
- *     <li>{@link io.crate.expression.scalar.arithmetic.BinaryScalar}</li>
+ *     <li>{@link io.crate.expression.scalar.BinaryScalar}</li>
  *     <li>{@link io.crate.expression.scalar.DoubleScalar}</li>
  *     <li>{@link io.crate.expression.scalar.TripleScalar}</li>
  * </ul>


### PR DESCRIPTION
To match the behavior of `TripleScalar`
Also moves it out of the `arithmetic` package. The other `*Scalar`
variants are all in the main `scalar` package.
