### PR TITLE
Ensure topk test data generation does not contain duplicate values

### DIFF
--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/TopKAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/TopKAggregationTest.java
@@ -155,7 +155,13 @@ public class TopKAggregationTest extends AggregationTestCase {
         var generator = DataTypeTesting.getDataGenerator(dataType);
         var first = generator.get();
         var second = generator.get();
+        while (second.equals(first)) {
+            second = generator.get();
+        }
         var third = generator.get();
+        while (third.equals(second) || (third.equals(first))) {
+            third = generator.get();
+        }
 
         Object[][] data = {
             new Object[]{first},
@@ -211,4 +217,5 @@ public class TopKAggregationTest extends AggregationTestCase {
                 )
             );
     }
+
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This fixes:

```
[ERROR] io.crate.execution.engine.aggregation.impl.TopKAggregationTest.test_top_k_byte -- Time elapsed: 0.023 s <<< FAILURE!
org.opentest4j.AssertionFailedError: 

expected: 
  [{"frequency"=3L, "item"=29},
      {"frequency"=2L, "item"=80},
      {"frequency"=1L, "item"=80}]
 but was: 
  [{"frequency"=3L, "item"=29}, {"frequency"=3L, "item"=80}]
	at __randomizedtesting.SeedInfo.seed([D360C4D8F95F4763:D7B00E7B83F83606]:0)
	at io.crate.execution.engine.aggregation.impl.TopKAggregationTest.execute_top_k_without_and_with_doc_values(TopKAggregationTest.java:179)
	at io.crate.execution.engine.aggregation.impl.TopKAggregationTest.test_top_k_byte(TopKAggregationTest.java:73)
```


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
