### PR TITLE
Add topk optimization for timestamp

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/TopKAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/TopKAggregation.java
@@ -71,6 +71,7 @@ import io.crate.types.IntegerType;
 import io.crate.types.LongType;
 import io.crate.types.ShortType;
 import io.crate.types.StringType;
+import io.crate.types.TimestampType;
 import io.crate.types.TypeSignature;
 
 public class TopKAggregation extends AggregationFunction<TopKAggregation.State, List<Map<String, Object>>> {
@@ -481,13 +482,15 @@ public class TopKAggregation extends AggregationFunction<TopKAggregation.State, 
             case IntegerType.ID -> true;
             case ShortType.ID -> true;
             case ByteType.ID -> true;
+            case TimestampType.ID_WITHOUT_TZ -> true;
+            case TimestampType.ID_WITH_TZ -> true;
             default -> false;
         };
     }
 
     private static long toLong(DataType<?> type, Object o) {
         return switch (type.id()) {
-            case LongType.ID -> (Long) o;
+            case LongType.ID, TimestampType.ID_WITHOUT_TZ, TimestampType.ID_WITH_TZ -> (Long) o;
             case DoubleType.ID -> NumericUtils.doubleToSortableLong((Double) o);
             case FloatType.ID -> (long) NumericUtils.floatToSortableInt((Float) o);
             case IntegerType.ID -> ((Integer) o).longValue();
@@ -499,7 +502,7 @@ public class TopKAggregation extends AggregationFunction<TopKAggregation.State, 
 
     private static Object toObject(DataType<?> type, long o) {
         return switch (type.id()) {
-            case LongType.ID -> o;
+            case LongType.ID, TimestampType.ID_WITHOUT_TZ, TimestampType.ID_WITH_TZ -> o;
             case DoubleType.ID -> NumericUtils.sortableLongToDouble(o);
             case FloatType.ID -> NumericUtils.sortableIntToFloat((int) o);
             case IntegerType.ID -> (int) o;

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/TopKAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/TopKAggregationTest.java
@@ -74,6 +74,12 @@ public class TopKAggregationTest extends AggregationTestCase {
     }
 
     @Test
+    public void test_top_k_timestamps() throws Exception {
+        execute_top_k_without_and_with_doc_values(DataTypes.TIMESTAMPZ);
+        execute_top_k_without_and_with_doc_values(DataTypes.TIMESTAMP);
+    }
+
+    @Test
     public void test_top_k_invalid_limit_parameters() throws Exception {
         Object[][] dataWithInvalidLimit = {
             new Object[]{1L, -1},


### PR DESCRIPTION
Timestamp without doc-values

```
Q: select topk("t") from t2
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |     2353.206 ±   86.438 |   2270.740 |   2321.613 |   2349.364 |   2678.864 |
|   V2    |     1922.058 ±   76.818 |   1864.220 |   1895.092 |   1917.363 |   2271.798 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  20.17%                           -  20.23%
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 20.17%
The test has statistical significance
```

Timestamp with doc-values

```
Q: select topk("t") from t1
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |       15.743 ±   36.841 |      9.018 |      9.790 |     10.147 |    268.035 |
|   V2    |       11.868 ±   28.383 |      5.974 |      7.574 |      7.802 |    208.022 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  28.06%                           -  25.52%
There is a 44.28% probability that the observed difference is not random, and the best estimate of that difference is 28.06%
The test has no statistical significance
```

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
