### PR TITLE
Add lucene query generation for `IS DISTINCT` queries when possible

### DIFF
--- a/docs/appendices/release-notes/5.9.0.rst
+++ b/docs/appendices/release-notes/5.9.0.rst
@@ -122,7 +122,7 @@ SQL Standard and PostgreSQL Compatibility
   be used as the unit name as well.
 
 - `Martin Stein <https://github.com/marstein>`_ added support for the
-  IS DISTINCT FROM operator. The operator is not yet optimized for Lucene queries.
+  IS DISTINCT FROM operator.
 
 Data Types
 ----------

--- a/docs/general/dql/selects.rst
+++ b/docs/general/dql/selects.rst
@@ -547,12 +547,6 @@ does always return ``NULL`` when comparing ``NULL``.
     SELECT 3 rows in set (... sec)
 
 
-.. NOTE::
-
-   Using ``IS DISTINCT FROM`` can be slow because the expression is not using
-   index structures and is not suitable for use on larger tables.
-   
-   
 .. _sql_dql_array_comparisons:
 
 Array comparisons

--- a/server/src/test/java/io/crate/expression/predicate/DistinctFromTest.java
+++ b/server/src/test/java/io/crate/expression/predicate/DistinctFromTest.java
@@ -27,6 +27,8 @@ import static io.crate.testing.DataTypeTesting.randomType;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -94,7 +96,14 @@ public class DistinctFromTest extends ScalarTestCase {
     }
 
     @Test
