### PR TITLE
Fix ClassCastException from EqOperator over nested array subscript expression

### DIFF
--- a/server/src/test/java/io/crate/lucene/NestedArrayLuceneQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/NestedArrayLuceneQueryBuilderTest.java
@@ -48,4 +48,11 @@ public class NestedArrayLuceneQueryBuilderTest extends LuceneQueryBuilderTest {
         var query = convert("a = [[]]");
         assertThat(query.toString()).isEqualTo("+NumTermsPerDoc: a +(a = [[]])");
     }
+
+    @Test
+    public void test_subscript_nested_array_equals() {
+        var query = convert("a[1] = [1, 2]");
+        // pre-filter by a terms query with 1 and 2 then a generic function query to make sure an exact match
+        assertThat(query.toString()).isEqualTo("+a:{1 2} #(a[1] = [1, 2])");
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes part of https://github.com/crate/crate/issues/16299:
```
cr> select * from t where a[1] != [1]; -- a int[][]                                                                                                                               
ClassCastException[class java.util.ArrayList cannot be cast to class java.lang.Number (java.util.ArrayList and java.lang.Number are in module java.base of loader 'bootstrap')]
```

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
