### PR TITLE
Improve assertEvaluate test failure message for ScalarTestCase

### DIFF
--- a/server/src/test/java/io/crate/expression/scalar/bitwise/BitwiseFunctionsTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/bitwise/BitwiseFunctionsTest.java
@@ -22,15 +22,10 @@
 package io.crate.expression.scalar.bitwise;
 
 
-import io.crate.expression.scalar.ScalarTestCase;
-import io.crate.sql.tree.BitString;
-import io.crate.testing.DataTypeTesting;
-import io.crate.types.BitStringType;
-import io.crate.types.DataType;
-
-import org.assertj.core.api.Assertions;
-import org.elasticsearch.common.TriFunction;
-import org.junit.Test;
+import static io.crate.types.DataTypes.BYTE;
+import static io.crate.types.DataTypes.INTEGER;
+import static io.crate.types.DataTypes.LONG;
+import static io.crate.types.DataTypes.SHORT;
 
 import java.util.HashMap;
 import java.util.List;
@@ -39,10 +34,15 @@ import java.util.Map;
 import java.util.function.BinaryOperator;
 import java.util.function.Supplier;
 
-import static io.crate.types.DataTypes.BYTE;
-import static io.crate.types.DataTypes.INTEGER;
-import static io.crate.types.DataTypes.LONG;
-import static io.crate.types.DataTypes.SHORT;
+import org.assertj.core.api.Assertions;
+import org.elasticsearch.common.TriFunction;
+import org.junit.Test;
+
+import io.crate.expression.scalar.ScalarTestCase;
+import io.crate.sql.tree.BitString;
+import io.crate.testing.DataTypeTesting;
+import io.crate.types.BitStringType;
+import io.crate.types.DataType;
 
 public class BitwiseFunctionsTest extends ScalarTestCase {
 
@@ -81,8 +81,7 @@ public class BitwiseFunctionsTest extends ScalarTestCase {
                     "%d::%s %s %d::%s",
                     a, type.getName(), entry.getKey(), b, type.getName()
                 );
-                String errorMessage = String.format(Locale.ENGLISH, "Error on computing expression %s", expression);
-                assertEvaluate(expression, entry.getValue().apply(type, a, b), errorMessage);
+                assertEvaluate(expression, entry.getValue().apply(type, a, b));
             }
         }
     }
@@ -115,8 +114,7 @@ public class BitwiseFunctionsTest extends ScalarTestCase {
                 "%s %s %s",
                 a.asPrefixedBitString(), entry.getKey(), b.asPrefixedBitString()
             );
-            String errorMessage = String.format(Locale.ENGLISH, "Error on computing expression %s", expression);
-            assertEvaluate(expression, entry.getValue().apply(a, b), errorMessage);
+            assertEvaluate(expression, entry.getValue().apply(a, b));
         }
     }
 }

--- a/server/src/testFixtures/java/io/crate/expression/scalar/ScalarTestCase.java
+++ b/server/src/testFixtures/java/io/crate/expression/scalar/ScalarTestCase.java
@@ -179,11 +179,12 @@ public abstract class ScalarTestCase extends CrateDummyClusterServiceUnitTest {
      * </code>
      */
     public void assertEvaluate(String functionExpression, Object expectedValue, Literal<?>... literals) {
-        assertEvaluate(functionExpression, s -> assertThat(s).isEqualTo(expectedValue), literals);
-    }
-
-    public void assertEvaluate(String functionExpression, Object expectedValue, String errorMessage, Literal<?>... literals) {
-        assertEvaluate(functionExpression, s -> assertThat(s).withFailMessage(errorMessage).isEqualTo(expectedValue), literals);
+        assertEvaluate(
+            functionExpression,
+            s -> assertThat(s)
+                .as("`" + functionExpression + "` must evaluate to %s (literals=%s)", expectedValue, Arrays.toString(literals))
+                .isEqualTo(expectedValue),
+            literals);
     }
 
     /**


### PR DESCRIPTION
It would only show `expected: ... was: ...` which doesn't give enough
insights if the values used in the expression are generated.
