### PR TITLE
Fix indexing of generated geo shapes

### DIFF
--- a/docs/appendices/release-notes/5.7.4.rst
+++ b/docs/appendices/release-notes/5.7.4.rst
@@ -48,6 +48,9 @@ See the :ref:`version_5.7.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that caused write operations to fail if the table contained
+  generated columns with a cast to ``geo_shape``.
+
 - Fixed a rare race condition that could lead to queries appearing stuck and
   eventually time out after 60 seconds if they were executed while a shard was
   being created. This could happen right after a table or a partition is

--- a/docs/appendices/release-notes/5.8.1.rst
+++ b/docs/appendices/release-notes/5.8.1.rst
@@ -47,6 +47,9 @@ See the :ref:`version_5.8.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that caused write operations to fail if the table contained
+  generated columns with a cast to ``geo_shape``.
+
 - Fixed a rare race condition that could lead to queries appearing stuck and
   eventually time out after 60 seconds if they were executed while a shard was
   being created. This could happen right after a table or a partition is

--- a/server/src/main/java/io/crate/execution/dml/GeoShapeIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/GeoShapeIndexer.java
@@ -48,6 +48,7 @@ import io.crate.execution.dml.Indexer.ColumnConstraint;
 import io.crate.geo.GeoJSONUtils;
 import io.crate.geo.LatLonShapeUtils;
 import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.GeneratedReference;
 import io.crate.metadata.GeoReference;
 import io.crate.metadata.Reference;
 import io.crate.metadata.doc.DocSysColumns;
@@ -71,6 +72,9 @@ public class GeoShapeIndexer implements ValueIndexer<Map<String, Object>> {
     }
 
     public GeoShapeIndexer(Reference ref) {
+        if (ref instanceof GeneratedReference generatedRef) {
+            ref = generatedRef.reference();
+        }
         assert ref instanceof GeoReference : "GeoShapeIndexer requires GeoReference";
         GeoReference geoReference = (GeoReference) ref;
         this.name = ref.storageIdent();

--- a/server/src/test/java/io/crate/execution/dml/IndexerTest.java
+++ b/server/src/test/java/io/crate/execution/dml/IndexerTest.java
@@ -26,6 +26,7 @@ import static io.crate.types.GeoShapeType.Names.TREE_BKD;
 import static io.crate.types.GeoShapeType.Names.TREE_GEOHASH;
 import static io.crate.types.GeoShapeType.Names.TREE_LEGACY_QUADTREE;
 import static io.crate.types.GeoShapeType.Names.TREE_QUADTREE;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
 
@@ -1255,6 +1256,26 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
 
             assertTranslogParses(doc, table);
         }
+    }
+
+    @Test
+    public void test_can_index_generated_geo_shape() throws Exception {
+        var sqlExecutor = SQLExecutor.of(clusterService)
+            .addTable("create table tbl (o object(ignored), geo generated always as o::geo_shape)");
+
+        DocTableInfo table = sqlExecutor.resolveTableInfo("tbl");
+        Indexer indexer = getIndexer(sqlExecutor, "tbl", "o");
+
+        Map<String, Object> obj = LinkedHashMap.newLinkedHashMap(2);
+        obj.put("coordinates", List.of(50, 50));
+        obj.put("type", "Point");
+        ParsedDocument doc = indexer.index(item(obj));
+
+        assertThat(doc.source().utf8ToString())
+            .isEqualToIgnoringWhitespace("""
+                {"1":{"_u_coordinates":[50,50],"_u_type":"Point"},"2":{"coordinates":[50,50],"type":"Point"}}
+                """);
+        assertTranslogParses(doc, table);
     }
 
     public static void assertTranslogParses(ParsedDocument doc, DocTableInfo info) throws Exception {

--- a/server/src/test/java/io/crate/integrationtests/GeoShapeIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/GeoShapeIntegrationTest.java
@@ -238,4 +238,17 @@ public class GeoShapeIntegrationTest extends IntegTestCase {
                 "-0.129089 51.536726))')");
         assertThat(response).hasRowCount(0);
     }
+
+    @Test
+    public void test_geo_shape_can_be_used_as_generated_column() throws Exception {
+        execute("create table tbl (o object, geo as o::geo_shape)");
+        execute(
+            "insert into tbl (o) values (?)",
+            new Object[] { Map.of("coordinates", List.of(10, 20), "type", "point")}
+        );
+        execute("refresh table tbl");
+        assertThat(execute("select geo from tbl")).hasRows(
+            "{coordinates=[10, 20], type=point}"
+        );
+    }
 }


### PR DESCRIPTION
A case like the following failed:

    CREATE TABLE tbl (
      o OBJECT,
      geo GENERATED ALWAYS AS o::geo_shape
    );
    INSERT INTO tbl (o)
      VALUES({"coordinates"= [50.0,50.0], "type"= 'Point'});

The `GeoShapeIndexer` requires a `GeoReference` to get the information
how it should index the shape, but in the example above it is wrapped in
a `GeneratedReference`

Closes https://github.com/crate/crate/issues/16355
