### PR TITLE
Fix BWC issue caused by creating mismatching TypeSignature

### DIFF
--- a/docs/appendices/release-notes/5.8.1.rst
+++ b/docs/appendices/release-notes/5.8.1.rst
@@ -64,6 +64,9 @@ Fixes
 - Fixed a regression introduced in 5.8.0 that prevented cluster to become GREEN
   after a rolling upgrade.
 
+- Fixed a regression introduced in 5.8.0 that lead to error when running an
+  aggregations in a mixed cluster.
+
 - Fixed an issue that caused ``WHERE`` clause to fail to filter rows when
   the clause contained array scalar functions under ``NOT`` operator. The
   affected scalars include :ref:`scalar-array_min`, :ref:`scalar-array_max`,

--- a/server/src/main/java/io/crate/metadata/functions/SignatureBinder.java
+++ b/server/src/main/java/io/crate/metadata/functions/SignatureBinder.java
@@ -44,7 +44,6 @@ import io.crate.common.collections.Lists;
 import io.crate.types.BitStringType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
-import io.crate.types.IntegerLiteralTypeSignature;
 import io.crate.types.FloatVectorType;
 import io.crate.types.ParameterTypeSignature;
 import io.crate.types.TypeSignature;
@@ -155,10 +154,6 @@ public class SignatureBinder {
     }
 
     private static TypeSignature applyBoundVariables(TypeSignature typeSignature, BoundVariables boundVariables, boolean onlyBindGenericTypes) {
-        if (typeSignature instanceof IntegerLiteralTypeSignature) {
-            // Parameter, don't convert it to plain TypeSignature and return as is.
-            return typeSignature;
-        }
         String baseType = typeSignature.getBaseTypeName();
         if (boundVariables.containsTypeVariable(baseType)) {
             if (typeSignature.getParameters().isEmpty() == false) {

--- a/server/src/main/java/io/crate/types/BitStringType.java
+++ b/server/src/main/java/io/crate/types/BitStringType.java
@@ -137,6 +137,9 @@ public final class BitStringType extends DataType<BitString> implements Streamer
 
     @Override
     public TypeSignature getTypeSignature() {
+        if (length == DEFAULT_LENGTH) {
+            return new TypeSignature(NAME);
+        }
         return new TypeSignature(getName(), List.of(TypeSignature.of(length)));
     }
 

--- a/server/src/main/java/io/crate/types/CharacterType.java
+++ b/server/src/main/java/io/crate/types/CharacterType.java
@@ -159,6 +159,9 @@ public class CharacterType extends StringType {
 
     @Override
     public TypeSignature getTypeSignature() {
+        if (lengthLimit == 1) {
+            return new TypeSignature(NAME);
+        }
         return new TypeSignature(NAME, List.of(TypeSignature.of(lengthLimit)));
     }
 

--- a/server/src/main/java/io/crate/types/FloatVectorType.java
+++ b/server/src/main/java/io/crate/types/FloatVectorType.java
@@ -164,6 +164,9 @@ public class FloatVectorType extends DataType<float[]> implements Streamer<float
 
     @Override
     public TypeSignature getTypeSignature() {
+        if (dimensions == 1) {
+            return new TypeSignature(NAME);
+        }
         return new TypeSignature(getName(), List.of(TypeSignature.of(dimensions)));
     }
 

--- a/server/src/test/java/io/crate/analyze/parser/TypeSignatureParserTest.java
+++ b/server/src/test/java/io/crate/analyze/parser/TypeSignatureParserTest.java
@@ -47,13 +47,7 @@ public class TypeSignatureParserTest extends ESTestCase {
     @Test
     public void testParsingOfPrimitiveDataTypes() {
         for (var type : DataTypes.PRIMITIVE_TYPES) {
-            if (type.id() == DataTypes.CHARACTER.id()) {
-                // Parametrized types with fixed length are registered with default length.
-                // bit and float_vector and not primitives, handle only char.
-                assertThat(TypeSignature.parse("character(1)")).isEqualTo(type.getTypeSignature());
-            } else {
-                assertThat(TypeSignature.parse(type.getName())).isEqualTo(type.getTypeSignature());
-            }
+            assertThat(TypeSignature.parse(type.getName())).isEqualTo(type.getTypeSignature());
         }
     }
 

--- a/server/src/test/java/io/crate/metadata/functions/SignatureBinderTest.java
+++ b/server/src/test/java/io/crate/metadata/functions/SignatureBinderTest.java
@@ -41,7 +41,6 @@ import io.crate.types.BitStringType;
 import io.crate.types.CharacterType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
-import io.crate.types.FloatVectorType;
 import io.crate.types.NumericType;
 import io.crate.types.ObjectType;
 import io.crate.types.RowType;
@@ -576,36 +575,6 @@ public class SignatureBinderTest extends ESTestCase {
             .boundTo(NumericType.INSTANCE, NumericType.of(10, 2))
             .hasBoundSignature(expected);
     }
-
-    @Test
-    public void test_binding_doesnt_lose_integral_parameter_type_signature_info() {
-        // Functions having types with parameters as their arguments
-        // are registered with instance with default value of the parameter.
-        // Verify that parameter info is not lost and SignatureBinder doesn't throw an error
-        // "The signature type of the based data type parameters can only be: INTEGER_LITERAL_SIGNATURE".
-        DataType[] types = new DataType[]{
-            BitStringType.INSTANCE_ONE,
-            CharacterType.INSTANCE,
-            FloatVectorType.INSTANCE_ONE
-        };
-        for (int i = 0; i < types.length; i++) {
-            var type = types[i];
-            Signature dummyWithBitArg = functionSignature()
-                .returnType(TypeSignature.parse("boolean"))
-                .argumentTypes(type.getTypeSignature())
-                .build();
-
-            BoundSignature expected = new BoundSignature(
-                List.of(type),
-                DataTypes.BOOLEAN
-            );
-
-            assertThatSignature(dummyWithBitArg)
-                .boundTo(type)
-                .hasBoundSignature(expected);
-        }
-    }
-
 
     private DataType<?> type(String signature) {
         TypeSignature typeSignature = TypeSignature.parse(signature);


### PR DESCRIPTION
Closes https://github.com/crate/crate/issues/16361

Reverts https://github.com/crate/crate/commit/fe1699a38cd0945781acce3e6ee39b69745f8876 to get back to <5.8 state when we created TypeSignature without parameter for default parameter values.

Linked commit caused issues with matching signature (both on incoming/outgoing from 5.8) requests.

Also adds logic to create TypeSignature without parameter for default dimension for FloatVectorType, to reflect pre 5.8 behaviour for parametrized types.

