### PR TITLE
Add braces in sql-parser

### DIFF
--- a/libs/dex/src/main/java/io/crate/data/Row1.java
+++ b/libs/dex/src/main/java/io/crate/data/Row1.java
@@ -40,8 +40,9 @@ public class Row1 extends Row {
 
     @Override
     public Object get(int index) {
-        if (index != 0)
+        if (index != 0) {
             throw new IndexOutOfBoundsException("Index: " + index + ", Size: 1");
+        }
         return value;
     }
 

--- a/libs/es-x-content/src/main/java/org/elasticsearch/common/xcontent/ConstructingObjectParser.java
+++ b/libs/es-x-content/src/main/java/org/elasticsearch/common/xcontent/ConstructingObjectParser.java
@@ -434,9 +434,13 @@ public final class ConstructingObjectParser<Value, Context> extends AbstractObje
              */
             StringBuilder message = null;
             for (int i = 0; i < constructorArgs.length; i++) {
-                if (constructorArgs[i] != null) continue;
+                if (constructorArgs[i] != null) {
+                    continue;
+                }
                 ConstructorArgInfo arg = constructorArgInfos.get(i);
-                if (false == arg.required) continue;
+                if (false == arg.required) {
+                    continue;
+                }
                 if (message == null) {
                     message = new StringBuilder("Required [").append(arg.field);
                 } else {

--- a/libs/shared/src/main/java/io/crate/common/unit/TimeValue.java
+++ b/libs/shared/src/main/java/io/crate/common/unit/TimeValue.java
@@ -269,10 +269,7 @@ public class TimeValue implements Comparable<TimeValue> {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        return this.compareTo(((TimeValue) o)) == 0;
+        return o instanceof TimeValue timeValue && this.compareTo(timeValue) == 0;
     }
 
     @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
@@ -1192,7 +1192,9 @@ public final class SqlFormatter {
                 int max = node.tables().size();
                 for (Table<?> table : node.tables()) {
                     table.accept(this, indent);
-                    if (++count < max) builder.append(",");
+                    if (++count < max) {
+                        builder.append(",");
+                    }
                 }
             } else {
                 builder.append(" ALL");
@@ -1528,7 +1530,9 @@ public final class SqlFormatter {
                 }
                 builder.append(key).append(" = ");
                 propertyEntry.getValue().accept(this, indent);
-                if (++count < properties.size()) builder.append(",");
+                if (++count < properties.size()) {
+                    builder.append(",");
+                }
                 builder.append("\n");
             }
         }
@@ -1600,7 +1604,9 @@ public final class SqlFormatter {
             builder.append("(");
             for (Node node : nodes) {
                 node.accept(this, indent);
-                if (++count < max) builder.append(", ");
+                if (++count < max) {
+                    builder.append(", ");
+                }
             }
             builder.append(")");
         }
@@ -1612,7 +1618,9 @@ public final class SqlFormatter {
             for (Node node : nodes) {
                 builder.append(indentString(indent + 1));
                 node.accept(this, indent + 1);
-                if (++count < max) builder.append(",");
+                if (++count < max) {
+                    builder.append(",");
+                }
                 builder.append("\n");
             }
             append(indent, ")");

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/AlterTableRenameColumn.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/AlterTableRenameColumn.java
@@ -49,10 +49,10 @@ public class AlterTableRenameColumn<T> extends Statement {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        AlterTableRenameColumn<?> that = (AlterTableRenameColumn<?>) o;
-        return table.equals(that.table) && column.equals(that.column) && newName.equals(that.newName);
+        return o instanceof AlterTableRenameColumn<?> that
+            && table.equals(that.table)
+            && column.equals(that.column)
+            && newName.equals(that.newName);
     }
 
     @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/ArrayComparisonExpression.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/ArrayComparisonExpression.java
@@ -58,15 +58,8 @@ public class ArrayComparisonExpression extends ComparisonExpression implements A
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        if (!super.equals(o)) return false;
-
-        ArrayComparisonExpression that = (ArrayComparisonExpression) o;
-
-        if (quantifier != that.quantifier) return false;
-
-        return true;
+        return o instanceof ArrayComparisonExpression cmp
+            && quantifier == cmp.quantifier;
     }
 
     @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/ArrayLikePredicate.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/ArrayLikePredicate.java
@@ -72,17 +72,11 @@ public class ArrayLikePredicate extends LikePredicate implements ArrayComparison
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        if (!super.equals(o)) return false;
-
-        ArrayLikePredicate that = (ArrayLikePredicate) o;
-
-        if (inverse != that.inverse) return false;
-        if (quantifier != that.quantifier) return false;
-        if (ignoreCase != that.ignoreCase) return false;
-
-        return true;
+        return super.equals(o)
+            && o instanceof ArrayLikePredicate that
+            && inverse == that.inverse
+            && quantifier == that.quantifier
+            && ignoreCase == that.ignoreCase;
     }
 
     @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/ArrayLiteral.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/ArrayLiteral.java
@@ -42,14 +42,7 @@ public class ArrayLiteral extends Literal {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        ArrayLiteral that = (ArrayLiteral) o;
-
-        if (!values.equals(that.values)) return false;
-
-        return true;
+        return o instanceof ArrayLiteral other && values.equals(other.values);
     }
 
     @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/ArraySubQueryExpression.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/ArraySubQueryExpression.java
@@ -42,10 +42,8 @@ public class ArraySubQueryExpression extends Expression {
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj) return true;
-        if (obj == null || getClass() != obj.getClass()) return false;
-        ArraySubQueryExpression that = (ArraySubQueryExpression) obj;
-        return Objects.equals(subqueryExpression, that.subqueryExpression);
+        return obj instanceof ArraySubQueryExpression other
+            && Objects.equals(subqueryExpression, other.subqueryExpression);
     }
 
     @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/CreateFunction.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/CreateFunction.java
