### PR TITLE
Propagate failure from rootTask.start() in TransportJobAction

### DIFF
--- a/docs/appendices/release-notes/5.7.4.rst
+++ b/docs/appendices/release-notes/5.7.4.rst
@@ -48,5 +48,10 @@ See the :ref:`version_5.7.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed a rare race condition that could lead to queries appearing stuck and
+  eventually time out after 60 seconds if they were executed while a shard was
+  being created. This could happen right after a table or a partition is
+  created, during shard relocation or node restarts.
+
 - Fixed an issue that could lead to ``ANALYZE`` over account the number of
   documents in a table if shards were relocating.

--- a/docs/appendices/release-notes/5.8.1.rst
+++ b/docs/appendices/release-notes/5.8.1.rst
@@ -47,6 +47,11 @@ See the :ref:`version_5.8.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed a rare race condition that could lead to queries appearing stuck and
+  eventually time out after 60 seconds if they were executed while a shard was
+  being created. This could happen right after a table or a partition is
+  created, during shard relocation or node restarts.
+
 - Fixed an issue that could lead to ``ANALYZE`` over account the number of
   documents in a table if shards were relocating.
 

--- a/server/src/main/java/io/crate/action/sql/Session.java
+++ b/server/src/main/java/io/crate/action/sql/Session.java
@@ -225,7 +225,6 @@ public class Session implements AutoCloseable {
         if (!analyzedStatement.isWriteOperation()) {
             resultReceiver = new RetryOnFailureResultReceiver<>(
                 executor.clusterService(),
-                clusterState,
                 // not using planner.currentClusterState().metadata()::hasIndex to make sure the *current*
                 // clusterState at the time of the index check is used
                 indexName -> clusterState.metadata().hasIndex(indexName),
@@ -733,7 +732,6 @@ public class Session implements AutoCloseable {
         if (!analyzedStmt.isWriteOperation()) {
             resultReceiver = new RetryOnFailureResultReceiver<>(
                 executor.clusterService(),
-                clusterState,
                 indexName -> executor.clusterService().state().metadata().hasIndex(indexName),
                 resultReceiver,
                 jobId,

--- a/server/src/main/java/io/crate/execution/jobs/transport/TransportJobAction.java
+++ b/server/src/main/java/io/crate/execution/jobs/transport/TransportJobAction.java
@@ -21,6 +21,22 @@
 
 package io.crate.execution.jobs.transport;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.UnaryOperator;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionListenerResponseHandler;
+import org.elasticsearch.action.support.TransportAction;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.search.profile.query.QueryProfiler;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
 import io.crate.common.concurrent.CompletableFutures;
 import io.crate.execution.engine.distribution.StreamBucket;
 import io.crate.execution.jobs.InstrumentedIndexSearcher;
@@ -32,21 +48,6 @@ import io.crate.execution.support.NodeActionRequestHandler;
 import io.crate.execution.support.NodeRequest;
 import io.crate.execution.support.Transports;
 import io.crate.profile.ProfilingContext;
-import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionListenerResponseHandler;
-import org.elasticsearch.action.support.TransportAction;
-import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.inject.Singleton;
-import org.elasticsearch.indices.IndicesService;
-import org.elasticsearch.search.profile.query.QueryProfiler;
-import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.transport.TransportService;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.function.UnaryOperator;
 
 @Singleton
 public class TransportJobAction extends TransportAction<NodeRequest<JobRequest>, JobResponse> {
@@ -102,17 +103,18 @@ public class TransportJobAction extends TransportAction<NodeRequest<JobRequest>,
             sharedShardContexts
         );
 
+        CompletableFuture<Void> startFuture;
         try {
             RootTask context = tasksService.createTask(contextBuilder);
-            context.start();
+            startFuture = context.start();
         } catch (Throwable t) {
             return CompletableFuture.failedFuture(t);
         }
 
         if (directResponseFutures.size() == 0) {
-            return CompletableFuture.completedFuture(new JobResponse(List.of()));
+            return startFuture.thenApply(ignored -> new JobResponse(List.of()));
         } else {
-            return CompletableFutures.allAsList(directResponseFutures).thenApply(JobResponse::new);
+            return startFuture.thenCompose(ignored -> CompletableFutures.allAsList(directResponseFutures)).thenApply(JobResponse::new);
         }
     }
 

--- a/server/src/test/java/io/crate/protocols/postgres/RetryOnFailureResultReceiverTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/RetryOnFailureResultReceiverTest.java
@@ -45,7 +45,6 @@ public class RetryOnFailureResultReceiverTest extends CrateDummyClusterServiceUn
         ClusterState initialState = clusterService.state();
         RetryOnFailureResultReceiver<?> retryOnFailureResultReceiver = new RetryOnFailureResultReceiver<>(
             clusterService,
-            initialState,
             indexName -> true,
             baseResultReceiver,
             UUID.randomUUID(),
@@ -68,7 +67,6 @@ public class RetryOnFailureResultReceiverTest extends CrateDummyClusterServiceUn
         ClusterState initialState = clusterService.state();
         RetryOnFailureResultReceiver<?> retryOnFailureResultReceiver = new RetryOnFailureResultReceiver<>(
             clusterService,
-            initialState,
             indexName -> true,
             resultReceiver,
             UUID.randomUUID(),


### PR DESCRIPTION
See commits.


To track down the root cause I used something like this:

```diff
diff --git a/server/src/main/java/io/crate/execution/jobs/SharedShardContexts.java b/server/src/main/java/io/crate/execution/jobs/SharedShardContexts.java
index 57c0e100560..7696bba8874 100644
--- a/server/src/main/java/io/crate/execution/jobs/SharedShardContexts.java
+++ b/server/src/main/java/io/crate/execution/jobs/SharedShardContexts.java
@@ -32,15 +32,16 @@
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.shard.ShardNotFoundException;
 import org.elasticsearch.indices.IndicesService;
-
-import com.carrotsearch.hppc.IntIndexedContainer;
-
 import org.jetbrains.annotations.VisibleForTesting;
+
+import com.carrotsearch.hppc.IntIndexedContainer;
+
 import io.crate.metadata.IndexParts;
 
 public class SharedShardContexts {
 
     private final IndicesService indicesService;
@@ -48,10 +49,12 @@ public class SharedShardContexts {
     @VisibleForTesting
     final Map<ShardId, SharedShardContext> allocatedShards = new HashMap<>();
     @VisibleForTesting
     int readerId = 0;
 
+    public static boolean fail = false;
+
     public SharedShardContexts(IndicesService indicesService, UnaryOperator<Engine.Searcher> wrapSearcher) {
         this.indicesService = indicesService;
         this.wrapSearcher = wrapSearcher;
     }
 
@@ -81,10 +84,14 @@ public CompletableFuture<Void> maybeRefreshReaders(Metadata metadata,
                 continue;
             }
             for (var shardCursor : entry.getValue()) {
                 int shardId = shardCursor.value;
                 IndexShard shard = indexService.getShard(shardId);
+                if (fail && shardId == 1 && indexName.endsWith("partitioned.t.04136")) {
+                    fail = false;
+                    throw new ShardNotFoundException(shard.shardId());
+                }
                 refreshActions.add(shard.awaitShardSearchActive());
             }
         }
         return CompletableFuture.allOf(refreshActions.toArray(CompletableFuture[]::new));
     }

```


Together with a test case like:


```java
    @Test
    @TestLogging("io.crate.execution.jobs:TRACE,io.crate.execution.engine.JobLauncher:TRACE")
    @UseJdbc(0)
    public void test_foo() throws Exception {
        execute("create table t (id integer primary key, a integer, b integer) partitioned by(id)");
        execute("insert into t (id, a, b) values(1, 11, 111)");
        execute("insert into t (id, a, b) values(2, 22, 222)");
        execute("insert into t (id, a, b) values(3, 33, 333)");
        execute("refresh table t");

        for (int i = 0; i < 50; i++) {
            logger.warn("----------- Start iteration -------");
            SharedShardContexts.fail = true;
            long start = System.nanoTime();
            try {
                execute("select * from t order by id");
            } catch (Exception ex) {
                long duration = System.nanoTime() - start;
                if (ex.getMessage().contains("no such shard")) {
                    continue;
                }
                logger.warn(
                    "---------------- query failed: duration={}ms ------------",
                    Duration.ofNanos(duration).toMillis()
                );
                throw ex;
            }
            long duration = System.nanoTime() - start;
            logger.warn(
                "----------- End iteration: duration={}ms -------",
                Duration.ofNanos(duration).toMillis()
            );
            Thread.sleep(50);
        }
        logger.warn("----------- End test -------");
    }
```
