### PR TITLE
Implement USER session settings

### DIFF
--- a/docs/admin/user-management.rst
+++ b/docs/admin/user-management.rst
@@ -214,6 +214,7 @@ statement returns an error::
     cr> DROP USER "Custom User";
     DROP OK, 1 row affected (... sec)
 
+.. _administration_user_management_alter_user:
 
 ``ALTER USER``
 ==============
@@ -233,6 +234,30 @@ The password can be reset (cleared) if specified as ``NULL``::
 
     The built-in superuser ``crate`` has no password and it is not possible to
     set a new password for this user.
+
+To add or alter :ref:`session settings <conf-session>` use the following SQL
+statement::
+
+    cr> ALTER USER user_b SET (search_path = 'myschema', statement_timeout = '10m');
+    ALTER OK, 1 row affected (... sec)
+
+To reset a :ref:`session setting <conf-session>` to its default value use the
+following SQL statement::
+
+    cr> ALTER USER user_b RESET statement_timeout;
+    ALTER OK, 1 row affected (... sec)
+
+.. hide:
+
+   cr> ALTER USER user_a SET (search_path = 'new_schema', statement_timeout = '1h');
+    ALTER OK, 1 row affected (... sec)
+
+To reset all modified :ref:`session setting <conf-session>` for a user to their
+default values, use the following SQL statement::
+
+    cr> ALTER USER user_a RESET ALL;
+    ALTER OK, 1 row affected (... sec)
+
 
 ``DROP USER``
 =============
@@ -280,14 +305,14 @@ CrateDB clusters is also part of that list.
 
 To list all existing users query the table::
 
-    cr> SELECT name, granted_roles, password, superuser FROM sys.users order by name;
-    +--------+----------------------------------------------------------------------------------+----------+-----------+
-    | name   | granted_roles                                                                    | password | superuser |
-    +--------+----------------------------------------------------------------------------------+----------+-----------+
-    | crate  | []                                                                               | NULL     | TRUE      |
-    | user_a | [{"grantor": "crate", "role": "role_a"}, {"grantor": "crate", "role": "role_b"}] | NULL     | FALSE     |
-    | user_b | []                                                                               | ******** | FALSE     |
-    +--------+----------------------------------------------------------------------------------+----------+-----------+
+    cr> SELECT name, granted_roles, password, session_settings, superuser FROM sys.users order by name;
+    +--------+----------------------------------------------------------------------------------+----------+-----------------------------+-----------+
+    | name   | granted_roles                                                                    | password | session_settings            | superuser |
+    +--------+----------------------------------------------------------------------------------+----------+-----------------------------+-----------+
+    | crate  | []                                                                               | NULL     | {}                          | TRUE      |
+    | user_a | [{"grantor": "crate", "role": "role_a"}, {"grantor": "crate", "role": "role_b"}] | NULL     | {}                          | FALSE     |
+    | user_b | []                                                                               | ******** | {"search_path": "myschema"} | FALSE     |
+    +--------+----------------------------------------------------------------------------------+----------+-----------------------------+-----------+
     SELECT 3 rows in set (... sec)
 
 

--- a/docs/appendices/release-notes/5.9.0.rst
+++ b/docs/appendices/release-notes/5.9.0.rst
@@ -123,6 +123,10 @@ None
 Administration and Operations
 -----------------------------
 
+- Added support to set :ref:`session settings <conf-session>` to a user via
+  :ref:`ALTER ROLE <ref-alter-role>` statement. For details and examples see:
+  :ref:`here <administration_user_management_alter_user>`.
+
 - Added support for :ref:`Shared Access Signatures (SAS) tokens <sql-create-repo-azure-sas-token>`
   as an alternative for authentication for :ref:`Azure repositories <sql-create-repo-azure>`.
 

--- a/docs/config/session.rst
+++ b/docs/config/session.rst
@@ -22,6 +22,9 @@ example:
 
   SET search_path TO myschema, doc;
 
+Alternatively, session settings can be modified permanently from their default
+values for a user, with the use of :ref:`ALTER ROLE <ref-alter-role>`.
+
 To retrieve the current value of a session setting, use :ref:`SHOW <ref-show>`
 e.g:
 

--- a/docs/sql/statements/alter-role.rst
+++ b/docs/sql/statements/alter-role.rst
@@ -18,15 +18,19 @@ Synopsis
 ::
 
     ALTER ROLE name
-      SET ( parameter = value [, ...] )
+        SET ( parameter = value [, ...] )
+      | RESET [parameter | ALL]
 
 
 Description
 ===========
 
-``ALTER ROLE`` applies a change to an existing database user or role. Only
+``ALTER ROLE SET`` applies a change to an existing database user or role. Only
 existing superusers or the user itself have the privilege to alter an existing
 database user.
+
+``ALTER ROLE RESET`` resets modifiable
+:ref:`session settings <conf-session>` to their default value.
 
 
 Arguments
@@ -74,3 +78,34 @@ are supported to alter an existing user account:
 
    Passwords and JWT properties can be changed only for existing database
    users, but not to roles.
+
+:session settings:
+
+  Any of the modifiable :ref:`session settings <conf-session>`. The value set
+  is used for the user when logins to the database, instead of the default
+  value, thus, there is no need to use ``SET`` statements to modify the setting
+  value on its user session.
+
+
+.. NOTE::
+
+    The session settings can only be set to a user and not on a role and
+    are therefore are not inherited to other users.
+
+    Changes to session settings are only applied to new sessions opened by the
+    user.
+
+
+``RESET``
+---------
+
+Resets modifiable :ref:`session settings <conf-session>` to their default value.
+
+:parameter:
+
+  Any of the modifiable :ref:`session settings <conf-session>`.
+
+:ALL:
+
+  Resets all the  modifiable :ref:`session settings <conf-session>` of the user
+  to their default values.

--- a/libs/sql-parser/src/main/antlr/io/crate/sql/parser/antlr/SqlBaseParser.g4
+++ b/libs/sql-parser/src/main/antlr/io/crate/sql/parser/antlr/SqlBaseParser.g4
@@ -138,7 +138,8 @@ alterStmt
     | ALTER CLUSTER DECOMMISSION node=expr                                           #alterClusterDecommissionNode
     | ALTER CLUSTER GC DANGLING ARTIFACTS                                            #alterClusterGCDanglingArtifacts
     | ALTER (USER | ROLE) name=ident
-        SET OPEN_ROUND_BRACKET genericProperties CLOSE_ROUND_BRACKET                 #alterRole
+        SET OPEN_ROUND_BRACKET genericProperties CLOSE_ROUND_BRACKET                 #alterRoleSet
+    | ALTER (USER | ROLE) name=ident RESET (property=ident | ALL)                    #alterRoleReset
     | ALTER PUBLICATION name=ident
         ((ADD | SET | DROP) TABLE qname ASTERISK?  (COMMA qname ASTERISK? )*)        #alterPublication
     | ALTER SUBSCRIPTION name=ident alterSubscriptionMode                            #alterSubscription

--- a/libs/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
@@ -43,7 +43,8 @@ import io.crate.common.collections.Lists;
 import io.crate.sql.tree.AliasedRelation;
 import io.crate.sql.tree.AllColumns;
 import io.crate.sql.tree.AlterPublication;
-import io.crate.sql.tree.AlterRole;
+import io.crate.sql.tree.AlterRoleReset;
+import io.crate.sql.tree.AlterRoleSet;
 import io.crate.sql.tree.AlterSubscription;
 import io.crate.sql.tree.Assignment;
 import io.crate.sql.tree.AstVisitor;
@@ -837,13 +838,31 @@ public final class SqlFormatter {
         }
 
         @Override
