### PR TITLE
Fix issue with json export from parted table using COPY TO

### DIFF
--- a/docs/appendices/release-notes/5.7.4.rst
+++ b/docs/appendices/release-notes/5.7.4.rst
@@ -48,6 +48,11 @@ See the :ref:`version_5.7.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that would add a whitespace character at the beginning of some
+  lines in the files containing the rows which are exported by executing
+  :ref:`COPY TO<sql-copy-to>` using the local filesystem on a whole partitioned
+  table.
+
 - Changed the behavior of :ref:`LIKE and ILIKE <sql_dql_like>` operators to
   throw an error, when the pattern to match ends with the ``ESCAPE`` character.
   Previously, the ``ESCAPE`` character was ignored, and the result was computed

--- a/docs/appendices/release-notes/5.8.1.rst
+++ b/docs/appendices/release-notes/5.8.1.rst
@@ -47,6 +47,11 @@ See the :ref:`version_5.8.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that would add a whitespace character at the beginning of some
+  lines in the files containing the rows which are exported by executing
+  :ref:`COPY TO<sql-copy-to>` using the local filesystem on a whole partitioned
+  table.
+
 - Changed the behavior of :ref:`LIKE and ILIKE <sql_dql_like>` operators to
   throw an error, when the pattern to match ends with the ``ESCAPE`` character.
   Previously, the ``ESCAPE`` character was ignored, and the result was computed

--- a/libs/es-x-content/src/main/java/org/elasticsearch/common/xcontent/XContent.java
+++ b/libs/es-x-content/src/main/java/org/elasticsearch/common/xcontent/XContent.java
@@ -23,6 +23,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
+import org.jetbrains.annotations.Nullable;
+
 import io.crate.common.Booleans;
 
 /**
@@ -62,8 +64,9 @@ public interface XContent {
      * Creates a new generator using the provided output stream.
      *
      * @param os       the output stream
+     * @param rootValueSeparator set the root value separator, if null the default single whitespace(" ") is used
      */
-    XContentGenerator createGenerator(OutputStream os) throws IOException;
+    XContentGenerator createGenerator(OutputStream os, @Nullable String rootValueSeparator) throws IOException;
 
     /**
      * Creates a parser over the provided string content.

--- a/libs/es-x-content/src/main/java/org/elasticsearch/common/xcontent/XContentBuilder.java
+++ b/libs/es-x-content/src/main/java/org/elasticsearch/common/xcontent/XContentBuilder.java
@@ -41,6 +41,8 @@ import java.util.Objects;
 import java.util.ServiceLoader;
 import java.util.function.UnaryOperator;
 
+import org.jetbrains.annotations.Nullable;
+
 /**
  * A utility to build XContent (ie json).
  */
