### PR TITLE
Make flattenUnique more general

### DIFF
--- a/libs/shared/src/main/java/io/crate/common/collections/Lists.java
+++ b/libs/shared/src/main/java/io/crate/common/collections/Lists.java
@@ -32,6 +32,7 @@ import java.util.ListIterator;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.RandomAccess;
+import java.util.SequencedSet;
 import java.util.StringJoiner;
 import java.util.function.Function;
 import java.util.stream.Collector;
@@ -105,13 +106,10 @@ public final class Lists {
         return result;
     }
 
-    public static Collection<?> flattenUnique(Collection<?> list) {
-        if (!(list instanceof List<?>)) {
-            throw new IllegalArgumentException("Cannot flatten unless it is a nested array");
-        }
+    public static SequencedSet<?> flattenUnique(Iterable<?> items) {
         LinkedHashSet<Object> result = new LinkedHashSet<>();
-        for (var element : list) {
-            if (element instanceof Collection<?> l) {
+        for (var element : items) {
+            if (element instanceof Iterable<?> l) {
                 result.addAll(flattenUnique(l));
             } else {
                 result.add(element);


### PR DESCRIPTION
Typing the parameter as `Collection<?>` only to raise a runtime
exception if it isn't a `List` is a bit odd, especially given that the
implementation works with just an `Iterable`.

This also changes the return value from `Collection` to `SequencedSet`
to signal both the ordering and the uniqueness.
