### PR TITLE
tests: Fix flaky test_types_with_storage_can_be_inserted_and_queried (numeric type issue)

### DIFF
--- a/server/src/testFixtures/java/io/crate/testing/DataTypeTesting.java
+++ b/server/src/testFixtures/java/io/crate/testing/DataTypeTesting.java
@@ -209,17 +209,14 @@ public class DataTypeTesting {
                 return () -> {
                     var numericType = (NumericType) type;
                     Integer precision = numericType.numericPrecision();
+                    int scale = numericType.scale() == null ? 0 : numericType.scale();
                     int maxDigits = precision == null ? 131072 : precision;
-                    int numDigits = random.nextInt(1, maxDigits + 1);
+                    int numDigits = random.nextInt(scale == 0 ? 1 : scale, maxDigits + 1);
                     StringBuilder sb = new StringBuilder(numDigits);
                     for (int i = 0; i < numDigits; i++) {
                         sb.append(random.nextInt(10));
                     }
-                    Integer scale = numericType.scale();
                     BigInteger bigInt = new BigInteger(sb.toString());
-                    if (scale == null) {
-                        return (T) new BigDecimal(bigInt, numericType.mathContext());
-                    }
                     return (T) new BigDecimal(bigInt, scale, numericType.mathContext());
                 };
             case BitStringType.ID:


### PR DESCRIPTION
Flakiness was caused by Numeric data generation, because previously, scale could be > numDigits that was selected randomly.

failure e.g.:
```
java.lang.IllegalArgumentException: Scale of numeric must be less than the precision. NUMERIC(19, 21) is unsupported.
    at __randomizedtesting.SeedInfo.seed([DD1858AE87042B54:F806A5D2595F59EA]:0)
    at io.crate.types.NumericType.<init>(NumericType.java:79)
    at io.crate.types.DataTypes.guessType(DataTypes.java:318)
    at io.crate.testing.DataTypeTesting.extendedType(DataTypeTesting.java:276)
    at io.crate.integrationtests.TransportSQLActionTest.test_types_with_storage_can_be_inserted_and_queried(TransportSQLActionTest.java:1944)
    at java.base/java.lang.reflect.Method.invoke(Method.java:580)
    at com.carrotsearch.randomizedtesting.RandomizedRunner.invoke(RandomizedRunner.java:1758)
    at com.carrotsearch.randomizedtesting.RandomizedRunner$8.evaluate(RandomizedRunner.java:946)
    at com.carrotsearch.randomizedtesting.RandomizedRunner$9.evaluate(RandomizedRunner.java:982)
    at com.carrotsearch.randomizedtesting.RandomizedRunner$10.evaluate(RandomizedRunner.java:996)
    at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
    at java.base/java.lang.Thread.run(Thread.java:1570)
```