@@ -78,11 +78,8 @@ public class CreateFunction<T> extends Statement {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        final CreateFunction<?> that = (CreateFunction<?>) o;
-        return Objects.equals(this.name, that.name)
+        return o instanceof CreateFunction<?> that
+            && Objects.equals(this.name, that.name)
             && Objects.equals(this.replace, that.replace)
             && Objects.equals(this.arguments, that.arguments)
             && Objects.equals(this.returnType, that.returnType)

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/CreateView.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/CreateView.java
@@ -47,14 +47,10 @@ public final class CreateView extends Statement {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        CreateView that = (CreateView) o;
-
-        if (replaceExisting != that.replaceExisting) return false;
-        if (!name.equals(that.name)) return false;
-        return query.equals(that.query);
+        return o instanceof CreateView that
+            && replaceExisting == that.replaceExisting
+            && name.equals(that.name)
+            && query.equals(that.query);
     }
 
     @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/DeallocateStatement.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/DeallocateStatement.java
@@ -21,8 +21,9 @@
 
 package io.crate.sql.tree;
 
-import org.jetbrains.annotations.Nullable;
 import java.util.Objects;
+
+import org.jetbrains.annotations.Nullable;
 
 public class DeallocateStatement extends Statement {
 
@@ -44,15 +45,13 @@ public class DeallocateStatement extends Statement {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        DeallocateStatement that = (DeallocateStatement) o;
-        return Objects.equals(preparedStmt, that.preparedStmt);
+        return o instanceof DeallocateStatement that
+            && Objects.equals(preparedStmt, that.preparedStmt);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(preparedStmt);
+        return Objects.hashCode(preparedStmt);
     }
 
     @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/DefaultConstraint.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/DefaultConstraint.java
@@ -71,9 +71,8 @@ public final class DefaultConstraint<T> extends ColumnConstraint<T> {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof DefaultConstraint<?> that)) return false;
-        return Objects.equals(name, that.name)
+        return o instanceof DefaultConstraint<?> that
+            && Objects.equals(name, that.name)
             && Objects.equals(expression, that.expression)
             && Objects.equals(expressionStr, that.expressionStr);
     }

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/DropAnalyzer.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/DropAnalyzer.java
@@ -37,10 +37,8 @@ public class DropAnalyzer extends Statement {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        DropAnalyzer that = (DropAnalyzer) o;
-        return Objects.equals(name, that.name);
+        return o instanceof DropAnalyzer that
+            && name.equals(that.name);
     }
 
     @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/DropFunction.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/DropFunction.java
@@ -54,14 +54,10 @@ public class DropFunction extends Statement {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        DropFunction that = (DropFunction) o;
-
-        if (exists != that.exists) return false;
-        if (!name.equals(that.name)) return false;
-        return arguments.equals(that.arguments);
+        return o instanceof DropFunction that
+            && exists == that.exists
+            && name.equals(that.name)
+            && arguments.equals(that.arguments);
     }
 
     @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/DropRepository.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/DropRepository.java
@@ -42,9 +42,8 @@ public class DropRepository extends Statement {
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj) return true;
-        if (obj == null || getClass() != obj.getClass()) return false;
-        return name.equals(((DropRepository) obj).name);
+        return obj instanceof DropRepository that
+            && name.equals(that.name);
     }
 
     @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/DropView.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/DropView.java
