### PR TITLE
Generate Lucene queries for AllEqOperator

### DIFF
--- a/docs/appendices/release-notes/6.0.0.rst
+++ b/docs/appendices/release-notes/6.0.0.rst
@@ -71,6 +71,8 @@ Scalar and Aggregation Functions
 Performance and Resilience Improvements
 ---------------------------------------
 
+- Improved the performance of the queries involving ``= ALL`` array operator.
+
 Administration and Operations
 -----------------------------
 

--- a/server/src/main/java/io/crate/expression/operator/all/AllEqOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/all/AllEqOperator.java
@@ -21,8 +21,18 @@
 
 package io.crate.expression.operator.all;
 
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 
+import io.crate.expression.operator.EqOperator;
+import io.crate.expression.operator.Operator;
+import io.crate.expression.operator.any.AnyNeqOperator;
+import io.crate.expression.predicate.NotPredicate;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.lucene.LuceneQueryBuilder;
@@ -46,11 +56,60 @@ public final class AllEqOperator extends AllOperator<Object> {
 
     @Override
     protected Query refMatchesAllArrayLiteral(Function all, Reference probe, Literal<?> literal, LuceneQueryBuilder.Context context) {
-        return null;
+        // col = ALL ([1,2,3]) --> col=1 and col=2 and col=3
+        var uniqueValues = StreamSupport
+            .stream(((Iterable<?>) literal.value()).spliterator(), false)
+            .collect(Collectors.toSet());
+        if (uniqueValues.isEmpty()) {
+            return new MatchAllDocsQuery();
+        }
+        if (uniqueValues.contains(null)) {
+            // i.e.::
+            // postgres=# select 1 = all(array[null, 1]);
+            // ?column?
+            //----------
+            //
+            //(1 row)
+            //
+            //postgres=# select 1 = all(array[null, 2]);
+            // ?column?
+            //----------
+            // f
+            //(1 row)
+            return new MatchNoDocsQuery("If the array literal contains nulls, it is either false or null; hence a no-match");
+        }
+        if (uniqueValues.size() > 1) {
+            // `col=x and col=y` evaluates to `false` unless `x == y`
+            return new MatchNoDocsQuery("A single value cannot match more than one unique values");
+        }
+        // col = all([1]) --> col = 1
+        var value = uniqueValues.iterator().next();
+        return EqOperator.fromPrimitive(
+            probe.valueType(),
+            probe.storageIdent(),
+            value,
+            probe.hasDocValues(),
+            probe.indexType()
+        );
     }
 
     @Override
-    protected Query literalMatchesAllArrayRef(Function all, Literal<?> probe, Reference candidates, LuceneQueryBuilder.Context context) {
-        return null;
+    protected Query literalMatchesAllArrayRef(Function allEq, Literal<?> literal, Reference ref, LuceneQueryBuilder.Context context) {
+        // 1 = ALL(array_col)
+        // --> 1 = array_col[1] and 1 = array_col[2] and 1 = array_col[3]
+        // --> not(1 != array_col[1] or 1 != array_col[2] or 1 != array_col[3])
+        // --> not(1 != ANY(array_col))
+        Function notAnyNeq = new Function(
+            NotPredicate.SIGNATURE,
+            List.of(
+                new Function(
+                    AnyNeqOperator.SIGNATURE,
+                    allEq.arguments(),
+                    Operator.RETURN_TYPE
+                )
+            ),
+            Operator.RETURN_TYPE
+        );
+        return context.visitor().visitFunction(notAnyNeq, context);
     }
 }

--- a/server/src/test/java/io/crate/expression/operator/AllOperatorTest.java
+++ b/server/src/test/java/io/crate/expression/operator/AllOperatorTest.java
@@ -58,6 +58,16 @@ public class AllOperatorTest extends ScalarTestCase {
     }
 
     @Test
+    public void test_automatically_levels_array_dimensions_to_left_arg() {
+        assertEvaluate("1 = ALL([ [1] ])", true);
+    }
+
+    @Test
+    public void test_nested_array() {
+        assertEvaluate("[1] = ALL([ [1] ])", true);
+    }
+
+    @Test
     public void test_value_eq_array_with_null_element_and_match_is_null() {
         assertEvaluateNull("1 = ALL(ARRAY[1, null])");
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Since `col != ANY ([1,2,3])` --> `not(col=1 and col=2 and col=3)` --> `not(col = ALL ([1,2,3]))`,
generate lucene queries for AllEqOperator referencing AnyNeqOperator.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
