### PR TITLE
Share Indexer and TranslogIndexer document building code

### DIFF
--- a/server/src/main/java/io/crate/execution/dml/ArrayIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/ArrayIndexer.java
@@ -23,11 +23,9 @@ package io.crate.execution.dml;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import org.apache.lucene.index.IndexableField;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -43,26 +41,16 @@ public class ArrayIndexer<T> implements ValueIndexer<List<T>> {
     }
 
     @Override
-    public void indexValue(@NotNull List<T> values,
-                           Consumer<? super IndexableField> addField,
-                           TranslogWriter translogWriter,
-                           Synthetics synthetics,
-                           Map<ColumnIdent, Indexer.ColumnConstraint> toValidate) throws IOException {
-        translogWriter.startArray();
+    public void indexValue(@NotNull List<T> values, IndexDocumentBuilder docBuilder) throws IOException {
+        docBuilder.translogWriter().startArray();
         for (T value : values) {
             if (value == null) {
-                translogWriter.writeNull();
+                docBuilder.translogWriter().writeNull();
             } else {
-                innerIndexer.indexValue(
-                    value,
-                    addField,
-                    translogWriter,
-                    synthetics,
-                    toValidate
-                );
+                innerIndexer.indexValue(value, docBuilder);
             }
         }
-        translogWriter.endArray();
+        docBuilder.translogWriter().endArray();
     }
 
     @Override

--- a/server/src/main/java/io/crate/execution/dml/FloatVectorIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/FloatVectorIndexer.java
@@ -24,7 +24,6 @@ package io.crate.execution.dml;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.util.Map;
 import java.util.function.Consumer;
 
 import org.apache.lucene.document.BinaryDocValuesField;
@@ -37,8 +36,6 @@ import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.util.BytesRef;
 import org.jetbrains.annotations.NotNull;
 
-import io.crate.execution.dml.Indexer.ColumnConstraint;
-import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.IndexType;
 import io.crate.metadata.Reference;
 import io.crate.metadata.doc.DocSysColumns;
@@ -70,23 +67,19 @@ public class FloatVectorIndexer implements ValueIndexer<float[]> {
     }
 
     @Override
-    public void indexValue(float @NotNull [] values,
-                           Consumer<? super IndexableField> addField,
-                           TranslogWriter translogWriter,
-                           Synthetics synthetics,
-                           Map<ColumnIdent, ColumnConstraint> toValidate) throws IOException {
+    public void indexValue(float @NotNull [] values, IndexDocumentBuilder docBuilder) throws IOException {
         createFields(
             name,
             fieldType,
             ref.indexType() != IndexType.NONE,
             ref.hasDocValues(),
             values,
-            addField
+            docBuilder::addField
         );
         if (fieldType.stored()) {
             throw new UnsupportedOperationException("Cannot store float_vector as stored field");
         }
-        translogWriter.writeValue(values);
+        docBuilder.translogWriter().writeValue(values);
     }
 
     public static void createFields(String fqn,

--- a/server/src/main/java/io/crate/execution/dml/FulltextIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/FulltextIndexer.java
@@ -23,16 +23,12 @@
 package io.crate.execution.dml;
 
 import java.io.IOException;
-import java.util.Map;
-import java.util.function.Consumer;
 
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.IndexOptions;
-import org.apache.lucene.index.IndexableField;
 import org.jetbrains.annotations.NotNull;
 
-import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.IndexType;
 import io.crate.metadata.Reference;
 
@@ -56,17 +52,12 @@ public class FulltextIndexer implements ValueIndexer<String> {
     }
 
     @Override
-    public void indexValue(@NotNull String value,
-                           Consumer<? super IndexableField> addField,
-                           TranslogWriter translogWriter,
-                           Synthetics synthetics,
-                           Map<ColumnIdent, Indexer.ColumnConstraint> toValidate) throws IOException {
+    public void indexValue(@NotNull String value, IndexDocumentBuilder docBuilder) throws IOException {
         String name = ref.storageIdent();
         if (ref.indexType() != IndexType.NONE) {
-            Field field = new Field(name, value, FIELD_TYPE);
-            addField.accept(field);
+            docBuilder.addField(new Field(name, value, FIELD_TYPE));
         }
-        translogWriter.writeValue(value);
+        docBuilder.translogWriter().writeValue(value);
     }
 
     @Override

--- a/server/src/main/java/io/crate/execution/dml/GeoShapeIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/GeoShapeIndexer.java
@@ -44,10 +44,8 @@ import org.elasticsearch.common.unit.DistanceUnit;
 import org.jetbrains.annotations.NotNull;
 import org.locationtech.spatial4j.shape.Shape;
 
-import io.crate.execution.dml.Indexer.ColumnConstraint;
 import io.crate.geo.GeoJSONUtils;
 import io.crate.geo.LatLonShapeUtils;
-import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.GeneratedReference;
 import io.crate.metadata.GeoReference;
 import io.crate.metadata.Reference;
@@ -89,17 +87,13 @@ public class GeoShapeIndexer implements ValueIndexer<Map<String, Object>> {
     }
 
     @Override
-    public void indexValue(@NotNull Map<String, Object> value,
-                           Consumer<? super IndexableField> addField,
-                           TranslogWriter translogWriter,
-                           Synthetics synthetics,
-                           Map<ColumnIdent, ColumnConstraint> toValidate) throws IOException {
-        indexableFieldsFactory.create(value, addField);
-        addField.accept(new Field(
+    public void indexValue(@NotNull Map<String, Object> value, IndexDocumentBuilder docBuilder) throws IOException {
+        indexableFieldsFactory.create(value, docBuilder::addField);
+        docBuilder.addField(new Field(
             DocSysColumns.FieldNames.NAME,
             name,
             DocSysColumns.FieldNames.FIELD_TYPE));
-        translogWriter.writeValue(value);
+        docBuilder.translogWriter().writeValue(value);
     }
 
     @Override

--- a/server/src/main/java/io/crate/execution/dml/IndexDocumentBuilder.java
+++ b/server/src/main/java/io/crate/execution/dml/IndexDocumentBuilder.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.dml;
+
+import java.util.Map;
+
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.document.StoredField;
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.index.mapper.ParsedDocument;
+import org.elasticsearch.index.mapper.SequenceIDFields;
+import org.elasticsearch.index.mapper.Uid;
+
+import io.crate.data.Input;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.doc.DocSysColumns;
+
+/**
+ * Used by ValueIndexer implementations to construct a lucene document for indexing
+ */
+public class IndexDocumentBuilder {
+
+    private final Document doc = new Document();
+    private final TranslogWriter translogWriter;
+    private final ValueIndexer.Synthetics synthetics;
+    private final Map<ColumnIdent, Indexer.ColumnConstraint> constraints;
+
+    /**
+     * Builds a new IndexDocumentBuilder
+     */
+    public IndexDocumentBuilder(
+        TranslogWriter translogWriter,
+        ValueIndexer.Synthetics synthetics,
+        Map<ColumnIdent, Indexer.ColumnConstraint> constraints
+    ) {
+        this.translogWriter = translogWriter;
+        this.synthetics = synthetics;
+        this.constraints = constraints;
+    }
+
+    /**
+     * Add a new lucene indexable field
+     */
+    public void addField(IndexableField field) {
+        doc.add(field);
+    }
+
+    /**
+     * @return the TranslogWriter
+     */
+    public TranslogWriter translogWriter() {
+        return translogWriter;
+    }
+
+    /**
+     * @return a generated value for the given column if one exists, otherwise null
+     */
+    public Object getSyntheticValue(ColumnIdent columnIdent) {
+        Input<Object> input = synthetics.get(columnIdent);
+        return input == null ? null : input.value();
+    }
+
+    /**
+     * Checks column constraints are all met for a given column and value
+     */
+    public void checkColumnConstraint(ColumnIdent columnIdent, Object value) {
+        Indexer.ColumnConstraint constraint = constraints.get(columnIdent);
+        if (constraint != null) {
+            constraint.verify(value);
+        }
+    }
+
+    /**
+     * Constructs a new ParsedDocument with the given id from the indexed values
+     */
+    public ParsedDocument build(String id) {
+
+        NumericDocValuesField version = new NumericDocValuesField(DocSysColumns.Names.VERSION, -1L);
+        addField(version);
+
+        BytesReference source = translogWriter.bytes();
+        BytesRef sourceRef = source.toBytesRef();
+        addField(new StoredField("_source", sourceRef.bytes, sourceRef.offset, sourceRef.length));
+
+        BytesRef idBytes = Uid.encodeId(id);
+        addField(new Field(DocSysColumns.Names.ID, idBytes, DocSysColumns.ID.FIELD_TYPE));
+
+        SequenceIDFields seqID = SequenceIDFields.emptySeqID();
+        // Actual values are set via ParsedDocument.updateSeqID
+        addField(seqID.seqNo);
+        addField(seqID.seqNoDocValue);
+        addField(seqID.primaryTerm);
+
+        return new ParsedDocument(version, seqID, id, doc, source);
+    }
+
+}

--- a/server/src/main/java/io/crate/execution/dml/ValueIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/ValueIndexer.java
@@ -22,16 +22,13 @@
 package io.crate.execution.dml;
 
 import java.io.IOException;
-import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import org.apache.lucene.index.IndexableField;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import io.crate.data.Input;
-import io.crate.execution.dml.Indexer.ColumnConstraint;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
 
@@ -81,13 +78,7 @@ public interface ValueIndexer<T> {
     /**
      * Writes a value into an indexable document
      */
-    void indexValue(
-        @NotNull T value,
-        Consumer<? super IndexableField> addField,
-        TranslogWriter translogWriter,
-        Synthetics synthetics,
-        Map<ColumnIdent, ColumnConstraint> toValidate
-    ) throws IOException;
+    void indexValue(@NotNull T value, IndexDocumentBuilder docBuilder) throws IOException;
 
     String storageIdentLeafName();
 


### PR DESCRIPTION
There's a chunk of code duplicated in Indexer and TranslogIndexer which 
deals with various metadata fields, including `_source`.  This moves this
shared code into a new `IndexDocumentBuilder` object, which also absorbs
all the various parameters that get passed to `ValueIndexer.indexValue()`.
