### PR TITLE
Fix automatic dimensions leveling of AnyEqOperator with nested arrays

### DIFF
--- a/docs/appendices/release-notes/5.8.4.rst
+++ b/docs/appendices/release-notes/5.8.4.rst
@@ -60,3 +60,7 @@ Fixes
 - Fixed an issue that caused filtering by :ref:`ALL <all_array_comparison>`
   operator on :ref:`REAL <type-real>` array columns against literals to return
   invalid results.
+
+- Fixed an issue that caused :ref:`in <sql_in_array_comparison>` operator with
+  array typed column on left hand side of the arguments to return invalid
+  results.

--- a/docs/appendices/release-notes/5.8.4.rst
+++ b/docs/appendices/release-notes/5.8.4.rst
@@ -64,3 +64,7 @@ Fixes
 - Fixed an issue that caused :ref:`in <sql_in_array_comparison>` operator with
   array typed column on left hand side of the arguments to return invalid
   results.
+
+- Fixed an issue that caused ``=`` :ref:`ANY <sql_any_array_comparison>`
+  operator to throw a ``ClassCastException`` when the right hand side argument
+  was more than 1 dimensions higher than the left hand side argument.

--- a/server/src/main/java/io/crate/expression/operator/any/AnyRangeOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/any/AnyRangeOperator.java
@@ -22,12 +22,13 @@
 package io.crate.expression.operator.any;
 
 
-import java.util.List;
+import java.util.Objects;
+import java.util.stream.StreamSupport;
 
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
-import org.jetbrains.annotations.NotNull;
 
 import io.crate.exceptions.UnsupportedFeatureException;
 import io.crate.expression.operator.CmpOperator;
@@ -38,6 +39,7 @@ import io.crate.metadata.Reference;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 import io.crate.sql.tree.ComparisonExpression;
+import io.crate.types.ArrayType;
 
 public final class AnyRangeOperator extends AnyOperator<Object> {
 
@@ -104,7 +106,16 @@ public final class AnyRangeOperator extends AnyOperator<Object> {
     }
 
     @Override
-    protected Query refMatchesAnyArrayLiteral(Function any, Reference probe, @NotNull List<?> nonNullValues, Context context) {
+    protected Query refMatchesAnyArrayLiteral(Function any, Reference probe, Literal<?> candidates, Context context) {
+        if (ArrayType.dimensions(candidates.valueType()) > 1) {
+            return null;
+        }
+        var nonNullValues = StreamSupport
+            .stream(((Iterable<?>) candidates.value()).spliterator(), false)
+            .filter(Objects::nonNull).toList();
+        if (nonNullValues.isEmpty()) {
+            return new MatchNoDocsQuery("Cannot match unless there is at least one non-null candidate");
+        }
         // col < ANY ([1,2,3]) --> or(col<1, col<2, col<3)
         BooleanQuery.Builder booleanQuery = new BooleanQuery.Builder();
         booleanQuery.setMinimumNumberShouldMatch(1);

--- a/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -811,4 +811,13 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
         Query query = convert("(obj_no_sub_columns != {})");
         assertThat(query).hasToString("+(+*:* -(obj_no_sub_columns = {})) #(NOT (obj_no_sub_columns = {}))");
     }
+
+    @Test
+    public void test_in_operator_with_arrays_on_both_lhs_and_rhs() {
+        Query query = convert("(string_array in (['hello', 'world']))");
+        assertThat(query).hasToString("+string_array:(hello world) #(string_array = ANY([['hello', 'world']]))");
+
+        query = convert("(['hello', 'world'] in (string_array))");
+        assertThat(query).hasToString("(['hello', 'world'] = ANY([string_array]))");
+    }
 }

--- a/server/src/test/java/io/crate/lucene/LuceneQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/LuceneQueryBuilderTest.java
@@ -93,6 +93,7 @@ public abstract class LuceneQueryBuilderTest extends CrateDummyClusterServiceUni
                " x_array_no_docvalues array(int) storage with (columnstore = false)," +
                " o_array array(object as (xs array(integer), obj object as (x int), o_array_2 array(object as (x int))))," +
                " ts_array array(timestamp with time zone)," +
+               " string_array array(string)," +
                " shape geo_shape," +
                " bkd_shape geo_shape index using bkdtree," +
                " point geo_point," +

--- a/server/src/test/java/io/crate/lucene/NestedArrayLuceneQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/NestedArrayLuceneQueryBuilderTest.java
@@ -31,7 +31,8 @@ public class NestedArrayLuceneQueryBuilderTest extends LuceneQueryBuilderTest {
     protected String createStmt() {
         return """
             create table t (
-                a int[][]
+                a int[][],
+                b int[]
             )
             """;
     }
@@ -61,5 +62,12 @@ public class NestedArrayLuceneQueryBuilderTest extends LuceneQueryBuilderTest {
         var query = convert("a = any([ [ [1], [1, 2] ], [ [3], [4, 5] ] ])");
         // pre-filter by a terms query with 1, 2, 3, 4, 5 then a generic function query to make sure an exact match
         assertThat(query.toString()).isEqualTo("+a:{1 2 3 4 5} #(a = ANY([[[1], [1, 2]], [[3], [4, 5]]]))");
+    }
+
+    @Test
+    public void test_any_equals_nested_array_literal_with_automatic_array_dimension_leveling() {
+        var query = convert("b = any([ [ [1], [1, 2] ], [ [3], [4, 5] ] ])");
+        // pre-filter by a terms query with 1, 2, 3, 4, 5 then a generic function query to make sure an exact match
+        assertThat(query.toString()).isEqualTo("+b:{1 2 3 4 5} #(b = ANY([[1], [1, 2], [3], [4, 5]]))");
     }
 }


### PR DESCRIPTION
Follows https://github.com/crate/crate/pull/16497.

## Summary of the changes / Why this improves CrateDB
Fixes:
```
cr> create table t (a int[]);
CREATE OK, 1 row affected (8.832 sec)
cr> select * from t where a = any([[[1]]]);
ClassCastException[class java.util.ArrayList cannot be cast to class java.lang.Number (java.util.ArrayList and java.lang.Number are in module java.base of loader 'bootstrap')]
```

And also https://github.com/crate/crate/issues/16652.
## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
