### PR TITLE
Adds the `array_prepend(value, array)` scalar and concat operator

### DIFF
--- a/docs/appendices/release-notes/5.9.0.rst
+++ b/docs/appendices/release-notes/5.9.0.rst
@@ -102,6 +102,11 @@ Scalar and Aggregation Functions
   :ref:`array_append(array, value) <scalar-array_append>` scalar function for
   improved compatibility with PostgreSQL.
 
+- Added the :ref:`array_prepend(value, array) <scalar-array_prepend>` scalar
+  function which prepends a value to an array. Additionally, added the
+  ``value || array`` operator as an alias to the new
+  :ref:`array_prepend(value, array) <scalar-array_prepend>` scalar function.
+
 Performance and Resilience Improvements
 ---------------------------------------
 

--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -2746,6 +2746,13 @@ values to an array::
     +--------------+
     SELECT 1 row in set (... sec)
 
+.. NOTE::
+
+    The ``||`` operator differs from the ``array_append`` function regarding
+    the handling of ``NULL`` arguments. It will ignore a ``NULL`` value while
+    the ``array_append`` function will append a ``NULL`` value to the array.
+
+
 .. _scalar-array_cat:
 
 ``array_cat(first_array, second_array)``
@@ -3238,6 +3245,45 @@ Begin the search from given position (optional).
     clause is much more efficient as it can utilize the index whereas
     ``array_position`` won't even when used inside the ``WHERE`` clause.
 
+
+.. _scalar-array_prepend:
+
+``array_prepend(value, anyarray)``
+----------------------------------
+
+The ``array_prepend`` function prepends a value to the beginning of the array.
+
+Returns: ``array``
+
+::
+
+    cr> select
+    ...     array_prepend(1, [2,3,4]) AS array_prepend;
+    +---------------+
+    | array_prepend |
+    +---------------+
+    | [1, 2, 3, 4]  |
+    +---------------+
+    SELECT 1 row in set (... sec)
+
+
+You can also use the concat :ref:`operator <gloss-operator>` ``||`` to prepend
+values to an array::
+
+    cr> select
+    ...    1 || [2,3,4] AS array_prepend;
+    +---------------+
+    | array_prepend |
+    +---------------+
+    | [1, 2, 3, 4]  |
+    +---------------+
+    SELECT 1 row in set (... sec)
+
+.. NOTE::
+
+    The ``||`` operator differs from the ``array_prepend`` function regarding the
+    handling of ``NULL`` arguments. It will ignore a ``NULL`` value while the
+    ``array_prepend`` function will prepend a ``NULL`` value to the array.
 
 .. _scalar-array_max:
 

--- a/server/src/main/java/io/crate/expression/scalar/ArrayPrependFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayPrependFunction.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar;
+
+import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.crate.data.Input;
+import io.crate.metadata.FunctionType;
+import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.BoundSignature;
+import io.crate.metadata.functions.Signature;
+import io.crate.types.ArrayType;
+import io.crate.types.DataType;
+import io.crate.types.TypeSignature;
+
+public class ArrayPrependFunction extends Scalar<List<Object>, Object> {
+
+    public static final String NAME = "array_prepend";
+
+    public static void register(Functions.Builder builder) {
+        builder.add(
+                Signature.builder(NAME, FunctionType.SCALAR)
+                        .argumentTypes(
+                            TypeSignature.parse("E"),
+                            TypeSignature.parse("array(E)")
+                            )
+                        .returnType(TypeSignature.parse("array(E)"))
+                        .typeVariableConstraints(typeVariable("E"))
+                        .features(Feature.DETERMINISTIC, Feature.NOTNULL)
+                        .build(),
+                ArrayPrependFunction::new
+        );
+    }
+
+    private final DataType<?> innerType;
+    private final boolean calledByOperator;
+
+    ArrayPrependFunction(Signature signature, BoundSignature boundSignature) {
+        this(signature, boundSignature, false);
+    }
+
+    ArrayPrependFunction(Signature signature, BoundSignature boundSignature, boolean calledByOperator) {
+        super(signature, boundSignature);
+        this.innerType = ((ArrayType<?>) boundSignature.returnType()).innerType();
+        this.calledByOperator = calledByOperator;
+    }
+
+    @Override
+    public final List<Object> evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input[] args) {
+        ArrayList<Object> resultList = new ArrayList<>();
+        Object valueToAdd = args[0].value();
+        @SuppressWarnings("unchecked")
+        List<Object> values = (List<Object>) args[1].value();
+
+        // null || array -> array (null is ignored)
+        if (valueToAdd != null || calledByOperator == false) {
+            resultList.add(innerType.sanitizeValue(valueToAdd));
+        }
+
+        if (values != null) {
+            for (Object value : values) {
+                resultList.add(innerType.sanitizeValue(value));
+            }
+        }
+
+        return resultList;
+    }
+}

