### PR TITLE
Update CONTRIBUTING.rst with clarification regarding the Contributor …

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -34,7 +34,7 @@ Before you report an issue, please `search the existing issues`_ to make sure
 someone hasn't already reported it.
 
 When reporting a new issue, include as much detail as possible. For some
-Crate.io_ repositories, issue templates have been configured.
+CrateDB_ repositories, issue templates have been configured.
 
 For repositories without configured issue templates, include:
 
@@ -65,7 +65,12 @@ like and don't like about CrateDB.
 Pull Requests
 =============
 
-Before we can accept any pull requests, we need you to agree to our CLA_.
+Before we can accept any pull requests, we need you to agree to our Contributor License Agreement (CLA).
+If you are contributing as an individual, you must sign an Individual Contributor License Agreement (ICLA_). 
+If you are contributing as an employee of a company and the company wants to allow you to contribute your work, then the representative of your company must sign a Corporate Contributor License Agreement (CCLA_). 
+Note: a CCLA does not remove the need for you to sign you own ICLA as an individual, to cover both contributions which are owned and those that are not owned by the company signing the CCLA.
+
+
 
 Once that is complete, you should:
 
@@ -154,13 +159,13 @@ If you're happy with the result, do a **force** push (since you're rewriting his
 See also: http://www.ericbmerritt.com/2011/09/21/commit-hygiene-and-git.html
 
 
-.. _CLA: https://crate.io/community/contribute/cla/
-.. _Crate.io: http://crate.io/
+.. _ICLA: https://app.hellosign.com/s/LP1Ul5Vj
+.. _CCLA: https://app.hellosign.com/s/b59e3c0a
 .. _developer guide: devs/docs/index.rst
-.. _get in touch: https://crate.io/contact/
+.. _get in touch: https://cratedb.com/contact
 .. _giving feedback: https://github.com/crate/crate/blob/master/CONTRIBUTING.rst#tell-us-about-your-experience
 .. _reporting new issues: https://github.com/crate/crate/blob/master/CONTRIBUTING.rst#reporting-issues
 .. _search the existing issues: https://github.com/search?q=org%3Acrate+is%3Aissue+is%3Aopen
 .. _sort issues by reaction: https://github.com/crate/crate/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc
-.. _support channels: https://crate.io/support/
+.. _support channels: https://cratedb.com/support
 .. _Upvoting existing issues: https://github.com/crate/crate/blob/master/CONTRIBUTING.rst#upvoting-issues


### PR DESCRIPTION
…Agreements

Heni asked me to update the Pull request section in alignment with the contribute section on the website (https://cratedb.com/developers/community/contribute), clarifying which CLA someone who wants to contribute needs to sign.

## Summary of the changes / Why this improves CrateDB
Only two instead of three CLA's. Clarification when to sign which one, easier internal process for signing those. 

## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
