### PR TITLE
Fix ambiguous symbol lookup

### DIFF
--- a/docs/appendices/release-notes/5.8.3.rst
+++ b/docs/appendices/release-notes/5.8.3.rst
@@ -47,6 +47,9 @@ See the :ref:`version_5.8.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that could cause errors like ``ClassCastException`` if using
+  column aliases in a Subquery that lead to ambiguous column names.
+
 - Fixed issue which caused :ref:`User Defined Functions<user-defined-functions>`
   with mixed case function names (e.g. ``mYfUncTIOn``) to throw errors when used
   in :ref:`generated columns<ddl-generated-columns>`.

--- a/server/src/main/java/io/crate/analyze/relations/AliasedAnalyzedRelation.java
+++ b/server/src/main/java/io/crate/analyze/relations/AliasedAnalyzedRelation.java
@@ -72,7 +72,7 @@ public class AliasedAnalyzedRelation implements AnalyzedRelation, FieldResolver 
                 columnAlias = ColumnIdent.of(columnAliases.get(i));
             }
             aliasToColumnMapping.put(columnAlias, childColumn);
-            var scopedSymbol = new ScopedSymbol(alias, columnAlias, childOutput.valueType());
+            var scopedSymbol = new ScopedSymbol(alias, columnAlias, childOutput);
             outputs.add(scopedSymbol);
             scopedSymbols.add(scopedSymbol);
         }
@@ -121,7 +121,7 @@ public class AliasedAnalyzedRelation implements AnalyzedRelation, FieldResolver 
                 new ReferenceIdent(alias, voidReference.column()),
                 voidReference.position());
         }
-        ScopedSymbol scopedSymbol = new ScopedSymbol(alias, column, field.valueType());
+        ScopedSymbol scopedSymbol = new ScopedSymbol(alias, column, field);
 
         // If the scopedSymbol exists already, return that instance.
         // Otherwise (e.g. lazy-loaded subscript expression) it must be stored to comply with

--- a/server/src/main/java/io/crate/analyze/relations/AnalyzedView.java
+++ b/server/src/main/java/io/crate/analyze/relations/AnalyzedView.java
@@ -60,7 +60,7 @@ public final class AnalyzedView implements AnalyzedRelation, FieldResolver {
         for (int i = 0; i < childOutputs.size(); i++) {
             var output = childOutputs.get(i);
             var column = output.toColumn();
-            outputs.add(new ScopedSymbol(name, column, output.valueType()));
+            outputs.add(new ScopedSymbol(name, column, output));
         }
         this.outputSymbols = List.copyOf(outputs);
     }
@@ -94,7 +94,7 @@ public final class AnalyzedView implements AnalyzedRelation, FieldResolver {
         if (field == null || field instanceof VoidReference) {
             return field;
         }
-        ScopedSymbol scopedSymbol = new ScopedSymbol(name, column, field.valueType());
+        ScopedSymbol scopedSymbol = new ScopedSymbol(name, column, field);
         int i = outputSymbols.indexOf(scopedSymbol);
         if (i >= 0) {
             return outputSymbols.get(i);


### PR DESCRIPTION
In cases like:

    SELECT *, y as x FROM tbl

With the table `tbl` having the columns `(x int, y int)`, any parent
query could mix up `x` and `y as x` because aliased relations would have
the outputs:

    ScopedSymbol(x, relation=tbl, type=int)
    ScopedSymbol(x, relation=tbl, type=int)

Which couldn't be distinguished via equals/hashCode.
This led to various places in the code mixing up the symbols, or
incorrectly pruning one of the outputs.

To make these two symbols unique this adds an `identity` property to
`ScopedSymbol` which can be set to the identity hash of a linked symbol
without introducing a hard reference to the child symbol. Adding a hard
reference would be confusing for methods like `symbol.any()` and doesn't
fit for cases like UNION where a `ScopedSymbol` points to more than one
child symbol.

Closes https://github.com/crate/crate/issues/16555