### PR TITLE
Separate _doc representation and lookup

### DIFF
--- a/benchmarks/src/main/java/io/crate/execution/engine/collect/collectors/LuceneBatchIteratorBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/execution/engine/collect/collectors/LuceneBatchIteratorBenchmark.java
@@ -23,9 +23,7 @@ package io.crate.execution.engine.collect.collectors;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.function.UnaryOperator;
 
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.document.Document;
@@ -71,7 +69,7 @@ public class LuceneBatchIteratorBenchmark {
         indexSearcher = new IndexSearcher(DirectoryReader.open(iw));
         IntegerColumnReference columnReference = new IntegerColumnReference(columnName);
         columnRefs = Collections.singletonList(columnReference);
-        collectorContext = new CollectorContext(Set.of(), UnaryOperator.identity());
+        collectorContext = new CollectorContext(() -> null);
     }
 
     @Benchmark

--- a/benchmarks/src/main/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorBenchmark.java
@@ -23,9 +23,7 @@ package io.crate.execution.engine.collect.collectors;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.function.UnaryOperator;
 
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.document.Document;
@@ -102,7 +100,7 @@ public class OrderedLuceneBatchIteratorBenchmark {
             iw.commit();
             iw.forceMerge(1, true);
             indexSearcher = new IndexSearcher(DirectoryReader.open(iw, true, true));
-            collectorContext = new CollectorContext(Set.of(), UnaryOperator.identity());
+            collectorContext = new CollectorContext(() -> null);
             reference = new SimpleReference(
                 new ReferenceIdent(new RelationName(Schemas.DOC_SCHEMA_NAME, "dummyTable"), columnName),
                 RowGranularity.DOC,

--- a/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
@@ -71,7 +71,7 @@ import io.crate.execution.dml.upsert.ShardUpsertRequest.DuplicateKeyAction;
 import io.crate.execution.engine.collect.PKLookupOperation;
 import io.crate.execution.jobs.TasksService;
 import io.crate.expression.reference.Doc;
-import io.crate.expression.reference.doc.lucene.SourceParser;
+import io.crate.expression.reference.doc.lucene.StoredRowLookup;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.NodeContext;
@@ -424,32 +424,25 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
                         ? Versions.MATCH_ANY
                         : Versions.MATCH_DELETED;
                 } else {
-                    SourceParser sourceParser;
                     DocTableInfo actualTable = tableInfo;
                     if (isRetry) {
                         // Get most-recent table info, could have changed (new columns, dropped columns)
                         actualTable = schemas.getTableInfo(tableInfo.ident());
                     }
-                    if (item.updateAssignments() != null && item.updateAssignments().length > 0) {
-                        // Use the source parser without registering any concrete column to get the complete
-                        // source which is required to write a new document with the updated values
-                        sourceParser = new SourceParser(actualTable.droppedColumns(), actualTable.lookupNameBySourceKey());
-                    } else {
-                        // No source is required for simple inserts and duplicate detection
-                        sourceParser = null;
-                    }
+                    assert updatingIndexer != null : "Dedicated indexer must be created for UPDATE or UPSERT";
+                    assert updateToInsert != null;
+                    assert item.updateAssignments() != null && item.updateAssignments().length > 0;
                     Doc doc = getDocument(
                         indexShard,
                         item.id(),
                         item.version(),
                         item.seqNo(),
                         item.primaryTerm(),
-                        sourceParser);
+                        StoredRowLookup.create(actualTable));
                     version = doc.getVersion();
                     IndexItem indexItem = updateToInsert.convert(doc, item.updateAssignments(), insertValues);
                     item.pkValues(indexItem.pkValues());
                     item.insertValues(indexItem.insertValues());
-                    assert updatingIndexer != null : "Dedicated indexer must be created for UPDATE or UPSERT";
                     request.insertColumns(updatingIndexer.insertColumns(updatingIndexer.columns()));
                 }
                 return insert(
@@ -585,10 +578,10 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
                                    long version,
                                    long seqNo,
                                    long primaryTerm,
-                                   @Nullable SourceParser sourceParser) {
+                                   StoredRowLookup storedRowLookup) {
         // when sequence versioning is used, this lookup will throw VersionConflictEngineException
         Doc doc = PKLookupOperation.lookupDoc(
-                indexShard, id, Versions.MATCH_ANY, VersionType.INTERNAL, seqNo, primaryTerm, sourceParser);
+                indexShard, id, Versions.MATCH_ANY, VersionType.INTERNAL, seqNo, primaryTerm, storedRowLookup);
         if (doc == null) {
             throw new DocumentMissingException(indexShard.shardId(), Constants.DEFAULT_MAPPING_TYPE, id);
         }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/CmpByAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/CmpByAggregation.java
@@ -42,6 +42,7 @@ import io.crate.execution.engine.fetch.ReaderContext;
 import io.crate.expression.reference.doc.lucene.CollectorContext;
 import io.crate.expression.reference.doc.lucene.LuceneCollectorExpression;
 import io.crate.expression.reference.doc.lucene.LuceneReferenceResolver;
+import io.crate.expression.reference.doc.lucene.StoredRowLookup;
 import io.crate.expression.symbol.Literal;
 import io.crate.memory.MemoryManager;
 import io.crate.metadata.FunctionType;
@@ -181,14 +182,14 @@ public final class CmpByAggregation extends AggregationFunction<CmpByAggregation
                         searchField.storageIdent(),
                         searchType,
                         resultExpression,
-                        new CollectorContext(table.droppedColumns(), table.lookupNameBySourceKey())
+                        new CollectorContext(() -> StoredRowLookup.create(table))
                     );
                 } else {
                     return new MaxByLong(
                         searchField.storageIdent(),
                         searchType,
                         resultExpression,
-                        new CollectorContext(table.droppedColumns(), table.lookupNameBySourceKey())
+                        new CollectorContext(() -> StoredRowLookup.create(table))
                     );
                 }
             default:

--- a/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
@@ -68,6 +68,7 @@ import io.crate.expression.InputFactory;
 import io.crate.expression.reference.doc.lucene.CollectorContext;
 import io.crate.expression.reference.doc.lucene.LuceneCollectorExpression;
 import io.crate.expression.reference.doc.lucene.LuceneReferenceResolver;
+import io.crate.expression.reference.doc.lucene.StoredRowLookup;
 import io.crate.expression.symbol.AggregateMode;
 import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Symbol;
@@ -159,7 +160,7 @@ final class DocValuesGroupByOptimizedIterator {
                 collectTask.memoryManager(),
                 collectTask.minNodeVersion(),
                 queryContext.query(),
-                new CollectorContext(sharedShardContext.readerId(), table.droppedColumns(), table.lookupNameBySourceKey())
+                new CollectorContext(sharedShardContext.readerId(), () -> StoredRowLookup.create(table))
             );
         } else {
             return GroupByIterator.forManyKeys(
@@ -171,7 +172,7 @@ final class DocValuesGroupByOptimizedIterator {
                 collectTask.memoryManager(),
                 collectTask.minNodeVersion(),
                 queryContext.query(),
-                new CollectorContext(sharedShardContext.readerId(), table.droppedColumns(), table.lookupNameBySourceKey())
+                new CollectorContext(sharedShardContext.readerId(), () -> StoredRowLookup.create(table))
             );
         }
     }

