### PR TITLE
tests: Fix flaky test_pk_extraction_breaks_after_x_iterations

### DIFF
--- a/server/src/test/java/io/crate/analyze/where/EqualityExtractorTest.java
+++ b/server/src/test/java/io/crate/analyze/where/EqualityExtractorTest.java
@@ -389,7 +389,7 @@ public class EqualityExtractorTest extends EqualityExtractorBaseTest {
     @Test
     public void test_pk_extraction_breaks_after_x_iterations() {
         StringJoiner sj = new StringJoiner(" or ");
-        for (int j = 0; j < 50; j++) {
+        for (int j = 0; j < 20; j++) {
             sj.add("x = ? AND i = ?");
         }
 


### PR DESCRIPTION
Reduce the number of expressions to make sure it extracts the pks with 100 iterations.

Tested with 5000 iterations and it works, previously there were around 20 failures out of the 5000 iterations.

https://wacklig.pipifein.dev/github/crate/crate/case/io.crate.analyze.where.EqualityExtractorTest/test_pk_extraction_breaks_after_x_iterations