### PR TITLE
Don't use XContentBuilder directly to write translog in ValueIndexer

### DIFF
--- a/server/src/main/java/io/crate/execution/dml/BitStringIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/BitStringIndexer.java
@@ -33,7 +33,7 @@ import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.jetbrains.annotations.NotNull;
 
 import io.crate.execution.dml.Indexer.ColumnConstraint;
 import io.crate.metadata.ColumnIdent;
@@ -63,14 +63,12 @@ public class BitStringIndexer implements ValueIndexer<BitString> {
     }
 
     @Override
-    public void indexValue(BitString value,
-                           XContentBuilder xcontentBuilder,
-                           Consumer<? super IndexableField> addField,
-                           Synthetics synthetics,
-                           Map<ColumnIdent, ColumnConstraint> toValidate) throws IOException {
+    public BitString indexValue(@NotNull BitString value,
+                                Consumer<? super IndexableField> addField,
+                                Synthetics synthetics,
+                                Map<ColumnIdent, ColumnConstraint> toValidate) throws IOException {
         BitSet bitSet = value.bitSet();
         byte[] bytes = bitSet.toByteArray();
-        xcontentBuilder.value(bytes);
 
         BytesRef binaryValue = new BytesRef(bytes);
         if (ref.indexType() != IndexType.NONE) {
@@ -85,5 +83,6 @@ public class BitStringIndexer implements ValueIndexer<BitString> {
                 name,
                 DocSysColumns.FieldNames.FIELD_TYPE));
         }
+        return value;
     }
 }

--- a/server/src/main/java/io/crate/execution/dml/BooleanIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/BooleanIndexer.java
@@ -30,7 +30,7 @@ import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
-import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.jetbrains.annotations.NotNull;
 
 import io.crate.execution.dml.Indexer.ColumnConstraint;
 import io.crate.metadata.ColumnIdent;
@@ -58,12 +58,10 @@ public class BooleanIndexer implements ValueIndexer<Boolean> {
     }
 
     @Override
-    public void indexValue(Boolean value,
-                           XContentBuilder xContentBuilder,
-                           Consumer<? super IndexableField> addField,
-                           Synthetics synthetics,
-                           Map<ColumnIdent, ColumnConstraint> toValidate) throws IOException {
-        xContentBuilder.value(value);
+    public Boolean indexValue(@NotNull Boolean value,
+                              Consumer<? super IndexableField> addField,
+                              Synthetics synthetics,
+                              Map<ColumnIdent, ColumnConstraint> toValidate) throws IOException {
         if (ref.indexType() != IndexType.NONE) {
             addField.accept(new Field(name, value ? "T" : "F", FIELD_TYPE));
         }
@@ -75,5 +73,6 @@ public class BooleanIndexer implements ValueIndexer<Boolean> {
                 name,
                 DocSysColumns.FieldNames.FIELD_TYPE));
         }
+        return value;
     }
 }

--- a/server/src/main/java/io/crate/execution/dml/DoubleIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/DoubleIndexer.java
@@ -31,7 +31,7 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.util.NumericUtils;
-import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.jetbrains.annotations.NotNull;
 
 import io.crate.execution.dml.Indexer.ColumnConstraint;
 import io.crate.metadata.ColumnIdent;
@@ -50,12 +50,10 @@ public class DoubleIndexer implements ValueIndexer<Number> {
     }
 
     @Override
-    public void indexValue(Number value,
-                           XContentBuilder xcontentBuilder,
-                           Consumer<? super IndexableField> addField,
-                           Synthetics synthetics,
-                           Map<ColumnIdent, ColumnConstraint> toValidate) throws IOException {
-        xcontentBuilder.value(value);
+    public Number indexValue(@NotNull Number value,
+                             Consumer<? super IndexableField> addField,
+                             Synthetics synthetics,
+                             Map<ColumnIdent, ColumnConstraint> toValidate) throws IOException {
         double doubleValue = value.doubleValue();
         if (ref.hasDocValues() && ref.indexType() != IndexType.NONE) {
             addField.accept(new DoubleField(name, doubleValue, Field.Store.NO));
@@ -74,5 +72,6 @@ public class DoubleIndexer implements ValueIndexer<Number> {
                         DocSysColumns.FieldNames.FIELD_TYPE));
             }
         }
+        return value;
     }
 }

--- a/server/src/main/java/io/crate/execution/dml/DynamicIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/DynamicIndexer.java
@@ -26,12 +26,12 @@ import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.apache.lucene.index.IndexableField;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.NotNull;
 
 import io.crate.execution.dml.Indexer.ColumnConstraint;
 import io.crate.expression.symbol.Symbol;
