### PR TITLE
Add assertion for doc-value-aggregator in top-k tests

### DIFF
--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/TopKAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/TopKAggregationTest.java
@@ -183,6 +183,8 @@ public class TopKAggregationTest extends AggregationTestCase {
             new Object[]{third},
         };
 
+        assertHasDocValueAggregator(TopKAggregation.NAME, List.of(dataType));
+
         var result = executeAggregation(
             TopKAggregation.PARAMETER_SIGNATURE,
             List.of(dataType),


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This change is because I want to enforce in the tests that doc-values support must be present.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