-        public Void visitAlterRole(AlterRole<?> node, Integer indent) {
+        public Void visitAlterRoleSet(AlterRoleSet<?> node, Integer indent) {
             builder.append("ALTER ROLE ");
             builder.append(quoteIdentifierIfNeeded(node.name()));
             if (node.properties().isEmpty() == false) {
                 builder.append("SET (");
                 appendProperties(node.properties(), 0);
                 builder.append(")");
+            }
+            return null;
+        }
+
+        @Override
+        public Void visitAlterRoleReset(AlterRoleReset node, Integer indent) {
+            builder.append("ALTER ROLE ");
+            builder.append(quoteIdentifierIfNeeded(node.name()));
+            builder.append("RESET ");
+            String property = node.property();
+            if (property == null) {
+                builder.append("ALL");
+            } else {
+                if (property.contains(".")) {
+                    builder.append(String.format(Locale.ENGLISH, "\"%s\"", property));
+                } else {
+                    builder.append(property);
+                }
             }
             return null;
         }

--- a/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -73,7 +73,8 @@ import io.crate.sql.tree.AliasedRelation;
 import io.crate.sql.tree.AllColumns;
 import io.crate.sql.tree.AlterClusterRerouteRetryFailed;
 import io.crate.sql.tree.AlterPublication;
-import io.crate.sql.tree.AlterRole;
+import io.crate.sql.tree.AlterRoleReset;
+import io.crate.sql.tree.AlterRoleSet;
 import io.crate.sql.tree.AlterSubscription;
 import io.crate.sql.tree.AlterTable;
 import io.crate.sql.tree.AlterTableAddColumn;
@@ -1487,11 +1488,18 @@ class AstBuilder extends SqlBaseParserBaseVisitor<Node> {
     }
 
     @Override
-    public Node visitAlterRole(SqlBaseParser.AlterRoleContext context) {
-        return new AlterRole<>(
+    public Node visitAlterRoleSet(SqlBaseParser.AlterRoleSetContext context) {
+        return new AlterRoleSet<>(
             getIdentText(context.name),
             extractGenericProperties(context.genericProperties())
         );
+    }
+
+    @Override
+    public Node visitAlterRoleReset(SqlBaseParser.AlterRoleResetContext context) {
+        return new AlterRoleReset(
+            getIdentText(context.name),
+            context.ALL() == null ? getIdentText(context.property) : null);
     }
 
     @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/AlterRoleReset.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/AlterRoleReset.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.sql.tree;
+
+import java.util.Objects;
+
+import org.jetbrains.annotations.Nullable;
+
+public class AlterRoleReset extends Statement {
+
+    private final String property;
+    private final String name;
+
+    public AlterRoleReset(String name, @Nullable String property) {
+        this.property = property;
+        this.name = name;
+    }
+
+    @Nullable
+    public String property() {
+        return property;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AlterRoleReset alterRoleReset = (AlterRoleReset) o;
+        return Objects.equals(property, alterRoleReset.property) &&
+               Objects.equals(name, alterRoleReset.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(property, name);
+    }
+
+    @Override
+    public String toString() {
+        return "AlterRoleReset{" +
+               "property=" + property +
+               ", name='" + name + '\'' +
+               '}';
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitAlterRoleReset(this, context);
+    }
+}

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/AlterRoleSet.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/AlterRoleSet.java
@@ -24,12 +24,12 @@ package io.crate.sql.tree;
 import java.util.Objects;
 import java.util.function.Function;
 
-public class AlterRole<T> extends Statement {
+public class AlterRoleSet<T> extends Statement {
 
     private final GenericProperties<T> properties;
     private final String name;
 
-    public AlterRole(String name, GenericProperties<T> properties) {
+    public AlterRoleSet(String name, GenericProperties<T> properties) {
         this.properties = properties;
         this.name = name;
     }
@@ -42,8 +42,8 @@ public class AlterRole<T> extends Statement {
         return name;
     }
 
-    public <U> AlterRole<U> map(Function<? super T, ? extends U> mapper) {
-        return new AlterRole<>(name, properties.map(mapper));
+    public <U> AlterRoleSet<U> map(Function<? super T, ? extends U> mapper) {
+        return new AlterRoleSet<>(name, properties.map(mapper));
     }
 
     @Override
@@ -54,9 +54,9 @@ public class AlterRole<T> extends Statement {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        AlterRole<?> alterRole = (AlterRole<?>) o;
-        return Objects.equals(properties, alterRole.properties) &&
-               Objects.equals(name, alterRole.name);
+        AlterRoleSet<?> alterRoleSet = (AlterRoleSet<?>) o;
+        return Objects.equals(properties, alterRoleSet.properties) &&
+               Objects.equals(name, alterRoleSet.name);
     }
 
     @Override
@@ -66,7 +66,7 @@ public class AlterRole<T> extends Statement {
 
     @Override
     public String toString() {
-        return "AlterRole{" +
+        return "AlterRoleSet{" +
                "properties=" + properties +
                ", name='" + name + '\'' +
                '}';
@@ -74,6 +74,6 @@ public class AlterRole<T> extends Statement {
 
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
-        return visitor.visitAlterRole(this, context);
+        return visitor.visitAlterRoleSet(this, context);
     }
 }

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
@@ -468,7 +468,11 @@ public abstract class AstVisitor<R, C> {
         return visitStatement(node, context);
     }
 
-    public R visitAlterRole(AlterRole<?> node, C context) {
+    public R visitAlterRoleSet(AlterRoleSet<?> node, C context) {
+        return visitStatement(node, context);
+    }
+
+    public R visitAlterRoleReset(AlterRoleReset node, C context) {
         return visitStatement(node, context);
     }
 

--- a/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -37,7 +37,8 @@ import org.junit.jupiter.api.Test;
 import io.crate.sql.Literals;
 import io.crate.sql.SqlFormatter;
 import io.crate.sql.tree.AlterPublication;
-import io.crate.sql.tree.AlterRole;
+import io.crate.sql.tree.AlterRoleReset;
+import io.crate.sql.tree.AlterRoleSet;
 import io.crate.sql.tree.AlterSubscription;
 import io.crate.sql.tree.ArrayComparisonExpression;
 import io.crate.sql.tree.ArrayLikePredicate;
@@ -1906,12 +1907,20 @@ public class TestStatementBuilder {
     public void testAlterUser() {
         printStatement("alter user crate set (password = 'password')");
         printStatement("alter user crate set (password = null, session_setting='foo')");
+        printStatement("alter user crate set (password = null, session_setting=?)");
+        printStatement("alter user crate reset session_setting");
+        printStatement("alter user crate reset \"session.setting\"");
+        printStatement("alter user crate reset all");
     }
 
     @Test
     public void testAlterRole() {
         printStatement("alter role r1 set (password = 'password')");
         printStatement("alter role r1 set (password = null, session_setting='foo')");
+        printStatement("alter role r1 set (session_setting=?)");
+        printStatement("alter role r1 reset session_setting");
+        printStatement("alter role r1 reset \"session.setting\"");
+        printStatement("alter role r1 reset all");
     }
 
     @Test
@@ -1919,7 +1928,7 @@ public class TestStatementBuilder {
         assertThatThrownBy(
             () -> printStatement("alter user crate"))
             .isExactlyInstanceOf(ParsingException.class)
-            .hasMessage("line 1:17: mismatched input '<EOF>' expecting 'SET'");
+            .hasMessage("line 1:17: no viable alternative at input 'alter user crate'");
     }
 
     @Test
@@ -1927,7 +1936,7 @@ public class TestStatementBuilder {
         assertThatThrownBy(
             () -> printStatement("alter role r1"))
             .isExactlyInstanceOf(ParsingException.class)
-            .hasMessage("line 1:14: mismatched input '<EOF>' expecting 'SET'");
+            .hasMessage("line 1:14: no viable alternative at input 'alter role r1'");
     }
 
     @Test
@@ -2216,7 +2225,8 @@ public class TestStatementBuilder {
             statement instanceof GrantPrivilege ||
             statement instanceof DenyPrivilege ||
             statement instanceof RevokePrivilege ||
-            statement instanceof AlterRole ||
+            statement instanceof AlterRoleSet ||
+            statement instanceof AlterRoleReset ||
             statement instanceof DropRole ||
             statement instanceof DropAnalyzer ||
             statement instanceof DropFunction ||

--- a/server/src/main/java/io/crate/analyze/AnalyzedAlterRole.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedAlterRole.java
@@ -26,8 +26,15 @@ import io.crate.sql.tree.GenericProperties;
 
 public class AnalyzedAlterRole extends AnalyzedRole {
 
-    public AnalyzedAlterRole(String roleName, GenericProperties<Symbol> properties) {
+    private final boolean isReset;
+
+    public AnalyzedAlterRole(String roleName, GenericProperties<Symbol> properties, boolean isReset) {
         super(roleName, properties);
+        this.isReset = isReset;
+    }
+
+    public boolean isReset() {
+        return isReset;
     }
 
     @Override

--- a/server/src/main/java/io/crate/analyze/Analyzer.java
+++ b/server/src/main/java/io/crate/analyze/Analyzer.java
@@ -50,7 +50,8 @@ import io.crate.role.Role;
 import io.crate.role.Roles;
 import io.crate.sql.tree.AlterClusterRerouteRetryFailed;
 import io.crate.sql.tree.AlterPublication;
-import io.crate.sql.tree.AlterRole;
+import io.crate.sql.tree.AlterRoleReset;
+import io.crate.sql.tree.AlterRoleSet;
 import io.crate.sql.tree.AlterSubscription;
 import io.crate.sql.tree.AlterTable;
 import io.crate.sql.tree.AlterTableAddColumn;
@@ -336,11 +337,16 @@ public class Analyzer {
         }
 
         @Override
-        public AnalyzedStatement visitAlterRole(AlterRole<?> node, Analysis context) {
+        public AnalyzedStatement visitAlterRoleSet(AlterRoleSet<?> node, Analysis context) {
             return roleAnalyzer.analyze(
-                (AlterRole<Expression>) node,
+                (AlterRoleSet<Expression>) node,
                 context.paramTypeHints(),
                 context.transactionContext());
+        }
+
+        @Override
+        public AnalyzedStatement visitAlterRoleReset(AlterRoleReset node, Analysis context) {
+            return roleAnalyzer.analyze(node);
         }
 
         @Override

--- a/server/src/main/java/io/crate/metadata/settings/CoordinatorSessionSettings.java
+++ b/server/src/main/java/io/crate/metadata/settings/CoordinatorSessionSettings.java
@@ -49,11 +49,11 @@ public class CoordinatorSessionSettings extends SessionSettings {
     private String dateStyle;
     private TimeValue statementTimeout;
 
-    public CoordinatorSessionSettings(Role authenticatedUser, String ... searchPath) {
+    public CoordinatorSessionSettings(Role authenticatedUser, String... searchPath) {
         this(authenticatedUser, authenticatedUser, Set.of(), searchPath);
     }
 
-    public CoordinatorSessionSettings(Role authenticatedUser, Role sessionUser, String ... searchPath) {
+    public CoordinatorSessionSettings(Role authenticatedUser, Role sessionUser, String... searchPath) {
         this(
             authenticatedUser,
             sessionUser,
@@ -65,7 +65,7 @@ public class CoordinatorSessionSettings extends SessionSettings {
     public CoordinatorSessionSettings(Role authenticatedUser,
                                       Role sessionUser,
                                       Set<Class<? extends Rule<?>>> excludedOptimizerRules,
-                                      String ... searchPath) {
+                                      String... searchPath) {
         this(
             authenticatedUser,
             sessionUser,

--- a/server/src/main/java/io/crate/metadata/settings/session/SessionSetting.java
+++ b/server/src/main/java/io/crate/metadata/settings/session/SessionSetting.java
@@ -70,6 +70,17 @@ public class SessionSetting<T> {
         setter.accept(sessionSettings, converted);
     }
 
+    public void apply(CoordinatorSessionSettings sessionSettings, Object value) {
+        Object[] values = new Object[] {value};
+        T converted = parse.apply(values);
+        setter.accept(sessionSettings, converted);
+    }
+
+    public void validate(Object value) {
+        Object[] values = new Object[] {value};
+        parse.apply(values);
+    }
+
     public String getValue(SessionSettings sessionSettings) {
         return getter.apply(sessionSettings);
     }

--- a/server/src/main/java/io/crate/planner/Planner.java
+++ b/server/src/main/java/io/crate/planner/Planner.java
@@ -420,12 +420,12 @@ public class Planner extends AnalyzedStatementVisitor<PlannerContext, Plan> {
     @Override
     protected Plan visitAnalyzedCreateRole(AnalyzedCreateRole analysis,
                                            PlannerContext context) {
-        return new CreateRolePlan(analysis, roleManager);
+        return new CreateRolePlan(analysis, roleManager, sessionSettingRegistry);
     }
 
     @Override
     public Plan visitAnalyzedAlterRole(AnalyzedAlterRole analysis, PlannerContext context) {
-        return new AlterRolePlan(analysis, roleManager);
+        return new AlterRolePlan(analysis, roleManager, sessionSettingRegistry);
     }
 
     @Override

--- a/server/src/main/java/io/crate/planner/node/ddl/AlterRolePlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/AlterRolePlan.java
@@ -22,6 +22,7 @@
 package io.crate.planner.node.ddl;
 
 
+import java.util.Map;
 import java.util.function.Function;
 
 import io.crate.analyze.AnalyzedAlterRole;
@@ -31,6 +32,7 @@ import io.crate.data.Row1;
 import io.crate.data.RowConsumer;
 import io.crate.execution.support.OneRowActionListener;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.settings.session.SessionSettingRegistry;
 import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Plan;
 import io.crate.planner.PlannerContext;
@@ -46,10 +48,14 @@ public class AlterRolePlan implements Plan {
 
     private final RoleManager roleManager;
     private final AnalyzedAlterRole alterRole;
+    private final SessionSettingRegistry sessionSettingRegistry;
 
-    public AlterRolePlan(AnalyzedAlterRole alterRole, RoleManager roleManager) {
+    public AlterRolePlan(AnalyzedAlterRole alterRole,
+                         RoleManager roleManager,
+                         SessionSettingRegistry sessionSettingRegistry) {
         this.alterRole = alterRole;
         this.roleManager = roleManager;
+        this.sessionSettingRegistry = sessionSettingRegistry;
     }
 
     @Override
@@ -70,13 +76,23 @@ public class AlterRolePlan implements Plan {
             subQueryResults
         );
         GenericProperties<Object> evaluatedProperties = alterRole.properties().map(eval);
-        Properties roleProperties = Role.Properties.of(false, evaluatedProperties);
+        Properties roleProperties = Role.Properties.of(
+            false,
+            alterRole.isReset(),
+            evaluatedProperties,
+            sessionSettingRegistry);
         SecureHash newPassword = roleProperties.password();
         boolean resetPassword = evaluatedProperties.contains(Properties.PASSWORD_KEY) && newPassword == null;
         JwtProperties newJwtProperties = roleProperties.jwtProperties();
         boolean resetJwtProperties = evaluatedProperties.contains(Properties.JWT_KEY) && newJwtProperties == null;
 
-        roleManager.alterRole(alterRole.roleName(), newPassword, newJwtProperties, resetPassword, resetJwtProperties)
+        roleManager.alterRole(
+                alterRole.roleName(),
+                newPassword,
+                newJwtProperties,
+                resetPassword,
+                resetJwtProperties,
+                Map.of(alterRole.isReset(), roleProperties.sessionSettings()))
             .whenComplete(new OneRowActionListener<>(consumer, rCount -> new Row1(rCount == null ? -1 : rCount)));
     }
 }

--- a/server/src/main/java/io/crate/planner/node/ddl/CreateRolePlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/CreateRolePlan.java
@@ -30,6 +30,7 @@ import io.crate.data.Row1;
 import io.crate.data.RowConsumer;
 import io.crate.execution.support.OneRowActionListener;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.settings.session.SessionSettingRegistry;
 import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Plan;
 import io.crate.planner.PlannerContext;
@@ -43,10 +44,14 @@ public class CreateRolePlan implements Plan {
 
     private final AnalyzedCreateRole createRole;
     private final RoleManager roleManager;
+    private final SessionSettingRegistry sessionSettingRegistry;
 
-    public CreateRolePlan(AnalyzedCreateRole createRole, RoleManager roleManager) {
+    public CreateRolePlan(AnalyzedCreateRole createRole,
+                          RoleManager roleManager,
+                          SessionSettingRegistry sessionSettingRegistry) {
         this.createRole = createRole;
         this.roleManager = roleManager;
+        this.sessionSettingRegistry = sessionSettingRegistry;
     }
 
     @Override
@@ -68,7 +73,11 @@ public class CreateRolePlan implements Plan {
             subQueryResults
         );
         GenericProperties<Object> evaluatedProperties = createRole.properties().map(eval);
-        Properties roleProperties = Role.Properties.of(createRole.isUser(), evaluatedProperties);
+        Properties roleProperties = Role.Properties.of(
+            createRole.isUser(),
+            false,
+            evaluatedProperties,
+            sessionSettingRegistry);
         if (roleProperties.login() == false && roleProperties.password() != null) {
             throw new UnsupportedOperationException(
                 "Creating a ROLE with a password is not allowed, use CREATE USER instead");

--- a/server/src/main/java/io/crate/role/CreateRoleRequest.java
+++ b/server/src/main/java/io/crate/role/CreateRoleRequest.java
@@ -21,13 +21,13 @@
 
 package io.crate.role;
 
+import java.io.IOException;
+
 import org.elasticsearch.Version;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
-import org.jetbrains.annotations.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-
-import java.io.IOException;
+import org.jetbrains.annotations.Nullable;
 
 public class CreateRoleRequest extends AcknowledgedRequest<CreateRoleRequest> {
 
@@ -38,7 +38,6 @@ public class CreateRoleRequest extends AcknowledgedRequest<CreateRoleRequest> {
 
     @Nullable
     private final JwtProperties jwtProperties;
-
 
     public CreateRoleRequest(String roleName,
                              boolean isUser,

--- a/server/src/main/java/io/crate/role/Role.java
+++ b/server/src/main/java/io/crate/role/Role.java
@@ -28,7 +28,9 @@ import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -43,7 +45,11 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.jetbrains.annotations.Nullable;
 
+import io.crate.common.collections.Sets;
 import io.crate.metadata.pgcatalog.OidHash;
+import io.crate.metadata.settings.session.SessionSetting;
+import io.crate.metadata.settings.session.SessionSettingProvider;
+import io.crate.metadata.settings.session.SessionSettingRegistry;
 import io.crate.sql.tree.GenericProperties;
 import io.crate.types.DataTypes;
 
@@ -53,18 +59,31 @@ public class Role implements Writeable, ToXContent {
         "crate",
         new RolePrivileges(Set.of()),
         Set.of(),
-        new Properties(true, null, null),
+        new Properties(true, null, null, Map.of()),
         true);
 
+    /**
+     * Create properties to store for a user/role
+     * @param login Ability to login or not
+     * @param password User's password
+     * @param jwtProperties User's JWT properties for alternative authentication method
+     * @param sessionSettings It can contain settings defined in {@link SessionSettingRegistry} and settings dynamically
+     *                        created through {@link SessionSettingProvider}, e.g. optimizer rules.
+     */
     public record Properties(boolean login,
                              @Nullable SecureHash password,
-                             @Nullable JwtProperties jwtProperties) implements Writeable, ToXContent {
+                             @Nullable JwtProperties jwtProperties,
+                             Map<String, Object> sessionSettings) implements Writeable, ToXContent {
 
         public static final String PASSWORD_KEY = "password";
         public static final String JWT_KEY = "jwt";
 
-        public static Properties of(boolean login, GenericProperties<Object> properties) throws GeneralSecurityException {
-            properties.ensureContainsOnly(Set.of(PASSWORD_KEY, JWT_KEY));
+        public static Properties of(boolean login,
+                                    boolean isReset,
+                                    GenericProperties<Object> properties,
+                                    SessionSettingRegistry sessionSettingRegistry) throws GeneralSecurityException {
+            properties.ensureContainsOnly(
+                Sets.concat(sessionSettingRegistry.settings().keySet(), PASSWORD_KEY, JWT_KEY));
             SecureHash hash = null;
             String pw = DataTypes.STRING.implicitCast(properties.get(PASSWORD_KEY, null));
             if (pw != null) {
@@ -76,13 +95,30 @@ public class Role implements Writeable, ToXContent {
                 }
             }
             JwtProperties jwtProperties = JwtProperties.fromMap(properties.getUnsafe(JWT_KEY));
-            return new Properties(login, hash, jwtProperties);
+
+            Map<String, Object> sessionSettings = new HashMap<>();
+            for (var p : properties) {
+                String property = p.getKey();
+                if (property.equals(PASSWORD_KEY) || property.equals(JWT_KEY)) {
+                    continue;
+                }
+                Object value = p.getValue();
+                if (isReset == false) {
+                    SessionSetting<?> sessionSetting = sessionSettingRegistry.settings().get(property);
+                    assert sessionSetting != null : "sessionSetting shouldn't be null";
+                    sessionSetting.validate(value);
+                }
+                sessionSettings.put(property, value);
+            }
+
+            return new Properties(login, hash, jwtProperties, Collections.unmodifiableMap(sessionSettings));
         }
 
         public static Properties fromXContent(XContentParser parser) throws IOException {
             boolean login = false;
             SecureHash secureHash = null;
             JwtProperties jwtProperties = null;
+            Map<String, Object> sessionSettings = null;
             while (parser.nextToken() == XContentParser.Token.FIELD_NAME) {
                 switch (parser.currentName()) {
                     case "login":
@@ -95,19 +131,24 @@ public class Role implements Writeable, ToXContent {
                     case "jwt":
                         jwtProperties = JwtProperties.fromXContent(parser);
                         break;
+                    case "session_settings":
+                        parser.nextToken();
+                        sessionSettings = parser.map();
+                        break;
                     default:
                         throw new ElasticsearchParseException(
                             "failed to parse role properties, unexpected field name: " + parser.currentName()
                         );
                 }
             }
-            return new Properties(login, secureHash, jwtProperties);
+            return new Properties(login, secureHash, jwtProperties, sessionSettings);
         }
 
         public Properties(StreamInput in) throws IOException {
             this(in.readBoolean(),
                  in.readOptionalWriteable(SecureHash::readFrom),
-                 in.getVersion().onOrAfter(Version.V_5_7_0) ? in.readOptionalWriteable(JwtProperties::readFrom) : null
+                 in.getVersion().onOrAfter(Version.V_5_7_0) ? in.readOptionalWriteable(JwtProperties::readFrom) : null,
+                 in.getVersion().onOrAfter(Version.V_5_9_0) ? in.readMap() : null
             );
         }
 
@@ -120,6 +161,9 @@ public class Role implements Writeable, ToXContent {
             if (jwtProperties != null) {
                 jwtProperties.toXContent(builder, params);
             }
+            if (sessionSettings != null) {
+                builder.field("session_settings", sessionSettings);
+            }
             return builder;
         }
 
@@ -129,6 +173,9 @@ public class Role implements Writeable, ToXContent {
             out.writeOptionalWriteable(password);
             if (out.getVersion().onOrAfter(Version.V_5_7_0)) {
                 out.writeOptionalWriteable(jwtProperties);
+            }
+            if (out.getVersion().onOrAfter(Version.V_5_9_0)) {
+                out.writeMap(sessionSettings);
             }
         }
     }
@@ -145,8 +192,18 @@ public class Role implements Writeable, ToXContent {
                 Set<Privilege> privileges,
                 Set<GrantedRole> grantedRoles,
                 @Nullable SecureHash password,
-                @Nullable JwtProperties jwtProperties) {
-        this(name, new RolePrivileges(privileges), grantedRoles, new Properties(login, password, jwtProperties), false);
+                @Nullable JwtProperties jwtProperties,
+                Map<String, Object> sessionSettings) {
+        this(
+            name,
+            new RolePrivileges(privileges),
+            grantedRoles,
+            new Properties(
+                login,
+                password,
+                jwtProperties,
+                sessionSettings),
+            false);
     }
 
     private Role(String name,
@@ -189,12 +246,17 @@ public class Role implements Writeable, ToXContent {
     }
 
     public Role with(@Nullable SecureHash password,
-                     @Nullable JwtProperties jwtProperties) {
+                     @Nullable JwtProperties jwtProperties,
+                     Map<String, Object> sessionSettings) {
         return new Role(
             name,
             privileges,
             grantedRoles,
-            new Properties(properties.login, password, jwtProperties),
+            new Properties(
+                properties.login,
+                password,
+                jwtProperties,
+                sessionSettings),
             false
         );
     }
@@ -215,6 +277,10 @@ public class Role implements Writeable, ToXContent {
     @Nullable
     public JwtProperties jwtProperties() {
         return properties.jwtProperties();
+    }
+
+    public Map<String, Object> sessionSettings() {
+        return properties.sessionSettings();
     }
 
     public boolean isSuperUser() {

--- a/server/src/main/java/io/crate/role/RoleManager.java
+++ b/server/src/main/java/io/crate/role/RoleManager.java
@@ -22,6 +22,7 @@
 package io.crate.role;
 
 import java.util.Collection;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import org.jetbrains.annotations.Nullable;
@@ -42,8 +43,7 @@ public interface RoleManager extends Roles {
     CompletableFuture<Long> createRole(String roleName,
                                        boolean isUser,
                                        @Nullable SecureHash hashedPw,
-                                       @Nullable JwtProperties jwtProperties
-    );
+                                       @Nullable JwtProperties jwtProperties);
 
     /**
      * Delete a roles.
@@ -64,13 +64,19 @@ public interface RoleManager extends Roles {
      * @param newJwtProperties new jwt properties. if null properties are removed from the role
      * @param resetPassword hints how to treat NULL password: as not provided and supposed to be kept or explicitly set to NULL.
      * @param resetJwtProperties hints how to treat NULL jwt: as not provided and supposed to be kept or explicitly set to NULL.
+     * @param sessionSettingsChange session settings to change, it can hold an entry with {@code false} key, which means
+     *                              add/overwrite with the settings defined in the {@code Map<String, Object>} value of
+     *                              the entry, or an entry with {@code true} key, which means reset all the settings in
+     *                              the {@code Map<String, Object>} value of the entry, or reset all settings if this map
+     *                              is empty.
      * @return 1 if the role has been updated, otherwise a failed future.
      */
     CompletableFuture<Long> alterRole(String roleName,
                                       @Nullable SecureHash newHashedPw,
                                       @Nullable JwtProperties newJwtProperties,
                                       boolean resetPassword,
-                                      boolean resetJwtProperties);
+                                      boolean resetJwtProperties,
+                                      Map<Boolean, Map<String, Object>> sessionSettingsChange);
 
     /**
      * Apply given list of {@link Privilege}s or {@link Role} for each given role

--- a/server/src/main/java/io/crate/role/RoleManagerService.java
+++ b/server/src/main/java/io/crate/role/RoleManagerService.java
@@ -23,6 +23,7 @@ package io.crate.role;
 
 import java.util.Collection;
 import java.util.Locale;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import org.elasticsearch.client.node.NodeClient;
@@ -102,13 +103,15 @@ public class RoleManagerService implements RoleManager {
                                              @Nullable SecureHash newHashedPw,
                                              @Nullable JwtProperties newJwtProperties,
                                              boolean resetPassword,
-                                             boolean resetJwtProperties) {
+                                             boolean resetJwtProperties,
+                                             Map<Boolean, Map<String, Object>> sessionSettingsChange) {
         AlterRoleRequest request = new AlterRoleRequest(
             roleName,
             newHashedPw,
             newJwtProperties,
             resetPassword,
-            resetJwtProperties
+            resetJwtProperties,
+            sessionSettingsChange
         );
         return client.execute(TransportAlterRoleAction.ACTION, request).thenApply(r -> {
             if (r.doesUserExist() == false) {

--- a/server/src/main/java/io/crate/role/RolesService.java
+++ b/server/src/main/java/io/crate/role/RolesService.java
@@ -90,7 +90,7 @@ public class RolesService implements Roles, ClusterStateListener {
                         privileges = oldPrivileges;
                     }
                 }
-                roles.put(userName, new Role(userName, true, privileges, Set.of(), user.getValue(), null));
+                roles.put(userName, new Role(userName, true, privileges, Set.of(), user.getValue(), null, Map.of()));
             }
         } else if (rolesMetadata != null) {
             roles.putAll(rolesMetadata.roles());

--- a/server/src/main/java/io/crate/role/TransportCreateRoleAction.java
+++ b/server/src/main/java/io/crate/role/TransportCreateRoleAction.java
@@ -22,6 +22,7 @@
 package io.crate.role;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.Set;
 
 import org.elasticsearch.Version;
@@ -104,7 +105,8 @@ public class TransportCreateRoleAction extends TransportMasterNodeAction<CreateR
                             request.roleName(),
                             request.isUser(),
                             request.secureHash(),
-                            request.jwtProperties()
+                            request.jwtProperties(),
+                            Map.of()
                         );
                         return ClusterState.builder(currentState).metadata(mdBuilder).build();
                     }
@@ -131,7 +133,8 @@ public class TransportCreateRoleAction extends TransportMasterNodeAction<CreateR
                            String roleName,
                            boolean isUser,
                            @Nullable SecureHash secureHash,
-                           @Nullable JwtProperties jwtProperties) {
+                           @Nullable JwtProperties jwtProperties,
+                           Map<String, Object> sessionSettings) {
         RolesMetadata oldRolesMetadata = (RolesMetadata) mdBuilder.getCustom(RolesMetadata.TYPE);
         UsersMetadata oldUsersMetadata = (UsersMetadata) mdBuilder.getCustom(UsersMetadata.TYPE);
 
@@ -144,7 +147,14 @@ public class TransportCreateRoleAction extends TransportMasterNodeAction<CreateR
             );
         }
         if (newMetadata.contains(roleName) == false) {
-            newMetadata.roles().put(roleName, new Role(roleName, isUser, Set.of(), Set.of(), secureHash, jwtProperties));
+            newMetadata.roles().put(roleName, new Role(
+                roleName,
+                isUser,
+                Set.of(),
+                Set.of(),
+                secureHash,
+                jwtProperties,
+                sessionSettings));
             exists = false;
         } else if (newMetadata.equals(oldRolesMetadata)) {
             // nothing changed, no need to update the cluster state

--- a/server/src/main/java/io/crate/role/metadata/RolesMetadata.java
+++ b/server/src/main/java/io/crate/role/metadata/RolesMetadata.java
@@ -83,7 +83,7 @@ public class RolesMetadata extends AbstractNamedDiffable<Metadata.Custom> implem
         RolesMetadata rolesMetadata = new RolesMetadata();
         for (var user : usersMetadata.users().entrySet()) {
             var userName = user.getKey();
-            var role = new Role(userName, true, getPrivileges.apply(userName), Set.of(), user.getValue(), null);
+            var role = new Role(userName, true, getPrivileges.apply(userName), Set.of(), user.getValue(), null, Map.of());
             rolesMetadata.roles().put(userName, role);
         }
         return rolesMetadata;
@@ -239,7 +239,14 @@ public class RolesMetadata extends AbstractNamedDiffable<Metadata.Custom> implem
             }
         }
         if (affectedCount > 0) {
-            roles.put(role.name(), new Role(role.name(), role.isUser(), Set.of(), grantedRoles, role.password(), role.jwtProperties()));
+            roles.put(role.name(), new Role(
+                role.name(),
+                role.isUser(),
+                Set.of(),
+                grantedRoles,
+                role.password(),
+                role.jwtProperties(),
+                role.sessionSettings()));
         }
         return affectedCount;
     }

--- a/server/src/main/java/io/crate/role/metadata/SysUsersTableInfo.java
+++ b/server/src/main/java/io/crate/role/metadata/SysUsersTableInfo.java
@@ -24,6 +24,7 @@ package io.crate.role.metadata;
 import static io.crate.types.DataTypes.BOOLEAN;
 import static io.crate.types.DataTypes.STRING;
 
+import java.util.TreeMap;
 import java.util.function.Supplier;
 
 import io.crate.metadata.ColumnIdent;
@@ -54,6 +55,7 @@ public class SysUsersTableInfo {
                 .add("role", STRING, GrantedRole::roleName)
                 .add("grantor", STRING, GrantedRole::grantor)
             .endObjectArray()
+            .addDynamicObject("session_settings", STRING, x -> new TreeMap<>(x.sessionSettings()))
             .setPrimaryKeys(ColumnIdent.of("name"))
             .build();
     }

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -771,7 +771,8 @@ public class Node implements Closeable {
                 dependencyCarrier,
                 jobsLogService.get(),
                 settings,
-                clusterService
+                clusterService,
+                sessionSettingRegistry
             );
             final HttpServerTransport httpServerTransport = newHttpTransport(
                 networkService,

--- a/server/src/test/java/io/crate/analyze/RoleDDLAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/RoleDDLAnalyzerTest.java
@@ -131,26 +131,60 @@ public class RoleDDLAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testCreateUserWithPasswordIsStringLiteral() throws Exception {
-        String userOrRole = randomBoolean() ? "USER" : "ROLE";
-        assertThatThrownBy(() -> e.analyze("CREATE " + userOrRole + " ROOT WITH (PASSWORD = NO_STRING)"))
-            .isExactlyInstanceOf(UnsupportedOperationException.class)
-            .hasMessage("Columns cannot be used in this context. " +
-                        "Maybe you wanted to use a string literal which requires single quotes: 'no_string'");
+        for (String userOrRole : List.of("USER", "ROLE")) {
+            assertThatThrownBy(() -> e.analyze("CREATE " + userOrRole + " ROOT WITH (PASSWORD = NO_STRING)"))
+                .isExactlyInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("Columns cannot be used in this context. " +
+                    "Maybe you wanted to use a string literal which requires single quotes: 'no_string'");
+        }
+    }
+
+    @Test
+    public void test_create_user_and_role_with_invalid_settings() throws Exception {
+        for (String userOrRole : List.of("USER", "ROLE")) {
+            assertThatThrownBy(() -> e.analyze("CREATE " + userOrRole + " ROOT WITH (enable_hashjoin = false)"))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Setting 'enable_hashjoin' is not supported");
+        }
     }
 
     @Test
     public void test_alter_role_with_password() throws Exception {
-        String userOrRole = randomBoolean() ? "USER" : "ROLE";
-        AnalyzedAlterRole analysis = e.analyze("ALTER " + userOrRole + " ROOT SET (PASSWORD = 'ROOT')");
-        assertThat(analysis.roleName()).isEqualTo("root");
-        assertThat(analysis.properties().get("password")).isLiteral("ROOT");
+        for (String userOrRole : List.of("USER", "ROLE")) {
+            AnalyzedAlterRole analysis = e.analyze("ALTER " + userOrRole + " ROOT SET (PASSWORD = 'ROOT')");
+            assertThat(analysis.roleName()).isEqualTo("root");
+            assertThat(analysis.properties().get("password")).isLiteral("ROOT");
+            assertThat(analysis.isReset()).isFalse();
+        }
     }
 
     @Test
     public void test_alter_role_reset_password() throws Exception {
-        String userOrRole = randomBoolean() ? "USER" : "ROLE";
-        AnalyzedAlterRole analysis = e.analyze("ALTER " + userOrRole + " ROOT SET (PASSWORD = NULL)");
-        assertThat(analysis.roleName()).isEqualTo("root");
-        assertThat(analysis.properties().get("password")).isLiteral(null, DataTypes.UNDEFINED);
+        for (String userOrRole : List.of("USER", "ROLE")) {
+            AnalyzedAlterRole analysis = e.analyze("ALTER " + userOrRole + " ROOT SET (PASSWORD = NULL)");
+            assertThat(analysis.roleName()).isEqualTo("root");
+            assertThat(analysis.properties().get("password")).isLiteral(null, DataTypes.UNDEFINED);
+            assertThat(analysis.isReset()).isFalse();
+        }
+    }
+
+    @Test
+    public void test_alter_role_reset_session_setting() throws Exception {
+        for (String userOrRole : List.of("USER", "ROLE")) {
+            AnalyzedAlterRole analysis = e.analyze("ALTER " + userOrRole + " ROOT RESET enable_hashjoin");
+            assertThat(analysis.roleName()).isEqualTo("root");
+            assertThat(analysis.properties().contains("enable_hashjoin")).isTrue();
+            assertThat(analysis.isReset()).isTrue();
+        }
+    }
+
+    @Test
+    public void test_alter_role_all_settings() throws Exception {
+        for (String userOrRole : List.of("USER", "ROLE")) {
+            AnalyzedAlterRole analysis = e.analyze("ALTER " + userOrRole + " ROOT RESET ALL");
+            assertThat(analysis.roleName()).isEqualTo("root");
+            assertThat(analysis.properties().isEmpty()).isTrue();
+            assertThat(analysis.isReset()).isTrue();
+        }
     }
 }

--- a/server/src/test/java/io/crate/auth/UserAuthenticationMethodTest.java
+++ b/server/src/test/java/io/crate/auth/UserAuthenticationMethodTest.java
@@ -342,7 +342,8 @@ public class UserAuthenticationMethodTest extends ESTestCase {
             Set.of(),
             Set.of(),
             null,
-            new JwtProperties("dummy", "dummy", null)
+            new JwtProperties("dummy", "dummy", null),
+            Map.of()
         );
         Roles roles = () -> List.of(userWithModifiedJwtProperty);
         JWTAuthenticationMethod jwtAuth = new JWTAuthenticationMethod(

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -569,7 +569,7 @@ public class InformationSchemaTest extends IntegTestCase {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertThat(response.rowCount()).isEqualTo(1012);
+        assertThat(response.rowCount()).isEqualTo(1013);
     }
 
     @Test

--- a/server/src/test/java/io/crate/role/AlterRoleRequestTest.java
+++ b/server/src/test/java/io/crate/role/AlterRoleRequestTest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.role;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Test;
+
+public class AlterRoleRequestTest extends ESTestCase {
+
+    @Test
+    public void testStreaming() throws Exception {
+        var arr1 =
+            new AlterRoleRequest("testUser",
+                SecureHash.of(new SecureString("passwd".toCharArray())),
+                new JwtProperties("https:dummy.org", "test", "test_aud"),
+                true,
+                true,
+                Map.of(true, Map.of("enable_hashjoin", "false", "statement_timeout", "10m"))
+            );
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        arr1.writeTo(out);
+        var arr2 = new AlterRoleRequest(out.bytes().streamInput());
+        assertThat(arr2.roleName()).isEqualTo(arr1.roleName());
+        assertThat(arr2.secureHash()).isEqualTo(arr1.secureHash());
+        var jwtProps = arr2.jwtProperties();
+        assertThat(jwtProps).isNotNull();
+        assertThat(jwtProps.iss()).isEqualTo("https:dummy.org");
+        assertThat(jwtProps.username()).isEqualTo("test");
+        assertThat(jwtProps.aud()).isEqualTo("test_aud");
+        assertThat(arr2.resetPassword()).isTrue();
+        assertThat(arr2.resetJwtProperties()).isTrue();
+        assertThat(arr2.sessionSettingsChange()).isEqualTo(arr1.sessionSettingsChange());
+
+        out = new BytesStreamOutput();
+        out.setVersion(Version.V_5_5_0);
+        arr1.writeTo(out);
+        var in = out.bytes().streamInput();
+        in.setVersion(Version.V_5_5_0);
+        arr2 = new AlterRoleRequest(in);
+        assertThat(arr2.roleName()).isEqualTo(arr1.roleName());
+        assertThat(arr2.secureHash()).isEqualTo(arr1.secureHash());
+        assertThat(arr2.resetPassword()).isFalse();
+        assertThat(arr2.resetJwtProperties()).isFalse();
+        assertThat(arr2.jwtProperties()).isNull();
+        assertThat(arr2.sessionSettingsChange()).isEmpty();
+
+        out = new BytesStreamOutput();
+        out.setVersion(Version.V_5_8_0);
+        arr1.writeTo(out);
+        in = out.bytes().streamInput();
+        in.setVersion(Version.V_5_8_0);
+        arr2 = new AlterRoleRequest(in);
+        assertThat(arr2.roleName()).isEqualTo(arr1.roleName());
+        assertThat(arr2.secureHash()).isEqualTo(arr1.secureHash());
+        assertThat(arr2.resetPassword()).isTrue();
+        assertThat(arr2.resetJwtProperties()).isTrue();
+        assertThat(arr2.jwtProperties()).isEqualTo(arr1.jwtProperties());
+        assertThat(arr2.sessionSettingsChange()).isEmpty();
+    }
+
+    @Test
+    public void testStreaming_with_empty_and_nulls() throws Exception {
+        var arr1 =
+            new AlterRoleRequest("testUser",
+                null,
+                null,
+                false,
+                false,
+                Map.of()
+            );
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        arr1.writeTo(out);
+        var arr2 = new AlterRoleRequest(out.bytes().streamInput());
+        assertThat(arr2.roleName()).isEqualTo("testUser");
+        assertThat(arr2.secureHash()).isNull();
+        assertThat(arr2.jwtProperties()).isNull();
+        assertThat(arr2.resetPassword()).isFalse();
+        assertThat(arr2.resetJwtProperties()).isFalse();
+        assertThat(arr2.sessionSettingsChange()).isEmpty();
+
+        arr1 =
+            new AlterRoleRequest("testUser",
+                null,
+                null,
+                false,
+                false,
+                Map.of(true, Map.of())
+            );
+
+        out = new BytesStreamOutput();
+        arr1.writeTo(out);
+        arr2 = new AlterRoleRequest(out.bytes().streamInput());
+        assertThat(arr2.roleName()).isEqualTo("testUser");
+        assertThat(arr2.secureHash()).isNull();
+        assertThat(arr2.jwtProperties()).isNull();
+        assertThat(arr2.resetPassword()).isFalse();
+        assertThat(arr2.resetJwtProperties()).isFalse();
+        assertThat(arr2.sessionSettingsChange()).containsExactly(Map.entry(true, Map.of()));
+    }
+}

--- a/server/src/test/java/io/crate/role/RolePropertiesTest.java
+++ b/server/src/test/java/io/crate/role/RolePropertiesTest.java
@@ -19,23 +19,26 @@
  * software solely pursuant to the terms of the relevant commercial agreement.
  */
 
-package io.crate.planner.node.ddl;
+package io.crate.role;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Map;
+import java.util.Set;
 
 import org.junit.Test;
 
-import io.crate.role.Role;
+import io.crate.metadata.settings.session.SessionSettingRegistry;
 import io.crate.sql.tree.GenericProperties;
 
-public class CreateRolePlanTest {
+public class RolePropertiesTest {
+
+    private final SessionSettingRegistry sessionSettingRegistry = new SessionSettingRegistry(Set.of());
 
     @Test
-    public void test_invalid_password_property() throws Exception {
+    public void test_invalid_property() throws Exception {
         GenericProperties<Object> properties = new GenericProperties<>(Map.of("invalid", "password"));
-        assertThatThrownBy(() -> Role.Properties.of(true, properties))
+        assertThatThrownBy(() -> Role.Properties.of(true, false, properties, sessionSettingRegistry))
             .isExactlyInstanceOf(IllegalArgumentException.class)
             .hasMessage("Setting 'invalid' is not supported");
     }
@@ -43,7 +46,7 @@ public class CreateRolePlanTest {
     @Test
     public void test_empty_password_string_is_rejected() throws Exception {
         GenericProperties<Object> properties = new GenericProperties<>(Map.of("password", ""));
-        assertThatThrownBy(() -> Role.Properties.of(true, properties))
+        assertThatThrownBy(() -> Role.Properties.of(true, false, properties, sessionSettingRegistry))
             .isExactlyInstanceOf(IllegalArgumentException.class)
             .hasMessage("Password must not be empty");
     }
@@ -52,15 +55,39 @@ public class CreateRolePlanTest {
     public void test_invalid_jwt_property() throws Exception {
         // Missing jwt property
         GenericProperties<Object> properties = new GenericProperties<>(Map.of("jwt", Map.of("iss", "dummy.org")));
-        assertThatThrownBy(() -> Role.Properties.of(true, properties))
+        assertThatThrownBy(() -> Role.Properties.of(true, false, properties, sessionSettingRegistry))
             .isExactlyInstanceOf(IllegalArgumentException.class)
             .hasMessage("JWT property 'username' must have a non-null value");
 
         // Invalid jwt property
         GenericProperties<Object> properties2 = new GenericProperties<>(Map.of("jwt",
             Map.of("iss", "dummy.org", "username", "test", "dummy_property", "dummy_val")));
-        assertThatThrownBy(() -> Role.Properties.of(true, properties2))
+        assertThatThrownBy(() -> Role.Properties.of(true, false, properties2, sessionSettingRegistry))
             .isExactlyInstanceOf(IllegalArgumentException.class)
             .hasMessage("Only 'iss', 'username' and 'aud' JWT properties are allowed");
+    }
+
+    @Test
+    public void test_session_property_with_invalid_value() {
+        GenericProperties<Object> properties = new GenericProperties<>(Map.of("statement_timeout", "invalid"));
+        assertThatThrownBy(() -> Role.Properties.of(true, false, properties, sessionSettingRegistry))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Invalid interval format: invalid");
+    }
+
+    @Test
+    public void test_session_property_which_is_read_only() {
+        GenericProperties<Object> properties = new GenericProperties<>(Map.of("server_version", "1.0.0."));
+        assertThatThrownBy(() -> Role.Properties.of(true, false, properties, sessionSettingRegistry))
+            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .hasMessage("\"server_version\" cannot be changed.");
+    }
+
+    @Test
+    public void test_session_setting_reset_invalid_session_setting() {
+        GenericProperties<Object> properties = new GenericProperties<>(Map.of("invalid_property", "NULL"));
+        assertThatThrownBy(() -> Role.Properties.of(true, false, properties, sessionSettingRegistry))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Setting 'invalid_property' is not supported");
     }
 }

--- a/server/src/test/java/io/crate/role/metadata/RolesHelper.java
+++ b/server/src/test/java/io/crate/role/metadata/RolesHelper.java
@@ -166,11 +166,11 @@ public final class RolesHelper {
     }
 
     public static Role userOf(String name, Set<Privilege> privileges, @Nullable SecureHash password) {
-        return new Role(name, true, privileges, Set.of(), password, null);
+        return new Role(name, true, privileges, Set.of(), password, null, Map.of());
     }
 
     public static Role userOf(String name, Set<Privilege> privileges, Set<GrantedRole> grantedRoles, @Nullable SecureHash password) {
-        return new Role(name, true, privileges, grantedRoles, password, null);
+        return new Role(name, true, privileges, grantedRoles, password, null, Map.of());
     }
 
     public static Role userOf(String name,
@@ -178,23 +178,29 @@ public final class RolesHelper {
                               Set<GrantedRole> grantedRoles,
                               @Nullable SecureHash password,
                               @Nullable JwtProperties jwtProperties) {
-        return new Role(name, true, privileges, grantedRoles, password, jwtProperties);
+        return new Role(name, true, privileges, grantedRoles, password, jwtProperties, Map.of());
+    }
+
+    public static Role userOf(String name,
+                              @Nullable SecureHash password,
+                              Map<String, Object> sessionSettings) {
+        return new Role(name, true, Set.of(), Set.of(), password, null, sessionSettings);
     }
 
     public static Role roleOf(String name) {
-        return new Role(name, false, Set.of(), Set.of(), null, null);
+        return new Role(name, false, Set.of(), Set.of(), null, null, Map.of());
     }
 
     public static Role roleOf(String name, Set<Privilege> privileges, List<String> grantedRoles) {
-        return new Role(name, false, privileges, buildGrantedRoles(grantedRoles), null, null);
+        return new Role(name, false, privileges, buildGrantedRoles(grantedRoles), null, null, Map.of());
     }
 
     public static Role roleOf(String name, Set<Privilege> privileges) {
-        return new Role(name, false, privileges, Set.of(), null, null);
+        return new Role(name, false, privileges, Set.of(), null, null, Map.of());
     }
 
     public static Role roleOf(String name, List<String> grantedRoles) {
-        return new Role(name, false, Set.of(), buildGrantedRoles(grantedRoles), null, null);
+        return new Role(name, false, Set.of(), buildGrantedRoles(grantedRoles), null, null, Map.of());
     }
 
     @NotNull

--- a/server/src/test/java/io/crate/role/metadata/RolesMetadataTest.java
+++ b/server/src/test/java/io/crate/role/metadata/RolesMetadataTest.java
@@ -33,7 +33,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -73,13 +72,14 @@ public class RolesMetadataTest extends ESTestCase {
             Set.of(),
             DummyParentRoles,
             getSecureHash("fords-pwd")));
-        DummyUsersAndRolesWithParentRoles.put("John", userOf(
-            "John",
-            Set.of(),
-            new HashSet<>(),
-            getSecureHash("johns-pwd"),
-            new JwtProperties("https:dummy.org", "test", null))
-        );
+
+        var passwd = getSecureHash("johns-pwd");
+        var jwt = new JwtProperties("https:dummy.org", "test", null);
+        DummyUsersAndRolesWithParentRoles.put("John", userOf("John", passwd).with(
+            passwd,
+            jwt,
+            Map.of("statement_timeout", "1m", "enable_hashjoin", false)
+        ));
         DummyUsersAndRolesWithParentRoles.put("role1", roleOf("role1"));
         DummyUsersAndRolesWithParentRoles.put("role2", roleOf("role2"));
         DummyUsersAndRolesWithParentRoles.put("role3", roleOf("role3"));

--- a/server/src/testFixtures/java/io/crate/role/StubRoleManager.java
+++ b/server/src/testFixtures/java/io/crate/role/StubRoleManager.java
@@ -23,6 +23,7 @@ package io.crate.role;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import org.jetbrains.annotations.Nullable;
@@ -65,7 +66,8 @@ public class StubRoleManager implements RoleManager {
                                              @Nullable SecureHash newHashedPw,
                                              @Nullable JwtProperties newJwtProperties,
                                              boolean resetPassword,
-                                             boolean resetJwtProperties) {
+                                             boolean resetJwtProperties,
+                                             Map<Boolean, Map<String, Object>> sessionSettingsChange) {
         return CompletableFuture.failedFuture(new UnsupportedFeatureException("alterRole is not implemented in StubRoleManager"));
     }
 

--- a/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
@@ -226,7 +226,7 @@ public class SQLExecutor {
 
 
     /**
-     * Shortcut for {@link #getPlannerContext(ClusterState, Random)}
+     * Shortcut for {@link #getPlannerContext(Random)}
      * This can only be used if {@link com.carrotsearch.randomizedtesting.RandomizedContext} is available
      * (e.g. TestCase using {@link com.carrotsearch.randomizedtesting.RandomizedRunner}
      */
@@ -401,6 +401,7 @@ public class SQLExecutor {
                         sessionSettingRegistry
                     ),
                 relationAnalyzer,
+                sessionSettingRegistry,
                 new CoordinatorSessionSettings(Role.CRATE_USER, Role.CRATE_USER, LoadedRules.INSTANCE.disabledRules()),
                 nodeCtx.schemas(),
                 Randomness.get(),
@@ -459,6 +460,7 @@ public class SQLExecutor {
                         Analyzer analyzer,
                         Planner planner,
                         RelationAnalyzer relAnalyzer,
+                        SessionSettingRegistry sessionSettingRegistry,
                         CoordinatorSessionSettings sessionSettings,
                         Schemas schemas,
                         Random random,
@@ -480,7 +482,8 @@ public class SQLExecutor {
             () -> dependencyMock,
             jobsLogs,
             clusterService.getSettings(),
-            clusterService
+            clusterService,
+            sessionSettingRegistry
         );
         this.analyzer = analyzer;
         this.planner = planner;


### PR DESCRIPTION
Added support for `ALTER USER SET (<session_setting> = <value>, ...)
Session settings are added if not existing on the user, or override existing settings,
previously set with `ALTER USER SET` statements.
Session settings can be reset to their default values with `ALTER USER RESET <session_setting>`
or with `ALTER USER RESET ALL` which resets all session settings to their default values.
The session settings get applied only to new sessions opened by the user.

Session settings are only allowed to be set on a user, not on roles, and inheritance is not supported.
Session settings are not applied when `SET SESSION AUTHORIZATION <user>` is executed.
See https://github.com/crate/crate/issues/16074 for details and investigation on PostgreSQL behavior.

Closes: #16074