### PR TITLE
Enable doc-values for ip-adresses in top-k

### DIFF
--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/TopKAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/TopKAggregationTest.java
@@ -80,6 +80,11 @@ public class TopKAggregationTest extends AggregationTestCase {
     }
 
     @Test
+    public void test_top_k_ip() throws Exception {
+        execute_top_k_without_and_with_doc_values(DataTypes.IP);
+    }
+
+    @Test
     public void test_top_k_invalid_limit_parameters() throws Exception {
         Object[][] dataWithInvalidLimit = {
             new Object[]{1L, -1},


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

```
Q: select topk("ip_addr") from t2
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |       65.181 ±   40.230 |     54.960 |     56.057 |     57.131 |    338.559 |
|   V2    |       48.764 ±   45.810 |     36.643 |     37.946 |     44.915 |    359.930 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  28.81%                           -  38.53%
There is a 94.02% probability that the observed difference is not random, and the best estimate of that difference is 28.81%
The test has no statistical significance
```


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