@@ -55,21 +55,17 @@ import io.crate.types.UndefinedType;
 public final class DynamicIndexer implements ValueIndexer<Object> {
 
     private final ReferenceIdent refIdent;
-    private Function<ColumnIdent, Reference> getRef;
+    private final Function<ColumnIdent, Reference> getRef;
     private final int position;
     private DataType<?> type = null;
     private ValueIndexer<Object> indexer;
-    @Nullable
-    private final String storageIdentPrefixForEmptyArrays;
 
     public DynamicIndexer(ReferenceIdent refIdent,
                           int position,
-                          Function<ColumnIdent, Reference> getRef,
-                          @Nullable String storageIdentPrefixForEmptyArrays) {
+                          Function<ColumnIdent, Reference> getRef) {
         this.refIdent = refIdent;
         this.getRef = getRef;
         this.position = position;
-        this.storageIdentPrefixForEmptyArrays = storageIdentPrefixForEmptyArrays;
     }
 
     @Override
@@ -82,7 +78,7 @@ public final class DynamicIndexer implements ValueIndexer<Object> {
             DynamicIndexer.throwOnNestedArray(type);
             StorageSupport<?> storageSupport = type.storageSupport();
             if (storageSupport == null) {
-                if (handleEmptyArray(type, value, null, null)) {
+                if (handleEmptyArray(type, value)) {
                     type = null; // guess type again with next value
                     return;
                 }
@@ -121,12 +117,10 @@ public final class DynamicIndexer implements ValueIndexer<Object> {
     }
 
     @Override
-    public void indexValue(Object value,
-                           String storageIdentLeafName,
-                           XContentBuilder xcontentBuilder,
-                           Consumer<? super IndexableField> addField,
-                           Synthetics synthetics,
-                           Map<ColumnIdent, ColumnConstraint> toValidate) throws IOException {
+    public Object indexValue(@NotNull Object value,
+                             Consumer<? super IndexableField> addField,
+                             Synthetics synthetics,
+                             Map<ColumnIdent, ColumnConstraint> toValidate) throws IOException {
         if (type == null) {
             // At the second phase of indexing type is not null in almost all cases
             // except the case with array of nulls
@@ -134,32 +128,14 @@ public final class DynamicIndexer implements ValueIndexer<Object> {
         }
         StorageSupport<?> storageSupport = type.storageSupport();
         if (storageSupport == null) {
-            var emptyArrayStorageIdent = storageIdentLeafName;
-            if (storageIdentPrefixForEmptyArrays != null) {
-                emptyArrayStorageIdent = storageIdentPrefixForEmptyArrays + storageIdentLeafName;
-            }
-            if (handleEmptyArray(type, value, emptyArrayStorageIdent, xcontentBuilder)) {
+            if (handleEmptyArray(type, value)) {
                 type = null; // guess type again with next value
-                return;
+                return value;
             }
             throw new IllegalArgumentException(
                 "Cannot create columns of type " + type.getName() + " dynamically. " +
                     "Storage is not supported for this type");
         }
-        if (storageIdentLeafName != null) {
-            xcontentBuilder.field(storageIdentLeafName);
-        }
-        indexValue(value, xcontentBuilder, addField, synthetics, toValidate);
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
-    public void indexValue(Object value,
-                           XContentBuilder xcontentBuilder,
-                           Consumer<? super IndexableField> addField,
-                           Synthetics synthetics,
-                           Map<ColumnIdent, ColumnConstraint> toValidate) throws IOException {
-        StorageSupport<?> storageSupport = type.storageSupport();
         boolean nullable = true;
         Symbol defaultExpression = null;
         Reference newColumn = new SimpleReference(
@@ -179,16 +155,12 @@ public final class DynamicIndexer implements ValueIndexer<Object> {
             // Reuse indexer if phase 1 already created one.
             // Phase 1 mutates indexer.innerTypes on new columns creation.
             // Phase 2 must be aware of all mapping updates.
-            indexer = (ValueIndexer<Object>) storageSupport.valueIndexer(
-                refIdent.tableIdent(),
-                newColumn,
-                getRef
-            );
+            // noinspection unchecked
+            indexer = (ValueIndexer<Object>) storageSupport.valueIndexer(refIdent.tableIdent(), newColumn, getRef);
         }
         value = type.sanitizeValue(value);
-        indexer.indexValue(
+        return indexer.indexValue(
             value,
-            xcontentBuilder,
             addField,
             synthetics,
             toValidate
@@ -196,22 +168,10 @@ public final class DynamicIndexer implements ValueIndexer<Object> {
     }
 
     static boolean handleEmptyArray(DataType<?> type,
-                                    Object value,
-                                    @Nullable String name,
-                                    @Nullable XContentBuilder builder) throws IOException {
+                                    Object value) {
         if (type instanceof ArrayType<?> && ArrayType.unnest(type) instanceof UndefinedType) {
             Collection<?> values = (Collection<?>) value;
-            if (values.isEmpty() || values.stream().allMatch(x -> x == null)) {
-                if (builder != null) {
-                    builder.field(name);
-                    builder.startArray();
-                    for (int i = 0; i < values.size(); i++) {
-                        builder.nullValue();
-                    }
-                    builder.endArray();
-                }
-                return true;
-            }
+            return values.isEmpty() || values.stream().allMatch(Objects::isNull);
         }
         return false;
     }

--- a/server/src/main/java/io/crate/execution/dml/FloatIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/FloatIndexer.java
@@ -31,7 +31,7 @@ import org.apache.lucene.document.FloatPoint;
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.util.NumericUtils;
-import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.jetbrains.annotations.NotNull;
 
 import io.crate.execution.dml.Indexer.ColumnConstraint;
 import io.crate.metadata.ColumnIdent;
@@ -50,12 +50,10 @@ public class FloatIndexer implements ValueIndexer<Float> {
     }
 
     @Override
-    public void indexValue(Float value,
-                           XContentBuilder xcontentBuilder,
-                           Consumer<? super IndexableField> addField,
-                           Synthetics synthetics,
-                           Map<ColumnIdent, ColumnConstraint> toValidate) throws IOException {
-        xcontentBuilder.value(value);
+    public Float indexValue(@NotNull Float value,
+                            Consumer<? super IndexableField> addField,
+                            Synthetics synthetics,
+                            Map<ColumnIdent, ColumnConstraint> toValidate) throws IOException {
         float floatValue = value.floatValue();
         if (ref.hasDocValues() && ref.indexType() != IndexType.NONE) {
             addField.accept(new FloatField(name, floatValue, Field.Store.NO));
@@ -74,5 +72,6 @@ public class FloatIndexer implements ValueIndexer<Float> {
                         DocSysColumns.FieldNames.FIELD_TYPE));
             }
         }
+        return value;
     }
 }

--- a/server/src/main/java/io/crate/execution/dml/FloatVectorIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/FloatVectorIndexer.java
@@ -35,7 +35,6 @@ import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -72,19 +71,13 @@ public class FloatVectorIndexer implements ValueIndexer<float[]> {
     }
 
     @Override
-    public void indexValue(float @Nullable [] values,
-                           XContentBuilder xcontentBuilder,
-                           Consumer<? super IndexableField> addField,
-                           Synthetics synthetics,
-                           Map<ColumnIdent, ColumnConstraint> toValidate) throws IOException {
+    public float[] indexValue(float @Nullable @NotNull [] values,
+                              Consumer<? super IndexableField> addField,
+                              Synthetics synthetics,
+                              Map<ColumnIdent, ColumnConstraint> toValidate) throws IOException {
         if (values == null) {
-            return;
+            return null;
         }
-        xcontentBuilder.startArray();
-        for (float value : values) {
-            xcontentBuilder.value(value);
-        }
-        xcontentBuilder.endArray();
 
         createFields(
             name,
@@ -97,6 +90,7 @@ public class FloatVectorIndexer implements ValueIndexer<float[]> {
         if (fieldType.stored()) {
             throw new UnsupportedOperationException("Cannot store float_vector as stored field");
         }
+        return values;
     }
 
     public static void createFields(String fqn,

--- a/server/src/main/java/io/crate/execution/dml/FulltextIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/FulltextIndexer.java
@@ -30,7 +30,7 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
-import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.jetbrains.annotations.NotNull;
 
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.IndexType;
@@ -56,19 +56,18 @@ public class FulltextIndexer implements ValueIndexer<String> {
     }
 
     @Override
-    public void indexValue(String value,
-                           XContentBuilder xcontentBuilder,
-                           Consumer<? super IndexableField> addField,
-                           Synthetics synthetics,
-                           Map<ColumnIdent, Indexer.ColumnConstraint> toValidate) throws IOException {
-        xcontentBuilder.value(value);
+    public String indexValue(@NotNull String value,
+                             Consumer<? super IndexableField> addField,
+                             Synthetics synthetics,
+                             Map<ColumnIdent, Indexer.ColumnConstraint> toValidate) throws IOException {
         if (value == null) {
-            return;
+            return null;
         }
         String name = ref.storageIdent();
         if (ref.indexType() != IndexType.NONE) {
             Field field = new Field(name, value, FIELD_TYPE);
             addField.accept(field);
         }
+        return value;
     }
 }

--- a/server/src/main/java/io/crate/execution/dml/GeoPointIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/GeoPointIndexer.java
@@ -29,7 +29,7 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.document.LatLonDocValuesField;
 import org.apache.lucene.document.LatLonPoint;
 import org.apache.lucene.index.IndexableField;
-import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.jetbrains.annotations.NotNull;
 import org.locationtech.spatial4j.shape.Point;
 
 import io.crate.execution.dml.Indexer.ColumnConstraint;
@@ -49,16 +49,11 @@ public class GeoPointIndexer implements ValueIndexer<Point> {
     }
 
     @Override
-    public void indexValue(Point point,
-                           XContentBuilder xcontentBuilder,
-                           Consumer<? super IndexableField> addField,
-                           Synthetics synthetics,
-                           Map<ColumnIdent, ColumnConstraint> toValidate) throws IOException {
+    public Point indexValue(@NotNull Point point,
+                            Consumer<? super IndexableField> addField,
+                            Synthetics synthetics,
+                            Map<ColumnIdent, ColumnConstraint> toValidate) throws IOException {
 
-        xcontentBuilder.startArray()
-            .value(point.getX())
-            .value(point.getY())
-            .endArray();
         if (ref.indexType() != IndexType.NONE) {
             addField.accept(new LatLonPoint(name, point.getLat(), point.getLon()));
         }
@@ -70,5 +65,6 @@ public class GeoPointIndexer implements ValueIndexer<Point> {
                 name,
                 DocSysColumns.FieldNames.FIELD_TYPE));
         }
+        return point;
     }
 }

--- a/server/src/main/java/io/crate/execution/dml/GeoShapeIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/GeoShapeIndexer.java
@@ -41,7 +41,7 @@ import org.elasticsearch.common.geo.GeoUtils;
 import org.elasticsearch.common.geo.builders.ShapeBuilder;
 import org.elasticsearch.common.geo.builders.ShapeBuilder.Orientation;
 import org.elasticsearch.common.unit.DistanceUnit;
-import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.jetbrains.annotations.NotNull;
 import org.locationtech.spatial4j.shape.Shape;
 
 import io.crate.execution.dml.Indexer.ColumnConstraint;
@@ -82,17 +82,16 @@ public class GeoShapeIndexer implements ValueIndexer<Map<String, Object>> {
     }
 
     @Override
-    public void indexValue(Map<String, Object> value,
-                           XContentBuilder xcontentBuilder,
-                           Consumer<? super IndexableField> addField,
-                           Synthetics synthetics,
-                           Map<ColumnIdent, ColumnConstraint> toValidate) throws IOException {
-        xcontentBuilder.map(value);
+    public Map<String, Object> indexValue(@NotNull Map<String, Object> value,
+                                          Consumer<? super IndexableField> addField,
+                                          Synthetics synthetics,
+                                          Map<ColumnIdent, ColumnConstraint> toValidate) throws IOException {
         indexableFieldsFactory.create(value, addField);
         addField.accept(new Field(
             DocSysColumns.FieldNames.NAME,
             name,
             DocSysColumns.FieldNames.FIELD_TYPE));
+        return value;
     }
 
     private interface IndexableFieldsFactory {

--- a/server/src/main/java/io/crate/execution/dml/Indexer.java
+++ b/server/src/main/java/io/crate/execution/dml/Indexer.java
@@ -32,6 +32,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -46,9 +47,6 @@ import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.io.stream.BytesStreamOutput;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.mapper.SequenceIDFields;
 import org.elasticsearch.index.mapper.Uid;
@@ -123,8 +121,8 @@ public class Indexer {
     private final List<IndexColumn> indexColumns;
     private final List<Input<?>> returnValueInputs;
     private final List<Synthetic> undeterministic = new ArrayList<>();
-    private final BytesStreamOutput stream;
     private final Function<ColumnIdent, Reference> getRef;
+    private final boolean writeOids;
 
     record IndexColumn(Reference reference, List<Input<?>> inputs) {
     }
@@ -406,8 +404,7 @@ public class Indexer {
                    Symbol[] returnValues) {
         this.columns = targetColumns;
         this.synthetics = new HashMap<>();
-        this.stream = new BytesStreamOutput();
-        boolean writeOids = table.versionCreated().onOrAfter(Version.V_5_5_0);
+        this.writeOids = table.versionCreated().onOrAfter(Version.V_5_5_0);
         this.getRef = table::getReference;
         PartitionName partitionName = table.isPartitioned()
             ? PartitionName.fromIndexOrTemplate(indexName)
@@ -433,8 +430,7 @@ public class Indexer {
                     ));
                 }
                 // Empty arrays are not registered as known references, such they are stored in the source as unknown columns
-                var storageIdentPrefixForEmptyArrays = writeOids ? UNKNOWN_COLUMN_PREFIX : null;
-                valueIndexer = new DynamicIndexer(ref.ident(), position, getRef, storageIdentPrefixForEmptyArrays);
+                valueIndexer = new DynamicIndexer(ref.ident(), position, getRef);
                 position--;
             } else {
                 valueIndexer = ref.valueType().valueIndexer(
@@ -731,108 +727,113 @@ public class Indexer {
         for (var expression : expressions) {
             expression.setNextRow(item);
         }
-        stream.reset();
-        for (Synthetic synthetic: synthetics.values()) {
+        for (Synthetic synthetic : synthetics.values()) {
             synthetic.reset();
         }
-        try (XContentBuilder xContentBuilder = XContentFactory.json(stream)) {
-            xContentBuilder.startObject();
-            Object[] values = item.insertValues();
-            for (int i = 0; i < values.length; i++) {
-                Reference reference = columns.get(i);
-                Object value = valueForInsert(reference.valueType(), values[i]);
-                ColumnConstraint check = columnConstraints.get(reference.column());
-                if (check != null) {
-                    check.verify(value);
-                }
-                if (reference.granularity() == RowGranularity.PARTITION) {
-                    continue;
-                }
+
+        Map<String, Object> translogValues = new LinkedHashMap<>();
+        Object[] values = item.insertValues();
+
+        for (int i = 0; i < values.length; i++) {
+            Reference reference = columns.get(i);
+            Object value = valueForInsert(reference.valueType(), values[i]);
+            ColumnConstraint check = columnConstraints.get(reference.column());
+            if (check != null) {
+                check.verify(value);
+            }
+            if (reference.granularity() == RowGranularity.PARTITION) {
+                continue;
+            }
+            ValueIndexer<Object> valueIndexer = (ValueIndexer<Object>) valueIndexers.get(i);
+            if (value == null) {
+                continue;
+            }
+            Object translogValue = valueIndexer.indexValue(
+                value,
+                addField,
+                synthetics::get,
+                columnConstraints
+            );
+            translogValues.put(translogFieldName(reference), translogValue);
+        }
+        for (var entry : synthetics.entrySet()) {
+            ColumnIdent column = entry.getKey();
+            if (!column.isRoot()) {
+                continue;
+            }
+            Synthetic synthetic = entry.getValue();
+
+            Object value = synthetic.value();
+            if (value == null) {
+                continue;
+            }
+            ValueIndexer<Object> indexer = synthetic.indexer();
+            value = indexer.indexValue(
+                value,
+                addField,
+                synthetics::get,
+                columnConstraints
+            );
+            translogValues.put(column.name(), value);
+        }
+
+        for (var indexColumn : indexColumns) {
+            String fqn = indexColumn.reference.storageIdent();
+            for (var input : indexColumn.inputs) {
+                Object value = input.value();
                 if (value == null) {
                     continue;
                 }
-                ValueIndexer<Object> valueIndexer = (ValueIndexer<Object>) valueIndexers.get(i);
-                valueIndexer.indexValue(
-                    value,
-                    reference.storageIdentLeafName(),
-                    xContentBuilder,
-                    addField,
-                    synthetics::get,
-                    columnConstraints
-                );
-            }
-            for (var entry : synthetics.entrySet()) {
-                ColumnIdent column = entry.getKey();
-                if (!column.isRoot()) {
-                    continue;
-                }
-                Synthetic synthetic = entry.getValue();
-
-                Object value = synthetic.value();
-                if (value == null) {
-                    continue;
-                }
-                ValueIndexer<Object> indexer = synthetic.indexer();
-                indexer.indexValue(
-                    value,
-                    synthetic.ref.storageIdentLeafName(),
-                    xContentBuilder,
-                    addField,
-                    synthetics::get,
-                    columnConstraints
-                );
-            }
-            xContentBuilder.endObject();
-
-            for (var indexColumn : indexColumns) {
-                String fqn = indexColumn.reference.storageIdent();
-                for (var input : indexColumn.inputs) {
-                    Object value = input.value();
-                    if (value == null) {
-                        continue;
-                    }
-                    if (value instanceof Iterable<?> it) {
-                        for (Object val : it) {
-                            if (val == null) {
-                                continue;
-                            }
-                            Field field = new Field(fqn, val.toString(), FulltextIndexer.FIELD_TYPE);
-                            doc.add(field);
+                if (value instanceof Iterable<?> it) {
+                    for (Object val : it) {
+                        if (val == null) {
+                            continue;
                         }
-                    } else {
-                        Field field = new Field(fqn, value.toString(), FulltextIndexer.FIELD_TYPE);
+                        Field field = new Field(fqn, val.toString(), FulltextIndexer.FIELD_TYPE);
                         doc.add(field);
                     }
+                } else {
+                    Field field = new Field(fqn, value.toString(), FulltextIndexer.FIELD_TYPE);
+                    doc.add(field);
                 }
             }
-
-            for (var constraint : tableConstraints) {
-                constraint.verify(item.insertValues());
-            }
-
-            NumericDocValuesField version = new NumericDocValuesField(DocSysColumns.Names.VERSION, -1L);
-            doc.add(version);
-
-            BytesReference source = BytesReference.bytes(xContentBuilder);
-            BytesRef sourceRef = source.toBytesRef();
-            doc.add(new StoredField("_source", sourceRef.bytes, sourceRef.offset, sourceRef.length));
-
-            BytesRef idBytes = Uid.encodeId(item.id());
-            doc.add(new Field(DocSysColumns.Names.ID, idBytes, DocSysColumns.ID.FIELD_TYPE));
-
-            SequenceIDFields seqID = SequenceIDFields.emptySeqID();
-            // Actual values are set via ParsedDocument.updateSeqID
-            doc.add(seqID.seqNo);
-            doc.add(seqID.seqNoDocValue);
-            doc.add(seqID.primaryTerm);
-            return new ParsedDocument(
-                version,
-                seqID,
-                item.id(),
-                doc,
-                source
-            );
         }
+
+        for (var constraint : tableConstraints) {
+            constraint.verify(item.insertValues());
+        }
+
+        NumericDocValuesField version = new NumericDocValuesField(DocSysColumns.Names.VERSION, -1L);
+        doc.add(version);
+        
+        BytesReference source = TranslogWriter.convert(translogValues);
+        BytesRef sourceRef = source.toBytesRef();
+        doc.add(new StoredField("_source", sourceRef.bytes, sourceRef.offset, sourceRef.length));
+
+        BytesRef idBytes = Uid.encodeId(item.id());
+        doc.add(new Field(DocSysColumns.Names.ID, idBytes, DocSysColumns.ID.FIELD_TYPE));
+
+        SequenceIDFields seqID = SequenceIDFields.emptySeqID();
+        // Actual values are set via ParsedDocument.updateSeqID
+        doc.add(seqID.seqNo);
+        doc.add(seqID.seqNoDocValue);
+        doc.add(seqID.primaryTerm);
+        return new ParsedDocument(
+            version,
+            seqID,
+            item.id(),
+            doc,
+            source
+        );
+
+    }
+
+    private String translogFieldName(Reference reference) {
+        String storageName = reference.storageIdentLeafName();
+        if (reference instanceof DynamicReference && this.writeOids) {
+            return UNKNOWN_COLUMN_PREFIX + storageName;
+        }
+        return storageName;
     }
 
     private static <T> T valueForInsert(DataType<T> valueType, Object value) {

--- a/server/src/main/java/io/crate/execution/dml/IntIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/IntIndexer.java
@@ -30,7 +30,7 @@ import org.apache.lucene.document.IntField;
 import org.apache.lucene.document.IntPoint;
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.index.IndexableField;
-import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.jetbrains.annotations.NotNull;
 
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.IndexType;
@@ -48,12 +48,10 @@ public class IntIndexer implements ValueIndexer<Number> {
     }
 
     @Override
-    public void indexValue(Number value,
-                           XContentBuilder xContentBuilder,
-                           Consumer<? super IndexableField> addField,
-                           Synthetics synthetics,
-                           Map<ColumnIdent, Indexer.ColumnConstraint> toValidate) throws IOException {
-        xContentBuilder.value(value);
+    public Number indexValue(@NotNull Number value,
+                             Consumer<? super IndexableField> addField,
+                             Synthetics synthetics,
+                             Map<ColumnIdent, Indexer.ColumnConstraint> toValidate) throws IOException {
         int intValue = value.intValue();
         if (ref.hasDocValues() && ref.indexType() != IndexType.NONE) {
             addField.accept(new IntField(name, intValue, Field.Store.NO));
@@ -70,5 +68,6 @@ public class IntIndexer implements ValueIndexer<Number> {
                         DocSysColumns.FieldNames.FIELD_TYPE));
             }
         }
+        return value;
     }
 }

--- a/server/src/main/java/io/crate/execution/dml/IpIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/IpIndexer.java
@@ -32,7 +32,7 @@ import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.network.InetAddresses;
-import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.jetbrains.annotations.NotNull;
 
 import io.crate.execution.dml.Indexer.ColumnConstraint;
 import io.crate.metadata.ColumnIdent;
@@ -51,12 +51,10 @@ public class IpIndexer implements ValueIndexer<String> {
     }
 
     @Override
-    public void indexValue(String value,
-                           XContentBuilder xContentBuilder,
-                           Consumer<? super IndexableField> addField,
-                           Synthetics synthetics,
-                           Map<ColumnIdent, ColumnConstraint> toValidate) throws IOException {
-        xContentBuilder.value(value);
+    public String indexValue(@NotNull String value,
+                             Consumer<? super IndexableField> addField,
+                             Synthetics synthetics,
+                             Map<ColumnIdent, ColumnConstraint> toValidate) throws IOException {
         InetAddress address = InetAddresses.forString(value);
         if (ref.indexType() != IndexType.NONE) {
             addField.accept(new InetAddressPoint(name, address));
@@ -69,5 +67,6 @@ public class IpIndexer implements ValueIndexer<String> {
                 name,
                 DocSysColumns.FieldNames.FIELD_TYPE));
         }
+        return value;
     }
 }

--- a/server/src/main/java/io/crate/execution/dml/LongIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/LongIndexer.java
@@ -30,7 +30,7 @@ import org.apache.lucene.document.LongField;
 import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.index.IndexableField;
-import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.jetbrains.annotations.NotNull;
 
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.IndexType;
@@ -48,12 +48,10 @@ public class LongIndexer implements ValueIndexer<Long> {
     }
 
     @Override
-    public void indexValue(Long value,
-                           XContentBuilder xcontentBuilder,
+    public Long indexValue(@NotNull Long value,
                            Consumer<? super IndexableField> addField,
                            Synthetics synthetics,
                            Map<ColumnIdent, Indexer.ColumnConstraint> toValidate) throws IOException {
-        xcontentBuilder.value(value);
         long longValue = value;
         if (ref.hasDocValues() && ref.indexType() != IndexType.NONE) {
             addField.accept(new LongField(name, longValue, Field.Store.NO));
@@ -70,5 +68,6 @@ public class LongIndexer implements ValueIndexer<Long> {
                         DocSysColumns.FieldNames.FIELD_TYPE));
             }
         }
+        return value;
     }
 }

--- a/server/src/main/java/io/crate/execution/dml/ObjectIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/ObjectIndexer.java
@@ -21,11 +21,11 @@
 
 package io.crate.execution.dml;
 
-import static io.crate.expression.reference.doc.lucene.SourceParser.UNKNOWN_COLUMN_PREFIX;
 import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -33,7 +33,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.apache.lucene.index.IndexableField;
-import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import io.crate.data.Input;
@@ -59,7 +59,7 @@ public class ObjectIndexer implements ValueIndexer<Map<String, Object>> {
     private final Function<ColumnIdent, Reference> getRef;
     private final RelationName table;
     private final Reference ref;
-    private final boolean prefixUnknownColumns;
+    private final String unknownColumnPrefix;
 
     private record Child(Reference reference, ValueIndexer<Object> indexer) {
         ColumnIdent ident() {
@@ -74,7 +74,7 @@ public class ObjectIndexer implements ValueIndexer<Map<String, Object>> {
         this.table = table;
         this.ref = ref;
         this.getRef = getRef;
-        this.prefixUnknownColumns = ref.oid() != COLUMN_OID_UNASSIGNED;
+        this.unknownColumnPrefix = ref.oid() != COLUMN_OID_UNASSIGNED ? "_u_" : "";
         this.column = ref.column();
         ObjectType objectType = (ObjectType) ArrayType.unnest(ref.valueType());
         for (var entry : objectType.innerTypes().entrySet()) {
@@ -94,12 +94,11 @@ public class ObjectIndexer implements ValueIndexer<Map<String, Object>> {
     }
 
     @Override
-    public void indexValue(@Nullable Map<String, Object> value,
-                           XContentBuilder xContentBuilder,
-                           Consumer<? super IndexableField> addField,
-                           Synthetics synthetics,
-                           Map<ColumnIdent, Indexer.ColumnConstraint> checks) throws IOException {
-        xContentBuilder.startObject();
+    public Map<String, Object> indexValue(@NotNull Map<String, Object> value,
+                                          Consumer<? super IndexableField> addField,
+                                          Synthetics synthetics,
+                                          Map<ColumnIdent, Indexer.ColumnConstraint> checks) throws IOException {
+        Map<String, Object> translogValues = new LinkedHashMap<>();
         for (var entry : children.entrySet()) {
             String innerName = entry.getKey();
             Child child = entry.getValue();
@@ -122,21 +121,23 @@ public class ObjectIndexer implements ValueIndexer<Map<String, Object>> {
             var valueIndexer = child.indexer;
             // valueIndexer is null for partitioned columns
             if (valueIndexer != null) {
-                valueIndexer.indexValue(
+                innerValue = valueIndexer.indexValue(
                     child.reference.valueType().sanitizeValue(innerValue),
-                    child.reference.storageIdentLeafName(),
-                    xContentBuilder,
                     addField,
                     synthetics,
                     checks
                 );
+                translogValues.put(child.reference.storageIdentLeafName(), innerValue);
             }
         }
-
         if (value != null) {
-            indexUnknownColumns(value, xContentBuilder);
+            value.forEach((k, v) -> {
+                if (children.containsKey(k) == false) {
+                    translogValues.put(this.unknownColumnPrefix + k, v);
+                }
+            });
         }
-        xContentBuilder.endObject();
+        return translogValues.isEmpty() && value == null ? null : translogValues;
     }
 
     @Override
@@ -210,7 +211,7 @@ public class ObjectIndexer implements ValueIndexer<Map<String, Object>> {
             innerValue = type.sanitizeValue(innerValue);
             StorageSupport<?> storageSupport = type.storageSupport();
             if (storageSupport == null) {
-                if (DynamicIndexer.handleEmptyArray(type, innerValue, null, null)) {
+                if (DynamicIndexer.handleEmptyArray(type, innerValue)) {
                     continue;
                 }
                 throw new IllegalArgumentException(
@@ -246,48 +247,5 @@ public class ObjectIndexer implements ValueIndexer<Map<String, Object>> {
                 synthetics
             );
         }
-    }
-
-    /**
-     * Writes keys and values for which there are no columns after {@link #collectSchemaUpdates(Map, Consumer, Synthetics) to the xContentBuilder.
-     *
-     * There are no columns for:
-     * <ul>
-     *  <li>OBJECT (IGNORED)</li>
-     *  <li>Empty arrays, or arrays with only null values</li>
-     * </ul>
-     */
-    private void indexUnknownColumns(Map<String, Object> value, XContentBuilder xContentBuilder) throws IOException {
-        for (var entry : value.entrySet()) {
-            String innerName = entry.getKey();
-            Object innerValue = entry.getValue();
-            if (children.containsKey(innerName)) {
-                continue;
-            }
-
-            if (prefixUnknownColumns) {
-                innerName = UNKNOWN_COLUMN_PREFIX + innerName;
-            }
-            if (innerValue == null) {
-                xContentBuilder.nullField(innerName);
-                continue;
-            }
-            if (ref.columnPolicy() == ColumnPolicy.IGNORED) {
-                xContentBuilder.field(innerName, innerValue);
-                continue;
-            }
-            var type = DynamicIndexer.guessType(innerValue);
-            innerValue = type.sanitizeValue(innerValue);
-            StorageSupport<?> storageSupport = type.storageSupport();
-            if (storageSupport == null) {
-                if (DynamicIndexer.handleEmptyArray(type, innerValue, innerName, xContentBuilder)) {
-                    continue;
-                }
-                throw new IllegalArgumentException(
-                    "Cannot create columns of type " + type.getName() + " dynamically. " +
-                        "Storage is not supported for this type");
-            }
-        }
-
     }
 }

--- a/server/src/main/java/io/crate/execution/dml/StringIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/StringIndexer.java
@@ -31,7 +31,7 @@ import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.jetbrains.annotations.NotNull;
 
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.IndexType;
@@ -57,12 +57,10 @@ public class StringIndexer implements ValueIndexer<String> {
     }
 
     @Override
-    public void indexValue(String value,
-                           XContentBuilder xcontentBuilder,
-                           Consumer<? super IndexableField> addField,
-                           Synthetics synthetics,
-                           Map<ColumnIdent, Indexer.ColumnConstraint> toValidate) throws IOException {
-        xcontentBuilder.value(value);
+    public String indexValue(@NotNull String value,
+                             Consumer<? super IndexableField> addField,
+                             Synthetics synthetics,
+                             Map<ColumnIdent, Indexer.ColumnConstraint> toValidate) throws IOException {
         String name = ref.storageIdent();
         BytesRef binaryValue = new BytesRef(value);
         if (ref.indexType() != IndexType.NONE) {
@@ -78,5 +76,6 @@ public class StringIndexer implements ValueIndexer<String> {
         if (ref.hasDocValues()) {
             addField.accept(new SortedSetDocValuesField(name, binaryValue));
         }
+        return value;
     }
 }

--- a/server/src/main/java/io/crate/execution/dml/TranslogIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/TranslogIndexer.java
@@ -34,9 +34,6 @@ import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.io.stream.BytesStreamOutput;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.mapper.SequenceIDFields;
@@ -92,10 +89,9 @@ public class TranslogIndexer {
 
         Document doc = new Document();
 
-        var stream = new BytesStreamOutput();
-        try (XContentBuilder xContentBuilder = XContentFactory.json(stream)) {
+        try {
 
-            populateLuceneFields(source, doc, xContentBuilder);
+            populateLuceneFields(source, doc);
 
             NumericDocValuesField version = new NumericDocValuesField(DocSysColumns.Names.VERSION, -1L);
             doc.add(version);
@@ -125,7 +121,7 @@ public class TranslogIndexer {
 
     }
 
-    private void populateLuceneFields(BytesReference source, Document doc, XContentBuilder xcontent) throws IOException {
+    private void populateLuceneFields(BytesReference source, Document doc) throws IOException {
         Map<String, Object> docMap = sourceParser.parse(source, ignoreUnknownColumns == false);
 
         for (var entry : docMap.entrySet()) {
@@ -140,7 +136,7 @@ public class TranslogIndexer {
 
             Object castValue = valueForInsert(indexer.dataType, entry.getValue());
             if (castValue != null) {
-                indexer.valueIndexer.indexValue(castValue, xcontent, doc::add, _ -> null, Map.of());
+                indexer.valueIndexer.indexValue(castValue, doc::add, _ -> null, Map.of());
                 if (tableIndexSources.containsKey(column)) {
                     addIndexField(doc, tableIndexSources.get(column), castValue);
                 }

--- a/server/src/main/java/io/crate/execution/dml/TranslogWriter.java
+++ b/server/src/main/java/io/crate/execution/dml/TranslogWriter.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.dml;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.Map;
+
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+
+import io.crate.sql.tree.BitString;
+
+/**
+ * Converts the translog as represented by a Map to a BytesReference
+ */
+public class TranslogWriter {
+
+    private TranslogWriter() { }
+
+    public static BytesReference convert(Map<String, Object> content) {
+        try (BytesStreamOutput output = new BytesStreamOutput()) {
+            try (
+                XContentBuilder builder = XContentFactory.json(output)) {
+                builder.startObject();
+                for (var entry : content.entrySet()) {
+                    writeValue(entry.getKey(), entry.getValue(), builder);
+                }
+                builder.endObject();
+            }
+            // XContentBuilder must be closed before we access the bytes
+            return output.bytes();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static void writeValue(String key, Object value, XContentBuilder builder) throws IOException {
+        builder.field(key);
+        switch (value) {
+            case null -> writeValue(value, builder);
+            case List<?> l -> {
+                builder.startArray();
+                for (var o : l) {
+                    writeValue(o, builder);
+                }
+                builder.endArray();
+            }
+            case Map<?, ?> m -> {
+                builder.startObject();
+                for (var entry : m.entrySet()) {
+                    writeValue(entry.getKey().toString(), entry.getValue(), builder);
+                }
+                builder.endObject();
+            }
+            case Object _ -> writeValue(value, builder);
+        }
+    }
+
+    private static void writeValue(Object value, XContentBuilder builder) throws IOException {
+        switch (value) {
+            case null -> builder.nullValue();
+            case BitString bitString -> builder.value(bitString.bitSet().toByteArray());
+            case Object o -> builder.value(o);
+        }
+    }
+}

--- a/server/src/main/java/io/crate/execution/dml/ValueIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/ValueIndexer.java
@@ -27,7 +27,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.apache.lucene.index.IndexableField;
-import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import io.crate.data.Input;
@@ -79,30 +79,13 @@ public interface ValueIndexer<T> {
     default void updateTargets(Function<ColumnIdent, Reference> getRef) {}
 
     /**
-     * @param storageIdentLeafName is a key in the source.
-     * If it's NULL, writing key must be skipped.
-     * For example, for array of primitives,
-     * we need to write key only once and inner primitive indexer should be writing only values.
+     * Writes a value into an indexable document, returning the value that should be written to the translog
      */
-    default void indexValue(
-        @Nullable T value,
-        @Nullable String storageIdentLeafName,
-        XContentBuilder xcontentBuilder,
-        Consumer<? super IndexableField> addField,
-        Synthetics synthetics,
-        Map<ColumnIdent, ColumnConstraint> toValidate
-    ) throws IOException {
-        if (storageIdentLeafName != null) {
-            xcontentBuilder.field(storageIdentLeafName);
-        }
-        indexValue(value, xcontentBuilder, addField, synthetics, toValidate);
-    }
-
-    void indexValue(
-        @Nullable T value,
-        XContentBuilder xcontentBuilder,
+    T indexValue(
+        @NotNull T value,
         Consumer<? super IndexableField> addField,
         Synthetics synthetics,
         Map<ColumnIdent, ColumnConstraint> toValidate
     ) throws IOException;
+
 }

--- a/server/src/main/java/io/crate/expression/symbol/DynamicReference.java
+++ b/server/src/main/java/io/crate/expression/symbol/DynamicReference.java
@@ -21,16 +21,17 @@
 
 package io.crate.expression.symbol;
 
+import java.io.IOException;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+
 import io.crate.metadata.IndexType;
-import io.crate.metadata.SimpleReference;
 import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RowGranularity;
+import io.crate.metadata.SimpleReference;
 import io.crate.sql.tree.ColumnPolicy;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
-import org.elasticsearch.common.io.stream.StreamInput;
-
-import java.io.IOException;
 
 public class DynamicReference extends SimpleReference {
 

--- a/server/src/main/java/io/crate/types/ArrayType.java
+++ b/server/src/main/java/io/crate/types/ArrayType.java
@@ -98,8 +98,7 @@ public class ArrayType<T> extends DataType<List<T>> {
                 @Override
                 public ValueIndexer<T> valueIndexer(RelationName table, Reference ref,
                                                     Function<ColumnIdent, Reference> getRef) {
-                    return new ArrayIndexer<>(
-                        innerStorage.valueIndexer(table, ref, getRef));
+                    return new ArrayIndexer<>(innerStorage.valueIndexer(table, ref, getRef));
                 }
             };
         }

--- a/server/src/test/java/io/crate/integrationtests/ObjectColumnTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ObjectColumnTest.java
@@ -27,18 +27,17 @@ import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import io.crate.testing.UseNewCluster;
 import org.elasticsearch.test.IntegTestCase;
 import org.junit.Test;
 
 import io.crate.testing.Asserts;
 import io.crate.testing.UseJdbc;
+import io.crate.testing.UseNewCluster;
 
 public class ObjectColumnTest extends IntegTestCase {
 


### PR DESCRIPTION
To allow different translog implementations, and to avoid constructing 
an unused translog entry during recovery, ValueIndexer.indexValue() 
no longer takes an XContentBuilder as a parameter. Instead, it returns 
the value that should be written to the translog if one is needed.  A 
separate TranslogWriter class takes a java Map as input and converts 
it to the json source representation.  Future implementations may use 
entirely different representations, but this is now fully isolated in the 
TranslogWriter and not spread across the various ValueIndexer subclasses.