### PR TITLE
Update PULL_REQUEST_TEMPLATE.md - removed CLA check

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,6 @@
  - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
  - [ ] Updated documentation & `sql_features` table for user facing changes
  - [ ] Touched code is covered by tests
- - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
  - [ ] This does not contain breaking changes, or if it does:
     - It is released within a major release
     - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

As a bot now automatically check that the CLA is signed, we no longer need this manual check.

