### PR TITLE
Apply auto calculation for `number_of_routing_shards` on parted tables

### DIFF
--- a/docs/appendices/release-notes/5.8.0.rst
+++ b/docs/appendices/release-notes/5.8.0.rst
@@ -45,14 +45,20 @@ Released on 2024-07-17.
 Breaking Changes
 ================
 
+.. _version_5.8.0_break_ch_remove_warmer_enabled:
+
 - Removed the ``index.warmer.enabled`` setting and its corresponding column
   within the ``settings`` column of ``information_schema.tables`` and
   ``information_schema.table_partitions``. The setting had been deprecated in
   CrateDB 4.2.0.
 
+.. _version_5.8.0_break_ch_remove_network_col:
+
 - Removed ``network`` column from :ref:`sys.nodes <sys-nodes>` table. The column
   was deprecated since :ref:`version_2.3.0` and all of the sub-columns where
   returning 0.
+
+.. _version_5.8.0_break_ch_no_route_shards:
 
 - Tables created with version :ref:`version_5.8.0` onwards will have an
   automatic

--- a/docs/appendices/release-notes/5.8.1.rst
+++ b/docs/appendices/release-notes/5.8.1.rst
@@ -47,6 +47,14 @@ See the :ref:`version_5.8.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Changed behavior to partitioned tables by automatically calculating
+  :ref:`number_of_routing_shards <sql-create-table-number-of-routing-shards>`,
+  so that they behave the same as simple tables, for which the
+  :ref:`change<version_5.8.0_break_ch_no_route_shards>` was already introduced
+  in :ref:`version_5.8.0`. With this fix, it's possible to
+  :ref:`alter the number_of_shards<partitioned-alter-single>` for a single
+  partition of a partitioned table.
+
 - Fixed an issue that would cause the
   :ref:`number_of_replicas <sql-create-table-number-of-replicas>` setting of a
   table to be reset to ``1``, when the number of shards for that table is


### PR DESCRIPTION
With #16042, this feature was applied only to simple tables, but the
behavior wasn't changed for partitioned tables. Therefore, if the
setting was not explicitly set on a partitioned table during creation,
it was not possible to increase the number of shards for existing
partitions.

Follows: #16042