### PR TITLE
Refactor ObjectIndexer to avoid parallel maps

### DIFF
--- a/server/src/main/java/io/crate/types/DataType.java
+++ b/server/src/main/java/io/crate/types/DataType.java
@@ -244,8 +244,9 @@ public abstract class DataType<T> implements Comparable<DataType<?>>, Writeable,
         return storageSupport;
     }
 
-
-    @Nullable
+    /**
+     * Returns a ValueIndexer for this type
+     */
     public final ValueIndexer<? super T> valueIndexer(RelationName table,
                                                       Reference ref,
                                                       Function<ColumnIdent, Reference> getRef) {


### PR DESCRIPTION
Also reworks AlterTableIntegrationTest to not rely on iteration order of 
Map.toString(), and removes an incorrect @Nullable annotation on DataType.