### PR TITLE
Optimize numeric lucene queries

### DIFF
--- a/docs/general/ddl/data-types.rst
+++ b/docs/general/ddl/data-types.rst
@@ -1002,8 +1002,10 @@ Example:
 An exact `fixed-point fractional number`_ with an arbitrary, user-specified
 precision.
 
-Variable size, with up to 131072 digits before the decimal point and up to
-16383 digits after the decimal point.
+Variable size, with up to 38 digits for storage.
+
+If using ``NUMERIC`` only for type casts up to 131072 digits before the decimal
+point and up to 16383 digits after the decimal point are supported.
 
 For example, using a :ref:`cast from a string literal
 <data-types-casting-str>`::

--- a/server/src/main/java/io/crate/types/NumericStorage.java
+++ b/server/src/main/java/io/crate/types/NumericStorage.java
@@ -65,8 +65,8 @@ public final class NumericStorage extends StorageSupport<BigDecimal> {
 
     public static final int COMPACT_PRECISION = 18;
 
-    public NumericStorage() {
-        super(true, true, new NumericEqQuery());
+    public NumericStorage(NumericType numericType) {
+        super(true, true, NumericEqQuery.of(numericType));
     }
 
     @Override

--- a/server/src/main/java/io/crate/types/NumericType.java
+++ b/server/src/main/java/io/crate/types/NumericType.java
@@ -63,8 +63,6 @@ public class NumericType extends DataType<BigDecimal> implements Streamer<BigDec
         }
     }
 
-    private static final StorageSupport<BigDecimal> STORAGE = new NumericStorage();
-
     @Nullable
     private final Integer scale;
     @Nullable
@@ -286,7 +284,7 @@ public class NumericType extends DataType<BigDecimal> implements Streamer<BigDec
     @Override
     @Nullable
     public StorageSupport<? super BigDecimal> storageSupport() {
-        return STORAGE;
+        return new NumericStorage(this);
     }
 
     @Override

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -2273,12 +2273,16 @@ public class TransportSQLActionTest extends IntegTestCase {
         Asserts.assertSQLError(() -> execute("create table tbl (x numeric)"))
             .hasMessageContaining("NUMERIC storage is only supported if precision and scale are specified");
 
+        Asserts.assertSQLError(() -> execute("create table tbl (x numeric(40))"))
+            .hasMessageContaining("Precision for NUMERIC(40) is too large. Only up to 38 can be stored");
+
         execute("create table tbl (x numeric(18, 9), y numeric(38, 2))");
         execute(
             """
             insert into tbl (x, y) values
                 ('123456789.123456789', '778941863531215726456187232788659941.79'),
                 ('999999999.999999999', '512885724621369365291419674621839399.84'),
+                (null, null),
                 ('-999999999.999999999', '8395855172541624311941.11')
             """
         );
@@ -2287,7 +2291,8 @@ public class TransportSQLActionTest extends IntegTestCase {
         assertThat(response).hasRows(
             "-999999999.999999999| 8395855172541624311941.11",
             "123456789.123456789| 778941863531215726456187232788659941.79",
-            "999999999.999999999| 512885724621369365291419674621839399.84"
+            "999999999.999999999| 512885724621369365291419674621839399.84",
+            "NULL| NULL"
         );
 
         execute("select * from tbl where x > 42 and y <= '778941863531215726456187232788659941.79' order by x");
@@ -2297,6 +2302,12 @@ public class TransportSQLActionTest extends IntegTestCase {
         );
 
         execute("select x from tbl where x = '123456789.123456789' and y = '778941863531215726456187232788659941.79'");
+        assertThat(response).hasRows("123456789.123456789");
+
+        execute("select x from tbl where x in ('123456789.123456789', '455456789.123456789')");
+        assertThat(response).hasRows("123456789.123456789");
+
+        execute("select x from tbl where y in ('123456789.123456789', '778941863531215726456187232788659941.79')");
         assertThat(response).hasRows("123456789.123456789");
     }
 }

