### PR TITLE
Move more COPY FROM related settings to the CopyStatementSettings; remove deprecated validation property; validate unknown settings, common for all schemes

### DIFF
--- a/docs/appendices/release-notes/5.9.0.rst
+++ b/docs/appendices/release-notes/5.9.0.rst
@@ -47,6 +47,9 @@ Breaking Changes
 
 - Removed deprecated ``validation`` parameter from ``COPY FROM``.
 
+- Added validation of unknown or irrelevant for the ``file`` scheme properties
+  for the ``COPY FROM`` and ``COPY TO`` statements.
+
 - Fixed an issue that caused ``WHERE`` clause containing ``NOT`` operator on
   an array type against a non-empty array to incorrectly filter empty arrays,
   e.g.::

--- a/docs/appendices/release-notes/5.9.0.rst
+++ b/docs/appendices/release-notes/5.9.0.rst
@@ -45,6 +45,8 @@ Version 5.9.0 - Unreleased
 Breaking Changes
 ================
 
+- Removed deprecated ``validation`` parameter from ``COPY FROM``.
+
 - Fixed an issue that caused ``WHERE`` clause containing ``NOT`` operator on
   an array type against a non-empty array to incorrectly filter empty arrays,
   e.g.::

--- a/server/src/main/java/io/crate/analyze/CopyStatementSettings.java
+++ b/server/src/main/java/io/crate/analyze/CopyStatementSettings.java
@@ -21,14 +21,17 @@
 
 package io.crate.analyze;
 
+import static io.crate.execution.dsl.projection.AbstractIndexWriterProjection.BULK_SIZE_SETTING;
 import static org.elasticsearch.common.settings.Setting.parseInt;
 
+import java.util.List;
 import java.util.Locale;
 
 import org.elasticsearch.common.settings.Setting;
 
 import com.fasterxml.jackson.dataformat.csv.CsvSchema;
 
+import io.crate.analyze.copy.NodeFilters;
 import io.crate.metadata.settings.Validators;
 import io.crate.types.DataTypes;
 
@@ -117,4 +120,32 @@ public final class CopyStatementSettings {
         }
         return Enum.valueOf(settingsEnum, settingValue.toUpperCase(Locale.ENGLISH));
     }
+
+    public static List<String> commonCopyToSettings = List.of(
+        COMPRESSION_SETTING.getKey(),
+        OUTPUT_FORMAT_SETTING.getKey(),
+        WAIT_FOR_COMPLETION_SETTING.getKey()
+    );
+
+    public static List<String> commonCopyFromSettings = List.of(
+        COMPRESSION_SETTING.getKey(),
+        INPUT_FORMAT_SETTING.getKey(),
+        WAIT_FOR_COMPLETION_SETTING.getKey(),
+        OVERWRITE_DUPLICATES_SETTING.getKey(),
+        FAIL_FAST_SETTING.getKey(),
+        SHARED_SETTING.getKey(),
+        NUM_READERS_SETTING.getKey(),
+        BULK_SIZE_SETTING.getKey(),
+        NodeFilters.NAME
+    );
+
+    // CSV specific settings.
+    // We keep them separate from common settings because
+    // we don't want '... FROM S3://... WITH (some_csv_setting)...' to pass "known setting" validation.
+    public static List<String> csvSettings = List.of(
+        EMPTY_STRING_AS_NULL.getKey(),
+        CSV_COLUMN_SEPARATOR.getKey(),
+        INPUT_HEADER_SETTINGS.getKey(),
+        CSV_COLUMN_SEPARATOR.getKey()
+    );
 }

--- a/server/src/main/java/io/crate/analyze/CopyStatementSettings.java
+++ b/server/src/main/java/io/crate/analyze/CopyStatementSettings.java
@@ -21,6 +21,8 @@
 
 package io.crate.analyze;
 
+import static org.elasticsearch.common.settings.Setting.parseInt;
+
 import java.util.Locale;
 
 import org.elasticsearch.common.settings.Setting;
