### PR TITLE
tests: Fix flakiness due to random NUMERIC data generation

### DIFF
--- a/server/src/testFixtures/java/io/crate/testing/DataTypeTesting.java
+++ b/server/src/testFixtures/java/io/crate/testing/DataTypeTesting.java
@@ -211,10 +211,11 @@ public class DataTypeTesting {
                     Integer precision = numericType.numericPrecision();
                     int scale = numericType.scale() == null ? 0 : numericType.scale();
                     int maxDigits = precision == null ? 131072 : precision;
-                    int numDigits = random.nextInt(scale == 0 ? 1 : scale + 1, maxDigits + 1);
+                    int numDigits = random.nextInt(scale + 1, maxDigits + 1);
                     StringBuilder sb = new StringBuilder(numDigits);
                     for (int i = 0; i < numDigits; i++) {
-                        sb.append(random.nextInt(10));
+                        int lowBound = (i == 0) ? 1 : 0; // don't allow leading zeros
+                        sb.append(random.nextInt(lowBound, 10));
                     }
                     BigInteger bigInt = new BigInteger(sb.toString());
                     return (T) new BigDecimal(bigInt, scale, numericType.mathContext());


### PR DESCRIPTION
During generation of the source big int, don't allow the first digit to be `0`, as this can lead to number like: `00021234...`, so the calculated scale can then be `>=` precision.

Follows: #16518
Follows: #16522
