### PR TITLE
Fix flaky test_explain_analyze_query_execution_contains_shard_and_partition_information

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/ExplainAnalyzeIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ExplainAnalyzeIntegrationTest.java
@@ -173,7 +173,7 @@ public class ExplainAnalyzeIntegrationTest extends IntegTestCase {
 
     @Test
     public void test_explain_analyze_query_execution_contains_shard_and_partition_information() {
-        execute("CREATE TABLE my_schema.parted (id int, p int) PARTITIONED BY (p)");
+        execute("CREATE TABLE my_schema.parted (id int, p int) PARTITIONED BY (p) with (number_of_replicas = 0)");
         execute("INSERT INTO my_schema.parted (id, p) VALUES (1, 0)");
         execute("EXPLAIN ANALYZE SELECT * FROM my_schema.parted");
         Map<String, Object> analysis = (Map<String, Object>) response.rows()[0][0];


### PR DESCRIPTION
Disable replicas as this can cause the execution plan to choose shards only from one node which will break the test.
