### PR TITLE
Ensure that partition column values are always added to _doc

### DIFF
--- a/docs/appendices/release-notes/5.9.0.rst
+++ b/docs/appendices/release-notes/5.9.0.rst
@@ -32,6 +32,11 @@ Version 5.9.0 - Unreleased
     You can recreate tables using ``COPY TO`` and ``COPY FROM`` or by
     `inserting the data into a new table`_.
 
+    The output of ``COPY TO`` when writing to a file from shards on 5.9 nodes now
+    includes partition values.  We recommend waiting until the entire cluster is
+    upgraded before running ``COPY TO`` with file output to ensure that the output
+    across different shards is consistent.
+
 .. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
 .. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
 
@@ -73,6 +78,9 @@ Breaking Changes
 - Changed the implementation of the :ref:`scalar-array_cat` to return an empty
   array of type ``ARRAY(UNDEFINED)`` when both arguments are an empty array
   instead of raising an exception.
+
+- The output of ``COPY TO`` against a partitioned table now includes
+  partition columns.
 
 Deprecations
 ============

--- a/docs/sql/statements/copy-to.rst
+++ b/docs/sql/statements/copy-to.rst
@@ -142,16 +142,6 @@ partition to export.
     of partition columns specified by the
     :ref:`sql-create-table-partitioned-by` clause.
 
-.. CAUTION::
-
-    The exported data doesn't contain the partition columns or the
-    corresponding values because they are not part of the partitioned tables.
-
-    If ``COPY TO`` is used on a partitioned table without the ``PARTITION``
-    clause, the partition columns and values will be included in the rows of
-    the exported files. If a partition column is a generated column, it will
-    not be included even if the ``PARTITION`` clause is missing.
-
 
 .. _sql-copy-to-where:
 

--- a/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
@@ -438,7 +438,7 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
                         item.version(),
                         item.seqNo(),
                         item.primaryTerm(),
-                        StoredRowLookup.create(actualTable));
+                        StoredRowLookup.create(actualTable, indexShard.shardId().getIndexName()));
                     version = doc.getVersion();
                     IndexItem indexItem = updateToInsert.convert(doc, item.updateAssignments(), insertValues);
                     item.pkValues(indexItem.pkValues());

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/CmpByAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/CmpByAggregation.java
@@ -182,14 +182,14 @@ public final class CmpByAggregation extends AggregationFunction<CmpByAggregation
                         searchField.storageIdent(),
                         searchType,
                         resultExpression,
-                        new CollectorContext(() -> StoredRowLookup.create(table))
+                        new CollectorContext(() -> StoredRowLookup.create(table, referenceResolver.getIndexName()))
                     );
                 } else {
                     return new MaxByLong(
                         searchField.storageIdent(),
                         searchType,
                         resultExpression,
-                        new CollectorContext(() -> StoredRowLookup.create(table))
+                        new CollectorContext(() -> StoredRowLookup.create(table, referenceResolver.getIndexName()))
                     );
                 }
             default:

