### PR TITLE
Fix MemorySegmentIndexInputProvider lookup failures in jmh benchmarks

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -33,6 +33,9 @@
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <mainClass>org.openjdk.jmh.Main</mainClass>
+                  <manifestEntries>
+                    <Multi-Release>true</Multi-Release>
+                  </manifestEntries>
                 </transformer>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
               </transformers>

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -22,6 +22,13 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <version>${versions.plugin.shade}</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-transform-maven-shade-plugin-extensions</artifactId>
+            <version>0.1.0</version>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
             <phase>package</phase>
@@ -31,6 +38,7 @@
             <configuration>
               <finalName>${uberjar.name}</finalName>
               <transformers>
+                <transformer implementation="org.apache.logging.log4j.maven.plugins.shade.transformer.Log4j2PluginCacheFileTransformer"/>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <mainClass>org.openjdk.jmh.Main</mainClass>
                   <manifestEntries>

--- a/devs/docs/benchmarks.rst
+++ b/devs/docs/benchmarks.rst
@@ -8,7 +8,7 @@ Microbenchmarks are written using `JMH`_. To execute them, first build the JAR::
 
 Then run the JAR::
 
-    $ java -jar benchmarks/target/benchmarks.jar
+    $ java --add-modules jdk.incubator.vector -jar benchmarks/target/benchmarks.jar
 
 The `java` version needs to be equal or greater than the configured toolchain.
 Maven automatically downloads the JDK when it is missing and it should be
@@ -20,11 +20,11 @@ To get the configured JDK version, use::
 
 If you want to execute specific benchmarks you can provide a filter argument::
 
-    $ java -jar benchmarks/target/benchmarks.jar <benchmarkMethodName | benchmarkClassName>"
+    $ java --add-modules jdk.incubator.vector -jar benchmarks/target/benchmarks.jar <benchmarkMethodName | benchmarkClassName>"
 
 To save the results to a file, use the ``-rf`` and ``-rff`` options::
 
-    $ java -jar benchmarks/target/benchmarks.jar -rf json -rff /tmp/jmh.json
+    $ java --add-modules jdk.incubator.vector -jar benchmarks/target/benchmarks.jar -rf json -rff /tmp/jmh.json
 
 If you are writing new benchmarks, take a look at this `JMH introduction`_ and
 these `JMH samples`_.


### PR DESCRIPTION
See commits. First commit fixes the benchmarks. Second commit fixes some log4j errors in the output.

Running `java -jar benchmarks/target/benchmarks.jar` led to errors like:

    java.lang.LinkageError: MemorySegmentIndexInputProvider is missing in Lucene JAR file
            at org.apache.lucene.store.MMapDirectory.lookupProvider(MMapDirectory.java:446)
            at java.base/java.security.AccessController.doPrivileged(AccessController.java:319)
            at org.apache.lucene.store.MMapDirectory.doPrivileged(MMapDirectory.java:404)
            at org.apache.lucene.store.MMapDirectory.<clinit>(MMapDirectory.java:462)
            at org.apache.lucene.store.FSDirectory.open(FSDirectory.java:161)
            at org.elasticsearch.env.NodeEnvironment$NodeLock.<init>(NodeEnvironment.java:203)
            at org.elasticsearch.env.NodeEnvironment.<init>(NodeEnvironment.java:259)
            at org.elasticsearch.node.Node.<init>(Node.java:319)
            at io.crate.analyze.PreExecutionBenchmark.setup(PreExecutionBenchmark.java:77)

Since we upgraded to Lucene 9.10, because Lucene makes use of
multi-releases JARs (https://openjdk.org/jeps/238)

The uberjar we generate for the benchmarks must be marked as
multi-release JAR as well, otherwise `MemorySegmentIndexInputProvider`
isn't available in the classpath.
