### PR TITLE
Preserve the number of shards of existing partitions when altering the table

### DIFF
--- a/docs/appendices/release-notes/5.8.2.rst
+++ b/docs/appendices/release-notes/5.8.2.rst
@@ -76,3 +76,7 @@ Fixes
 
 - Fixed an issue that caused queries with nested arrays, compared with `=` and
   `= ANY` operators in the ``WHERE`` clause to throw ``ClassCastException``.
+
+- Fixed a regression introduced with :ref:`version_5.6.0` that caused an
+  exception when altering a partitioned table where the current number of shards
+  differs from the number of shards of existing partitions.

--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
@@ -85,6 +85,7 @@ import io.crate.expression.symbol.format.Style;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.GeneratedReference;
+import io.crate.metadata.IndexParts;
 import io.crate.metadata.IndexReference;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.PartitionInfo;
@@ -1055,10 +1056,17 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
             if (allColumns.size() > allowedTotalColumns) {
                 throw new IllegalArgumentException("Limit of total columns [" + allowedTotalColumns + "] in table [" + ident + "] exceeded");
             }
+            var indexNumberOfShards = numberOfShards;
+            if (isPartitioned && IndexParts.isPartitioned(indexName)) {
+                // if the index is a part of a partitioned table,
+                // the actual value of the index must be used as the value for the whole partitioned table may have changed
+                indexNumberOfShards = indexMetadata.getNumberOfShards();
+            }
+
             metadataBuilder.put(
                 IndexMetadata.builder(indexMetadata)
                     .putMapping(new MappingMetadata(mapping))
-                    .numberOfShards(numberOfShards)
+                    .numberOfShards(indexNumberOfShards)
                     .mappingVersion(indexMetadata.getMappingVersion() + 1)
             );
         }

--- a/server/src/test/java/io/crate/metadata/doc/DocTableInfoTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocTableInfoTest.java
@@ -22,7 +22,7 @@
 package io.crate.metadata.doc;
 
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
 
@@ -36,6 +36,7 @@ import org.assertj.core.api.Assertions;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.settings.Settings;
 import org.junit.Test;
@@ -49,6 +50,7 @@ import io.crate.expression.symbol.VoidReference;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.IndexReference;
 import io.crate.metadata.IndexType;
+import io.crate.metadata.PartitionName;
 import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RelationName;
@@ -60,6 +62,7 @@ import io.crate.metadata.table.TableInfo;
 import io.crate.sql.tree.ColumnPolicy;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
+import io.crate.testing.UseRandomizedSchema;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.ObjectType;
@@ -568,5 +571,47 @@ public class DocTableInfoTest extends CrateDummyClusterServiceUnitTest {
         assertThat(table.getReference(oo)).hasName("o['o']")
             .hasType(ooType);
         assertThat(table.getReference(o)).hasName("o").hasType(oType);
+    }
+
+
+    /**
+     * Tests a regression introduced by https://github.com/crate/crate/commit/111ffe166e523a4a5cd3278975772ce365112b64
+     * where the number of shards of a partitioned table was not preserved when writing the table info to metadata.
+     */
+    @UseRandomizedSchema(random = false)
+    @Test
+    public void test_write_to_preserves_number_of_shards_of_partitions() throws Exception {
+        var partitionIndexName = new PartitionName(new RelationName("doc", "tbl"), singletonList("1")).asIndexName();
+        SQLExecutor e = SQLExecutor.of(clusterService)
+            .addPartitionedTable(
+                """
+                create table tbl (
+                    id int,
+                    p int
+                ) clustered into 2 shards partitioned by (p) with (number_of_replicas=0)
+                """,
+                partitionIndexName
+            );
+
+        ClusterState state = clusterService.state();
+        Metadata metadata = state.metadata();
+
+        // Change the number of shards of the partition table/template aka. ALTER TABLE tbl SET (number_of_shards=3)
+        var oldTemplate = metadata.templates().get(PartitionName.templateName("doc", "tbl"));
+        var newTemplate = new IndexTemplateMetadata.Builder(oldTemplate);
+        newTemplate.settings(Settings.builder().put(oldTemplate.settings()).put("index.number_of_shards", 3));
+
+        Metadata.Builder builder = new Metadata.Builder(metadata);
+        builder.put(newTemplate);
+        var newMetadata = builder.build();
+
+        DocTableInfoFactory docTableInfoFactory = new DocTableInfoFactory(e.nodeCtx);
+        DocTableInfo tbl = docTableInfoFactory.create(RelationName.fromIndexName("tbl"), newMetadata);
+
+        var newBuilder = new Metadata.Builder(metadata);
+        tbl.writeTo(newMetadata, newBuilder);
+
+        var partitionIndex = newBuilder.build().index(partitionIndexName);
+        assertThat(partitionIndex.getNumberOfShards()).isEqualTo(2);
     }
 }


### PR DESCRIPTION
Fixes a regression introduced by https://github.com/crate/crate/commit/111ffe166e523a4a5cd3278975772ce365112b64 which falsely applied the current number of shards of the parititioned table to existing partitions when altering the table. This causes an exception as changing the number of shards is only possible by using the special `resize` operation.

Fixes #16521.