### PR TITLE
Fall back to GenericFunctionQuery when the pattern literal is not a pattern

### DIFF
--- a/docs/appendices/release-notes/5.8.3.rst
+++ b/docs/appendices/release-notes/5.8.3.rst
@@ -84,3 +84,6 @@ Fixes
 
 - Fixed an issue that caused filtering by ``LIKE ALL`` on arrays to behave like
   ``LIKE ANY``.
+
+- Fixed an issue that prevented filtering by ``LIKE ANY`` on array columns
+  containing patterns.

--- a/server/src/main/java/io/crate/expression/operator/LikeOperators.java
+++ b/server/src/main/java/io/crate/expression/operator/LikeOperators.java
@@ -295,6 +295,33 @@ public class LikeOperators {
         return makePattern(pattern, caseSensitivity, escape).matcher(expression).matches();
     }
 
+    public static boolean containsWildCards(String string, @Nullable Character escapeChar) {
+        boolean escaped = false;
+        for (char c : string.toCharArray()) {
+            if (escapeChar != null && !escaped && c == escapeChar) {
+                escaped = true;
+            } else {
+                switch (c) {
+                    case '%':
+                        if (!escaped) {
+                            return true;
+                        }
+                        escaped = false;
+                        break;
+                    case '_':
+                        if (!escaped) {
+                            return true;
+                        }
+                        escaped = false;
+                        break;
+                    default:
+                        escaped = false;
+                }
+            }
+        }
+        return false;
+    }
+
     public static String patternToRegex(String patternString, @Nullable Character escapeChar) {
         StringBuilder regex = new StringBuilder(patternString.length() * 2);
         regex.append('^');

--- a/server/src/test/java/io/crate/lucene/LikeQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/LikeQueryBuilderTest.java
@@ -45,7 +45,7 @@ public class LikeQueryBuilderTest extends LuceneQueryBuilderTest {
 
     @Test
     public void testLikeAnyOnArrayLiteral() throws Exception {
-        Query likeQuery = convert("name like any (['a', 'b', 'c'])");
+        Query likeQuery = convert("name like any (['a_', 'b_', 'c'])");
         assertThat(likeQuery).isExactlyInstanceOf(BooleanQuery.class);
         BooleanQuery likeBQuery = (BooleanQuery) likeQuery;
         assertThat(likeBQuery.clauses()).hasSize(3);
@@ -58,7 +58,7 @@ public class LikeQueryBuilderTest extends LuceneQueryBuilderTest {
 
     @Test
     public void testILikeAnyOnArrayLiteral() throws Exception {
-        Query likeQuery = convert("name ilike any (['A', 'B', 'B'])");
+        Query likeQuery = convert("name ilike any (['A_', 'B', 'B'])");
         assertThat(likeQuery).isExactlyInstanceOf(BooleanQuery.class);
         BooleanQuery likeBQuery = (BooleanQuery) likeQuery;
         assertThat(likeBQuery.clauses()).hasSize(3);
@@ -70,7 +70,7 @@ public class LikeQueryBuilderTest extends LuceneQueryBuilderTest {
 
     @Test
     public void testNotLikeAnyOnArrayLiteral() throws Exception {
-        Query notLikeQuery = convert("name not like any (['a', 'b', 'c'])");
+        Query notLikeQuery = convert("name not like any (['a%', 'b', 'c'])");
         assertThat(notLikeQuery).isExactlyInstanceOf(BooleanQuery.class);
         BooleanQuery notLikeBQuery = (BooleanQuery) notLikeQuery;
         assertThat(notLikeBQuery.clauses()).hasSize(2);
@@ -85,7 +85,7 @@ public class LikeQueryBuilderTest extends LuceneQueryBuilderTest {
 
     @Test
     public void testNotILikeAnyOnArrayLiteral() throws Exception {
-        Query notLikeQuery = convert("name not ilike any (['A', 'B', 'C'])");
+        Query notLikeQuery = convert("name not ilike any (['A_', 'B', 'C'])");
         assertThat(notLikeQuery).isExactlyInstanceOf(BooleanQuery.class);
         BooleanQuery notLikeBQuery = (BooleanQuery) notLikeQuery;
         assertThat(notLikeBQuery.clauses()).hasSize(2);
@@ -215,7 +215,7 @@ public class LikeQueryBuilderTest extends LuceneQueryBuilderTest {
     public void test_like_ilike_any_with_trailing_escape_char() {
         for (var op : List.of("like", "ilike")) {
             for (var not : List.of("", "not")) {
-                assertThatThrownBy(() -> convert("name " + not + " " + op + " any(['a', 'b', 'ab\\'])"))
+                assertThatThrownBy(() -> convert("name " + not + " " + op + " any(['a_', 'b%', 'ab\\'])"))
                     .isExactlyInstanceOf(IllegalArgumentException.class)
                     .hasMessage("pattern 'ab\\' must not end with escape character '\\'");
             }

--- a/server/src/test/java/io/crate/lucene/LuceneQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/LuceneQueryBuilderTest.java
@@ -101,7 +101,8 @@ public abstract class LuceneQueryBuilderTest extends CrateDummyClusterServiceUni
                " vchar_name varchar(40)," +
                " byte_col byte, " +
                " bool_col boolean, " +
-               " d_array_index_off_no_docvalues array(double) index off storage with (columnstore = false) " +
+               " d_array_index_off_no_docvalues array(double) index off storage with (columnstore = false), " +
+               " text_array array(text)" +
                ")";
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes https://github.com/crate/crate/issues/16593. The bug scenario occurs because when an argument of `like any` is a literal, CrateDB assumed it as the pattern literal.(ignoring the possibility that the references could contain patterns) To fix this, we need to fall back to generic function query when the literal does not contain any wildcards.  

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
