### PR TITLE
Fix issue with LIKE/ILIKE on INDEX OFF cols with empty pattern    

### DIFF
--- a/docs/appendices/release-notes/5.8.3.rst
+++ b/docs/appendices/release-notes/5.8.3.rst
@@ -47,6 +47,11 @@ See the :ref:`version_5.8.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that caused ``WHERE`` clause to filter out all rows when the
+  clause contained a :ref:`LIKE or ILIKE<sql_dql_like>` operator on a column
+  declared with :ref:`INDEX OFF<sql_ddl_index_off>` and the pattern was an empty
+  string (``''``).
+
 - Fixed an issue that caused ``WHERE`` clause to fail to filter rows when
   the clause contained casts on null object columns under ``NOT`` operator.
   e.g.::
@@ -58,9 +63,10 @@ Fixes
 - Fixed an issue that could cause errors like ``ClassCastException`` if using
   column aliases in a Subquery that lead to ambiguous column names.
 
-- Fixed issue which caused :ref:`User Defined Functions<user-defined-functions>`
-  with mixed case function names (e.g. ``mYfUncTIOn``) to throw errors when used
-  in :ref:`generated columns<ddl-generated-columns>`.
+- Fixed an issue which caused
+  :ref:`User Defined Functions<user-defined-functions>` with mixed case function
+  names (e.g. ``mYfUncTIOn``) to throw errors when used in
+  :ref:`generated columns<ddl-generated-columns>`.
 
 - Fixed an issue that caused failure of ``ALTER ROLE`` statements updating or
   resetting password of a user with specified :ref:`JWT <create-user-jwt>`

--- a/server/src/main/java/io/crate/expression/operator/LikeOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/LikeOperator.java
@@ -71,8 +71,8 @@ public class LikeOperator extends Operator<String> {
             };
         } else {
             // BWC branch for pre-5.6 signature without ESCAPE.
-            escapeFromInputs = (ignored) -> LikeOperators.DEFAULT_ESCAPE;
-            escapeFromSymbols = (ignored) -> LikeOperators.DEFAULT_ESCAPE;
+            escapeFromInputs = ignored -> LikeOperators.DEFAULT_ESCAPE;
+            escapeFromSymbols = ignored -> LikeOperators.DEFAULT_ESCAPE;
         }
     }
 

--- a/server/src/main/java/io/crate/expression/operator/LikeOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/LikeOperator.java
@@ -24,9 +24,7 @@ package io.crate.expression.operator;
 import java.util.List;
 import java.util.regex.Pattern;
 
-import org.apache.lucene.index.Term;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.TermQuery;
 import org.jetbrains.annotations.Nullable;
 
 import io.crate.data.Input;
@@ -43,6 +41,8 @@ import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 import io.crate.role.Roles;
+import io.crate.types.EqQuery;
+import io.crate.types.StorageSupport;
 
 public class LikeOperator extends Operator<String> {
 
@@ -132,7 +132,13 @@ public class LikeOperator extends Operator<String> {
             assert value instanceof String
                 : "LikeOperator is registered for string types. Value must be a string";
             if (((String) value).isEmpty()) {
-                return new TermQuery(new Term(ref.storageIdent(), ""));
+                StorageSupport<?> storageSupport = ref.valueType().storageSupport();
+                EqQuery<?> eqQuery = storageSupport == null ? null : storageSupport.eqQuery();
+                if (eqQuery == null) {
+                    return null;
+                }
+                return ((EqQuery<Object>) eqQuery).termQuery(
+                    ref.storageIdent(), value, ref.hasDocValues(), ref.indexType() != IndexType.NONE);
             }
             Character escapeChar = escapeFromSymbols.apply(args);
             return caseSensitivity.likeQuery(ref.storageIdent(),

--- a/server/src/main/java/io/crate/expression/operator/any/AnyOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/any/AnyOperator.java
@@ -151,7 +151,6 @@ public abstract sealed class AnyOperator<T> extends Operator<T>
         return anyNulls ? null : false;
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public Query toQuery(Function function, Context context) {
         List<Symbol> args = function.arguments();
@@ -161,7 +160,7 @@ public abstract sealed class AnyOperator<T> extends Operator<T>
             candidates = fn.arguments().get(0);
         }
         if (probe instanceof Literal<?> literal && candidates instanceof Reference ref) {
-            return literalMatchesAnyArrayRef(function, (Literal<T>) literal, ref, context);
+            return literalMatchesAnyArrayRef(function, literal, ref, context);
         } else if (probe instanceof Reference ref && candidates instanceof Literal<?> literal) {
             var nonNullValues = StreamSupport
                 .stream(((Iterable<?>) literal.value()).spliterator(), false)

--- a/server/src/test/java/io/crate/lucene/LikeQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/LikeQueryBuilderTest.java
@@ -140,6 +140,12 @@ public class LikeQueryBuilderTest extends LuceneQueryBuilderTest {
         assertThat(query)
             .hasToString("(text_no_index LIKE '%abc%')")
             .isExactlyInstanceOf(GenericFunctionQuery.class);
+
+        // When pattern is empty string, if follows a different code path
+        query = convert("text_no_index LIKE ''");
+        assertThat(query)
+            .hasToString("(text_no_index LIKE '')")
+            .isExactlyInstanceOf(GenericFunctionQuery.class);
     }
 
     @Test
@@ -147,6 +153,12 @@ public class LikeQueryBuilderTest extends LuceneQueryBuilderTest {
         Query query = convert("text_no_index ILIKE '%abc%'");
         assertThat(query)
             .hasToString("(text_no_index ILIKE '%abc%')")
+            .isExactlyInstanceOf(GenericFunctionQuery.class);
+
+        // When pattern is empty string, if follows a different code path
+        query = convert("text_no_index ILIKE ''");
+        assertThat(query)
+            .hasToString("(text_no_index ILIKE '')")
             .isExactlyInstanceOf(GenericFunctionQuery.class);
     }
 

--- a/server/src/test/java/io/crate/lucene/LikeQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/LikeQueryBuilderTest.java
@@ -123,49 +123,56 @@ public class LikeQueryBuilderTest extends LuceneQueryBuilderTest {
     @Test
     public void test_like_on_varchar_column_uses_wildcard_query() throws Exception {
         Query query = convert("vchar_name LIKE 'Trillian%'");
-        assertThat(query).hasToString("vchar_name:Trillian*");
-        assertThat(query).isExactlyInstanceOf(WildcardQuery.class);
+        assertThat(query)
+            .hasToString("vchar_name:Trillian*")
+            .isExactlyInstanceOf(WildcardQuery.class);
 
         // Verify that version with ESCAPE doesn't lose it on rewriting function.
         query = convert("vchar_name LIKE 'Trillian%' ESCAPE '\\'");
-        assertThat(query).hasToString("vchar_name:Trillian*");
-        assertThat(query).isExactlyInstanceOf(WildcardQuery.class);
+        assertThat(query)
+            .hasToString("vchar_name:Trillian*")
+            .isExactlyInstanceOf(WildcardQuery.class);
     }
 
     @Test
     public void test_like_on_index_off_column_falls_back_to_generic_query() {
         Query query = convert("text_no_index LIKE '%abc%'");
-        assertThat(query).hasToString("(text_no_index LIKE '%abc%')");
-        assertThat(query).isExactlyInstanceOf(GenericFunctionQuery.class);
+        assertThat(query)
+            .hasToString("(text_no_index LIKE '%abc%')")
+            .isExactlyInstanceOf(GenericFunctionQuery.class);
     }
 
     @Test
     public void test_ilike_on_index_off_column_falls_back_to_generic_query() {
         Query query = convert("text_no_index ILIKE '%abc%'");
-        assertThat(query).hasToString("(text_no_index ILIKE '%abc%')");
-        assertThat(query).isExactlyInstanceOf(GenericFunctionQuery.class);
+        assertThat(query)
+            .hasToString("(text_no_index ILIKE '%abc%')")
+            .isExactlyInstanceOf(GenericFunctionQuery.class);
     }
 
     @Test
     public void test_not_like_any_on_index_off_column_falls_back_to_generic_query() {
         Query query = convert("text_no_index not LIKE any(['%abc%'])");
-        assertThat(query).hasToString("(text_no_index NOT LIKE ANY(['%abc%']))");
-        assertThat(query).isExactlyInstanceOf(GenericFunctionQuery.class);
+        assertThat(query)
+            .hasToString("(text_no_index NOT LIKE ANY(['%abc%']))")
+            .isExactlyInstanceOf(GenericFunctionQuery.class);
     }
 
     @Test
     public void test_ilike_any_on_index_off_column_falls_back_to_generic_query() {
         Query query = convert("text_no_index ILIKE any(['%abc%'])");
-        assertThat(query).hasToString("(text_no_index ILIKE ANY(['%abc%']))");
-        assertThat(query).isExactlyInstanceOf(GenericFunctionQuery.class);
+        assertThat(query)
+            .hasToString("(text_no_index ILIKE ANY(['%abc%']))")
+            .isExactlyInstanceOf(GenericFunctionQuery.class);
     }
 
     // tracks a bug https://github.com/crate/crate/issues/15743
     @Test
     public void test_like_empty_string_results_in_term_query() {
         Query query = convert("name like ''");
-        assertThat(query).hasToString("name:");
-        assertThat(query).isExactlyInstanceOf(TermQuery.class);
+        assertThat(query)
+            .hasToString("name:")
+            .isExactlyInstanceOf(TermQuery.class);
     }
 
     @Test


### PR DESCRIPTION
When the pattern is empty, a different code path is followed, to
use a more performant `TermsQuery`, but if the column is declared
with `INDEX OFF`, the `TermsQuery` wouldn't match any row. Fallback
to a `GenericFunctionFilter` in that case.
    
Fixes: #16567
