### PR TITLE
Fix issue with empty array and dynamic col policy

### DIFF
--- a/docs/appendices/release-notes/5.8.2.rst
+++ b/docs/appendices/release-notes/5.8.2.rst
@@ -47,6 +47,14 @@ See the :ref:`version_5.8.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that would cause rows to not be inserted, on a table with
+  :ref:`dynamic column policy <sql-create-table-column-policy>`, when the row
+  contained an empty array (``[]``) for a new column (to be added dynamically),
+  together with one or more new columns (also to be added dynamically), e.g.::
+
+    CREATE TABLE t (id TEXT PRIMARY KEY) WITH (column_policy = 'dynamic');
+    INSERT INTO t (id, a ,b) VALUES ('abc',[],'Text');
+
 - Fixed an issue that could lead to a ``SQLParseException[Couldn't create
   executionContexts from ...`` error if using ``INSERT INTO`` with a ``SELECT``
   query containing a trailing ``ORDER BY``.

--- a/server/src/main/java/io/crate/execution/dml/Indexer.java
+++ b/server/src/main/java/io/crate/execution/dml/Indexer.java
@@ -584,10 +584,9 @@ public class Indexer {
                 // the reference may be invalid
                 Reference newRef = getRef.apply(oldRef.column());
                 if (newRef == null) {
-                    // column was dropped or new column is invalid
-                    it.remove();
-                    valueIndexers.remove(idx);
-                    // don't increase idx, since we removed the current element
+                    // column can be of an undetermined type, e.g. `[]` (array with undefined inner type)
+                    valueIndexers.get(idx).updateTargets(getRef);
+                    idx++;
                     continue;
                 }
                 if (oldRef.equals(newRef) == false) {


### PR DESCRIPTION
When an empty array (`[]`) was attempted to be added as a new column dynamically, together with 1 or more other cols (to be also added dynamically), then the schema of the table got updated with the rest of the non-array new columns, but no row was inserted.

That was because the value indexer was completely removed for the column with the empty array, while the relevant value (`[]`), was not removed from the item to be indexed.

To fix this, don't remove the value indexer, but just use the `DynamicIndexer` which was already selected for that column (being unable to guess the inner type of the array).

Fixes: #16470
