### PR TITLE
Fix issue with mixed case names in UDFs

### DIFF
--- a/docs/appendices/release-notes/5.8.3.rst
+++ b/docs/appendices/release-notes/5.8.3.rst
@@ -47,6 +47,10 @@ See the :ref:`version_5.8.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed issue which caused :ref:`User Defined Functions<user-defined-functions>`
+  with mixed case function names (e.g. ``mYfUncTIOn``) to throw errors when used
+  in :ref:`generated columns<ddl-generated-columns>`.
+
 - Fixed an issue that caused failure of ``ALTER ROLE`` statements updating or
   resetting password of a user with specified :ref:`JWT <create-user-jwt>`
   properties.

--- a/libs/sql-parser/src/main/java/io/crate/sql/Identifiers.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/Identifiers.java
@@ -36,7 +36,7 @@ import io.crate.sql.parser.SqlParser;
 import io.crate.sql.parser.antlr.SqlBaseLexer;
 import io.crate.sql.tree.QualifiedNameReference;
 
-public class Identifiers {
+public final class Identifiers {
 
     private static final Pattern IDENTIFIER = Pattern.compile("(^[a-zA-Z_]+[a-zA-Z0-9_]*)");
     private static final Pattern ESCAPE_REPLACE_RE = Pattern.compile("\"", Pattern.LITERAL);
@@ -66,6 +66,8 @@ public class Identifiers {
         .filter(Keyword::isReserved)
         .map(Keyword::getWord)
         .collect(Collectors.toSet());
+
+    private Identifiers() {}
 
     /**
      * quote and escape the given identifier

--- a/server/src/main/java/io/crate/metadata/FunctionName.java
+++ b/server/src/main/java/io/crate/metadata/FunctionName.java
@@ -34,7 +34,7 @@ import io.crate.metadata.information.InformationSchemaInfo;
 import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
 import io.crate.sql.Identifiers;
 
-public final record FunctionName(@Nullable String schema, String name)
+public record FunctionName(@Nullable String schema, String name)
         implements Writeable, Accountable {
 
     public FunctionName(String name) {

--- a/server/src/main/java/io/crate/metadata/FunctionName.java
+++ b/server/src/main/java/io/crate/metadata/FunctionName.java
@@ -66,10 +66,16 @@ public record FunctionName(@Nullable String schema, String name)
     }
 
     public String displayName() {
-        if (schema == null) {
-            return name;
+        String functionName;
+        if (isBuiltin()) {
+            functionName = name;
+        } else {
+            functionName = Identifiers.quoteIfNeeded(name);
         }
-        return Identifiers.quoteIfNeeded(schema) + "." + name;
+        if (schema == null) {
+            return functionName;
+        }
+        return Identifiers.quoteIfNeeded(schema) + "." + functionName;
     }
 
     public boolean isBuiltin() {

--- a/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -1240,7 +1240,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
         Map<String, String> generatedColumnsMapping = (Map<String, String>) metaMapping.get("generated_columns");
         assertThat(generatedColumnsMapping).hasSize(1);
         // current_timestamp used to get evaluated and then this contained the actual timestamp instead of the function name
-        assertThat(generatedColumnsMapping.get("ts")).isEqualTo("\"current_timestamp\"(3)");
+        assertThat(generatedColumnsMapping.get("ts")).isEqualTo("current_timestamp(3)");
     }
 
     @Test
@@ -1371,7 +1371,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
         Map<String, Object> mappingProperties = Maps.get(mapping, "properties");
         assertThat(mappingProperties).isEqualTo(Map.of(
             "ts", Map.of(
-                "default_expr", "\"current_timestamp\"(3)",
+                "default_expr", "current_timestamp(3)",
                 "format", "epoch_millis||strict_date_optional_time",
                 "position", 1,
                 "type", "date"

--- a/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -26,7 +26,6 @@ import static io.crate.metadata.FulltextAnalyzerResolver.CustomType.ANALYZER;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_ROUTING_EXCLUDE_GROUP_SETTING;
 import static org.elasticsearch.index.engine.EngineConfig.INDEX_CODEC_SETTING;
@@ -884,7 +883,6 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
         Map<String, Object> mapping = TestingHelpers.toMapping(analysis);
         Map<String, Object> meta = (Map<String, Object>) mapping.get("_meta");
         List<String> primaryKeys = (List<String>) meta.get("primary_keys");
-        assertThat(primaryKeys).hasSize(2);
         assertThat(primaryKeys).containsExactly("id1", "id2");
     }
 
@@ -1242,7 +1240,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
         Map<String, String> generatedColumnsMapping = (Map<String, String>) metaMapping.get("generated_columns");
         assertThat(generatedColumnsMapping).hasSize(1);
         // current_timestamp used to get evaluated and then this contained the actual timestamp instead of the function name
-        assertThat(generatedColumnsMapping.get("ts")).isEqualTo("current_timestamp(3)");
+        assertThat(generatedColumnsMapping.get("ts")).isEqualTo("\"current_timestamp\"(3)");
     }
 
     @Test
@@ -1296,7 +1294,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
                     day as date_trunc('day', ts),
                     date_string as cast(day as string)
                 )
-                    """))
+                """))
             .isExactlyInstanceOf(ColumnValidationException.class)
             .hasMessage("Validation failed for date_string: Generated column cannot be based on generated column `day`");
     }
@@ -1373,7 +1371,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
         Map<String, Object> mappingProperties = Maps.get(mapping, "properties");
         assertThat(mappingProperties).isEqualTo(Map.of(
             "ts", Map.of(
-                "default_expr", "current_timestamp(3)",
+                "default_expr", "\"current_timestamp\"(3)",
                 "format", "epoch_millis||strict_date_optional_time",
                 "position", 1,
                 "type", "date"

--- a/server/src/test/java/io/crate/expression/udf/UserDefinedFunctionsMetadataTest.java
+++ b/server/src/test/java/io/crate/expression/udf/UserDefinedFunctionsMetadataTest.java
@@ -45,18 +45,18 @@ import io.crate.types.DataTypes;
 
 public class UserDefinedFunctionsMetadataTest extends ESTestCase {
 
-    private static String definition = "function(a, b) {return a - b;}";
-    private static List<FunctionArgumentDefinition> args = List.of(
+    private static final String DEFINITION = "function(a, b) {return a - b;}";
+    private static final List<FunctionArgumentDefinition> ARGS = List.of(
         FunctionArgumentDefinition.of(DataTypes.DOUBLE_ARRAY),
         FunctionArgumentDefinition.of("my_named_arg", DataTypes.DOUBLE)
     );
     private static final UserDefinedFunctionMetadata FUNCTION_METADATA = new UserDefinedFunctionMetadata(
         "my_schema",
         "my_add",
-        args,
+        ARGS,
         DataTypes.FLOAT,
         "dummy_lang",
-        definition
+        DEFINITION
     );
 
     public static final UserDefinedFunctionsMetadata DUMMY_UDF_METADATA = UserDefinedFunctionsMetadata.of(FUNCTION_METADATA);
@@ -68,7 +68,7 @@ public class UserDefinedFunctionsMetadataTest extends ESTestCase {
 
         StreamInput in = out.bytes().streamInput();
         UserDefinedFunctionMetadata udfMeta2 = new UserDefinedFunctionMetadata(in);
-        assertThat(FUNCTION_METADATA).isEqualTo(udfMeta2);
+        assertThat(udfMeta2).isEqualTo(FUNCTION_METADATA);
 
         assertThat(udfMeta2.schema()).isEqualTo("my_schema");
         assertThat(udfMeta2.name()).isEqualTo("my_add");
@@ -80,7 +80,7 @@ public class UserDefinedFunctionsMetadataTest extends ESTestCase {
         assertThat(udfMeta2.argumentTypes().get(1)).isEqualTo(DataTypes.DOUBLE);
         assertThat(udfMeta2.returnType()).isEqualTo(DataTypes.FLOAT);
         assertThat(udfMeta2.language()).isEqualTo("dummy_lang");
-        assertThat(udfMeta2.definition()).isEqualTo(definition);
+        assertThat(udfMeta2.definition()).isEqualTo(DEFINITION);
     }
 
     @Test
@@ -125,15 +125,15 @@ public class UserDefinedFunctionsMetadataTest extends ESTestCase {
         XContentParser parser = JsonXContent.JSON_XCONTENT.createParser(
             xContentRegistry(), DeprecationHandler.THROW_UNSUPPORTED_OPERATION, BytesReference.toBytes(BytesReference.bytes(builder)));
         parser.nextToken();  // enter START_OBJECT
-        ArrayType type2 = (ArrayType) UserDefinedFunctionMetadata.DataTypeXContent.fromXContent(parser);
+        ArrayType<?> type2 = (ArrayType<?>) UserDefinedFunctionMetadata.DataTypeXContent.fromXContent(parser);
         assertThat(type.equals(type2)).isTrue();
     }
 
     @Test
     public void testSameSignature() throws Exception {
-        assertThat(FUNCTION_METADATA.sameSignature("my_schema", "my_add", argumentTypesFrom(args))).isTrue();
-        assertThat(FUNCTION_METADATA.sameSignature("different_schema", "my_add", argumentTypesFrom(args))).isFalse();
-        assertThat(FUNCTION_METADATA.sameSignature("my_schema", "different_name", argumentTypesFrom(args))).isFalse();
+        assertThat(FUNCTION_METADATA.sameSignature("my_schema", "my_add", argumentTypesFrom(ARGS))).isTrue();
+        assertThat(FUNCTION_METADATA.sameSignature("different_schema", "my_add", argumentTypesFrom(ARGS))).isFalse();
+        assertThat(FUNCTION_METADATA.sameSignature("my_schema", "different_name", argumentTypesFrom(ARGS))).isFalse();
         assertThat(FUNCTION_METADATA.sameSignature("my_schema", "my_add", List.of())).isFalse();
     }
 

--- a/server/src/test/java/io/crate/expression/udf/UserDefinedFunctionsTest.java
+++ b/server/src/test/java/io/crate/expression/udf/UserDefinedFunctionsTest.java
@@ -22,9 +22,9 @@
 package io.crate.expression.udf;
 
 import static io.crate.testing.Asserts.assertThat;
-import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -34,6 +34,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import io.crate.analyze.FunctionArgumentDefinition;
+import io.crate.exceptions.UnsupportedFunctionException;
+import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.format.Style;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.FunctionProvider;
@@ -61,7 +64,7 @@ public class UserDefinedFunctionsTest extends UdfUnitTest {
         var udf = new UserDefinedFunctionMetadata(
             schema,
             name,
-            types.stream().map(FunctionArgumentDefinition::of).collect(toList()),
+            types.stream().map(FunctionArgumentDefinition::of).toList(),
             returnType,
             lang,
             definition);
@@ -85,6 +88,44 @@ public class UserDefinedFunctionsTest extends UdfUnitTest {
             "function subtract(a, b) { return a + b; }");
         assertThat(sqlExecutor.asSymbol("test.subtract(2::integer, 1::integer)"))
             .isLiteral(DummyFunction.RESULT);
+    }
+
+    @Test
+    public void test_function_name_and_schema_with_camel_case_strings() throws IOException {
+        // camelCase Schema and name
+        registerUserDefinedFunction(
+            DUMMY_LANG.name(),
+            "MyScHEmA",
+            "mYFunCTioN",
+            DataTypes.INTEGER,
+            List.of(DataTypes.INTEGER, DataTypes.INTEGER),
+            "function mYFunCTioN(a, b) { return a + b; }");
+
+        assertThatThrownBy(() -> sqlExecutor.asSymbol("MyScHEmA.mYFunCTioN(1::integer, 2::integer)"))
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
+            .hasMessage("Unknown function: myschema.myfunction(1, 2)");
+
+        Function f = (Function) sqlExecutor.asSymbol("\"MyScHEmA\".\"mYFunCTioN\"(ints, 10)");
+        assertThat(f.toString(Style.QUALIFIED)).isEqualTo("\"MyScHEmA\".\"mYFunCTioN\"(doc.users.ints, 10)");
+        assertThat(f.toString(Style.UNQUALIFIED)).isEqualTo("\"MyScHEmA\".\"mYFunCTioN\"(ints, 10)");
+
+        // null schema and camelCase name is considered as builtin -> no quoting
+        // a UDF cannot be created with a null schema, if not defined, the schema from `search_path` is used
+        registerUserDefinedFunction(
+            DUMMY_LANG.name(),
+            null,
+            "myOTHerFUncTIOn",
+            DataTypes.INTEGER,
+            List.of(DataTypes.INTEGER, DataTypes.INTEGER),
+            "function myOTHerFUncTIOn(a, b) { return a + b; }");
+
+        assertThatThrownBy(() -> sqlExecutor.asSymbol("myOTHerFUncTIOn(1::integer, 2::integer)"))
+            .isExactlyInstanceOf(UnsupportedFunctionException.class)
+            .hasMessage("Unknown function: myotherfunction(1, 2)");
+
+        f = (Function) sqlExecutor.asSymbol("\"myOTHerFUncTIOn\"(ints, 10)");
+        assertThat(f.toString(Style.QUALIFIED)).isEqualTo("myOTHerFUncTIOn(doc.users.ints, 10)");
+        assertThat(f.toString(Style.UNQUALIFIED)).isEqualTo("myOTHerFUncTIOn(ints, 10)");
     }
 
     @Test


### PR DESCRIPTION
When a UDF is used in a generated column then an Expression is built
with the use of the `SqlParser`, and `Function#toString(Style)`
is called to create a `GeneratedReference`. `toString(Style)` calls
in turn `Function#displayName()` which previously was not quoting
neither the schema nor the function name, thus the UDF in the generated
column ended up as lowercase, because of the use of
`SqlParser.createExpression()` which lowercases all unquoted
identifiers.

Fixes: #16549

Also some minor code improvements & warnings fix
