### PR TITLE
Inline constants in ArrayLengthQueryTest

### DIFF
--- a/server/src/test/java/io/crate/lucene/ArrayLengthQueryTest.java
+++ b/server/src/test/java/io/crate/lucene/ArrayLengthQueryTest.java
@@ -24,7 +24,6 @@ package io.crate.lucene;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
@@ -46,43 +45,6 @@ import io.crate.types.ObjectType;
 public class ArrayLengthQueryTest extends CrateDummyClusterServiceUnitTest {
 
     protected QueryTester tester;
-
-    protected static final List<Integer> ARRAY_NULL;
-    protected static final List<Integer> ARRAY_NULL_NULL;
-    protected static final List<Integer> ARRAY_NULL_NULL_NULL;
-
-    protected static final List<Integer> ARRAY_NULL_1;
-    protected static final List<Integer> ARRAY_NULL_NULL_1;
-
-    protected static final List<Integer> ARRAY_NULL_1_1;
-
-    static {
-        ARRAY_NULL = new ArrayList<>();
-        ARRAY_NULL.add(null);
-
-        ARRAY_NULL_NULL = new ArrayList<>();
-        ARRAY_NULL_NULL.add(null);
-        ARRAY_NULL_NULL.add(null);
-
-        ARRAY_NULL_NULL_NULL = new ArrayList<>();
-        ARRAY_NULL_NULL_NULL.add(null);
-        ARRAY_NULL_NULL_NULL.add(null);
-        ARRAY_NULL_NULL_NULL.add(null);
-
-        ARRAY_NULL_1 = new ArrayList<>();
-        ARRAY_NULL_1.add(null);
-        ARRAY_NULL_1.add(1);
-
-        ARRAY_NULL_NULL_1 = new ArrayList<>();
-        ARRAY_NULL_NULL_1.add(null);
-        ARRAY_NULL_NULL_1.add(null);
-        ARRAY_NULL_NULL_1.add(1);
-
-        ARRAY_NULL_1_1 = new ArrayList<>();
-        ARRAY_NULL_1_1.add(null);
-        ARRAY_NULL_1_1.add(1);
-        ARRAY_NULL_1_1.add(1);
-    }
 
     protected Version tableVersionCreatedToTest() {
         return Version.CURRENT;
@@ -108,12 +70,12 @@ public class ArrayLengthQueryTest extends CrateDummyClusterServiceUnitTest {
                 List.of(10, 20),
                 List.of(10, 10, 20),
                 List.of(10, 20, 30),
-                ARRAY_NULL,
-                ARRAY_NULL_NULL,
-                ARRAY_NULL_NULL_NULL,
-                ARRAY_NULL_1,
-                ARRAY_NULL_NULL_1,
-                ARRAY_NULL_1_1
+                Arrays.asList(new Integer[] { null }),
+                Arrays.asList(null, null),
+                Arrays.asList(null, null, null),
+                Arrays.asList(null, 1),
+                Arrays.asList(null, null, 1),
+                Arrays.asList(null, 1, 1)
             )
             .build();
     }
@@ -133,12 +95,12 @@ public class ArrayLengthQueryTest extends CrateDummyClusterServiceUnitTest {
             List.of(10, 20),
             List.of(10, 10, 20),
             List.of(10, 20, 30),
-            ARRAY_NULL,
-            ARRAY_NULL_NULL,
-            ARRAY_NULL_NULL_NULL,
-            ARRAY_NULL_1,
-            ARRAY_NULL_NULL_1,
-            ARRAY_NULL_1_1
+            Arrays.asList(new Integer[] { null }),
+            Arrays.asList(null, null),
+            Arrays.asList(null, null, null),
+            Arrays.asList(null, 1),
+            Arrays.asList(null, null, 1),
+            Arrays.asList(null, 1, 1)
         );
     }
 
@@ -153,12 +115,12 @@ public class ArrayLengthQueryTest extends CrateDummyClusterServiceUnitTest {
             List.of(10, 20),
             List.of(10, 10, 20),
             List.of(10, 20, 30),
-            ARRAY_NULL,
-            ARRAY_NULL_NULL,
-            ARRAY_NULL_NULL_NULL,
-            ARRAY_NULL_1,
-            ARRAY_NULL_NULL_1,
-            ARRAY_NULL_1_1
+            Arrays.asList(new Integer[] { null }),
+            Arrays.asList(null, null),
+            Arrays.asList(null, null, null),
+            Arrays.asList(null, 1),
+            Arrays.asList(null, null, 1),
+            Arrays.asList(null, 1, 1)
         );
     }
 
