### PR TITLE
Add doc-value support for strings/longs for topk aggregations

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/TopKAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/TopKAggregation.java
@@ -28,10 +28,12 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.apache.datasketches.frequencies.ErrorType;
 import org.apache.datasketches.frequencies.ItemsSketch;
 import org.apache.datasketches.memory.Memory;
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -44,19 +46,28 @@ import io.crate.Streamer;
 import io.crate.data.Input;
 import io.crate.data.breaker.RamAccounting;
 import io.crate.execution.engine.aggregation.AggregationFunction;
+import io.crate.execution.engine.aggregation.DocValueAggregator;
+import io.crate.execution.engine.aggregation.impl.templates.BinaryDocValueAggregator;
+import io.crate.execution.engine.aggregation.impl.templates.SortedNumericDocValueAggregator;
+import io.crate.expression.reference.doc.lucene.LuceneReferenceResolver;
+import io.crate.expression.symbol.Literal;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
+import io.crate.metadata.Reference;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 import io.crate.statistics.SketchStreamer;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
+import io.crate.types.LongType;
+import io.crate.types.StringType;
 import io.crate.types.TypeSignature;
 
-public class TopKAggregation extends AggregationFunction<TopKAggregation.State, List<Object>> {
+public class TopKAggregation extends AggregationFunction<TopKAggregation.State, List<Map<String, Object>>> {
 
     public static final String NAME = "topk";
 
@@ -96,7 +107,6 @@ public class TopKAggregation extends AggregationFunction<TopKAggregation.State, 
     private final Signature signature;
     private final BoundSignature boundSignature;
 
-    private static final int DEFAULT_MAP_SIZE = 32;
     private static final int DEFAULT_LIMIT = 8;
     private static final int MAX_LIMIT = 10_000;
 
@@ -139,16 +149,11 @@ public class TopKAggregation extends AggregationFunction<TopKAggregation.State, 
                     throw new IllegalArgumentException(
                         "Limit parameter for topk must be between 0 and 10_000. Got: " + limit);
                 }
-                int maxMapSize = maxMapSize(limit);
-                ramAccounting.addBytes(calculateRamUsage(maxMapSize));
-                state = new TopKState(new ItemsSketch<>(maxMapSize), limit);
+                state = topKState(ramAccounting, limit);
 
             } else if (args.length == 1) {
-                // We don't have a limit provided, let's go with the default values
-                ramAccounting.addBytes(calculateRamUsage(DEFAULT_MAP_SIZE));
-                state = new TopKState(new ItemsSketch<>(DEFAULT_MAP_SIZE), DEFAULT_LIMIT);
+                state = topKState(ramAccounting, DEFAULT_LIMIT);
             }
-            ramAccounting.addBytes(RamUsageEstimator.shallowSizeOf(state));
         }
         if (state instanceof TopKState topKState) {
             topKState.itemsSketch.update(value);
@@ -180,31 +185,119 @@ public class TopKAggregation extends AggregationFunction<TopKAggregation.State, 
     }
 
     @Override
