### PR TITLE
[TEMP] Update to crate-docs-theme==0.34.0.dev6

### DIFF
--- a/blackbox/requirements.txt
+++ b/blackbox/requirements.txt
@@ -16,7 +16,7 @@ dnslib
 # Documentation
 sphinx>=4.6
 sphinx-csv-filter==0.4.0
-crate-docs-theme>=0.30.0
+crate-docs-theme==0.34.0.dev6
 
 # Documentation: local development
 sphinx-autobuild<2024

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 # packages for RTD to pick up (not used for local dev)
-crate-docs-theme>=0.30.0
+crate-docs-theme==0.34.0.dev6
 sphinx-csv-filter==0.4.0
 Pygments>=2.7.4,<3


### PR DESCRIPTION
## About
This RTD build gives you the chance to preview and review the documentation, using a pre-release of the modernized crate-docs-theme, based on sphinx-basic-ng/Furo. **Please do not merge.**

## Preview
https://crate--16344.org.readthedocs.build/en/16344/

## References
- https://github.com/crate/crate-docs-theme/pull/390
