### PR TITLE
Restrict numeric scale to positive; require precision for scale

### DIFF
--- a/docs/general/ddl/data-types.rst
+++ b/docs/general/ddl/data-types.rst
@@ -1030,7 +1030,7 @@ significant digits in the unscaled numeric value. The ``scale`` value of a
 numeric is the count of decimal digits in the fractional part, to the right of
 the decimal point. For example, the number 123.45 has a precision of ``5`` and
 a scale of ``2``. Integers have a scale of zero.
-The scale must be smaller than the precision.
+The scale must be smaller than the precision and greater or equal to zero.
 
 To declare the ``NUMERIC`` type with the precision and scale, use the syntax::
 

--- a/server/src/main/java/io/crate/types/NumericType.java
+++ b/server/src/main/java/io/crate/types/NumericType.java
@@ -71,13 +71,21 @@ public class NumericType extends DataType<BigDecimal> implements Streamer<BigDec
     private final Integer precision;
 
     public NumericType(@Nullable Integer precision, @Nullable Integer scale) {
-        if (precision != null && scale != null && scale >= precision) {
-            throw new IllegalArgumentException(String.format(
-                Locale.ENGLISH,
-                "Scale of numeric must be less than the precision. NUMERIC(%d, %d) is unsupported.",
-                precision,
-                scale
-            ));
+        if (scale != null) {
+            if (precision == null) {
+                throw new IllegalArgumentException("If scale is set for NUMERIC, precision must be set too");
+            }
+            if (scale >= precision) {
+                throw new IllegalArgumentException(String.format(
+                    Locale.ENGLISH,
+                    "Scale of numeric must be less than the precision. NUMERIC(%d, %d) is unsupported.",
+                    precision,
+                    scale
+                ));
+            }
+            if (scale < 0) {
+                throw new IllegalArgumentException("Scale of NUMERIC must not be negative");
+            }
         }
         this.precision = precision;
         this.scale = scale;

--- a/server/src/test/java/io/crate/types/NumericTypeTest.java
+++ b/server/src/test/java/io/crate/types/NumericTypeTest.java
@@ -43,12 +43,27 @@ public class NumericTypeTest extends DataTypeTestCase<BigDecimal> {
     }
 
     @Test
+    public void test_scale_cant_be_negative() throws Exception {
+        assertThatThrownBy(() -> new NumericType(2, -4))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Scale of NUMERIC must not be negative");
+    }
+
+    @Test
+    public void test_precision_is_required_if_scale_is_set() throws Exception {
+        assertThatThrownBy(() -> new NumericType(null, 4))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("If scale is set for NUMERIC, precision must be set too");
+    }
+
+    @Test
     public void test_implicit_cast_text_to_unscaled_numeric() {
         assertThat(NumericType.INSTANCE.implicitCast("12839")).isEqualTo(BigDecimal.valueOf(12839));
         assertThat(NumericType.INSTANCE.implicitCast("-12839")).isEqualTo(BigDecimal.valueOf(-12839));
         assertThat(NumericType.INSTANCE.implicitCast("+2147483647111")).isEqualTo(BigDecimal.valueOf(2147483647111L));
         assertThat(NumericType.INSTANCE.implicitCast("+214748364711119475")).isEqualTo(new BigDecimal("214748364711119475"));
     }
+
 
     @Test
     public void test_implicit_cast_floating_point_to_unscaled_numeric() {


### PR DESCRIPTION
This is already more or less enforced by the parser - `NUMERIC(4, -4)`
raises an exception because we currently don't support `-` in type
parameter literals.