@@ -43,13 +43,9 @@ public final class DropView extends Statement {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        DropView dropView = (DropView) o;
-
-        if (ifExists != dropView.ifExists) return false;
-        return names.equals(dropView.names);
+        return o instanceof DropView that
+            && ifExists == that.ifExists
+            && names.equals(that.names);
     }
 
     @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/FrameBound.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/FrameBound.java
@@ -29,6 +29,7 @@ import static io.crate.sql.tree.WindowFrame.Mode.ROWS;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -276,13 +277,9 @@ public class FrameBound extends Node {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        FrameBound that = (FrameBound) o;
-
-        if (type != that.type) return false;
-        return value != null ? value.equals(that.value) : that.value == null;
+        return o instanceof FrameBound that
+            && type == that.type
+            && Objects.equals(value, that.value);
     }
 
     @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/FunctionArgument.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/FunctionArgument.java
@@ -21,8 +21,9 @@
 
 package io.crate.sql.tree;
 
-import org.jetbrains.annotations.Nullable;
 import java.util.Objects;
+
+import org.jetbrains.annotations.Nullable;
 
 public class FunctionArgument extends Node {
 
@@ -51,12 +52,9 @@ public class FunctionArgument extends Node {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        final FunctionArgument that = (FunctionArgument) o;
-        return Objects.equals(this.name, that.name)
-            && Objects.equals(this.type, that.type);
+        return o instanceof FunctionArgument that
+            && Objects.equals(name, that.name)
+            && Objects.equals(type, that.type);
     }
 
     @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/GeneratedExpressionConstraint.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/GeneratedExpressionConstraint.java
@@ -71,9 +71,8 @@ public final class GeneratedExpressionConstraint<T> extends ColumnConstraint<T> 
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof GeneratedExpressionConstraint<?> that)) return false;
-        return Objects.equals(name, that.name)
+        return o instanceof GeneratedExpressionConstraint<?> that
+            && Objects.equals(name, that.name)
             && Objects.equals(expression, that.expression)
             && Objects.equals(expressionStr, that.expressionStr);
     }

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/NotNullColumnConstraint.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/NotNullColumnConstraint.java
@@ -30,8 +30,7 @@ public final class NotNullColumnConstraint<T> extends ColumnConstraint<T> {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        return !(o == null || getClass() != o.getClass());
+        return o instanceof NotNullColumnConstraint<?>;
     }
 
     @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/NullColumnConstraint.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/NullColumnConstraint.java
@@ -38,8 +38,7 @@ public final class NullColumnConstraint<T> extends ColumnConstraint<T> {
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj) return true;
-        return !(obj == null || getClass() != obj.getClass());
+        return obj instanceof NullColumnConstraint<?>;
     }
 
     @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/ObjectLiteral.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/ObjectLiteral.java
@@ -42,14 +42,8 @@ public class ObjectLiteral extends Literal {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        ObjectLiteral that = (ObjectLiteral) o;
-
-        if (!values.equals(that.values)) return false;
-
-        return true;
+        return o instanceof ObjectLiteral that
+            && values.equals(that.values);
     }
 
     @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/ParameterExpression.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/ParameterExpression.java
@@ -37,14 +37,8 @@ public class ParameterExpression extends Expression {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        ParameterExpression that = (ParameterExpression) o;
-
-        if (position != that.position) return false;
-
-        return true;
+        return o instanceof ParameterExpression that
+            && position == that.position;
     }
 
     @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/PartitionedBy.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/PartitionedBy.java
@@ -23,7 +23,6 @@ package io.crate.sql.tree;
 
 
 import java.util.List;
-import java.util.Objects;
 import java.util.function.Function;
 
 import io.crate.common.collections.Lists;
@@ -46,17 +45,13 @@ public final class PartitionedBy<T> extends Node {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(columns);
+        return columns.hashCode();
     }
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        PartitionedBy<?> that = (PartitionedBy<?>) o;
-
-        return Objects.equals(columns, that.columns);
+        return o instanceof PartitionedBy<?> that
+            && columns.equals(that.columns);
     }
 
     @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/PrimaryKeyColumnConstraint.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/PrimaryKeyColumnConstraint.java
@@ -43,15 +43,13 @@ public final class PrimaryKeyColumnConstraint<T> extends ColumnConstraint<T> {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        PrimaryKeyColumnConstraint<?> that = (PrimaryKeyColumnConstraint<?>) o;
-        return Objects.equals(constraintName, that.constraintName);
+        return o instanceof PrimaryKeyColumnConstraint<?> that
+            && Objects.equals(constraintName, that.constraintName);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(constraintName, NAME);
+        return Objects.hashCode(constraintName);
     }
 
     @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/PrivilegeStatement.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/PrivilegeStatement.java
