### PR TITLE
Add IS NOT? DISTINCT FROM predicate

### DIFF
--- a/docs/appendices/compatibility.rst
+++ b/docs/appendices/compatibility.rst
@@ -156,8 +156,6 @@ supported:
 
 - ``ENUM`` support functions
 
-- ``IS DISTINCT FROM``
-
 - Network address functions and :ref:`operators <gloss-operator>`
 
 - Mathematical functions

--- a/docs/appendices/release-notes/5.9.0.rst
+++ b/docs/appendices/release-notes/5.9.0.rst
@@ -109,6 +109,9 @@ SQL Standard and PostgreSQL Compatibility
   ``ms``, ``msec``, ``msecs``, ``millisecond`` or ``milliseconds`` can
   be used as the unit name as well.
 
+- `Martin Stein <https://github.com/marstein>`_ added support for the
+  IS DISTINCT FROM operator. The operator is not yet optimized for Lucene queries.
+
 Data Types
 ----------
 

--- a/docs/general/dql/selects.rst
+++ b/docs/general/dql/selects.rst
@@ -509,6 +509,50 @@ does always return ``NULL`` when comparing ``NULL``.
    <scalar-null-or-empty>` scalar for improved performance.
 
 
+.. _sql_dql_is_distinct_from:
+
+``IS DISTINCT FROM``
+--------------------
+
+Returns ``TRUE`` if ``expr`` is not equal to :ref:`evaluate <gloss-evaluation>`.
+If both expressions are ``NULL`` the result is false. Comparing a non-NULL value
+to ``NULL`` returns ``TRUE`` - ``NULL`` is considered distinct from any value.
+
+Use this predicate to check for non-``NULL`` values as SQL's three-valued logic
+does always return ``NULL`` when comparing ``NULL``.
+
+.. vale off
+
+:expr:
+  :ref:`Expression <gloss-expression>` of one of the supported
+  :ref:`data types <data-types>` supported by CrateDB.
+
+.. vale on
+
+::
+
+    cr> SELECT
+    ...   name,
+    ...   name IS DISTINCT FROM 'Trillian' as is_distinct,
+    ...   name != 'Trillian' as not_eq
+    ... FROM unnest(['Arthur', 'Trillian', null]) as t(name)
+    ... ORDER BY 1;
+    +----------+-------------+--------+
+    | name     | is_distinct | not_eq |
+    +----------+-------------+--------+
+    | Arthur   | TRUE        | TRUE   |
+    | Trillian | FALSE       | FALSE  |
+    | NULL     | TRUE        | NULL   |
+    +----------+-------------+--------+
+    SELECT 3 rows in set (... sec)
+
+
+.. NOTE::
+
+   Using ``IS DISTINCT FROM`` can be slow because the expression is not using
+   index structures and is not suitable for use on larger tables.
+   
+   
 .. _sql_dql_array_comparisons:
 
 Array comparisons

--- a/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -2089,8 +2089,8 @@ class AstBuilder extends SqlBaseParserBaseVisitor<Node> {
 
     @Override
     public Node visitPosition(SqlBaseParser.PositionContext context) {
-        Expression substr = (Expression) visit(context.expr(0)); 
-        Expression str = (Expression) visit(context.expr(1)); 
+        Expression substr = (Expression) visit(context.expr(0));
+        Expression str = (Expression) visit(context.expr(1));
         return new FunctionCall(QualifiedName.of("strpos"), List.of(str, substr));
     }
 
@@ -2544,6 +2544,7 @@ class AstBuilder extends SqlBaseParserBaseVisitor<Node> {
             case SqlBaseLexer.GT -> ComparisonExpression.Type.GREATER_THAN;
             case SqlBaseLexer.GTE -> ComparisonExpression.Type.GREATER_THAN_OR_EQUAL;
             case SqlBaseLexer.LLT -> ComparisonExpression.Type.CONTAINED_WITHIN;
+            case SqlBaseLexer.DISTINCT -> ComparisonExpression.Type.IS_DISTINCT_FROM;
             case SqlBaseLexer.REGEX_MATCH -> ComparisonExpression.Type.REGEX_MATCH;
             case SqlBaseLexer.REGEX_NO_MATCH -> ComparisonExpression.Type.REGEX_NO_MATCH;
             case SqlBaseLexer.REGEX_MATCH_CI -> ComparisonExpression.Type.REGEX_MATCH_CI;

--- a/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -1094,6 +1094,7 @@ public class ExpressionAnalyzer {
             return allocateFunction(AndOperator.NAME, List.of(gteFunc, lteFunc), context);
         }
 
+
         @Override
         public Symbol visitMatchPredicate(MatchPredicate node, ExpressionAnalysisContext context) {
             Map<Symbol, Symbol> identBoostMap = HashMap.newHashMap(node.idents().size());

--- a/server/src/main/java/io/crate/expression/operator/DistinctFrom.java
+++ b/server/src/main/java/io/crate/expression/operator/DistinctFrom.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.operator;
+
+import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
+
+import io.crate.data.Input;
+import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.FunctionType;
+import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.BoundSignature;
+import io.crate.metadata.functions.Signature;
+import io.crate.types.DataType;
+import io.crate.types.TypeSignature;
+
+public class DistinctFrom extends Operator<Object> {
+
+    public static final String NAME = "op_IS DISTINCT FROM";
+    public static final Signature SIGNATURE = Signature.builder(NAME, FunctionType.SCALAR)
+        .argumentTypes(TypeSignature.parse("E"), TypeSignature.parse("E"))
+        .returnType(Operator.RETURN_TYPE.getTypeSignature())
+        .features(Feature.DETERMINISTIC, Feature.NOTNULL)
+        .typeVariableConstraints(typeVariable("E"))
+        .build();
+
+    public static void register(Functions.Builder builder) {
+        builder.add(
+            SIGNATURE,
+            DistinctFrom::new
+        );
+    }
+
+    private final DataType<Object> argType;
+
+    @SuppressWarnings("unchecked")
+    private DistinctFrom(Signature signature, BoundSignature boundSignature) {
+        super(signature, boundSignature);
+        this.argType = (DataType<Object>) boundSignature.argTypes().getFirst();
+    }
+
+    @Override
+    public Symbol normalizeSymbol(Function function, TransactionContext txnCtx, NodeContext nodeCtx) {
+        try {
+            return evaluateIfLiterals(this, txnCtx, nodeCtx, function);
+        } catch (Throwable t) {
+            return function;
+        }
+    }
+
+    @Override
+    @SafeVarargs
+    public final Boolean evaluate(TransactionContext txnCtx, NodeContext nodeCtx, Input<Object>... args) {
+        // This operator does not evaluate to NULL if one argument is NULL! If both are NULL it evaluates to FALSE.
+        assert args.length == 2 : "number of arguments must be 2";
+        Object arg1 = args[0].value();
+        Object arg2 = args[1].value();
+
+        // two ``NULL`` values are not distinct from one other
+        if (arg1 == null && arg2 == null) {
+            return false;
+        }
+        // Any non-null Literal is distinct from null
+        if (arg1 == null || arg2 == null) {
+            return true;
+        }
+        return argType.compare(arg1, arg2) != 0;
+    }
+}

--- a/server/src/main/java/io/crate/expression/operator/Operators.java
+++ b/server/src/main/java/io/crate/expression/operator/Operators.java
@@ -41,7 +41,8 @@ public class Operators implements FunctionsProvider {
         EqOperator.NAME,
         GtOperator.NAME, GteOperator.NAME,
         LtOperator.NAME, LteOperator.NAME,
-        CIDROperator.CONTAINED_WITHIN
+        CIDROperator.CONTAINED_WITHIN,
+        DistinctFrom.NAME
     );
 
     @Override
@@ -63,5 +64,6 @@ public class Operators implements FunctionsProvider {
         AllOperator.register(builder);
         LikeOperators.register(builder);
         ExistsOperator.register(builder);
+        DistinctFrom.register(builder);
     }
 }

--- a/server/src/main/resources/sql_features.tsv
+++ b/server/src/main/resources/sql_features.tsv
@@ -419,8 +419,8 @@ T122	WITH (excluding RECURSIVE) in subquery			YES
 T131	Recursive query			NO		
 T132	Recursive query in subquery			NO		
 T141	SIMILAR predicate			NO		
-T151	DISTINCT predicate			NO		
-T152	DISTINCT predicate with negation			NO		
+T151	DISTINCT predicate			YES		
+T152	DISTINCT predicate with negation			YES		
 T171	LIKE clause in table definition			NO		
 T172	AS subquery clause in table definition			NO		
 T173	Extended LIKE clause in table definition			NO		

--- a/server/src/test/java/io/crate/expression/predicate/DistinctFromTest.java
+++ b/server/src/test/java/io/crate/expression/predicate/DistinctFromTest.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.predicate;
+
+import static io.crate.testing.Asserts.isLiteral;
+import static io.crate.testing.DataTypeTesting.getDataGenerator;
+import static io.crate.testing.DataTypeTesting.randomType;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import java.util.Set;
+import java.util.function.Supplier;
+
+import org.apache.lucene.search.Query;
+import org.elasticsearch.Version;
+import org.junit.Test;
+
+import io.crate.expression.scalar.ScalarTestCase;
+import io.crate.expression.symbol.Literal;
+import io.crate.expression.symbol.format.Style;
+import io.crate.lucene.GenericFunctionQuery;
+import io.crate.testing.DataTypeTesting;
+import io.crate.testing.QueryTester;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+
+/*
+    A <distinct predicate> tests two values to see whether they are distinct and
+    returns either ``TRUE`` or ``FALSE``.
+    The two expressions must be comparable. If the attributes are rows, they
+    must be of the same degree and each corresponding pair of Fields must have
+    comparable <data type>s.
+ */
+public class DistinctFromTest extends ScalarTestCase {
+    @Test
+    public void testEvaluateIncomparableDatatypes() {
+        assertThatThrownBy(() -> assertEvaluate("3 is distinct from true", isLiteral(false)))
+            .isExactlyInstanceOf(ClassCastException.class);
+    }
+
+    @Test
+    public void testNormalizeSymbolNullNull() {
+        // two ``NULL`` values are not distinct from one other
+        assertNormalize("null is distinct from null", isLiteral(Boolean.FALSE));
+    }
+
+    @Test
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public void test_random_data_type() {
+        DataType<?> type = DataTypeTesting.randomTypeExcluding(Set.of(DataTypes.GEO_SHAPE));
+        Supplier<?> dataGenerator = getDataGenerator(type);
+
+        Object value1 = dataGenerator.get();
+        Object value2 = dataGenerator.get();
+        // Make sure the two values are distinct. Important for boolean or BitStringType.
+        while (((DataType) type).compare(value1, value2) == 0) {
+            value2 = dataGenerator.get();
+        }
+
+        Literal<?> literal1 = Literal.ofUnchecked(type, value1);
+        assertEvaluate("? IS NOT DISTINCT FROM ?", Boolean.TRUE, literal1, literal1);
+
+        Literal<?> literal2 = Literal.ofUnchecked(type, value2);
+        assertEvaluate("? IS DISTINCT FROM ?", Boolean.TRUE, literal1, literal2);
+    }
+
+    @Test
+    public void test_random_data_type_against_null() {
+        DataType<?> randomType = randomType();
+        var val = Literal.ofUnchecked(randomType, getDataGenerator(randomType).get()).toString(Style.QUALIFIED);
+
+        // Random value IS DISTINCT from another random value.
+        assertEvaluate("? IS DISTINCT FROM null", Boolean.TRUE, Literal.of(val));
+        assertEvaluate("null IS DISTINCT FROM ?", Boolean.TRUE, Literal.of(val));
+    }
+
+    @Test
+    public void test_terms_query_on_empty_object() throws Exception {
+        QueryTester.Builder builder = new QueryTester.Builder(
+            THREAD_POOL,
+            clusterService,
+            Version.CURRENT,
+            "create table tbl (str string)");
+        builder.indexValue("str", "hello");
+        builder.indexValue("str", "Duke");
+        builder.indexValue("str", "rules");
+        builder.indexValue("str", null);
+        try (QueryTester tester = builder.build()) {
+            Query query = tester.toQuery("str IS DISTINCT FROM 'hello'");
+            assertThat(query)
+                .isExactlyInstanceOf(GenericFunctionQuery.class)
+                .hasToString("(str IS DISTINCT FROM 'hello')");
+
+            assertThat(tester.runQuery("str", "str IS DISTINCT FROM 'hello'"))
+                .containsExactly("Duke", "rules", null);
+            assertThat(tester.runQuery("str", "str IS DISTINCT FROM null"))
+                .containsExactly("hello", "Duke", "rules");
+            assertThat(tester.runQuery("str", "str IS NOT DISTINCT FROM 'hello'"))
+                .containsExactly("hello");
+        }
+    }
+}

--- a/server/src/testFixtures/java/io/crate/expression/scalar/ScalarTestCase.java
+++ b/server/src/testFixtures/java/io/crate/expression/scalar/ScalarTestCase.java
@@ -23,7 +23,6 @@ package io.crate.expression.scalar;
 
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.isNull;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.LinkedList;


### PR DESCRIPTION
Added sql parsing and execution classes for the DISTINCT predicate.
Closes #14644

## Summary of the changes / Why this improves CrateDB
Implement the IS DISTINCT FROM predicate. It is just like `<>` but handles NULL values differently.
TODO: arrays and possibly type check.
The predicate is implemented as a Function. Please review if this is the right choice.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x ] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
