### PR TITLE
Fix DoubleType's float to double conversion

### DIFF
--- a/server/src/main/java/io/crate/types/DoubleType.java
+++ b/server/src/main/java/io/crate/types/DoubleType.java
@@ -165,7 +165,7 @@ public class DoubleType extends DataType<Double> implements FixedWidthType, Stre
             }
             return bigDecimalValue.doubleValue();
         } else if (value instanceof Number n) {
-            return n.doubleValue();
+            return Double.valueOf(String.valueOf(n)); // prevent precision errors
         } else {
             throw new ClassCastException("Can't cast '" + value + "' to " + getName());
         }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes precision errors while converting float to double.
```
cr> create table t (a float);
insert into CREATE OK, 1 row affected (1.687 sec)
cr> insert into t values (1.1);
INSERT OK, 1 row affected (0.045 sec)
cr> select a::double from t;
+-----------------------------+
| cast(a AS double precision) |
+-----------------------------+
|           1.100000023841858 | -- should be `1.1`
+-----------------------------+
SELECT 1 row in set (0.003 sec)
```

## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