--- a/server/src/test/java/io/crate/lucene/NumericEqQueryTest.java
+++ b/server/src/test/java/io/crate/lucene/NumericEqQueryTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.lucene;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.lucene.search.PointRangeQuery;
+import org.apache.lucene.search.Query;
+import org.junit.Test;
+
+public class NumericEqQueryTest extends LuceneQueryBuilderTest {
+
+    @Override
+    protected String createStmt() {
+        return """
+            create table n (
+                x numeric(18, 2),
+                y numeric(38, 2)
+            )
+            """;
+    }
+
+    @Test
+    public void test_uses_point_range_queries_for_compact_numeric() throws Exception {
+        Query query = convert("x = '2746799837116176.76'");
+        assertThat(query).isInstanceOf(PointRangeQuery.class);
+        assertThat(query.toString()).isEqualTo("x:[274679983711617676 TO 274679983711617676]");
+
+        query = convert("x > '2746799837116176.76'");
+        assertThat(query).isInstanceOf(PointRangeQuery.class);
+        assertThat(query.toString()).isEqualTo("x:[274679983711617677 TO 999999999999999999]");
+
+        query = convert("x <= '2746799837116176.76'");
+        assertThat(query).isInstanceOf(PointRangeQuery.class);
+        assertThat(query.toString()).isEqualTo("x:[-999999999999999999 TO 274679983711617676]");
+    }
+
+    @Test
+    public void test_uses_binary_encoded_range_queries_for_large_numeric() throws Exception {
+        Query query = convert("y = '2746799837116176.76'");
+        assertThat(query).isInstanceOf(PointRangeQuery.class);
+        assertThat(query.toString()).isEqualTo("y:[274679983711617676 TO 274679983711617676]");
+
+        query = convert("y > '2746799837116176.76'");
+        assertThat(query).isInstanceOf(PointRangeQuery.class);
+        assertThat(query.toString()).isEqualTo("y:[274679983711617677 TO 99999999999999999999999999999999999999]");
+
+        query = convert("y <= '2746799837116176.76'");
+        assertThat(query).isInstanceOf(PointRangeQuery.class);
+        assertThat(query.toString()).isEqualTo("y:[-99999999999999999999999999999999999999 TO 274679983711617676]");
+    }
+}


### PR DESCRIPTION
Benchmark results (https://github.com/crate/crate-benchmarks/pull/319):

```
Q: select count(*) from tcompact where x = (select x from tcompact limit 1)
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |       42.102 ±   97.594 |      6.764 |      9.648 |     11.502 |    338.166 |
|   V2    |       24.612 ±   49.079 |      1.854 |      4.272 |      6.005 |    167.405 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  52.43%                           -  77.25%
There is a 88.90% probability that the observed difference is not random, and the best estimate of that difference is 52.43%
The test has no statistical significance

Q: select count(*) from tcompact where x in (select x from tcompact limit 50)
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |       49.725 ±   80.765 |     16.158 |     23.494 |     25.019 |    309.929 |
|   V2    |       15.972 ±   34.305 |      3.194 |      4.366 |      5.086 |    118.581 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               - 102.76%                           - 137.31%
There is a 99.98% probability that the observed difference is not random, and the best estimate of that difference is 102.76%
The test has statistical significance

Q: select count(*) from tcompact where x >= (select x from tcompact limit 1)
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |       20.411 ±   33.758 |      6.981 |      9.153 |     10.075 |    123.141 |
|   V2    |        4.997 ±    3.893 |      2.034 |      4.001 |      4.657 |     16.615 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               - 121.34%                           -  78.34%
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 121.34%
The test has statistical significance

Q: select count(*) from tlarge where x = (select x from tlarge limit 1)
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |      166.665 ±  238.781 |     59.327 |     88.791 |     97.149 |    929.404 |
|   V2    |        5.592 ±    7.311 |      1.291 |      3.253 |      4.129 |     27.481 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               - 187.01%                           - 185.86%
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 187.01%
The test has statistical significance


Q: select count(*) from tlarge where x >= (select x from tlarge limit 1)
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |      155.416 ±  208.358 |     60.938 |     86.924 |     94.869 |    825.635 |
|   V2    |        2.490 ±    1.637 |      1.065 |      1.991 |      2.479 |      7.292 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               - 193.69%                           - 191.04%
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 193.69%
The test has statistical significance
```
