### PR TITLE
Fix `refMatchesAnyArrayLiteral` for empty arrays or array of nulls

### DIFF
--- a/docs/appendices/release-notes/5.8.2.rst
+++ b/docs/appendices/release-notes/5.8.2.rst
@@ -61,3 +61,7 @@ Fixes
 - Fixed an issue that caused ``WHERE`` clause containing ``ARRAY_LENGTH``
   scalar on an array type that is a child of an object array to match and
   return a wrong result set.
+
+- Fixed an issue that caused ``WHERE`` clause to fail to filter rows when the
+  clause contained :ref:`ANY <sql_any_array_comparison>` over array literals
+  that are empty or containing only nulls.

--- a/server/src/main/java/io/crate/expression/operator/any/AnyEqOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/any/AnyEqOperator.java
@@ -29,6 +29,7 @@ import java.util.function.Consumer;
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
+import org.jetbrains.annotations.NotNull;
 
 import io.crate.expression.operator.EqOperator;
 import io.crate.expression.symbol.Function;
@@ -57,11 +58,10 @@ public final class AnyEqOperator extends AnyOperator<Object> {
     }
 
     @Override
-    protected Query refMatchesAnyArrayLiteral(Function any, Reference probe, Literal<?> candidates, Context context) {
+    protected Query refMatchesAnyArrayLiteral(Function any, Reference probe, @NotNull List<?> nonNullValues, Context context) {
         String columnName = probe.storageIdent();
-        List<?> values = (List<?>) candidates.value();
         DataType<?> innerType = ArrayType.unnest(probe.valueType());
-        return EqOperator.termsQuery(columnName, innerType, values, probe.hasDocValues(), probe.indexType());
+        return EqOperator.termsQuery(columnName, innerType, nonNullValues, probe.hasDocValues(), probe.indexType());
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/operator/any/AnyNeqOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/any/AnyNeqOperator.java
@@ -21,11 +21,14 @@
 
 package io.crate.expression.operator.any;
 
+import java.util.List;
+
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.common.lucene.search.Queries;
+import org.jetbrains.annotations.NotNull;
 
 import io.crate.expression.operator.EqOperator;
 import io.crate.expression.predicate.IsNullPredicate;
@@ -54,14 +57,11 @@ public final class AnyNeqOperator extends AnyOperator<Object> {
     }
 
     @Override
-    protected Query refMatchesAnyArrayLiteral(Function any, Reference probe, Literal<?> candidates, Context context) {
+    protected Query refMatchesAnyArrayLiteral(Function any, Reference probe, @NotNull List<?> nonNullValues, Context context) {
         //  col != ANY ([1,2,3]) --> not(col=1 and col=2 and col=3)
         String columnName = probe.storageIdent();
         BooleanQuery.Builder andBuilder = new BooleanQuery.Builder();
-        for (Object value : (Iterable<?>) candidates.value()) {
-            if (value == null) {
-                continue;
-            }
+        for (Object value : nonNullValues) {
             var fromPrimitive = EqOperator.fromPrimitive(
                 probe.valueType(),
                 columnName,

--- a/server/src/main/java/io/crate/expression/operator/any/AnyNotLikeOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/any/AnyNotLikeOperator.java
@@ -21,6 +21,8 @@
 
 package io.crate.expression.operator.any;
 
+import java.util.List;
+
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
@@ -28,6 +30,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.RegexpQuery;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.index.query.RegexpFlag;
+import org.jetbrains.annotations.NotNull;
 
 import io.crate.expression.operator.LikeOperators;
 import io.crate.expression.operator.LikeOperators.CaseSensitivity;
@@ -62,15 +65,11 @@ public final class AnyNotLikeOperator extends AnyOperator<String> {
     }
 
     @Override
-    protected Query refMatchesAnyArrayLiteral(Function any, Reference probe, Literal<?> candidates, Context context) {
+    protected Query refMatchesAnyArrayLiteral(Function any, Reference probe, @NotNull List<?> nonNullValues, Context context) {
         // col not like ANY (['a', 'b']) --> not(and(like(col, 'a'), like(col, 'b')))
         String columnName = probe.storageIdent();
         BooleanQuery.Builder andLikeQueries = new BooleanQuery.Builder();
-        Iterable<?> values = (Iterable<?>) candidates.value();
-        for (Object value : values) {
-            if (value == null) {
-                continue;
-            }
+        for (Object value : nonNullValues) {
             var likeQuery = caseSensitivity.likeQuery(columnName,
                 (String) value,
                 LikeOperators.DEFAULT_ESCAPE,

--- a/server/src/main/java/io/crate/expression/operator/any/AnyRangeOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/any/AnyRangeOperator.java
@@ -22,9 +22,12 @@
 package io.crate.expression.operator.any;
 
 
+import java.util.List;
+
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.Query;
+import org.jetbrains.annotations.NotNull;
 
 import io.crate.exceptions.UnsupportedFeatureException;
 import io.crate.expression.operator.CmpOperator;
@@ -101,14 +104,11 @@ public final class AnyRangeOperator extends AnyOperator<Object> {
     }
 
     @Override
-    protected Query refMatchesAnyArrayLiteral(Function any, Reference probe, Literal<?> candidates, Context context) {
+    protected Query refMatchesAnyArrayLiteral(Function any, Reference probe, @NotNull List<?> nonNullValues, Context context) {
         // col < ANY ([1,2,3]) --> or(col<1, col<2, col<3)
         BooleanQuery.Builder booleanQuery = new BooleanQuery.Builder();
         booleanQuery.setMinimumNumberShouldMatch(1);
-        for (Object value : (Iterable<?>) candidates.value()) {
-            if (value == null) {
-                continue;
-            }
+        for (Object value : nonNullValues) {
             booleanQuery.add(
                 CmpOperator.toQuery(comparison.innerOpName, probe, value),
                 BooleanClause.Occur.SHOULD);

--- a/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -676,6 +676,42 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
     }
 
     @Test
+    public void test_any_operators_with_empty_array_literal() {
+        Query query = convert("x != any([])");
+        assertThat(query).hasToString("MatchNoDocsQuery(\"Cannot match unless there is at least one non-null candidate\")");
+
+        query = convert("x = any([])");
+        assertThat(query).hasToString("MatchNoDocsQuery(\"Cannot match unless there is at least one non-null candidate\")");
+
+        query = convert("x < any([])");
+        assertThat(query).hasToString("MatchNoDocsQuery(\"Cannot match unless there is at least one non-null candidate\")");
+
+        query = convert("name like any([])");
+        assertThat(query).hasToString("MatchNoDocsQuery(\"Cannot match unless there is at least one non-null candidate\")");
+
+        query = convert("name not ilike any([])");
+        assertThat(query).hasToString("MatchNoDocsQuery(\"Cannot match unless there is at least one non-null candidate\")");
+    }
+
+    @Test
+    public void test_any_operators_with_null_array_literal() {
+        Query query = convert("x != any([null])");
+        assertThat(query).hasToString("MatchNoDocsQuery(\"Cannot match unless there is at least one non-null candidate\")");
+
+        query = convert("x = any([null])");
+        assertThat(query).hasToString("MatchNoDocsQuery(\"Cannot match unless there is at least one non-null candidate\")");
+
+        query = convert("x < any([null])");
+        assertThat(query).hasToString("MatchNoDocsQuery(\"Cannot match unless there is at least one non-null candidate\")");
+
+        query = convert("name like any([null])");
+        assertThat(query).hasToString("MatchNoDocsQuery(\"Cannot match unless there is at least one non-null candidate\")");
+
+        query = convert("name not ilike any([null])");
+        assertThat(query).hasToString("MatchNoDocsQuery(\"Cannot match unless there is at least one non-null candidate\")");
+    }
+
+    @Test
     public void test_any_neq_operator_maps_column_names_to_oids() throws Exception {
         final long oid = 123;
         try (QueryTester tester = new QueryTester.Builder(


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Follows #14811 which only handled null elements in the arrays. This PR fixes when the input to `any` operator is an empty array or array of nulls. In such cases, we should return empty results since there are no candidates to compare against.

```
create table t (c text);
insert into t values ('a');

--Postgres:
select * from t where c = any(array[]::text[]); -- no rows
select * from t where c != any(array[]::text[]); -- no rows
select * from t where c = any(array[null]::text[]); -- no rows
select * from t where c != any(array[null]::text[]); -- no rows

--CrateDB:
cr> select * from t where c = any([]);
+---+
| c |
+---+
+---+
SELECT 0 rows in set (0.003 sec)
cr> select * from t where c != any([]);
+---+
| c |
+---+
| a |
+---+
SELECT 1 row in set (0.006 sec)
cr> select * from t where c = any([null]);
+---+
| c |
+---+
+---+
SELECT 0 rows in set (0.010 sec)
cr> select * from t where c != any([null]);
+---+
| c |
+---+
| a |
+---+
SELECT 1 row in set (0.011 sec)
```

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
