### PR TITLE
Sort the QueryBreakdown map of the EXPLAIN ANALYZE stmt 

### DIFF
--- a/docs/sql/statements/explain.rst
+++ b/docs/sql/statements/explain.rst
@@ -111,26 +111,28 @@ expression.  Some familiarity with Lucene helps in interpreting the output.
 A short excerpt of a query breakdown looks like this::
 
     {
-      "QueryName": "PointRangeQuery",
-      "QueryDescription": "x:[1 TO 1]",
-      "SchemaName": "doc",
-      "TableName": "employees",
-      "ShardId": 0,
-      "Time": 0.004096,
       "BreakDown": {
-        "score": 0,
-        "match_count": 0,
-        "build_scorer_count": 0,
-        "create_weight": 0.004095,
-        "next_doc": 0,
-        "match": 0,
-        "score_count": 0,
-        "next_doc_count": 0,
-        "create_weight_count": 1,
-        "build_scorer": 0,
+        "advance": 0,
         "advance_count": 0,
-        "advance": 0
-      }
+        "build_scorer": 0,
+        "build_scorer_count": 0,
+        "compute_max_score": 0,
+        "compute_max_score_count": 0,
+        "create_weight": 0.004095,
+        "create_weight_count": 1,
+        "match": 0,
+        "match_count": 0,
+        "next_doc": 0,
+        "next_doc_count": 0,
+        "score": 0,
+        "score_count": 0
+      },
+      "QueryDescription": "x:[1 TO 1]",
+      "QueryName": "PointRangeQuery",
+      "SchemaName": "doc",
+      "ShardId": 0,
+      "TableName": "employees",
+      "Time": 0.004096
     }
 
 The time values are in milliseconds. Fields suffixed with ``_count`` indicate

--- a/docs/sql/statements/explain.rst
+++ b/docs/sql/statements/explain.rst
@@ -140,41 +140,41 @@ how often an operation was invoked.
 If the query is executed on a partitioned table, each query breakdown will also
 contain the related ``PartitionIdent`` entry.
 
-+-----------------------------------+-----------------------------------+
-| field                             | description                       |
-+===================================+===================================+
-| ``create_weight``                 | A ``Weight`` object is created    |
-|                                   | for a query and acts as a         |
-|                                   | temporary object containing       |
-|                                   | state. This metric shows how long |
-|                                   | this process took.                |
-+-----------------------------------+-----------------------------------+
-| ``build_scorer``                  | A ``Scorer`` object is used to    |
-|                                   | iterate over documents matching   |
-|                                   | the query and generate scores for |
-|                                   | them. Note that this includes     |
-|                                   | only the time to create the       |
-|                                   | scorer, not that actual time      |
-|                                   | spent on the iteration.           |
-+-----------------------------------+-----------------------------------+
-| ``score``                         | Shows the time it takes to score  |
-|                                   | a particular document via its     |
-|                                   | ``Scorer``.                       |
-+-----------------------------------+-----------------------------------+
-| ``next_doc``                      | Shows the time it takes to        |
-|                                   | determine which document is the   |
-|                                   | next match.                       |
-+-----------------------------------+-----------------------------------+
-| ``advance``                       | A lower level version of          |
-|                                   | ``next_doc``.                     |
-+-----------------------------------+-----------------------------------+
-| ``match``                         | Some queries use a two-phase      |
-|                                   | execution, doing an               |
-|                                   | ``approximation`` first, and then |
-|                                   | a second more expensive phase.    |
-|                                   | This metric measures the second   |
-|                                   | phase.                            |
-+-----------------------------------+-----------------------------------+
+.. list-table::
+    :header-rows: 1
+    :widths: auto
+    :align: left
+
+    * - Field
+      - Description
+    * - ``create_weight``
+      - A ``Weight`` object is created for a query and acts as a temporary
+        object containing state. This metric shows how long this process took.
+    * - ``build_scorer``
+      - A ``Scorer`` object is used to iterate over documents matching the
+        query and generate scores for them. Note that this includes only the
+        time to create the scorer, not that actual time spent on the iteration.
+    * - ``score``
+      - Shows the time it takes to score a particular document via its
+        ``Scorer``.
+    * - ``next_doc``
+      - Shows the time it takes to determine which document is the next match.
+    * - ``advance``
+      - A lower level version of ``next_doc``. It also finds the next matching
+        document but necessitates that the calling query perform additional
+        tasks, such as identifying skips. Some queries, such as conjunctions
+        (``must`` clauses in Boolean queries), cannot use ``next_doc``. For
+        those queries, ``advance`` is timed.
+    * - ``match``
+      - Some queries use a two-phase execution, doing an ``approximation``
+        first, and then a second more expensive phase. This metric measures
+        the second phase.
+    * - ``*_count``
+      - Records the number of invocations of the particular method. For
+        example, ``"next_doc_count": 2``, means the ``nextDoc()`` method was
+        called on two different documents. This can be used to help judge how
+        selective queries are, by comparing counts between different query
+        components.
 
 .. NOTE::
 


### PR DESCRIPTION
Additionally, slighlty improve the query breakdown documentation of ``EXPLAIN ANALYZE``:
- Add more verbose description for `advance`.
- Add description for `*_count` entries.

Relates to https://github.com/crate/crate/pull/16591#discussion_r1750685671.