--- a/server/src/main/java/io/crate/expression/scalar/ConcatFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ConcatFunction.java
@@ -122,6 +122,18 @@ public abstract class ConcatFunction extends Scalar<String, String> {
         );
         module.add(
             Signature.builder(OPERATOR_NAME, FunctionType.SCALAR)
+                .argumentTypes(
+                    TypeSignature.parse("E"),
+                    TypeSignature.parse("array(E)")
+                )
+                .returnType(TypeSignature.parse("array(E)"))
+                .typeVariableConstraints(typeVariable("E"))
+                .features(Feature.DETERMINISTIC)
+                .build(),
+            (signature, boundSignature) -> new ArrayPrependFunction(signature, boundSignature, true)
+        );
+        module.add(
+            Signature.builder(OPERATOR_NAME, FunctionType.SCALAR)
                 .argumentTypes(DataTypes.UNTYPED_OBJECT.getTypeSignature(),
                     DataTypes.UNTYPED_OBJECT.getTypeSignature())
                 .returnType(DataTypes.UNTYPED_OBJECT.getTypeSignature())

--- a/server/src/main/java/io/crate/expression/scalar/ScalarFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/ScalarFunctions.java
@@ -210,6 +210,7 @@ public class ScalarFunctions implements FunctionsProvider {
         ArrayAvgFunction.register(builder);
         ArraySliceFunction.register(builder);
         ArrayPositionFunction.register(builder);
+        ArrayPrependFunction.register(builder);
         ArrayUnnestFunction.register(builder);
         ArraySetFunction.register(builder);
 

--- a/server/src/test/java/io/crate/expression/scalar/ArrayPrependFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayPrependFunctionTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar;
+
+import static io.crate.testing.Asserts.isLiteral;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+public class ArrayPrependFunctionTest extends ScalarTestCase {
+
+    @Test
+    public void test_prepending_element() {
+        assertNormalize("array_prepend(1, [2, 3])", isLiteral(List.of(1, 2, 3)));
+    }
+
+    @Test
+    public void test_prepending_null() {
+        assertNormalize("array_prepend(null, [2, 3])", isLiteral(Arrays.asList(null, 2, 3)));
+    }
+
+    @Test
+    public void test_prepend_to_null_array() {
+        assertNormalize("array_prepend(1, null)", isLiteral(List.of(1)));
+    }
+
+    @Test
+    public void test_prepend_null_to_null() {
+        assertNormalize("array_prepend(null, null)", isLiteral(Collections.singletonList(null)));
+    }
+
+    @Test
+    public void test_prepend_with_different_types() {
+        assertNormalize("array_prepend(1.0, [2, 3])", isLiteral(List.of(1.0, 2.0, 3.0)));
+    }
+}

--- a/server/src/test/java/io/crate/expression/scalar/ConcatFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ConcatFunctionTest.java
@@ -145,4 +145,9 @@ public class ConcatFunctionTest extends ScalarTestCase {
     public void test_concat_operator_with_array_and_element() {
         assertEvaluate("[1] || 2", List.of(1, 2));
     }
+
+    @Test
+    public void test_concat_operator_with_element_and_array() {
+        assertEvaluate("1 || [2]", List.of(1, 2));
+    }
 }


### PR DESCRIPTION
The ``value || array`` concat operator is an alias to the ``array_prepend`` scalar.
