### PR TITLE
Optimize short and byte for topk aggregation

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/TopKAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/TopKAggregation.java
@@ -62,12 +62,14 @@ import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 import io.crate.statistics.SketchStreamer;
 import io.crate.types.ArrayType;
+import io.crate.types.ByteType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.DoubleType;
 import io.crate.types.FloatType;
 import io.crate.types.IntegerType;
 import io.crate.types.LongType;
+import io.crate.types.ShortType;
 import io.crate.types.StringType;
 import io.crate.types.TypeSignature;
 
@@ -477,6 +479,8 @@ public class TopKAggregation extends AggregationFunction<TopKAggregation.State, 
             case DoubleType.ID -> true;
             case FloatType.ID -> true;
             case IntegerType.ID -> true;
+            case ShortType.ID -> true;
+            case ByteType.ID -> true;
             default -> false;
         };
     }
@@ -487,6 +491,8 @@ public class TopKAggregation extends AggregationFunction<TopKAggregation.State, 
             case DoubleType.ID -> NumericUtils.doubleToSortableLong((Double) o);
             case FloatType.ID -> (long) NumericUtils.floatToSortableInt((Float) o);
             case IntegerType.ID -> ((Integer) o).longValue();
+            case ShortType.ID -> ((Short) o).longValue();
+            case ByteType.ID -> ((Byte) o).longValue();
             default -> throw new IllegalArgumentException("Type cannot be converted to long");
         };
     }
@@ -497,6 +503,8 @@ public class TopKAggregation extends AggregationFunction<TopKAggregation.State, 
             case DoubleType.ID -> NumericUtils.sortableLongToDouble(o);
             case FloatType.ID -> NumericUtils.sortableIntToFloat((int) o);
             case IntegerType.ID -> (int) o;
+            case ShortType.ID -> (short) o;
+            case ByteType.ID -> (byte) o;
             default -> throw new IllegalArgumentException("Long value cannot be converted");
         };
     }

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/TopKAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/TopKAggregationTest.java
@@ -64,6 +64,16 @@ public class TopKAggregationTest extends AggregationTestCase {
     }
 
     @Test
+    public void test_top_k_shorts() throws Exception {
+        execute_top_k_without_and_with_doc_values(DataTypes.SHORT);
+    }
+
+    @Test
+    public void test_top_k_byte() throws Exception {
+        execute_top_k_without_and_with_doc_values(DataTypes.BYTE);
+    }
+
+    @Test
     public void test_top_k_invalid_limit_parameters() throws Exception {
         Object[][] dataWithInvalidLimit = {
             new Object[]{1L, -1},


### PR DESCRIPTION
This optimizes the types short and byte for topk aggregation using Longsketch and enables doc-values.

Shorts no-doc-values:

```
Q: select topk("s") from t1
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |       21.813 ±   55.800 |     12.495 |     13.123 |     13.260 |    406.668 |
|   V2    |       20.140 ±   39.723 |     12.911 |     13.522 |     13.848 |    290.984 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -   7.97%                           +   2.99%
There is a 13.67% probability that the observed difference is not random, and the best estimate of that difference is 7.97%
The test has no statistical significance
```

Shorts with doc-values:

```
Q: select topk("s") from t1
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |       16.357 ±    4.634 |     14.204 |     14.899 |     15.781 |     39.293 |
|   V2    |        8.635 ±    0.168 |      8.323 |      8.610 |      8.760 |      8.999 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  61.80%                           -  53.51%
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 61.80%
The test has statistical significance
```

Bytes no-doc-values:

```
Q: select topk("b") from t1
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |       23.892 ±   35.376 |     15.074 |     17.253 |     19.362 |    263.158 |
|   V2    |       18.798 ±   31.344 |     12.598 |     13.019 |     13.645 |    225.786 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  23.87%                           -  27.98%
There is a 55.22% probability that the observed difference is not random, and the best estimate of that difference is 23.87%
The test has no statistical significance
```

Bytes with doc-values:

```
Q: select topk("b") from t1
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |       21.235 ±   33.440 |     13.799 |     14.818 |     15.557 |    246.492 |
|   V2    |       13.342 ±   26.733 |      8.580 |      8.917 |      9.146 |    197.457 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  45.65%                           -  49.72%
There is a 80.46% probability that the observed difference is not random, and the best estimate of that difference is 45.65%
The test has no statistical significance
```

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
