### PR TITLE
Fix BWC issue of the sys.nodes table

### DIFF
--- a/docs/appendices/release-notes/5.8.1.rst
+++ b/docs/appendices/release-notes/5.8.1.rst
@@ -47,4 +47,5 @@ See the :ref:`version_5.8.0` release notes for a full list of changes in the
 Fixes
 =====
 
-None
+- Fixed a regression introduced in 5.8.0 that led to error when running a query
+  ``SELECT * FROM sys.nodes`` in a mixed cluster.

--- a/server/src/main/java/io/crate/expression/reference/sys/node/NodeStatsContextFieldResolver.java
+++ b/server/src/main/java/io/crate/expression/reference/sys/node/NodeStatsContextFieldResolver.java
@@ -241,6 +241,10 @@ public class NodeStatsContextFieldResolver {
                 context.threadPools(threadPool.stats());
             }
         }),
+        // TODO: Added due to BWC reasons, <= 5.7 nodes should be able to query this column.
+        // Remove it in 6.0
+        entry(SysNodesTableInfo.Columns.NETWORK, context -> {
+        }),
         entry(SysNodesTableInfo.Columns.CONNECTIONS, new Consumer<>() {
             @Override
             public void accept(NodeStatsContext nodeStatsContext) {

--- a/server/src/main/java/io/crate/metadata/sys/SysNodesTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/sys/SysNodesTableInfo.java
@@ -57,6 +57,7 @@ public class SysNodesTableInfo {
     private static final String SYS_COL_HEAP = "heap";
     private static final String SYS_COL_VERSION = "version";
     private static final String SYS_COL_THREAD_POOLS = "thread_pools";
+    private static final String SYS_COL_NETWORK = "network";
     private static final String SYS_COL_OS = "os";
     private static final String SYS_COL_OS_INFO = "os_info";
     private static final String SYS_COL_PROCESS = "process";
@@ -81,6 +82,8 @@ public class SysNodesTableInfo {
         public static final ColumnIdent VERSION = ColumnIdent.of(SYS_COL_VERSION);
 
         public static final ColumnIdent THREAD_POOLS = ColumnIdent.of(SYS_COL_THREAD_POOLS);
+
+        public static final ColumnIdent NETWORK = ColumnIdent.of(SYS_COL_NETWORK);
 
         public static final ColumnIdent CONNECTIONS = ColumnIdent.of("connections");
 


### PR DESCRIPTION
Fixes regression introduced in https://github.com/crate/crate/commit/0653a1f99fbb14574d607e90f4a5523726ff7479

crate-qa test from https://github.com/crate/crate-qa/pull/319 passes locally if I replace upgrade path to

```
ROLLING_UPGRADES = (
    # 4.0.0 -> 4.0.1 -> 4.0.2 don't support rolling upgrades due to a bug
    UpgradePath('5.7.x', 'path_to_the_crate_folder'),
) 
```