### PR TITLE
Add support for large integers to parser/expression analyzer

### DIFF
--- a/libs/sql-parser/src/main/java/io/crate/sql/ExpressionFormatter.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/ExpressionFormatter.java
@@ -76,6 +76,7 @@ import io.crate.sql.tree.NegativeExpression;
 import io.crate.sql.tree.Node;
 import io.crate.sql.tree.NotExpression;
 import io.crate.sql.tree.NullLiteral;
+import io.crate.sql.tree.NumericLiteral;
 import io.crate.sql.tree.ObjectColumnType;
 import io.crate.sql.tree.ObjectLiteral;
 import io.crate.sql.tree.ParameterExpression;
@@ -265,6 +266,11 @@ public final class ExpressionFormatter {
         @Override
         protected String visitIntegerLiteral(IntegerLiteral node, @Nullable List<Expression> parameters) {
             return Integer.toString(node.getValue());
+        }
+
+        @Override
+        public String visitNumericLiteral(NumericLiteral numericLiteral, List<Expression> context) {
+            return numericLiteral.value().toString();
         }
 
         @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -2306,7 +2306,11 @@ class AstBuilder extends SqlBaseParserBaseVisitor<Node> {
     @Override
     public Node visitDecimalLiteral(SqlBaseParser.DecimalLiteralContext context) {
         String text = context.getText().replace("_", "");
-        return new DoubleLiteral(text);
+        BigDecimal bigDecimal = new BigDecimal(text);
+        if (bigDecimal.precision() <= 18 || bigDecimal.scale() < 0) {
+            return new DoubleLiteral(bigDecimal.doubleValue());
+        }
+        return new NumericLiteral(bigDecimal);
     }
 
     @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -23,6 +23,8 @@ package io.crate.sql.parser;
 
 import static java.util.Collections.emptyList;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -202,6 +204,7 @@ import io.crate.sql.tree.NotExpression;
 import io.crate.sql.tree.NotNullColumnConstraint;
 import io.crate.sql.tree.NullColumnConstraint;
 import io.crate.sql.tree.NullLiteral;
+import io.crate.sql.tree.NumericLiteral;
 import io.crate.sql.tree.ObjectColumnType;
 import io.crate.sql.tree.ObjectLiteral;
 import io.crate.sql.tree.OptimizeStatement;
@@ -2290,11 +2293,14 @@ class AstBuilder extends SqlBaseParserBaseVisitor<Node> {
     @Override
     public Node visitIntegerLiteral(SqlBaseParser.IntegerLiteralContext context) {
         String text = context.getText().replace("_", "");
-        long value = Long.parseLong(text);
-        if (value < Integer.MAX_VALUE + 1L) {
-            return new IntegerLiteral((int) value);
+        BigInteger bigInteger = new BigInteger(text);
+        int bitLength = bigInteger.bitLength();
+        if (bitLength <= 31) {
+            return new IntegerLiteral(bigInteger.intValueExact());
+        } else if (bitLength <= 63) {
+            return new LongLiteral(bigInteger.longValueExact());
         }
-        return new LongLiteral(value);
+        return new NumericLiteral(new BigDecimal(bigInteger, 0));
     }
 
     @Override

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
@@ -739,4 +739,8 @@ public abstract class AstVisitor<R, C> {
     public R visitDropUserMapping(DropUserMapping dropUserMapping, C context) {
         return visitStatement(dropUserMapping, context);
     }
+
+    public R visitNumericLiteral(NumericLiteral numericLiteral, C context) {
+        return visitLiteral(numericLiteral, context);
+    }
 }

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/DoubleLiteral.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/DoubleLiteral.java
@@ -21,14 +21,12 @@
 
 package io.crate.sql.tree;
 
-import static java.util.Objects.requireNonNull;
-
 public class DoubleLiteral extends Literal {
 
     private final double value;
 
-    public DoubleLiteral(String value) {
-        this.value = Double.parseDouble(requireNonNull(value, "value is null"));
+    public DoubleLiteral(double value) {
+        this.value = value;
     }
 
     public double getValue() {

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/NumericLiteral.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/NumericLiteral.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.sql.tree;
+
+import java.math.BigDecimal;
+
+public final class NumericLiteral extends Literal {
+
+    private final BigDecimal value;
+
+    public NumericLiteral(BigDecimal value) {
+        this.value = value;
+    }
+
+    public BigDecimal value() {
+        return value;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitNumericLiteral(this, context);
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof NumericLiteral num
+            && value.equals(num.value);
+    }
+}

--- a/libs/sql-parser/src/test/java/io/crate/sql/LiteralsTest.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/LiteralsTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 
 import io.crate.sql.parser.SqlParser;
 import io.crate.sql.tree.IntegerLiteral;
+import io.crate.sql.tree.Literal;
 import io.crate.sql.tree.NumericLiteral;
 
 public class LiteralsTest {
@@ -299,5 +300,13 @@ public class LiteralsTest {
     public void test_number_exceeding_long_range() throws Exception {
         var literal = SqlParser.createExpression("34533365386010436550");
         assertThat(literal).isEqualTo(new NumericLiteral(new BigDecimal("34533365386010436550")));
+    }
+
+    @Test
+    public void test_literal_from_bigdecimal() throws Exception {
+        var v = new BigDecimal("34533365386010436550");
+        Literal literal = Literal.fromObject(v);
+        assertThat(literal).isExactlyInstanceOf(NumericLiteral.class);
+        assertThat(((NumericLiteral) literal).value()).isEqualTo(v);
     }
 }

--- a/libs/sql-parser/src/test/java/io/crate/sql/LiteralsTest.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/LiteralsTest.java
@@ -25,10 +25,13 @@ package io.crate.sql;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.math.BigDecimal;
+
 import org.junit.jupiter.api.Test;
 
 import io.crate.sql.parser.SqlParser;
 import io.crate.sql.tree.IntegerLiteral;
+import io.crate.sql.tree.NumericLiteral;
 
 public class LiteralsTest {
 
@@ -290,5 +293,11 @@ public class LiteralsTest {
     public void test_integer_literal() {
         var literal = SqlParser.createExpression("2147483647");
         assertThat(literal).isEqualTo(new IntegerLiteral(Integer.MAX_VALUE));
+    }
+
+    @Test
+    public void test_number_exceeding_long_range() throws Exception {
+        var literal = SqlParser.createExpression("34533365386010436550");
+        assertThat(literal).isEqualTo(new NumericLiteral(new BigDecimal("34533365386010436550")));
     }
 }

--- a/libs/sql-parser/src/test/java/io/crate/sql/parser/TestSqlParser.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/parser/TestSqlParser.java
@@ -133,24 +133,24 @@ public class TestSqlParser {
 
     @Test
     public void testDouble() {
-        assertExpression("123.", new DoubleLiteral("123"));
-        assertExpression("123.0", new DoubleLiteral("123"));
-        assertExpression(".5", new DoubleLiteral(".5"));
-        assertExpression("123.5", new DoubleLiteral("123.5"));
+        assertExpression("123.", new DoubleLiteral(123));
+        assertExpression("123.0", new DoubleLiteral(123));
+        assertExpression(".5", new DoubleLiteral(.5));
+        assertExpression("123.5", new DoubleLiteral(123.5));
 
-        assertExpression("123E7", new DoubleLiteral("123E7"));
-        assertExpression("123.E7", new DoubleLiteral("123E7"));
-        assertExpression("123.0E7", new DoubleLiteral("123E7"));
-        assertExpression("123E+7", new DoubleLiteral("123E7"));
-        assertExpression("123E-7", new DoubleLiteral("123E-7"));
+        assertExpression("123E7", new DoubleLiteral(123E7));
+        assertExpression("123.E7", new DoubleLiteral(123E7));
+        assertExpression("123.0E7", new DoubleLiteral(123E7));
+        assertExpression("123E+7", new DoubleLiteral(123E7));
+        assertExpression("123E-7", new DoubleLiteral(123E-7));
 
-        assertExpression("123.456E7", new DoubleLiteral("123.456E7"));
-        assertExpression("123.456E+7", new DoubleLiteral("123.456E7"));
-        assertExpression("123.456E-7", new DoubleLiteral("123.456E-7"));
+        assertExpression("123.456E7", new DoubleLiteral(123.456E7));
+        assertExpression("123.456E+7", new DoubleLiteral(123.456E7));
+        assertExpression("123.456E-7", new DoubleLiteral(123.456E-7));
 
-        assertExpression(".4E42", new DoubleLiteral(".4E42"));
-        assertExpression(".4E+42", new DoubleLiteral(".4E42"));
-        assertExpression(".4E-42", new DoubleLiteral(".4E-42"));
+        assertExpression(".4E42", new DoubleLiteral(.4E42));
+        assertExpression(".4E+42", new DoubleLiteral(.4E42));
+        assertExpression(".4E-42", new DoubleLiteral(.4E-42));
     }
 
     @Test
@@ -167,7 +167,7 @@ public class TestSqlParser {
             new Query(
                 Optional.empty(),
                 new QuerySpecification(
-                    selectList(new DoubleLiteral("123.456E7")),
+                    selectList(new DoubleLiteral(123.456E7)),
                     table(QualifiedName.of("dual")),
                     Optional.empty(),
                     List.of(),

--- a/server/src/main/java/io/crate/analyze/NegateLiterals.java
+++ b/server/src/main/java/io/crate/analyze/NegateLiterals.java
@@ -21,6 +21,8 @@
 
 package io.crate.analyze;
 
+import java.math.BigDecimal;
+
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitor;
@@ -30,6 +32,7 @@ import io.crate.types.DoubleType;
 import io.crate.types.FloatType;
 import io.crate.types.IntegerType;
 import io.crate.types.LongType;
+import io.crate.types.NumericType;
 import io.crate.types.ShortType;
 
 public final class NegateLiterals extends SymbolVisitor<Void, Symbol> {
@@ -61,6 +64,8 @@ public final class NegateLiterals extends SymbolVisitor<Void, Symbol> {
                 return Literal.ofUnchecked(valueType, (Integer) value * -1);
             case LongType.ID:
                 return Literal.ofUnchecked(valueType, (Long) value * -1);
+            case NumericType.ID:
+                return Literal.ofUnchecked(valueType, ((BigDecimal) value).negate());
             default:
                 throw new UnsupportedOperationException(Symbols.format(
                     "Cannot negate %s. You may need to add explicit type casts", symbol));

--- a/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -28,6 +28,7 @@ import static io.crate.sql.tree.IntervalLiteral.IntervalField.MONTH;
 import static io.crate.sql.tree.IntervalLiteral.IntervalField.SECOND;
 import static io.crate.sql.tree.IntervalLiteral.IntervalField.YEAR;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -146,6 +147,7 @@ import io.crate.sql.tree.NegativeExpression;
 import io.crate.sql.tree.Node;
 import io.crate.sql.tree.NotExpression;
 import io.crate.sql.tree.NullLiteral;
+import io.crate.sql.tree.NumericLiteral;
 import io.crate.sql.tree.ObjectLiteral;
 import io.crate.sql.tree.ParameterExpression;
 import io.crate.sql.tree.QualifiedName;
@@ -164,6 +166,7 @@ import io.crate.types.ArrayType;
 import io.crate.types.BitStringType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
+import io.crate.types.NumericType;
 import io.crate.types.UndefinedType;
 
 /**
@@ -1000,6 +1003,13 @@ public class ExpressionAnalyzer {
         @Override
         protected Symbol visitIntegerLiteral(IntegerLiteral node, ExpressionAnalysisContext context) {
             return Literal.of(node.getValue());
+        }
+
+        @Override
+        public Symbol visitNumericLiteral(NumericLiteral numericLiteral, ExpressionAnalysisContext context) {
+            BigDecimal value = numericLiteral.value();
+            NumericType numericType = new NumericType(value.precision(), value.scale());
+            return Literal.of(numericType, value);
         }
 
         @Override

--- a/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -30,6 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -73,6 +74,7 @@ import io.crate.testing.SqlExpressions;
 import io.crate.testing.T3;
 import io.crate.types.BitStringType;
 import io.crate.types.DataTypes;
+import io.crate.types.NumericType;
 
 /**
  * Additional tests for the ExpressionAnalyzer.
@@ -403,6 +405,15 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         assertThatThrownBy(() -> executor.asSymbol("\"\"\"a[1]\"\"\""))
             .isExactlyInstanceOf(ColumnUnknownException.class)
             .hasMessage("Column \"a[1]\" unknown");
+    }
+
+    @Test
+    public void test_can_handle_large_numbers() throws Exception {
+        String expression = "34533365386010436550";
+        Symbol symbol = executor.asSymbol(expression);
+        assertThat(symbol).isExactlyInstanceOf(Literal.class);
+        assertThat(symbol.valueType()).isExactlyInstanceOf(NumericType.class);
+        assertThat(((Literal<?>) symbol).value()).isEqualTo(new BigDecimal(expression));
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -415,6 +415,11 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(symbol).isExactlyInstanceOf(Literal.class);
         assertThat(symbol.valueType()).isExactlyInstanceOf(NumericType.class);
         assertThat(((Literal<?>) symbol).value()).isEqualTo(new BigDecimal(expression));
+
+        symbol = executor.asSymbol("- " + expression);
+        assertThat(symbol).isExactlyInstanceOf(Literal.class);
+        assertThat(symbol.valueType()).isExactlyInstanceOf(NumericType.class);
+        assertThat(((Literal<?>) symbol).value()).isEqualTo(new BigDecimal(expression).negate());
     }
 
     @Test
@@ -427,6 +432,11 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(numericType.scale()).isEqualTo(4);
         assertThat(numericType.numericPrecision()).isEqualTo(24);
         assertThat(((Literal<?>) symbol).value()).isEqualTo(new BigDecimal(expression));
+
+        symbol = executor.asSymbol("- " + expression);
+        assertThat(symbol).isExactlyInstanceOf(Literal.class);
+        assertThat(symbol.valueType()).isExactlyInstanceOf(NumericType.class);
+        assertThat(((Literal<?>) symbol).value()).isEqualTo(new BigDecimal(expression).negate());
     }
 
     @Test

--- a/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -74,6 +74,7 @@ import io.crate.testing.SqlExpressions;
 import io.crate.testing.T3;
 import io.crate.types.BitStringType;
 import io.crate.types.DataTypes;
+import io.crate.types.DoubleType;
 import io.crate.types.NumericType;
 
 /**
@@ -408,12 +409,33 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
-    public void test_can_handle_large_numbers() throws Exception {
+    public void test_can_handle_large_integers() throws Exception {
         String expression = "34533365386010436550";
         Symbol symbol = executor.asSymbol(expression);
         assertThat(symbol).isExactlyInstanceOf(Literal.class);
         assertThat(symbol.valueType()).isExactlyInstanceOf(NumericType.class);
         assertThat(((Literal<?>) symbol).value()).isEqualTo(new BigDecimal(expression));
+    }
+
+    @Test
+    public void test_can_handle_large_float_numbers() throws Exception {
+        String expression = "34533365386010436550.1234";
+        Symbol symbol = executor.asSymbol(expression);
+        assertThat(symbol).isExactlyInstanceOf(Literal.class);
+        assertThat(symbol.valueType()).isExactlyInstanceOf(NumericType.class);
+        NumericType numericType = (NumericType) symbol.valueType();
+        assertThat(numericType.scale()).isEqualTo(4);
+        assertThat(numericType.numericPrecision()).isEqualTo(24);
+        assertThat(((Literal<?>) symbol).value()).isEqualTo(new BigDecimal(expression));
+    }
+
+    @Test
+    public void test_negative_scale_numeric_uses_double_type() throws Exception {
+        String expression = "1.79769313486231572014e+308";
+        Symbol symbol = executor.asSymbol(expression);
+        assertThat(symbol).isExactlyInstanceOf(Literal.class);
+        assertThat(symbol.valueType()).isExactlyInstanceOf(DoubleType.class);
+        assertThat(((Literal<?>) symbol).value()).isEqualTo(Double.parseDouble(expression));
     }
 
     @Test


### PR DESCRIPTION
Users couldn't use integer literals exceeding the `long` range.

Relates to https://github.com/crate/crate/issues/11119
Fixes a `test_neq_on_array_types_with_non_empty_array_does_not_filter_empty_array` failure:

    java.lang.NumberFormatException: For input string: "34533365386010436550"
    	at __randomizedtesting.SeedInfo.seed([565E8FD407F212F1:80E0CFB35C5DC3A4]:0)
    	at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:67)
    	at java.base/java.lang.Long.parseLong(Long.java:618)
    	at java.base/java.lang.Long.parseLong(Long.java:722)
    	at io.crate.sql.parser.AstBuilder.visitIntegerLiteral(AstBuilder.java:2293)
    	at io.crate.sql.parser.AstBuilder.visitIntegerLiteral(AstBuilder.java:267)
    [...]
    	at io.crate.sql.parser.SqlParser.invokeParser(SqlParser.java:138)
    	at io.crate.sql.parser.SqlParser.generateExpression(SqlParser.java:103)
    	at io.crate.sql.parser.SqlParser.createExpression(SqlParser.java:99)
    	at io.crate.testing.SqlExpressions.asSymbol(SqlExpressions.java:107)
    	at io.crate.testing.QueryTester$Builder.lambda$build$3(QueryTester.java:193)
    	at io.crate.testing.QueryTester.toQuery(QueryTester.java:234)
    	at io.crate.testing.QueryTester.runQuery(QueryTester.java:242)
    	at io.crate.expression.predicate.NotPredicateTest.test_neq_on_array_types_with_non_empty_array_does_not_filter_empty_array(NotPredicateTest.java:119)
