### PR TITLE
Replace hppc RamUsageEstimator with the Lucene one

### DIFF
--- a/extensions/functions/src/test/java/io/crate/window/OffsetValueFunctionsTest.java
+++ b/extensions/functions/src/test/java/io/crate/window/OffsetValueFunctionsTest.java
@@ -28,18 +28,12 @@ import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
-import com.carrotsearch.hppc.RamUsageEstimator;
-
-import io.crate.data.RowN;
 import io.crate.data.breaker.RamAccounting;
 import io.crate.execution.engine.window.AbstractWindowFunctionTest;
 import io.crate.metadata.ColumnIdent;
 import io.crate.testing.PlainRamAccounting;
 
 public class OffsetValueFunctionsTest extends AbstractWindowFunctionTest {
-
-    private static long SHALLOW_ROW_N_SIZE = RamUsageEstimator.shallowSizeOfInstance(RowN.class);
-
 
     @Test
     public void testLagWithSingleArgumentAndEmptyOver() throws Throwable {

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/TopKAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/TopKAggregation.java
@@ -34,13 +34,12 @@ import org.apache.datasketches.frequencies.ErrorType;
 import org.apache.datasketches.frequencies.ItemsSketch;
 import org.apache.datasketches.memory.Memory;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.jetbrains.annotations.Nullable;
-
-import com.carrotsearch.hppc.RamUsageEstimator;
 
 import io.crate.Streamer;
 import io.crate.data.Input;


### PR DESCRIPTION
- Replace hppc RamUsageEstimator with the Lucene one
    
  We use the Lucene RamUsageEstimator everywhere else in the code,
  and with hppc version `0.10.0` the class is no longer public.
    
  Follows: #16304

- tests: Remove unused hppc.RamUsageEstimator from OffsetValueFunctionsTest



    

