### PR TITLE
Extract names of sessions settings to constants

### DIFF
--- a/server/src/main/java/io/crate/action/sql/Sessions.java
+++ b/server/src/main/java/io/crate/action/sql/Sessions.java
@@ -60,13 +60,17 @@ import io.crate.role.Securable;
 @Singleton
 public class Sessions {
 
+    public static final String MEMORY_LIMIT_KEY = "memory.operation_limit";
+    public static final String NODE_READ_ONLY_SETTING_KEY = "node.sql.read_only";
+    public static final String STATEMENT_TIMEOUT_KEY = "statement_timeout";
+
     public static final Setting<Boolean> NODE_READ_ONLY_SETTING = Setting.boolSetting(
-        "node.sql.read_only",
+        NODE_READ_ONLY_SETTING_KEY,
         false,
         Setting.Property.NodeScope);
 
     public static final Setting<TimeValue> STATEMENT_TIMEOUT = Setting.timeSetting(
-        "statement_timeout",
+        STATEMENT_TIMEOUT_KEY,
         TimeValue.timeValueMillis(0),
         Setting.Property.Dynamic,
         Setting.Property.NodeScope,
@@ -74,7 +78,7 @@ public class Sessions {
     );
 
     public static final Setting<Integer> MEMORY_LIMIT = Setting.intSetting(
-        "memory.operation_limit", 0, Property.Dynamic, Property.NodeScope, Property.Exposed);
+        MEMORY_LIMIT_KEY, 0, Property.Dynamic, Property.NodeScope, Property.Exposed);
 
 
     private static final Logger LOGGER = LogManager.getLogger(Sessions.class);

--- a/server/src/main/java/io/crate/metadata/settings/session/SessionSettingRegistry.java
+++ b/server/src/main/java/io/crate/metadata/settings/session/SessionSettingRegistry.java
@@ -58,8 +58,10 @@ public class SessionSettingRegistry {
     static final String STANDARD_CONFORMING_STRINGS = "standard_conforming_strings";
     static final String ERROR_ON_UNKNOWN_OBJECT_KEY = "error_on_unknown_object_key";
     static final String DATE_STYLE_KEY = "datestyle";
+    static final String APPLICATION_NAME_KEY = "application_name";
+
     static final SessionSetting<String> APPLICATION_NAME = new SessionSetting<>(
-        "application_name",
+        APPLICATION_NAME_KEY,
         inputs -> DataTypes.STRING.implicitCast(inputs[0]),
         CoordinatorSessionSettings::setApplicationName,
         SessionSettings::applicationName,
@@ -81,7 +83,7 @@ public class SessionSettingRegistry {
     );
 
     static final SessionSetting<TimeValue> STATEMENT_TIMEOUT = new SessionSetting<>(
-        "statement_timeout",
+        Sessions.STATEMENT_TIMEOUT_KEY,
         inputs -> {
             Object input = inputs[0];
             // Interpret values without explicit unit/interval format as milliseconds for PostgreSQL compat.
@@ -109,7 +111,7 @@ public class SessionSettingRegistry {
     );
 
     static final SessionSetting<Integer> MEMORY_LIMIT = new SessionSetting<>(
-        Sessions.MEMORY_LIMIT.getKey(),
+        Sessions.MEMORY_LIMIT_KEY,
         inputs -> DataTypes.INTEGER.implicitCast(inputs[0]),
         CoordinatorSessionSettings::memoryLimit,
         settings -> Integer.toString(settings.memoryLimitInBytes()),


### PR DESCRIPTION
Some sessions settings names where not defined as constants, so to avoid repeating strings between `Sessions` and `SessionSettingsRegistry`, but also for consistency with all the other settings.

