### PR TITLE
Fix flaky `testNullOperators`

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/LuceneQueryBuilderIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/LuceneQueryBuilderIntegrationTest.java
@@ -352,7 +352,7 @@ public class LuceneQueryBuilderIntegrationTest extends IntegTestCase {
     @Test
     public void testNullOperators() throws Exception {
         DataType<?> type = randomType();
-        String typeDefinition = SqlFormatter.formatSql(type.toColumnType(ColumnPolicy.STRICT, null));
+        String typeDefinition = SqlFormatter.formatSql(type.toColumnType(ColumnPolicy.DYNAMIC, null));
         execute("create table t1 (c " + typeDefinition + ") with (number_of_replicas = 0)");
         Supplier<?> dataGenerator = DataTypeTesting.getDataGenerator(type);
 


### PR DESCRIPTION
Failed with seed `3C22653F7B086B9F:965A79FB2D5A9BD6` because the type
randomized to an empty `OBJECT(STRICT)` but the generated random values
included a `x` key causing insert failures.