-    public List<Object> terminatePartial(RamAccounting ramAccounting, State state) {
-        if (state instanceof TopKState topKState) {
-            ItemsSketch.Row<Object>[] frequentItems = topKState.itemsSketch.getFrequentItems(ErrorType.NO_FALSE_NEGATIVES);
-            int limit = Math.min(frequentItems.length, topKState.limit);
-            var result = new ArrayList<>(limit);
-            for (int i = 0; i < limit; i++) {
-                var item = frequentItems[i];
-                result.add(Map.of("item", item.getItem(), "frequency", item.getEstimate()));
-            }
-            return result;
-        }
-        return List.of();
+    public List<Map<String, Object>> terminatePartial(RamAccounting ramAccounting, State state) {
+        return state.result();
     }
 
     public DataType<?> partialType() {
         return new StateType(boundSignature.argTypes().getFirst());
     }
 
-    sealed interface State {
-        State EMPTY = new Empty();
+    @Nullable
+    @Override
+    public DocValueAggregator<?> getDocValueAggregator(LuceneReferenceResolver referenceResolver,
+                                                       List<Reference> aggregationReferences,
+                                                       DocTableInfo table,
+                                                       List<Literal<?>> optionalParams) {
+        if (aggregationReferences.isEmpty()) {
+            return null;
+        }
+
+        Reference reference = aggregationReferences.getFirst();
+        if (reference == null) {
+            return null;
+        }
+
+        if (!reference.hasDocValues()) {
+            return null;
+        }
+
+        if (optionalParams.isEmpty()) {
+            return getDocValueAggregator(reference, DEFAULT_LIMIT);
+        }
+
+        Literal<?> limit = optionalParams.getLast();
+        if (limit == null) {
+            return getDocValueAggregator(reference, DEFAULT_LIMIT);
+        }
+        return getDocValueAggregator(reference, (int) limit.value());
     }
 
-    record Empty() implements State { }
+    @Nullable
+    private DocValueAggregator<?> getDocValueAggregator(Reference ref, int limit) {
+        return switch (ref.valueType().id()) {
+            case LongType.ID -> new SortedNumericDocValueAggregator<>(
+                ref.storageIdent(),
+                (ramAccounting, _, _) -> topKState(ramAccounting, limit),
+                (values, state) -> {
+                    state.itemsSketch.update(values.nextValue());
+                }
+            );
+            case StringType.ID -> new BinaryDocValueAggregator<>(
+                ref.storageIdent(),
+                (ramAccounting, _, _) -> topKState(ramAccounting, limit),
+                (values, state) -> {
+                    long ord = values.nextOrd();
+                    BytesRef value = values.lookupOrd(ord);
+                    state.itemsSketch.update(value.utf8ToString());
+                }
+            );
+            default -> null;
+        };
+    }
 
-    record TopKState(ItemsSketch<Object> itemsSketch, int limit) implements State { }
+    sealed interface State {
+
+        State EMPTY = new Empty();
+
+        List<Map<String, Object>> result();
+    }
+
+    record Empty() implements State {
+
+        @Override
+        public List<Map<String, Object>> result() {
+            return List.of();
+        }
+    }
+
+    record TopKState(ItemsSketch<Object> itemsSketch, int limit) implements State {
+
+        static long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(TopKState.class);
+
+        public List<Map<String, Object>> result() {
+            if (itemsSketch.isEmpty()) {
+                return List.of();
+            }
+            ItemsSketch.Row<Object>[] frequentItems = itemsSketch.getFrequentItems(ErrorType.NO_FALSE_NEGATIVES);
+            int limit = Math.min(frequentItems.length, this.limit);
+            var result = new ArrayList<Map<String, Object>>(limit);
+            for (int i = 0; i < limit; i++) {
+                var item = frequentItems[i];
+                result.add(Map.of("item", item.getItem(), "frequency", item.getEstimate()));
+            }
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            TopKState topKState = (TopKState) o;
+            return limit == topKState.limit && Objects.equals(result(), topKState.result());
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(result(), limit);
+        }
+    }
+
+    private static TopKState topKState(RamAccounting ramAccounting, int limit) {
+        int maxMapSize = maxMapSize(limit);
+        ramAccounting.addBytes(calculateRamUsage(maxMapSize) + TopKState.SHALLOW_SIZE);
+        return new TopKState(new ItemsSketch<>(maxMapSize), limit);
+    }
 
     static final class StateType extends DataType<State> implements Streamer<State> {
 

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/TopKAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/TopKAggregationTest.java
@@ -22,32 +22,35 @@
 package io.crate.execution.engine.aggregation.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 import java.util.Map;
 
 import org.junit.Test;
 
+import io.crate.expression.symbol.Literal;
 import io.crate.operation.aggregation.AggregationTestCase;
 import io.crate.types.DataTypes;
 
 public class TopKAggregationTest extends AggregationTestCase {
 
-
     @Test
     public void test_top_k_longs() throws Exception {
+        Object[][] data = {
+            new Long[]{1L},
+            new Long[]{2L},
+            new Long[]{2L},
+            new Long[]{3L},
+            new Long[]{3L},
+            new Long[]{3L},
+        };
+
         var result = executeAggregation(
             TopKAggregation.PARAMETER_SIGNATURE,
             List.of(DataTypes.LONG),
             DataTypes.UNTYPED_OBJECT,
-            new Object[][]{
-                new Long[]{1L},
-                new Long[]{2L},
-                new Long[]{2L},
-                new Long[]{3L},
-                new Long[]{3L},
-                new Long[]{3L},
-            },
+            data,
             true,
             List.of()
         );
@@ -63,25 +66,44 @@ public class TopKAggregationTest extends AggregationTestCase {
     }
 
     @Test
+    public void test_top_k_invalid_limit_parameters() throws Exception {
+        Object[][] dataWithInvalidLimit = {
+            new Object[]{1L, -1},
+        };
+
+        assertThatThrownBy(() -> executeAggregation(
+            TopKAggregation.PARAMETER_SIGNATURE,
+            List.of(DataTypes.LONG, DataTypes.INTEGER),
+            DataTypes.UNTYPED_OBJECT,
+            dataWithInvalidLimit,
+            true,
+            List.of()
+        )).isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageStartingWith("Limit parameter for topk must be between 0 and 10_000. Got: -1");
+    }
+
     public void test_top_k_longs_with_limit() throws Exception {
         int limit = 2;
-        var result = executeAggregation(
+
+        Object[][] dataWithLimit = {
+            new Object[]{1L, limit},
+            new Object[]{2L, limit},
+            new Object[]{2L, limit},
+            new Object[]{3L, limit},
+            new Object[]{3L, limit},
+            new Object[]{3L, limit},
+        };
+
+        var resultWithLimit = executeAggregation(
             TopKAggregation.PARAMETER_SIGNATURE,
             List.of(DataTypes.LONG, DataTypes.LONG),
             DataTypes.UNTYPED_OBJECT,
-            new Object[][]{
-                new Object[]{1L, limit},
-                new Object[]{2L, limit},
-                new Object[]{2L, limit},
-                new Object[]{3L, limit},
-                new Object[]{3L, limit},
-                new Object[]{3L, limit},
-            },
+            dataWithLimit,
             true,
-            List.of()
+            List.of(Literal.of(limit))
         );
 
-        assertThat(result)
+        assertThat(resultWithLimit)
             .isEqualTo(
                 List.of(
                     Map.of("item", 3L, "frequency", 3L),
@@ -91,22 +113,25 @@ public class TopKAggregationTest extends AggregationTestCase {
     }
 
     @Test
-    public void test_top_K_strings() throws Exception {
+    public void test_top_k_strings() throws Exception {
+        Object[][] data = {
+            new String[]{"1"},
+            new String[]{"2"},
+            new String[]{"2"},
+            new String[]{"3"},
+            new String[]{"3"},
+            new String[]{"3"}
+        };
+
         var result = executeAggregation(
             TopKAggregation.PARAMETER_SIGNATURE,
             List.of(DataTypes.STRING),
             DataTypes.UNTYPED_OBJECT,
-            new Object[][]{
-                new String[]{"1"},
-                new String[]{"2"},
-                new String[]{"2"},
-                new String[]{"3"},
-                new String[]{"3"},
-                new String[]{"3"}
-            },
+            data,
             true,
             List.of()
         );
+
         assertThat(result)
             .isEqualTo(
                 List.of(
@@ -117,28 +142,89 @@ public class TopKAggregationTest extends AggregationTestCase {
             );
     }
 
+    public void test_top_k_strings_with_limit() throws Exception {
+        int limit = 2;
+
+        Object[][] data = {
+            new Object[]{"1", limit},
+            new Object[]{"2", limit},
+            new Object[]{"2", limit},
+            new Object[]{"3", limit},
+            new Object[]{"3", limit},
+            new Object[]{"3", limit},
+        };
+
+        var resultWithLimit = executeAggregation(
+            TopKAggregation.PARAMETER_SIGNATURE,
+            List.of(DataTypes.STRING, DataTypes.INTEGER),
+            DataTypes.UNTYPED_OBJECT,
+            data,
+            true,
+            List.of(Literal.of(limit))
+        );
+
+        assertThat(resultWithLimit)
+            .isEqualTo(
+                List.of(
+                    Map.of("item", "3", "frequency", 3L),
+                    Map.of("item", "2", "frequency", 2L)
+                )
+            );
+    }
+
     @Test
-    public void test_top_K_boolean() throws Exception {
+    public void test_top_k_boolean() throws Exception {
+        var data = new Object[][]{
+            new Boolean[]{true},
+            new Boolean[]{true},
+            new Boolean[]{true},
+            new Boolean[]{false},
+            new Boolean[]{false},
+        };
+
         var result = executeAggregation(
             TopKAggregation.PARAMETER_SIGNATURE,
             List.of(DataTypes.BOOLEAN),
             DataTypes.UNTYPED_OBJECT,
-            new Object[][]{
-                new Boolean[]{true},
-                new Boolean[]{true},
-                new Boolean[]{true},
-                new Boolean[]{false},
-                new Boolean[]{false},
-
-            },
+            data,
             true,
             List.of()
         );
+
         assertThat(result)
             .isEqualTo(
                 List.of(
                     Map.of("item", true, "frequency", 3L),
                     Map.of("item", false, "frequency", 2L)
+                )
+            );
+    }
+
+    @Test
+    public void test_top_k_boolean_with_limit() throws Exception {
+        int limit = 1;
+
+        var data = new Object[][]{
+            new Object[]{true, limit},
+            new Object[]{true, limit},
+            new Object[]{true, limit},
+            new Object[]{false, limit},
+            new Object[]{false, limit},
+        };
+
+        var resultWithLimit = executeAggregation(
+            TopKAggregation.PARAMETER_SIGNATURE,
+            List.of(DataTypes.BOOLEAN, DataTypes.INTEGER),
+            DataTypes.UNTYPED_OBJECT,
+            data,
+            true,
+            List.of(Literal.of(1))
+        );
+
+        assertThat(resultWithLimit)
+            .isEqualTo(
+                List.of(
+                    Map.of("item", true, "frequency", 3L)
                 )
             );
     }


### PR DESCRIPTION
This adds doc-value support for strings/longs for topk aggregations.

String:

```
Q: select topk("cCode") from uservisits
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |      342.387 ±   47.303 |    329.017 |    332.368 |    335.657 |    655.839 |
|   V2    |      281.675 ±   66.351 |    267.042 |    269.210 |    273.750 |    738.836 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  19.46%                           -  21.00%
```

Long:

```
Q: select topk("duration") from uservisits
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |      123.669 ±   35.474 |    114.543 |    116.382 |    118.881 |    358.900 |
|   V2    |       85.045 ±   35.625 |     78.401 |     79.483 |     79.956 |    330.953 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  37.01%                           -  37.68%
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 37.01%
The test has statistical significance
```

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
