### PR TITLE
Fix array_length function for arrays containing nulls as inputs

### DIFF
--- a/docs/appendices/release-notes/5.9.0.rst
+++ b/docs/appendices/release-notes/5.9.0.rst
@@ -53,6 +53,12 @@ Breaking Changes
 
   It is a breaking change because the fix causes performance degradations.
 
+- Fixed an issue that caused ``WHERE`` clause containing
+  :ref:`scalar-array_length` under ``<``, ``<=`` or ``=`` to return invalid
+  results. It is a breaking change because the fix causes performance
+  regressions on tables created before 5.9.0. For tables created on and after
+  5.9.0, the fix has positive impact on the performance.
+
 - Changed the return value of the concat operator to return a ``NULL`` literal
   instead of an empty string when any of the operand is ``NULL``.
 

--- a/server/src/main/java/io/crate/execution/dml/IndexDocumentBuilder.java
+++ b/server/src/main/java/io/crate/execution/dml/IndexDocumentBuilder.java
@@ -29,6 +29,7 @@ import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.mapper.SequenceIDFields;
@@ -47,6 +48,7 @@ public class IndexDocumentBuilder {
     private final TranslogWriter translogWriter;
     private final ValueIndexer.Synthetics synthetics;
     private final Map<ColumnIdent, Indexer.ColumnConstraint> constraints;
+    private final Version tableVersionCreated;
 
     /**
      * Builds a new IndexDocumentBuilder
@@ -54,11 +56,13 @@ public class IndexDocumentBuilder {
     public IndexDocumentBuilder(
         TranslogWriter translogWriter,
         ValueIndexer.Synthetics synthetics,
-        Map<ColumnIdent, Indexer.ColumnConstraint> constraints
+        Map<ColumnIdent, Indexer.ColumnConstraint> constraints,
+        Version tableVersionCreated
     ) {
         this.translogWriter = translogWriter;
         this.synthetics = synthetics;
         this.constraints = constraints;
+        this.tableVersionCreated = tableVersionCreated;
     }
 
     /**
@@ -117,4 +121,7 @@ public class IndexDocumentBuilder {
         return new ParsedDocument(version, seqID, id, doc, source);
     }
 
+    public Version getTableVersionCreated() {
+        return tableVersionCreated;
+    }
 }

--- a/server/src/main/java/io/crate/execution/dml/Indexer.java
+++ b/server/src/main/java/io/crate/execution/dml/Indexer.java
@@ -114,6 +114,7 @@ public class Indexer {
     private final List<Synthetic> undeterministic = new ArrayList<>();
     private final Function<ColumnIdent, Reference> getRef;
     private final boolean writeOids;
+    private final Version tableVersionCreated;
 
     record IndexColumn(Reference reference, List<Input<?>> inputs) {
     }
@@ -529,6 +530,7 @@ public class Indexer {
             }
         }
         this.expressions = ctxForRefs.expressions();
+        this.tableVersionCreated = table.versionCreated();
     }
 
     /**
@@ -720,7 +722,7 @@ public class Indexer {
         }
 
         TranslogWriter translogWriter = new XContentTranslogWriter();
-        IndexDocumentBuilder docBuilder = new IndexDocumentBuilder(translogWriter, synthetics::get, columnConstraints);
+        IndexDocumentBuilder docBuilder = new IndexDocumentBuilder(translogWriter, synthetics::get, columnConstraints, tableVersionCreated);
         Object[] values = item.insertValues();
 
         for (int i = 0; i < values.length; i++) {

--- a/server/src/main/java/io/crate/types/ArrayType.java
+++ b/server/src/main/java/io/crate/types/ArrayType.java
@@ -96,9 +96,10 @@ public class ArrayType<T> extends DataType<List<T>> {
                     innerStorage.eqQuery()) {
 
                 @Override
-                public ValueIndexer<T> valueIndexer(RelationName table, Reference ref,
+                public ValueIndexer<T> valueIndexer(RelationName table,
+                                                    Reference ref,
                                                     Function<ColumnIdent, Reference> getRef) {
-                    return new ArrayIndexer<>(innerStorage.valueIndexer(table, ref, getRef));
+                    return new ArrayIndexer<>(innerStorage.valueIndexer(table, ref, getRef), ref);
                 }
             };
         }

--- a/server/src/test/java/io/crate/lucene/ArrayLengthQueryBeforeV590Test.java
+++ b/server/src/test/java/io/crate/lucene/ArrayLengthQueryBeforeV590Test.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.lucene;
+
+import org.elasticsearch.Version;
+
+public class ArrayLengthQueryBeforeV590Test extends ArrayLengthQueryTest {
+    @Override
+    protected Version tableVersionCreatedToTest() {
+        return Version.V_5_8_0;
+    }
+}

--- a/server/src/test/java/io/crate/lucene/ArrayLengthQueryBuilderBeforeV590Test.java
+++ b/server/src/test/java/io/crate/lucene/ArrayLengthQueryBuilderBeforeV590Test.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.  You may
  * obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
@@ -30,9 +30,11 @@ import org.assertj.core.api.Assertions;
 import org.elasticsearch.Version;
 import org.junit.Test;
 
+import io.crate.testing.IndexVersionCreated;
 import io.crate.testing.QueryTester;
 
-public class ArrayLengthQueryBuilderTest extends LuceneQueryBuilderTest {
+@IndexVersionCreated(value = 8_08_00_99) // V_5_8_0
+public class ArrayLengthQueryBuilderBeforeV590Test extends LuceneQueryBuilderTest {
 
     @Test
     public void testArrayLengthGtColumnIsNotOptimized() {
@@ -43,7 +45,7 @@ public class ArrayLengthQueryBuilderTest extends LuceneQueryBuilderTest {
     @Test
     public void testArrayLengthGt0UsesExistsQuery() {
         Query query = convert("array_length(y_array, 1) > 0");
-        assertThat(query).hasToString("_array_length_y_array:[1 TO 2147483647]");
+        assertThat(query).hasToString("(NumTermsPerDoc: y_array (array_length(y_array, 1) > 0))~1");
     }
 
     @Test
@@ -55,13 +57,13 @@ public class ArrayLengthQueryBuilderTest extends LuceneQueryBuilderTest {
     @Test
     public void testArrayLengthGte1UsesNumTermsPerDocQuery() {
         Query query = convert("array_length(y_array, 1) >= 1");
-        assertThat(query).hasToString("_array_length_y_array:[1 TO 2147483647]");
+        assertThat(query).hasToString("(NumTermsPerDoc: y_array (array_length(y_array, 1) >= 1))~1");
     }
 
     @Test
     public void testArrayLengthGt1UsesNumTermsPerOrAndGenericFunction() {
         Query query = convert("array_length(y_array, 1) > 1");
-        assertThat(query).hasToString("_array_length_y_array:[2 TO 2147483647]");
+        assertThat(query).hasToString("(NumTermsPerDoc: y_array (array_length(y_array, 1) > 1))~1");
     }
 
     @Test
@@ -84,12 +86,12 @@ public class ArrayLengthQueryBuilderTest extends LuceneQueryBuilderTest {
         try (QueryTester tester = new QueryTester.Builder(
             THREAD_POOL,
             clusterService,
-            Version.CURRENT,
+            Version.V_5_8_0,
             "create table t (int_array array(int))",
             () -> oid
         ).indexValues("int_array", List.of(), List.of(1)).build()) {
             Query query = tester.toQuery("array_length(int_array, 1) >= 1");
-            assertThat(query).hasToString(String.format("_array_length_%s:[1 TO 2147483647]", oid));
+            assertThat(query).hasToString(String.format("(NumTermsPerDoc: %s (array_length(int_array, 1) >= 1))~1", oid));
             Assertions.assertThat(tester.runQuery("int_array", "array_length(int_array, 1) >= 1"))
                 .containsExactly(List.of(1));
         }

--- a/server/src/test/java/io/crate/lucene/ArrayLengthQueryTest.java
+++ b/server/src/test/java/io/crate/lucene/ArrayLengthQueryTest.java
@@ -24,6 +24,7 @@ package io.crate.lucene;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
@@ -44,14 +45,55 @@ import io.crate.types.ObjectType;
 
 public class ArrayLengthQueryTest extends CrateDummyClusterServiceUnitTest {
 
-    private QueryTester tester;
+    protected QueryTester tester;
+
+    protected static final List<Integer> ARRAY_NULL;
+    protected static final List<Integer> ARRAY_NULL_NULL;
+    protected static final List<Integer> ARRAY_NULL_NULL_NULL;
+
+    protected static final List<Integer> ARRAY_NULL_1;
+    protected static final List<Integer> ARRAY_NULL_NULL_1;
+
+    protected static final List<Integer> ARRAY_NULL_1_1;
+
+    static {
+        ARRAY_NULL = new ArrayList<>();
+        ARRAY_NULL.add(null);
+
+        ARRAY_NULL_NULL = new ArrayList<>();
+        ARRAY_NULL_NULL.add(null);
+        ARRAY_NULL_NULL.add(null);
+
+        ARRAY_NULL_NULL_NULL = new ArrayList<>();
+        ARRAY_NULL_NULL_NULL.add(null);
+        ARRAY_NULL_NULL_NULL.add(null);
+        ARRAY_NULL_NULL_NULL.add(null);
+
+        ARRAY_NULL_1 = new ArrayList<>();
+        ARRAY_NULL_1.add(null);
+        ARRAY_NULL_1.add(1);
+
+        ARRAY_NULL_NULL_1 = new ArrayList<>();
+        ARRAY_NULL_NULL_1.add(null);
+        ARRAY_NULL_NULL_1.add(null);
+        ARRAY_NULL_NULL_1.add(1);
+
+        ARRAY_NULL_1_1 = new ArrayList<>();
+        ARRAY_NULL_1_1.add(null);
+        ARRAY_NULL_1_1.add(1);
+        ARRAY_NULL_1_1.add(1);
+    }
+
+    protected Version tableVersionCreatedToTest() {
+        return Version.CURRENT;
+    }
 
     @Before
     public void setUpTester() throws Exception {
         QueryTester.Builder builder = new QueryTester.Builder(
             THREAD_POOL,
             clusterService,
-            Version.CURRENT,
+            tableVersionCreatedToTest(),
             "create table t (xs array(integer))"
         );
         tester = builder
@@ -65,7 +107,13 @@ public class ArrayLengthQueryTest extends CrateDummyClusterServiceUnitTest {
                 List.of(10, 10),
                 List.of(10, 20),
                 List.of(10, 10, 20),
-                List.of(10, 20, 30)
+                List.of(10, 20, 30),
+                ARRAY_NULL,
+                ARRAY_NULL_NULL,
+                ARRAY_NULL_NULL_NULL,
+                ARRAY_NULL_1,
+                ARRAY_NULL_NULL_1,
+                ARRAY_NULL_1_1
             )
             .build();
     }
@@ -84,7 +132,13 @@ public class ArrayLengthQueryTest extends CrateDummyClusterServiceUnitTest {
             List.of(10, 10),
             List.of(10, 20),
             List.of(10, 10, 20),
-            List.of(10, 20, 30)
+            List.of(10, 20, 30),
+            ARRAY_NULL,
+            ARRAY_NULL_NULL,
+            ARRAY_NULL_NULL_NULL,
+            ARRAY_NULL_1,
+            ARRAY_NULL_NULL_1,
+            ARRAY_NULL_1_1
         );
     }
 
@@ -98,7 +152,13 @@ public class ArrayLengthQueryTest extends CrateDummyClusterServiceUnitTest {
             List.of(10, 10),
             List.of(10, 20),
             List.of(10, 10, 20),
-            List.of(10, 20, 30)
+            List.of(10, 20, 30),
+            ARRAY_NULL,
+            ARRAY_NULL_NULL,
+            ARRAY_NULL_NULL_NULL,
+            ARRAY_NULL_1,
+            ARRAY_NULL_NULL_1,
+            ARRAY_NULL_1_1
         );
     }
 
@@ -109,7 +169,12 @@ public class ArrayLengthQueryTest extends CrateDummyClusterServiceUnitTest {
             List.of(10, 10),
             List.of(10, 20),
             List.of(10, 10, 20),
-            List.of(10, 20, 30)
+            List.of(10, 20, 30),
+            ARRAY_NULL_NULL,
+            ARRAY_NULL_NULL_NULL,
+            ARRAY_NULL_1,
+            ARRAY_NULL_NULL_1,
+            ARRAY_NULL_1_1
         );
     }
 
@@ -122,7 +187,13 @@ public class ArrayLengthQueryTest extends CrateDummyClusterServiceUnitTest {
             List.of(10, 10),
             List.of(10, 20),
             List.of(10, 10, 20),
-            List.of(10, 20, 30)
+            List.of(10, 20, 30),
+            ARRAY_NULL,
+            ARRAY_NULL_NULL,
+            ARRAY_NULL_NULL_NULL,
+            ARRAY_NULL_1,
+            ARRAY_NULL_NULL_1,
+            ARRAY_NULL_1_1
         );
     }
 
@@ -131,7 +202,10 @@ public class ArrayLengthQueryTest extends CrateDummyClusterServiceUnitTest {
         List<Object> rows = tester.runQuery("xs", "array_length(xs, 1) > 2");
         assertThat(rows).containsExactlyInAnyOrder(
             List.of(10, 10, 20),
-            List.of(10, 20, 30)
+            List.of(10, 20, 30),
+            ARRAY_NULL_NULL_NULL,
+            ARRAY_NULL_NULL_1,
+            ARRAY_NULL_1_1
         );
     }
 
@@ -142,7 +216,12 @@ public class ArrayLengthQueryTest extends CrateDummyClusterServiceUnitTest {
             List.of(10, 10),
             List.of(10, 20),
             List.of(10, 10, 20),
-            List.of(10, 20, 30)
+            List.of(10, 20, 30),
+            ARRAY_NULL_NULL,
+            ARRAY_NULL_NULL_NULL,
+            ARRAY_NULL_1,
+            ARRAY_NULL_NULL_1,
+            ARRAY_NULL_1_1
         );
     }
 
@@ -171,7 +250,8 @@ public class ArrayLengthQueryTest extends CrateDummyClusterServiceUnitTest {
         List<Object> rows = tester.runQuery("xs", "array_length(xs, 1) <= 1");
         assertThat(rows).containsExactlyInAnyOrder(
             List.of(10),
-            List.of(20)
+            List.of(20),
+            ARRAY_NULL
         );
     }
 
@@ -184,7 +264,13 @@ public class ArrayLengthQueryTest extends CrateDummyClusterServiceUnitTest {
             List.of(10, 10),
             List.of(10, 20),
             List.of(10, 10, 20),
-            List.of(10, 20, 30)
+            List.of(10, 20, 30),
+            ARRAY_NULL,
+            ARRAY_NULL_NULL,
+            ARRAY_NULL_NULL_NULL,
+            ARRAY_NULL_1,
+            ARRAY_NULL_NULL_1,
+            ARRAY_NULL_1_1
         );
     }
 
@@ -195,7 +281,10 @@ public class ArrayLengthQueryTest extends CrateDummyClusterServiceUnitTest {
             List.of(10),
             List.of(20),
             List.of(10, 10),
-            List.of(10, 20)
+            List.of(10, 20),
+            ARRAY_NULL,
+            ARRAY_NULL_NULL,
+            ARRAY_NULL_1
         );
     }
 
@@ -204,7 +293,8 @@ public class ArrayLengthQueryTest extends CrateDummyClusterServiceUnitTest {
         List<Object> rows = tester.runQuery("xs", "array_length(xs, 1) = 1");
         assertThat(rows).containsExactlyInAnyOrder(
             List.of(10),
-            List.of(20)
+            List.of(20),
+            ARRAY_NULL
         );
     }
 
@@ -213,7 +303,9 @@ public class ArrayLengthQueryTest extends CrateDummyClusterServiceUnitTest {
         List<Object> rows = tester.runQuery("xs", "array_length(xs, 1) = 2");
         assertThat(rows).containsExactlyInAnyOrder(
             List.of(10, 10),
-            List.of(10, 20)
+            List.of(10, 20),
+            ARRAY_NULL_NULL,
+            ARRAY_NULL_1
         );
     }
 

--- a/server/src/testFixtures/java/io/crate/testing/QueryTester.java
+++ b/server/src/testFixtures/java/io/crate/testing/QueryTester.java
@@ -36,7 +36,9 @@ import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.threadpool.ThreadPool;
 
@@ -100,7 +102,7 @@ public final class QueryTester implements AutoCloseable {
             var sqlExecutor = SQLExecutor
                 .of(clusterService)
                 .setColumnOidSupplier(columnOidSupplier)
-                .addTable(createTableStmt);
+                .addTable(createTableStmt, Settings.builder().put(IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(), indexVersion).build());
             plannerContext = sqlExecutor.getPlannerContext();
 
             var createTable = (CreateTable<?>) SqlParser.createStatement(createTableStmt);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Second attempt of https://github.com/crate/crate/pull/16300 which fixes:
```
cr> create table t (a int[]);                                                                                                                                         
cr> insert into t values (null), ([]), ([null]), ([null, null]), ([null, null, null]);                                                                                

cr> select * from t where array_length(a,1) > 0;                                                                                                                      
+---+
| a |
+---+
+---+
=> expect [null], [null, null], [null, null, null]

cr> select * from t where array_length(a,1) >= 0;                                                                                                                     
+---+
| a |
+---+
+---+
=> expect [null], [null, null], [null, null, null]

cr> select * from t where array_length(a,1) >= 1;                                                                                                                     
+---+
| a |
+---+
+---+
=> expect [null], [null, null], [null, null, null]

cr> select * from t where array_length(a,1) = 1;                                                                                                                      
+---+
| a |
+---+
+---+
=> expect [null]

cr> select * from t where array_length(a,1) = 2;                                                                                                                      
+---+
| a |
+---+
+---+
=> expect [null, null]
```
```
cr> create table t (t text[]);
cr> insert into t values (['c','c']);

+---+
| t |
+---+
+---+

=> expect ['c', 'c']
Apparently, doc-value-count for text arrays only count unique elements.
```

As discussed in https://github.com/crate/crate/pull/16300 due to the performance impact of the initial fix,
array length field is introduced per array columns. The array length field will be created only for tables created on and after `5.9`. Hence `array_length` scalar on arrays from tables created before `5.9` will observer performance regressions but with correct result set.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
