### PR TITLE
tests: Replace `refresh()` with `execute("refresh table XXX")`

### DIFF
--- a/plugins/es-analysis-common/src/test/java/io/crate/integrationtests/FulltextAnalyzerResolverTest.java
+++ b/plugins/es-analysis-common/src/test/java/io/crate/integrationtests/FulltextAnalyzerResolverTest.java
@@ -449,7 +449,7 @@ public class FulltextAnalyzerResolverTest extends IntegTestCase {
         execute("insert into test (id, name, content) values (?, ?, ?)", new Object[]{
             2, "another phrase", "Don't panic!"
         });
-        refresh();
+        execute("refresh table test");
         SQLResponse response = execute("select id from test where match(content, 'brown jump')");
         assertThat(response.rowCount()).isEqualTo(1L);
         assertThat(response.rows()[0][0]).isEqualTo(1);

--- a/server/src/test/java/io/crate/execution/engine/collect/DocLevelCollectTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/DocLevelCollectTest.java
@@ -101,7 +101,7 @@ public class DocLevelCollectTest extends IntegTestCase {
                                               "  id integer," +
                                               "  name string," +
                                               "  date timestamp with time zone" +
-                                              ") clustered into 2 shards partitioned by (date, name) with(number_of_replicas=0)", PARTITIONED_TABLE_NAME));
+                                              ") clustered into 2 shards partitioned by (date) with(number_of_replicas=0)", PARTITIONED_TABLE_NAME));
         ensureGreen();
         execute(String.format(Locale.ENGLISH, "insert into %s (id, name, date) values (?, ?, ?)",
             PARTITIONED_TABLE_NAME),
@@ -110,7 +110,7 @@ public class DocLevelCollectTest extends IntegTestCase {
             PARTITIONED_TABLE_NAME),
             new Object[]{2, "Trillian", 1L});
         ensureGreen();
