### PR TITLE
Add `cla-signed` label as pre-requisite to mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -13,7 +13,7 @@ queue_rules:
 pull_request_rules:
   - name: automatic merge
     conditions:
-      - label=ready-to-merge
+      - label=ready-to-merge,cla-signed
       - '#approved-reviews-by>=1'
       - status-success=ci/jenkins/pr_tests
       - status-success~=^Test CrateDB SQL on ubuntu


### PR DESCRIPTION
Since we enabled the cla bot which verifies that a user has signed the licence agreement and adds the `cla-signed` if so, add the label as a pre-requisite to mergify, so that it doesn't merge a PR without it.
