### PR TITLE
Increase test timeouts of some flaky Logical Replication tests

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/LogicalReplicationITest.java
+++ b/server/src/test/java/io/crate/integrationtests/LogicalReplicationITest.java
@@ -629,6 +629,6 @@ public class LogicalReplicationITest extends LogicalReplicationITestCase {
                     " JOIN pg_subscription_rel sr ON s.oid = sr.srsubid" +
                     " JOIN pg_class r ON sr.srrelid = r.oid");
             assertThat(res).hasRows("sub1| t1| r| NULL");
-        });
+        }, 30, TimeUnit.SECONDS);
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/MetadataTrackerITest.java
+++ b/server/src/test/java/io/crate/integrationtests/MetadataTrackerITest.java
@@ -97,7 +97,7 @@ public class MetadataTrackerITest extends LogicalReplicationITestCase {
                 "5| luke| 37",
                 "6| yoda| 900"
             );
-        });
+        }, 60, TimeUnit.SECONDS);
     }
 
     @Test
@@ -129,7 +129,7 @@ public class MetadataTrackerITest extends LogicalReplicationITestCase {
                     "name"
                 );
             }
-        }, 30, TimeUnit.SECONDS);
+        }, 60, TimeUnit.SECONDS);
     }
 
     @Test


### PR DESCRIPTION
These tests fail from time to time only at the CI. This suspects that this may be a timing issue on low resource bounded CI instances.