--- a/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
@@ -137,6 +137,7 @@ final class DocValuesGroupByOptimizedIterator {
 
         InputFactory.Context<? extends LuceneCollectorExpression<?>> docCtx
             = docInputFactory.getCtx(collectTask.txnCtx());
+        String indexName = indexShard.shardId().getIndexName();
         List<LuceneCollectorExpression<?>> keyExpressions = new ArrayList<>();
         for (var keyRef : columnKeyRefs) {
             keyExpressions.add((LuceneCollectorExpression<?>) docCtx.add(keyRef));
@@ -144,7 +145,7 @@ final class DocValuesGroupByOptimizedIterator {
         LuceneQueryBuilder.Context queryContext = luceneQueryBuilder.convert(
             collectPhase.where(),
             collectTask.txnCtx(),
-            indexShard.shardId().getIndexName(),
+            indexName,
             indexService.indexAnalyzers(),
             table,
             indexService.cache()
@@ -160,7 +161,7 @@ final class DocValuesGroupByOptimizedIterator {
                 collectTask.memoryManager(),
                 collectTask.minNodeVersion(),
                 queryContext.query(),
-                new CollectorContext(sharedShardContext.readerId(), () -> StoredRowLookup.create(table))
+                new CollectorContext(sharedShardContext.readerId(), () -> StoredRowLookup.create(table, indexName))
             );
         } else {
             return GroupByIterator.forManyKeys(
@@ -172,7 +173,7 @@ final class DocValuesGroupByOptimizedIterator {
                 collectTask.memoryManager(),
                 collectTask.minNodeVersion(),
                 queryContext.query(),
-                new CollectorContext(sharedShardContext.readerId(), () -> StoredRowLookup.create(table))
+                new CollectorContext(sharedShardContext.readerId(), () -> StoredRowLookup.create(table, indexName))
             );
         }
     }

--- a/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
@@ -162,13 +162,15 @@ final class GroupByOptimizedIterator {
 
         RamAccounting ramAccounting = collectTask.getRamAccounting();
 
-        CollectorContext collectorContext = new CollectorContext(sharedShardContext.readerId(), () -> StoredRowLookup.create(table));
+        String indexName = indexShard.shardId().getIndexName();
+        CollectorContext collectorContext
+            = new CollectorContext(sharedShardContext.readerId(), () -> StoredRowLookup.create(table, indexName));
         InputRow inputRow = new InputRow(docCtx.topLevelInputs());
 
         LuceneQueryBuilder.Context queryContext = luceneQueryBuilder.convert(
             collectPhase.where(),
             collectTask.txnCtx(),
-            indexShard.shardId().getIndexName(),
+            indexName,
             indexService.indexAnalyzers(),
             table,
             indexService.cache()

--- a/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
@@ -143,7 +143,7 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
             queryContext.query(),
             queryContext.minScore(),
             Symbols.hasColumn(collectPhase.toCollect(), DocSysColumns.SCORE),
-            new CollectorContext(sharedShardContext.readerId(), () -> StoredRowLookup.create(table)),
+            new CollectorContext(sharedShardContext.readerId(), () -> StoredRowLookup.create(table, indexShard.shardId().getIndexName())),
             docCtx.topLevelInputs(),
             docCtx.expressions()
         );
@@ -210,7 +210,10 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
             indexService.cache()
         );
         ctx = docInputFactory.extractImplementations(collectTask.txnCtx(), phase);
-        collectorContext = new CollectorContext(sharedShardContext.readerId(), () -> StoredRowLookup.create(table));
+        collectorContext = new CollectorContext(
+            sharedShardContext.readerId(),
+            () -> StoredRowLookup.create(table, indexShard.shardId().getIndexName())
+        );
         int batchSize = phase.shardQueueSize(localNodeId.get());
         if (LOGGER.isTraceEnabled()) {
             LOGGER.trace("[{}][{}] creating LuceneOrderedDocCollector. Expected number of rows to be collected: {}",

--- a/server/src/main/java/io/crate/execution/engine/export/FileWriterProjector.java
+++ b/server/src/main/java/io/crate/execution/engine/export/FileWriterProjector.java
@@ -21,6 +21,13 @@
 
 package io.crate.execution.engine.export;
 
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executor;
+
+import org.elasticsearch.common.settings.Settings;
+import org.jetbrains.annotations.Nullable;
+
 import io.crate.data.BatchIterator;
 import io.crate.data.CollectingBatchIterator;
 import io.crate.data.Input;
@@ -28,20 +35,12 @@ import io.crate.data.Projector;
 import io.crate.data.Row;
 import io.crate.execution.dsl.projection.WriterProjection;
 import io.crate.execution.engine.collect.CollectExpression;
-import io.crate.metadata.ColumnIdent;
-import org.elasticsearch.common.settings.Settings;
-
-import org.jetbrains.annotations.Nullable;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.Executor;
 
 public class FileWriterProjector implements Projector {
 
     private final String uri;
     private final Iterable<CollectExpression<Row, ?>> collectExpressions;
     private final List<Input<?>> inputs;
-    private final Map<ColumnIdent, Object> overwrites;
     @Nullable
     private final List<String> outputNames;
     private final WriterProjection.OutputFormat outputFormat;
@@ -63,7 +62,6 @@ public class FileWriterProjector implements Projector {
                                @Nullable WriterProjection.CompressionType compressionType,
                                @Nullable List<Input<?>> inputs,
                                Iterable<CollectExpression<Row, ?>> collectExpressions,
-                               Map<ColumnIdent, Object> overwrites,
                                @Nullable List<String> outputNames,
                                WriterProjection.OutputFormat outputFormat,
                                Map<String, FileOutputFactory> fileOutputFactoryMap,
@@ -71,7 +69,6 @@ public class FileWriterProjector implements Projector {
         this.collectExpressions = collectExpressions;
         this.executor = executor;
         this.inputs = inputs;
-        this.overwrites = overwrites;
         this.outputNames = outputNames;
         this.outputFormat = outputFormat;
         this.compressionType = compressionType;
@@ -90,7 +87,6 @@ public class FileWriterProjector implements Projector {
                 compressionType,
                 inputs,
                 collectExpressions,
-                overwrites,
                 outputNames,
                 outputFormat,
                 fileOutputFactoryMap,

--- a/server/src/main/java/io/crate/execution/engine/fetch/FetchCollector.java
+++ b/server/src/main/java/io/crate/execution/engine/fetch/FetchCollector.java
@@ -51,6 +51,7 @@ class FetchCollector {
     private final FetchTask fetchTask;
 
     FetchCollector(List<LuceneCollectorExpression<?>> collectorExpressions,
+                   String indexName,
                    Streamer<?>[] streamers,
                    FetchTask fetchTask,
                    RamAccounting ramAccounting,
@@ -62,7 +63,7 @@ class FetchCollector {
         this.ramAccounting = ramAccounting;
         this.readerId = readerId;
         var table = fetchTask.table(readerId);
-        CollectorContext collectorContext = new CollectorContext(readerId, () -> StoredRowLookup.create(table));
+        CollectorContext collectorContext = new CollectorContext(readerId, () -> StoredRowLookup.create(table, indexName));
         for (LuceneCollectorExpression<?> collectorExpression : this.collectorExpressions) {
             collectorExpression.startCollect(collectorContext);
         }

--- a/server/src/main/java/io/crate/execution/engine/fetch/NodeFetchOperation.java
+++ b/server/src/main/java/io/crate/execution/engine/fetch/NodeFetchOperation.java
@@ -78,8 +78,9 @@ public class NodeFetchOperation {
 
         FetchCollector createCollector(int readerId, RamAccounting ramAccounting) {
             IndexService indexService = fetchTask.indexService(readerId);
+            String indexName = indexService.index().getName();
             LuceneReferenceResolver resolver = new LuceneReferenceResolver(
-                indexService.index().getName(),
+                indexName,
                 fetchTask.table(readerId).partitionedByColumns()
             );
             ArrayList<LuceneCollectorExpression<?>> exprs = new ArrayList<>(refs.size());
@@ -88,6 +89,7 @@ public class NodeFetchOperation {
             }
             return new FetchCollector(
                 exprs,
+                indexName,
                 streamers,
                 fetchTask,
                 ramAccounting,

--- a/server/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
+++ b/server/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
@@ -398,37 +398,17 @@ public class ProjectionToProjectorVisitor
         }
         uri = sb.toString();
 
-        Map<ColumnIdent, Object> overwrites =
-            symbolMapToObject(projection.overwrites(), ctx, context.txnCtx);
-
         return new FileWriterProjector(
             threadPool.generic(),
             uri,
             projection.compressionType(),
             inputs,
             ctx.expressions(),
-            overwrites,
             projection.outputNames(),
             projection.outputFormat(),
             fileOutputFactoryMap,
             projection.withClauseOptions()
         );
-    }
-
-    private Map<ColumnIdent, Object> symbolMapToObject(
-            Map<ColumnIdent, Symbol> symbolMap,
-            InputFactory.Context<CollectExpression<Row, ?>> symbolContext,
-            TransactionContext txnCtx) {
-        Map<ColumnIdent, Object> objectMap = new HashMap<>(symbolMap.size());
-        for (Map.Entry<ColumnIdent, Symbol> entry : symbolMap.entrySet()) {
-            Symbol symbol = entry.getValue();
-            assert symbol != null : "symbol must not be null";
-            objectMap.put(
-                entry.getKey(),
-                symbolContext.add(normalizer.normalize(symbol, txnCtx)).value()
-            );
-        }
-        return objectMap;
     }
 
     @Override

--- a/server/src/main/java/io/crate/execution/jobs/PKLookupTask.java
+++ b/server/src/main/java/io/crate/execution/jobs/PKLookupTask.java
@@ -109,8 +109,9 @@ public final class PKLookupTask extends AbstractTask {
 
         var shardIt = idsByShard.keySet().iterator();
         if (shardIt.hasNext()) {
-            var relationName = RelationName.fromIndexName(shardIt.next().getIndexName());
-            this.storedRowLookup = StoredRowLookup.create(schemas.getTableInfo(relationName));
+            String indexName = shardIt.next().getIndexName();
+            var relationName = RelationName.fromIndexName(indexName);
+            this.storedRowLookup = StoredRowLookup.create(schemas.getTableInfo(relationName), indexName);
             this.storedRowLookup.register(toCollect);
         } else {
             this.storedRowLookup = null;

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/DocCollectorExpression.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/DocCollectorExpression.java
@@ -34,10 +34,6 @@ public class DocCollectorExpression extends LuceneCollectorExpression<Map<String
     private StoredRow source;
     private ReaderContext context;
 
-    public DocCollectorExpression() {
-        super();
-    }
-
     @Override
     public void startCollect(CollectorContext context) {
         storedRowLookup = context.storedRowLookup();

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/PartitionValueInjector.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/PartitionValueInjector.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.reference.doc.lucene;
+
+import java.util.List;
+import java.util.Map;
+
+import io.crate.common.collections.Maps;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.PartitionName;
+import io.crate.metadata.Reference;
+
+public interface PartitionValueInjector {
+
+    Map<String, Object> injectValues(Map<String, Object> input);
+
+    static PartitionValueInjector create(String indexName, List<Reference> partitionColumns) {
+
+        if (partitionColumns.isEmpty()) {
+            return m -> m;
+        }
+
+        PartitionName partitionName = PartitionName.fromIndexOrTemplate(indexName);
+        if (partitionName.values().size() != partitionColumns.size()) {
+            throw new IllegalArgumentException("Partition values " + partitionName.values() + " from index " + indexName
+                + " must match partition columns " + partitionColumns);
+        }
+
+        return input -> {
+            for (int i = 0; i < partitionColumns.size(); i++) {
+                ColumnIdent columnIdent = partitionColumns.get(i).column();
+                Maps.mergeInto(input, columnIdent.name(), columnIdent.path(), partitionName.values().get(i));
+            }
+            return input;
+        };
+    }
+}

--- a/server/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
+++ b/server/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
@@ -128,6 +128,7 @@ public class LuceneQueryBuilder {
         final QueryCache queryCache;
         private final TransactionContext txnCtx;
         private final IndexAnalyzers indexAnalyzers;
+        private final String indexName;
 
         final NodeContext nodeContext;
         private final Symbol parentQuery;
@@ -153,6 +154,7 @@ public class LuceneQueryBuilder {
             );
             this.queryCache = queryCache;
             this.parentQuery = parentQuery;
+            this.indexName = indexName;
         }
 
         public Query query() {
@@ -371,7 +373,8 @@ public class LuceneQueryBuilder {
         @SuppressWarnings("unchecked")
         final Input<Boolean> condition = (Input<Boolean>) ctx.add(function);
         final Collection<? extends LuceneCollectorExpression<?>> expressions = ctx.expressions();
-        final CollectorContext collectorContext = new CollectorContext(() -> StoredRowLookup.create(context.table));
+        final CollectorContext collectorContext
+            = new CollectorContext(() -> StoredRowLookup.create(context.table, context.indexName));
         for (LuceneCollectorExpression<?> expression : expressions) {
             expression.startCollect(collectorContext);
         }

--- a/server/src/main/java/io/crate/planner/statement/CopyToPlan.java
+++ b/server/src/main/java/io/crate/planner/statement/CopyToPlan.java
@@ -28,7 +28,6 @@ import static io.crate.analyze.CopyStatementSettings.settingAsEnum;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -61,7 +60,6 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.DocReferences;
-import io.crate.metadata.GeneratedReference;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.Reference;
@@ -226,7 +224,7 @@ public final class CopyToPlan implements Plan {
         Map<ColumnIdent, Symbol> overwrites = null;
         boolean columnsDefined = false;
         final List<String> outputNames = new ArrayList<>(copyTo.columns().size());
-        if (!copyTo.columns().isEmpty()) {
+        if (copyTo.columns().isEmpty() == false) {
             // TODO: remove outputNames?
             for (Symbol symbol : copyTo.columns()) {
                 assert symbol instanceof Reference : "Only references are expected here";
@@ -235,28 +233,9 @@ public final class CopyToPlan implements Plan {
             }
             columnsDefined = true;
         } else {
-            Symbol toCollect;
-            if (table.isPartitioned() && partitions.isEmpty()) {
-                // table is partitioned, insert partitioned columns into the output
-                overwrites = new HashMap<>();
-                for (Reference reference : table.partitionedByColumns()) {
-                    if (!(reference instanceof GeneratedReference)) {
-                        overwrites.put(reference.column(), reference);
-                    }
-                }
-                if (overwrites.size() > 0) {
-                    toCollect = table.getReference(DocSysColumns.DOC);
-                } else {
-                    var docRef = table.getReference(DocSysColumns.DOC);
-                    assert docRef != null : "_doc reference must be resolvable";
-                    toCollect = docRef.cast(DataTypes.STRING, CastMode.EXPLICIT);
-                }
-            } else {
-                var docRef = table.getReference(DocSysColumns.DOC);
-                assert docRef != null : "_doc reference must be resolvable";
-                toCollect = docRef.cast(DataTypes.STRING, CastMode.EXPLICIT);
-            }
-            outputs = List.of(toCollect);
+            var docRef = table.getReference(DocSysColumns.DOC);
+            assert docRef != null : "_doc reference must be resolvable";
+            outputs = List.of(docRef.cast(DataTypes.STRING, CastMode.EXPLICIT));
         }
 
         GenericProperties<Object> properties = copyTo.properties().map(eval);

--- a/server/src/main/java/io/crate/statistics/ReservoirSampler.java
+++ b/server/src/main/java/io/crate/statistics/ReservoirSampler.java
@@ -243,8 +243,9 @@ public final class ReservoirSampler {
         DocTableInfo docTable,
         List<Reference> columns
     ) {
+        String indexName = indexService.index().getName();
         LuceneReferenceResolver referenceResolver = new LuceneReferenceResolver(
-            indexService.index().getName(),
+            indexName,
             docTable.partitionedByColumns()
         );
         List<? extends LuceneCollectorExpression<?>> expressions = Lists.map(
@@ -252,7 +253,8 @@ public final class ReservoirSampler {
             x -> referenceResolver.getImplementation(DocReferences.toDocLookup(x))
         );
 
-        CollectorContext collectorContext = new CollectorContext(() -> StoredRowLookup.create(docTable));
+        CollectorContext collectorContext
+            = new CollectorContext(() -> StoredRowLookup.create(docTable, indexName));
         for (LuceneCollectorExpression<?> expression : expressions) {
             expression.startCollect(collectorContext);
         }

--- a/server/src/test/java/io/crate/analyze/CopyAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CopyAnalyzerTest.java
@@ -258,7 +258,6 @@ public class CopyAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     public void testCopyToFileWithPartitionedTable() throws Exception {
         BoundCopyTo analysis = analyze("COPY parted TO DIRECTORY '/blah'");
         assertThat(analysis.table().ident().name()).isEqualTo("parted");
-        assertThat(analysis.overwrites()).hasSize(1);
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/engine/collect/DocLevelCollectTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/DocLevelCollectTest.java
@@ -101,7 +101,7 @@ public class DocLevelCollectTest extends IntegTestCase {
                                               "  id integer," +
                                               "  name string," +
                                               "  date timestamp with time zone" +
-                                              ") clustered into 2 shards partitioned by (date) with(number_of_replicas=0)", PARTITIONED_TABLE_NAME));
+                                              ") clustered into 2 shards partitioned by (date, name) with(number_of_replicas=0)", PARTITIONED_TABLE_NAME));
         ensureGreen();
         execute(String.format(Locale.ENGLISH, "insert into %s (id, name, date) values (?, ?, ?)",
             PARTITIONED_TABLE_NAME),

--- a/server/src/test/java/io/crate/execution/engine/export/FileWriterCountCollectorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/export/FileWriterCountCollectorTest.java
@@ -26,9 +26,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
 
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.test.ESTestCase;
@@ -36,20 +33,7 @@ import org.junit.Test;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 
-import io.crate.metadata.ColumnIdent;
-
 public class FileWriterCountCollectorTest extends ESTestCase {
-
-    @Test
-    public void testToNestedStringObjectMap() {
-        Map<ColumnIdent, Object> columnIdentMap = new HashMap<>();
-        columnIdentMap.put(ColumnIdent.of("some", Arrays.asList("nested", "column")), "foo");
-        Map<String, Object> convertedMap = FileWriterCountCollector.toNestedStringObjectMap(columnIdentMap);
-
-        Map<?, ?> someMap = (Map<?, ?>) convertedMap.get("some");
-        Map<?, ?> nestedMap = (Map<?, ?>) someMap.get("nested");
-        assertThat(nestedMap.get("column")).isEqualTo("foo");
-    }
 
     @Test
     public void testJsonBuilderDoesNotPassFlushToStream() throws Exception {

--- a/server/src/test/java/io/crate/execution/engine/export/FileWriterProjectorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/export/FileWriterProjectorTest.java
@@ -27,7 +27,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -69,7 +68,7 @@ public class FileWriterProjectorTest extends ESTestCase {
         Path file = createTempFile("out", "json");
 
         FileWriterProjector fileWriterProjector = new FileWriterProjector(executorService, file.toUri().toString(),
-            null, null, Set.of(), new HashMap<>(),
+            null, null, Set.of(),
             null, WriterProjection.OutputFormat.JSON_OBJECT,
             Map.of(LocalFsFileOutputFactory.NAME, new LocalFsFileOutputFactory()), Settings.EMPTY);
 
@@ -89,7 +88,7 @@ public class FileWriterProjectorTest extends ESTestCase {
 
         FileWriterProjector fileWriterProjector = new FileWriterProjector(
                 executorService, directory.toUri().toString(),
-                null, null, Set.of(), new HashMap<>(),
+                null, null, Set.of(),
                 null, WriterProjection.OutputFormat.JSON_OBJECT,
                 Map.of(LocalFsFileOutputFactory.NAME, new LocalFsFileOutputFactory()), Settings.EMPTY);
         assertThatThrownBy(() -> new TestingRowConsumer().accept(fileWriterProjector.apply(sourceSupplier.get()), null))
@@ -102,7 +101,7 @@ public class FileWriterProjectorTest extends ESTestCase {
         String uri = Paths.get(folder.newFile().toURI()).resolve("out.json").toUri().toString();
 
         FileWriterProjector fileWriterProjector = new FileWriterProjector(executorService, uri,
-                null, null, Set.of(), new HashMap<>(),
+                null, null, Set.of(),
                 null, WriterProjection.OutputFormat.JSON_OBJECT,
                 Map.of(LocalFsFileOutputFactory.NAME, new LocalFsFileOutputFactory()), Settings.EMPTY);
 

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionClassLifecycleTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionClassLifecycleTest.java
@@ -370,7 +370,7 @@ public class TransportSQLActionClassLifecycleTest extends IntegTestCase {
         assertThat(lines).hasSize(2);
         for (String line : lines) {
             assertThat(line.contains("2") || line.contains("1")).isTrue();
-            assertThat(line.contains("1388534400000")).isFalse();  // date column not included in export
+            assertThat(line).contains("1388534400000");
             assertThat(line).startsWith("{");
             assertThat(line).endsWith("}");
         }
@@ -393,8 +393,8 @@ public class TransportSQLActionClassLifecycleTest extends IntegTestCase {
         assertThat(lines).hasSize(4);
         for (String line : lines) {
             // date column included in output
-            if (!line.contains("1388534400000")) {
-                assertThat(line.contains("1391212800000")).isTrue();
+            if (line.contains("1388534400000") == false) {
+                assertThat(line).contains("1391212800000");
             }
             assertThat(line).startsWith("{");
             assertThat(line).endsWith("}");

--- a/server/src/testFixtures/java/io/crate/testing/QueryTester.java
+++ b/server/src/testFixtures/java/io/crate/testing/QueryTester.java
@@ -178,7 +178,7 @@ public final class QueryTester implements AutoCloseable {
                 query,
                 null,
                 false,
-                new CollectorContext(() -> StoredRowLookup.create(table)),
+                new CollectorContext(() -> StoredRowLookup.create(table, indexEnv.luceneReferenceResolver().getIndexName())),
                 Collections.singletonList(input),
                 ctx.expressions()
             );

--- a/server/src/testFixtures/java/io/crate/types/DataTypeTestCase.java
+++ b/server/src/testFixtures/java/io/crate/types/DataTypeTestCase.java
@@ -139,7 +139,7 @@ public abstract class DataTypeTestCase<T> extends CrateDummyClusterServiceUnitTe
             );
 
             Scorer scorer = weight.scorer(leafReader);
-            CollectorContext collectorContext = new CollectorContext(1, () -> StoredRowLookup.create(table));
+            CollectorContext collectorContext = new CollectorContext(1, () -> StoredRowLookup.create(table, "index"));
             ReaderContext readerContext = new ReaderContext(leafReader);
             DocIdSetIterator iterator = scorer.iterator();
             int nextDoc = iterator.nextDoc();


### PR DESCRIPTION
LuceneReferenceResolver contained code to automatically add partition 
column values to the stored source used to return _doc.  However, this logic 
was broken. Here, the logic is moved directly into StoredRowLookup to 
ensure that these values are always injected into the source map.