### PR TITLE
Fix handling of un-merged ordered result in INSERT INTO

### DIFF
--- a/docs/appendices/release-notes/5.8.2.rst
+++ b/docs/appendices/release-notes/5.8.2.rst
@@ -47,6 +47,10 @@ See the :ref:`version_5.8.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that could lead to a ``SQLParseException[Couldn't create
+  executionContexts from ...`` error if using ``INSERT INTO`` with a ``SELECT``
+  query containing a trailing ``ORDER BY``.
+
 - Added a ``schema`` property to the ``NodeInfo/ShardInfo`` JMX property to fix
   an issue with Prometheus 2.52.0 rejecting values due to duplicate entries.
 


### PR DESCRIPTION
Fixes https://github.com/crate/crate/issues/16449

Problem:

In a statement like:

    insert into tdst (x, y) (select x, y from tsrc order by y)

The execution plan for the select contained a `PositionalOrderBy` to
indicate that the result is still distributed but pre-sorted.

The `Insert` operator added a `IndexWriterProjection` on top - turning
the rows into row-counts - and afterwards tried to do a merge to
handler. The merge to handler used the `PositionalOrderBy` information
to attempt to do a sorted merge. This could fail because the columns
required for the sorted merge were no longer available due to the insert
projection.

Solution:

- Drop the pre-sort information. It is not required

Note we could further improve this via a optimization rule that drops
the `ORDER BY` completely, to avoid unnecessary pre-sort logic.
