### PR TITLE
Fix a few layout issues in release notes

### DIFF
--- a/docs/appendices/release-notes/5.6.2.rst
+++ b/docs/appendices/release-notes/5.6.2.rst
@@ -71,7 +71,7 @@ Fixes
 
 - Fixed :ref:`trim <scalar-trim>`, :ref:`ltrim <scalar-ltrim>`,
   :ref:`rtrim <scalar-rtrim>`, and :ref:`btrim <scalar-btrim>` scalar functions
-  to return ``NULL`, instead of the original string, when the ``trimmingText``
+  to return ``NULL``, instead of the original string, when the ``trimmingText``
   argument is ``NULL``, complying with PostgreSQL behaviour for these functions.
 
 - Fixed a regression introduced in 5.6.0 that caused

--- a/docs/appendices/release-notes/5.7.2.rst
+++ b/docs/appendices/release-notes/5.7.2.rst
@@ -54,7 +54,7 @@ Fixes
   download a blob via HTTPS.
 
 - Fixed an issue leading to slow query processing during the analysis phase,
-  when the ``WHERE``` clause of a query contains columns of a
+  when the ``WHERE`` clause of a query contains columns of a
   :ref:`PRIMARY KEY <constraints-primary-key>` and combines them using complex
   logical expressions, e.g.::
 
@@ -67,7 +67,7 @@ Fixes
   some of its outputs weren't used in the outer-query.
 
 - Fixed an issue leading to a ``ArrayIndexOutOfBoundsException``  instead of a
-  user friendly error message when the ``WHERE``` clause of a query contains
+  user friendly error message when the ``WHERE`` clause of a query contains
   all columns of a :ref:`PRIMARY KEY <constraints-primary-key>`, uses
   parameters for them, and binds less actual values than the required, e.g.::
 
@@ -76,8 +76,8 @@ Fixes
   and less than 3 values are provided.
 
 - Added memory accounting for multi-phase execution to prevent out-of-memory
-  errors caused by sub-queries such as ''SELECT * FROM t1 WHERE id IN
-  (SELECT id FROM t2)'' or lookup-joins with large intermediate results.
+  errors caused by sub-queries such as ``SELECT * FROM t1 WHERE id IN
+  (SELECT id FROM t2)`` or lookup-joins with large intermediate results.
 
 - Fixed an issue that caused ``WHERE`` clause to fail to filter rows when
   the clause contained ``CONCAT``, ``CURRENT_SETTING``,

--- a/docs/appendices/release-notes/5.8.0.rst
+++ b/docs/appendices/release-notes/5.8.0.rst
@@ -105,7 +105,7 @@ Scalar and Aggregation Functions
 --------------------------------
 
 - `azatyamanaev <https://github.com/azatyamanaev>`_ added support for the
-   :ref:`sign <scalar-sign>` function.
+  :ref:`sign <scalar-sign>` function.
 
 - `Dhruv Patel <https://github.com/DHRUV6029>`_ added support for the
   :ref:`strpos <scalar-strpos>` scalar function.

--- a/docs/appendices/release-notes/5.9.0.rst
+++ b/docs/appendices/release-notes/5.9.0.rst
@@ -60,7 +60,7 @@ Breaking Changes
   literal instead of an empty array when both arguments are ``NULL``.
 
 - Changed the implementation of the :ref:`scalar-array_cat` to return an empty
-  array of type `ARRAY(UNDEFINED)` when both arguments are an empty array
+  array of type ``ARRAY(UNDEFINED)`` when both arguments are an empty array
   instead of raising an exception.
 
 Deprecations


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

A few minor layout fixes, mostly around the usage of backticks or removing whitespace that causes an unwanted linebreak in one case.

## Checklist

 - [X] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user-facing changes
 - [X] Updated documentation & `sql_features` table for user-facing changes
 - [X] Touched code is covered by tests
 - [X] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [X] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
