### PR TITLE
Make Aggregation parameters position aware

### DIFF
--- a/docs/appendices/release-notes/5.7.4.rst
+++ b/docs/appendices/release-notes/5.7.4.rst
@@ -48,6 +48,12 @@ See the :ref:`version_5.7.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that caused an ``IndexOutOfBoundsException`` when the
+  :ref:`max_by <aggregation-max_by>` aggregation was called with a literal
+  as searchfield parameter instead of a column e.g.::
+
+    SELECT MAX_BY(x, 1) from tbl;
+
 - Fixed an issue that caused write operations to fail if the table contained
   generated columns with a cast to ``geo_shape``.
 

--- a/docs/appendices/release-notes/5.8.1.rst
+++ b/docs/appendices/release-notes/5.8.1.rst
@@ -47,6 +47,12 @@ See the :ref:`version_5.8.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that caused an ``IndexOutOfBoundsException`` when the
+  :ref:`max_by <aggregation-max_by>` aggregation was called with a literal
+  as searchfield parameter instead of a column e.g.::
+
+    SELECT MAX_BY(x, 1) from tbl;
+
 - Fixed an issue that caused write operations to fail if the table contained
   generated columns with a cast to ``geo_shape``.
 

--- a/server/src/main/java/io/crate/execution/engine/aggregation/AggregationFunction.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/AggregationFunction.java
@@ -117,6 +117,17 @@ public abstract class AggregationFunction<TPartial, TFinal> implements FunctionI
                                                 "not removable cumulative");
     }
 
