### PR TITLE
Add schema, table, shardId and partition info to profiling results

### DIFF
--- a/docs/appendices/release-notes/5.9.0.rst
+++ b/docs/appendices/release-notes/5.9.0.rst
@@ -173,3 +173,6 @@ Administration and Operations
   contain sub-queries, e.g.::
 
     EXPLAIN ANALYZE SELECT * FROM t1 WHERE c = (SELECT count(*) FROM t2);
+
+- Added schema, table, partition and shard information to ``QueryBreakdown``
+  entries of the ``EXPLAIN ANALYZE`` statement.

--- a/docs/sql/statements/explain.rst
+++ b/docs/sql/statements/explain.rst
@@ -113,6 +113,9 @@ A short excerpt of a query breakdown looks like this::
     {
       "QueryName": "PointRangeQuery",
       "QueryDescription": "x:[1 TO 1]",
+      "SchemaName": "doc",
+      "TableName": "employees",
+      "ShardId": 0,
       "Time": 0.004096,
       "BreakDown": {
         "score": 0,
@@ -132,6 +135,8 @@ A short excerpt of a query breakdown looks like this::
 
 The time values are in milliseconds. Fields suffixed with ``_count`` indicate
 how often an operation was invoked.
+If the query is executed on a partitioned table, each query breakdown will also
+contain the related ``PartitionIdent`` entry.
 
 +-----------------------------------+-----------------------------------+
 | field                             | description                       |

--- a/server/src/main/java/io/crate/analyze/ExplainStatementAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/ExplainStatementAnalyzer.java
@@ -22,7 +22,7 @@
 package io.crate.analyze;
 
 import java.util.EnumSet;
-import java.util.List;
+import java.util.Map;
 
 import io.crate.exceptions.UnsupportedFeatureException;
 import io.crate.planner.node.management.ExplainPlan;
@@ -64,7 +64,7 @@ public class ExplainStatementAnalyzer {
         } else if (isAnalyzeActivated && isVerboseActivated) {
             throw new IllegalArgumentException("The ANALYZE and VERBOSE options are not allowed together");
         } else if (isAnalyzeActivated) {
-            var profilingContext = new ProfilingContext(List.of());
+            var profilingContext = new ProfilingContext(Map.of());
             var timer = profilingContext.createAndStartTimer(ExplainPlan.Phase.Analyze.name());
             var subStatement = analyzer.analyzedStatement(statement, analysis);
             profilingContext.stopTimerAndStoreDuration(timer);

--- a/server/src/main/java/io/crate/execution/jobs/SharedShardContext.java
+++ b/server/src/main/java/io/crate/execution/jobs/SharedShardContext.java
@@ -21,7 +21,7 @@
 
 package io.crate.execution.jobs;
 
-import java.util.function.UnaryOperator;
+import java.util.function.BiFunction;
 
 import org.apache.lucene.search.IndexSearcher;
 import org.elasticsearch.index.IndexNotFoundException;
@@ -44,12 +44,12 @@ public class SharedShardContext {
     SharedShardContext(IndexService indexService,
                        ShardId shardId,
                        int readerId,
-                       UnaryOperator<Engine.Searcher> wrapSearcher) {
+                       BiFunction<ShardId, Engine.Searcher, Engine.Searcher> wrapSearcher) {
         this.indexService = indexService;
         IndexShard indexShard = indexService.getShard(shardId.id());
         this.readerId = readerId;
         this.searcher = new RefCountedItem<Engine.Searcher>(
-            source -> wrapSearcher.apply(indexShard.acquireSearcher(source)),
+            source -> wrapSearcher.apply(shardId, indexShard.acquireSearcher(source)),
             Engine.Searcher::close
         );
     }

--- a/server/src/main/java/io/crate/execution/jobs/SharedShardContexts.java
+++ b/server/src/main/java/io/crate/execution/jobs/SharedShardContexts.java
@@ -25,7 +25,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.UnaryOperator;
+import java.util.function.BiFunction;
 
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
@@ -35,22 +35,23 @@ import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndicesService;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import com.carrotsearch.hppc.IntIndexedContainer;
 
-import org.jetbrains.annotations.VisibleForTesting;
 import io.crate.metadata.IndexParts;
 
 public class SharedShardContexts {
 
     private final IndicesService indicesService;
-    private final UnaryOperator<Engine.Searcher> wrapSearcher;
+    private final BiFunction<ShardId, Engine.Searcher, Engine.Searcher> wrapSearcher;
     @VisibleForTesting
     final Map<ShardId, SharedShardContext> allocatedShards = new HashMap<>();
     @VisibleForTesting
     int readerId = 0;
 
-    public SharedShardContexts(IndicesService indicesService, UnaryOperator<Engine.Searcher> wrapSearcher) {
+    public SharedShardContexts(IndicesService indicesService,
+                               BiFunction<ShardId, Engine.Searcher, Engine.Searcher> wrapSearcher) {
         this.indicesService = indicesService;
         this.wrapSearcher = wrapSearcher;
     }

--- a/server/src/main/java/io/crate/planner/node/management/ExplainPlan.java
+++ b/server/src/main/java/io/crate/planner/node/management/ExplainPlan.java
@@ -326,7 +326,7 @@ public class ExplainPlan implements Plan {
                                                                              List<Map<String, Object>> explainResults) {
         RowConsumer rowConsumer = MultiPhaseExecutor.getConsumer(selectSymbol, ramAccounting);
 
-        var subPlanContext = new ProfilingContext(List.of());
+        var subPlanContext = new ProfilingContext(Map.of());
         Timer subPlanTimer = subPlanContext.createTimer(Phase.Execute.name());
         subPlanTimer.start();
 

--- a/server/src/main/java/io/crate/profile/ProfilingContext.java
+++ b/server/src/main/java/io/crate/profile/ProfilingContext.java
@@ -21,15 +21,18 @@
 
 package io.crate.profile;
 
-import org.elasticsearch.search.profile.ProfileResult;
-import org.elasticsearch.search.profile.query.QueryProfiler;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.search.profile.ProfileResult;
+import org.elasticsearch.search.profile.query.QueryProfiler;
+
+import io.crate.metadata.IndexParts;
 
 /**
  * Simple stop watch type class that can be used as a context across multiple layers (analyzer, planner, executor)
@@ -42,9 +45,9 @@ public class ProfilingContext {
 
     private static final double NS_TO_MS_FACTOR = 1_000_000.0d;
     private final HashMap<String, Double> durationInMSByTimer;
-    private final List<QueryProfiler> profilers;
+    private final Map<ShardId, QueryProfiler> profilers;
 
-    public ProfilingContext(List<QueryProfiler> profilers) {
+    public ProfilingContext(Map<ShardId, QueryProfiler> profilers) {
         this.profilers = profilers;
         this.durationInMSByTimer = new HashMap<>();
     }
@@ -52,9 +55,10 @@ public class ProfilingContext {
     public Map<String, Object> getDurationInMSByTimer() {
         HashMap<String, Object> builder = new HashMap<>(durationInMSByTimer);
         ArrayList<Map<String, Object>> queryTimings = new ArrayList<>();
-        for (var profiler : profilers) {
+        for (var entry : profilers.entrySet()) {
+            var profiler = entry.getValue();
             for (var profileResult : profiler.getTree()) {
-                queryTimings.add(resultAsMap(profileResult));
+                queryTimings.add(resultAsMap(entry.getKey(), profileResult));
             }
         }
         if (!queryTimings.isEmpty()) {
@@ -63,8 +67,15 @@ public class ProfilingContext {
         return Collections.unmodifiableMap(builder);
     }
 
-    private static Map<String, Object> resultAsMap(ProfileResult profileResult) {
+    private static Map<String, Object> resultAsMap(ShardId shardId, ProfileResult profileResult) {
         HashMap<String, Object> queryTimingsBuilder = new HashMap<>();
+        var indexParts = new IndexParts(shardId.getIndexName());
+        queryTimingsBuilder.put("SchemaName", indexParts.getSchema());
+        queryTimingsBuilder.put("TableName", indexParts.getTable());
+        if (indexParts.isPartitioned()) {
+            queryTimingsBuilder.put("PartitionIdent", indexParts.getPartitionIdent());
+        }
+        queryTimingsBuilder.put("ShardId", shardId.id());
         queryTimingsBuilder.put("QueryName", profileResult.getQueryName());
         queryTimingsBuilder.put("QueryDescription", profileResult.getLuceneDescription());
         queryTimingsBuilder.put("Time", profileResult.getTime() / NS_TO_MS_FACTOR);
@@ -74,7 +85,7 @@ public class ProfilingContext {
                 e -> e.getKey().endsWith("_count") ? e.getValue() : e.getValue() / NS_TO_MS_FACTOR))
         );
         List<Map<String, Object>> children = profileResult.getProfiledChildren().stream()
-            .map(ProfilingContext::resultAsMap)
+            .map((ProfileResult pr) -> resultAsMap(shardId, pr))
             .collect(Collectors.toList());
         if (!children.isEmpty()) {
             queryTimingsBuilder.put("Children", children);

--- a/server/src/test/java/io/crate/execution/engine/collect/DocLevelCollectTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/DocLevelCollectTest.java
@@ -33,7 +33,6 @@ import java.util.TreeMap;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.function.UnaryOperator;
 import java.util.stream.StreamSupport;
 
 import org.elasticsearch.cluster.routing.ShardRouting;
@@ -227,7 +226,7 @@ public class DocLevelCollectTest extends IntegTestCase {
         JobSetup jobSetup = cluster().getDataNodeInstance(JobSetup.class);
         TasksService tasksService = cluster().getDataNodeInstance(TasksService.class);
         SharedShardContexts sharedShardContexts = new SharedShardContexts(
-            cluster().getDataNodeInstance(IndicesService.class), UnaryOperator.identity());
+            cluster().getDataNodeInstance(IndicesService.class), (ignored, searcher) -> searcher);
         RootTask.Builder builder = tasksService.newBuilder(collectNode.jobId());
         NodeOperation nodeOperation = NodeOperation.withDirectResponse(collectNode, mock(ExecutionPhase.class), (byte) 0,
             "remoteNode");

--- a/server/src/test/java/io/crate/execution/engine/fetch/FetchTaskTest.java
+++ b/server/src/test/java/io/crate/execution/engine/fetch/FetchTaskTest.java
@@ -40,7 +40,6 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.UnaryOperator;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -76,7 +75,7 @@ public class FetchTaskTest extends CrateDummyClusterServiceUnitTest {
                 List.of()),
             0,
             "dummy",
-            new SharedShardContexts(mock(IndicesService.class), UnaryOperator.identity()),
+            new SharedShardContexts(mock(IndicesService.class), (ignored, searcher) -> searcher),
             clusterService.state().metadata(),
             relationName -> null,
             Collections.emptyList());
@@ -106,7 +105,7 @@ public class FetchTaskTest extends CrateDummyClusterServiceUnitTest {
             .build();
         IndicesService indicesService = mock(IndicesService.class, RETURNS_MOCKS);
         AtomicBoolean calledRefreshReaders = new AtomicBoolean(false);
-        SharedShardContexts sharedShardContexts = new SharedShardContexts(indicesService, UnaryOperator.identity()) {
+        SharedShardContexts sharedShardContexts = new SharedShardContexts(indicesService, (ignored, searcher) -> searcher) {
             @Override
             public CompletableFuture<Void> maybeRefreshReaders(Metadata metadata,
                                                                Map<String, IntIndexedContainer> shardsByIndex,

--- a/server/src/test/java/io/crate/execution/jobs/RootTaskTest.java
+++ b/server/src/test/java/io/crate/execution/jobs/RootTaskTest.java
@@ -32,7 +32,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
-import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import org.apache.logging.log4j.LogManager;
@@ -167,7 +167,7 @@ public class RootTaskTest extends ESTestCase {
     public void testEnablingProfilingGathersExecutionTimes() throws Throwable {
         RootTask.Builder builder =
             new RootTask.Builder(logger, UUID.randomUUID(), "dummy-user", coordinatorNode, Collections.emptySet(), mock(JobsLogs.class));
-        ProfilingContext profilingContext = new ProfilingContext(List.of());
+        ProfilingContext profilingContext = new ProfilingContext(Map.of());
         builder.profilingContext(profilingContext);
 
         AbstractTaskTest.TestingTask ctx1 = new AbstractTaskTest.TestingTask(1);

--- a/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
+++ b/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
@@ -39,7 +39,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
 import org.apache.lucene.index.Term;
@@ -655,7 +654,7 @@ public abstract class AggregationTestCase extends ESTestCase {
             RAM_ACCOUNTING,
             ramAccounting -> new OnHeapMemoryManager(ramAccounting::addBytes),
             new TestingRowConsumer(),
-            new SharedShardContexts(indexServices, UnaryOperator.identity()),
+            new SharedShardContexts(indexServices, (ignored, searcher) -> searcher),
             minNodeVersion,
             4096
         );


### PR DESCRIPTION
Include these inside the `QueryBreakdown` of each shard query to make it visible for `EXPLAIN ANALYZE` statements.

Closes #15101.