-        refresh();
+        execute(String.format(Locale.ENGLISH, "refresh table %s", PARTITIONED_TABLE_NAME));
 
         execute(String.format(Locale.ENGLISH, "create table %s (" +
                                               " id integer primary key," +
@@ -119,7 +119,7 @@ public class DocLevelCollectTest extends IntegTestCase {
         ensureGreen();
         execute(String.format(Locale.ENGLISH, "insert into %s (id, doc) values (?, ?)", TEST_TABLE_NAME), new Object[]{1, 2});
         execute(String.format(Locale.ENGLISH, "insert into %s (id, doc) values (?, ?)", TEST_TABLE_NAME), new Object[]{3, 4});
-        refresh();
+        execute(String.format(Locale.ENGLISH, "refresh table %s", TEST_TABLE_NAME));
 
         var table = schemas.getTableInfo(RelationName.fromIndexName(TEST_TABLE_NAME));
         testDocLevelReference = table.getReference(ColumnIdent.fromPath("doc"));

--- a/server/src/test/java/io/crate/integrationtests/AlterTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/AlterTableIntegrationTest.java
@@ -197,7 +197,7 @@ public class AlterTableIntegrationTest extends IntegTestCase {
     public void test_drop_sub_column_readd_and_update() {
         execute("CREATE TABLE t1 (id int, obj object as (x int, y int))");
         execute("INSERT INTO t1 (id, obj) VALUES (1, {x=11, y=21})");
-        execute("REFRESH TABLE t1");
+        execute("refresh table t1");
         execute("SELECT id, obj FROM t1");
         assertThat(response).hasRows("1| {x=11, y=21}");
 
@@ -208,7 +208,7 @@ public class AlterTableIntegrationTest extends IntegTestCase {
         execute("ALTER TABLE t1 ADD COLUMN obj['y'] TEXT");
         execute("UPDATE t1 SET obj['y'] = 'foo'");
         assertThat(response.rowCount()).isEqualTo(1L);
-        execute("REFRESH TABLE t1");
+        execute("refresh table t1");
         execute("SELECT id, obj FROM t1");
         assertThat(response).hasRows("1| {x=11, y=foo}");
     }
@@ -308,7 +308,7 @@ public class AlterTableIntegrationTest extends IntegTestCase {
             """);
         execute("insert into doc.t(a, o) values (1, {a=2})");
         execute("insert into doc.t(a, o) values (4, {a=5})");
-        execute("REFRESH TABLE doc.t");
+        execute("refresh table doc.t");
 
         execute("alter table doc.t rename column a to a2");
         execute("alter table doc.t rename column o to o2");

--- a/server/src/test/java/io/crate/integrationtests/AnyIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/AnyIntegrationTest.java
@@ -127,7 +127,7 @@ public class AnyIntegrationTest extends IntegTestCase {
                 "(2, ['two', 'three'])," +
                 "(3, ['three', 'four'])," +
                 "(4, [])");
-        refresh();
+        execute("refresh table t");
 
         execute("select b from t where not 'two' = ANY(labels) order by b");
         assertThat(response).hasRows("3", "4");

--- a/server/src/test/java/io/crate/integrationtests/ArithmeticIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ArithmeticIntegrationTest.java
@@ -185,9 +185,8 @@ public class ArithmeticIntegrationTest extends IntegTestCase {
         ensureYellow();
         execute("insert into t (i, l, d) values (1, 2, 90.5), (-1, 4, 90.5), (193384, 31234594433, 99.0)");
         execute("insert into t (i, l, d) values (1, 2, 99.0), (-1, 4, 99.0)");
-        refresh();
+        execute("refresh table t");
         execute("select l, log(d,l) from t order by l, log(d,l) desc");
-        assertThat(response).hasRowCount(5L);
         assertThat(response).hasRows(
             "2| 6.6293566200796095",
             "2| 6.499845887083206",
@@ -205,7 +204,7 @@ public class ArithmeticIntegrationTest extends IntegTestCase {
             new Object[]{2, "bar"},
             new Object[]{3, "foobar"}
         });
-        refresh();
+        execute("refresh table regex_noindex");
         execute("select regexp_replace(s, 'foo', 'crate') from regex_noindex order by i");
         assertThat(response).hasRowCount(3L);
         assertThat((String) response.rows()[0][0]).isEqualTo("crate");
@@ -226,7 +225,7 @@ public class ArithmeticIntegrationTest extends IntegTestCase {
             new Object[]{3, "foobar is great"},
             new Object[]{4, "crate is greater"}
         });
-        refresh();
+        execute("refresh table regex_fulltext");
 
         execute("select regexp_replace(s, 'is', 'was') from regex_fulltext order by i");
         assertThat(response).hasRowCount(4L);
@@ -262,11 +261,9 @@ public class ArithmeticIntegrationTest extends IntegTestCase {
         execute("create table t (i integer, l long, d double) clustered into 3 shards with (number_of_replicas=0)");
         ensureYellow();
         execute("insert into t (i, l, d) values (1, 2, 90.5), (2, 5, 90.5), (193384, 31234594433, 99.0), (10, 21, 99.0), (-1, 4, 99.0)");
-        refresh();
+        execute("refresh table t");
 
         execute("select i from t where i%2 = 0 order by i");
-        assertThat(response).hasRowCount(3L);
-
         assertThat(response).hasRows(
             "2",
             "10",
@@ -289,7 +286,7 @@ public class ArithmeticIntegrationTest extends IntegTestCase {
         execute("create table t (i integer, l long, d double) clustered into 3 shards with (number_of_replicas=0)");
         ensureYellow();
         execute("insert into t (i, l, d) values (1, 2, 90.5), (2, 5, 90.5), (193384, 31234594433, 99.0), (10, 21, 99.0), (-1, 4, 99.0)");
-        refresh();
+        execute("refresh table t");
 
         execute("select i, i%3 from t order by i%3, l");
         assertThat(response).hasRows(
@@ -305,7 +302,7 @@ public class ArithmeticIntegrationTest extends IntegTestCase {
         execute("create table t (i integer, l long, d double) clustered into 1 shards with (number_of_replicas=0)");
         ensureYellow();
         execute("insert into t (i, l, d) values (1, 2, 90.5)");
-        refresh();
+        execute("refresh table t");
         Asserts.assertSQLError(() -> execute("select log(d, l) from t where log(d, -1) >= 0"))
             .hasPGError(INTERNAL_ERROR)
             .hasHTTPError(BAD_REQUEST, 4000)
@@ -339,7 +336,7 @@ public class ArithmeticIntegrationTest extends IntegTestCase {
                 "   t timestamp without time zone " +
                 ") with (number_of_replicas=0)");
         execute("insert into t (b, s, i, l, f, d, tz, t) values (1, 2, 3, 4, 5.7, 6.3, '2014-07-30', '2018-07-30')");
-        refresh();
+        execute("refresh table t");
 
         String[] functionCalls = new String[]{
             "abs(%s)",
@@ -395,7 +392,7 @@ public class ArithmeticIntegrationTest extends IntegTestCase {
     public void test_floating_point_arithmetic() {
         execute("create table t1 (i int, bi bigint, d double, f float)");
         execute("insert into t1 (i, bi, d, f) values (1, 1, 1, 1)");
-        refresh();
+        execute("refresh table t1");
         execute(
             """
             select

--- a/server/src/test/java/io/crate/integrationtests/CastIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CastIntegrationTest.java
@@ -57,7 +57,7 @@ public class CastIntegrationTest extends IntegTestCase {
         execute("create table types (i integer, str string, arr array(long))");
         execute("insert into types (i, str, arr) values (?, ?, ?)", new Object[]{1, null, new Object[]{1, 2}});
         execute("insert into types (i, str, arr) values (?, ?, ?)", new Object[]{2, "3d", new Object[]{1, 128}});
-        refresh();
+        execute("refresh table types");
         execute("select try_cast(i as integer), try_cast(str as integer), try_cast(arr as array(byte))" +
                 " from types order by i asc");
         assertThat(response).hasRowCount(2L);

--- a/server/src/test/java/io/crate/integrationtests/CircuitBreakerIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CircuitBreakerIntegrationTest.java
@@ -46,7 +46,7 @@ public class CircuitBreakerIntegrationTest extends IntegTestCase {
     public void testQueryBreakerIsDecrementedWhenQueryCompletes() throws Exception {
         execute("create table t1 (text string)");
         execute("insert into t1 values ('this is some text'), ('other text')");
-        refresh();
+        execute("refresh table t1");
 
         CircuitBreakerService circuitBreakerService = cluster().getInstance(CircuitBreakerService.class);
         CircuitBreaker queryBreaker = circuitBreakerService.getBreaker(HierarchyCircuitBreakerService.QUERY);
@@ -63,7 +63,7 @@ public class CircuitBreakerIntegrationTest extends IntegTestCase {
     public void testQueryBreakerIsUpdatedWhenSettingIsChanged() {
         execute("create table t1 (text string) clustered into 1 shards");
         execute("insert into t1 values ('this is some text'), ('other text')");
-        refresh();
+        execute("refresh table t1");
 
         execute("select text from t1 group by text");
 

--- a/server/src/test/java/io/crate/integrationtests/ColumnPolicyIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ColumnPolicyIntegrationTest.java
@@ -25,7 +25,6 @@ import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertSQLError;
 import static io.crate.testing.Asserts.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.URISyntaxException;
 import java.nio.file.Paths;
@@ -99,10 +98,9 @@ public class ColumnPolicyIntegrationTest extends IntegTestCase {
 
         execute("select person['name'], person['addresses']['city'] from dynamic_table");
 
-        assertThat(response).hasColumns("person['name']", "person['addresses']['city']");
-        assertThat(response).hasRows(
-            "Ford| [West Country]"
-        );
+        assertThat(response)
+            .hasColumns("person['name']", "person['addresses']['city']")
+            .hasRows("Ford| [West Country]");
 
         // Verify that PKLookup can fetch a sub-column, which is array of objects.
         execute("select person['addresses']['city'] from dynamic_table where id = 1");

--- a/server/src/test/java/io/crate/integrationtests/CopyFromFailFastITest.java
+++ b/server/src/test/java/io/crate/integrationtests/CopyFromFailFastITest.java
@@ -44,9 +44,7 @@ import org.elasticsearch.test.IntegTestCase;
 import org.elasticsearch.test.MockLogAppender;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.junit.After;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
 import com.carrotsearch.randomizedtesting.LifecycleScope;
 
@@ -58,9 +56,6 @@ import io.crate.testing.UseRandomizedOptimizerRules;
 
 @IntegTestCase.ClusterScope(numDataNodes = 0, numClientNodes = 0, supportsDedicatedMasters = false)
 public class CopyFromFailFastITest extends IntegTestCase {
-
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
 
     @After
     public void resetSettings() {
@@ -262,7 +257,7 @@ public class CopyFromFailFastITest extends IntegTestCase {
         execute("CREATE TABLE t (a int)");
 
         execute("COPY t FROM ? WITH (fail_fast = true, shared = false)", new Object[]{target.toUri().toString() + "*"});
-        refresh();
+        execute("refresh table t");
         execute("select * from t");
         assertThat(response.rowCount()).isEqualTo(cluster().numDataNodes());
     }

--- a/server/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
@@ -96,7 +96,7 @@ public class CopyIntegrationTest extends SQLHttpIntegrationTest {
 
         execute("copy quotes from ?", new Object[] {copyFilePath + "test_copy_from.json"});
         assertThat(response).hasRowCount(3L);
-        refresh();
+        execute("refresh table quotes");
 
         execute("select * from quotes");
         assertThat(response).hasRowCount(3L);
@@ -113,7 +113,7 @@ public class CopyIntegrationTest extends SQLHttpIntegrationTest {
 
         execute("copy quotes from ? with (format='csv')", new Object[]{copyFilePath + "test_copy_from_csv.ext"});
         assertThat(response).hasRowCount(3L);
-        refresh();
+        execute("refresh table quotes");
 
         execute("select * from quotes");
         assertThat(response).hasRowCount(3L);
@@ -130,7 +130,7 @@ public class CopyIntegrationTest extends SQLHttpIntegrationTest {
 
         execute("copy quotes from ? with (format='csv')", new Object[]{copyFilePath + "test_copy_from_csv_extra_column.ext"});
         assertThat(response).hasRowCount(3L);
-        refresh();
+        execute("refresh table quotes");
 
         execute("select * from quotes");
         assertThat(response).hasRowCount(3L);
@@ -148,7 +148,7 @@ public class CopyIntegrationTest extends SQLHttpIntegrationTest {
 
         execute("copy quotes(id, quote, comment) from ? with (format='csv')", new Object[]{copyFilePath + "test_copy_from_csv_extra_column.ext"});
         assertThat(response).hasRowCount(3L);
-        refresh();
+        execute("refresh table quotes");
 
         execute("select * from quotes");
         assertThat(response).hasRowCount(3L);

--- a/server/src/test/java/io/crate/integrationtests/CorrelatedSubqueryITest.java
+++ b/server/src/test/java/io/crate/integrationtests/CorrelatedSubqueryITest.java
@@ -23,7 +23,6 @@ package io.crate.integrationtests;
 
 
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.sql.DriverManager;
@@ -456,7 +455,7 @@ public class CorrelatedSubqueryITest extends IntegTestCase {
     public void test_can_mix_correlated_qubquery_and_sub_select() {
         execute("CREATE TABLE tbl(x int)");
         execute("INSERT INTO tbl(x) VALUES (1)");
-        refresh();
+        execute("refresh table tbl");
         execute(
             """
            SELECT (

--- a/server/src/test/java/io/crate/integrationtests/CountStarIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CountStarIntegrationTest.java
@@ -45,7 +45,7 @@ public class CountStarIntegrationTest extends IntegTestCase {
         execute("insert into t (name, p) values ('Arthur', 'foo')");
         execute("insert into t (name, p) values ('Trillian', 'foobar')");
         ensureYellow();
-        refresh();
+        execute("refresh table t");
 
         execute("select count(*) from t where p = 'foobar'");
         assertThat(response.rowCount()).isEqualTo(1L);

--- a/server/src/test/java/io/crate/integrationtests/CreateTableAsIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CreateTableAsIntegrationTest.java
@@ -62,9 +62,9 @@ public class CreateTableAsIntegrationTest extends IntegTestCase {
             ")";
         execute(createTableStmt);
         execute("insert into tbl values({col_nested_integer=null,col_nested_object={col_text=null}})");
-        refresh();
+        execute("refresh table tbl");
         execute("create table cpy as select * from tbl");
-        refresh();
+        execute("refresh table cpy");
         execute("select * from cpy");
 
         assertThat(response).hasRowCount(1);
@@ -87,9 +87,9 @@ public class CreateTableAsIntegrationTest extends IntegTestCase {
             ")";
         execute(createTableStmt);
         execute("insert into tbl values({col_nested_integer=1,col_nested_object={col_text='test'}})");
-        refresh();
+        execute("refresh table tbl");
         execute("create table cpy as (select * from tbl)");
-        refresh();
+        execute("refresh table cpy");
         execute("select * from cpy");
 
         assertThat(response).hasRowCount(1);

--- a/server/src/test/java/io/crate/integrationtests/CreateTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CreateTableIntegrationTest.java
@@ -27,7 +27,6 @@ import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -155,7 +154,7 @@ public class CreateTableIntegrationTest extends IntegTestCase {
     public void test_intervals_in_generated_column() {
         execute("create table test(t timestamp, calculated timestamp generated always as DATE_BIN('15 minutes'::INTERVAL, t, '2001-01-01'))");
         execute("insert into test(t) values('2020-02-11 15:44:17')");
-        refresh();
+        execute("refresh table test");
         execute("select date_format('%Y-%m-%d %H:%i:%s', calculated) from test");
         assertThat(printedTable(response.rows())).isEqualTo("2020-02-11 15:30:00\n");
     }

--- a/server/src/test/java/io/crate/integrationtests/DefaultSchemaIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/DefaultSchemaIntegrationTest.java
@@ -70,9 +70,8 @@ public class DefaultSchemaIntegrationTest extends IntegTestCase {
         File foobarExport = tmpFolder.newFolder("foobar_export");
         String uriTemplate = Paths.get(foobarExport.toURI()).toUri().toString();
         execute("copy foobar to directory ?", new Object[]{uriTemplate}, "foo");
-        refresh();
         execute("delete from foobar", "foo");
-        refresh();
+        execute("refresh table foobar", "foo");
 
         execute("select * from foobar", "foo");
         assertThat(response.rowCount()).isEqualTo(0L);

--- a/server/src/test/java/io/crate/integrationtests/DiskThresholdDeciderIT.java
+++ b/server/src/test/java/io/crate/integrationtests/DiskThresholdDeciderIT.java
@@ -248,7 +248,7 @@ public class DiskThresholdDeciderIT extends IntegTestCase {
             ensureGreen();
             execute("optimize table " + tableName + " with (max_num_segments=1)");
 
-            refresh();
+            execute("refresh table " + tableName);
 
             var indicesStats = client().admin().indices().stats(new IndicesStatsRequest().indices(indexName).store(true)).get();
             final List<ShardStats> shardStatses = indicesStats.getIndex(indexName).getShards();

--- a/server/src/test/java/io/crate/integrationtests/EmptyStringRoutingIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/EmptyStringRoutingIntegrationTest.java
@@ -51,7 +51,7 @@ public class EmptyStringRoutingIntegrationTest extends IntegTestCase {
         ensureYellow();
         execute("insert into t (i, c) values (1, '')");
         execute("insert into t (i, c) values (2, '')");
-        refresh();
+        execute("refresh table t");
         execute("select c, count(*) from t group by c");
         assertThat(response.rowCount()).isEqualTo(1L);
         assertThat((long) response.rows()[0][1]).isEqualTo(2L);
@@ -62,7 +62,7 @@ public class EmptyStringRoutingIntegrationTest extends IntegTestCase {
         execute("create table t (i int primary key, c string primary key) clustered by (c)");
         ensureYellow();
         execute("insert into t (i, c) values (1, ''), (2, '')");
-        refresh();
+        execute("refresh table t");
         execute("select c, count(*) from t group by c");
         assertThat(response.rowCount()).isEqualTo(1L);
         assertThat((long) response.rows()[0][1]).isEqualTo(2L);
@@ -74,8 +74,7 @@ public class EmptyStringRoutingIntegrationTest extends IntegTestCase {
         ensureYellow();
         execute("insert into t (i, c) values (?, ?)", new Object[]{1, ""});
         execute("insert into t (i, c) values (?, ?)", new Object[]{2, ""});
-        ;
-        refresh();
+        execute("refresh table t");
         execute("select c, count(*) from t group by c");
         assertThat(response.rowCount()).isEqualTo(1L);
         assertThat((long) response.rows()[0][1]).isEqualTo(2L);
@@ -86,7 +85,7 @@ public class EmptyStringRoutingIntegrationTest extends IntegTestCase {
         execute("create table t (i int primary key, c string primary key) clustered by (c)");
         ensureYellow();
         execute("insert into t (i, c) values (?, ?)", new Object[][]{{1, ""}, {2, ""}});
-        refresh();
+        execute("refresh table t");
         execute("select c, count(*) from t group by c");
         assertThat(response.rowCount()).isEqualTo(1L);
         assertThat((long) response.rows()[0][1]).isEqualTo(2L);
@@ -114,17 +113,17 @@ public class EmptyStringRoutingIntegrationTest extends IntegTestCase {
         execute("create table t (i int primary key, c string primary key, a int) clustered by (c)");
         ensureYellow();
         execute("insert into t (i, c) values (1, ''), (2, '')");
-        refresh();
+        execute("refresh table t");
 
         String uri = Paths.get(folder.getRoot().toURI()).toUri().toString();
         SQLResponse response = execute("copy t to directory ?", new Object[]{uri});
         assertThat(response.rowCount()).isEqualTo(2L);
 
         execute("delete from t");
-        refresh();
+        execute("refresh table t");
 
         execute("copy t from ? with (shared=true)", new Object[]{uri + "t_*"});
-        refresh();
+        execute("refresh table t");
         response = execute("select c, count(*) from t group by c");
         assertThat(response.rowCount()).isEqualTo(1L);
         assertThat((long) response.rows()[0][1]).isEqualTo(2L);

--- a/server/src/test/java/io/crate/integrationtests/FixCorruptedMetadataCommandITest.java
+++ b/server/src/test/java/io/crate/integrationtests/FixCorruptedMetadataCommandITest.java
@@ -83,7 +83,7 @@ public class FixCorruptedMetadataCommandITest extends IntegTestCase {
             )
         );
         execute("insert into m1.t1 values (null), ('x'), ('y')"); // just in case...
-        refresh();
+        execute("refresh table m1.t1");
         execute("select * from m1.t1");
         assertThat(printedTable(response.rows())).isEqualTo("NULL\nNULL\nNULL\nx\ny\n");
 
@@ -297,7 +297,7 @@ public class FixCorruptedMetadataCommandITest extends IntegTestCase {
             )
         );
         execute("insert into m7.s7 values (true), (null), (false)");
-        refresh();
+        execute("refresh table m7.s7");
         execute("select * from m7.s7 order by t desc");
         assertThat(printedTable(response.rows())).isEqualTo("NULL\nNULL\nNULL\ntrue\nfalse\n");
 
@@ -340,7 +340,7 @@ public class FixCorruptedMetadataCommandITest extends IntegTestCase {
             )
         );
         execute("insert into m10.s10 values (true, true), (false, true)");
-        refresh();
+        execute("refresh table m10.s10");
         execute("select * from m10.s10 order by t");
         assertThat(printedTable(response.rows())).isEqualTo("false| true\ntrue| true\nNULL| NULL\n");
 
@@ -360,7 +360,7 @@ public class FixCorruptedMetadataCommandITest extends IntegTestCase {
             )
         );
         execute("insert into m10.t10 values ('t', 't'), ('q', 'q')");
-        refresh();
+        execute("refresh table m10.t10");
         execute("select * from m10.t10 order by s");
         assertThat(printedTable(response.rows())).isEqualTo("q| q\nt| t\nNULL| NULL\n");
 

--- a/server/src/test/java/io/crate/integrationtests/OuterJoinIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/OuterJoinIntegrationTest.java
@@ -21,8 +21,8 @@
 
 package io.crate.integrationtests;
 
-import static io.crate.testing.TestingHelpers.printedTable;
-import static org.assertj.core.api.Assertions.assertThat;
+
+import static io.crate.testing.Asserts.assertThat;
 
 import org.elasticsearch.test.IntegTestCase;
 import org.junit.Before;
@@ -49,9 +49,10 @@ public class OuterJoinIntegrationTest extends IntegTestCase {
         execute("select persons.name, offices.name from" +
                 " employees as persons left join offices on office_id = offices.id" +
                 " order by persons.id");
-        assertThat(printedTable(response.rows())).isEqualTo("Trillian| Entresol\n" +
-                                                     "Ford Perfect| NULL\n" +
-                                                     "Douglas Adams| Chief Office\n");
+        assertThat(response).hasRows(
+            "Trillian| Entresol",
+            "Ford Perfect| NULL",
+            "Douglas Adams| Chief Office");
     }
 
     @Test
@@ -60,9 +61,10 @@ public class OuterJoinIntegrationTest extends IntegTestCase {
         execute("select persons.name, offices.name from" +
                 " employees as persons left join offices on office_id = offices.id" +
                 " order by offices.name nulls first");
-        assertThat(printedTable(response.rows())).isEqualTo("Ford Perfect| NULL\n" +
-                                                     "Douglas Adams| Chief Office\n" +
-                                                     "Trillian| Entresol\n");
+        assertThat(response).hasRows(
+            "Ford Perfect| NULL",
+            "Douglas Adams| Chief Office",
+            "Trillian| Entresol");
     }
 
     @Test
@@ -72,10 +74,11 @@ public class OuterJoinIntegrationTest extends IntegTestCase {
             " professions left join employees on profession_id = professions.id" +
             " left join offices on office_id = offices.id" +
             " order by professions.id");
-        assertThat(printedTable(response.rows())).isEqualTo("Writer| Douglas Adams| Chief Office\n" +
-                                                     "Traveler| Ford Perfect| NULL\n" +
-                                                     "Commander| Trillian| Entresol\n" +
-                                                     "Janitor| NULL| NULL\n");
+        assertThat(response).hasRows(
+            "Writer| Douglas Adams| Chief Office",
+            "Traveler| Ford Perfect| NULL",
+            "Commander| Trillian| Entresol",
+            "Janitor| NULL| NULL");
     }
 
     @Test
@@ -85,10 +88,11 @@ public class OuterJoinIntegrationTest extends IntegTestCase {
             " professions left join employees on profession_id = professions.id" +
             " left join offices on office_id = offices.id" +
             " order by offices.name nulls first, professions.id nulls first");
-        assertThat(printedTable(response.rows())).isEqualTo("Traveler| Ford Perfect| NULL\n" +
-                                                     "Janitor| NULL| NULL\n" +
-                                                     "Writer| Douglas Adams| Chief Office\n" +
-                                                     "Commander| Trillian| Entresol\n");
+        assertThat(response).hasRows(
+            "Traveler| Ford Perfect| NULL",
+            "Janitor| NULL| NULL",
+            "Writer| Douglas Adams| Chief Office",
+            "Commander| Trillian| Entresol");
     }
 
     @Test
@@ -96,9 +100,10 @@ public class OuterJoinIntegrationTest extends IntegTestCase {
         execute("select offices.name, persons.name from" +
                 " employees as persons right join offices on office_id = offices.id" +
                 " order by offices.id");
-        assertThat(printedTable(response.rows())).isEqualTo("Hobbit House| NULL\n" +
-                                                     "Entresol| Trillian\n" +
-                                                     "Chief Office| Douglas Adams\n");
+        assertThat(response).hasRows(
+            "Hobbit House| NULL",
+            "Entresol| Trillian",
+            "Chief Office| Douglas Adams");
     }
 
     @Test
@@ -108,10 +113,11 @@ public class OuterJoinIntegrationTest extends IntegTestCase {
             " offices left join employees on office_id = offices.id" +
             " right join professions on profession_id = professions.id" +
             " order by professions.id");
-        assertThat(printedTable(response.rows())).isEqualTo("Writer| Douglas Adams| Chief Office\n" +
-                                                     "Traveler| NULL| NULL\n" +
-                                                     "Commander| Trillian| Entresol\n" +
-                                                     "Janitor| NULL| NULL\n");
+        assertThat(response).hasRows(
+            "Writer| Douglas Adams| Chief Office",
+            "Traveler| NULL| NULL",
+            "Commander| Trillian| Entresol",
+            "Janitor| NULL| NULL");
     }
 
     @Test
@@ -119,10 +125,11 @@ public class OuterJoinIntegrationTest extends IntegTestCase {
         execute("select persons.name, offices.name from" +
                 " offices full join employees as persons on office_id = offices.id" +
                 " order by offices.id");
-        assertThat(printedTable(response.rows())).isEqualTo("NULL| Hobbit House\n" +
-                                                     "Trillian| Entresol\n" +
-                                                     "Douglas Adams| Chief Office\n" +
-                                                     "Ford Perfect| NULL\n");
+        assertThat(response).hasRows(
+            "NULL| Hobbit House",
+            "Trillian| Entresol",
+            "Douglas Adams| Chief Office",
+            "Ford Perfect| NULL");
     }
 
     @Test
@@ -132,29 +139,32 @@ public class OuterJoinIntegrationTest extends IntegTestCase {
                 " offices full join employees as persons on office_id = offices.id" +
                 " where offices.name='Entresol' and persons.name='Trillian' " +
                 " order by offices.id");
-        assertThat(printedTable(response.rows())).isEqualTo("Trillian| Entresol\n");
+        assertThat(response).hasRows("Trillian| Entresol");
     }
 
     @Test
     public void test_filter_will_be_applied_after_outer_join() {
         execute("create table t1 (id int, is_match int)");
         execute("create table t2 (id int, t1_id int)");
-        execute("insert into t1 (id, is_match) values " +
-                "(1, 0),\n" +
-                "(2, 1),\n" +
-                "(36, 1)");
-        execute("insert into t2 (id, t1_id) values " +
-                "(1, 1),\n" +
-                "(2, 2),\n" +
-                "(3, null)");   // this row must be filtered out after the full join
-        refresh();
+        execute("""
+            insert into t1 (id, is_match) values
+            (1, 0),
+            (2, 1),
+            (36, 1)""");
+        execute("""
+            insert into t2 (id, t1_id) values
+            (1, 1),
+            (2, 2),
+            (3, null)""");   // this row must be filtered out after the full join
+        execute("refresh table t1, t2");
 
         execute("SELECT t2.id, t2.t1_id, t1.id, t1.is_match " +
                 "FROM t2 " +
                 "FULL OUTER JOIN t1 ON (t1.id = t2.t1_id) " +
                 "WHERE (t1.is_match = 1) ");
-        assertThat(printedTable(response.rows())).isEqualTo("2| 2| 2| 1\n" +
-                                                     "NULL| NULL| 36| 1\n");
+        assertThat(response).hasRows(
+            "2| 2| 2| 1",
+            "NULL| NULL| 36| 1");
     }
 
     @Test
@@ -162,10 +172,11 @@ public class OuterJoinIntegrationTest extends IntegTestCase {
         execute("select coalesce(persons.name, ''), coalesce(offices.name, '') from" +
                 " offices full join employees as persons on office_id = offices.id" +
                 " order by 1, 2");
-        assertThat(printedTable(response.rows())).isEqualTo("| Hobbit House\n" +
-                                                     "Douglas Adams| Chief Office\n" +
-                                                     "Ford Perfect| \n" +
-                                                     "Trillian| Entresol\n");
+        assertThat(response).hasRows(
+            "| Hobbit House",
+            "Douglas Adams| Chief Office",
+            "Ford Perfect| ",
+            "Trillian| Entresol");
     }
 
     @Test
@@ -174,8 +185,9 @@ public class OuterJoinIntegrationTest extends IntegTestCase {
                 " employees left join offices on office_id = offices.id" +
                 " where employees.id < 3" +
                 " order by offices.id");
-        assertThat(printedTable(response.rows())).isEqualTo("Trillian| Entresol\n" +
-                                                     "Ford Perfect| NULL\n");
+        assertThat(response).hasRows(
+            "Trillian| Entresol",
+            "Ford Perfect| NULL");
     }
 
     @Test
@@ -185,7 +197,7 @@ public class OuterJoinIntegrationTest extends IntegTestCase {
                 " employees left join offices on office_id = offices.id" +
                 " where offices.size > 100" +
                 " order by offices.id");
-        assertThat(printedTable(response.rows())).isEqualTo("Douglas Adams| Chief Office\n");
+        assertThat(response).hasRows("Douglas Adams| Chief Office");
     }
 
     @Test
@@ -195,7 +207,8 @@ public class OuterJoinIntegrationTest extends IntegTestCase {
                 " employees left join offices on office_id = offices.id" +
                 " where coalesce(offices.size, cast(110 as integer)) > 100" +
                 " order by offices.id");
-        assertThat(printedTable(response.rows())).isEqualTo("Douglas Adams| Chief Office\n" +
-               "Ford Perfect| NULL\n");
+        assertThat(response).hasRows(
+            "Douglas Adams| Chief Office",
+            "Ford Perfect| NULL");
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/RelationAliasITest.java
+++ b/server/src/test/java/io/crate/integrationtests/RelationAliasITest.java
@@ -21,8 +21,7 @@
 
 package io.crate.integrationtests;
 
-import static io.crate.testing.TestingHelpers.printedTable;
-import static org.assertj.core.api.Assertions.assertThat;
+import static io.crate.testing.Asserts.assertThat;
 
 import org.elasticsearch.test.IntegTestCase;
 import org.junit.Test;
@@ -31,46 +30,51 @@ public class RelationAliasITest extends IntegTestCase {
 
     @Test
     public void testRelationAliasWithColumnAliases() {
-        execute("SELECT\n" +
-                "    y,\n" +
-                "    avg(x) OVER (ORDER BY x),\n" +
-                "    avg(y) OVER ()\n" +
-                "FROM\n" +
-                "    unnest(array[1, 2, 3, 4, 5, 6, 7], array[10, 20, 30, 40, 50, 60, 70]) as t (x, y)\n" +
-                "ORDER BY\n" +
-                "    y\n" +
-                "LIMIT 3 offset 2");
-        assertThat(printedTable(response.rows())).isEqualTo("30| 2.0| 40.0\n" +
-                                                     "40| 2.5| 40.0\n" +
-                                                     "50| 3.0| 40.0\n");
+        execute("""
+            SELECT
+                y,
+                avg(x) OVER (ORDER BY x),
+                avg(y) OVER ()
+            FROM
+                unnest(array[1, 2, 3, 4, 5, 6, 7], array[10, 20, 30, 40, 50, 60, 70]) as t (x, y)
+            ORDER BY
+                y
+            LIMIT 3 offset 2""");
+        assertThat(response).hasRows(
+            "30| 2.0| 40.0",
+            "40| 2.5| 40.0",
+            "50| 3.0| 40.0");
     }
 
     @Test
     public void testRelationAliasWithSomeColumnsAliases() {
-        execute("SELECT\n" +
-                "    col2,\n" +
-                "    avg(x) OVER (ORDER BY x),\n" +
-                "    avg(col2) OVER ()\n" +
-                "FROM\n" +
-                "    unnest(array[1, 2, 3, 4, 5, 6, 7], array[10, 20, 30, 40, 50, 60, 70]) as t (x)\n" +
-                "ORDER BY\n" +
-                "    col2\n" +
-                "LIMIT 3 offset 2");
-        assertThat(printedTable(response.rows())).isEqualTo("30| 2.0| 40.0\n" +
-                                                     "40| 2.5| 40.0\n" +
-                                                     "50| 3.0| 40.0\n");
+        execute("""
+            SELECT
+                col2,
+                avg(x) OVER (ORDER BY x),
+                avg(col2) OVER ()
+            FROM
+                unnest(array[1, 2, 3, 4, 5, 6, 7], array[10, 20, 30, 40, 50, 60, 70]) as t (x)
+            ORDER BY
+                col2
+            LIMIT 3 offset 2""");
+        assertThat(response).hasRows(
+            "30| 2.0| 40.0",
+            "40| 2.5| 40.0",
+            "50| 3.0| 40.0");
     }
 
     @Test
     public void testSameColumnWithDifferentOutputNamesAndARelationBoundary() {
         execute("create table t1 (id int, a text)");
         execute("insert into t1 (id, a) values (1, 'foo'), (2, 'foo'), (3, 'bar')");
-        refresh();
+        execute("refresh table t1");
         execute("select count(*) as cnt, t.a as a_alias, t.a" +
                 " from t1 t" +
                 " group by 2" +
                 " order by 1");
-        assertThat(printedTable(response.rows())).isEqualTo("1| bar| bar\n" +
-                                                     "2| foo| foo\n");
+        assertThat(response).hasRows(
+            "1| bar| bar",
+            "2| foo| foo");
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/SchemaAndRelationNamesIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SchemaAndRelationNamesIntegrationTest.java
@@ -57,7 +57,7 @@ public class SchemaAndRelationNamesIntegrationTest extends IntegTestCase {
         execute("insert into \"_Abc\".\"_T\" values (1)");
         execute("create view \"_Abc\".v1 as select a from \"_Abc\".\"_T\"");
         execute("CREATE FUNCTION \"_Abc\".func(string) RETURNS STRING LANGUAGE dummy_lang AS 'DUMMY EATS text'");
-        refresh();
+        execute("refresh table \"_Abc\".\"_T\"");
 
         // check index/template names
         var meta = clusterService().state().metadata();
@@ -82,7 +82,7 @@ public class SchemaAndRelationNamesIntegrationTest extends IntegTestCase {
         // a little more complex scenario involving schema names with upper cases
         execute("create table Abc.\"_T\" (b string, c string as \"_Abc\".func(b))");
         execute("insert into Abc.\"_T\"(b) values ('Abc')"); // NOTE: here failed before due to - Unknown function: _abc.func(abc."_T".b)
-        refresh();
+        execute("refresh table Abc.\"_T\"");
 
         execute("select * from Abc.\"_T\"");
         assertThat(printedTable(response.rows())).isEqualTo("Abc| DUMMY EATS text\n");

--- a/server/src/test/java/io/crate/integrationtests/ShardingUpsertIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ShardingUpsertIntegrationTest.java
@@ -64,7 +64,7 @@ public class ShardingUpsertIntegrationTest extends IntegTestCase {
             new Object[]{ copyFilePath + "data_import.json"}
         );
         assertThat(response.rowCount()).isEqualTo(150L);
-        refresh();
+        execute("refresh table contributors");
         execute("select id, day_joined, name from contributors");
         assertThat(response.rowCount()).isEqualTo(150L);
     }

--- a/server/src/test/java/io/crate/integrationtests/SqlAlchemyIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SqlAlchemyIntegrationTest.java
@@ -37,7 +37,7 @@ public class SqlAlchemyIntegrationTest extends IntegTestCase {
         ensureYellow();
         execute("insert into test values (?, ?)", new Object[]{1, "foo"});
         execute("insert into test values (?, ?)", new Object[]{2, "bar"});
-        refresh();
+        execute("refresh table test");
 
         execute(
             "SELECT count(?) AS count_1 FROM test WHERE test.col2 = ?",
@@ -55,7 +55,7 @@ public class SqlAlchemyIntegrationTest extends IntegTestCase {
         ensureYellow();
         execute("insert into test values (?, ?)", new Object[]{1, "foo"});
         execute("insert into test values (?, ?)", new Object[]{2, "bar"});
-        refresh();
+        execute("refresh table test");
 
         execute(
             "SELECT count(test.col1) AS count_1 FROM test WHERE test.col2 = ?",
@@ -74,7 +74,7 @@ public class SqlAlchemyIntegrationTest extends IntegTestCase {
         execute("insert into test values (?, ?)", new Object[]{1, "foo"});
         execute("insert into test values (?, ?)", new Object[]{2, "bar"});
         execute("insert into test values (?, ?)", new Object[]{3, "foo"});
-        refresh();
+        execute("refresh table test");
 
         execute(
             "SELECT count(?) AS count_1, test.col2 AS test_col2 FROM test " +
@@ -96,7 +96,7 @@ public class SqlAlchemyIntegrationTest extends IntegTestCase {
         execute("insert into test values (?, ?)", new Object[]{1, "foo"});
         execute("insert into test values (?, ?)", new Object[]{2, "bar"});
         execute("insert into test values (?, ?)", new Object[]{3, "foo"});
-        refresh();
+        execute("refresh table test");
 
         execute(
             "SELECT count(test.col1) AS count_1, test.col2 AS test_col2 FROM test " +

--- a/server/src/test/java/io/crate/integrationtests/StorageOptionsITest.java
+++ b/server/src/test/java/io/crate/integrationtests/StorageOptionsITest.java
@@ -37,7 +37,7 @@ public class StorageOptionsITest extends IntegTestCase {
 
         String bigString = RandomStrings.randomRealisticUnicodeOfLength(random(), MAX_TERM_LENGTH + 2);
         execute("insert into t1 (s) values (?)", new Object[]{bigString});
-        refresh();
+        execute("refresh table t1");
 
         execute("select s from t1 limit 1");
         assertThat(response.rows()[0][0]).isEqualTo(bigString);
@@ -54,7 +54,7 @@ public class StorageOptionsITest extends IntegTestCase {
 
         execute("insert into t1 (i, s) values (?, ?), (?, ?)",
                 new Object[][]{{1, "hello", 2, "foo"}});
-        refresh();
+        execute("refresh table t1");
 
         execute("select max(i), max(s) from t1");
         assertThat(response).hasRows("2| hello");
@@ -71,7 +71,7 @@ public class StorageOptionsITest extends IntegTestCase {
 
         execute("insert into t1 (i, s) values (?, ?), (?, ?)",
                 new Object[][]{{1, "hello", 2, "foo"}});
-        refresh();
+        execute("refresh table t1");
 
         execute("select count(s), count(i), i, s from t1 group by s, i order by i, s");
         assertThat(response).hasRows(
@@ -90,7 +90,7 @@ public class StorageOptionsITest extends IntegTestCase {
 
         execute("insert into t1 (i, s) values (?, ?), (?, ?)",
                 new Object[][]{{1, "foo", 2, "bar"}});
-        refresh();
+        execute("refresh table t1");
 
         execute("select s from t1 order by s");
         assertThat(response).hasRows(

--- a/server/src/test/java/io/crate/integrationtests/SysHealthITest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysHealthITest.java
@@ -21,8 +21,8 @@
 
 package io.crate.integrationtests;
 
-import static io.crate.testing.TestingHelpers.printedTable;
-import static org.assertj.core.api.Assertions.assertThat;
+
+import static io.crate.testing.Asserts.assertThat;
 
 import java.io.IOException;
 
@@ -43,9 +43,10 @@ public class SysHealthITest extends IntegTestCase {
         execute("create table doc.t3 (id int) with(number_of_replicas=0)");
 
         execute("select * from sys.health order by severity desc");
-        assertThat(printedTable(response.rows())).isEqualTo("RED| 2| NULL| 3| t1| doc| 0\n" +
-                                                     "YELLOW| 0| NULL| 2| t2| doc| 4\n" +
-                                                     "GREEN| 0| NULL| 1| t3| doc| 0\n");
+        assertThat(response).hasRows(
+            "RED| 2| NULL| 3| t1| doc| 0",
+            "YELLOW| 0| NULL| 2| t2| doc| 4",
+            "GREEN| 0| NULL| 1| t3| doc| 0");
     }
 
     @Test
@@ -58,11 +59,11 @@ public class SysHealthITest extends IntegTestCase {
         execute("insert into doc.p1 (id, p) values (1, 1)");
         execute("alter table doc.p1 set (number_of_shards = 4)");
         execute("insert into doc.p1 (id, p) values (2, 2)");
-        refresh();
+        execute("refresh table doc.p1");
 
         execute("select * from sys.health order by severity, partition_ident desc");
-        assertThat(printedTable(response.rows())).isEqualTo(
-            "GREEN| 0| 04134| 1| p1| doc| 0\n" +
-            "GREEN| 0| 04132| 1| p1| doc| 0\n");
+        assertThat(response).hasRows(
+            "GREEN| 0| 04134| 1| p1| doc| 0",
+            "GREEN| 0| 04132| 1| p1| doc| 0");
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/SysSegmentsTableInfoTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysSegmentsTableInfoTest.java
@@ -43,7 +43,7 @@ public class SysSegmentsTableInfoTest extends IntegTestCase {
                 WITH (number_of_replicas = 1)
             """);
         execute("INSERT INTO t1 VALUES(1, 'test')");
-        refresh();
+        execute("refresh table t1");
         ensureGreen();
         execute(
             """

--- a/server/src/test/java/io/crate/integrationtests/TasksServiceIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TasksServiceIntegrationTest.java
@@ -60,7 +60,7 @@ public class TasksServiceIntegrationTest extends IntegTestCase {
             new Object[]{1, -7L},
             new Object[]{2, 3L},
         });
-        refresh();
+        execute("refresh table upserts");
 
         // upsert-by-id (UpsertByIdContext is created)
         execute("update upserts set d = 5 where id = 1");

--- a/server/src/test/java/io/crate/integrationtests/UserDefinedFunctionsIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/UserDefinedFunctionsIntegrationTest.java
@@ -24,7 +24,6 @@ package io.crate.integrationtests;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.Locale;
@@ -125,7 +124,7 @@ public class UserDefinedFunctionsIntegrationTest extends IntegTestCase {
             rows[i] = new Object[]{(long) i, String.valueOf(i)};
         }
         execute("insert into test (id, str) values (?, ?)", rows);
-        refresh();
+        execute("refresh table test");
         try {
             execute("create function foo(long)" +
                 " returns string language dummy_lang as 'function foo(x) { return \"1\"; }'");

--- a/server/src/test/java/io/crate/integrationtests/WherePKIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/WherePKIntegrationTest.java
@@ -294,7 +294,7 @@ public class WherePKIntegrationTest extends IntegTestCase {
 
         execute("delete from expl_routing where name = ''");
         assertThat(response).hasRowCount(2L);
-        refresh();
+        execute("refresh table expl_routing");
         execute("select count(*) from expl_routing");
         assertThat(response).hasRowCount(1);
     }

--- a/server/src/test/java/io/crate/integrationtests/disruption/seqno/SequenceConsistencyIT.java
+++ b/server/src/test/java/io/crate/integrationtests/disruption/seqno/SequenceConsistencyIT.java
@@ -66,7 +66,7 @@ public class SequenceConsistencyIT extends AbstractDisruptionTestCase {
                     )
                 """);
         execute("insert into registers values (1, 'initial value')");
-        refresh();
+        execute("refresh table registers");
 
         // not setting this when creating the table because we want the replica to be initialized before we start disrupting
         // otherwise the replica might not be ready to be promoted to primary due to "primary failed while replica initializing"

--- a/server/src/test/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
@@ -24,7 +24,6 @@ package org.elasticsearch.indices.recovery;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.biasedDoubleBetween;
 import static io.crate.testing.Asserts.assertThat;
 import static java.util.Collections.singletonMap;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.elasticsearch.node.RecoverySettingsChunkSizePlugin.CHUNK_SIZE_SETTING;
 
 import java.io.IOException;
@@ -326,7 +325,7 @@ public class IndexRecoveryIT extends IntegTestCase {
             waitForDocs(numOfDocs, indexer, sqlExecutor);
         }
 
-        refresh();
+        execute("refresh table " + INDEX_NAME);
         execute("SELECT COUNT(*) FROM " + INDEX_NAME);
         assertThat(response).hasRows(new Object[] { (long) numOfDocs });
 
@@ -730,7 +729,7 @@ public class IndexRecoveryIT extends IntegTestCase {
 
         assertThat(stateResponse.getState().getRoutingNodes().node(blueNodeId).isEmpty()).isFalse();
 
-        refresh();
+        execute("refresh table doc." + indexName);
         var searchResponse = execute("SELECT COUNT(*) FROM doc." + indexName);
         assertThat(searchResponse).hasRows(new Object[] { (long) numDocs });
 
@@ -855,7 +854,7 @@ public class IndexRecoveryIT extends IntegTestCase {
 
         assertThat(stateResponse.getState().getRoutingNodes().node(blueNodeId).isEmpty()).isFalse();
 
-        refresh();
+        execute("refresh table doc." + indexName);
         var searchResponse = execute("SELECT COUNT(*) FROM doc." + indexName);
         assertThat(searchResponse).hasRows(new Object[] { (long) numDocs });
 
@@ -983,7 +982,7 @@ public class IndexRecoveryIT extends IntegTestCase {
         execute("INSERT INTO test (id) VALUES (?)", args);
         ensureGreen();
 
-        refresh();
+        execute("refresh table test");
         var searchResponse = execute("SELECT COUNT(*) FROM test");
         assertThat(searchResponse).hasRows(new Object[] { (long) numDocs });
 
@@ -1063,7 +1062,7 @@ public class IndexRecoveryIT extends IntegTestCase {
             // shard is marked as started again (and ensureGreen returns), but while applying the cluster state the primary is failed and
             // will be reallocated. The cluster will thus become green, then red, then green again. Triggering a refresh here before
             // searching helps, as in contrast to search actions, refresh waits for the closed shard to be reallocated.
-            refresh();
+            execute("refresh table test");
         } else {
             logger.info("--> starting replica recovery from blue to red");
             execute("ALTER TABLE test SET (" +
@@ -1123,7 +1122,7 @@ public class IndexRecoveryIT extends IntegTestCase {
             args[i] = new Object[]{i};
         }
         execute("INSERT INTO test (id) VALUES (?)", args);
-        refresh();
+        execute("refresh table test");
         // Flush twice to update the safe commit's local checkpoint
         execute("OPTIMIZE TABLE test");
         execute("OPTIMIZE TABLE test");
@@ -1176,7 +1175,7 @@ public class IndexRecoveryIT extends IntegTestCase {
         }
         execute("ALTER TABLE test SET (number_of_replicas = 1)");
         ensureGreen();
-        refresh();
+        execute("refresh table test");
         var searchResponse = execute("SELECT COUNT(*) FROM test");
         assertThat(searchResponse).hasRows(new Object[] { (long) numDocs });
     }

--- a/server/src/test/java/org/elasticsearch/snapshots/BlobStoreIncrementalityIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/BlobStoreIncrementalityIT.java
@@ -90,7 +90,7 @@ public class BlobStoreIncrementalityIT extends AbstractSnapshotIntegTestCase {
         }
         int documentCountOriginal = data.size();
         execute("INSERT INTO " + indexName + "(a) VALUES(?)", data.toArray(new Object[][]{}));
-        refresh();
+        execute("refresh table " + indexName);
 
         final String snapshot1 = "snap_1";
         final String repo = "test_repo";
@@ -137,7 +137,7 @@ public class BlobStoreIncrementalityIT extends AbstractSnapshotIntegTestCase {
         }
         execute("INSERT INTO " + indexName + "(a) VALUES(?)", data.toArray(new Object[][]{}));
         int countAfterRecreation = data.size();
-        refresh();
+        execute("refresh table " + indexName);
 
         final String snapshot3 = "snap_3";
         logger.info("--> creating snapshot 3");
@@ -177,7 +177,7 @@ public class BlobStoreIncrementalityIT extends AbstractSnapshotIntegTestCase {
                 data.add(new Object[]{"foo" + j + "_bar" + i});
             }
             execute("INSERT INTO " + indexName + "(a) VALUES(?)", data.toArray(new Object[][]{}));
-            refresh();
+            execute("refresh table " + indexName);
         }
         execute("SELECT count(*) FROM sys.segments WHERE primary=true AND table_name=?", new Object[]{indexName});
         assertThat((long) response.rows()[0][0]).isGreaterThan(1);
@@ -193,7 +193,7 @@ public class BlobStoreIncrementalityIT extends AbstractSnapshotIntegTestCase {
 
         logger.info("--> force merging down to a single segment");
         execute("OPTIMIZE TABLE " + indexName + " WITH(max_num_segments=1)");
-        refresh();
+        execute("refresh table " + indexName);
         execute("SELECT count(*) FROM sys.segments WHERE primary=true AND table_name=?", new Object[]{indexName});
         assertThat((long) response.rows()[0][0]).isEqualTo(1);
 


### PR DESCRIPTION
`refresh()` is marked as deprecated and we want to get rid of it in the long run.
Also, some minor test code improvements.