+    /**
+     * @param referenceResolver A LuceneReferenceResolver to resolve references.
+     * @param aggregationReferences contains a list of references of the size of the input values of the function.
+     *                              If the value at the position is not a reference in the inputs the value in
+     *                              the list is null.
+     * @param table DocTableInfo for the underlying table which is the source of the doc-values.
+     * @param optionalParams contains a list of literals of the size of the input values of the function.
+     *                       If the value at the position is not a literal in the inputs the value in the list is
+     *                       null.
+     * @return A DocValueAggregator or null if there is no doc-value support for the given input parameters.
+     */
     @Nullable
     public DocValueAggregator<?> getDocValueAggregator(LuceneReferenceResolver referenceResolver,
                                                        List<Reference> aggregationReferences,

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregation.java
@@ -163,6 +163,9 @@ public class ArbitraryAggregation extends AggregationFunction<Object, Object> {
                                                        DocTableInfo table,
                                                        List<Literal<?>> optionalParams) {
         Reference arg = aggregationReferences.get(0);
+        if (arg == null) {
+            return null;
+        }
         if (!arg.hasDocValues()) {
             return null;
         }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/CmpByAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/CmpByAggregation.java
@@ -155,11 +155,19 @@ public final class CmpByAggregation extends AggregationFunction<CmpByAggregation
                                                        List<Reference> aggregationReferences,
                                                        DocTableInfo table,
                                                        List<Literal<?>> optionalParams) {
-        Reference searchRef = aggregationReferences.get(1);
-        if (!searchRef.hasDocValues()) {
+        Reference returnField = aggregationReferences.getFirst();
+        Reference searchField = aggregationReferences.getLast();
+        if (returnField == null) {
             return null;
         }
-        DataType<?> searchType = searchRef.valueType();
+        if (searchField == null) {
+            return null;
+        }
+        if (!searchField.hasDocValues()) {
+            return null;
+        }
+
+        DataType<?> searchType = searchField.valueType();
         switch (searchType.id()) {
             case ByteType.ID:
             case ShortType.ID:
@@ -167,17 +175,17 @@ public final class CmpByAggregation extends AggregationFunction<CmpByAggregation
             case LongType.ID:
             case TimestampType.ID_WITH_TZ:
             case TimestampType.ID_WITHOUT_TZ:
-                var resultExpression = referenceResolver.getImplementation(aggregationReferences.get(0));
+                var resultExpression = referenceResolver.getImplementation(returnField);
                 if (signature.getName().name().equalsIgnoreCase("min_by")) {
                     return new MinByLong(
-                        searchRef.storageIdent(),
+                        searchField.storageIdent(),
                         searchType,
                         resultExpression,
                         new CollectorContext(table.droppedColumns(), table.lookupNameBySourceKey())
                     );
                 } else {
                     return new MaxByLong(
-                        searchRef.storageIdent(),
+                        searchField.storageIdent(),
                         searchType,
                         resultExpression,
                         new CollectorContext(table.droppedColumns(), table.lookupNameBySourceKey())

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/CountAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/CountAggregation.java
@@ -304,6 +304,9 @@ public class CountAggregation extends AggregationFunction<MutableLong, Long> {
             return null;
         }
         Reference reference = aggregationReferences.get(0);
+        if (reference == null) {
+            return null;
+        }
         if (reference.valueType().id() == ObjectType.ID) {
             // Count on object would require loading the source just to check if there is a value.
             // Try to count on a non-null sub-column to be able to utilize doc-values.

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregation.java
@@ -308,6 +308,9 @@ public class GeometricMeanAggregation extends AggregationFunction<GeometricMeanA
                                                        DocTableInfo table,
                                                        List<Literal<?>> optionalParams) {
         Reference reference = aggregationReferences.get(0);
+        if (reference == null) {
+            return null;
+        }
         if (!reference.hasDocValues()) {
             return null;
         }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
@@ -222,6 +222,11 @@ public abstract class MaximumAggregation extends AggregationFunction<Object, Obj
                                                            DocTableInfo table,
                                                            List<Literal<?>> optionalParams) {
             Reference reference = aggregationReferences.get(0);
+
+            if (reference == null) {
+                return null;
+            }
+
             if (!reference.hasDocValues()) {
                 return null;
             }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/MinimumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/MinimumAggregation.java
@@ -256,6 +256,9 @@ public abstract class MinimumAggregation extends AggregationFunction<Object, Obj
                                                            DocTableInfo table,
                                                            List<Literal<?>> optionalParams) {
             Reference reference = aggregationReferences.get(0);
+            if (reference == null) {
+                return null;
+            }
             if (!reference.hasDocValues()) {
                 return null;
             }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/NumericSumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/NumericSumAggregation.java
@@ -183,6 +183,9 @@ public class NumericSumAggregation extends AggregationFunction<BigDecimal, BigDe
                                                        DocTableInfo table,
                                                        List<Literal<?>> optionalParams) {
         Reference reference = aggregationReferences.get(0);
+        if (reference == null) {
+            return null;
+        }
         if (!reference.hasDocValues()) {
             return null;
         }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationAggregation.java
@@ -230,6 +230,9 @@ public class StandardDeviationAggregation extends AggregationFunction<StandardDe
                                                        DocTableInfo table,
                                                        List<Literal<?>> optionalParams) {
         Reference reference = aggregationReferences.get(0);
+        if (reference == null) {
+            return null;
+        }
         if (!reference.hasDocValues()) {
             return null;
         }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/SumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/SumAggregation.java
@@ -196,9 +196,15 @@ public class SumAggregation<T extends Number> extends AggregationFunction<T, T> 
                                                        DocTableInfo table,
                                                        List<Literal<?>> optionalParams) {
         Reference reference = aggregationReferences.get(0);
+
+        if (reference == null) {
+            return null;
+        }
+
         if (!reference.hasDocValues()) {
             return null;
         }
+
         switch (reference.valueType().id()) {
             case ByteType.ID:
             case ShortType.ID:

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
@@ -230,6 +230,9 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
                                                        DocTableInfo table,
                                                        List<Literal<?>> optionalParams) {
         Reference reference = aggregationReferences.get(0);
+        if (reference == null) {
+            return null;
+        }
         if (!reference.hasDocValues()) {
             return null;
         }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/AverageAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/AverageAggregation.java
@@ -312,6 +312,9 @@ public class AverageAggregation extends AggregationFunction<AverageAggregation.A
                                                        DocTableInfo table,
                                                        List<Literal<?>> optionalParams) {
         Reference reference = aggregationReferences.get(0);
+        if (reference == null) {
+            return null;
+        }
         if (!reference.hasDocValues()) {
             return null;
         }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/numeric/NumericAverageAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/numeric/NumericAverageAggregation.java
@@ -198,6 +198,9 @@ public class NumericAverageAggregation extends AggregationFunction<NumericAverag
                                                        DocTableInfo table,
                                                        List<Literal<?>> optionalParams) {
         Reference reference = aggregationReferences.get(0);
+        if (reference == null) {
+            return null;
+        }
         if (!reference.hasDocValues()) {
             return null;
         }

--- a/server/src/main/java/io/crate/execution/engine/collect/DocValuesAggregates.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/DocValuesAggregates.java
@@ -154,6 +154,7 @@ public final class DocValuesAggregates {
             for (var input : aggregation.inputs()) {
                 if (input instanceof Literal<?> literal) {
                     literals.add(literal);
+                    aggregationReferences.add(null);
                 } else {
                     var reference = input.accept(AggregationInputToReferenceResolver.INSTANCE, toCollect);
                     if (reference == null) {
@@ -164,6 +165,7 @@ public final class DocValuesAggregates {
                     assert reference.ident().columnIdent().fqn().startsWith(DocSysColumns.Names.DOC) == false :
                         "Source look-up for Reference " + reference + " is not allowed in DocValuesAggregates.";
                     aggregationReferences.add(reference);
+                    literals.add(null);
                 }
             }
             FunctionImplementation func = functions.getQualified(aggregation);

--- a/server/src/test/java/io/crate/integrationtests/AggregateExpressionIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/AggregateExpressionIntegrationTest.java
@@ -297,4 +297,12 @@ public class AggregateExpressionIntegrationTest extends IntegTestCase {
             "b",
             "c");
     }
+
+    public void test_assure_cmp_by_function_call_with_reference_and_literal_does_not_throw_exception() {
+        execute("create table tbl (name text, x int);");
+        execute("insert into tbl (name, x) values ('foo', 10)");
+        execute("refresh table tbl");
+        execute("select max_by(name, 1) from tbl;");
+        assertThat(response).hasRows("foo");
+    }
 }


### PR DESCRIPTION
Add null values to the Aggregator parameters to make them position aware:

```
 agg_function(col, 1) -> references: [col], literals: [1]
 ```
 becomes:

```
agg_function(col, 1) -> references: [col, null], literals: [null, 1]
```

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
