### PR TITLE
Optimize topk for integer type

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/TopKAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/TopKAggregation.java
@@ -66,6 +66,7 @@ import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.DoubleType;
 import io.crate.types.FloatType;
+import io.crate.types.IntegerType;
 import io.crate.types.LongType;
 import io.crate.types.StringType;
 import io.crate.types.TypeSignature;
@@ -475,6 +476,7 @@ public class TopKAggregation extends AggregationFunction<TopKAggregation.State, 
             case LongType.ID -> true;
             case DoubleType.ID -> true;
             case FloatType.ID -> true;
+            case IntegerType.ID -> true;
             default -> false;
         };
     }
@@ -484,6 +486,7 @@ public class TopKAggregation extends AggregationFunction<TopKAggregation.State, 
             case LongType.ID -> (Long) o;
             case DoubleType.ID -> NumericUtils.doubleToSortableLong((Double) o);
             case FloatType.ID -> (long) NumericUtils.floatToSortableInt((Float) o);
+            case IntegerType.ID -> ((Integer) o).longValue();
             default -> throw new IllegalArgumentException("Type cannot be converted to long");
         };
     }
@@ -493,6 +496,7 @@ public class TopKAggregation extends AggregationFunction<TopKAggregation.State, 
             case LongType.ID -> o;
             case DoubleType.ID -> NumericUtils.sortableLongToDouble(o);
             case FloatType.ID -> NumericUtils.sortableIntToFloat((int) o);
+            case IntegerType.ID -> (int) o;
             default -> throw new IllegalArgumentException("Long value cannot be converted");
         };
     }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/TopKAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/TopKAggregationTest.java
@@ -31,38 +31,36 @@ import org.junit.Test;
 
 import io.crate.expression.symbol.Literal;
 import io.crate.operation.aggregation.AggregationTestCase;
