### PR TITLE
Allow users with AL permission to execute alter role

### DIFF
--- a/docs/sql/statements/alter-role.rst
+++ b/docs/sql/statements/alter-role.rst
@@ -25,9 +25,9 @@ Synopsis
 Description
 ===========
 
-``ALTER ROLE SET`` applies a change to an existing database user or role. Only
-existing superusers or the user itself have the privilege to alter an existing
-database user.
+``ALTER ROLE SET`` applies a change to an existing database user or role.
+Superusers and users with ``AL`` privileges can modify other roles. Every role
+has permission to modify themselves.
 
 ``ALTER ROLE RESET`` resets modifiable
 :ref:`session settings <conf-session>` to their default value.

--- a/server/src/main/java/io/crate/auth/AccessControlImpl.java
+++ b/server/src/main/java/io/crate/auth/AccessControlImpl.java
@@ -364,10 +364,16 @@ public final class AccessControlImpl implements AccessControl {
         @Override
         public Void visitAnalyzedAlterRole(AnalyzedAlterRole analysis, Role user) {
             // user is allowed to change it's own properties
-            if (!analysis.roleName().equals(user.name())) {
-                throw new UnauthorizedException("A regular user can use ALTER USER only on himself. " +
-                                                "To modify other users superuser permissions are required.");
+            if (analysis.roleName().equals(user.name())) {
+                return null;
             }
+            Privileges.ensureUserHasPrivilege(
+                relationVisitor.roles,
+                user,
+                Permission.AL,
+                Securable.CLUSTER,
+                null
+            );
             return null;
         }
 

--- a/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
+++ b/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
@@ -199,11 +199,9 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
     }
 
     @Test
-    public void testAlterOtherUsersNotAllowedAsNormalUser() {
-        assertThatThrownBy(() -> analyze("alter user ford set (password = 'pass')"))
-            .isExactlyInstanceOf(UnauthorizedException.class)
-            .hasMessage("A regular user can use ALTER USER only on himself. " +
-                        "To modify other users superuser permissions are required.");
+    public void test_alter_other_user_requires_al_permission() {
+        analyze("alter user ford set (password = 'pass')");
+        assertAskedForCluster(Permission.AL);
     }
 
     @Test


### PR DESCRIPTION
Although there were discussions to not extend AL and instead move in the
direction of allowing a `GRANT crate TO..` to give other users superuser
privileges, users with AL can already create and drop roles. Disallowing
ALTER would seem inconsistent.
