### PR TITLE
Fix ClassCastException from AnyEqOperator on nested array literals

### DIFF
--- a/server/src/test/java/io/crate/lucene/NestedArrayLuceneQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/NestedArrayLuceneQueryBuilderTest.java
@@ -55,4 +55,11 @@ public class NestedArrayLuceneQueryBuilderTest extends LuceneQueryBuilderTest {
         // pre-filter by a terms query with 1 and 2 then a generic function query to make sure an exact match
         assertThat(query.toString()).isEqualTo("+a:{1 2} #(a[1] = [1, 2])");
     }
+
+    @Test
+    public void test_any_equals_nested_array_literal() {
+        var query = convert("a = any([ [ [1], [1, 2] ], [ [3], [4, 5] ] ])");
+        // pre-filter by a terms query with 1, 2, 3, 4, 5 then a generic function query to make sure an exact match
+        assertThat(query.toString()).isEqualTo("+a:{1 2 3 4 5} #(a = ANY([[[1], [1, 2]], [[3], [4, 5]]]))");
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes part of https://github.com/crate/crate/issues/16299:
```
cr> select * from t2 where a = any([[]]); -- a int[]                                                                                                                             
ClassCastException[class java.util.ImmutableCollections$ListN cannot be cast to class java.lang.Number (java.util.ImmutableCollections$ListN and java.lang.Number are in module java.base of loader 'bootstrap')]
```

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
