### PR TITLE
Don't use XContentBuilder directly to write translog in ValueIndexer

### DIFF
--- a/server/src/main/java/io/crate/execution/dml/BitStringIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/BitStringIndexer.java
@@ -33,7 +33,7 @@ import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.jetbrains.annotations.NotNull;
 
 import io.crate.execution.dml.Indexer.ColumnConstraint;
 import io.crate.metadata.ColumnIdent;
@@ -63,14 +63,13 @@ public class BitStringIndexer implements ValueIndexer<BitString> {
     }
 
     @Override
-    public void indexValue(BitString value,
-                           XContentBuilder xcontentBuilder,
+    public void indexValue(@NotNull BitString value,
                            Consumer<? super IndexableField> addField,
+                           TranslogWriter translogWriter,
                            Synthetics synthetics,
                            Map<ColumnIdent, ColumnConstraint> toValidate) throws IOException {
         BitSet bitSet = value.bitSet();
         byte[] bytes = bitSet.toByteArray();
-        xcontentBuilder.value(bytes);
 
         BytesRef binaryValue = new BytesRef(bytes);
         if (ref.indexType() != IndexType.NONE) {
@@ -85,5 +84,11 @@ public class BitStringIndexer implements ValueIndexer<BitString> {
                 name,
                 DocSysColumns.FieldNames.FIELD_TYPE));
         }
+        translogWriter.writeValue(bytes);
+    }
+
+    @Override
+    public String storageIdentLeafName() {
+        return ref.storageIdentLeafName();
     }
 }

--- a/server/src/main/java/io/crate/execution/dml/BooleanIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/BooleanIndexer.java
@@ -30,7 +30,7 @@ import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
-import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.jetbrains.annotations.NotNull;
 
 import io.crate.execution.dml.Indexer.ColumnConstraint;
 import io.crate.metadata.ColumnIdent;
@@ -58,12 +58,11 @@ public class BooleanIndexer implements ValueIndexer<Boolean> {
     }
 
     @Override
-    public void indexValue(Boolean value,
-                           XContentBuilder xContentBuilder,
+    public void indexValue(@NotNull Boolean value,
                            Consumer<? super IndexableField> addField,
+                           TranslogWriter translogWriter,
                            Synthetics synthetics,
                            Map<ColumnIdent, ColumnConstraint> toValidate) throws IOException {
-        xContentBuilder.value(value);
         if (ref.indexType() != IndexType.NONE) {
             addField.accept(new Field(name, value ? "T" : "F", FIELD_TYPE));
         }
@@ -75,5 +74,11 @@ public class BooleanIndexer implements ValueIndexer<Boolean> {
                 name,
                 DocSysColumns.FieldNames.FIELD_TYPE));
         }
+        translogWriter.writeValue(value);
+    }
+
+    @Override
+    public String storageIdentLeafName() {
+        return ref.storageIdentLeafName();
     }
 }

--- a/server/src/main/java/io/crate/execution/dml/FulltextIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/FulltextIndexer.java
@@ -30,7 +30,7 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
-import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.jetbrains.annotations.NotNull;
 
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.IndexType;
@@ -56,19 +56,21 @@ public class FulltextIndexer implements ValueIndexer<String> {
     }
 
     @Override
-    public void indexValue(String value,
-                           XContentBuilder xcontentBuilder,
+    public void indexValue(@NotNull String value,
                            Consumer<? super IndexableField> addField,
+                           TranslogWriter translogWriter,
                            Synthetics synthetics,
                            Map<ColumnIdent, Indexer.ColumnConstraint> toValidate) throws IOException {
-        xcontentBuilder.value(value);
-        if (value == null) {
-            return;
-        }
         String name = ref.storageIdent();
         if (ref.indexType() != IndexType.NONE) {
             Field field = new Field(name, value, FIELD_TYPE);
             addField.accept(field);
         }
+        translogWriter.writeValue(value);
+    }
+
+    @Override
+    public String storageIdentLeafName() {
+        return ref.storageIdentLeafName();
     }
 }

--- a/server/src/main/java/io/crate/execution/dml/IntIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/IntIndexer.java
@@ -30,7 +30,7 @@ import org.apache.lucene.document.IntField;
 import org.apache.lucene.document.IntPoint;
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.index.IndexableField;
-import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.jetbrains.annotations.NotNull;
 
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.IndexType;
@@ -48,12 +48,11 @@ public class IntIndexer implements ValueIndexer<Number> {
     }
 
     @Override
-    public void indexValue(Number value,
-                           XContentBuilder xContentBuilder,
+    public void indexValue(@NotNull Number value,
                            Consumer<? super IndexableField> addField,
+                           TranslogWriter translogWriter,
                            Synthetics synthetics,
                            Map<ColumnIdent, Indexer.ColumnConstraint> toValidate) throws IOException {
-        xContentBuilder.value(value);
         int intValue = value.intValue();
         if (ref.hasDocValues() && ref.indexType() != IndexType.NONE) {
             addField.accept(new IntField(name, intValue, Field.Store.NO));
@@ -65,10 +64,16 @@ public class IntIndexer implements ValueIndexer<Number> {
                 addField.accept(new SortedNumericDocValuesField(name, intValue));
             } else {
                 addField.accept(new Field(
-                        DocSysColumns.FieldNames.NAME,
-                        name,
-                        DocSysColumns.FieldNames.FIELD_TYPE));
+                    DocSysColumns.FieldNames.NAME,
+                    name,
+                    DocSysColumns.FieldNames.FIELD_TYPE));
             }
         }