+import io.crate.testing.DataTypeTesting;
+import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 
 public class TopKAggregationTest extends AggregationTestCase {
 
     @Test
     public void test_top_k_longs() throws Exception {
-        Object[][] data = {
-            new Long[]{1L},
-            new Long[]{2L},
-            new Long[]{2L},
-            new Long[]{3L},
-            new Long[]{3L},
-            new Long[]{3L},
-        };
+        execute_top_k_without_and_with_doc_values(DataTypes.LONG);
+    }
 
-        var result = executeAggregation(
-            TopKAggregation.PARAMETER_SIGNATURE,
-            List.of(DataTypes.LONG),
-            DataTypes.UNTYPED_OBJECT,
-            data,
-            true,
-            List.of()
-        );
+    @Test
+    public void test_top_k_doubles() throws Exception {
+        execute_top_k_without_and_with_doc_values(DataTypes.DOUBLE);
+    }
 
-        assertThat(result)
-            .isEqualTo(
-                List.of(
-                    Map.of("item", 3L, "frequency", 3L),
-                    Map.of("item", 2L, "frequency", 2L),
-                    Map.of("item", 1L, "frequency", 1L)
-                )
-            );
+    @Test
+    public void test_top_k_floats() throws Exception {
+        execute_top_k_without_and_with_doc_values(DataTypes.FLOAT);
+        ;
+    }
+
+    @Test
+    public void test_top_k_strings() throws Exception {
+        execute_top_k_without_and_with_doc_values(DataTypes.STRING);
+    }
+
+    @Test
+    public void test_top_k_integer() throws Exception {
+        execute_top_k_without_and_with_doc_values(DataTypes.INTEGER);
     }
 
     @Test
@@ -84,217 +82,6 @@ public class TopKAggregationTest extends AggregationTestCase {
         Object[][] data = {
             new Object[]{1L},
         };
-    }
-
-    public void test_top_k_longs_with_limit() throws Exception {
-        int limit = 2;
-
-        Object[][] dataWithLimit = {
-            new Object[]{1L, limit},
-            new Object[]{2L, limit},
-            new Object[]{2L, limit},
-            new Object[]{3L, limit},
-            new Object[]{3L, limit},
-            new Object[]{3L, limit},
-        };
-
-        var resultWithLimit = executeAggregation(
-            TopKAggregation.PARAMETER_SIGNATURE,
-            List.of(DataTypes.LONG, DataTypes.LONG),
-            DataTypes.UNTYPED_OBJECT,
-            dataWithLimit,
-            true,
-            List.of(Literal.of(limit))
-        );
-
-        assertThat(resultWithLimit)
-            .isEqualTo(
-                List.of(
-                    Map.of("item", 3L, "frequency", 3L),
-                    Map.of("item", 2L, "frequency", 2L)
-                )
-            );
-    }
-
-    @Test
-    public void test_top_k_doubles() throws Exception {
-        Object[][] data = {
-            new Double[]{1.0D},
-            new Double[]{2.0D},
-            new Double[]{2.0D},
-            new Double[]{3.0D},
-            new Double[]{3.0D},
-            new Double[]{3.0D},
-        };
-
-        var result = executeAggregation(
-            TopKAggregation.PARAMETER_SIGNATURE,
-            List.of(DataTypes.DOUBLE),
-            DataTypes.UNTYPED_OBJECT,
-            data,
-            true,
-            List.of()
-        );
-
-        assertThat(result)
-            .isEqualTo(
-                List.of(
-                    Map.of("item", 3.0D, "frequency", 3L),
-                    Map.of("item", 2.0D, "frequency", 2L),
-                    Map.of("item", 1.0D, "frequency", 1L)
-                )
-            );
-    }
-
-    public void test_top_k_doubles_with_limit() throws Exception {
-        int limit = 2;
-
-        Object[][] dataWithLimit = {
-            new Object[]{1.0D, limit},
-            new Object[]{2.0D, limit},
-            new Object[]{2.0D, limit},
-            new Object[]{3.0D, limit},
-            new Object[]{3.0D, limit},
-            new Object[]{3.0D, limit},
-        };
-
-        var resultWithLimit = executeAggregation(
-            TopKAggregation.PARAMETER_SIGNATURE,
-            List.of(DataTypes.DOUBLE, DataTypes.INTEGER),
-            DataTypes.UNTYPED_OBJECT,
-            dataWithLimit,
-            true,
-            List.of(Literal.of(limit))
-        );
-
-        assertThat(resultWithLimit)
-            .isEqualTo(
-                List.of(
-                    Map.of("item", 3.0D, "frequency", 3L),
-                    Map.of("item", 2.0D, "frequency", 2L)
-                )
-            );
-    }
-
-    @Test
-    public void test_top_k_floats() throws Exception {
-        Object[][] data = {
-            new Float[]{1.0F},
-            new Float[]{2.0F},
-            new Float[]{2.0F},
-            new Float[]{3.0F},
-            new Float[]{3.0F},
-            new Float[]{3.0F},
-        };
-
-        var result = executeAggregation(
-            TopKAggregation.PARAMETER_SIGNATURE,
-            List.of(DataTypes.FLOAT),
-            DataTypes.UNTYPED_OBJECT,
-            data,
-            true,
-            List.of()
-        );
-
-        assertThat(result)
-            .isEqualTo(
-                List.of(
-                    Map.of("item", 3.0F, "frequency", 3L),
-                    Map.of("item", 2.0F, "frequency", 2L),
-                    Map.of("item", 1.0F, "frequency", 1L)
-                )
-            );
-    }
-
-    public void test_top_k_floats_with_limit() throws Exception {
-        int limit = 2;
-
-        Object[][] dataWithLimit = {
-            new Object[]{1.0F, limit},
-            new Object[]{2.0F, limit},
-            new Object[]{2.0F, limit},
-            new Object[]{3.0F, limit},
-            new Object[]{3.0F, limit},
-            new Object[]{3.0F, limit},
-        };
-
-        var resultWithLimit = executeAggregation(
-            TopKAggregation.PARAMETER_SIGNATURE,
-            List.of(DataTypes.FLOAT, DataTypes.INTEGER),
-            DataTypes.UNTYPED_OBJECT,
-            dataWithLimit,
-            true,
-            List.of(Literal.of(limit))
-        );
-
-        assertThat(resultWithLimit)
-            .isEqualTo(
-                List.of(
-                    Map.of("item", 3.0F, "frequency", 3L),
-                    Map.of("item", 2.0F, "frequency", 2L)
-                )
-            );
-    }
-
-
-    @Test
-    public void test_top_k_strings() throws Exception {
-        Object[][] data = {
-            new String[]{"1"},
-            new String[]{"2"},
-            new String[]{"2"},
-            new String[]{"3"},
-            new String[]{"3"},
-            new String[]{"3"}
-        };
-
-        var result = executeAggregation(
-            TopKAggregation.PARAMETER_SIGNATURE,
-            List.of(DataTypes.STRING),
-            DataTypes.UNTYPED_OBJECT,
-            data,
-            true,
-            List.of()
-        );
-
-        assertThat(result)
-            .isEqualTo(
-                List.of(
-                    Map.of("item", "3", "frequency", 3L),
-                    Map.of("item", "2", "frequency", 2L),
-                    Map.of("item", "1", "frequency", 1L)
-                )
-            );
-    }
-
-    public void test_top_k_strings_with_limit() throws Exception {
-        int limit = 2;
-
-        Object[][] data = {
-            new Object[]{"1", limit},
-            new Object[]{"2", limit},
-            new Object[]{"2", limit},
-            new Object[]{"3", limit},
-            new Object[]{"3", limit},
-            new Object[]{"3", limit},
-        };
-
-        var resultWithLimit = executeAggregation(
-            TopKAggregation.PARAMETER_SIGNATURE,
-            List.of(DataTypes.STRING, DataTypes.INTEGER),
-            DataTypes.UNTYPED_OBJECT,
-            data,
-            true,
-            List.of(Literal.of(limit))
-        );
-
-        assertThat(resultWithLimit)
-            .isEqualTo(
-                List.of(
-                    Map.of("item", "3", "frequency", 3L),
-                    Map.of("item", "2", "frequency", 2L)
-                )
-            );
     }
 
     @Test
@@ -350,6 +137,67 @@ public class TopKAggregationTest extends AggregationTestCase {
             .isEqualTo(
                 List.of(
                     Map.of("item", true, "frequency", 3L)
+                )
+            );
+    }
+
+    private void execute_top_k_without_and_with_doc_values(DataType<?> dataType) throws Exception {
+        var generator = DataTypeTesting.getDataGenerator(dataType);
+        var first = generator.get();
+        var second = generator.get();
+        var third = generator.get();
+
+        Object[][] data = {
+            new Object[]{first},
+            new Object[]{second},
+            new Object[]{second},
+            new Object[]{third},
+            new Object[]{third},
+            new Object[]{third},
+        };
+
+        var result = executeAggregation(
+            TopKAggregation.PARAMETER_SIGNATURE,
+            List.of(dataType),
+            DataTypes.UNTYPED_OBJECT,
+            data,
+            true,
+            List.of()
+        );
+
+        assertThat(result)
+            .isEqualTo(
+                List.of(
+                    Map.of("item", third, "frequency", 3L),
+                    Map.of("item", second, "frequency", 2L),
+                    Map.of("item", first, "frequency", 1L)
+                )
+            );
+        int limit = 2;
+
+        Object[][] dataWithLimit = {
+            new Object[]{first, limit},
+            new Object[]{second, limit},
+            new Object[]{second, limit},
+            new Object[]{third, limit},
+            new Object[]{third, limit},
+            new Object[]{third, limit},
+        };
+
+        result = executeAggregation(
+            TopKAggregation.PARAMETER_SIGNATURE,
+            List.of(dataType, DataTypes.INTEGER),
+            DataTypes.UNTYPED_OBJECT,
+            dataWithLimit,
+            true,
+            List.of(Literal.of(limit))
+        );
+
+        assertThat(result)
+            .isEqualTo(
+                List.of(
+                    Map.of("item", third, "frequency", 3L),
+                    Map.of("item", second, "frequency", 2L)
                 )
             );
     }


### PR DESCRIPTION
This optimizes topk for integer type and improves the tests by making them more generic.

LongSketch on Integer without doc-values:

```
Q: select topk("duration") from uservisits
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |      117.091 ±   40.531 |    109.425 |    110.794 |    111.217 |    396.598 |
|   V2    |      107.756 ±   44.957 |     99.024 |    100.528 |    101.423 |    417.682 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -   8.30%                           -   9.72%
There is a 72.18% probability that the observed difference is not random, and the best estimate of that difference is 8.30%
The test has no statistical significance
```

LongSketch on Integer with doc-values:

```
Q: select topk("duration") from uservisits
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |      115.106 ±   33.689 |    108.596 |    109.615 |    110.248 |    347.149 |
|   V2    |       57.961 ±   37.246 |     50.621 |     51.933 |     52.219 |    312.769 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  66.04%                           -  71.41%
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 66.04%
The test has statistical significance
```

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