@@ -38,6 +40,31 @@ public final class CopyStatementSettings {
     public static final Setting<Boolean> WAIT_FOR_COMPLETION_SETTING = Setting.boolSetting(
         "wait_for_completion",
         true
+    );
+
+    public static final Setting<Boolean> OVERWRITE_DUPLICATES_SETTING = Setting.boolSetting(
+        "overwrite_duplicates",
+        false
+    );
+
+    public static final Setting<Boolean> FAIL_FAST_SETTING = Setting.boolSetting(
+        "fail_fast",
+        false
+    );
+
+    // "false" is not an actual default.
+    // We use getOrNull and in case of NULL(not specified by a user) we take schema specific default.
+    public static final Setting<Boolean> SHARED_SETTING = Setting.boolSetting(
+        "shared",
+        false
+    );
+
+    public static final Setting<Integer> NUM_READERS_SETTING = new Setting<>(
+        "num_readers",
+        _ -> "1", // Dummy default to pass NULL/minValue check in parseInt, actually defaults to the number of nodes.
+        (s) -> parseInt(s, 1, "num_readers"),
+        DataTypes.INTEGER,
+        Setting.Property.Dynamic
     );
 
     public static final Setting<String> COMPRESSION_SETTING = Setting.simpleString(

--- a/server/src/main/java/io/crate/execution/dsl/projection/SourceIndexWriterProjection.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/SourceIndexWriterProjection.java
@@ -21,6 +21,9 @@
 
 package io.crate.execution.dsl.projection;
 
+import static io.crate.analyze.CopyStatementSettings.FAIL_FAST_SETTING;
+import static io.crate.analyze.CopyStatementSettings.OVERWRITE_DUPLICATES_SETTING;
+
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
@@ -43,10 +46,6 @@ import io.crate.metadata.RelationName;
  * IndexWriterProjector that gets its values from a source input
  */
 public class SourceIndexWriterProjection extends AbstractIndexWriterProjection {
-
-    private static final String OVERWRITE_DUPLICATES = "overwrite_duplicates";
-    private static final boolean OVERWRITE_DUPLICATES_DEFAULT = false;
-    private static final String FAIL_FAST = "fail_fast";
 
     private final boolean failFast;
     private final Boolean overwriteDuplicates;
@@ -78,8 +77,8 @@ public class SourceIndexWriterProjection extends AbstractIndexWriterProjection {
         this.clusteredBySymbol = clusteredBySymbol;
         this.rawSourceSymbol = rawSourcePtr;
         this.outputs = outputs;
-        overwriteDuplicates = settings.getAsBoolean(OVERWRITE_DUPLICATES, OVERWRITE_DUPLICATES_DEFAULT);
-        this.failFast = settings.getAsBoolean(FAIL_FAST, false);
+        this.overwriteDuplicates = OVERWRITE_DUPLICATES_SETTING.get(settings);
+        this.failFast = FAIL_FAST_SETTING.get(settings);
     }
 
     SourceIndexWriterProjection(StreamInput in) throws IOException {

--- a/server/src/main/java/io/crate/planner/statement/CopyFromPlan.java
+++ b/server/src/main/java/io/crate/planner/statement/CopyFromPlan.java
@@ -39,11 +39,8 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
-import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
@@ -96,8 +93,6 @@ import io.crate.types.DataTypes;
 
 public final class CopyFromPlan implements Plan {
 
-    private static final Logger LOGGER = LogManager.getLogger(CopyFromPlan.class);
-    static final DeprecationLogger DEPRECATION_LOGGER = new DeprecationLogger(LOGGER);
     private final AnalyzedCopyFrom copyFrom;
 
     public CopyFromPlan(AnalyzedCopyFrom copyFrom) {
@@ -171,9 +166,7 @@ public final class CopyFromPlan implements Plan {
         final var settings = Settings.builder().put(properties).build();
 
         if (properties.contains("validation")) {
-            DEPRECATION_LOGGER.deprecatedAndMaybeLog(
-                "copy_from.validation",
-                "Using (validation = ?) in COPY FROM is no longer supported. Validation is always enforced");
+            throw new IllegalArgumentException("Setting 'validation' is not supported");
         }
         boolean returnSummary = copyFrom instanceof AnalyzedCopyFromReturnSummary;
         boolean waitForCompletion = WAIT_FOR_COMPLETION_SETTING.get(settings);

--- a/server/src/test/java/io/crate/analyze/CopyAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CopyAnalyzerTest.java
@@ -27,7 +27,6 @@ import static io.crate.analyze.TableDefinitions.USER_TABLE_IDENT;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.isFunction;
 import static io.crate.testing.Asserts.isLiteral;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;

--- a/server/src/test/java/io/crate/integrationtests/DeleteIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/DeleteIntegrationTest.java
@@ -26,6 +26,7 @@ import static io.crate.testing.Asserts.assertThat;
 
 import java.util.List;
 
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.IntegTestCase;
 import org.junit.Test;
 
@@ -231,7 +232,7 @@ public class DeleteIntegrationTest extends IntegTestCase {
     @Test
     public void testDeleteExceedingInternalDefaultBulkSize() throws Exception {
         execute("create table t1 (x int) clustered into 1 shards with (number_of_replicas = 0)");
-        Object[][] bulkArgs = new Object[AbstractIndexWriterProjection.BULK_SIZE_DEFAULT + 10][];
+        Object[][] bulkArgs = new Object[AbstractIndexWriterProjection.BULK_SIZE_SETTING.getDefault(Settings.EMPTY) + 10][];
         for (int i = 0; i < bulkArgs.length; i++) {
             bulkArgs[i] = new Object[] { i };
         }

--- a/server/src/test/java/io/crate/planner/statement/CopyFromPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/statement/CopyFromPlannerTest.java
@@ -162,10 +162,10 @@ public class CopyFromPlannerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
-    public void test_logs_deprecation_on_validation_false() throws Exception {
-        CopyFromPlan.DEPRECATION_LOGGER.resetLRU();
-        plan("copy users from '/path' with (validation = false)");
-        assertWarnings("Using (validation = ?) in COPY FROM is no longer supported. Validation is always enforced");
+    public void test_validation_is_not_supported() throws Exception {
+        assertThatThrownBy(() -> plan("copy users from '/path' with (validation = false)"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Setting 'validation' is not supported");
     }
 
     @Test

--- a/server/src/test/java/io/crate/planner/statement/CopyFromPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/statement/CopyFromPlannerTest.java
@@ -23,7 +23,6 @@ package io.crate.planner.statement;
 
 import static io.crate.analyze.TableDefinitions.USER_TABLE_DEFINITION;
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
@@ -146,7 +145,7 @@ public class CopyFromPlannerTest extends CrateDummyClusterServiceUnitTest {
     public void testCopyFromPlanWithInvalidParameters() {
         assertThatThrownBy(() -> plan("copy users from '/path/to/file.ext' with (bulk_size=-28)"))
             .isExactlyInstanceOf(IllegalArgumentException.class)
-            .hasMessage("\"bulk_size\" must be greater than 0.");
+            .hasMessage("Failed to parse value [-28] for setting [bulk_size] must be >= 1");
     }
 
     @Test
@@ -167,5 +166,13 @@ public class CopyFromPlannerTest extends CrateDummyClusterServiceUnitTest {
         CopyFromPlan.DEPRECATION_LOGGER.resetLRU();
         plan("copy users from '/path' with (validation = false)");
         assertWarnings("Using (validation = ?) in COPY FROM is no longer supported. Validation is always enforced");
+    }
+
+    @Test
+    public void test_num_readers_minimal_value_must_be_greater_than_0() {
+        assertThatThrownBy(
+            () -> plan("copy users from '/path/to/file.extension' with (num_readers = 0)")
+        ).isExactlyInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Failed to parse value [0] for setting [num_readers] must be >= 1");
     }
 }


### PR DESCRIPTION
Follows https://github.com/crate/crate/pull/16475 (I checked only COPY TO and forgot to check COPY FROM)

Also, add missing validation for num_readers minimal value to match docs.

Setting node_filters has a dedicated Predicate.

Main objective is to have all common settings scattered around as constants in a single place (and also utilize minValue/default value logic from Settings where applicable).

Then we can validate "unknown `WITH` clause parameter" and take all known settings from a single source. 
Scheme specific settings (s3 -> protocol, azure -> some more...) will be additionally validated in plugins.

