### PR TITLE
Make sure MetaDataTracker is inactive first, when stopped

### DIFF
--- a/server/src/main/java/io/crate/replication/logical/MetadataTracker.java
+++ b/server/src/main/java/io/crate/replication/logical/MetadataTracker.java
@@ -131,11 +131,11 @@ public final class MetadataTracker implements Closeable {
     }
 
     private void stop() {
+        isActive = false;
         Cancellable currentCancellable = cancellable;
         if (currentCancellable != null) {
             currentCancellable.cancel();
         }
-        isActive = false;
     }
 
     private void schedule() {


### PR DESCRIPTION
This prevents the MetaDataTracker from getting rescheduled again when stopped is already called.

Relates to:

```
MetadataTrackerITest Multiple Failures (2 failures)
	com.carrotsearch.randomizedtesting.ThreadLeakError: 141 threads leaked from SUITE scope at io.crate.integrationtests.MetadataTrackerITest: 
   1) Thread[id=2698, name=cratedb[publisherd4][fetch_shard_store][T#1], state=TIMED_WAITING, group=TGRP-MetadataTrackerITest]
```

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
