### PR TITLE
Fix nullability issue for CAST on object columns

### DIFF
--- a/docs/appendices/release-notes/5.8.3.rst
+++ b/docs/appendices/release-notes/5.8.3.rst
@@ -47,6 +47,14 @@ See the :ref:`version_5.8.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that caused ``WHERE`` clause to fail to filter rows when
+  the clause contained casts on null object columns under ``NOT`` operator.
+  e.g.::
+
+    CREATE  TABLE  t1(c0 OBJECT NULL);
+    INSERT INTO t1(c0) VALUES (NULL);
+    SELECT * FROM t1 WHERE NOT (CAST(t1.c0 AS STRING) ='');
+
 - Fixed an issue that could cause errors like ``ClassCastException`` if using
   column aliases in a Subquery that lead to ambiguous column names.
 

--- a/server/src/main/java/io/crate/expression/predicate/NotPredicate.java
+++ b/server/src/main/java/io/crate/expression/predicate/NotPredicate.java
@@ -153,6 +153,7 @@ public class NotPredicate extends Scalar<Boolean, Boolean> {
                 var b = function.arguments().get(1);
                 if (a instanceof Reference ref && b instanceof Literal<?>) {
                     if (ref.valueType().id() == DataTypes.UNTYPED_OBJECT.id()) {
+                        context.enforceThreeValuedLogic = true;
                         return null;
                     }
                 }

--- a/server/src/test/java/io/crate/expression/predicate/FieldExistsQueryTest.java
+++ b/server/src/test/java/io/crate/expression/predicate/FieldExistsQueryTest.java
@@ -102,10 +102,9 @@ public class FieldExistsQueryTest extends LuceneQueryBuilderTest {
             if (values == null) {
                 assertThat(results).isEmpty();
             } else {
-                assertThat(results).hasSize(2);
+                assertThat(results).hasSize(1);
                 assertThat(results.get(0)).isInstanceOf(Map.class);
                 assertThat((Map<?, ?>) results.get(0)).isEmpty();
-                assertThat(results.get(1)).isNull();
             }
         }
     }

--- a/server/src/test/java/io/crate/lucene/ThreeValuedLogicQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/ThreeValuedLogicQueryBuilderTest.java
@@ -135,4 +135,10 @@ public class ThreeValuedLogicQueryBuilderTest extends LuceneQueryBuilderTest {
         assertThat(convert("NOT pg_catalog.format_type(x, null)")).hasToString(
             "+(+*:* -pg_catalog.format_type(x, NULL)) #(NOT pg_catalog.format_type(x, NULL))");
     }
+
+    @Test
+    public void test_negated_cast_on_object() {
+        assertThat(convert("NOT (cast(obj as string))")).hasToString(
+            "+(+*:* -cast(obj AS text)) #(NOT cast(obj AS text))");
+    }
 }


### PR DESCRIPTION
Previously, when using `CAST` on an object column in the WHERE clause, it would falsely match and return back rows for which the value for the object column was `null`. Set `enforceThreeValuedLogic` flag to true to correctly produce the Lucene query to filter out the nulls.

Fixes: #16556
