### PR TITLE
reproduction

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/StaticInformationSchemaQueryTest.java
+++ b/server/src/test/java/io/crate/integrationtests/StaticInformationSchemaQueryTest.java
@@ -87,7 +87,7 @@ public class StaticInformationSchemaQueryTest extends IntegTestCase {
     }
 
     @Test
-    @Repeat(iterations = 20)
+    @Repeat(iterations = 100)
     public void testIsNotNull() throws Exception {
         execute("select * from information_schema.tables where table_name is not null and table_schema = ?", new Object[]{sqlExecutor.getCurrentSchema()});
         assertThat(response.rowCount()).isEqualTo(3L);

--- a/server/src/test/java/io/crate/integrationtests/StaticInformationSchemaQueryTest.java
+++ b/server/src/test/java/io/crate/integrationtests/StaticInformationSchemaQueryTest.java
@@ -29,8 +29,12 @@ import org.elasticsearch.test.IntegTestCase;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.carrotsearch.randomizedtesting.annotations.Repeat;
+import com.carrotsearch.randomizedtesting.annotations.Seed;
+
 import io.crate.testing.Asserts;
 
+@Seed("B37AA2673C72CDDE")
 public class StaticInformationSchemaQueryTest extends IntegTestCase {
 
     @Before
@@ -83,6 +87,7 @@ public class StaticInformationSchemaQueryTest extends IntegTestCase {
     }
 
     @Test
+    @Repeat(iterations = 20)
     public void testIsNotNull() throws Exception {
         execute("select * from information_schema.tables where table_name is not null and table_schema = ?", new Object[]{sqlExecutor.getCurrentSchema()});
         assertThat(response.rowCount()).isEqualTo(3L);


### PR DESCRIPTION


```

org.elasticsearch.ElasticsearchTimeoutException: Timeout while running `create table t2 (col1 integer, col2 string) clustered into 10 shards`
	at __randomizedtesting.SeedInfo.seed([B37AA2673C72CDDE:A484121952819FDB]:0)


[i.c.i.StaticInformationSchemaQueryTest] before test
[i.c.i.StaticInformationSchemaQueryTest] [StaticInformationSchemaQueryTest#testIsNotNull]: setting up test
[i.c.i.StaticInformationSchemaQueryTest] [StaticInformationSchemaQueryTest#testIsNotNull]: all set up test
[i.c.p.s.SetSessionPlan   ] [T#1]]] SET SESSION STATEMENT WILL BE IGNORED: extra_float_digits
[o.e.c.m.MetadataCreateIndexService] [masterService#updateTask][T#1]]] [q.t1] creating index, cause [api], shards [7]/[0]
[o.e.c.r.a.AllocationService] [masterService#updateTask][T#1]]] updating number_of_replicas to [1] for indices [q.t1]
[o.e.c.m.MetadataCreateIndexService] masterService#updateTask][T#1]]] [q.t2] creating index, cause [api], shards [10]/[0]
[o.e.c.r.a.AllocationService] [masterService#updateTask][T#1]]] updating number_of_replicas to [1] for indices [q.t2]
[2024-07-29T03:17:42,124][ERROR][o.e.t.IntegTestCase      ] [[Time-limited test]] Timeout on SQL statement: create table t2 (col1 integer, col2 string) clustered into 10 shards org.elasticsearch.ElasticsearchTimeoutException: Timeout while running `create table t2 (col1 integer, col2 string) clustered into 10 shards`
```


`./mvnw -pl server test -Dtest=io.crate.integrationtests.StaticInformationSchemaQueryTest -Dtests.method=testIsNotNull -Dtests.seed=B37AA2673C72CDDE -Dtests.locale=pt-AO -Dtests.timezone=America/Nome -Dtests.iters=20`

got 4 failures out of 20 iterations

