### PR TITLE
Add support for explaining insert statements

### DIFF
--- a/docs/appendices/release-notes/5.9.0.rst
+++ b/docs/appendices/release-notes/5.9.0.rst
@@ -81,7 +81,8 @@ Changes
 SQL Statements
 --------------
 
-None
+- Extended :ref:`ref-explain` with initial support for ``INSERT INTO``. Using
+  ``VERBOSE`` is still not supported.
 
 SQL Standard and PostgreSQL Compatibility
 -----------------------------------------

--- a/server/src/main/java/io/crate/analyze/ExplainStatementAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/ExplainStatementAnalyzer.java
@@ -92,6 +92,10 @@ public class ExplainStatementAnalyzer {
             return null;
         }
 
+        public Void visitInsert(io.crate.sql.tree.Insert<?> node, Void context) {
+            return node.insertSource().accept(this, context);
+        }
+
         @Override
         protected Void visitNode(Node node, Void context) {
             throw new UnsupportedFeatureException("EXPLAIN is not supported for " + node);


### PR DESCRIPTION
Was a low hanging fruit and being able to display the logical plan helps
debugging issues like

https://github.com/crate/crate/issues/16449
