### PR TITLE
Fix ClassCastException from EqOperator on nested arrays

### DIFF
--- a/libs/shared/src/main/java/io/crate/common/collections/Lists.java
+++ b/libs/shared/src/main/java/io/crate/common/collections/Lists.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.NoSuchElementException;
@@ -99,6 +100,21 @@ public final class Lists {
         for (T item : list2) {
             if (!list1.contains(item)) {
                 result.add(item);
+            }
+        }
+        return result;
+    }
+
+    public static Collection<?> flattenUnique(Collection<?> list) {
+        if (!(list instanceof List<?>)) {
+            throw new IllegalArgumentException("Cannot flatten unless it is a nested array");
+        }
+        LinkedHashSet<Object> result = new LinkedHashSet<>();
+        for (var element : list) {
+            if (element instanceof Collection<?> l) {
+                result.addAll(flattenUnique(l));
+            } else {
+                result.add(element);
             }
         }
         return result;

--- a/server/src/main/java/io/crate/expression/operator/EqOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/EqOperator.java
@@ -21,6 +21,7 @@
 
 package io.crate.expression.operator;
 
+import static io.crate.common.collections.Lists.flattenUnique;
 import static io.crate.lucene.LuceneQueryBuilder.genericFunctionFilter;
 import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
 
@@ -192,7 +193,7 @@ public final class EqOperator extends Operator<Object> {
                                                Context context,
                                                boolean hasDocValues,
                                                IndexType indexType) {
-
+        values = flattenUnique(values);
         BooleanQuery.Builder filterClauses = new BooleanQuery.Builder();
         Query genericFunctionFilter = genericFunctionFilter(function, context);
         if (values.isEmpty()) {

--- a/server/src/test/java/io/crate/lucene/NestedArrayLuceneQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/NestedArrayLuceneQueryBuilderTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.lucene;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class NestedArrayLuceneQueryBuilderTest extends LuceneQueryBuilderTest {
+
+    @Override
+    protected String createStmt() {
+        return """
+            create table t (
+                a int[][]
+            )
+            """;
+    }
+
+    @Test
+    public void test_nested_array_equals() {
+        var query = convert("a = [[1], [1, 2], null]");
+        // pre-filter by a terms query with 1 and 2 then a generic function query to make sure an exact match
+        assertThat(query.toString()).isEqualTo("+a:{1 2} +(a = [[1], [1, 2], NULL])");
+    }
+
+    @Test
+    public void test_empty_nested_array_equals() {
+        var query = convert("a = [[]]");
+        assertThat(query.toString()).isEqualTo("+NumTermsPerDoc: a +(a = [[]])");
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes part of https://github.com/crate/crate/issues/16299:
```
ClassCastException[class java.util.ArrayList cannot be cast to class java.lang.Number (java.util.ArrayList and java.lang.Number are in module java.base of loader 'bootstrap')]
cr> select * from t where a = [[1], [2,3]];  
```

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