-    public void test_terms_query_on_empty_object() throws Exception {
+    public void test_is_distinct_on_array() {
+        assertEvaluate("[1, 2] IS DISTINCT FROM [1, 2]", Boolean.FALSE);
+        assertEvaluate("[1, 2] IS DISTINCT FROM null", Boolean.TRUE);
+        assertEvaluate("null IS DISTINCT FROM [1, 2]", Boolean.TRUE);
+    }
+
+    @Test
+    public void test_terms_query_primitive_type() throws Exception {
         QueryTester.Builder builder = new QueryTester.Builder(
             THREAD_POOL,
             clusterService,
@@ -107,8 +116,7 @@ public class DistinctFromTest extends ScalarTestCase {
         try (QueryTester tester = builder.build()) {
             Query query = tester.toQuery("str IS DISTINCT FROM 'hello'");
             assertThat(query)
-                .isExactlyInstanceOf(GenericFunctionQuery.class)
-                .hasToString("(str IS DISTINCT FROM 'hello')");
+                .hasToString("+*:* -str:hello");
 
             assertThat(tester.runQuery("str", "str IS DISTINCT FROM 'hello'"))
                 .containsExactly("Duke", "rules", null);
@@ -117,5 +125,179 @@ public class DistinctFromTest extends ScalarTestCase {
             assertThat(tester.runQuery("str", "str IS NOT DISTINCT FROM 'hello'"))
                 .containsExactly("hello");
         }
+    }
+
+    @Test
+    public void test_terms_query_on_internal_id_column() throws Exception {
+        QueryTester.Builder builder = new QueryTester.Builder(
+            THREAD_POOL,
+            clusterService,
+            Version.CURRENT,
+            "create table tbl (str string)");
+        builder.indexValue("str", "hello");
+        builder.indexValue("str", null);
+        try (QueryTester tester = builder.build()) {
+            var query = tester.toQuery("_id IS DISTINCT FROM 'dummy-id'");
+            assertThat(query)
+                .hasToString("+*:* -_id:[76 e9 a6 cb e8 9d]");
+            assertThat(tester.runQuery("_id", "_id IS DISTINCT FROM null"))
+                .containsExactly("dummy-id", "dummy-id");
+
+            assertThat(tester.runQuery("str", "_id IS DISTINCT FROM 'dummy-id'"))
+                .isEmpty();
+        }
+    }
+
+    @Test
+    public void test_is_distinct_on_null_object_results_in_generic_function() throws Exception {
+        QueryTester.Builder builder = new QueryTester.Builder(
+            THREAD_POOL,
+            clusterService,
+            Version.CURRENT,
+            "create table tbl (obj object)");
+        builder.indexValue("obj", Map.of());
+        builder.indexValue("obj", Map.of("a", 1));
+        builder.indexValue("obj", null);
+        try (QueryTester tester = builder.build()) {
+            Query query = tester.toQuery("obj IS DISTINCT FROM null");
+            assertThat(query)
+                .isExactlyInstanceOf(GenericFunctionQuery.class)
+                .hasToString("(obj IS DISTINCT FROM NULL)");
+
+            assertThat(tester.runQuery("obj", "obj IS DISTINCT FROM null")).containsExactly(
+                Map.of(), Map.of("a", 1)
+            );
+        }
+    }
+
+    @Test
+    public void test_is_distinct_on_empty_object_results_in_generic_function() throws Exception {
+        QueryTester.Builder builder = new QueryTester.Builder(
+            THREAD_POOL,
+            clusterService,
+            Version.CURRENT,
+            "create table tbl (obj object)");
+        builder.indexValue("obj", Map.of());
+        builder.indexValue("obj", Map.of("a", 1));
+        builder.indexValue("obj", null);
+        try (QueryTester tester = builder.build()) {
+            Query query = tester.toQuery("obj IS DISTINCT FROM {}");
+            assertThat(query)
+                .isExactlyInstanceOf(GenericFunctionQuery.class)
+                .hasToString("(obj IS DISTINCT FROM {})");
+
+            assertThat(tester.runQuery("obj", "obj IS DISTINCT FROM {}")).containsExactly(
+                Map.of("a", 1), null
+            );
+        }
+    }
+
+    @Test
+    public void test_is_distinct_on_object_with_known_childs() throws Exception {
+        QueryTester.Builder builder = new QueryTester.Builder(
+            THREAD_POOL,
+            clusterService,
+            Version.CURRENT,
+            "create table tbl (obj object as (a integer))");
+        builder.indexValue("obj", Map.of());
+        builder.indexValue("obj", Map.of("a", 1));
+        builder.indexValue("obj", Map.of("a", 2, "b", 2));
+        builder.indexValue("obj", null);
+        try (QueryTester tester = builder.build()) {
+            Query query = tester.toQuery("obj IS DISTINCT FROM {a=1}");
+            assertThat(query)
+                .hasToString("+(+*:* -obj.a:[1 TO 1])");
+
+            assertThat(tester.runQuery("obj", "obj IS DISTINCT FROM {a=1}")).containsExactly(
+                Map.of(), Map.of("a", 2, "b", 2), null
+            );
+        }
+    }
+
+    @Test
+    public void test_is_distinct_on_object_including_unknown_childs() throws Exception {
+        QueryTester.Builder builder = new QueryTester.Builder(
+            THREAD_POOL,
+            clusterService,
+            Version.CURRENT,
+            "create table tbl (obj object as (a integer))");
+        builder.indexValue("obj", Map.of());
+        builder.indexValue("obj", Map.of("a", 1));
+        builder.indexValue("obj", Map.of("a", 2, "b", 2));
+        builder.indexValue("obj", null);
+        try (QueryTester tester = builder.build()) {
+            var query = tester.toQuery("obj IS DISTINCT FROM {a=2, b=2}");
+            assertThat(query)
+                .hasToString("+(+*:* -obj.a:[2 TO 2]) #(obj IS DISTINCT FROM {\"a\"=2, \"b\"=2})");
+
+            assertThat(tester.runQuery("obj", "obj IS DISTINCT FROM {a=2, b=2}")).containsExactly(
+                Map.of(), Map.of("a", 1), null
+            );
+        }
+    }
+
+    @Test
+    public void test_is_distinct_on_null_array_uses_field_exists() throws Exception {
+        QueryTester.Builder builder = new QueryTester.Builder(
+            THREAD_POOL,
+            clusterService,
+            Version.CURRENT,
+            "create table tbl (arr array(integer))");
+        builder.indexValue("arr", List.of());
+        builder.indexValue("arr", List.of(1, 2));
+        builder.indexValue("arr", null);
+        try (QueryTester tester = builder.build()) {
+            Query query = tester.toQuery("arr IS DISTINCT FROM null");
+            assertThat(query)
+                .hasToString("FieldExistsQuery [field=_array_length_arr]");
+
+            assertThat(tester.runQuery("arr", "arr IS DISTINCT FROM null")).containsExactly(
+                List.of(), List.of(1, 2)
+            );
+        }
+
+    }
+
+    @Test
+    public void test_is_distinct_on_array_uses_array_term_query() throws Exception {
+        QueryTester.Builder builder = new QueryTester.Builder(
+            THREAD_POOL,
+            clusterService,
+            Version.CURRENT,
+            "create table tbl (arr array(integer))");
+        builder.indexValue("arr", List.of());
+        builder.indexValue("arr", List.of(1, 2));
+        builder.indexValue("arr", null);
+        try (QueryTester tester = builder.build()) {
+            Query query = tester.toQuery("arr IS DISTINCT FROM [1]");
+            assertThat(query)
+                .hasToString("-arr:{1} +(arr IS DISTINCT FROM [1])");
+
+            assertThat(tester.runQuery("arr", "arr IS DISTINCT FROM [1, 2]")).containsExactly(
+                List.of(), null
+            );
+        }
+    }
+
+    @Test
+    public void test_is_distinct_on_empty_array_uses_array_length_query() throws Exception {
+        QueryTester.Builder builder = new QueryTester.Builder(
+            THREAD_POOL,
+            clusterService,
+            Version.CURRENT,
+            "create table tbl (arr array(integer))");
+        builder.indexValue("arr", List.of());
+        builder.indexValue("arr", List.of(1, 2));
+        builder.indexValue("arr", null);
+        try (QueryTester tester = builder.build()) {
+            Query query = tester.toQuery("arr IS DISTINCT FROM []");
+            assertThat(query)
+                .hasToString("+*:* -_array_length_arr:[0 TO 0]");
+
+            assertThat(tester.runQuery("arr", "arr IS DISTINCT FROM []")).containsExactly(
+                List.of(1, 2), null
+            );
+        }
+
     }
 }


### PR DESCRIPTION
This should improve performance a lot when using `IS (NOT)? DISTINCT` inside the ``WHERE`` clause as it will utilize lucene indexes or docvalues.

Closes #16537.