+        translogWriter.writeValue(intValue);
+    }
+
+    @Override
+    public String storageIdentLeafName() {
+        return ref.storageIdentLeafName();
     }
 }

--- a/server/src/main/java/io/crate/execution/dml/LongIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/LongIndexer.java
@@ -30,7 +30,7 @@ import org.apache.lucene.document.LongField;
 import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.index.IndexableField;
-import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.jetbrains.annotations.NotNull;
 
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.IndexType;
@@ -48,12 +48,11 @@ public class LongIndexer implements ValueIndexer<Long> {
     }
 
     @Override
-    public void indexValue(Long value,
-                           XContentBuilder xcontentBuilder,
+    public void indexValue(@NotNull Long value,
                            Consumer<? super IndexableField> addField,
+                           TranslogWriter translogWriter,
                            Synthetics synthetics,
                            Map<ColumnIdent, Indexer.ColumnConstraint> toValidate) throws IOException {
-        xcontentBuilder.value(value);
         long longValue = value;
         if (ref.hasDocValues() && ref.indexType() != IndexType.NONE) {
             addField.accept(new LongField(name, longValue, Field.Store.NO));
@@ -70,5 +69,11 @@ public class LongIndexer implements ValueIndexer<Long> {
                         DocSysColumns.FieldNames.FIELD_TYPE));
             }
         }
+        translogWriter.writeValue(longValue);
+    }
+
+    @Override
+    public String storageIdentLeafName() {
+        return ref.storageIdentLeafName();
     }
 }

--- a/server/src/main/java/io/crate/execution/dml/StringIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/StringIndexer.java
@@ -31,7 +31,7 @@ import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.jetbrains.annotations.NotNull;
 
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.IndexType;
@@ -57,12 +57,11 @@ public class StringIndexer implements ValueIndexer<String> {
     }
 
     @Override
