### PR TITLE
Fix `!= <array>` for unfiltered nulls and missing array of nulls

### DIFF
--- a/docs/appendices/release-notes/5.9.0.rst
+++ b/docs/appendices/release-notes/5.9.0.rst
@@ -69,6 +69,18 @@ Breaking Changes
   regressions on tables created before 5.9.0. For tables created on and after
   5.9.0, the fix has positive impact on the performance.
 
+- Fixed an issue that caused ``WHERE`` clause containing ``NOT`` operator on
+  an array type against an empty array to incorrectly filter array of nulls. It
+  is a breaking change because the fix causes performance regressions on tables
+  created before 5.9.0. For tables created on and after 5.9.0, the fix has
+  positive impact on the performance.
+
+- Fixed an issue that caused ``WHERE`` clause containing ``NOT`` operator on
+  an array type without doc-values against a non-empty array to incorrectly
+  un-filter null rows. It is a breaking change because the fix causes
+  performance regressions on tables created before 5.9.0. For tables created on
+  and after 5.9.0, the fix has positive impact on the performance.
+
 - Changed the return value of the concat operator to return a ``NULL`` literal
   instead of an empty string when any of the operand is ``NULL``.
 

--- a/server/src/main/java/io/crate/execution/dml/ArrayIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/ArrayIndexer.java
@@ -30,6 +30,7 @@ import java.util.function.Function;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.IntField;
 import org.apache.lucene.document.IntPoint;
+import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.Version;
 import org.jetbrains.annotations.NotNull;
@@ -49,6 +50,10 @@ public class ArrayIndexer<T> implements ValueIndexer<List<T>> {
 
     public static Query arrayLengthRangeQuery(Reference arrayRef, int includeLower, int includeUpper, Function<ColumnIdent, Reference> getRef) {
         return IntPoint.newRangeQuery(toArrayLengthFieldName(arrayRef, getRef), includeLower, includeUpper);
+    }
+
+    public static Query arrayLengthExistsQuery(Reference arrayRef, Function<ColumnIdent, Reference> getRef) {
+        return new FieldExistsQuery(toArrayLengthFieldName(arrayRef, getRef));
     }
 
     static String toArrayLengthFieldName(Reference arrayRef, Function<ColumnIdent, Reference> getRef) {

--- a/server/src/main/java/io/crate/expression/operator/any/AnyNeqOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/any/AnyNeqOperator.java
@@ -73,7 +73,7 @@ public final class AnyNeqOperator extends AnyOperator<Object> {
             }
             andBuilder.add(fromPrimitive, BooleanClause.Occur.MUST);
         }
-        Query exists = IsNullPredicate.refExistsQuery(probe, context, false);
+        Query exists = IsNullPredicate.refExistsQuery(probe, context);
         return new BooleanQuery.Builder()
             .add(Queries.not(andBuilder.build()), Occur.MUST)
             .add(exists, Occur.FILTER)

--- a/server/src/main/java/io/crate/expression/predicate/NotPredicate.java
+++ b/server/src/main/java/io/crate/expression/predicate/NotPredicate.java
@@ -204,7 +204,7 @@ public class NotPredicate extends Scalar<Boolean, Boolean> {
                 if (!ref.isNullable()) {
                     return new MatchAllDocsQuery();
                 }
-                return IsNullPredicate.refExistsQuery(ref, context, true);
+                return IsNullPredicate.refExistsQuery(ref, context);
             }
         }
 
@@ -229,10 +229,16 @@ public class NotPredicate extends Scalar<Boolean, Boolean> {
                 // result set of the query
                 var refExistsQuery = IsNullPredicate.refExistsQuery(
                     nullableRef,
-                    context,
-                    countEmptyArrays(context.parentQuery(), nullableRef, context));
+                    context
+                );
                 if (refExistsQuery != null) {
                     builder.add(refExistsQuery, BooleanClause.Occur.MUST);
+                } else {
+                    // fall back
+                    return new BooleanQuery.Builder()
+                        .add(notX, Occur.MUST)
+                        .add(LuceneQueryBuilder.genericFunctionFilter(input, context), Occur.FILTER)
+                        .build();
                 }
             }
             return builder.build();

