### PR TITLE
Fix `number_of_replicas` resetting to `1` when inc/dec `number_of_shards`

### DIFF
--- a/docs/appendices/release-notes/5.8.1.rst
+++ b/docs/appendices/release-notes/5.8.1.rst
@@ -47,6 +47,12 @@ See the :ref:`version_5.8.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that would cause the
+  :ref:`number_of_replicas <sql-create-table-number-of-replicas>` setting of a
+  table to be reset to ``1``, when the number of shards for that table is
+  :ref:`increased <alter-shard-number-increase>` or
+  :ref:`decreased <alter-shard-number-decrease>`.
+
 - Fixed an issue that would add a whitespace character at the beginning of some
   lines in the files containing the rows which are exported by executing
   :ref:`COPY TO<sql-copy-to>` using the local filesystem on a whole partitioned

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -327,8 +327,8 @@ public class MetadataCreateIndexService {
                 }
             } else {
                 List<Reference> references = DocReferences.applyOid(
-                        createTableRequest.references(),
-                        metadataBuilder.columnOidSupplier()
+                    createTableRequest.references(),
+                    metadataBuilder.columnOidSupplier()
                 );
 
                 mapping = new MappingMetadata(Map.of("default", MappingUtil.createMapping(
@@ -349,13 +349,14 @@ public class MetadataCreateIndexService {
             if (indexSettingsBuilder.get(SETTING_NUMBER_OF_SHARDS) == null) {
                 throw new IllegalArgumentException("Number of shards must be supplied");
             }
-            if (indexSettingsBuilder.get(SETTING_NUMBER_OF_REPLICAS) == null) {
-                indexSettingsBuilder.put(SETTING_NUMBER_OF_REPLICAS, settings.getAsInt(SETTING_NUMBER_OF_REPLICAS, 1));
+            if (request.resizeType() == null && request.copySettings() == false) {
+                if (indexSettingsBuilder.get(SETTING_NUMBER_OF_REPLICAS) == null) {
+                    indexSettingsBuilder.put(SETTING_NUMBER_OF_REPLICAS, settings.getAsInt(SETTING_NUMBER_OF_REPLICAS, 1));
+                }
+                if (settings.get(AutoExpandReplicas.SETTING_KEY) != null && indexSettingsBuilder.get(AutoExpandReplicas.SETTING_KEY) == null) {
+                    indexSettingsBuilder.put(AutoExpandReplicas.SETTING_KEY, settings.get(AutoExpandReplicas.SETTING_KEY));
+                }
             }
-            if (settings.get(AutoExpandReplicas.SETTING_KEY) != null && indexSettingsBuilder.get(AutoExpandReplicas.SETTING_KEY) == null) {
-                indexSettingsBuilder.put(AutoExpandReplicas.SETTING_KEY, settings.get(AutoExpandReplicas.SETTING_KEY));
-            }
-
             setIndexVersionCreatedSetting(indexSettingsBuilder, currentState);
             validateSoftDeletesSetting(indexSettingsBuilder.build());
 
@@ -364,6 +365,7 @@ public class MetadataCreateIndexService {
             }
             indexSettingsBuilder.put(IndexMetadata.SETTING_INDEX_PROVIDED_NAME, request.getProvidedName());
             indexSettingsBuilder.put(SETTING_INDEX_UUID, UUIDs.randomBase64UUID());
+
             final IndexMetadata.Builder tmpImdBuilder = IndexMetadata.builder(request.index());
             final Settings idxSettings = indexSettingsBuilder.build();
             int numTargetShards = IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.get(idxSettings);

--- a/server/src/test/java/io/crate/integrationtests/ResizeShardsITest.java
+++ b/server/src/test/java/io/crate/integrationtests/ResizeShardsITest.java
@@ -46,7 +46,7 @@ public class ResizeShardsITest extends IntegTestCase {
             "   id integer," +
             "   quote string," +
             "   date timestamp with time zone" +
-            ") clustered into 3 shards with (number_of_replicas = 1)");
+            ") clustered into 3 shards with (number_of_replicas = 0)");
 
         execute("insert into quotes (id, quote, date) values (?, ?, ?), (?, ?, ?)",
             new Object[]{
@@ -75,8 +75,8 @@ public class ResizeShardsITest extends IntegTestCase {
         execute("alter table quotes set (number_of_shards=?)", $(1));
         ensureYellow();
 
-        execute("select number_of_shards from information_schema.tables where table_name = 'quotes'");
-        assertThat(response).hasRows("1");
+        execute("select count(*), primary from sys.shards where table_name = 'quotes' group by primary order by 2");
+        assertThat(response).hasRows("1| true");
         execute("select id from quotes");
         assertThat(response).hasRowCount(2L);
     }
@@ -122,7 +122,7 @@ public class ResizeShardsITest extends IntegTestCase {
     @Test
     public void testShrinkShardsOfPartition() throws Exception {
         execute("create table quotes (id integer, quote string, date timestamp with time zone) " +
-                "partitioned by(date) clustered into 3 shards with (number_of_replicas = 1)");
+                "partitioned by(date) clustered into 3 shards with (number_of_replicas = 2)");
         execute("insert into quotes (id, quote, date) values (?, ?, ?), (?, ?, ?)",
             new Object[]{
                 1, "Don't panic", 1395874800000L,
@@ -151,10 +151,17 @@ public class ResizeShardsITest extends IntegTestCase {
             $(1));
         ensureYellow();
 
-        execute("select number_of_shards from information_schema.table_partitions " +
+        execute("select partition_ident, number_of_shards from information_schema.table_partitions " +
                 "where table_name = 'quotes' " +
                 "and values = '{\"date\": 1395874800000}'");
-        assertThat(response).hasRows("1");
+        assertThat(response.rows()[0][1]).isEqualTo(1);
+
+        String partitionIdent = (String) response.rows()[0][0];
+        execute("select count(*), primary from sys.shards where table_name = 'quotes' and " + "" +
+            "partition_ident='" + partitionIdent + "' group by primary order by 2");
+        assertThat(response).hasRows(
+            "2| false",
+            "1| true");
         execute("select id from quotes");
         assertThat(response).hasRowCount(2L);
     }
@@ -170,16 +177,18 @@ public class ResizeShardsITest extends IntegTestCase {
         execute("alter table t1 set (number_of_shards = 2)");
         ensureYellow();
 
-        execute("select number_of_shards from information_schema.tables where table_name = 't1'");
-        assertThat(response).hasRows("2");
+        execute("select count(*), primary from sys.shards where table_name = 't1' group by primary order by 2");
+        assertThat(response).hasRows(
+            "2| false",
+            "2| true");
         execute("select x from t1");
         assertThat(response).hasRowCount(2L);
     }
 
     @Test
     public void test_number_of_shards_of_a_table_can_be_increased_without_explicitly_setting_number_of_routing_shards() {
-        execute("create table t1 (x int, p int) clustered into 3 shards " +
-            "with (number_of_replicas = 1)");
+        execute("create table t1 (x int, p int) clustered into 1 shards " +
+            "with (number_of_replicas = 2)");
         execute("insert into t1 (x, p) select g, g from generate_series(1, 12, 1) as g");
         execute("refresh table t1");
 
@@ -188,8 +197,10 @@ public class ResizeShardsITest extends IntegTestCase {
         execute("alter table t1 set (number_of_shards = 12)");
         ensureYellow();
 
-        execute("select number_of_shards from information_schema.tables where table_name = 't1'");
-        assertThat(response).hasRows("12");
+        execute("select count(*), primary from sys.shards where table_name = 't1' group by primary order by 2");
+        assertThat(response).hasRows(
+            "24| false",
+            "12| true");
         execute("select x from t1");
         assertThat(response).hasRowCount(12L);
     }
@@ -197,7 +208,7 @@ public class ResizeShardsITest extends IntegTestCase {
     @Test
     public void test_number_of_shards_on_a_one_sharded_table_can_be_increased_without_explicitly_setting_number_of_routing_shards() {
         execute("create table t1 (x int, p int) clustered into 1 shards " +
-            "with (number_of_replicas = 1)");
+            "with (number_of_replicas = 2)");
         execute("insert into t1 (x, p) select g, g from generate_series(1, 12, 1) as g");
         execute("refresh table t1");
 
@@ -206,8 +217,10 @@ public class ResizeShardsITest extends IntegTestCase {
         execute("alter table t1 set (number_of_shards = 3)");
         ensureYellow();
 
-        execute("select number_of_shards from information_schema.tables where table_name = 't1'");
-        assertThat(response).hasRows("3");
+        execute("select count(*), primary from sys.shards where table_name = 't1' group by primary order by 2");
+        assertThat(response).hasRows(
+            "6| false",
+            "3| true");
         execute("select x from t1");
         assertThat(response).hasRowCount(12L);
 
@@ -220,25 +233,29 @@ public class ResizeShardsITest extends IntegTestCase {
         execute("alter table t1 set (number_of_shards = 12)");
         ensureYellow();
 
-        execute("select number_of_shards from information_schema.tables where table_name = 't1'");
-        assertThat(response).hasRows("12");
+        execute("select count(*), primary from sys.shards where table_name = 't1' group by primary order by 2");
+        assertThat(response).hasRows(
+            "24| false",
+            "12| true");
         execute("select x from t1");
         assertThat(response).hasRowCount(12L);
     }
 
     @Test
     public void testNumberOfShardsOfAPartitionCanBeIncreased() {
-        execute("create table t1 (x int, p int) partitioned by (p) clustered into 1 shards " +
-                "with (number_of_replicas = 1, number_of_routing_shards = 10)");
-        execute("insert into t1 (x, p) values (1, 1), (2, 1)");
-        execute("alter table t1 partition (p = 1) set (\"blocks.write\" = true)");
+        execute("create table t_parted (x int, p int) partitioned by (p) clustered into 1 shards " +
+                "with (number_of_replicas = 0, number_of_routing_shards = 10)");
+        execute("insert into t_parted (x, p) values (1, 1), (2, 1)");
+        execute("refresh table t_parted");
+        execute("alter table t_parted partition (p = 1) set (\"blocks.write\" = true)");
 
-        execute("alter table t1 partition (p = 1) set (number_of_shards = 2)");
+        execute("alter table t_parted partition (p = 1) set (number_of_shards = 5)");
         ensureYellow();
 
-        execute("select number_of_shards from information_schema.table_partitions where table_name = 't1'");
-        assertThat(response).hasRows("2");
-        execute("select x from t1");
+        execute("select count(*), primary from sys.shards where table_name = 't_parted' group by primary order by 2");
+        assertThat(response).hasRows(
+            "5| true");
+        execute("select x from t_parted");
         assertThat(response).hasRowCount(2L);
     }
 }


### PR DESCRIPTION
In `MetadataCreateIndexService` which is also called when resizing the shards of a table (simple or partitioned) was not checking if the request is a resize or a create, therefore it set the `number_of_replicas` and `auto_expand_replicas`, as there were not found on the request (which only changes the `number_of_shards`). As a result the `copySettings` logic was finding those settings (reset to default values) and didn't copy them from the existing index settings during the index settings update.

Reproduction example:
```
cr> CREATE TABLE tbl (x int, p int) CLUSTERED INTO 1 SHARDS WITH (number_of_routing_shards = 32, number_of_replicas = 0);
CREATE OK, 1 row affected (0.014 sec)
cr> INSERT INTO tbl(x, p) SELECT g, 1 FROM generate_series(1, 4, 1) AS g;
INSERT OK, 4 rows affected (0.004 sec)
cr> refresh table tbl;
REFRESH OK, 1 row affected (0.002 sec)
cr> select count(*), primary from sys.shards where table_name='tbl' group by primary;
+----------+---------+
| count(*) | primary |
+----------+---------+
|        1 | TRUE    |
+----------+---------+
SELECT 1 row in set (0.002 sec)
cr> ALTER TABLE tbl SET ("blocks.write" = false);
ALTER OK, -1 rows affected (0.006 sec)
cr> ALTER TABLE tbl SET ("blocks.write" = true);
ALTER OK, -1 rows affected (0.007 sec)
cr> ALTER TABLE tbl SET (number_of_shards = 2);
ALTER OK, 0 rows affected (0.023 sec)
cr> ALTER TABLE tbl SET ("blocks.write" = false);
ALTER OK, -1 rows affected (0.007 sec)
cr> select count(*), primary from sys.shards where table_name='tbl' group by primary;
+----------+---------+
| count(*) | primary |
+----------+---------+
|        2 | FALSE   |
|        2 | TRUE    |
+----------+---------+
SELECT 2 rows in set (0.002 sec)
```