### PR TITLE
Add optimization for float and double for topk

### DIFF
--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/TopKAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/TopKAggregationTest.java
@@ -80,6 +80,10 @@ public class TopKAggregationTest extends AggregationTestCase {
             List.of()
         )).isExactlyInstanceOf(IllegalArgumentException.class)
             .hasMessageStartingWith("Limit parameter for topk must be between 0 and 10_000. Got: -1");
+
+        Object[][] data = {
+            new Object[]{1L},
+        };
     }
 
     public void test_top_k_longs_with_limit() throws Exception {
@@ -111,6 +115,127 @@ public class TopKAggregationTest extends AggregationTestCase {
                 )
             );
     }
+
+    @Test
+    public void test_top_k_doubles() throws Exception {
+        Object[][] data = {
+            new Double[]{1.0D},
+            new Double[]{2.0D},
+            new Double[]{2.0D},
+            new Double[]{3.0D},
+            new Double[]{3.0D},
+            new Double[]{3.0D},
+        };
+
+        var result = executeAggregation(
+            TopKAggregation.PARAMETER_SIGNATURE,
+            List.of(DataTypes.DOUBLE),
+            DataTypes.UNTYPED_OBJECT,
+            data,
+            true,
+            List.of()
+        );
+
+        assertThat(result)
+            .isEqualTo(
+                List.of(
+                    Map.of("item", 3.0D, "frequency", 3L),
+                    Map.of("item", 2.0D, "frequency", 2L),
+                    Map.of("item", 1.0D, "frequency", 1L)
+                )
+            );
+    }
+
+    public void test_top_k_doubles_with_limit() throws Exception {
+        int limit = 2;
+
+        Object[][] dataWithLimit = {
+            new Object[]{1.0D, limit},
+            new Object[]{2.0D, limit},
+            new Object[]{2.0D, limit},
+            new Object[]{3.0D, limit},
+            new Object[]{3.0D, limit},
+            new Object[]{3.0D, limit},
+        };
+
+        var resultWithLimit = executeAggregation(
+            TopKAggregation.PARAMETER_SIGNATURE,
+            List.of(DataTypes.DOUBLE, DataTypes.INTEGER),
+            DataTypes.UNTYPED_OBJECT,
+            dataWithLimit,
+            true,
+            List.of(Literal.of(limit))
+        );
+
+        assertThat(resultWithLimit)
+            .isEqualTo(
+                List.of(
+                    Map.of("item", 3.0D, "frequency", 3L),
+                    Map.of("item", 2.0D, "frequency", 2L)
+                )
+            );
+    }
+
+    @Test
+    public void test_top_k_floats() throws Exception {
+        Object[][] data = {
+            new Float[]{1.0F},
+            new Float[]{2.0F},
+            new Float[]{2.0F},
+            new Float[]{3.0F},
+            new Float[]{3.0F},
+            new Float[]{3.0F},
+        };
+
+        var result = executeAggregation(
+            TopKAggregation.PARAMETER_SIGNATURE,
+            List.of(DataTypes.FLOAT),
+            DataTypes.UNTYPED_OBJECT,
+            data,
+            true,
+            List.of()
+        );
+
+        assertThat(result)
+            .isEqualTo(
+                List.of(
+                    Map.of("item", 3.0F, "frequency", 3L),
+                    Map.of("item", 2.0F, "frequency", 2L),
+                    Map.of("item", 1.0F, "frequency", 1L)
+                )
+            );
+    }
+
+    public void test_top_k_floats_with_limit() throws Exception {
+        int limit = 2;
+
+        Object[][] dataWithLimit = {
+            new Object[]{1.0F, limit},
+            new Object[]{2.0F, limit},
+            new Object[]{2.0F, limit},
+            new Object[]{3.0F, limit},
+            new Object[]{3.0F, limit},
+            new Object[]{3.0F, limit},
+        };
+
+        var resultWithLimit = executeAggregation(
+            TopKAggregation.PARAMETER_SIGNATURE,
+            List.of(DataTypes.FLOAT, DataTypes.INTEGER),
+            DataTypes.UNTYPED_OBJECT,
+            dataWithLimit,
+            true,
+            List.of(Literal.of(limit))
+        );
+
+        assertThat(resultWithLimit)
+            .isEqualTo(
+                List.of(
+                    Map.of("item", 3.0F, "frequency", 3L),
+                    Map.of("item", 2.0F, "frequency", 2L)
+                )
+            );
+    }
+
 
     @Test
     public void test_top_k_strings() throws Exception {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This adds optimizations for topk for float and double using Longsketch.

LongSketch on Float without doc-values:

```
Q: select topk("adRevenue") from uservisits
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |      134.097 ±   36.380 |    123.716 |    126.270 |    130.851 |    381.398 |
|   V2    |      123.092 ±   37.852 |    113.961 |    115.290 |    115.806 |    378.510 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -   8.56%                           -   9.09%
There is a 85.85% probability that the observed difference is not random, and the best estimate of that difference is 8.56%
The test has no statistical significance
```

LongSketch on Double without doc-values:

```
Q: select topk("adRevenue") from uservisits
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |      139.428 ±   40.291 |    129.250 |    131.023 |    133.054 |    413.767 |
|   V2    |      122.509 ±   41.041 |    113.353 |    114.557 |    115.018 |    402.697 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  12.92%                           -  13.41%
There is a 95.99% probability that the observed difference is not random, and the best estimate of that difference is 12.92%
The test has no statistical significance
```

LongSketch on Float with doc-values:

```
Q: select topk("adRevenue") from uservisits
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |      135.849 ±   41.943 |    125.416 |    126.621 |    127.295 |    416.757 |
|   V2    |       84.116 ±   42.969 |     76.225 |     77.189 |     77.697 |    381.078 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  47.04%                           -  48.51%
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 47.04%
The test has statistical significance
```
LongSketch on Double with doc-values:

```
Q: select topk("adRevenue") from uservisits
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |      136.504 ±   37.309 |    126.788 |    128.370 |    130.603 |    389.240 |
|   V2    |       87.695 ±   47.568 |     79.380 |     80.280 |     80.633 |    416.584 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  43.54%                           -  46.10%
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 43.54%
The test has statistical significance
```


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