@@ -72,17 +72,17 @@ public abstract sealed class PrivilegeStatement extends Statement
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        PrivilegeStatement that = (PrivilegeStatement) o;
-        return all == that.all &&
-               Objects.equals(userNames, that.userNames) &&
-               Objects.equals(permissions, that.permissions);
+        return o instanceof PrivilegeStatement that
+            && all == that.all
+            && Objects.equals(userNames, that.userNames)
+            && Objects.equals(permissions, that.permissions)
+            && Objects.equals(securable, that.securable)
+            && Objects.equals(tableOrSchemaNames, that.tableOrSchemaNames);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(userNames, permissions, all);
+        return Objects.hash(all, userNames, permissions, securable, tableOrSchemaNames);
     }
 
 }

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/ShowSessionParameter.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/ShowSessionParameter.java
@@ -21,8 +21,9 @@
 
 package io.crate.sql.tree;
 
-import org.jetbrains.annotations.Nullable;
 import java.util.Objects;
+
+import org.jetbrains.annotations.Nullable;
 
 public class ShowSessionParameter extends Statement {
 
@@ -45,15 +46,13 @@ public class ShowSessionParameter extends Statement {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        ShowSessionParameter that = (ShowSessionParameter) o;
-        return Objects.equals(parameter, that.parameter);
+        return o instanceof ShowSessionParameter that
+            && Objects.equals(parameter, that.parameter);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(parameter);
+        return Objects.hashCode(parameter);
     }
 
     @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/SubscriptExpression.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/SubscriptExpression.java
@@ -59,21 +59,15 @@ public class SubscriptExpression extends Expression {
 
     @Override
     public int hashCode() {
-        int result = base != null ? base.hashCode() : 0;
-        result = 31 * result + (index != null ? index.hashCode() : 0);
+        int result = base.hashCode();
+        result = 31 * result + index.hashCode();
         return result;
     }
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        SubscriptExpression that = (SubscriptExpression) o;
-
-        if (index != null ? !index.equals(that.index) : that.index != null) return false;
-        if (base != null ? !base.equals(that.base) : that.base != null) return false;
-
-        return true;
+        return o instanceof SubscriptExpression that
+            && index.equals(that.index)
+            && base.equals(that.base);
     }
 }

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/Window.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/Window.java
@@ -21,9 +21,10 @@
 
 package io.crate.sql.tree;
 
-import org.jetbrains.annotations.Nullable;
 import java.util.List;
 import java.util.Optional;
+
+import org.jetbrains.annotations.Nullable;
 
 public final class Window extends Statement {
 
@@ -113,14 +114,10 @@ public final class Window extends Statement {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        Window window = (Window) o;
-
-        if (!partitions.equals(window.partitions)) return false;
-        if (!orderBy.equals(window.orderBy)) return false;
-        return windowFrame.equals(window.windowFrame);
+        return o instanceof Window that
+            && partitions.equals(that.partitions)
+            && orderBy.equals(that.orderBy)
+            && windowFrame.equals(that.windowFrame);
     }
 
     @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/WindowFrame.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/WindowFrame.java
@@ -54,14 +54,10 @@ public class WindowFrame extends Node {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        WindowFrame that = (WindowFrame) o;
-
-        if (mode != that.mode) return false;
-        if (!start.equals(that.start)) return false;
-        return end.equals(that.end);
+        return o instanceof WindowFrame that
+            && mode == that.mode
+            && start.equals(that.start)
+            && end.equals(that.end);
     }
 
     @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/With.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/With.java
@@ -22,7 +22,6 @@
 package io.crate.sql.tree;
 
 import java.util.List;
-import java.util.Objects;
 
 public class With extends Statement {
 
@@ -50,14 +49,12 @@ public class With extends Statement {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        With with = (With) o;
-        return withQueries.equals(with.withQueries);
+        return o instanceof With that
+            && withQueries.equals(that.withQueries);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(withQueries);
+        return withQueries.hashCode();
     }
 }

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/WithQuery.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/WithQuery.java
@@ -64,12 +64,10 @@ public class WithQuery extends Node {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        WithQuery withQuery = (WithQuery) o;
-        return name.equals(withQuery.name)
-            && query.equals(withQuery.query)
-            && Objects.equals(columnNames, withQuery.columnNames);
+        return o instanceof WithQuery that
+            && name.equals(that.name)
+            && query.equals(that.query)
+            && Objects.equals(columnNames, that.columnNames);
     }
 
     @Override


### PR DESCRIPTION
We mostly require braces, but the NeedBraces checkstyle rule is
currently commented out so some places slipped through and omit them.

This changes the sql-parser module to use it everywhere to be able to
active the rule in the future.
