### PR TITLE
Workaround eclipse.jdt compiler bug

### DIFF
--- a/server/src/test/java/io/crate/execution/engine/sort/OrderingByPositionTest.java
+++ b/server/src/test/java/io/crate/execution/engine/sort/OrderingByPositionTest.java
@@ -77,10 +77,11 @@ public class OrderingByPositionTest extends ESTestCase {
 
     @Test
     public void testMultipleOrderBy() throws Exception {
-        Comparator<Object[]> ordering = CompoundOrdering.of(Arrays.asList(
+        var orderings = Arrays.asList(
             OrderingByPosition.arrayOrdering(DataTypes.INTEGER, 1, false, false),
             OrderingByPosition.arrayOrdering(DataTypes.INTEGER, 0, false, false)
-        ));
+        );
+        Comparator<Object[]> ordering = CompoundOrdering.of(orderings);
 
         assertThat(ordering.compare(new Object[]{0, 0}, new Object[]{4, 0})).isEqualTo(-1);
         assertThat(ordering.compare(new Object[]{4, 0}, new Object[]{1, 1})).isEqualTo(-1);


### PR DESCRIPTION
For some reason `OrderingByPositionTest` triggered a bug in the
eclipse compiler, causing it to crash.

See https://github.com/eclipse-jdtls/eclipse.jdt.ls/issues/3199