@@ -170,11 +132,11 @@ public class ArrayLengthQueryTest extends CrateDummyClusterServiceUnitTest {
             List.of(10, 20),
             List.of(10, 10, 20),
             List.of(10, 20, 30),
-            ARRAY_NULL_NULL,
-            ARRAY_NULL_NULL_NULL,
-            ARRAY_NULL_1,
-            ARRAY_NULL_NULL_1,
-            ARRAY_NULL_1_1
+            Arrays.asList(null, null),
+            Arrays.asList(null, null, null),
+            Arrays.asList(null, 1),
+            Arrays.asList(null, null, 1),
+            Arrays.asList(null, 1, 1)
         );
     }
 
@@ -188,12 +150,12 @@ public class ArrayLengthQueryTest extends CrateDummyClusterServiceUnitTest {
             List.of(10, 20),
             List.of(10, 10, 20),
             List.of(10, 20, 30),
-            ARRAY_NULL,
-            ARRAY_NULL_NULL,
-            ARRAY_NULL_NULL_NULL,
-            ARRAY_NULL_1,
-            ARRAY_NULL_NULL_1,
-            ARRAY_NULL_1_1
+            Arrays.asList(new Integer[] { null }),
+            Arrays.asList(null, null),
+            Arrays.asList(null, null, null),
+            Arrays.asList(null, 1),
+            Arrays.asList(null, null, 1),
+            Arrays.asList(null, 1, 1)
         );
     }
 
@@ -203,9 +165,9 @@ public class ArrayLengthQueryTest extends CrateDummyClusterServiceUnitTest {
         assertThat(rows).containsExactlyInAnyOrder(
             List.of(10, 10, 20),
             List.of(10, 20, 30),
-            ARRAY_NULL_NULL_NULL,
-            ARRAY_NULL_NULL_1,
-            ARRAY_NULL_1_1
+            Arrays.asList(null, null, null),
+            Arrays.asList(null, null, 1),
+            Arrays.asList(null, 1, 1)
         );
     }
 
@@ -217,11 +179,11 @@ public class ArrayLengthQueryTest extends CrateDummyClusterServiceUnitTest {
             List.of(10, 20),
             List.of(10, 10, 20),
             List.of(10, 20, 30),
-            ARRAY_NULL_NULL,
-            ARRAY_NULL_NULL_NULL,
-            ARRAY_NULL_1,
-            ARRAY_NULL_NULL_1,
-            ARRAY_NULL_1_1
+            Arrays.asList(null, null),
+            Arrays.asList(null, null, null),
+            Arrays.asList(null, 1),
+            Arrays.asList(null, null, 1),
+            Arrays.asList(null, 1, 1)
         );
     }
 
@@ -251,7 +213,7 @@ public class ArrayLengthQueryTest extends CrateDummyClusterServiceUnitTest {
         assertThat(rows).containsExactlyInAnyOrder(
             List.of(10),
             List.of(20),
-            ARRAY_NULL
+            Arrays.asList(new Integer[] { null })
         );
     }
 
@@ -265,12 +227,12 @@ public class ArrayLengthQueryTest extends CrateDummyClusterServiceUnitTest {
             List.of(10, 20),
             List.of(10, 10, 20),
             List.of(10, 20, 30),
-            ARRAY_NULL,
-            ARRAY_NULL_NULL,
-            ARRAY_NULL_NULL_NULL,
-            ARRAY_NULL_1,
-            ARRAY_NULL_NULL_1,
-            ARRAY_NULL_1_1
+            Arrays.asList(new Integer[] { null }),
+            Arrays.asList(null, null),
+            Arrays.asList(null, null, null),
+            Arrays.asList(null, 1),
+            Arrays.asList(null, null, 1),
+            Arrays.asList(null, 1, 1)
         );
     }
 
@@ -282,9 +244,9 @@ public class ArrayLengthQueryTest extends CrateDummyClusterServiceUnitTest {
             List.of(20),
             List.of(10, 10),
             List.of(10, 20),
-            ARRAY_NULL,
-            ARRAY_NULL_NULL,
-            ARRAY_NULL_1
+            Arrays.asList(new Integer[] { null }),
+            Arrays.asList(null, null),
+            Arrays.asList(null, 1)
         );
     }
 
@@ -294,7 +256,7 @@ public class ArrayLengthQueryTest extends CrateDummyClusterServiceUnitTest {
         assertThat(rows).containsExactlyInAnyOrder(
             List.of(10),
             List.of(20),
-            ARRAY_NULL
+            Arrays.asList(new Integer[] { null })
         );
     }
 
@@ -304,8 +266,8 @@ public class ArrayLengthQueryTest extends CrateDummyClusterServiceUnitTest {
         assertThat(rows).containsExactlyInAnyOrder(
             List.of(10, 10),
             List.of(10, 20),
-            ARRAY_NULL_NULL,
-            ARRAY_NULL_1
+            Arrays.asList(null, null),
+            Arrays.asList(null, 1)
         );
     }
 


### PR DESCRIPTION
Defining the lists as `static final` means they'd need to be kept alive
over the whole test run duration.

A regular `final` class property would do, but this instead inlines them
for consistency with the other `List.of()` literals.
