### PR TITLE
Add support for numeric storage

### DIFF
--- a/docs/appendices/release-notes/5.9.0.rst
+++ b/docs/appendices/release-notes/5.9.0.rst
@@ -112,7 +112,7 @@ SQL Standard and PostgreSQL Compatibility
 Data Types
 ----------
 
-None
+- Added storage support for the :ref:`NUMERIC <type-numeric>` data type.
 
 Scalar and Aggregation Functions
 --------------------------------

--- a/docs/general/ddl/data-types.rst
+++ b/docs/general/ddl/data-types.rst
@@ -1016,13 +1016,6 @@ For example, using a :ref:`cast from a string literal
     +--------+
     SELECT 1 row in set (... sec)
 
-.. NOTE::
-
-    The ``NUMERIC`` type is only supported as a type literal (i.e., for use in
-    SQL :ref:`expressions <gloss-expression>`, like a :ref:`type cast
-    <data-types-casting-exp>`, as above).
-
-    You cannot create table columns of type ``NUMERIC``.
 
 This type is usually used when it is important to preserve exact precision
 or handle values that exceed the range of the numeric types of the fixed
@@ -1049,6 +1042,12 @@ Without configuring the precision and scale the ``NUMERIC`` type value will be
 represented by an unscaled value of the unlimited precision::
 
     NUMERIC
+
+.. NOTE::
+
+    ``NUMERIC`` without precision and scale cannot be used in CREATE TABLE
+    statements. To store values of type NUMERIC it is required to define the
+    precision and scale.
 
 The ``NUMERIC`` type is internally backed by the Java ``BigDecimal`` class. For
 more detailed information about its behaviour, see `BigDecimal documentation`_.

--- a/extensions/lang-js/src/test/java/io/crate/operation/language/PolyglotValuesTest.java
+++ b/extensions/lang-js/src/test/java/io/crate/operation/language/PolyglotValuesTest.java
@@ -98,7 +98,7 @@ public class PolyglotValuesTest extends ESTestCase {
                 );
             }
 
-            NumericType type = NumericType.of(18, 9);
+            NumericType type = new NumericType(18, 9);
             assertEvaluatesTo(
                 context,
                 "function getValue() { return 42; }",

--- a/server/src/main/java/io/crate/analyze/validator/SemanticSortValidator.java
+++ b/server/src/main/java/io/crate/analyze/validator/SemanticSortValidator.java
@@ -50,6 +50,7 @@ public class SemanticSortValidator {
         Stream.of(
             DataTypes.REGCLASS,
             DataTypes.REGPROC,
+            DataTypes.NUMERIC,
             BitStringType.INSTANCE_ONE,
             FloatVectorType.INSTANCE_ONE
         )

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/numeric/NumericAverageStateType.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/numeric/NumericAverageStateType.java
@@ -21,15 +21,16 @@
 
 package io.crate.execution.engine.aggregation.impl.average.numeric;
 
+import java.io.IOException;
+import java.math.BigDecimal;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
 import io.crate.Streamer;
 import io.crate.execution.engine.aggregation.impl.util.BigDecimalValueWrapper;
 import io.crate.types.DataType;
 import io.crate.types.NumericType;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
-
-import java.io.IOException;
-import java.math.BigDecimal;
 
 @SuppressWarnings("rawtypes")
 public class NumericAverageStateType extends DataType<NumericAverageState> implements Streamer<NumericAverageState> {
@@ -74,7 +75,7 @@ public class NumericAverageStateType extends DataType<NumericAverageState> imple
         // Cannot use NumericType.INSTANCE as it has default precision and scale values
         // which might not be equal to written BigDecimal's precision and scale.
         return new NumericAverageState<>(
-            new BigDecimalValueWrapper(NumericType.of(in.readInt(), in.readInt()).readValueFrom(in)),
+            new BigDecimalValueWrapper(new NumericType(in.readInt(), in.readInt()).readValueFrom(in)),
             in.readVLong()
         );
     }

--- a/server/src/main/java/io/crate/execution/engine/sort/LuceneSort.java
+++ b/server/src/main/java/io/crate/execution/engine/sort/LuceneSort.java
@@ -66,6 +66,7 @@ import io.crate.types.FloatVectorType;
 import io.crate.types.GeoPointType;
 import io.crate.types.IntegerType;
 import io.crate.types.LongType;
+import io.crate.types.NumericType;
 import io.crate.types.ShortType;
 import io.crate.types.StringType;
 import io.crate.types.TimestampType;
@@ -153,7 +154,8 @@ public class LuceneSort extends SymbolVisitor<LuceneSort.SortSymbolContext, Sort
 
         if (ref.valueType().equals(DataTypes.IP)
                 || ref.valueType().id() == BitStringType.ID
-                || ref.valueType().id() == FloatVectorType.ID) {
+                || ref.valueType().id() == FloatVectorType.ID
+                || ref.valueType().id() == NumericType.ID) {
             return customSortField(ref.toString(), ref, context);
         } else {
             NullValueOrder nullValueOrder = NullValueOrder.fromFlag(context.nullFirst);

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/IntegerColumnReference.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/IntegerColumnReference.java
@@ -31,6 +31,4 @@ public class IntegerColumnReference extends NumericColumnReference<Integer> {
     protected Integer convert(long input) {
         return (int) input;
     }
-
 }
-

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/LuceneReferenceResolver.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/LuceneReferenceResolver.java
@@ -39,6 +39,7 @@ import io.crate.types.BitStringType;
 import io.crate.types.BooleanType;
 import io.crate.types.ByteType;
 import io.crate.types.CharacterType;
+import io.crate.types.DataType;
 import io.crate.types.DoubleType;
 import io.crate.types.FloatType;
 import io.crate.types.FloatVectorType;
@@ -46,6 +47,8 @@ import io.crate.types.GeoPointType;
 import io.crate.types.IntegerType;
 import io.crate.types.IpType;
 import io.crate.types.LongType;
+import io.crate.types.NumericStorage;
+import io.crate.types.NumericType;
 import io.crate.types.ShortType;
 import io.crate.types.StringType;
 import io.crate.types.TimestampType;
@@ -123,8 +126,9 @@ public class LuceneReferenceResolver implements ReferenceResolver<LuceneCollecto
         if (ref.hasDocValues() == false) {
             return DocCollectorExpression.create(DocReferences.toDocLookup(ref));
         }
-        return switch (ref.valueType().id()) {
-            case BitStringType.ID -> new BitStringColumnReference(fqn, ((BitStringType) ref.valueType()).length());
+        DataType<?> valueType = ref.valueType();
+        return switch (valueType.id()) {
+            case BitStringType.ID -> new BitStringColumnReference(fqn, ((BitStringType) valueType).length());
             case ByteType.ID -> new ByteColumnReference(fqn);
             case ShortType.ID -> new ShortColumnReference(fqn);
             case IpType.ID -> new IpColumnReference(fqn);
@@ -137,7 +141,8 @@ public class LuceneReferenceResolver implements ReferenceResolver<LuceneCollecto
             case GeoPointType.ID -> new GeoPointColumnReference(fqn);
             case ArrayType.ID -> DocCollectorExpression.create(DocReferences.toDocLookup(ref));
             case FloatVectorType.ID -> new FloatVectorColumnReference(fqn);
-            default -> throw new UnhandledServerException("Unsupported type: " + ref.valueType().getName());
+            case NumericType.ID -> NumericStorage.getCollectorExpression(fqn, (NumericType) valueType);
+            default -> throw new UnhandledServerException("Unsupported type: " + valueType.getName());
         };
     }
 

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/SourceParser.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/SourceParser.java
@@ -67,6 +67,7 @@ import io.crate.types.GeoPointType;
 import io.crate.types.GeoShapeType;
 import io.crate.types.IntegerType;
 import io.crate.types.LongType;
+import io.crate.types.NumericType;
 import io.crate.types.ObjectType;
 import io.crate.types.ShortType;
 import io.crate.types.TimestampType;
@@ -324,6 +325,7 @@ public final class SourceParser {
                 BitSet.valueOf(parser.binaryValue()),
                 ((BitStringType) elementType).length()
             );
+            case NumericType.ID -> elementType.sanitizeValue(parser.text());
             default -> parser.text();
         };
     }

--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfoFactory.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfoFactory.java
@@ -82,6 +82,7 @@ import io.crate.types.CharacterType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.FloatVectorType;
+import io.crate.types.NumericType;
 import io.crate.types.ObjectType;
 import io.crate.types.StorageSupport;
 import io.crate.types.StringType;
@@ -728,6 +729,11 @@ public class DocTableInfoFactory {
                 Integer length = (Integer) columnProperties.get("length");
                 assert length != null : "Length is required for bit string type";
                 yield new BitStringType(length);
+            }
+            case NumericType.NAME -> {
+                Integer precision = (Integer) columnProperties.get("precision");
+                Integer scale = (Integer) columnProperties.get("scale");
+                yield new NumericType(precision, scale);
             }
             case FloatVectorType.NAME -> {
                 Integer dimensions = (Integer) columnProperties.get("dimensions");

--- a/server/src/main/java/io/crate/types/NumericEqQuery.java
+++ b/server/src/main/java/io/crate/types/NumericEqQuery.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.types;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import org.apache.lucene.search.Query;
+import org.jetbrains.annotations.Nullable;
+
+public class NumericEqQuery implements EqQuery<BigDecimal> {
+
+    @Override
+    @Nullable
+    public Query termQuery(String field,
+                           BigDecimal value,
+                           boolean hasDocValues,
+                           boolean isIndexed) {
+        return null;
+    }
+
+    @Override
+    @Nullable
+    public Query rangeQuery(String field,
+                            BigDecimal lowerTerm,
+                            BigDecimal upperTerm,
+                            boolean includeLower,
+                            boolean includeUpper,
+                            boolean hasDocValues,
+                            boolean isIndexed) {
+        return null;
+    }
+
+    @Override
+    @Nullable
+    public Query termsQuery(String field,
+                            List<BigDecimal> nonNullValues,
+                            boolean hasDocValues,
+                            boolean isIndexed) {
+        return null;
+    }
+}

--- a/server/src/main/java/io/crate/types/NumericStorage.java
+++ b/server/src/main/java/io/crate/types/NumericStorage.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.types;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.MathContext;
+import java.util.function.Function;
+
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.LongPoint;
+import org.apache.lucene.document.SortedNumericDocValuesField;
+import org.apache.lucene.document.SortedSetDocValuesField;
+import org.apache.lucene.index.IndexOptions;
+import org.apache.lucene.search.PointRangeQuery;
+import org.apache.lucene.util.BytesRef;
+import org.jetbrains.annotations.NotNull;
+
+import io.crate.execution.dml.IndexDocumentBuilder;
+import io.crate.execution.dml.ValueIndexer;
+import io.crate.expression.reference.doc.lucene.BinaryColumnReference;
+import io.crate.expression.reference.doc.lucene.LuceneCollectorExpression;
+import io.crate.expression.reference.doc.lucene.NumericColumnReference;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.IndexType;
+import io.crate.metadata.Reference;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.doc.DocSysColumns;
+
+/**
+ * Takes care of writing, reading and querying of values of type {@link NumericType} in Lucene.
+ *
+ * <ul>
+ * <li>Values with <= 18 digits are stored as `long` with numeric
+ * doc-values</li>
+ * <li>
+ * Values with > 18 digits are stored with binary doc-values with dimensions set
+ * to support using {@link PointRangeQuery}
+ * </li>
+ * </p>
+ *
+ **/
+public final class NumericStorage extends StorageSupport<BigDecimal> {
+
+    public static final int COMPACT_PRECISION = 18;
+
+    public NumericStorage() {
+        super(true, true, new NumericEqQuery());
+    }
+
+    @Override
+    public ValueIndexer<? super BigDecimal> valueIndexer(RelationName table,
+                                                         Reference ref,
+                                                         Function<ColumnIdent, Reference> getRef) {
+        DataType<?> type = ArrayType.unnest(ref.valueType());
+        assert type instanceof NumericType
+            : "ValueIndexer on NumericStorage can only be used for numeric types";
+        NumericType numericType = (NumericType) type;
+        Integer precision = numericType.numericPrecision();
+        if (precision == null || numericType.scale() == null) {
+            throw new UnsupportedOperationException(
+                "NUMERIC type requires precision and scale to support storage");
+        } else if (precision <= COMPACT_PRECISION) {
+            return new CompactNumericIndexer(ref);
+        } else {
+            return new FixedNumericIndexer(ref, precision);
+        }
+    }
+
+    private abstract static class BaseNumericIndexer implements ValueIndexer<BigDecimal> {
+
+        protected final Reference ref;
+        protected final String name;
+
+        protected BaseNumericIndexer(Reference ref) {
+            this.ref = ref;
+            this.name = ref.storageIdent();
+        }
+
+        @Override
+        public String storageIdentLeafName() {
+            return ref.storageIdentLeafName();
+        }
+    }
+
+    private static class CompactNumericIndexer extends BaseNumericIndexer {
+
+        private CompactNumericIndexer(Reference ref) {
+            super(ref);
+        }
+
+        @Override
+        public void indexValue(@NotNull BigDecimal value, IndexDocumentBuilder docBuilder) throws IOException {
+            BigInteger unscaled = value.unscaledValue();
+            long longValue = unscaled.longValueExact();
+
+            if (this.ref.indexType() != IndexType.NONE) {
+                docBuilder.addField(new LongPoint(name, longValue));
+            }
+            if (ref.hasDocValues()) {
+                docBuilder.addField(new SortedNumericDocValuesField(name, longValue));
+            } else {
+                docBuilder.addField(new Field(
+                    DocSysColumns.FieldNames.NAME,
+                    name,
+                    DocSysColumns.FieldNames.FIELD_TYPE));
+            }
+
+            docBuilder.translogWriter().writeValue(value);
+        }
+    }
+
+    private static class FixedNumericIndexer extends BaseNumericIndexer {
+
+        private final FieldType fieldType;
+
+        private FixedNumericIndexer(Reference ref, int precision) {
+            super(ref);
+            this.fieldType = new FieldType();
+            this.fieldType.setOmitNorms(true);
+            this.fieldType.setIndexOptions(IndexOptions.DOCS);
+            this.fieldType.setTokenized(false);
+            this.fieldType.setStored(false);
+            this.fieldType.freeze();
+        }
+
+        @Override
+        public void indexValue(@NotNull BigDecimal value, IndexDocumentBuilder docBuilder) throws IOException {
+            BigInteger unscaled = value.unscaledValue();
+            BytesRef binaryValue = new BytesRef(unscaled.toByteArray());
+            if (this.ref.indexType() != IndexType.NONE) {
+                docBuilder.addField(new Field(name, binaryValue, fieldType));
+            }
+            if (ref.hasDocValues()) {
+                docBuilder.addField(new SortedSetDocValuesField(name, binaryValue));
+            } else {
+                docBuilder.addField(new Field(
+                    DocSysColumns.FieldNames.NAME,
+                    name,
+                    DocSysColumns.FieldNames.FIELD_TYPE));
+            }
+            docBuilder.translogWriter().writeValue(value);
+        }
+    }
+
+    public static LuceneCollectorExpression<BigDecimal> getCollectorExpression(String fqn, NumericType type) {
+        final Integer precision = type.numericPrecision();
+        final MathContext mathContext = type.mathContext();
+
+        if (precision == null || precision > COMPACT_PRECISION) {
+            return new BinaryColumnReference<BigDecimal>(fqn) {
+
+                @Override
+                protected BigDecimal convert(BytesRef input) {
+                    BigInteger bigInt = new BigInteger(input.bytes, input.offset, input.length);
+                    Integer scale = type.scale();
+                    return new BigDecimal(bigInt, scale == null ? 0 : scale, mathContext);
+                }
+            };
+        }
+
+        return new NumericColumnReference<>(fqn) {
+
+            @Override
+            protected BigDecimal convert(long input) {
+                BigInteger bigInt = BigInteger.valueOf(input);
+                Integer scale = type.scale();
+                return new BigDecimal(bigInt, scale == null ? 0 : scale, mathContext);
+            }
+        };
+    }
+}

--- a/server/src/test/java/io/crate/analyze/parser/TypeSignatureParserTest.java
+++ b/server/src/test/java/io/crate/analyze/parser/TypeSignatureParserTest.java
@@ -174,7 +174,7 @@ public class TypeSignatureParserTest extends ESTestCase {
         var signature = TypeSignature.parse("numeric(1)");
         assertThat(signature.getBaseTypeName()).isEqualTo("numeric");
         assertThat(signature.getParameters()).containsExactly(new IntegerLiteralTypeSignature(1));
-        assertThat(signature.createType()).isEqualTo(NumericType.of(1));
+        assertThat(signature.createType()).isEqualTo(new NumericType(1, 0));
     }
 
     @Test
@@ -183,7 +183,7 @@ public class TypeSignatureParserTest extends ESTestCase {
         assertThat(signature.getBaseTypeName()).isEqualTo("numeric");
         assertThat(signature.getParameters()).containsExactly(
             new IntegerLiteralTypeSignature(1), new IntegerLiteralTypeSignature(2));
-        assertThat(signature.createType()).isEqualTo(NumericType.of(1, 2));
+        assertThat(signature.createType()).isEqualTo(new NumericType(1, 2));
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/AverageAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/AverageAggregationTest.java
@@ -221,7 +221,7 @@ public class AverageAggregationTest extends AggregationTestCase {
 
     @Test
     public void test_avg_numeric_with_precision_and_scale_on_double_non_doc_values() {
-        var type = NumericType.of(16, 2);
+        var type = new NumericType(16, 2);
         var expected = type.implicitCast(12.4357);
         assertThat(expected).hasToString("12.44");
 

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/SumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/SumAggregationTest.java
@@ -255,7 +255,7 @@ public class SumAggregationTest extends AggregationTestCase {
 
     @Test
     public void test_sum_numeric_with_precision_and_scale_on_double_non_doc_values_field() {
-        var type = NumericType.of(16, 2);
+        var type = new NumericType(16, 2);
         var expected = type.implicitCast(12.4357);
         assertThat(expected.toString()).isEqualTo("12.44");
 

--- a/server/src/test/java/io/crate/expression/predicate/FieldExistsQueryTest.java
+++ b/server/src/test/java/io/crate/expression/predicate/FieldExistsQueryTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.elasticsearch.Version;
 import org.junit.Test;
 
@@ -78,7 +79,9 @@ public class FieldExistsQueryTest extends CrateDummyClusterServiceUnitTest {
                 if (results.get(0) instanceof Map<?, ?> map) {
                     assertThat(map).isEmpty();
                 } else {
-                    assertThat(results.get(0)).asList().isEmpty();
+                    assertThat(results.get(0))
+                        .asInstanceOf(InstanceOfAssertFactories.LIST)
+                        .isEmpty();
                 }
             }
         }
@@ -108,27 +111,29 @@ public class FieldExistsQueryTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void test_is_null_does_not_match_empty_arrays() throws Exception {
-        for (DataType<?> type : DataTypeTesting.ALL_STORED_TYPES_EXCEPT_ARRAYS) {
+        for (DataType<?> type : DataTypeTesting.getStorableTypesExceptArrays(random())) {
             if (type instanceof FloatVectorType) {
                 continue;
             }
+            String typeDefinition = SqlFormatter.formatSql(type.toColumnType(ColumnPolicy.STRICT, null));
             String createStatement = "create table t_" +
                 type.getName().replaceAll(" ", "_") +
-                " (xs array(" + type.getName() + "))";
+                " (xs array(" + typeDefinition + "))";
             assertMatches(createStatement, true, ARRAY_VALUES);
         }
     }
 
     @Test
     public void test_is_null_does_not_match_empty_arrays_with_index_off() throws Exception {
-        for (DataType<?> type : DataTypeTesting.ALL_STORED_TYPES_EXCEPT_ARRAYS) {
+        for (DataType<?> type : DataTypeTesting.getStorableTypesExceptArrays(random())) {
             if (type instanceof FloatVectorType) {
                 continue;
             }
             if (TableElementsAnalyzer.UNSUPPORTED_INDEX_TYPE_IDS.contains(type.id()) == false) {
+                String typeDefinition = SqlFormatter.formatSql(type.toColumnType(ColumnPolicy.STRICT, null));
                 String createStatement = "create table t_" +
                     type.getName().replaceAll(" ", "_") +
-                    " (xs array(" + type.getName() + ") index off)";
+                    " (xs array(" + typeDefinition + ") index off)";
                 assertMatches(createStatement, true, ARRAY_VALUES);
             }
         }
@@ -163,28 +168,30 @@ public class FieldExistsQueryTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void test_is_not_null_does_not_match_empty_arrays() throws Exception {
-        for (DataType<?> type : DataTypeTesting.ALL_STORED_TYPES_EXCEPT_ARRAYS) {
+        for (DataType<?> type : DataTypeTesting.getStorableTypesExceptArrays(random())) {
             if (type instanceof FloatVectorType) {
                 continue;
             }
+            String typeDefinition = SqlFormatter.formatSql(type.toColumnType(ColumnPolicy.STRICT, null));
             // including geo_shape
             String createStatement = "create table t_" +
                 type.getName().replaceAll(" ", "_") +
-                " (xs array(" + type.getName() + "))";
+                " (xs array(" + typeDefinition + "))";
             assertMatches(createStatement, false, ARRAY_VALUES);
         }
     }
 
     @Test
     public void test_is_not_null_does_not_match_empty_arrays_with_index_off() throws Exception {
-        for (DataType<?> type : DataTypeTesting.ALL_STORED_TYPES_EXCEPT_ARRAYS) {
+        for (DataType<?> type : DataTypeTesting.getStorableTypesExceptArrays(random())) {
             if (type instanceof FloatVectorType) {
                 continue;
             }
             if (TableElementsAnalyzer.UNSUPPORTED_INDEX_TYPE_IDS.contains(type.id()) == false) {
+                String typeDefinition = SqlFormatter.formatSql(type.toColumnType(ColumnPolicy.STRICT, null));
                 String createStatement = "create table t_" +
                     type.getName().replaceAll(" ", "_") +
-                    " (xs array(" + type.getName() + ") index off)";
+                    " (xs array(" + typeDefinition + ") index off)";
                 assertMatches(createStatement, false, ARRAY_VALUES);
             }
         }
@@ -223,7 +230,7 @@ public class FieldExistsQueryTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void test_is_null_on_columns_without_doc_values() throws Exception {
-        for (var type : DataTypeTesting.ALL_STORED_TYPES_EXCEPT_ARRAYS) {
+        for (var type : DataTypeTesting.getStorableTypesExceptArrays(random())) {
             StorageSupport<?> storageSupport = type.storageSupport();
             if (storageSupport == null || !storageSupport.supportsDocValuesOff()) {
                 continue;

--- a/server/src/test/java/io/crate/integrationtests/LuceneQueryBuilderIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/LuceneQueryBuilderIntegrationTest.java
@@ -36,6 +36,8 @@ import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.test.IntegTestCase;
 import org.junit.Test;
 
+import io.crate.sql.SqlFormatter;
+import io.crate.sql.tree.ColumnPolicy;
 import io.crate.testing.DataTypeTesting;
 import io.crate.types.DataType;
 
@@ -350,7 +352,8 @@ public class LuceneQueryBuilderIntegrationTest extends IntegTestCase {
     @Test
     public void testNullOperators() throws Exception {
         DataType<?> type = randomType();
-        execute("create table t1 (c " + type.getName() + ") with (number_of_replicas = 0)");
+        String typeDefinition = SqlFormatter.formatSql(type.toColumnType(ColumnPolicy.STRICT, null));
+        execute("create table t1 (c " + typeDefinition + ") with (number_of_replicas = 0)");
         Supplier<?> dataGenerator = DataTypeTesting.getDataGenerator(type);
 
         Object[][] bulkArgs = $$($(dataGenerator.get()), $(dataGenerator.get()), new Object[]{null});

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -28,6 +28,7 @@ import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 
@@ -1830,7 +1831,7 @@ public class TransportSQLActionTest extends IntegTestCase {
         StringBuilder selectInlineValues = new StringBuilder("SELECT 1 FROM tbl WHERE ");
         StringBuilder selectParams = new StringBuilder("SELECT 1 FROM tbl WHERE ");
         for (int i = 0; i < args.length; i++) {
-            var arg = args[i];
+            final var arg = args[i];
             selectInlineValues.append("col");
             selectParams.append("col");
 
@@ -1933,7 +1934,7 @@ public class TransportSQLActionTest extends IntegTestCase {
     @UseJdbc(0)
     @SuppressWarnings({"unchecked", "rawtypes"})
     public void test_types_with_storage_can_be_inserted_and_queried() {
-        for (var type : DataTypeTesting.ALL_STORED_TYPES_EXCEPT_ARRAYS) {
+        for (var type : DataTypeTesting.getStorableTypesExceptArrays(random())) {
             if (type.equals(DataTypes.GEO_POINT)) {
                 // source and doc-value values don't match exactly
                 continue;
@@ -2265,5 +2266,28 @@ public class TransportSQLActionTest extends IntegTestCase {
                 );
             assertThat(execute(stmt, session)).isEmpty();
         }
+    }
+
+    @Test
+    public void test_numeric_storage_support() throws Exception {
+        Asserts.assertSQLError(() -> execute("create table tbl (x numeric)"))
+            .hasMessageContaining("NUMERIC storage is only supported if precision and scale are specified");
+
+        execute("create table tbl (x numeric(18, 9))");
+        execute(
+            """
+            insert into tbl (x) values
+                ('123456789.123456789'),
+                ('999999999.999999999'),
+                ('-999999999.999999999')
+            """
+        );
+        execute("refresh table tbl");
+        execute("select * from tbl order by x");
+        assertThat(response).hasRows(
+            "-999999999.999999999",
+            "123456789.123456789",
+            "999999999.999999999"
+        );
     }
 }

--- a/server/src/test/java/io/crate/lucene/ArrayLengthQueryTest.java
+++ b/server/src/test/java/io/crate/lucene/ArrayLengthQueryTest.java
@@ -281,7 +281,7 @@ public class ArrayLengthQueryTest extends CrateDummyClusterServiceUnitTest {
     @Test
     @SuppressWarnings({"rawtypes", "unchecked"})
     public void testArrayLengthWithAllSupportedTypes() throws Exception {
-        for (DataType<?> type : DataTypeTesting.ALL_STORED_TYPES_EXCEPT_ARRAYS) {
+        for (DataType<?> type : DataTypeTesting.getStorableTypesExceptArrays(random())) {
             // This is temporary as long as interval is not fully implemented
             if (type.storageSupport() == null || type instanceof FloatVectorType) {
                 continue;

--- a/server/src/test/java/io/crate/metadata/functions/SignatureBinderTest.java
+++ b/server/src/test/java/io/crate/metadata/functions/SignatureBinderTest.java
@@ -553,7 +553,7 @@ public class SignatureBinderTest extends ESTestCase {
 
     @Test
     public void testNumericParameters() {
-        NumericType dt = NumericType.of(10, 2);
+        NumericType dt = new NumericType(10, 2);
         assertThatSignature(NumericSumAggregation.SIGNATURE)
             .boundTo(dt)
             .hasReturnType(dt);
@@ -566,13 +566,14 @@ public class SignatureBinderTest extends ESTestCase {
             .argumentTypes(TypeSignature.parse("numeric"), TypeSignature.parse("numeric"))
             .build();
 
+        NumericType numericType = new NumericType(10, 2);
         BoundSignature expected = new BoundSignature(
             List.of(NumericType.INSTANCE, NumericType.INSTANCE),
-            NumericType.of(10, 2)
+            numericType
         );
 
         assertThatSignature(foo)
-            .boundTo(NumericType.INSTANCE, NumericType.of(10, 2))
+            .boundTo(NumericType.INSTANCE, numericType)
             .hasBoundSignature(expected);
     }
 

--- a/server/src/test/java/io/crate/testing/DataTypeTestingTest.java
+++ b/server/src/test/java/io/crate/testing/DataTypeTestingTest.java
@@ -30,7 +30,7 @@ public class DataTypeTestingTest extends ESTestCase {
 
     @Test
     public void testDataGeneratorReturnValidValues() throws Exception {
-        for (DataType<?> type : DataTypeTesting.ALL_STORED_TYPES_EXCEPT_ARRAYS) {
+        for (DataType<?> type : DataTypeTesting.getStorableTypesExceptArrays(random())) {
             type.sanitizeValue(DataTypeTesting.getDataGenerator(type).get());
         }
     }

--- a/server/src/test/java/io/crate/types/NestedArrayTypeTest.java
+++ b/server/src/test/java/io/crate/types/NestedArrayTypeTest.java
@@ -23,6 +23,7 @@ package io.crate.types;
 
 import static io.crate.execution.dml.IndexerTest.getIndexer;
 import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.List;

--- a/server/src/test/java/io/crate/types/NumericTypeTest.java
+++ b/server/src/test/java/io/crate/types/NumericTypeTest.java
@@ -21,7 +21,7 @@
 
 package io.crate.types;
 
-import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
@@ -31,10 +31,9 @@ import java.util.Map;
 
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
 
-public class NumericTypeTest extends ESTestCase {
+public class NumericTypeTest extends DataTypeTestCase<BigDecimal> {
 
     @Test
     public void test_implicit_cast_text_to_unscaled_numeric() {
@@ -60,42 +59,42 @@ public class NumericTypeTest extends ESTestCase {
 
     @Test
     public void test_implicit_cast_text_types_to_numeric_with_precision() {
-        assertThat(NumericType.of(5).implicitCast("12345")).isEqualTo(BigDecimal.valueOf(12345));
-        assertThat(NumericType.of(6).implicitCast("12345")).isEqualTo(BigDecimal.valueOf(12345));
+        assertThat(new NumericType(5, 0).implicitCast("12345")).isEqualTo(BigDecimal.valueOf(12345));
+        assertThat(new NumericType(6, null).implicitCast("12345")).isEqualTo(BigDecimal.valueOf(12345));
     }
 
     @Test
     public void test_implicit_cast_text_types_to_numeric_with_precision_and_scale() {
-        assertThat(NumericType.of(16, 0).implicitCast("12345")).isEqualTo(BigDecimal.valueOf(12345));
-        assertThat(NumericType.of(16, 2).implicitCast("12345").toString()).isEqualTo("12345.00");
-        assertThat(NumericType.of(10, 4).implicitCast("12345").toString()).isEqualTo("12345.0000");
+        assertThat(new NumericType(16, 0).implicitCast("12345")).isEqualTo(BigDecimal.valueOf(12345));
+        assertThat(new NumericType(16, 2).implicitCast("12345").toString()).isEqualTo("12345.00");
+        assertThat(new NumericType(10, 4).implicitCast("12345").toString()).isEqualTo("12345.0000");
     }
 
     @Test
     public void test_implicit_cast_decimal_types_to_numeric_with_precision() {
-        assertThat(NumericType.of(5).implicitCast(12345)).isEqualTo(BigDecimal.valueOf(12345));
-        assertThat(NumericType.of(6).implicitCast(12345)).isEqualTo(BigDecimal.valueOf(12345));
+        assertThat(new NumericType(5, null).implicitCast(12345)).isEqualTo(BigDecimal.valueOf(12345));
+        assertThat(new NumericType(6, null).implicitCast(12345)).isEqualTo(BigDecimal.valueOf(12345));
     }
 
     @Test
     public void test_implicit_cast_decimal_types_to_numeric_with_precision_and_scale() {
-        assertThat(NumericType.of(16, 0).implicitCast(12345)).isEqualTo(BigDecimal.valueOf(12345));
-        assertThat(NumericType.of(16, 2).implicitCast(12345).toString()).isEqualTo("12345.00");
-        assertThat(NumericType.of(10, 4).implicitCast(12345).toString()).isEqualTo("12345.0000");
+        assertThat(new NumericType(16, 0).implicitCast(12345)).isEqualTo(BigDecimal.valueOf(12345));
+        assertThat(new NumericType(16, 2).implicitCast(12345).toString()).isEqualTo("12345.00");
+        assertThat(new NumericType(10, 4).implicitCast(12345).toString()).isEqualTo("12345.0000");
     }
 
     @Test
     public void test_implicit_cast_floating_point_to_numeric_with_precision() {
-        assertThat(NumericType.of(2).implicitCast(10.1234d)).isEqualTo(BigDecimal.valueOf(10));
-        assertThat(NumericType.of(3).implicitCast(10.1234d)).isEqualTo(BigDecimal.valueOf(10));
-        assertThat(NumericType.of(3).implicitCast(10.9234d)).isEqualTo(BigDecimal.valueOf(11));
+        assertThat(new NumericType(2, 0).implicitCast(10.1234d)).isEqualTo(BigDecimal.valueOf(10));
+        assertThat(new NumericType(3, 0).implicitCast(10.1234d)).isEqualTo(BigDecimal.valueOf(10));
+        assertThat(new NumericType(3, 0).implicitCast(10.9234d)).isEqualTo(BigDecimal.valueOf(11));
     }
 
     @Test
     public void test_implicit_cast_floating_point_to_numeric_with_precision_and_scale() {
-        assertThat(NumericType.of(6, 0).implicitCast(10.1235d)).isEqualTo(BigDecimal.valueOf(10));
-        assertThat(NumericType.of(6, 2).implicitCast(10.1235d)).isEqualTo(BigDecimal.valueOf(10.12));
-        assertThat(NumericType.of(6, 3).implicitCast(10.1235d)).isEqualTo(BigDecimal.valueOf(10.124));
+        assertThat(new NumericType(6, 0).implicitCast(10.1235d)).isEqualTo(BigDecimal.valueOf(10));
+        assertThat(new NumericType(6, 2).implicitCast(10.1235d)).isEqualTo(BigDecimal.valueOf(10.12));
+        assertThat(new NumericType(6, 3).implicitCast(10.1235d)).isEqualTo(BigDecimal.valueOf(10.124));
     }
 
     @Test
@@ -178,7 +177,7 @@ public class NumericTypeTest extends ESTestCase {
     @Test
     public void test_numeric_with_precision_and_scale_serialization_round_trip() throws IOException {
         var out = new BytesStreamOutput();
-        var expected = NumericType.of(1, 2);
+        var expected = new NumericType(1, 2);
         DataTypes.toStream(expected, out);
 
         var in = out.bytes().streamInput();
@@ -186,5 +185,13 @@ public class NumericTypeTest extends ESTestCase {
 
         assertThat(actual.numericPrecision()).isEqualTo(1);
         assertThat(actual.scale()).isEqualTo(2);
+    }
+
+    @Override
+    public DataType<BigDecimal> getType() {
+        var random = random();
+        int precision = random.nextInt(2, 39);
+        int scale = random.nextInt(0, precision - 1);
+        return new NumericType(precision, scale);
     }
 }

--- a/server/src/test/java/io/crate/types/TypeCompatibilityTest.java
+++ b/server/src/test/java/io/crate/types/TypeCompatibilityTest.java
@@ -39,9 +39,9 @@ public class TypeCompatibilityTest {
 
     @Test
     public void test_numeric_highest_precision_wins() {
-        assertCommonType(NumericType.INSTANCE, NumericType.of(2, 1), NumericType.of(2, 1));
-        assertCommonType(NumericType.of(2, 1), NumericType.INSTANCE, NumericType.of(2, 1));
-        assertCommonType(NumericType.of(2, 1), NumericType.of(3, 1), NumericType.of(3, 1));
+        assertCommonType(NumericType.INSTANCE, new NumericType(2, 1), new NumericType(2, 1));
+        assertCommonType(new NumericType(2, 1), NumericType.INSTANCE, new NumericType(2, 1));
+        assertCommonType(new NumericType(2, 1), new NumericType(3, 1), new NumericType(3, 1));
     }
 
     private static void assertCommonType(DataType<?> first, DataType<?> second, DataType<?> expected) {

--- a/server/src/testFixtures/java/io/crate/types/DataTypeTestCase.java
+++ b/server/src/testFixtures/java/io/crate/types/DataTypeTestCase.java
@@ -24,6 +24,7 @@ package io.crate.types;
 import static io.crate.execution.dml.IndexerTest.getIndexer;
 import static io.crate.execution.dml.IndexerTest.item;
 import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.List;
@@ -183,6 +184,7 @@ public abstract class DataTypeTestCase<T> extends CrateDummyClusterServiceUnitTe
         DataType<?> fromStream = DataTypes.fromStream(in);
         assertThat(fromStream.id()).isEqualTo(type.id());
         assertThat(fromStream.characterMaximumLength()).isEqualTo(type.characterMaximumLength());
+        assertThat(fromStream.numericPrecision()).isEqualTo(type.numericPrecision());
     }
 
     @Test


### PR DESCRIPTION
Initial support for storage for `NUMERIC`

- Queries are unoptimized. Optimizing eq/range will be done in a follow up PR
- Storing `NUMERIC` without precision/scale definition is not supported

I diverged a bit from the usual pattern of having separate classes for `*ColumnReference` / `Indexer` and kept everything together in a `NumericStorage` class to keep the read/write logic closer together, which is more important here because <= 18 digits uses a different storage format than > 18 digits.