### PR TITLE
Don't compute number_of_routing_shards during the rolling upgrade

### DIFF
--- a/docs/appendices/release-notes/5.8.1.rst
+++ b/docs/appendices/release-notes/5.8.1.rst
@@ -73,6 +73,12 @@ Fixes
 - Fixed a regression introduced in 5.8.0 that lead to error when running an
   aggregations in a mixed cluster.
 
+- Fixed a regression introduced in 5.8.0 that lead to error when running a
+  query with ``WHERE`` clause on a ``PRIMARY KEY`` column during a rolling
+  upgrade. The setting
+  :ref:`number_of_routing_shards <sql-create-table-number-of-routing-shards>`
+  in not automatically set on tables in the middle of a rolling upgrade.
+
 - Fixed an issue that caused ``WHERE`` clause to fail to filter rows when
   the clause contained array scalar functions under ``NOT`` operator. The
   affected scalars include :ref:`scalar-array_min`, :ref:`scalar-array_max`,


### PR DESCRIPTION
Follow up to https://github.com/crate/crate/commit/1e92620fc3271f8300501645674f0a83d31dbdac

