### PR TITLE
Remove type specific logic from TypeCompatibility; support array_sum/avg([])

### DIFF
--- a/docs/appendices/release-notes/5.9.0.rst
+++ b/docs/appendices/release-notes/5.9.0.rst
@@ -153,6 +153,10 @@ Scalar and Aggregation Functions
 - Added an optional ``precision`` parameter to the :ref:`round <scalar-round>`
   scalar function.
 
+- Functions like :ref:`array_sum <scalar-array_sum>` or :ref:`array_avg
+  <scalar-array_avg>` can now be used with an empty array literal without
+  requiring an explicit type cast.
+
 Performance and Resilience Improvements
 ---------------------------------------
 

--- a/server/src/main/java/io/crate/types/DataType.java
+++ b/server/src/main/java/io/crate/types/DataType.java
@@ -100,7 +100,7 @@ public abstract class DataType<T> implements Comparable<DataType<?>>, Writeable,
      * type should be preferred (higher precedence) or converted (lower
      * precedence) during type conversions.
      */
-    public abstract Precedence precedence();
+    protected abstract Precedence precedence();
 
     public abstract String getName();
 
@@ -174,8 +174,32 @@ public abstract class DataType<T> implements Comparable<DataType<?>>, Writeable,
      * @param other The other type to compare against.
      * @return True if the current type precedes, false otherwise.
      */
-    public boolean precedes(DataType<?> other) {
-        return this.precedence().ordinal() > other.precedence().ordinal();
+    public boolean precedes(DataType<?> that) {
+        int thisOrdinal = this.precedence().ordinal();
+        int thatOrdinal = that.precedence().ordinal();
+        if (thisOrdinal == thatOrdinal) {
+            Integer thisPrecision = this.numericPrecision();
+            Integer thatPrecision = that.numericPrecision();
+            if (thisPrecision == null && thatPrecision == null) {
+                Integer thisLength = this.characterMaximumLength();
+                Integer thatLength = that.characterMaximumLength();
+                if (thisLength == null) {
+                    return true;
+                }
+                if (thatLength == null) {
+                    return false;
+                }
+                return thisLength > thatLength;
+            }
+            if (thisPrecision == null) {
+                return false;
+            }
+            if (thatPrecision == null) {
+                return true;
+            }
+            return thisPrecision > thatPrecision;
+        }
+        return thisOrdinal > thatOrdinal;
     }
 
     /**

--- a/server/src/test/java/io/crate/expression/scalar/ArrayAvgFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArrayAvgFunctionTest.java
@@ -21,14 +21,11 @@
 
 package io.crate.expression.scalar;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import java.math.BigDecimal;
 import java.util.List;
 
 import org.junit.Test;
 
-import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.expression.symbol.Literal;
 import io.crate.types.ArrayType;
 import io.crate.types.DataTypes;
@@ -117,10 +114,8 @@ public class ArrayAvgFunctionTest extends ScalarTestCase {
     }
 
     @Test
-    public void test_array_avg_with_array_of_undefined_inner_type_throws_exception() {
-        assertThatThrownBy(
-            () -> assertEvaluateNull("array_avg([])"))
-            .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: array_avg([]), no overload found for matching argument types: (undefined_array).");
+    public void test_average_of_empty_array_is_null() {
+        assertEvaluateNull("array_avg([])");
+        assertEvaluateNull("array_avg([]::int[])");
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/ArraySumFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ArraySumFunctionTest.java
@@ -30,7 +30,6 @@ import java.util.Objects;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
-import io.crate.exceptions.UnsupportedFunctionException;
 import io.crate.execution.engine.aggregation.impl.util.KahanSummationForDouble;
 import io.crate.expression.symbol.Literal;
 import io.crate.testing.TestingHelpers;
@@ -45,7 +44,7 @@ public class ArraySumFunctionTest extends ScalarTestCase {
 
         // This test picks up random numbers but controls that overflow will not happen (overflow case is checked in another test).
 
-        List<DataType> typesToTest = new ArrayList(DataTypes.NUMERIC_PRIMITIVE_TYPES);
+        List<DataType<?>> typesToTest = new ArrayList<>(DataTypes.NUMERIC_PRIMITIVE_TYPES);
         typesToTest.add(DataTypes.NUMERIC);
 
         for (DataType type : typesToTest) {
@@ -130,14 +129,7 @@ public class ArraySumFunctionTest extends ScalarTestCase {
 
     @Test
     public void test_empty_array_results_in_null() {
+        assertEvaluateNull("array_sum([])");
         assertEvaluateNull("array_sum(cast([] as array(integer)))");
-    }
-
-    @Test
-    public void test_empty_array_given_directly_throws_exception() {
-        Assertions.assertThatThrownBy(() -> assertEvaluate("array_sum([])", null))
-            .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageContaining(
-                    "Unknown function: array_sum([]), no overload found for matching argument types: (undefined_array).");
     }
 }


### PR DESCRIPTION
- Instead of having type specific special treatment for string and
  numeric within TypeCompatiblity this adds the logic in a generic way
  to DataType.precedes

- Re-uses DataTypes.merge if the type parameters differ. This will allow
  object and array types to be merged to ensure type
  signatures like `array(E)` can match if one array is an object array
  with `{x=..}` items, and other one with `{y=..}`.
  This will be important for:

  - https://github.com/crate/crate/pull/16589
  - https://github.com/crate/crate/issues/14828

  Where object literals will have inner types
