### PR TITLE
Guess inner types for objects and unify list/union cast semantics

### DIFF
--- a/server/src/test/java/io/crate/DataTypeTest.java
+++ b/server/src/test/java/io/crate/DataTypeTest.java
@@ -88,7 +88,17 @@ public class DataTypeTest extends ESTestCase {
 
         List<Object> objects = List.of(objA, objB);
         DataType<?> dataType = DataTypes.guessType(objects);
-        assertThat(dataType).isEqualTo(new ArrayType<>(DataTypes.UNTYPED_OBJECT));
+        var expectedObjectType = ObjectType.builder()
+            .setInnerType("a", DataTypes.INTEGER)
+            .setInnerType(
+                "b",
+                ObjectType.builder()
+                    .setInnerType("bn1", DataTypes.INTEGER)
+                    .setInnerType("bn2", DataTypes.INTEGER)
+                    .build()
+            )
+            .build();
+        assertThat(dataType).isEqualTo(new ArrayType<>(expectedObjectType));
     }
 
     @Test
@@ -108,7 +118,7 @@ public class DataTypeTest extends ESTestCase {
 
     @Test
     public void testForValueMixedDataTypeInList() {
-        List<Object> objects = Arrays.<Object>asList("foo", 1);
+        List<Object> objects = Arrays.<Object>asList("foo", List.of(1));
         assertThatThrownBy(() -> DataTypes.guessType(objects))
             .isExactlyInstanceOf(IllegalArgumentException.class);
     }

--- a/server/src/test/java/io/crate/integrationtests/GeoShapeIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/GeoShapeIntegrationTest.java
@@ -41,18 +41,18 @@ import io.crate.types.JsonType;
 
 public class GeoShapeIntegrationTest extends IntegTestCase {
 
-    private static final Map<String, Object> GEO_SHAPE1 = Map.of(
-        "coordinates", new double[][]{
-            {0, 0},
-            {1, 1}
-        },
+    private final Map<String, Object> geoShape1 = Map.of(
+        "coordinates", List.of(
+            List.of(0.0, 0.0),
+            List.of(1.0, 1.0)
+        ),
         "type", "LineString"
     );
-    private static final Map<String, Object> GEO_SHAPE2 = Map.of(
-        "coordinates", new double[][]{
-            {2, 2},
-            {3, 3}
-        },
+    private final Map<String, Object> geoShape2 = Map.of(
+        "coordinates", List.of(
+            List.of(2.0, 2.0),
+            List.of(3.0, 3.0)
+        ),
         "type", "LineString"
     );
 
@@ -69,11 +69,11 @@ public class GeoShapeIntegrationTest extends IntegTestCase {
         execute("INSERT INTO shaped (id, shape, bkd_shape) VALUES (?, ?, ?)",
             $$(
                 $(1L, "POINT (13.0 52.4)", "POINT (13.0 52.4)"),
-                $(2L, GEO_SHAPE1, GEO_SHAPE1)
+                $(2L, geoShape1, geoShape1)
             )
         );
         execute("INSERT INTO shaped (id, shapes, bkd_shapes) VALUES (?, ?, ?)",
-            $(3, new Object[]{GEO_SHAPE1, GEO_SHAPE2}, new Object[]{GEO_SHAPE1, GEO_SHAPE2})
+            $(3, new Object[]{geoShape1, geoShape2}, new Object[]{geoShape1, geoShape2})
         );
         execute("REFRESH TABLE shaped");
     }

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -1302,15 +1302,13 @@ public class TransportSQLActionTest extends IntegTestCase {
         assertThat(response).hasRowCount(1L);
         execute("select * from t where within(p, ?)", $(Map.of(
             "type", "Polygon",
-            "coordinates", new double[][][]{
-                {
-                    {5.0, 5.0},
-                    {30.0, 5.0},
-                    {30.0, 30.0},
-                    {5.0, 30.0},
-                    {5.0, 5.0}
-                }
-            }
+            "coordinates", List.of(List.of(
+                    List.of(5.0, 5.0),
+                    List.of(30.0, 5.0),
+                    List.of(30.0, 30.0),
+                    List.of(5.0, 30.0),
+                    List.of(5.0, 5.0)
+                ))
         )));
         assertThat(response).hasRowCount(1L);
 


### PR DESCRIPTION
This adds inner type information for object literals to support cases
like `{x=10}['x']`.

Adding the type information caused issues with list of objects because
type detection for lists had special cast semantics not used elsewhere
in the system and it didn't merge type information from objects.

This changes the list type inference to use the same logic we also use
for union - which makes it a bit more lenient.
