### PR TITLE
Downgrade sphinx-autobuild to < 2024

### DIFF
--- a/blackbox/requirements.txt
+++ b/blackbox/requirements.txt
@@ -19,4 +19,4 @@ sphinx-csv-filter==0.4.0
 crate-docs-theme>=0.30.0
 
 # Documentation: local development
-sphinx-autobuild>=2020.9.1
+sphinx-autobuild<2024


### PR DESCRIPTION
With the latest version: `2024.04.16` we get a bunch of errors like the following, when running `sphinx dev` and making on the fly changes to `.rst` documents.

It happens for **all** configured intersphinx inventories, this is just one sample:

```
encountered some issues with some of the inventories, but they had working alternatives:
intersphinx inventory 'https://sql-99.readthedocs.io/en/latest/' not readable due to ValueError: unknown or unsupported inventory version: ValueError('invalid inventory header: <!DOCTYPE html>')
```
