### PR TITLE
Fix concurrent access on result values of UDFs

### DIFF
--- a/docs/appendices/release-notes/5.8.2.rst
+++ b/docs/appendices/release-notes/5.8.2.rst
@@ -47,4 +47,6 @@ See the :ref:`version_5.8.0` release notes for a full list of changes in the
 Fixes
 =====
 
-None
+- Fixed an issue that led to a ``IllegalStateException`` or
+  ``SQLParseException`` when trying to use a user defined function which returns
+  a value of type ``GEO_SHAPE`` within a ``MATCH`` predicate.

--- a/extensions/lang-js/src/main/java/io/crate/operation/language/PolyglotScalar.java
+++ b/extensions/lang-js/src/main/java/io/crate/operation/language/PolyglotScalar.java
@@ -76,7 +76,7 @@ public final class PolyglotScalar extends Scalar<Object, Object> {
         try {
             String functionName = signature.getName().name();
             var function = PolyglotLanguage.getFunctionValue(graalLanguageId, functionName, script);
-            Object[] values = PolyglotValues.toPolyglotValues(args, boundSignature.argTypes());
+            Object[] values = PolyglotValues.toPolyglotValues(args);
             return PolyglotValues.toCrateObject(
                 function.execute(values),
                 boundSignature.returnType()
@@ -107,7 +107,7 @@ public final class PolyglotScalar extends Scalar<Object, Object> {
         @Override
         @SafeVarargs
         public final Object evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object> ... args) {
-            Object[] values = PolyglotValues.toPolyglotValues(args, boundSignature.argTypes());
+            Object[] values = PolyglotValues.toPolyglotValues(args);
             try {
                 return PolyglotValues.toCrateObject(function.execute(values), boundSignature.returnType());
             } catch (PolyglotException e) {

--- a/extensions/lang-js/src/test/java/io/crate/operation/language/PolyglotValuesTest.java
+++ b/extensions/lang-js/src/test/java/io/crate/operation/language/PolyglotValuesTest.java
@@ -1,0 +1,260 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.operation.language;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+
+import org.elasticsearch.test.ESTestCase;
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Engine;
+import org.graalvm.polyglot.HostAccess;
+import org.graalvm.polyglot.Source;
+import org.graalvm.polyglot.Value;
+import org.junit.Test;
+
+import io.crate.sql.tree.BitString;
+import io.crate.types.BitStringType;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+import io.crate.types.FloatVectorType;
+
+public class PolyglotValuesTest extends ESTestCase {
+
+    @Test
+    public void test_polyglot_value_conversion_boolean() throws Exception {
+        try (var context = createContext()) {
+            assertEvaluatesTo(
+                context,
+                """
+                function getValue() {
+                    return true;
+                }
+                """,
+                DataTypes.BOOLEAN,
+                true
+            );
+        }
+    }
+
+    @Test
+    public void test_polyglot_value_conversion_string() throws Exception {
+        try (var context = createContext()) {
+            assertEvaluatesTo(
+                context,
+                """
+                function getValue() {
+                    return "Hoschi";
+                }
+                """,
+                DataTypes.STRING,
+                "Hoschi"
+            );
+        }
+    }
+
+    @Test
+    public void test_polyglot_value_conversion_numbers() throws Exception {
+        try (var context = createContext()) {
+            for (DataType<?> type : DataTypes.NUMERIC_PRIMITIVE_TYPES) {
+                assertEvaluatesTo(
+                    context,
+                    "function getValue() { return 42; }",
+                    type,
+                    type.implicitCast(42)
+                );
+                assertEvaluatesTo(
+                    context,
+                    "function getValue() { return 3.14; }",
+                    type,
+                    type.implicitCast(3.14)
+                );
+            }
+        }
+    }
+
+
+    @Test
+    public void test_polyglot_value_conversion_object() throws Exception {
+        try (var context = createContext()) {
+            assertEvaluatesTo(
+                context,
+                """
+                function getValue() {
+                    return {
+                        x: 10,
+                        y: 20,
+                        obj: {
+                            a: "a",
+                            obj2: {
+                                b: "b"
+                            }
+                        }
+                    }
+                }
+                """,
+                DataTypes.UNTYPED_OBJECT,
+                Map.of(
+                    "x", 10,
+                    "y", 20,
+                    "obj", Map.of(
+                        "a", "a",
+                        "obj2", Map.of("b", "b")
+                    )
+                )
+            );
+        }
+    }
+
+    @Test
+    public void test_polyglot_value_conversion_geo_shape() throws Exception {
+        try (var context = createContext()) {
+            assertEvaluatesTo(
+                context,
+                """
+                function getValue() {
+                    return {
+                        coordinates: [[
+                            [2.0, 2.0],
+                            [2.0, 3.0],
+                            [1.0, 3.0],
+                            [1.0, 2.0],
+                            [2.0, 2.0]]],
+                        type: "Polygon"
+                    }
+                }
+                """,
+                DataTypes.GEO_SHAPE,
+                Map.of(
+                    "coordinates", List.of(List.of(
+                        List.of(2, 2),
+                        List.of(2, 3),
+                        List.of(1, 3),
+                        List.of(1, 2),
+                        List.of(2, 2)
+                    )),
+                    "type", "Polygon"
+                )
+            );
+        }
+    }
+
+    @Test
+    public void test_polyglot_value_conversion_float_vector() throws Exception {
+        try (var context = createContext()) {
+            assertEvaluatesTo(
+                context,
+                """
+                function getValue() {
+                    return [0.4, 0.5, 0.6, 0.2];
+                }
+                """,
+                new FloatVectorType(4),
+                new float[] { 0.4f, 0.5f, 0.6f, 0.2f }
+            );
+        }
+    }
+
+    @Test
+    public void test_polyglot_value_conversion_bitstring() throws Exception {
+        try (var context = createContext()) {
+            BitSet bitSet = new BitSet(4);
+            bitSet.set(0, false);
+            bitSet.set(1, true);
+            bitSet.set(0, false);
+            bitSet.set(0, false);
+            assertEvaluatesTo(
+                context,
+                """
+                function getValue() {
+                    return "0100";
+                }
+                """,
+                new BitStringType(4),
+                new BitString(bitSet, 4)
+            );
+        }
+    }
+
+    /**
+     * @param sourceStr function definition. Function must be called "getValue"
+     **/
+    private void assertEvaluatesTo(Context context,
+                                   String sourceStr,
+                                   DataType<?> type,
+                                   Object expectedValue) throws Exception {
+        var source = Source
+            .newBuilder("js", sourceStr, "getValue")
+            .build();
+        context.eval(source);
+        Value func = context.getBindings("js").getMember("getValue");
+        Value result = func.execute(new Object[0]);
+        Object output = PolyglotValues.toCrateObject(result, type);
+        assertThat(output).isEqualTo(expectedValue);
+
+        // Ensure concurrent access on the value is possible
+        int numThreads = 5;
+        ArrayList<Thread> threads = new ArrayList<>(numThreads);
+        CyclicBarrier barrier = new CyclicBarrier(numThreads);
+        for (int i = 0; i < numThreads; i++) {
+            var thread = new Thread(() -> {
+                try {
+                    barrier.await();
+                } catch (BrokenBarrierException | InterruptedException e) {
+                    // ignore
+                }
+                type.implicitCast(output);
+                assertThat(output).isEqualTo(expectedValue);
+            });
+            thread.start();
+            threads.add(thread);
+        }
+        for (var thread : threads) {
+            thread.join();
+        }
+    }
+
+    private static Context createContext() {
+        return Context.newBuilder("js")
+            .engine(
+                Engine.newBuilder()
+                    .option("js.foreign-object-prototype", "true")
+                    .option("engine.WarnInterpreterOnly", "false")
+                    .build()
+            )
+            .allowHostAccess(
+                HostAccess.newBuilder()
+                    .allowListAccess(true)
+                    .allowArrayAccess(true)
+                    .allowMapAccess(true)
+                    .build()
+            )
+            .build();
+    }
+}
+

--- a/server/src/testFixtures/java/io/crate/testing/DataTypeTesting.java
+++ b/server/src/testFixtures/java/io/crate/testing/DataTypeTesting.java
@@ -151,8 +151,7 @@ public class DataTypeTesting {
             case GeoShapeType.ID:
                 return () -> {
                     // Can't use immutable Collections.singletonMap; insert-analyzer mutates the map
-                    Map<String, Object> geoShape = new HashMap<>(2);
-
+                    Map<String, Object> geoShape = HashMap.newHashMap(2);
                     geoShape.put(
                         "coordinates",
                         Arrays.asList(


### PR DESCRIPTION
`value.as(MAP_TYPE_LITERAL)` only returns a view/proxy onto the
underlying values in the foreign language and doesn't support concurrent
read access.

This can be problematic e.g. if the value is a container (object or
array, and nested) and accessed by multiple threads - which can be the
case - for example while building Lucene queries.

Fixes https://github.com/crate/crate/issues/16368