-    public void indexValue(String value,
-                           XContentBuilder xcontentBuilder,
+    public void indexValue(@NotNull String value,
                            Consumer<? super IndexableField> addField,
+                           TranslogWriter translogWriter,
                            Synthetics synthetics,
                            Map<ColumnIdent, Indexer.ColumnConstraint> toValidate) throws IOException {
-        xcontentBuilder.value(value);
         String name = ref.storageIdent();
         BytesRef binaryValue = new BytesRef(value);
         if (ref.indexType() != IndexType.NONE) {
@@ -78,5 +77,11 @@ public class StringIndexer implements ValueIndexer<String> {
         if (ref.hasDocValues()) {
             addField.accept(new SortedSetDocValuesField(name, binaryValue));
         }
+        translogWriter.writeValue(value);
+    }
+
+    @Override
+    public String storageIdentLeafName() {
+        return ref.storageIdentLeafName();
     }
 }

--- a/server/src/main/java/io/crate/execution/dml/TranslogWriter.java
+++ b/server/src/main/java/io/crate/execution/dml/TranslogWriter.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.dml;
+
+import org.elasticsearch.common.bytes.BytesReference;
+
+/**
+ * Builds a transaction log entry for an indexed document
+ */
+public interface TranslogWriter {
+
+    /** Start writing an array of values */
+    void startArray();
+
+    /** Finish writing an array of values */
+    void endArray();
+
+    /** Start writing a key-value object */
+    void startObject();
+
+    /** Finish writing a key-value object */
+    void endObject();
+
+    /** Write a field name */
+    void writeFieldName(String fieldName);
+
+    /** Write a null field value */
+    void writeNull();
+
+    /** Write a non-null field value */
+    void writeValue(Object value);
+
+    /** Write an array of null values */
+    default void writeNullArray(int size) {
+        startArray();
+        for (int i = 0; i < size; i++) {
+            writeNull();
+        }
+        endArray();
+    }
+
+    /**
+     * Return a byte array representation of the transaction log entry
+     * <p/>
+     * Once this method has been called, no other methods should be called
+     * on the TranslogWriter
+     */
+    BytesReference bytes();
+}

--- a/server/src/main/java/io/crate/execution/dml/ValueIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/ValueIndexer.java
@@ -27,7 +27,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.apache.lucene.index.IndexableField;
-import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import io.crate.data.Input;
@@ -79,30 +79,16 @@ public interface ValueIndexer<T> {
     default void updateTargets(Function<ColumnIdent, Reference> getRef) {}
 
     /**
-     * @param storageIdentLeafName is a key in the source.
-     * If it's NULL, writing key must be skipped.
-     * For example, for array of primitives,
-     * we need to write key only once and inner primitive indexer should be writing only values.
+     * Writes a value into an indexable document
      */
-    default void indexValue(
-        @Nullable T value,
-        @Nullable String storageIdentLeafName,
-        XContentBuilder xcontentBuilder,
-        Consumer<? super IndexableField> addField,
-        Synthetics synthetics,
-        Map<ColumnIdent, ColumnConstraint> toValidate
-    ) throws IOException {
-        if (storageIdentLeafName != null) {
-            xcontentBuilder.field(storageIdentLeafName);
-        }
-        indexValue(value, xcontentBuilder, addField, synthetics, toValidate);
-    }
-
     void indexValue(
-        @Nullable T value,
-        XContentBuilder xcontentBuilder,
+        @NotNull T value,
         Consumer<? super IndexableField> addField,
+        TranslogWriter translogWriter,
         Synthetics synthetics,
         Map<ColumnIdent, ColumnConstraint> toValidate
     ) throws IOException;
+
+    String storageIdentLeafName();
+
 }

--- a/server/src/main/java/io/crate/execution/dml/XContentTranslogWriter.java
+++ b/server/src/main/java/io/crate/execution/dml/XContentTranslogWriter.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.dml;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+import org.apache.lucene.util.IORunnable;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+
+/**
+ * A TranslogWriter implementation that writes the transaction log entry as
+ * a json map
+ */
+public class XContentTranslogWriter implements TranslogWriter {
+
+    private final XContentBuilder builder;
+    private final BytesStreamOutput output = new BytesStreamOutput();
+
+    public XContentTranslogWriter() {
+        try {
+            this.builder = XContentFactory.json(output);
+            this.builder.startObject();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private void uncheck(IORunnable runnable) {
+        try {
+            runnable.run();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public void startArray() {
+        uncheck(builder::startArray);
+    }
+
+    @Override
+    public void endArray() {
+        uncheck(builder::endArray);
+    }
+
+    @Override
+    public void startObject() {
+        uncheck(builder::startObject);
+    }
+
+    @Override
+    public void endObject() {
+        uncheck(builder::endObject);
+    }
+
+    @Override
+    public void writeNull() {
+        uncheck(builder::nullValue);
+    }
+
+    @Override
+    public void writeFieldName(String fieldName) {
+        uncheck(() -> builder.field(fieldName));
+    }
+
+    @Override
+    public void writeValue(Object value) {
+        uncheck(() -> builder.value(value));
+    }
+
+    @Override
+    public BytesReference bytes() {
+        uncheck(builder::endObject);
+        builder.close();
+        return output.bytes();
+    }
+}

--- a/server/src/main/java/io/crate/expression/symbol/DynamicReference.java
+++ b/server/src/main/java/io/crate/expression/symbol/DynamicReference.java
@@ -21,16 +21,17 @@
 
 package io.crate.expression.symbol;
 
+import java.io.IOException;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+
 import io.crate.metadata.IndexType;
-import io.crate.metadata.SimpleReference;
 import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RowGranularity;
+import io.crate.metadata.SimpleReference;
 import io.crate.sql.tree.ColumnPolicy;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
-import org.elasticsearch.common.io.stream.StreamInput;
-
-import java.io.IOException;
 
 public class DynamicReference extends SimpleReference {
 

--- a/server/src/main/java/io/crate/types/ArrayType.java
+++ b/server/src/main/java/io/crate/types/ArrayType.java
@@ -98,8 +98,7 @@ public class ArrayType<T> extends DataType<List<T>> {
                 @Override
                 public ValueIndexer<T> valueIndexer(RelationName table, Reference ref,
                                                     Function<ColumnIdent, Reference> getRef) {
-                    return new ArrayIndexer<>(
-                        innerStorage.valueIndexer(table, ref, getRef));
+                    return new ArrayIndexer<>(innerStorage.valueIndexer(table, ref, getRef));
                 }
             };
         }

--- a/server/src/test/java/io/crate/execution/dml/IndexerTest.java
+++ b/server/src/test/java/io/crate/execution/dml/IndexerTest.java
@@ -26,7 +26,6 @@ import static io.crate.types.GeoShapeType.Names.TREE_BKD;
 import static io.crate.types.GeoShapeType.Names.TREE_GEOHASH;
 import static io.crate.types.GeoShapeType.Names.TREE_LEGACY_QUADTREE;
 import static io.crate.types.GeoShapeType.Names.TREE_QUADTREE;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
 

--- a/server/src/test/java/io/crate/integrationtests/ObjectColumnTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ObjectColumnTest.java
@@ -27,18 +27,17 @@ import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import io.crate.testing.UseNewCluster;
 import org.elasticsearch.test.IntegTestCase;
 import org.junit.Test;
 
 import io.crate.testing.Asserts;
 import io.crate.testing.UseJdbc;
+import io.crate.testing.UseNewCluster;
 
 public class ObjectColumnTest extends IntegTestCase {
 


### PR DESCRIPTION
To allow different translog implementations, and to avoid constructing 
an unused translog entry during recover, we replace the XContentBuilder 
parameter to ValueIndexer.indexValue() with a new TranslogWriter interface.  
Fieldname handling is moved directly into Indexer and ObjectIndexer.