--- a/server/src/main/java/io/crate/expression/scalar/NullOrEmptyFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/NullOrEmptyFunction.java
@@ -110,7 +110,7 @@ public final class NullOrEmptyFunction extends Scalar<Boolean, Object> {
                 if (childRef == null) {
                     return null;
                 }
-                Query refExistsQuery = IsNullPredicate.refExistsQuery(childRef, context, true);
+                Query refExistsQuery = IsNullPredicate.refExistsQuery(childRef, context);
                 if (refExistsQuery == null) {
                     return null;
                 }

--- a/server/src/test/java/io/crate/expression/predicate/FieldExistsQueryBeforeV590Test.java
+++ b/server/src/test/java/io/crate/expression/predicate/FieldExistsQueryBeforeV590Test.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.predicate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.lucene.search.Query;
+import org.junit.Test;
+
+import io.crate.testing.IndexVersionCreated;
+
+@IndexVersionCreated(value = 8_08_00_99) // V_5_8_0
+public class FieldExistsQueryBeforeV590Test extends FieldExistsQueryTest {
+
+    @Test
+    public void testIsNullOnObjectArray() throws Exception {
+        Query isNull = convert("o_array IS NULL");
+        assertThat(isNull).hasToString("(o_array IS NULL)");
+        Query isNotNull = convert("o_array IS NOT NULL");
+        assertThat(isNotNull).hasToString("(NOT (o_array IS NULL))");
+    }
+
+    @Test
+    public void test_neq_on_array() {
+        Query query = convert("(y_array != [1])");
+        // (+*:* -(y_array IS NULL)))~1) is required to make sure empty arrays are not filtered by the FieldExistsQuery
+        assertThat(query).hasToString("+(+*:* -(+y_array:{1} +(y_array = [1::bigint]))) +((FieldExistsQuery [field=y_array] (+*:* -(y_array IS NULL)))~1)");
+    }
+}

--- a/server/src/test/java/io/crate/expression/predicate/IsNullPredicateTest.java
+++ b/server/src/test/java/io/crate/expression/predicate/IsNullPredicateTest.java
@@ -76,7 +76,7 @@ public class IsNullPredicateTest extends ScalarTestCase {
                 1,
                 null
             );
-            Query refExistsQuery = IsNullPredicate.refExistsQuery(ref, context, true);
+            Query refExistsQuery = IsNullPredicate.refExistsQuery(ref, context);
             assertThat(refExistsQuery).isNull();
         }
     }

--- a/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -358,16 +358,6 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
     }
 
     @Test
-    public void testIsNullOnObjectArray() throws Exception {
-        Query isNull = convert("o_array IS NULL");
-        assertThat(isNull).hasToString(
-            "(o_array IS NULL)");
-        Query isNotNull = convert("o_array IS NOT NULL");
-        assertThat(isNotNull).hasToString(
-            "(NOT (o_array IS NULL))");
-    }
-
-    @Test
     public void testRewriteDocReferenceInWhereClause() throws Exception {
         Query query = convert("_doc['name'] = 'foo'");
         assertThat(query)
@@ -814,12 +804,5 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
     public void test_not_operator_on_query_equivalent_to_null() {
         Query query = convert("(y % null != 1)");
         assertThat(query).hasToString("+(+*:* -((y % NULL) = 1)) #(NOT ((y % NULL) = 1))");
-    }
-
-    @Test
-    public void test_neq_on_array() {
-        Query query = convert("(y_array != [1])");
-        // (+*:* -(y_array IS NULL)))~1) is required to make sure empty arrays are not filtered by the FieldExistsQuery
-        assertThat(query).hasToString("+(+*:* -(+y_array:{1} +(y_array = [1::bigint]))) +((FieldExistsQuery [field=y_array] (+*:* -(y_array IS NULL)))~1)");
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes:
```
cr> show create table t;
+-----------------------------------------------------+
| SHOW CREATE TABLE doc.t                             |
+-----------------------------------------------------+
| CREATE TABLE IF NOT EXISTS "doc"."t" (              |
|    "a" ARRAY(INTEGER)                               |
| )                                                   |
| CLUSTERED INTO 4 SHARDS                             |

cr> select * from t;
+--------+
| a      |
+--------+
| [null] |
| NULL   |
| [1]    |
| []     |
+--------+

cr> select * from t where a != [];
+-----+
| a   |
+-----+
| [1] | -- missing [null]
+-----+
```


```
cr> show create table t5;
+-----------------------------------------------------+
| SHOW CREATE TABLE doc.t5                            |
+-----------------------------------------------------+
| CREATE TABLE IF NOT EXISTS "doc"."t5" (             |
|    "a" ARRAY(INTEGER) STORAGE WITH (                |
|       columnstore = false                           |
|    )                                                |
| )                                                   |
| CLUSTERED INTO 4 SHARDS                             |

cr> select * from t5;
+--------+
| a      |
+--------+
| []     |
| NULL   |
| [1]    |
| [null] |
+--------+

cr> select * from t5 where a != [1];
+--------+
| a      |
+--------+
| []     |
| NULL   | -- unfiltered
| [null] |
+--------+
```

We did not handle for the cases where refExistsQuery was null:
https://github.com/crate/crate/pull/16427/files#diff-b98ffbe4dd33f483188fef958602ca8513268138164548a489a98b25e2da00bcR236-R241

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
