### PR TITLE
Don't sample docs from relocating shards during ANALYZE

### DIFF
--- a/docs/appendices/release-notes/5.7.4.rst
+++ b/docs/appendices/release-notes/5.7.4.rst
@@ -48,4 +48,5 @@ See the :ref:`version_5.7.0` release notes for a full list of changes in the
 Fixes
 =====
 
-None
+- Fixed an issue that could lead to ``ANALYZE`` over account the number of
+  documents in a table if shards were relocating.

--- a/docs/appendices/release-notes/5.8.1.rst
+++ b/docs/appendices/release-notes/5.8.1.rst
@@ -47,5 +47,8 @@ See the :ref:`version_5.8.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that could lead to ``ANALYZE`` over account the number of
+  documents in a table if shards were relocating.
+
 - Fixed a regression introduced in 5.8.0 that led to error when running a query
   ``SELECT * FROM sys.nodes`` in a mixed cluster.

--- a/server/src/main/java/io/crate/statistics/PublishTableStatsRequest.java
+++ b/server/src/main/java/io/crate/statistics/PublishTableStatsRequest.java
@@ -21,14 +21,15 @@
 
 package io.crate.statistics;
 
-import io.crate.metadata.RelationName;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.transport.TransportRequest;
 
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
+import io.crate.metadata.RelationName;
 
 public final class PublishTableStatsRequest extends TransportRequest {
 
@@ -40,7 +41,7 @@ public final class PublishTableStatsRequest extends TransportRequest {
 
     public PublishTableStatsRequest(StreamInput in) throws IOException {
         int numRelations = in.readVInt();
-        statsByRelation = new HashMap<>();
+        statsByRelation = HashMap.newHashMap(numRelations);
         for (int i = 0; i < numRelations; i++) {
             statsByRelation.put(new RelationName(in), new Stats(in));
         }

--- a/server/src/main/java/io/crate/statistics/ReservoirSampler.java
+++ b/server/src/main/java/io/crate/statistics/ReservoirSampler.java
@@ -46,6 +46,7 @@ import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.RateLimiter;
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.breaker.CircuitBreaker;
@@ -191,7 +192,8 @@ public final class ReservoirSampler {
                     = getCollectorExpressions(indexService, docTable, columns);
 
                 for (IndexShard indexShard : indexService) {
-                    if (!indexShard.routingEntry().primary()) {
+                    ShardRouting routingEntry = indexShard.routingEntry();
+                    if (!routingEntry.primary() || !routingEntry.active()) {
                         continue;
                     }
                     try {

--- a/server/src/main/java/io/crate/statistics/Stats.java
+++ b/server/src/main/java/io/crate/statistics/Stats.java
@@ -26,14 +26,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.jetbrains.annotations.Nullable;
-
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
+
 import io.crate.common.collections.Maps;
 import io.crate.expression.symbol.AliasSymbol;
 import io.crate.expression.symbol.ScopedSymbol;
@@ -70,7 +69,7 @@ public class Stats implements Writeable {
         this.numDocs = in.readLong();
         this.sizeInBytes = in.readLong();
         int numColumnStats = in.readVInt();
-        this.statsByColumn = new HashMap<>();
+        this.statsByColumn = HashMap.newHashMap(numColumnStats);
         for (int i = 0; i < numColumnStats; i++) {
             statsByColumn.put(ColumnIdent.of(in), new ColumnStats<>(in));
         }

--- a/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -48,7 +48,6 @@ import io.crate.statistics.Stats;
 import io.crate.statistics.TableStats;
 import io.crate.testing.Asserts;
 import io.crate.testing.UseHashJoins;
-import io.crate.testing.UseJdbc;
 import io.crate.testing.UseRandomizedOptimizerRules;
 import io.crate.testing.UseRandomizedSchema;
 import io.crate.types.DataTypes;
@@ -1524,7 +1523,6 @@ public class JoinIntegrationTest extends IntegTestCase {
      *
      * https://github.com/crate/crate/issues/14583
      */
-    @UseJdbc(1)
     @UseHashJoins(1)
     @UseRandomizedSchema(random = false)
     @UseRandomizedOptimizerRules(0)


### PR DESCRIPTION
Fixes flaky:

- `test_ensure_hash_symbols_match_after_hash_join_is_reordered`
- `test_analyze_statement_refreshes_table_stats_and_stats_are_visible_in_pg_class_and_pg_stats`

If a shard is relocating `ANALYZE` counted the number of documents and
took samples as seen in the following log output:

    [[cratedb[node_sd2][search][T#1]]] Get samples for index=[t1][3], numDocs=1 active=true relocating=true routingEntry=node[E_1OXWhCSUC5q60m5UBklg], relocating [k01O8dHESK-cxLgBDQHMFQ], [P], s[RELOCATING], a[id=ALnPxa0cQiGl5SXmpOM7og, rId=hlwvtMuyTwS9GKt7LqQV5w]
    [[cratedb[node_sd3][search][T#2]]] Get samples for index=[t2][3], numDocs=0 active=true relocating=false routingEntry=node[qDBaObG1Sia7Ad4UDJNDjA], [P], s[STARTED], a[id=mDSdJlh7QW-17ZtRNd6JBw]
    [[cratedb[node_sd2][search][T#3]]] Get samples for index=[t3][5], numDocs=1 active=true relocating=false routingEntry=node[E_1OXWhCSUC5q60m5UBklg], [P], s[STARTED], a[id=-X7--tr0RhSEJYCoSTS5Cg]
    [[cratedb[node_sd1][search][T#1]]] Get samples for index=[t1][3], numDocs=1 active=false relocating=false routingEntry=node[k01O8dHESK-cxLgBDQHMFQ], relocating [E_1OXWhCSUC5q60m5UBklg], [P], recovery_source[peer recovery], s[INITIALIZING], a[id=hlwvtMuyTwS9GKt7LqQV5w, rId=ALnPxa0cQiGl5SXmpOM7og]
