### PR TITLE
Enable missing version-chooser in documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,3 +27,8 @@ linkcheck_ignore = [
     'https://www.iso.org/obp/ui/.*',  # Breaks accessibility via JS ¯\_(ツ)_/¯
 ]
 linkcheck_retries = 3
+
+# Enable version chooser.
+html_context.update({
+    "display_version": True,
+})


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

With the latest changes in the crate-docs-theme for the documentation the version chooser dropdown requires `display_version` to be set to `True` to be shown. This will do just that.