### PR TITLE
Merge validator & converter into parser for SessionSetting

### DIFF
--- a/server/src/main/java/io/crate/metadata/settings/session/SessionSetting.java
+++ b/server/src/main/java/io/crate/metadata/settings/session/SessionSetting.java
@@ -23,7 +23,6 @@ package io.crate.metadata.settings.session;
 
 import java.util.List;
 import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -35,8 +34,7 @@ import io.crate.types.DataType;
 public class SessionSetting<T> {
 
     private final String name;
-    private final Consumer<Object[]> validator;
-    private final Function<Object[], T> converter;
+    private final Function<Object[], T> parse;
     private final BiConsumer<CoordinatorSessionSettings, T> setter;
     private final Function<SessionSettings, String> getter;
     private final Supplier<String> defaultValue;
@@ -45,16 +43,14 @@ public class SessionSetting<T> {
     private final DataType<?> type;
 
     public SessionSetting(String name,
-                   Consumer<Object[]> validator,
-                   Function<Object[], T> converter,
+                   Function<Object[], T> parse,
                    BiConsumer<CoordinatorSessionSettings, T> setter,
                    Function<SessionSettings, String> getter,
                    Supplier<String> defaultValue,
                    String description,
                    DataType<?> type) {
         this.name = name;
-        this.validator = validator;
-        this.converter = converter;
+        this.parse = parse;
         this.setter = setter;
         this.getter = getter;
         this.defaultValue = defaultValue;
@@ -70,8 +66,7 @@ public class SessionSetting<T> {
             Symbol symbol = symbols.get(i);
             values[i] = eval.apply(symbol);
         }
-        validator.accept(values);
-        T converted = converter.apply(values);
+        T converted = parse.apply(values);
         setter.accept(sessionSettings, converted);
     }
 

--- a/server/src/main/java/io/crate/metadata/settings/session/SessionSettingRegistry.java
+++ b/server/src/main/java/io/crate/metadata/settings/session/SessionSettingRegistry.java
@@ -28,7 +28,6 @@ import java.util.ArrayList;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
 
 import org.elasticsearch.cluster.metadata.MetadataCreateIndexService;
 import org.elasticsearch.common.inject.Inject;
@@ -61,7 +60,6 @@ public class SessionSettingRegistry {
     static final String DATE_STYLE_KEY = "datestyle";
     static final SessionSetting<String> APPLICATION_NAME = new SessionSetting<>(
         "application_name",
-        inputs -> {},
         inputs -> DataTypes.STRING.implicitCast(inputs[0]),
         CoordinatorSessionSettings::setApplicationName,
         SessionSettings::applicationName,
@@ -71,18 +69,19 @@ public class SessionSettingRegistry {
     );
     static final SessionSetting<String> DATE_STYLE = new SessionSetting<>(
         DATE_STYLE_KEY,
-        inputs -> validateDateStyleFrom(objectsToStringArray(inputs)),
-        inputs -> DEFAULT_DATE_STYLE,
+        inputs -> {
+            validateDateStyleFrom(objectsToStringArray(inputs));
+            return DEFAULT_DATE_STYLE;
+        },
         CoordinatorSessionSettings::setDateStyle,
         SessionSettings::dateStyle,
-        () -> String.valueOf(DEFAULT_DATE_STYLE),
+        () -> DEFAULT_DATE_STYLE,
         "Display format for date and time values.",
         DataTypes.STRING
     );
 
     static final SessionSetting<TimeValue> STATEMENT_TIMEOUT = new SessionSetting<>(
         "statement_timeout",
-        inputs -> {},
         inputs -> {
             Object input = inputs[0];
             // Interpret values without explicit unit/interval format as milliseconds for PostgreSQL compat.
@@ -111,7 +110,6 @@ public class SessionSettingRegistry {
 
     static final SessionSetting<Integer> MEMORY_LIMIT = new SessionSetting<>(
         Sessions.MEMORY_LIMIT.getKey(),
-        input -> {},
         inputs -> DataTypes.INTEGER.implicitCast(inputs[0]),
         CoordinatorSessionSettings::memoryLimit,
         settings -> Integer.toString(settings.memoryLimitInBytes()),
@@ -128,7 +126,7 @@ public class SessionSettingRegistry {
             .put(SEARCH_PATH_KEY,
                  new SessionSetting<>(
                      SEARCH_PATH_KEY,
-                     objects -> {}, // everything allowed, empty list (resulting by ``SET .. TO DEFAULT`` results in defaults
+                     // everything allowed, empty list (resulting by ``SET .. TO DEFAULT`` results in defaults
                      objects -> createSearchPathFrom(objectsToStringArray(objects)),
                      CoordinatorSessionSettings::setSearchPath,
                      s -> String.join(", ", s.searchPath().showPath()),
@@ -142,8 +140,8 @@ public class SessionSettingRegistry {
                          if (objects.length != 1) {
                              throw new IllegalArgumentException(HASH_JOIN_KEY + " should have only one argument.");
                          }
+                         return DataTypes.BOOLEAN.implicitCast(objects[0]);
                      },
-                     objects -> DataTypes.BOOLEAN.implicitCast(objects[0]),
                      CoordinatorSessionSettings::setHashJoinEnabled,
                      s -> Boolean.toString(s.hashJoinsEnabled()),
                      () -> String.valueOf(true),
@@ -152,11 +150,10 @@ public class SessionSettingRegistry {
             .put(MAX_INDEX_KEYS,
                  new SessionSetting<>(
                      MAX_INDEX_KEYS,
-                     objects -> {},
-                     Function.identity(),
-                     (s, v) -> {
+                     _ -> {
                          throw new UnsupportedOperationException("\"" + MAX_INDEX_KEYS + "\" cannot be changed.");
                      },
+                     (s, v) -> {},
                      s -> String.valueOf(32),
                      () -> String.valueOf(32),
                      "Shows the maximum number of index keys.",
@@ -164,11 +161,10 @@ public class SessionSettingRegistry {
             .put(MAX_IDENTIFIER_LENGTH,
                  new SessionSetting<>(
                      MAX_IDENTIFIER_LENGTH,
-                     objects -> {},
-                     Function.identity(),
-                     (s, v) -> {
+                     _ -> {
                          throw new UnsupportedOperationException("\"" + MAX_IDENTIFIER_LENGTH + "\" cannot be changed.");
                      },
+                     (s, v) -> {},
                      s -> String.valueOf(MetadataCreateIndexService.MAX_INDEX_NAME_BYTES),
                      () -> String.valueOf(MetadataCreateIndexService.MAX_INDEX_NAME_BYTES),
                      "Shows the maximum length of identifiers in bytes.",
@@ -176,11 +172,10 @@ public class SessionSettingRegistry {
             .put(SERVER_VERSION_NUM,
                  new SessionSetting<>(
                      SERVER_VERSION_NUM,
-                     objects -> {},
-                     Function.identity(),
-                     (s, v) -> {
+                     _ -> {
                          throw new UnsupportedOperationException("\"" + SERVER_VERSION_NUM + "\" cannot be changed.");
                      },
+                     (s, v) -> {},
                      s -> String.valueOf(PostgresWireProtocol.SERVER_VERSION_NUM),
                      () -> String.valueOf(PostgresWireProtocol.SERVER_VERSION_NUM),
                      "Reports the emulated PostgreSQL version number",
@@ -190,11 +185,10 @@ public class SessionSettingRegistry {
             .put(SERVER_VERSION,
                  new SessionSetting<>(
                      SERVER_VERSION,
-                     objects -> {},
-                     Function.identity(),
-                     (s, v) -> {
+                     _ -> {
                          throw new UnsupportedOperationException("\"" + SERVER_VERSION + "\" cannot be changed.");
                      },
+                     (s, v) -> {},
                      s -> String.valueOf(PostgresWireProtocol.PG_SERVER_VERSION),
                      () -> String.valueOf(PostgresWireProtocol.PG_SERVER_VERSION),
                      "Reports the emulated PostgreSQL version number",
@@ -209,8 +203,8 @@ public class SessionSettingRegistry {
                              throw new IllegalArgumentException(STANDARD_CONFORMING_STRINGS + " should have only one argument.");
                          }
                          validateStandardConformingStrings(objectsToStringArray(objects)[0]);
+                         return objects;
                      },
-                     Function.identity(),
                      (s, v) -> {},
                      s -> "on",
                      () -> "on",
@@ -225,8 +219,8 @@ public class SessionSettingRegistry {
                          if (objects.length != 1) {
                              throw new IllegalArgumentException(ERROR_ON_UNKNOWN_OBJECT_KEY + " should have only one argument.");
                          }
+                         return DataTypes.BOOLEAN.implicitCast(objects[0]);
                      },
-                     objects -> DataTypes.BOOLEAN.implicitCast(objects[0]),
                      CoordinatorSessionSettings::setErrorOnUnknownObjectKey,
                      s -> Boolean.toString(s.errorOnUnknownObjectKey()),
                      () -> String.valueOf(true),

--- a/server/src/main/java/io/crate/planner/optimizer/LoadedRules.java
+++ b/server/src/main/java/io/crate/planner/optimizer/LoadedRules.java
@@ -70,7 +70,6 @@ public class LoadedRules implements SessionSettingProvider {
         var optimizerRuleName = Rule.sessionSettingName(rule);
         return new SessionSetting<>(
             optimizerRuleName,
-            objects -> {},
             objects -> DataTypes.BOOLEAN.sanitizeValue(objects[0]),
             (sessionSettings, activateRule) -> {
                 if (activateRule) {


### PR DESCRIPTION
There is no need to have 2 different functions to validate the SessionSettings values.
Move exceptions for read-only settings into the new parser method, so that a new validation method can be introduced, which can only call the parser and doesn't need CoordinatorSessionSettings (needed by the setter) in order to throw the appropriate exception for read-only settings.

Useful for: https://github.com/crate/crate/pull/16345
(avoid the need for `CoordinatorSessionSettings` to do a setting validation)