@@ -152,8 +154,16 @@ public final class XContentBuilder implements Closeable, Flushable {
      * to call {@link #close()} when the builder is done with.
      */
     public XContentBuilder(XContent xContent, OutputStream bos) throws IOException {
+        this(xContent, bos, null);
+    }
+
+    /**
+     * Constructs a new builder using the provided XContent and an OutputStream. Make sure
+     * to call {@link #close()} when the builder is done with.
+     */
+    public XContentBuilder(XContent xContent, OutputStream bos, @Nullable String rootValueSeparator) throws IOException {
         this.bos = bos;
-        this.generator = xContent.createGenerator(bos);
+        this.generator = xContent.createGenerator(bos, rootValueSeparator);
     }
 
     public XContentType contentType() {

--- a/libs/es-x-content/src/main/java/org/elasticsearch/common/xcontent/XContentFactory.java
+++ b/libs/es-x-content/src/main/java/org/elasticsearch/common/xcontent/XContentFactory.java
@@ -27,6 +27,7 @@ import java.io.OutputStream;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.common.xcontent.smile.SmileXContent;
 import org.elasticsearch.common.xcontent.yaml.YamlXContent;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A one stop to use {@link org.elasticsearch.common.xcontent.XContent} and {@link XContentBuilder}.
@@ -37,7 +38,16 @@ public class XContentFactory {
      * Constructs a new json builder that will output the result into the provided output stream.
      */
     public static XContentBuilder json(OutputStream os) throws IOException {
-        return new XContentBuilder(JsonXContent.JSON_XCONTENT, os);
+        return json(os, null);
+    }
+
+    /**
+     * Constructs a new json builder that will output the result into the provided output stream.
+     * @param os the output stream
+     * @param rootValueSeparator the rootValueSeparator, if null the default whitespace (" ") is used
+     */
+    public static XContentBuilder json(OutputStream os, @Nullable String rootValueSeparator) throws IOException {
+        return new XContentBuilder(JsonXContent.JSON_XCONTENT, os, rootValueSeparator);
     }
 
     /**

--- a/libs/es-x-content/src/main/java/org/elasticsearch/common/xcontent/json/JsonXContent.java
+++ b/libs/es-x-content/src/main/java/org/elasticsearch/common/xcontent/json/JsonXContent.java
@@ -31,12 +31,15 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentGenerator;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.jetbrains.annotations.Nullable;
 
 import com.fasterxml.jackson.core.JsonEncoding;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonFactoryBuilder;
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.StreamReadFeature;
 import com.fasterxml.jackson.core.StreamWriteFeature;
+import com.fasterxml.jackson.core.io.SerializedString;
 import com.fasterxml.jackson.core.json.JsonReadFeature;
 import com.fasterxml.jackson.core.json.JsonWriteFeature;
 
@@ -74,8 +77,12 @@ public class JsonXContent implements XContent {
     }
 
     @Override
-    public XContentGenerator createGenerator(OutputStream os) throws IOException {
-        return new JsonXContentGenerator(JSON_FACTORY.createGenerator(os, JsonEncoding.UTF8), os);
+    public XContentGenerator createGenerator(OutputStream os, @Nullable String rootValueSeparator) throws IOException {
+        JsonGenerator generator = JSON_FACTORY.createGenerator(os, JsonEncoding.UTF8);
+        if (rootValueSeparator != null) {
+            generator.setRootValueSeparator(new SerializedString(rootValueSeparator));
+        }
+        return new JsonXContentGenerator(generator, os);
     }
 
     @Override

--- a/libs/es-x-content/src/main/java/org/elasticsearch/common/xcontent/smile/SmileXContent.java
+++ b/libs/es-x-content/src/main/java/org/elasticsearch/common/xcontent/smile/SmileXContent.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentGenerator;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.jetbrains.annotations.Nullable;
 
 import com.fasterxml.jackson.core.JsonEncoding;
 import com.fasterxml.jackson.core.StreamReadFeature;
@@ -72,7 +73,7 @@ public class SmileXContent implements XContent {
     }
 
     @Override
-    public XContentGenerator createGenerator(OutputStream os) throws IOException {
+    public XContentGenerator createGenerator(OutputStream os, @Nullable String rootValueSeparator) throws IOException {
         return new SmileXContentGenerator(SMILE_FACTORY.createGenerator(os, JsonEncoding.UTF8), os);
     }
 

--- a/libs/es-x-content/src/main/java/org/elasticsearch/common/xcontent/yaml/YamlXContent.java
+++ b/libs/es-x-content/src/main/java/org/elasticsearch/common/xcontent/yaml/YamlXContent.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentGenerator;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.jetbrains.annotations.Nullable;
 
 import com.fasterxml.jackson.core.JsonEncoding;
 import com.fasterxml.jackson.core.StreamReadFeature;
@@ -64,7 +65,7 @@ public class YamlXContent implements XContent {
     }
 
     @Override
-    public XContentGenerator createGenerator(OutputStream os) throws IOException {
+    public XContentGenerator createGenerator(OutputStream os, @Nullable String rootValueSeparator) throws IOException {
         return new YamlXContentGenerator(YAML_FACTORY.createGenerator(os, JsonEncoding.UTF8), os);
     }
 

--- a/server/src/main/java/io/crate/execution/engine/export/FileWriterCountCollector.java
+++ b/server/src/main/java/io/crate/execution/engine/export/FileWriterCountCollector.java
@@ -215,7 +215,10 @@ public class FileWriterCountCollector implements Collector<Row, long[], Iterable
 
     @VisibleForTesting
     static XContentBuilder createJsonBuilder(OutputStream outputStream) throws IOException {
-        XContentBuilder builder = XContentFactory.json(outputStream);
+        // Override the default rootValueSeparator to avoid whitespace characters added
+        // in the beginning of json data lines, when partitioned tables with multiple shards
+        // are exported.
+        XContentBuilder builder = XContentFactory.json(outputStream, "");
         builder.generator().configure(JsonGenerator.Feature.FLUSH_PASSED_TO_STREAM, false);
         return builder;
     }

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionClassLifecycleTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionClassLifecycleTest.java
@@ -378,7 +378,9 @@ public class TransportSQLActionClassLifecycleTest extends IntegTestCase {
 
     @Test
     public void testCopyToDirectoryOnPartitionedTableWithoutPartitionClause() throws Exception {
-        new Setup(sqlExecutor).partitionTableSetup();
+        // Use 2 shards to ensure that each partition's documents go into different shards and hence each
+        // partition will have more than one shard.
+        new Setup(sqlExecutor).partitionTableSetup(2);
         String uriTemplate = Paths.get(folder.getRoot().toURI()).toUri().toString();
         SQLResponse response = execute("copy parted to DIRECTORY ?", $(uriTemplate));
         assertThat(response.rowCount()).isEqualTo(4L);

--- a/server/src/testFixtures/java/io/crate/integrationtests/Setup.java
+++ b/server/src/testFixtures/java/io/crate/integrationtests/Setup.java
@@ -28,6 +28,8 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
+import org.jetbrains.annotations.Nullable;
+
 import io.crate.testing.SQLResponse;
 import io.crate.testing.SQLTransportExecutor;
 
@@ -259,11 +261,19 @@ public class Setup {
     }
 
     public void partitionTableSetup() {
-        transportExecutor.exec("create table parted (" +
-                               "id int primary key," +
-                               "date timestamp with time zone primary key," +
-                               "o object(ignored)" +
-                               ") partitioned by (date) with (number_of_replicas=0)");
+        partitionTableSetup(null);
+    }
+
+    public void partitionTableSetup(@Nullable Integer numberOfShards) {
+        String stmt = "create table parted (" +
+            "id int primary key," +
+            "date timestamp with time zone primary key," +
+            "o object(ignored)) ";
+        if (numberOfShards != null) {
+            stmt += "clustered into " + numberOfShards + " shards ";
+        }
+        stmt += "partitioned by (date) with (number_of_replicas=0)";
+        transportExecutor.exec(stmt);
         transportExecutor.ensureGreen();
         transportExecutor.exec("insert into parted (id, date) values (1, '2014-01-01')");
         transportExecutor.exec("insert into parted (id, date) values (2, '2014-01-01')");


### PR DESCRIPTION
Previously, when the partitioned table has multiple shards per partition and its data is exported using `COPY TO` without specifying certain partitions to export, but the whole table, a whitespace character was added at the beginning of some lines. e.g.:
```
{"id":1,"name":"foo"}
 {"id":2,"name":"bar"}
{"id:3,"name":{cratedb"}
```
This extra whitespace came from the default `rootValueSeparator` used i the `JsonGenerator` when constructing the `XContentBuilder`.

To avoid touching the existing behavior everywhere, since the `XContentBuilder` is used in a variety of cases in vital internal operations, add new methods and ctors down the stack to be able to override the `rootValueSeparator` with an empty string `""` instead of the default whitespace `" "`, only for the case of `COPY TO` json export (`FileWriterCountCollector`).

The issue was identified in https://github.com/crate/crate/pull/16403, since the change of automated calculation of number of shards caused `io.crate.integrationtests.TransportSQLActionClassLifecycleTest#testCopyToDirectoryOnPartitionedTableWithoutPartitionClause` to fail, since 2 lines started with a whitespace char.

Thank you @romseygeek for investigating and identifying the root cause of this failure!