### PR TITLE
Move wait_for_completion setting to CopyStatementSettings

### DIFF
--- a/server/src/main/java/io/crate/analyze/CopyStatementSettings.java
+++ b/server/src/main/java/io/crate/analyze/CopyStatementSettings.java
@@ -35,6 +35,11 @@ public final class CopyStatementSettings {
     private CopyStatementSettings() {
     }
 
+    public static final Setting<Boolean> WAIT_FOR_COMPLETION_SETTING = Setting.boolSetting(
+        "wait_for_completion",
+        true
+    );
+
     public static final Setting<String> COMPRESSION_SETTING = Setting.simpleString(
         "compression",
         Validators.stringValidator("compression", "gzip"),

--- a/server/src/main/java/io/crate/planner/statement/CopyFromPlan.java
+++ b/server/src/main/java/io/crate/planner/statement/CopyFromPlan.java
@@ -23,6 +23,7 @@ package io.crate.planner.statement;
 
 import static io.crate.analyze.CopyStatementSettings.COMPRESSION_SETTING;
 import static io.crate.analyze.CopyStatementSettings.INPUT_FORMAT_SETTING;
+import static io.crate.analyze.CopyStatementSettings.WAIT_FOR_COMPLETION_SETTING;
 import static io.crate.analyze.CopyStatementSettings.settingAsEnum;
 
 import java.util.ArrayList;
@@ -141,7 +142,8 @@ public final class CopyFromPlan implements Plan {
         jobLauncher.execute(
             consumer,
             plannerContext.transactionContext(),
-            boundedCopyFrom.settings().getAsBoolean("wait_for_completion", true));
+            WAIT_FOR_COMPLETION_SETTING.get(boundedCopyFrom.settings())
+        );
     }
 
     @VisibleForTesting
@@ -172,7 +174,7 @@ public final class CopyFromPlan implements Plan {
                 "Using (validation = ?) in COPY FROM is no longer supported. Validation is always enforced");
         }
         boolean returnSummary = copyFrom instanceof AnalyzedCopyFromReturnSummary;
-        boolean waitForCompletion = settings.getAsBoolean("wait_for_completion", true);
+        boolean waitForCompletion = WAIT_FOR_COMPLETION_SETTING.get(settings);
         if (!waitForCompletion && returnSummary) {
             throw new UnsupportedOperationException(
                 "Cannot use RETURN SUMMARY with wait_for_completion=false. Either set wait_for_completion=true, or remove RETURN SUMMARY");

--- a/server/src/main/java/io/crate/planner/statement/CopyToPlan.java
+++ b/server/src/main/java/io/crate/planner/statement/CopyToPlan.java
@@ -23,6 +23,7 @@ package io.crate.planner.statement;
 
 import static io.crate.analyze.CopyStatementSettings.COMPRESSION_SETTING;
 import static io.crate.analyze.CopyStatementSettings.OUTPUT_FORMAT_SETTING;
+import static io.crate.analyze.CopyStatementSettings.WAIT_FOR_COMPLETION_SETTING;
 import static io.crate.analyze.CopyStatementSettings.settingAsEnum;
 
 import java.util.ArrayList;
@@ -137,7 +138,8 @@ public final class CopyToPlan implements Plan {
         jobLauncher.execute(
             consumer,
             plannerContext.transactionContext(),
-            boundedCopyTo.withClauseOptions().getAsBoolean("wait_for_completion", true));
+            WAIT_FOR_COMPLETION_SETTING.get(boundedCopyTo.withClauseOptions())
+        );
     }
 
     @VisibleForTesting


### PR DESCRIPTION
Preparation for validation. We currently don't validate unknown settings, I wanted to group CopyStatementSettings to common and csv/s3 specific and found out that it doesn't have wait_for_completion