--- a/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
@@ -76,6 +76,7 @@ import io.crate.expression.InputFactory;
 import io.crate.expression.InputRow;
 import io.crate.expression.reference.doc.lucene.CollectorContext;
 import io.crate.expression.reference.doc.lucene.LuceneCollectorExpression;
+import io.crate.expression.reference.doc.lucene.StoredRowLookup;
 import io.crate.expression.symbol.AggregateMode;
 import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Symbol;
@@ -161,7 +162,7 @@ final class GroupByOptimizedIterator {
 
         RamAccounting ramAccounting = collectTask.getRamAccounting();
 
-        CollectorContext collectorContext = new CollectorContext(sharedShardContext.readerId(), table.droppedColumns(), table.lookupNameBySourceKey());
+        CollectorContext collectorContext = new CollectorContext(sharedShardContext.readerId(), () -> StoredRowLookup.create(table));
         InputRow inputRow = new InputRow(docCtx.topLevelInputs());
 
         LuceneQueryBuilder.Context queryContext = luceneQueryBuilder.convert(

--- a/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
@@ -54,6 +54,7 @@ import io.crate.expression.InputFactory;
 import io.crate.expression.reference.doc.lucene.CollectorContext;
 import io.crate.expression.reference.doc.lucene.LuceneCollectorExpression;
 import io.crate.expression.reference.doc.lucene.LuceneReferenceResolver;
+import io.crate.expression.reference.doc.lucene.StoredRowLookup;
 import io.crate.expression.reference.sys.shard.ShardRowContext;
 import io.crate.expression.symbol.Symbols;
 import io.crate.lucene.LuceneQueryBuilder;
@@ -142,7 +143,7 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
             queryContext.query(),
             queryContext.minScore(),
             Symbols.hasColumn(collectPhase.toCollect(), DocSysColumns.SCORE),
-            new CollectorContext(sharedShardContext.readerId(), table.droppedColumns(), table.lookupNameBySourceKey()),
+            new CollectorContext(sharedShardContext.readerId(), () -> StoredRowLookup.create(table)),
             docCtx.topLevelInputs(),
             docCtx.expressions()
         );
@@ -209,7 +210,7 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
             indexService.cache()
         );
         ctx = docInputFactory.extractImplementations(collectTask.txnCtx(), phase);
-        collectorContext = new CollectorContext(sharedShardContext.readerId(), table.droppedColumns(), table.lookupNameBySourceKey());
+        collectorContext = new CollectorContext(sharedShardContext.readerId(), () -> StoredRowLookup.create(table));
         int batchSize = phase.shardQueueSize(localNodeId.get());
         if (LOGGER.isTraceEnabled()) {
             LOGGER.trace("[{}][{}] creating LuceneOrderedDocCollector. Expected number of rows to be collected: {}",

--- a/server/src/main/java/io/crate/execution/engine/fetch/FetchCollector.java
+++ b/server/src/main/java/io/crate/execution/engine/fetch/FetchCollector.java
@@ -38,6 +38,7 @@ import io.crate.execution.engine.distribution.StreamBucket;
 import io.crate.expression.InputRow;
 import io.crate.expression.reference.doc.lucene.CollectorContext;
 import io.crate.expression.reference.doc.lucene.LuceneCollectorExpression;
+import io.crate.expression.reference.doc.lucene.StoredRowLookup;
 import io.netty.util.collection.IntObjectHashMap;
 
 class FetchCollector {
@@ -61,7 +62,7 @@ class FetchCollector {
         this.ramAccounting = ramAccounting;
         this.readerId = readerId;
         var table = fetchTask.table(readerId);
-        CollectorContext collectorContext = new CollectorContext(readerId, table.droppedColumns(), table.lookupNameBySourceKey());
+        CollectorContext collectorContext = new CollectorContext(readerId, () -> StoredRowLookup.create(table));
         for (LuceneCollectorExpression<?> collectorExpression : this.collectorExpressions) {
             collectorExpression.startCollect(collectorContext);
         }

--- a/server/src/main/java/io/crate/expression/reference/Doc.java
+++ b/server/src/main/java/io/crate/expression/reference/Doc.java
@@ -22,12 +22,12 @@
 package io.crate.expression.reference;
 
 import java.util.Map;
-import java.util.function.Supplier;
+
+import io.crate.expression.reference.doc.lucene.StoredRow;
 
 public final class Doc {
 
-    private final Map<String, Object> source;
-    private final Supplier<String> raw;
+    private final StoredRow storedRow;
     private final int docId;
     private final String index;
     private final String id;
@@ -41,14 +41,12 @@ public final class Doc {
                long version,
                long seqNo,
                long primaryTerm,
-               Map<String, Object> source,
-               Supplier<String> raw) {
+               StoredRow storedRow) {
         this.docId = docId;
         this.index = index;
         this.id = id;
         this.version = version;
-        this.source = source;
-        this.raw = raw;
+        this.storedRow = storedRow;
         this.seqNo = seqNo;
         this.primaryTerm = primaryTerm;
     }
@@ -74,11 +72,11 @@ public final class Doc {
     }
 
     public String getRaw() {
-        return raw.get();
+        return storedRow.asString();
     }
 
     public Map<String, Object> getSource() {
-        return source;
+        return storedRow.asMap();
     }
 
     public String getIndex() {
@@ -87,6 +85,6 @@ public final class Doc {
 
     @Override
     public String toString() {
-        return source != null ? source.toString() : null;
+        return storedRow != null ? storedRow.toString() : null;
     }
 }

--- a/server/src/main/java/io/crate/expression/reference/DocRefResolver.java
+++ b/server/src/main/java/io/crate/expression/reference/DocRefResolver.java
@@ -28,7 +28,7 @@ import java.util.List;
 import io.crate.common.collections.Maps;
 import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.execution.engine.collect.NestableCollectExpression;
-import io.crate.expression.reference.doc.lucene.Source;
+import io.crate.expression.reference.doc.lucene.StoredRow;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.Reference;
@@ -94,7 +94,7 @@ public final class DocRefResolver implements ReferenceResolver<CollectExpression
                             var partitionValue = partitionName.values().get(idx);
                             var source = response.getSource();
                             Maps.mergeInto(source, pColumn.name(), pColumn.path(), partitionValue);
-                            Object value = Source.extractValue(source, column);
+                            Object value = StoredRow.extractValue(source, column);
                             return ref.valueType().implicitCast(value);
                         });
                     }
@@ -104,7 +104,7 @@ public final class DocRefResolver implements ReferenceResolver<CollectExpression
                     if (response == null) {
                         return null;
                     }
-                    return ref.valueType().sanitizeValue(Source.extractValue(response.getSource(), column));
+                    return ref.valueType().sanitizeValue(StoredRow.extractValue(response.getSource(), column));
                 });
 
         }

