### PR TITLE
Specialize createIndex for create-table

### DIFF
--- a/server/src/main/java/io/crate/execution/ddl/Templates.java
+++ b/server/src/main/java/io/crate/execution/ddl/Templates.java
@@ -83,7 +83,7 @@ public final class Templates {
         String templatePrefix = PartitionName.templatePrefix(relationName.schema(), relationName.name());
         Alias alias = new Alias(relationName.indexNameOrAlias());
 
-        validate(metadataIndexService, templateName, templatePrefix, settings, alias);
+        validate(metadataIndexService, templateName, templatePrefix, request.settings(), alias);
 
         final String temporaryIndexName = UUIDs.randomBase64UUID();
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreateIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreateIndexAction.java
@@ -85,7 +85,6 @@ public class TransportCreateIndexAction extends TransportMasterNodeAction<Create
 
         createIndexService.createIndex(
             updateRequest,
-            null,
             listener.map(response ->
                 new CreateIndexResponse(response.isAcknowledged(), response.isShardsAcknowledged(), indexName))
         );

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/TransportResizeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/TransportResizeAction.java
@@ -109,7 +109,6 @@ public class TransportResizeAction extends TransportMasterNodeAction<ResizeReque
                     );
                     createIndexService.createIndex(
                         updateRequest,
-                        null,
                         delegate.map(
                             response -> new ResizeResponse(
                                 response.isAcknowledged(),


### PR DESCRIPTION
As part of the work on https://github.com/crate/crate/issues/11939 I'd
like to temporarily add new structures parallel to the existing
structures.

To make that easier for create-table, it helps if both the index and
template creation happen within the same cluster state update task. This
shuffles things around to do that.