### PR TITLE
Fix ARRAY_LENGTH on array sub-cols of object arrays to fall back to generic function query

### DIFF
--- a/docs/appendices/release-notes/5.8.2.rst
+++ b/docs/appendices/release-notes/5.8.2.rst
@@ -57,3 +57,7 @@ Fixes
 - Fixed an issue that led to a ``IllegalStateException`` or
   ``SQLParseException`` when trying to use a user defined function which returns
   a value of type ``GEO_SHAPE`` within a ``MATCH`` predicate.
+
+- Fixed an issue that caused ``WHERE`` clause containing ``ARRAY_LENGTH``
+  scalar on an array type that is a child of an object array to match and
+  return a wrong result set.

--- a/server/src/main/java/io/crate/expression/scalar/ArrayUpperFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayUpperFunction.java
@@ -185,6 +185,12 @@ public class ArrayUpperFunction extends Scalar<Integer, Object> {
             return toQueryUsingArrayLengthIndex(parentName, arrayRef, cmpVal);
         }
 
+        DataType<?> innerType = ((ArrayType<?>) arrayRef.valueType()).innerType();
+        if (innerType instanceof ArrayType<?>) {
+            // Cannot utilize `_array_length_` index for arrays in tables created before 5.9
+            return null;
+        }
+
         // For numeric types all values are stored, so the doc-value-count represents the number of not-null values
         // Only unique values are stored for IP and TEXT types, so the doc-value-count represents the number of unique not-null  values
         // [a, a, a]

--- a/server/src/test/java/io/crate/lucene/ArrayLengthQueryBuilderBeforeV590Test.java
+++ b/server/src/test/java/io/crate/lucene/ArrayLengthQueryBuilderBeforeV590Test.java
@@ -96,4 +96,11 @@ public class ArrayLengthQueryBuilderBeforeV590Test extends LuceneQueryBuilderTes
                 .containsExactly(List.of(1));
         }
     }
+
+    @Test
+    public void test_array_length_on_array_sub_columns_of_array_of_objects() {
+        Query query = convert("array_length(o_array['xs'], 1) > 0");
+        assertThat(query).isExactlyInstanceOf(GenericFunctionQuery.class);
+        assertThat(query).hasToString("(array_length(o_array['xs'], 1) > 0)");
+    }
 }

--- a/server/src/test/java/io/crate/lucene/ArrayLengthQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/ArrayLengthQueryBuilderTest.java
@@ -94,4 +94,10 @@ public class ArrayLengthQueryBuilderTest extends LuceneQueryBuilderTest {
                 .containsExactly(List.of(1));
         }
     }
+
+    @Test
+    public void test_array_length_on_array_sub_columns_of_array_of_objects() {
+        Query query = convert("array_length(o_array['xs'], 1) > 0");
+        assertThat(query).hasToString("_array_length_xs:[1 TO 2147483647]");
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes https://github.com/crate/crate/issues/16448

As described in the bug description, we are lacking the indexes to utilize but to fall back to generic function queries.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