--- a/server/src/main/java/io/crate/expression/reference/DocRefResolver.java
+++ b/server/src/main/java/io/crate/expression/reference/DocRefResolver.java
@@ -28,7 +28,7 @@ import java.util.List;
 import io.crate.common.collections.Maps;
 import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.execution.engine.collect.NestableCollectExpression;
-import io.crate.expression.reference.doc.lucene.SourceLookup;
+import io.crate.expression.reference.doc.lucene.Source;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.Reference;
@@ -94,7 +94,7 @@ public final class DocRefResolver implements ReferenceResolver<CollectExpression
                             var partitionValue = partitionName.values().get(idx);
                             var source = response.getSource();
                             Maps.mergeInto(source, pColumn.name(), pColumn.path(), partitionValue);
-                            Object value = SourceLookup.extractValue(source, column);
+                            Object value = Source.extractValue(source, column);
                             return ref.valueType().implicitCast(value);
                         });
                     }
@@ -104,7 +104,7 @@ public final class DocRefResolver implements ReferenceResolver<CollectExpression
                     if (response == null) {
                         return null;
                     }
-                    return ref.valueType().sanitizeValue(SourceLookup.extractValue(response.getSource(), column));
+                    return ref.valueType().sanitizeValue(Source.extractValue(response.getSource(), column));
                 });
 
         }

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/CollectorContext.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/CollectorContext.java
@@ -32,7 +32,7 @@ public class CollectorContext {
     private final Set<Reference> droppedColumns;
     private final UnaryOperator<String> lookupNameBySourceKey;
 
-    private SourceLookup sourceLookup;
+    private StoredRowLookup storedRowLookup;
 
     public CollectorContext(Set<Reference> droppedColumns, UnaryOperator<String> lookupNameBySourceKey) {
         this(-1, droppedColumns, lookupNameBySourceKey);
@@ -48,17 +48,17 @@ public class CollectorContext {
         return readerId;
     }
 
-    public SourceLookup sourceLookup() {
-        if (sourceLookup == null) {
-            sourceLookup = new SourceLookup(droppedColumns, lookupNameBySourceKey);
+    public StoredRowLookup storedRowLookup() {
+        if (storedRowLookup == null) {
+            storedRowLookup = new StoredRowLookup(droppedColumns, lookupNameBySourceKey);
         }
-        return sourceLookup;
+        return storedRowLookup;
     }
 
-    public SourceLookup sourceLookup(Reference ref) {
-        if (sourceLookup == null) {
-            sourceLookup = new SourceLookup(droppedColumns, lookupNameBySourceKey);
+    public StoredRowLookup storedRowLookup(Reference ref) {
+        if (storedRowLookup == null) {
+            storedRowLookup = new StoredRowLookup(droppedColumns, lookupNameBySourceKey);
         }
-        return sourceLookup.registerRef(ref);
+        return storedRowLookup.registerRef(ref);
     }
 }

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/CollectorContext.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/CollectorContext.java
@@ -21,27 +21,24 @@
 
 package io.crate.expression.reference.doc.lucene;
 
-import java.util.Set;
-import java.util.function.UnaryOperator;
+import java.util.function.Supplier;
 
 import io.crate.metadata.Reference;
 
 public class CollectorContext {
 
     private final int readerId;
-    private final Set<Reference> droppedColumns;
-    private final UnaryOperator<String> lookupNameBySourceKey;
+    private final Supplier<StoredRowLookup> storedRowLookupSupplier;
 
     private StoredRowLookup storedRowLookup;
 
-    public CollectorContext(Set<Reference> droppedColumns, UnaryOperator<String> lookupNameBySourceKey) {
-        this(-1, droppedColumns, lookupNameBySourceKey);
+    public CollectorContext(Supplier<StoredRowLookup> storedRowLookupSupplier) {
+        this(-1, storedRowLookupSupplier);
     }
 
-    public CollectorContext(int readerId, Set<Reference> droppedColumns, UnaryOperator<String> lookupNameBySourceKey) {
+    public CollectorContext(int readerId, Supplier<StoredRowLookup> storedRowLookupSupplier) {
         this.readerId = readerId;
-        this.droppedColumns = droppedColumns;
-        this.lookupNameBySourceKey = lookupNameBySourceKey;
+        this.storedRowLookupSupplier = storedRowLookupSupplier;
     }
 
     public int readerId() {
@@ -50,14 +47,14 @@ public class CollectorContext {
 
     public StoredRowLookup storedRowLookup() {
         if (storedRowLookup == null) {
-            storedRowLookup = new StoredRowLookup(droppedColumns, lookupNameBySourceKey);
+            storedRowLookup = storedRowLookupSupplier.get();
         }
         return storedRowLookup;
     }
 
     public StoredRowLookup storedRowLookup(Reference ref) {
         if (storedRowLookup == null) {
-            storedRowLookup = new StoredRowLookup(droppedColumns, lookupNameBySourceKey);
+            storedRowLookup = storedRowLookupSupplier.get();
         }
         return storedRowLookup.registerRef(ref);
     }

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/DocCollectorExpression.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/DocCollectorExpression.java
@@ -30,8 +30,8 @@ import io.crate.metadata.doc.DocSysColumns;
 
 public class DocCollectorExpression extends LuceneCollectorExpression<Map<String, Object>> {
 
-    private SourceLookup sourceLookup;
-    private Source source;
+    private StoredRowLookup storedRowLookup;
+    private StoredRow source;
     private ReaderContext context;
 
     public DocCollectorExpression() {
@@ -40,13 +40,13 @@ public class DocCollectorExpression extends LuceneCollectorExpression<Map<String
 
     @Override
     public void startCollect(CollectorContext context) {
-        sourceLookup = context.sourceLookup();
+        storedRowLookup = context.storedRowLookup();
     }
 
 
     @Override
     public void setNextDocId(int doc) {
-        this.source = sourceLookup.getSource(context, doc);
+        this.source = storedRowLookup.getStoredRow(context, doc);
     }
 
     @Override
@@ -56,7 +56,7 @@ public class DocCollectorExpression extends LuceneCollectorExpression<Map<String
 
     @Override
     public Map<String, Object> value() {
-        return source.sourceAsMap();
+        return source.asMap();
     }
 
     public static LuceneCollectorExpression<?> create(final Reference reference) {
@@ -71,8 +71,8 @@ public class DocCollectorExpression extends LuceneCollectorExpression<Map<String
     static final class ChildDocCollectorExpression extends LuceneCollectorExpression<Object> {
 
         private final Reference ref;
-        private SourceLookup sourceLookup;
-        private Source source;
+        private StoredRowLookup storedRowLookup;
+        private StoredRow source;
         private ReaderContext context;
 
         ChildDocCollectorExpression(Reference ref) {
@@ -81,7 +81,7 @@ public class DocCollectorExpression extends LuceneCollectorExpression<Map<String
 
         @Override
         public void setNextDocId(int doc) {
-            this.source = sourceLookup.getSource(context, doc);
+            this.source = storedRowLookup.getStoredRow(context, doc);
         }
 
         @Override
@@ -91,7 +91,7 @@ public class DocCollectorExpression extends LuceneCollectorExpression<Map<String
 
         @Override
         public void startCollect(CollectorContext context) {
-            sourceLookup = context.sourceLookup(ref);
+            storedRowLookup = context.storedRowLookup(ref);
         }
 
         @Override

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/DocCollectorExpression.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/DocCollectorExpression.java
@@ -31,6 +31,7 @@ import io.crate.metadata.doc.DocSysColumns;
 public class DocCollectorExpression extends LuceneCollectorExpression<Map<String, Object>> {
 
     private SourceLookup sourceLookup;
+    private Source source;
     private ReaderContext context;
 
     public DocCollectorExpression() {
@@ -45,7 +46,7 @@ public class DocCollectorExpression extends LuceneCollectorExpression<Map<String
 
     @Override
     public void setNextDocId(int doc) {
-        sourceLookup.setSegmentAndDocument(context, doc);
+        this.source = sourceLookup.getSource(context, doc);
     }
 
     @Override
@@ -55,7 +56,7 @@ public class DocCollectorExpression extends LuceneCollectorExpression<Map<String
 
     @Override
     public Map<String, Object> value() {
-        return sourceLookup.sourceAsMap();
+        return source.sourceAsMap();
     }
 
     public static LuceneCollectorExpression<?> create(final Reference reference) {
@@ -71,6 +72,7 @@ public class DocCollectorExpression extends LuceneCollectorExpression<Map<String
 
         private final Reference ref;
         private SourceLookup sourceLookup;
+        private Source source;
         private ReaderContext context;
 
         ChildDocCollectorExpression(Reference ref) {
@@ -79,7 +81,7 @@ public class DocCollectorExpression extends LuceneCollectorExpression<Map<String
 
         @Override
         public void setNextDocId(int doc) {
-            sourceLookup.setSegmentAndDocument(context, doc);
+            this.source = sourceLookup.getSource(context, doc);
         }
 
         @Override
@@ -95,7 +97,7 @@ public class DocCollectorExpression extends LuceneCollectorExpression<Map<String
         @Override
         public Object value() {
             // correct type detection is ensured by the source parser
-            return sourceLookup.get(ref.column().path());
+            return source.get(ref.column().path());
         }
     }
 }

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/LuceneReferenceResolver.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/LuceneReferenceResolver.java
@@ -21,8 +21,6 @@
 
 package io.crate.expression.reference.doc.lucene;
 
-import static io.crate.metadata.DocReferences.toSourceLookup;
-
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -37,6 +35,7 @@ import io.crate.expression.reference.ReferenceResolver;
 import io.crate.expression.symbol.DynamicReference;
 import io.crate.expression.symbol.VoidReference;
 import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.DocReferences;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.Reference;
 import io.crate.metadata.doc.DocSysColumns;
@@ -154,7 +153,7 @@ public class LuceneReferenceResolver implements ReferenceResolver<LuceneCollecto
         }
         assert ref instanceof DynamicReference == false || ref.columnPolicy() == ColumnPolicy.IGNORED;
         if (ref.hasDocValues() == false) {
-            return DocCollectorExpression.create(toSourceLookup(ref));
+            return DocCollectorExpression.create(DocReferences.toDocLookup(ref));
         }
         return switch (ref.valueType().id()) {
             case BitStringType.ID -> new BitStringColumnReference(fqn, ((BitStringType) ref.valueType()).length());
@@ -168,7 +167,7 @@ public class LuceneReferenceResolver implements ReferenceResolver<LuceneCollecto
             case LongType.ID, TimestampType.ID_WITH_TZ, TimestampType.ID_WITHOUT_TZ -> new LongColumnReference(fqn);
             case IntegerType.ID -> new IntegerColumnReference(fqn);
             case GeoPointType.ID -> new GeoPointColumnReference(fqn);
-            case ArrayType.ID -> DocCollectorExpression.create(toSourceLookup(ref));
+            case ArrayType.ID -> DocCollectorExpression.create(DocReferences.toDocLookup(ref));
             case FloatVectorType.ID -> new FloatVectorColumnReference(fqn);
             default -> throw new UnhandledServerException("Unsupported type: " + ref.valueType().getName());
         };

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/RawCollectorExpression.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/RawCollectorExpression.java
@@ -27,18 +27,18 @@ import io.crate.execution.engine.fetch.ReaderContext;
 
 public class RawCollectorExpression extends LuceneCollectorExpression<String> {
 
-    private SourceLookup sourceLookup;
-    private Source source;
+    private StoredRowLookup storedRowLookup;
+    private StoredRow storedRow;
     private ReaderContext context;
 
     @Override
     public void startCollect(CollectorContext context) {
-        this.sourceLookup = context.sourceLookup();
+        this.storedRowLookup = context.storedRowLookup();
     }
 
     @Override
     public void setNextDocId(int doc) {
-        this.source = sourceLookup.getSource(context, doc);
+        this.storedRow = storedRowLookup.getStoredRow(context, doc);
     }
 
     @Override
@@ -48,6 +48,6 @@ public class RawCollectorExpression extends LuceneCollectorExpression<String> {
 
     @Override
     public String value() {
-        return source.rawSource();
+        return storedRow.asString();
     }
 }

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/RawCollectorExpression.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/RawCollectorExpression.java
@@ -21,14 +21,14 @@
 
 package io.crate.expression.reference.doc.lucene;
 
-import io.crate.execution.engine.fetch.ReaderContext;
-import org.elasticsearch.common.compress.CompressorFactory;
-
 import java.io.IOException;
+
+import io.crate.execution.engine.fetch.ReaderContext;
 
 public class RawCollectorExpression extends LuceneCollectorExpression<String> {
 
     private SourceLookup sourceLookup;
+    private Source source;
     private ReaderContext context;
 
     @Override
@@ -38,7 +38,7 @@ public class RawCollectorExpression extends LuceneCollectorExpression<String> {
 
     @Override
     public void setNextDocId(int doc) {
-        sourceLookup.setSegmentAndDocument(context, doc);
+        this.source = sourceLookup.getSource(context, doc);
     }
 
     @Override
@@ -48,10 +48,6 @@ public class RawCollectorExpression extends LuceneCollectorExpression<String> {
 
     @Override
     public String value() {
-        try {
-            return CompressorFactory.uncompressIfNeeded(sourceLookup.rawSource()).utf8ToString();
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to uncompress source", e);
-        }
+        return source.rawSource();
     }
 }

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/Source.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/Source.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.reference.doc.lucene;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.RandomAccess;
+
+import io.crate.metadata.ColumnIdent;
+
+public interface Source {
+
+    Map<String, Object> sourceAsMap();
+
+    String rawSource();
+
+    default Object get(List<String> path) {
+        return extractValue(sourceAsMap(), path, 0);
+    }
+
+    static Object extractValue(final Map<?, ?> map, ColumnIdent columnIdent) {
+        List<String> fullPath = new ArrayList<>();
+        fullPath.add(columnIdent.name());
+        fullPath.addAll(columnIdent.path());
+        return extractValue(map, fullPath, 0);
+    }
+
+    static Object extractValue(final Map<?, ?> map, List<String> path, int pathStartIndex) {
+        assert path instanceof RandomAccess : "path should support RandomAccess for fast index optimized loop";
+        Map<?, ?> m = map;
+        Object tmp = null;
+        for (int i = pathStartIndex; i < path.size(); i++) {
+            tmp = m.get(path.get(i));
+            if (tmp instanceof Map) {
+                m = (Map<?, ?>) tmp;
+            } else if (tmp instanceof List<?> list) {
+                if (i + 1 == path.size()) {
+                    return list;
+                }
+                ArrayList<Object> newList = new ArrayList<>(list.size());
+                for (Object o : list) {
+                    if (o instanceof Map) {
+                        newList.add(extractValue((Map<?, ?>) o, path, i + 1));
+                    } else {
+                        newList.add(o);
+                    }
+                }
+                return newList;
+            } else {
+                if (i + 1 != path.size()) {
+                    return null;
+                }
+                break;
+            }
+        }
+        return tmp;
+    }
+}

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/SourceParser.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/SourceParser.java
@@ -96,7 +96,7 @@ public final class SourceParser {
         if (!Symbols.hasColumn(symbols, DocSysColumns.DOC)) {
             Consumer<Reference> register = ref -> {
                 if (ref.column().isSystemColumn() == false && ref.granularity() == RowGranularity.DOC) {
-                    register(DocReferences.toSourceLookup(ref).column(), ref.valueType());
+                    register(DocReferences.toDocLookup(ref).column(), ref.valueType());
                 }
             };
             for (Symbol symbol : symbols) {

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/StoredRow.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/StoredRow.java
@@ -21,10 +21,15 @@
 
 package io.crate.expression.reference.doc.lucene;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.RandomAccess;
+
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
 
 import io.crate.metadata.ColumnIdent;
 
@@ -36,6 +41,24 @@ public interface StoredRow {
 
     default Object get(List<String> path) {
         return extractValue(asMap(), path, 0);
+    }
+
+    static StoredRow wrap(Map<String, Object> map) {
+        return new StoredRow() {
+            @Override
+            public Map<String, Object> asMap() {
+                return map;
+            }
+
+            @Override
+            public String asString() {
+                try {
+                    return Strings.toString(JsonXContent.builder().map(map));
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            }
+        };
     }
 
     static Object extractValue(final Map<?, ?> map, ColumnIdent columnIdent) {

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/StoredRow.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/StoredRow.java
@@ -28,14 +28,14 @@ import java.util.RandomAccess;
 
 import io.crate.metadata.ColumnIdent;
 
-public interface Source {
+public interface StoredRow {
 
-    Map<String, Object> sourceAsMap();
+    Map<String, Object> asMap();
 
-    String rawSource();
+    String asString();
 
     default Object get(List<String> path) {
-        return extractValue(sourceAsMap(), path, 0);
+        return extractValue(asMap(), path, 0);
     }
 
     static Object extractValue(final Map<?, ?> map, ColumnIdent columnIdent) {

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/StoredRowLookup.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/StoredRowLookup.java
@@ -24,6 +24,7 @@ package io.crate.expression.reference.doc.lucene;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.UnaryOperator;
@@ -31,7 +32,9 @@ import java.util.function.UnaryOperator;
 import org.elasticsearch.common.compress.CompressorFactory;
 
 import io.crate.execution.engine.fetch.ReaderContext;
+import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.Reference;
+import io.crate.metadata.doc.DocTableInfo;
 
 public final class StoredRowLookup {
 
@@ -64,7 +67,11 @@ public final class StoredRowLookup {
         }
     };
 
-    StoredRowLookup(Set<Reference> droppedColumns, UnaryOperator<String> lookupNameBySourceKey) {
+    public static StoredRowLookup create(DocTableInfo table) {
+        return new StoredRowLookup(table.droppedColumns(), table.lookupNameBySourceKey());
+    }
+
+    private StoredRowLookup(Set<Reference> droppedColumns, UnaryOperator<String> lookupNameBySourceKey) {
         sourceParser = new SourceParser(droppedColumns, lookupNameBySourceKey);
     }
 
@@ -98,5 +105,9 @@ public final class StoredRowLookup {
     public StoredRowLookup registerRef(Reference ref) {
         sourceParser.register(ref.column(), ref.valueType());
         return this;
+    }
+
+    public void register(List<Symbol> symbols) {
+        sourceParser.register(symbols);
     }
 }

--- a/server/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
+++ b/server/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
@@ -51,6 +51,7 @@ import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.expression.reference.doc.lucene.CollectorContext;
 import io.crate.expression.reference.doc.lucene.LuceneCollectorExpression;
 import io.crate.expression.reference.doc.lucene.LuceneReferenceResolver;
+import io.crate.expression.reference.doc.lucene.StoredRowLookup;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
@@ -370,7 +371,7 @@ public class LuceneQueryBuilder {
         @SuppressWarnings("unchecked")
         final Input<Boolean> condition = (Input<Boolean>) ctx.add(function);
         final Collection<? extends LuceneCollectorExpression<?>> expressions = ctx.expressions();
-        final CollectorContext collectorContext = new CollectorContext(context.table.droppedColumns(), context.table.lookupNameBySourceKey());
+        final CollectorContext collectorContext = new CollectorContext(() -> StoredRowLookup.create(context.table));
         for (LuceneCollectorExpression<?> expression : expressions) {
             expression.startCollect(collectorContext);
         }

--- a/server/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
+++ b/server/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
@@ -363,7 +363,7 @@ public class LuceneQueryBuilder {
         // - no docValues are available for the related column, currently only on objects defined as `ignored`
         // - docValues value differs from source, currently happening on GeoPoint types as lucene's internal format
         //   results in precision changes (e.g. longitude 11.0 will be 10.999999966)
-        function = (Function) DocReferences.toSourceLookup(function,
+        function = (Function) DocReferences.toDocLookup(function,
             r -> r.columnPolicy() == ColumnPolicy.IGNORED
                  || r.valueType() == DataTypes.GEO_POINT);
 

--- a/server/src/main/java/io/crate/metadata/DocReferences.java
+++ b/server/src/main/java/io/crate/metadata/DocReferences.java
@@ -60,8 +60,8 @@ public final class DocReferences {
      *     x -> _doc['x']
      * </pre>
      */
-    public static Symbol toSourceLookup(Symbol tree) {
-        return RefReplacer.replaceRefs(tree, DocReferences::toSourceLookup);
+    public static Symbol toDocLookup(Symbol tree) {
+        return RefReplacer.replaceRefs(tree, DocReferences::toDocLookup);
     }
 
     /**
@@ -71,23 +71,23 @@ public final class DocReferences {
      *     x -> _doc['x']
      * </pre>
      */
-    public static Symbol toSourceLookup(Symbol tree, Predicate<Reference> condition) {
-        return RefReplacer.replaceRefs(tree, r -> toSourceLookup(r, condition));
+    public static Symbol toDocLookup(Symbol tree, Predicate<Reference> condition) {
+        return RefReplacer.replaceRefs(tree, r -> toDocLookup(r, condition));
     }
 
     /**
-     * Rewrite the reference to do a source lookup if possible.
-     * @see #toSourceLookup(Symbol)
+     * Rewrite the reference to do a _doc lookup if possible.
+     * @see #toDocLookup(Symbol)
      *
      * <pre>
      *     x -> _doc['x']
      * </pre>
      */
-    public static Reference toSourceLookup(Reference reference) {
-        return toSourceLookup(reference, r -> true);
+    public static Reference toDocLookup(Reference reference) {
+        return toDocLookup(reference, r -> true);
     }
 
-    private static Reference toSourceLookup(Reference reference, Predicate<Reference> condition) {
+    private static Reference toDocLookup(Reference reference, Predicate<Reference> condition) {
         ReferenceIdent ident = reference.ident();
         if (ident.columnIdent().isSystemColumn()) {
             return reference;

--- a/server/src/main/java/io/crate/planner/operators/Collect.java
+++ b/server/src/main/java/io/crate/planner/operators/Collect.java
@@ -146,7 +146,7 @@ public class Collect implements LogicalPlan {
         PositionalOrderBy positionalOrderBy = getPositionalOrderBy(order, outputs);
         if (positionalOrderBy != null) {
             if (hints.contains(PlanHint.PREFER_SOURCE_LOOKUP)) {
-                order = order.map(DocReferences::toSourceLookup);
+                order = order.map(DocReferences::toDocLookup);
             }
             collectPhase.orderBy(
                 order.map(binder)
@@ -293,7 +293,7 @@ public class Collect implements LogicalPlan {
                 sessionSettings),
             tableInfo.rowGranularity(),
             planHints.contains(PlanHint.PREFER_SOURCE_LOOKUP) && tableInfo instanceof DocTableInfo
-                ? Lists.map(boundOutputs, DocReferences::toSourceLookup)
+                ? Lists.map(boundOutputs, DocReferences::toDocLookup)
                 : boundOutputs,
             Collections.emptyList(),
             Optimizer.optimizeCasts(mutableBoundWhere.queryOrFallback(), plannerContext),
@@ -369,7 +369,7 @@ public class Collect implements LogicalPlan {
                 replacedOutputs.put(output, output);
             } else {
                 Symbol outputWithFetchStub = RefReplacer.replaceRefs(output, ref -> {
-                    Reference sourceLookup = DocReferences.toSourceLookup(ref);
+                    Reference sourceLookup = DocReferences.toDocLookup(ref);
                     refsToFetch.add(sourceLookup);
                     return new FetchStub(fetchMarker, sourceLookup);
                 });

--- a/server/src/main/java/io/crate/planner/statement/CopyToPlan.java
+++ b/server/src/main/java/io/crate/planner/statement/CopyToPlan.java
@@ -227,7 +227,7 @@ public final class CopyToPlan implements Plan {
             for (Symbol symbol : copyTo.columns()) {
                 assert symbol instanceof Reference : "Only references are expected here";
                 symbol.visit(Reference.class, r -> outputNames.add(r.column().sqlFqn()));
-                outputs.add(DocReferences.toSourceLookup(symbol));
+                outputs.add(DocReferences.toDocLookup(symbol));
             }
             columnsDefined = true;
         } else {

--- a/server/src/main/java/io/crate/statistics/ReservoirSampler.java
+++ b/server/src/main/java/io/crate/statistics/ReservoirSampler.java
@@ -75,6 +75,7 @@ import io.crate.execution.engine.fetch.ReaderContext;
 import io.crate.expression.reference.doc.lucene.CollectorContext;
 import io.crate.expression.reference.doc.lucene.LuceneCollectorExpression;
 import io.crate.expression.reference.doc.lucene.LuceneReferenceResolver;
+import io.crate.expression.reference.doc.lucene.StoredRowLookup;
 import io.crate.metadata.DocReferences;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
@@ -251,7 +252,7 @@ public final class ReservoirSampler {
             x -> referenceResolver.getImplementation(DocReferences.toSourceLookup(x))
         );
 
-        CollectorContext collectorContext = new CollectorContext(docTable.droppedColumns(), docTable.lookupNameBySourceKey());
+        CollectorContext collectorContext = new CollectorContext(() -> StoredRowLookup.create(docTable));
         for (LuceneCollectorExpression<?> expression : expressions) {
             expression.startCollect(collectorContext);
         }

--- a/server/src/main/java/io/crate/statistics/ReservoirSampler.java
+++ b/server/src/main/java/io/crate/statistics/ReservoirSampler.java
@@ -249,7 +249,7 @@ public final class ReservoirSampler {
         );
         List<? extends LuceneCollectorExpression<?>> expressions = Lists.map(
             columns,
-            x -> referenceResolver.getImplementation(DocReferences.toSourceLookup(x))
+            x -> referenceResolver.getImplementation(DocReferences.toDocLookup(x))
         );
 
         CollectorContext collectorContext = new CollectorContext(() -> StoredRowLookup.create(docTable));

--- a/server/src/test/java/io/crate/execution/dml/upsert/UpdateToInsertTest.java
+++ b/server/src/test/java/io/crate/execution/dml/upsert/UpdateToInsertTest.java
@@ -23,23 +23,19 @@ package io.crate.execution.dml.upsert;
 
 
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Supplier;
 
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.UUIDs;
-import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.junit.Test;
 
 import io.crate.analyze.Id;
 import io.crate.execution.dml.IndexItem;
 import io.crate.expression.reference.Doc;
+import io.crate.expression.reference.doc.lucene.StoredRow;
 import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
@@ -53,14 +49,7 @@ import io.crate.testing.SQLExecutor;
 public class UpdateToInsertTest extends CrateDummyClusterServiceUnitTest {
 
     private static Doc doc(String id, String index, Map<String, Object> source) {
-        Supplier<String> rawSource = () -> {
-            try {
-                return Strings.toString(JsonXContent.builder().map(source));
-            } catch (IOException e1) {
-                throw new RuntimeException(e1);
-            }
-        };
-        return new Doc(1, index, id, 1, 1, 1, source, rawSource);
+        return new Doc(1, index, id, 1, 1, 1, StoredRow.wrap(source));
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIteratorTest.java
@@ -32,12 +32,10 @@ import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
-import java.util.function.UnaryOperator;
 
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.NumericDocValuesField;
@@ -165,7 +163,7 @@ public class DocValuesGroupByOptimizedIteratorTest extends CrateDummyClusterServ
             null,
             null,
             new MatchAllDocsQuery(),
-            new CollectorContext(Set.of(), UnaryOperator.identity())
+            new CollectorContext(() -> null)
         );
 
         var rowConsumer = new TestingRowConsumer();
@@ -243,7 +241,7 @@ public class DocValuesGroupByOptimizedIteratorTest extends CrateDummyClusterServ
             null,
             null,
             new MatchAllDocsQuery(),
-            new CollectorContext(Set.of(), UnaryOperator.identity())
+            new CollectorContext(() -> null)
         );
 
         var rowConsumer = new TestingRowConsumer();
@@ -373,7 +371,7 @@ public class DocValuesGroupByOptimizedIteratorTest extends CrateDummyClusterServ
             (expressions) -> expressions.get(0).value(),
             (key, cells) -> cells[0] = key,
             new MatchAllDocsQuery(),
-            new CollectorContext(Set.of(), UnaryOperator.identity())
+            new CollectorContext(() -> null)
         );
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/collect/GroupByOptimizedIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/GroupByOptimizedIteratorTest.java
@@ -33,12 +33,10 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
-import java.util.function.UnaryOperator;
 
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.document.Document;
@@ -147,7 +145,7 @@ public class GroupByOptimizedIteratorTest extends CrateDummyClusterServiceUnitTe
             Version.CURRENT,
             new InputRow(Collections.singletonList(inExpr)),
             new MatchAllDocsQuery(),
-            new CollectorContext(Set.of(), UnaryOperator.identity()),
+            new CollectorContext(() -> null),
             AggregateMode.ITER_FINAL
         );
     }

--- a/server/src/test/java/io/crate/execution/engine/collect/collectors/LuceneBatchIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/collectors/LuceneBatchIteratorTest.java
@@ -24,8 +24,6 @@ package io.crate.execution.engine.collect.collectors;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
-import java.util.function.UnaryOperator;
 
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.document.Document;
@@ -76,7 +74,7 @@ public class LuceneBatchIteratorTest {
                 new MatchAllDocsQuery(),
                 null,
                 false,
-                new CollectorContext(Set.of(), UnaryOperator.identity()),
+                new CollectorContext(() -> null),
                 columnRefs,
                 columnRefs
             ), ResultOrder.EXACT

--- a/server/src/test/java/io/crate/execution/engine/collect/collectors/LuceneOrderedDocCollectorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/collectors/LuceneOrderedDocCollectorTest.java
@@ -28,8 +28,6 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
-import java.util.function.UnaryOperator;
 import java.util.stream.StreamSupport;
 
 import org.apache.lucene.analysis.core.KeywordAnalyzer;
@@ -380,7 +378,7 @@ public class LuceneOrderedDocCollectorTest extends RandomizedTest {
             doDocScores,
             2,
             RamAccounting.NO_ACCOUNTING,
-            new CollectorContext(Set.of(), UnaryOperator.identity()),
+            new CollectorContext(() -> null),
             f -> null,
             new Sort(SortField.FIELD_SCORE),
             columnReferences,

--- a/server/src/test/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorFactoryTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorFactoryTest.java
@@ -31,11 +31,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 
@@ -248,7 +246,7 @@ public class OrderedLuceneBatchIteratorFactoryTest extends ESTestCase {
     }
 
     private LuceneOrderedDocCollector createOrderedCollector(IndexSearcher searcher, int shardId) {
-        CollectorContext collectorContext = new CollectorContext(Set.of(), UnaryOperator.identity());
+        CollectorContext collectorContext = new CollectorContext(() -> null);
         List<LuceneCollectorExpression<?>> expressions = Collections.singletonList(
             new OrderByCollectorExpression(reference, orderBy, o -> o));
         return new LuceneOrderedDocCollector(

--- a/server/src/test/java/io/crate/executor/transport/task/elasticsearch/DocRefResolverTest.java
+++ b/server/src/test/java/io/crate/executor/transport/task/elasticsearch/DocRefResolverTest.java
@@ -27,24 +27,33 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
-import org.elasticsearch.common.bytes.BytesArray;
-import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
 
 import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.expression.reference.Doc;
 import io.crate.expression.reference.DocRefResolver;
+import io.crate.expression.reference.doc.lucene.StoredRow;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.doc.DocSysColumns;
-import io.crate.server.xcontent.XContentHelper;
 
 public class DocRefResolverTest extends ESTestCase {
 
-    private static final BytesReference SOURCE = new BytesArray("{\"x\": 1}".getBytes());
+    private static final StoredRow SOURCE = new StoredRow() {
+        @Override
+        public Map<String, Object> asMap() {
+            return Map.of("x", 1);
+        }
+
+        @Override
+        public String asString() {
+            return "{\"x\":1}";
+        }
+    };
+
     private static final DocRefResolver REF_RESOLVER =
         new DocRefResolver(Collections.emptyList());
     private static final Doc GET_RESULT = new Doc(2,
@@ -53,8 +62,7 @@ public class DocRefResolverTest extends ESTestCase {
                                                   1L,
                                                   1L,
                                                   1L,
-                                                  XContentHelper.convertToMap(SOURCE, false, XContentType.JSON).map(),
-                                                  SOURCE::utf8ToString);
+                                                  SOURCE);
 
     @Test
     public void testSystemColumnsCollectExpressions() throws Exception {
@@ -77,8 +85,8 @@ public class DocRefResolverTest extends ESTestCase {
 
         assertThat(collectExpressions.get(0).value()).isEqualTo("abc");
         assertThat(collectExpressions.get(1).value()).isEqualTo(1L);
-        assertThat(collectExpressions.get(2).value()).isEqualTo(XContentHelper.convertToMap(SOURCE, false, XContentType.JSON).map());
-        assertThat(collectExpressions.get(3).value()).isEqualTo(SOURCE.utf8ToString());
+        assertThat(collectExpressions.get(2).value()).isEqualTo(SOURCE.asMap());
+        assertThat(collectExpressions.get(3).value()).isEqualTo(SOURCE.asString());
         assertThat(collectExpressions.get(4).value()).isEqualTo(2);
         assertThat(collectExpressions.get(5).value()).isEqualTo(1L);
         assertThat(collectExpressions.get(6).value()).isEqualTo(1L);

--- a/server/src/test/java/io/crate/expression/reference/doc/DocLevelExpressionsTest.java
+++ b/server/src/test/java/io/crate/expression/reference/doc/DocLevelExpressionsTest.java
@@ -21,8 +21,6 @@
 
 package io.crate.expression.reference.doc;
 
-import java.util.Set;
-import java.util.function.UnaryOperator;
 import java.util.stream.StreamSupport;
 
 import org.apache.lucene.index.DirectoryReader;
@@ -71,7 +69,7 @@ public abstract class DocLevelExpressionsTest extends CrateDummyClusterServiceUn
         insertValues(writer);
         DirectoryReader directoryReader = DirectoryReader.open(writer, true, true);
         readerContext = directoryReader.leaves().get(0);
-        ctx = new CollectorContext(Set.of(), UnaryOperator.identity());
+        ctx = new CollectorContext(() -> null);
     }
 
     @After

--- a/server/src/test/java/io/crate/expression/reference/doc/lucene/SourceLookupTest.java
+++ b/server/src/test/java/io/crate/expression/reference/doc/lucene/SourceLookupTest.java
@@ -37,7 +37,7 @@ public class SourceLookupTest {
     @Test
     public void testExtractValueFromNestedObject() {
         Map<String, Map<String, Integer>> map = singletonMap("x", singletonMap("y", 10));
-        Object o = SourceLookup.extractValue(map, Arrays.asList("x", "y"), 0);
+        Object o = Source.extractValue(map, Arrays.asList("x", "y"), 0);
         assertThat(o).isEqualTo(10);
     }
 
@@ -48,7 +48,7 @@ public class SourceLookupTest {
             singletonMap("y", singletonMap("z", 10)),
             singletonMap("y", singletonMap("z", 20))
         ));
-        Object o = SourceLookup.extractValue(m, Arrays.asList("x", "y", "z"), 0);
+        Object o = Source.extractValue(m, Arrays.asList("x", "y", "z"), 0);
         assertThat((Collection<Integer>) o).containsExactly(10, 20);
     }
 
@@ -56,13 +56,13 @@ public class SourceLookupTest {
     @Test
     public void testExtractValueFromNestedObjectWithListAsLeaf() {
         Map<String, List<Integer>> m = singletonMap("x", Arrays.asList(10, 20));
-        Object o = SourceLookup.extractValue(m, singletonList("x"), 0);
+        Object o = Source.extractValue(m, singletonList("x"), 0);
         assertThat((Collection<Integer>) o).containsExactly(10, 20);
     }
 
     @Test
     public void test_extractValue_from_object_with_unknown_subscript_returns_null() {
         Map<String, Map<String, Integer>> m = singletonMap("x", singletonMap("a", 1)); // such that x['a'] = 1
-        assertThat(SourceLookup.extractValue(m, Arrays.asList("x", "a", "a"), 0)).isNull(); // x['a']['a'] should return null
+        assertThat(Source.extractValue(m, Arrays.asList("x", "a", "a"), 0)).isNull(); // x['a']['a'] should return null
     }
 }

--- a/server/src/test/java/io/crate/expression/reference/doc/lucene/StoredRowLookupTest.java
+++ b/server/src/test/java/io/crate/expression/reference/doc/lucene/StoredRowLookupTest.java
@@ -32,12 +32,12 @@ import java.util.Map;
 
 import org.junit.Test;
 
-public class SourceLookupTest {
+public class StoredRowLookupTest {
 
     @Test
     public void testExtractValueFromNestedObject() {
         Map<String, Map<String, Integer>> map = singletonMap("x", singletonMap("y", 10));
-        Object o = Source.extractValue(map, Arrays.asList("x", "y"), 0);
+        Object o = StoredRow.extractValue(map, Arrays.asList("x", "y"), 0);
         assertThat(o).isEqualTo(10);
     }
 
@@ -48,7 +48,7 @@ public class SourceLookupTest {
             singletonMap("y", singletonMap("z", 10)),
             singletonMap("y", singletonMap("z", 20))
         ));
-        Object o = Source.extractValue(m, Arrays.asList("x", "y", "z"), 0);
+        Object o = StoredRow.extractValue(m, Arrays.asList("x", "y", "z"), 0);
         assertThat((Collection<Integer>) o).containsExactly(10, 20);
     }
 
@@ -56,13 +56,13 @@ public class SourceLookupTest {
     @Test
     public void testExtractValueFromNestedObjectWithListAsLeaf() {
         Map<String, List<Integer>> m = singletonMap("x", Arrays.asList(10, 20));
-        Object o = Source.extractValue(m, singletonList("x"), 0);
+        Object o = StoredRow.extractValue(m, singletonList("x"), 0);
         assertThat((Collection<Integer>) o).containsExactly(10, 20);
     }
 
     @Test
     public void test_extractValue_from_object_with_unknown_subscript_returns_null() {
         Map<String, Map<String, Integer>> m = singletonMap("x", singletonMap("a", 1)); // such that x['a'] = 1
-        assertThat(Source.extractValue(m, Arrays.asList("x", "a", "a"), 0)).isNull(); // x['a']['a'] should return null
+        assertThat(StoredRow.extractValue(m, Arrays.asList("x", "a", "a"), 0)).isNull(); // x['a']['a'] should return null
     }
 }

--- a/server/src/testFixtures/java/io/crate/testing/QueryTester.java
+++ b/server/src/testFixtures/java/io/crate/testing/QueryTester.java
@@ -52,6 +52,7 @@ import io.crate.execution.engine.collect.collectors.LuceneBatchIterator;
 import io.crate.expression.InputFactory;
 import io.crate.expression.reference.doc.lucene.CollectorContext;
 import io.crate.expression.reference.doc.lucene.LuceneCollectorExpression;
+import io.crate.expression.reference.doc.lucene.StoredRowLookup;
 import io.crate.expression.symbol.FunctionCopyVisitor;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.ParameterSymbol;
@@ -177,7 +178,7 @@ public final class QueryTester implements AutoCloseable {
                 query,
                 null,
                 false,
-                new CollectorContext(table.droppedColumns(), table.lookupNameBySourceKey()),
+                new CollectorContext(() -> StoredRowLookup.create(table)),
                 Collections.singletonList(input),
                 ctx.expressions()
             );

--- a/server/src/testFixtures/java/io/crate/types/DataTypeTestCase.java
+++ b/server/src/testFixtures/java/io/crate/types/DataTypeTestCase.java
@@ -27,7 +27,6 @@ import static io.crate.testing.Asserts.assertThat;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Set;
 import java.util.function.Supplier;
 
 import org.apache.lucene.index.DirectoryReader;
@@ -52,6 +51,7 @@ import io.crate.execution.engine.fetch.ReaderContext;
 import io.crate.expression.reference.doc.lucene.CollectorContext;
 import io.crate.expression.reference.doc.lucene.LuceneCollectorExpression;
 import io.crate.expression.reference.doc.lucene.LuceneReferenceResolver;
+import io.crate.expression.reference.doc.lucene.StoredRowLookup;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
 import io.crate.metadata.doc.DocTableInfo;
@@ -139,7 +139,7 @@ public abstract class DataTypeTestCase<T> extends CrateDummyClusterServiceUnitTe
             );
 
             Scorer scorer = weight.scorer(leafReader);
-            CollectorContext collectorContext = new CollectorContext(1, Set.of(), table.lookupNameBySourceKey());
+            CollectorContext collectorContext = new CollectorContext(1, () -> StoredRowLookup.create(table));
             ReaderContext readerContext = new ReaderContext(leafReader);
             DocIdSetIterator iterator = scorer.iterator();
             int nextDoc = iterator.nextDoc();


### PR DESCRIPTION
When moving to field-based storage, rather than storing _doc directly,
we will need to support multiple ways of loading and representing the
_doc map.  This will be much easier to handle if the loading and the 
representation classes are separated.

This PR also moves away from the 'source' name, instead using 
'StoredRow', as we won't actually be storing a source map any more.

Finally, the PKLookup and Doc classes are migrated to refer to a StoredRow
rather than directly to a source Map and string representation.  This means
that we can instantiate things lazily, and in future will allow us to extract
individual fields from a StoredRow without reifying the whole stored document.