### PR TITLE
Utilize array length index for `= []`

### DIFF
--- a/server/src/main/java/io/crate/execution/dml/ArrayIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/ArrayIndexer.java
@@ -29,6 +29,8 @@ import java.util.function.Function;
 
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.IntField;
+import org.apache.lucene.document.IntPoint;
+import org.apache.lucene.search.Query;
 import org.elasticsearch.Version;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -41,7 +43,15 @@ import io.crate.types.DataType;
 
 public class ArrayIndexer<T> implements ValueIndexer<List<T>> {
 
-    public static String toArrayLengthFieldName(Reference arrayRef, Function<ColumnIdent, Reference> getRef) {
+    public static Query arrayLengthTermQuery(Reference arrayRef, int length, Function<ColumnIdent, Reference> getRef) {
+        return IntPoint.newExactQuery(toArrayLengthFieldName(arrayRef, getRef), length);
+    }
+
+    public static Query arrayLengthRangeQuery(Reference arrayRef, int includeLower, int includeUpper, Function<ColumnIdent, Reference> getRef) {
+        return IntPoint.newRangeQuery(toArrayLengthFieldName(arrayRef, getRef), includeLower, includeUpper);
+    }
+
+    static String toArrayLengthFieldName(Reference arrayRef, Function<ColumnIdent, Reference> getRef) {
         // If the arrayRef is a descendant of an object array its type can be a readType. i.e. the type of
         // obj_array['int_col'] is 'int' BUT its readType is 'array(int)'. If so, there is no '_array_length_' indexed
         // for obj_array['int_col']. Imagine indexing obj_array = [{int_col = 1}, {int_col = 2}], '_array_length_obj_array'

--- a/server/src/main/java/io/crate/expression/scalar/ArrayUpperFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayUpperFunction.java
@@ -21,7 +21,6 @@
 
 package io.crate.expression.scalar;
 
-import static io.crate.execution.dml.ArrayIndexer.toArrayLengthFieldName;
 import static io.crate.expression.scalar.array.ArrayArgumentValidators.ensureInnerTypeIsNotUndefined;
 import static io.crate.lucene.LuceneQueryBuilder.genericFunctionFilter;
 import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
@@ -37,6 +36,7 @@ import org.elasticsearch.Version;
 import org.jetbrains.annotations.Nullable;
 
 import io.crate.data.Input;
+import io.crate.execution.dml.ArrayIndexer;
 import io.crate.expression.operator.EqOperator;
 import io.crate.expression.operator.GtOperator;
 import io.crate.expression.operator.GteOperator;
@@ -60,7 +60,6 @@ import io.crate.metadata.functions.Signature;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
-import io.crate.types.IntEqQuery;
 import io.crate.types.ObjectType;
 import io.crate.types.TypeSignature;
 
@@ -68,6 +67,9 @@ public class ArrayUpperFunction extends Scalar<Integer, Object> {
 
     public static final String ARRAY_UPPER = "array_upper";
     public static final String ARRAY_LENGTH = "array_length";
+    // 'array_length([], 1)' = NULL, hence the lower bound must be 1
+    public static final int LOWER_BOUND = 1;
+    public static final int UPPER_BOUND = Integer.MAX_VALUE;
 
     public static void register(Functions.Builder module) {
         for (var name : List.of(ARRAY_UPPER, ARRAY_LENGTH)) {
@@ -307,29 +309,29 @@ public class ArrayUpperFunction extends Scalar<Integer, Object> {
                 if (cmpVal == 0) {
                     return new MatchNoDocsQuery("array_length([], 1) is NULL, so array_length([], 1) = 0 can't match");
                 }
-                return new IntEqQuery().termQuery(toArrayLengthFieldName(arrayRef, getRef), cmpVal, true, true);
+                return ArrayIndexer.arrayLengthTermQuery(arrayRef, cmpVal, getRef);
 
             case GtOperator.NAME:
-                return new IntEqQuery().rangeQuery(toArrayLengthFieldName(arrayRef, getRef), cmpVal, null, false, false, true, true);
+                return ArrayIndexer.arrayLengthRangeQuery(arrayRef, cmpVal + 1, UPPER_BOUND, getRef);
 
             case GteOperator.NAME:
                 if (cmpVal == 0) {
-                    return new IntEqQuery().rangeQuery(toArrayLengthFieldName(arrayRef, getRef), 0, null, false, false, true, true);
-                } else {
-                    return new IntEqQuery().rangeQuery(toArrayLengthFieldName(arrayRef, getRef), cmpVal, null, true, false, true, true);
+                    // 'array_length >= 0' is equivalent to 'array_length >= 1' since 'array_length([], 1)' is NULL
+                    return ArrayIndexer.arrayLengthRangeQuery(arrayRef, LOWER_BOUND, UPPER_BOUND, getRef);
                 }
+                return ArrayIndexer.arrayLengthRangeQuery(arrayRef, cmpVal, UPPER_BOUND, getRef);
 
             case LtOperator.NAME:
                 if (cmpVal == 0 || cmpVal == 1) {
                     return new MatchNoDocsQuery("array_length([], 1) is NULL, so array_length([], 1) < 0 or < 1 can't match");
                 }
-                return new IntEqQuery().rangeQuery(toArrayLengthFieldName(arrayRef, getRef), 0, cmpVal, false, false, true, true);
+                return ArrayIndexer.arrayLengthRangeQuery(arrayRef, LOWER_BOUND, cmpVal - 1, getRef);
 
             case LteOperator.NAME:
                 if (cmpVal == 0) {
                     return new MatchNoDocsQuery("array_length([], 1) is NULL, so array_length([], 1) <= 0 can't match");
                 }
-                return new IntEqQuery().rangeQuery(toArrayLengthFieldName(arrayRef, getRef), 0, cmpVal, false, true, true, true);
+                return ArrayIndexer.arrayLengthRangeQuery(arrayRef, LOWER_BOUND, cmpVal, getRef);
 
             default:
                 throw new IllegalArgumentException("Illegal operator: " + operator);

--- a/server/src/main/java/io/crate/expression/scalar/ArrayUpperFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayUpperFunction.java
@@ -54,7 +54,6 @@ import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
-import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.ArrayType;
@@ -177,9 +176,8 @@ public class ArrayUpperFunction extends Scalar<Integer, Object> {
         int cmpVal = cmpNumber.intValue();
         // If the array col is from a table created on or after 5.9, we can utilize '_array_length_' indexes,
         // see ArrayIndexer for details
-        if (context.nodeContext().schemas().getTableInfo((arrayRef).ident().tableIdent()) instanceof DocTableInfo tableInfo &&
-            tableInfo.versionCreated().onOrAfter(Version.V_5_9_0)) {
-            return toQueryUsingArrayLengthIndex(parentName, arrayRef, cmpVal, tableInfo::getReference);
+        if (context.tableInfo().versionCreated().onOrAfter(Version.V_5_9_0)) {
+            return toQueryUsingArrayLengthIndex(parentName, arrayRef, cmpVal, context.tableInfo()::getReference);
         }
 
         DataType<?> innerType = ((ArrayType<?>) arrayRef.valueType()).innerType();

--- a/server/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
+++ b/server/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
@@ -217,6 +217,10 @@ public class LuceneQueryBuilder {
             return table.getReadReference(column);
         }
 
+        public DocTableInfo tableInfo() {
+            return table;
+        }
+
         public TransactionContext transactionContext() {
             return txnCtx;
         }

--- a/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -60,6 +60,7 @@ import io.crate.metadata.RelationName;
 import io.crate.metadata.doc.DocSchemaInfo;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.role.Role;
+import io.crate.testing.IndexVersionCreated;
 import io.crate.testing.QueryTester;
 import io.crate.testing.SQLExecutor;
 import io.crate.testing.SqlExpressions;
@@ -651,10 +652,17 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
         );
     }
 
+    @IndexVersionCreated(value = 8_08_00_99) // V_5_8_0
+    @Test
+    public void test_arr_eq_empty_array_literal_is_optimized_before_V590() {
+        Query query = convert("y_array = []");
+        assertThat(query).hasToString("+NumTermsPerDoc: y_array +(y_array = [])");
+    }
+
     @Test
     public void test_arr_eq_empty_array_literal_is_optimized() {
         Query query = convert("y_array = []");
-        assertThat(query).hasToString("+NumTermsPerDoc: y_array +(y_array = [])");
+        assertThat(query).hasToString("_array_length_y_array:[0 TO 0]");
     }
 
     @Test

--- a/server/src/test/java/io/crate/lucene/NestedArrayLuceneQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/NestedArrayLuceneQueryBuilderTest.java
@@ -46,7 +46,7 @@ public class NestedArrayLuceneQueryBuilderTest extends LuceneQueryBuilderTest {
     @Test
     public void test_empty_nested_array_equals() {
         var query = convert("a = [[]]");
-        assertThat(query.toString()).isEqualTo("+NumTermsPerDoc: a +(a = [[]])");
+        assertThat(query.toString()).isEqualTo("+_array_length_a:[0 TO 0] +(a = [[]])");
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
For arrays from tables created on or after `5.9` can utilize `_array_length_` index. For `= []`, `_array_length_ = 0` should be enough, but for non empty arrays(i.e. `= [1]`), array length queries [did not improve the performance.](https://github.com/crate/crate/pull/16479#issuecomment-2310825868)

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
