### PR TITLE
Ensure precision > scale for random numeric type values

### DIFF
--- a/server/src/testFixtures/java/io/crate/testing/DataTypeTesting.java
+++ b/server/src/testFixtures/java/io/crate/testing/DataTypeTesting.java
@@ -211,7 +211,7 @@ public class DataTypeTesting {
                     Integer precision = numericType.numericPrecision();
                     int scale = numericType.scale() == null ? 0 : numericType.scale();
                     int maxDigits = precision == null ? 131072 : precision;
-                    int numDigits = random.nextInt(scale == 0 ? 1 : scale, maxDigits + 1);
+                    int numDigits = random.nextInt(scale == 0 ? 1 : scale + 1, maxDigits + 1);
                     StringBuilder sb = new StringBuilder(numDigits);
                     for (int i = 0; i < numDigits; i++) {
                         sb.append(random.nextInt(10));


### PR DESCRIPTION
Follow up to https://github.com/crate/crate/pull/16522
Sample failure:

    java.lang.IllegalArgumentException: Scale of numeric must be less than the precision. NUMERIC(15, 15) is unsupported.
    	at __randomizedtesting.SeedInfo.seed([D43F79D5607EA337:F12184A9BE25D189]:0)
    	at io.crate.types.NumericType.<init>(NumericType.java:79)
    	at io.crate.types.DataTypes.guessType(DataTypes.java:318)
    	at io.crate.testing.DataTypeTesting.extendedType(DataTypeTesting.java:273)
    	at io.crate.integrationtests.TransportSQLActionTest.test_types_with_storage_can_be_inserted_and_queried(TransportSQLActionTest.java:1944)
