### PR TITLE
Fix ARRAY_LENGTH on array object types to also utilize array length index

### DIFF
--- a/server/src/main/java/io/crate/execution/dml/ArrayIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/ArrayIndexer.java
@@ -32,6 +32,7 @@ import org.apache.lucene.document.IntField;
 import org.elasticsearch.Version;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
@@ -66,7 +67,8 @@ public class ArrayIndexer<T> implements ValueIndexer<List<T>> {
         return ARRAY_LENGTH_FIELD_PREFIX + arrayRef.storageIdentLeafName();
     }
 
-    private static final String ARRAY_LENGTH_FIELD_PREFIX = "_array_length_";
+    @VisibleForTesting
+    static final String ARRAY_LENGTH_FIELD_PREFIX = "_array_length_";
 
     private final ValueIndexer<T> innerIndexer;
     private final String arrayLengthFieldName;

--- a/server/src/main/java/io/crate/execution/dml/ArrayIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/ArrayIndexer.java
@@ -23,6 +23,7 @@ package io.crate.execution.dml;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -34,10 +35,34 @@ import org.jetbrains.annotations.Nullable;
 
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
+import io.crate.metadata.table.TableInfo;
+import io.crate.types.DataType;
 
 public class ArrayIndexer<T> implements ValueIndexer<List<T>> {
 
-    public static String toArrayLengthFieldName(Reference arrayRef) {
+    public static String toArrayLengthFieldName(Reference arrayRef, Function<ColumnIdent, Reference> getRef) {
+        // If the arrayRef is a descendant of an object array its type can be a readType. i.e. the type of
+        // obj_array['int_col'] is 'int' BUT its readType is 'array(int)'. If so, there is no '_array_length_' indexed
+        // for obj_array['int_col']. Imagine indexing obj_array = [{int_col = 1}, {int_col = 2}], '_array_length_obj_array'
+        // will be indexed but NOT '_array_length_int_col' since its type is an int.
+        // However, queries like array_length(obj_array['int_col'], 1) are valid since the readType of obj_array['int_col']
+        // is an array(int) - [1, 2]. In such cases we can simply use the fact that every element of 'obj_array' there
+        // exists its sub-column 'int_col' such that array_length(obj_array, 1) = array_length(obj_array['int_col'], 1)
+        DataType<?> valueType = Optional
+            .ofNullable(getRef.apply(arrayRef.column())) // null if the arrayRef is dynamically added
+            .orElse(arrayRef).valueType();
+
+        // if the arrayRef is a ReadReference
+        if (!arrayRef.valueType().equals(valueType)) {
+            ColumnIdent topMostObjectArray = null;
+            for (var columnIdent = arrayRef.column(); columnIdent != null; columnIdent = columnIdent.getParent()) {
+                if (TableInfo.IS_OBJECT_ARRAY.test(getRef.apply(columnIdent).valueType())) {
+                    topMostObjectArray = columnIdent;
+                }
+            }
+            assert topMostObjectArray != null : "When the arrayRef is a ReadReference it must be a child of an object array type";
+            return ARRAY_LENGTH_FIELD_PREFIX + getRef.apply(topMostObjectArray).storageIdentLeafName();
+        }
         return ARRAY_LENGTH_FIELD_PREFIX + arrayRef.storageIdentLeafName();
     }
 
@@ -46,9 +71,9 @@ public class ArrayIndexer<T> implements ValueIndexer<List<T>> {
     private final ValueIndexer<T> innerIndexer;
     private final String arrayLengthFieldName;
 
-    public ArrayIndexer(ValueIndexer<T> innerIndexer, Reference reference) {
+    public ArrayIndexer(ValueIndexer<T> innerIndexer, Function<ColumnIdent, Reference> getRef, Reference reference) {
         this.innerIndexer = innerIndexer;
-        this.arrayLengthFieldName = toArrayLengthFieldName(reference);
+        this.arrayLengthFieldName = toArrayLengthFieldName(reference, getRef);
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/scalar/ArrayUpperFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayUpperFunction.java
@@ -171,13 +171,7 @@ public class ArrayUpperFunction extends Scalar<Integer, Object> {
             // Storage of the multidimensional arrays is not supported.
             return null;
         }
-        DataType<?> elementType = ArrayType.unnest(arrayRef.valueType());
-        if (elementType.id() == ObjectType.ID || elementType.equals(DataTypes.GEO_SHAPE)) {
-            // No doc-values for these, can't utilize doc-value-count
-            return null;
-        }
         int cmpVal = cmpNumber.intValue();
-
         // If the array col is from a table created on or after 5.9, we can utilize '_array_length_' indexes,
         // see ArrayIndexer for details
         if (context.nodeContext().schemas().getTableInfo((arrayRef).ident().tableIdent()) instanceof DocTableInfo tableInfo &&
@@ -190,7 +184,11 @@ public class ArrayUpperFunction extends Scalar<Integer, Object> {
             // Cannot utilize `_array_length_` index for arrays in tables created before 5.9
             return null;
         }
-
+        DataType<?> elementType = ArrayType.unnest(arrayRef.valueType());
+        if (elementType.id() == ObjectType.ID || elementType.equals(DataTypes.GEO_SHAPE)) {
+            // No doc-values for these, can't utilize doc-value-count
+            return null;
+        }
         // For numeric types all values are stored, so the doc-value-count represents the number of not-null values
         // Only unique values are stored for IP and TEXT types, so the doc-value-count represents the number of unique not-null  values
         // [a, a, a]

--- a/server/src/main/java/io/crate/expression/scalar/ArrayUpperFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayUpperFunction.java
@@ -47,6 +47,7 @@ import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
 import io.crate.lucene.LuceneQueryBuilder;
 import io.crate.lucene.LuceneQueryBuilder.Context;
+import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NodeContext;
@@ -176,7 +177,7 @@ public class ArrayUpperFunction extends Scalar<Integer, Object> {
         // see ArrayIndexer for details
         if (context.nodeContext().schemas().getTableInfo((arrayRef).ident().tableIdent()) instanceof DocTableInfo tableInfo &&
             tableInfo.versionCreated().onOrAfter(Version.V_5_9_0)) {
-            return toQueryUsingArrayLengthIndex(parentName, arrayRef, cmpVal);
+            return toQueryUsingArrayLengthIndex(parentName, arrayRef, cmpVal, tableInfo::getReference);
         }
 
         DataType<?> innerType = ((ArrayType<?>) arrayRef.valueType()).innerType();
@@ -300,35 +301,35 @@ public class ArrayUpperFunction extends Scalar<Integer, Object> {
         }
     }
 
-    private static Query toQueryUsingArrayLengthIndex(String operator, Reference arrayRef, int cmpVal) {
+    private static Query toQueryUsingArrayLengthIndex(String operator, Reference arrayRef, int cmpVal, java.util.function.Function<ColumnIdent, Reference> getRef) {
         switch (operator) {
             case EqOperator.NAME:
                 if (cmpVal == 0) {
                     return new MatchNoDocsQuery("array_length([], 1) is NULL, so array_length([], 1) = 0 can't match");
                 }
-                return new IntEqQuery().termQuery(toArrayLengthFieldName(arrayRef), cmpVal, true, true);
+                return new IntEqQuery().termQuery(toArrayLengthFieldName(arrayRef, getRef), cmpVal, true, true);
 
             case GtOperator.NAME:
-                return new IntEqQuery().rangeQuery(toArrayLengthFieldName(arrayRef), cmpVal, null, false, false, true, true);
+                return new IntEqQuery().rangeQuery(toArrayLengthFieldName(arrayRef, getRef), cmpVal, null, false, false, true, true);
 
             case GteOperator.NAME:
                 if (cmpVal == 0) {
-                    return new IntEqQuery().rangeQuery(toArrayLengthFieldName(arrayRef), 0, null, false, false, true, true);
+                    return new IntEqQuery().rangeQuery(toArrayLengthFieldName(arrayRef, getRef), 0, null, false, false, true, true);
                 } else {
-                    return new IntEqQuery().rangeQuery(toArrayLengthFieldName(arrayRef), cmpVal, null, true, false, true, true);
+                    return new IntEqQuery().rangeQuery(toArrayLengthFieldName(arrayRef, getRef), cmpVal, null, true, false, true, true);
                 }
 
             case LtOperator.NAME:
                 if (cmpVal == 0 || cmpVal == 1) {
                     return new MatchNoDocsQuery("array_length([], 1) is NULL, so array_length([], 1) < 0 or < 1 can't match");
                 }
-                return new IntEqQuery().rangeQuery(toArrayLengthFieldName(arrayRef), 0, cmpVal, false, false, true, true);
+                return new IntEqQuery().rangeQuery(toArrayLengthFieldName(arrayRef, getRef), 0, cmpVal, false, false, true, true);
 
             case LteOperator.NAME:
                 if (cmpVal == 0) {
                     return new MatchNoDocsQuery("array_length([], 1) is NULL, so array_length([], 1) <= 0 can't match");
                 }
-                return new IntEqQuery().rangeQuery(toArrayLengthFieldName(arrayRef), 0, cmpVal, false, true, true, true);
+                return new IntEqQuery().rangeQuery(toArrayLengthFieldName(arrayRef, getRef), 0, cmpVal, false, true, true, true);
 
             default:
                 throw new IllegalArgumentException("Illegal operator: " + operator);

--- a/server/src/main/java/io/crate/types/ArrayType.java
+++ b/server/src/main/java/io/crate/types/ArrayType.java
@@ -99,7 +99,7 @@ public class ArrayType<T> extends DataType<List<T>> {
                 public ValueIndexer<T> valueIndexer(RelationName table,
                                                     Reference ref,
                                                     Function<ColumnIdent, Reference> getRef) {
-                    return new ArrayIndexer<>(innerStorage.valueIndexer(table, ref, getRef), ref);
+                    return new ArrayIndexer<>(innerStorage.valueIndexer(table, ref, getRef), getRef, ref);
                 }
             };
         }

--- a/server/src/test/java/io/crate/execution/dml/IndexerTest.java
+++ b/server/src/test/java/io/crate/execution/dml/IndexerTest.java
@@ -810,7 +810,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
 
         var indexer = getIndexer(e, "tbl", "xs");
         ParsedDocument doc = indexer.index(item(List.of()));
-        assertThat(doc.doc().getFields(toArrayLengthFieldName((Reference) e.asSymbol("xs")))[0].toString())
+        assertThat(doc.doc().getFields(toArrayLengthFieldName((Reference) e.asSymbol("xs"), table::getReference))[0].toString())
             .isEqualTo("IntField <_array_length_1:0>");
         assertTranslogParses(doc, table);
     }
@@ -820,10 +820,11 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         SQLExecutor e = SQLExecutor.of(clusterService)
             .addTable("create table tbl (xs int[] index off storage with (columnstore='false'))",
                 Settings.builder().put(IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(), Version.V_5_8_0).build());
+        DocTableInfo table = e.resolveTableInfo("tbl");
 
         var indexer = getIndexer(e, "tbl", "xs");
         ParsedDocument doc = indexer.index(item(List.of()));
-        var arrayLengthField = doc.doc().getFields(toArrayLengthFieldName((Reference) e.asSymbol("xs")));
+        var arrayLengthField = doc.doc().getFields(toArrayLengthFieldName((Reference) e.asSymbol("xs"), table::getReference));
         assertThat(arrayLengthField).isEmpty();
     }
 

--- a/server/src/test/java/io/crate/lucene/ArrayLengthQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/ArrayLengthQueryBuilderTest.java
@@ -100,4 +100,10 @@ public class ArrayLengthQueryBuilderTest extends LuceneQueryBuilderTest {
         Query query = convert("array_length(o_array['xs'], 1) > 0");
         assertThat(query).hasToString("_array_length_xs:[1 TO 2147483647]");
     }
+
+    public void test_array_length_on_object_array() {
+        Query query = convert("array_length(o_array, 1) >= 1");
+        assertThat(query).hasToString(
+            "_array_length_o_array:[1 TO 2147483647]");
+    }
 }

--- a/server/src/test/java/io/crate/lucene/ArrayLengthQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/ArrayLengthQueryBuilderTest.java
@@ -95,15 +95,38 @@ public class ArrayLengthQueryBuilderTest extends LuceneQueryBuilderTest {
         }
     }
 
-    @Test
-    public void test_array_length_on_array_sub_columns_of_array_of_objects() {
-        Query query = convert("array_length(o_array['xs'], 1) > 0");
-        assertThat(query).hasToString("_array_length_xs:[1 TO 2147483647]");
-    }
-
     public void test_array_length_on_object_array() {
         Query query = convert("array_length(o_array, 1) >= 1");
         assertThat(query).hasToString(
             "_array_length_o_array:[1 TO 2147483647]");
+    }
+
+    @Test
+    public void test_array_length_on_object_arrays_subcolumn() {
+        // 'o_array' is indexed but 'o_array['xs']' is not indexed. We can use the fact that
+        // for every element of 'o_array' there exists its sub-column 'xs' such that
+        // array_length(o_array, 1) = array_length(o_array['xs'], 1)
+        Query query = convert("array_length(o_array['xs'], 1) >= 1");
+        assertThat(query).hasToString("_array_length_o_array:[1 TO 2147483647]");
+
+        query = convert("array_length(o_array['obj']['x'], 1) >= 1");
+        assertThat(query).hasToString("_array_length_o_array:[1 TO 2147483647]");
+
+        query = convert("array_length(o_array['o_array_2']['x'], 1) >= 1");
+        assertThat(query).hasToString("_array_length_o_array:[1 TO 2147483647]");
+
+        // 'obj' is not array(object)
+        query = convert("array_length(obj['o_array']['x'], 1) >= 1");
+        assertThat(query).hasToString("_array_length_o_array:[1 TO 2147483647]");
+
+        // when the dimension argument is > 1, then fall back to GenericFunctionQuery
+        query = convert("array_length(o_array['xs'], 2) >= 1");
+        assertThat(query).isExactlyInstanceOf(GenericFunctionQuery.class);
+        assertThat(query).hasToString("(array_length(o_array['xs'], 2) >= 1)");
+
+        // when the ref symbol is not a Reference but a function(subscript function in this case), then fall back to GenericFunctionQuery
+        query = convert("array_length(o_array['xs'][1], 1) >= 1");
+        assertThat(query).isExactlyInstanceOf(GenericFunctionQuery.class);
+        assertThat(query).hasToString("(array_length(o_array[1]['xs'], 1) >= 1)");
     }
 }

--- a/server/src/test/java/io/crate/lucene/LuceneQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/LuceneQueryBuilderTest.java
@@ -83,13 +83,14 @@ public abstract class LuceneQueryBuilderTest extends CrateDummyClusterServiceUni
                " d double," +
                " obj object as (" +
                "     x integer," +
-               "     y integer" +
+               "     y integer," +
+               "     o_array array(object as (x int))" +
                " )," +
                " obj_ignored object (ignored), " +
                " d_array array(double)," +
                " y_array array(long)," +
                " x_array_no_docvalues array(int) storage with (columnstore = false)," +
-               " o_array array(object as (xs array(integer)))," +
+               " o_array array(object as (xs array(integer), obj object as (x int), o_array_2 array(object as (x int))))," +
                " ts_array array(timestamp with time zone)," +
                " shape geo_shape," +
                " bkd_shape geo_shape index using bkdtree," +


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Follows https://github.com/crate/crate/pull/16329 which is not yet released.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
