### PR TITLE
Update maven plugins to their latest versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -361,16 +361,16 @@
 
     <versions.min_maven>3.6.3</versions.min_maven>
     <!-- Maven Plugins -->
-    <versions.plugin.dependency>3.7.1</versions.plugin.dependency>
+    <versions.plugin.dependency>3.8.0</versions.plugin.dependency>
     <versions.plugin.versions>2.17.1</versions.plugin.versions>
     <versions.plugin.enforcer>3.5.0</versions.plugin.enforcer>
     <versions.plugin.clean>3.4.0</versions.plugin.clean>
     <versions.plugin.resources>3.3.1</versions.plugin.resources>
-    <versions.plugin.install>3.1.2</versions.plugin.install>
+    <versions.plugin.install>3.1.3</versions.plugin.install>
     <versions.plugin.compiler>3.13.0</versions.plugin.compiler>
     <versions.plugin.jar>3.3.0</versions.plugin.jar>
-    <versions.plugin.surefire>3.3.1</versions.plugin.surefire>
-    <versions.plugin.checkstyle>3.4.0</versions.plugin.checkstyle>
+    <versions.plugin.surefire>3.5.0</versions.plugin.surefire>
+    <versions.plugin.checkstyle>3.5.0</versions.plugin.checkstyle>
     <versions.plugin.puppycrawl>10.17.0</versions.plugin.puppycrawl>
     <versions.plugin.toolchains>4.5.0</versions.plugin.toolchains>
     <versions.plugin.jacoco>0.8.12</versions.plugin.jacoco>
@@ -382,7 +382,7 @@
     <versions.plugin.shade>3.6.0</versions.plugin.shade>
     <versions.plugin.jar>3.4.2</versions.plugin.jar>
     <versions.plugin.build-helper>3.6.0</versions.plugin.build-helper>
-    <versions.plugin.antlr>4.13.1</versions.plugin.antlr>
+    <versions.plugin.antlr>4.13.2</versions.plugin.antlr>
   </properties>
 
   <modules>


### PR DESCRIPTION
dependency: 3.7.1 -> 3.8.0
install: 3.1.2 -> 3.1.3
surefire: 3.3.1 -> 3.5.0
checkstyle: 3.4.0 -> 3.5.0
antlr4: 4.13.1 -> 4.13.2

Unfortunately, surefire releases haven't been updated:
https://github.com/apache/maven-surefire/releases
but from Jira I only see bug fixes: https://issues.apache.org/jira/browse/SUREFIRE-2251?jql=project%20%3D%20SUREFIRE%20AND%20fixVersion%20in%20(3.4.0%2C%203.5.0)
nothing new to use for us.