### PR TITLE
Pass URI on FileOutput creation; make FileInput and FileOutput Closable

### DIFF
--- a/plugins/cr8-copy-s3/src/main/java/io/crate/copy/s3/S3FileOutput.java
+++ b/plugins/cr8-copy-s3/src/main/java/io/crate/copy/s3/S3FileOutput.java
@@ -53,15 +53,18 @@ import java.util.zip.GZIPOutputStream;
 @NotThreadSafe
 public class S3FileOutput implements FileOutput {
 
+    private final URI uri;
+
     @Nullable
     private final String protocolSetting;
 
-    public S3FileOutput(String protocol) {
+    public S3FileOutput(URI uri, String protocol) {
+        this.uri = uri;
         protocolSetting = protocol;
     }
 
     @Override
-    public OutputStream acquireOutputStream(Executor executor, URI uri, WriterProjection.CompressionType compressionType) throws IOException {
+    public OutputStream acquireOutputStream(Executor executor,WriterProjection.CompressionType compressionType) throws IOException {
         OutputStream outputStream = new S3OutputStream(executor, S3URI.toS3URI(uri), new S3ClientHelper(), protocolSetting);
         if (compressionType != null) {
             outputStream = new GZIPOutputStream(outputStream);

--- a/plugins/cr8-copy-s3/src/main/java/io/crate/copy/s3/S3FileOutputFactory.java
+++ b/plugins/cr8-copy-s3/src/main/java/io/crate/copy/s3/S3FileOutputFactory.java
@@ -21,6 +21,8 @@
 
 package io.crate.copy.s3;
 
+import java.net.URI;
+
 import io.crate.copy.s3.common.S3Protocol;
 import io.crate.execution.engine.export.FileOutput;
 import io.crate.execution.engine.export.FileOutputFactory;
@@ -31,7 +33,7 @@ public class S3FileOutputFactory implements FileOutputFactory {
     public static final String NAME = "s3";
 
     @Override
-    public FileOutput create(Settings withClauseOptions) {
-        return new S3FileOutput(S3Protocol.get(withClauseOptions));
+    public FileOutput create(URI uri, Settings withClauseOptions) {
+        return new S3FileOutput(uri, S3Protocol.get(withClauseOptions));
     }
 }

--- a/server/src/main/java/io/crate/execution/engine/collect/files/FileInput.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/files/FileInput.java
@@ -26,7 +26,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.util.List;
 
-public interface FileInput {
+public interface FileInput extends AutoCloseable {
 
     /**
      * this method returns all files that are found within fileUri
@@ -43,4 +43,9 @@ public interface FileInput {
     URI uri();
 
     boolean sharedStorageDefault();
+
+    @Override
+    default void close() {
+        // No-op, implement if FileInput implementation has resources to free.
+    }
 }

--- a/server/src/main/java/io/crate/execution/engine/collect/files/FileReadingIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/files/FileReadingIterator.java
@@ -352,6 +352,9 @@ public class FileReadingIterator implements BatchIterator<FileReadingIterator.Li
     private void reset() {
         fileInputsIterator = null;
         currentInputUriIterator = null;
+        if (currentInput != null) {
+            currentInput.close();
+        }
         currentInput = null;
         cursor.failure = null;
     }

--- a/server/src/main/java/io/crate/execution/engine/export/FileOutput.java
+++ b/server/src/main/java/io/crate/execution/engine/export/FileOutput.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.concurrent.Executor;
 
-public interface FileOutput {
+public interface FileOutput extends AutoCloseable {
 
     /**
      * calling this method creates & acquires an OutputStream which must be closed by the caller if it is no longer needed
@@ -35,4 +35,9 @@ public interface FileOutput {
      * @throws IOException in case the Output can't be created (e.g. due to file permission errors or something like that)
      */
     OutputStream acquireOutputStream(Executor executor, WriterProjection.CompressionType compressionType) throws IOException;
+
+    @Override
+    default void close() {
+        // No-op, implement if FileOutput implementation has resources to free.
+    }
 }

--- a/server/src/main/java/io/crate/execution/engine/export/FileOutput.java
+++ b/server/src/main/java/io/crate/execution/engine/export/FileOutput.java
@@ -25,7 +25,6 @@ import io.crate.execution.dsl.projection.WriterProjection;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.net.URI;
 import java.util.concurrent.Executor;
 
 public interface FileOutput {
@@ -35,5 +34,5 @@ public interface FileOutput {
      *
      * @throws IOException in case the Output can't be created (e.g. due to file permission errors or something like that)
      */
-    OutputStream acquireOutputStream(Executor executor, URI uri, WriterProjection.CompressionType compressionType) throws IOException;
+    OutputStream acquireOutputStream(Executor executor, WriterProjection.CompressionType compressionType) throws IOException;
 }

--- a/server/src/main/java/io/crate/execution/engine/export/FileOutputFactory.java
+++ b/server/src/main/java/io/crate/execution/engine/export/FileOutputFactory.java
@@ -21,9 +21,11 @@
 
 package io.crate.execution.engine.export;
 
+import java.net.URI;
+
 import org.elasticsearch.common.settings.Settings;
 
 public interface FileOutputFactory {
 
-    FileOutput create(Settings withClauseOptions);
+    FileOutput create(URI uri, Settings withClauseOptions);
 }

--- a/server/src/main/java/io/crate/execution/engine/export/FileWriterCountCollector.java
+++ b/server/src/main/java/io/crate/execution/engine/export/FileWriterCountCollector.java
@@ -101,18 +101,18 @@ public class FileWriterCountCollector implements Collector<Row, long[], Iterable
         if (fileOutputFactory == null) {
             throw new UnsupportedFeatureException(String.format(Locale.ENGLISH, "Unknown scheme '%s'", scheme));
         }
-        fileOutput = fileOutputFactory.create(withClauseOptions);
+        fileOutput = fileOutputFactory.create(uri, withClauseOptions);
         this.rowWriter = initWriter();
     }
 
     private RowWriter initWriter() {
         try {
             if (outputFormat.equals(WriterProjection.OutputFormat.JSON_ARRAY)) {
-                return new ColumnRowWriter(fileOutput.acquireOutputStream(executor, uri, compressionType), collectExpressions, inputs);
+                return new ColumnRowWriter(fileOutput.acquireOutputStream(executor, compressionType), collectExpressions, inputs);
             } else if (outputNames != null && outputFormat.equals(WriterProjection.OutputFormat.JSON_OBJECT)) {
-                return new ColumnRowObjectWriter(fileOutput.acquireOutputStream(executor, uri, compressionType), collectExpressions, inputs, outputNames);
+                return new ColumnRowObjectWriter(fileOutput.acquireOutputStream(executor, compressionType), collectExpressions, inputs, outputNames);
             } else {
-                return new RawRowWriter(fileOutput.acquireOutputStream(executor, uri, compressionType));
+                return new RawRowWriter(fileOutput.acquireOutputStream(executor, compressionType));
             }
         } catch (IOException e) {
             throw new UnhandledServerException(String.format(Locale.ENGLISH, "Failed to open output: '%s'", e.getMessage()), e);

--- a/server/src/main/java/io/crate/execution/engine/export/LocalFsFileOutput.java
+++ b/server/src/main/java/io/crate/execution/engine/export/LocalFsFileOutput.java
@@ -34,8 +34,14 @@ import java.util.zip.GZIPOutputStream;
 
 public class LocalFsFileOutput implements FileOutput {
 
+    private final URI uri;
+
+    public LocalFsFileOutput(URI uri) {
+        this.uri = uri;
+    }
+
     @Override
-    public OutputStream acquireOutputStream(Executor executor, URI uri, WriterProjection.CompressionType compressionType) throws IOException {
+    public OutputStream acquireOutputStream(Executor executor, WriterProjection.CompressionType compressionType) throws IOException {
         if (uri.getHost() != null) {
             throw new IllegalArgumentException("the URI host must be defined");
         }

--- a/server/src/main/java/io/crate/execution/engine/export/LocalFsFileOutputFactory.java
+++ b/server/src/main/java/io/crate/execution/engine/export/LocalFsFileOutputFactory.java
@@ -21,14 +21,16 @@
 
 package io.crate.execution.engine.export;
 
+import java.net.URI;
+
 import org.elasticsearch.common.settings.Settings;
 
 public class LocalFsFileOutputFactory implements FileOutputFactory {
     public static final String NAME = "file";
 
     @Override
-    public FileOutput create(Settings withClauseOptions) {
-        return new LocalFsFileOutput();
+    public FileOutput create(URI uri, Settings withClauseOptions) {
+        return new LocalFsFileOutput(uri);
     }
 
 }

--- a/server/src/test/java/io/crate/execution/engine/export/LocalFsFileOutputTest.java
+++ b/server/src/test/java/io/crate/execution/engine/export/LocalFsFileOutputTest.java
@@ -37,8 +37,8 @@ public class LocalFsFileOutputTest extends ESTestCase {
     @Test
     public void testIsBufferedOutputStream() throws Exception {
         Path file = createTempFile("out", "json");
-        LocalFsFileOutput localFsFileOutput = new LocalFsFileOutput();
-        try (OutputStream os = localFsFileOutput.acquireOutputStream(mock(Executor.class), file.toUri(), null)) {
+        LocalFsFileOutput localFsFileOutput = new LocalFsFileOutput(file.toUri());
+        try (OutputStream os = localFsFileOutput.acquireOutputStream(mock(Executor.class), null)) {
             assertThat(os).isExactlyInstanceOf(BufferedOutputStream.class);
         }
     }


### PR DESCRIPTION
Relates to https://github.com/crate/crate/issues/13852


We extract some info from the URL for different providers (S3, Azure).

This is a pre-requisite for using OpenDAL Operator. We will create it once per FileInput/FileOutput and need info from the URI, so passing it to the ctor. 

Second commit is cherry picking AutoClosable part from another PR - later on, plugins using OpenDAL will override `close` and close `Operator` there.
