### PR TITLE
Do not treat LHS of `LIKE ALL` operator as patterns

### DIFF
--- a/server/src/main/java/io/crate/expression/operator/all/AllLikeOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/all/AllLikeOperator.java
@@ -51,9 +51,7 @@ public final class AllLikeOperator extends AllOperator<String> {
 
     @Override
     boolean matches(String probe, String candidate) {
-        // Accept both sides of arguments to be patterns
-        return LikeOperators.matches(probe, candidate, LikeOperators.DEFAULT_ESCAPE, caseSensitivity) ||
-            LikeOperators.matches(candidate, probe, LikeOperators.DEFAULT_ESCAPE, caseSensitivity);
+        return LikeOperators.matches(probe, candidate, LikeOperators.DEFAULT_ESCAPE, caseSensitivity);
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/operator/all/AllNotLikeOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/all/AllNotLikeOperator.java
@@ -50,9 +50,7 @@ public final class AllNotLikeOperator extends AllOperator<String> {
 
     @Override
     boolean matches(String probe, String candidate) {
-        // Accept both sides of arguments to be patterns
-        return !LikeOperators.matches(probe, candidate, LikeOperators.DEFAULT_ESCAPE, caseSensitivity) &&
-            !LikeOperators.matches(candidate, probe, LikeOperators.DEFAULT_ESCAPE, caseSensitivity);
+        return !LikeOperators.matches(probe, candidate, LikeOperators.DEFAULT_ESCAPE, caseSensitivity);
     }
 
     @Override


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
`AllLike` has been falsely translated to `AnyLike` which was recently [fixed by porting `AnyLike` logic to `AllLike`](https://github.com/crate/crate/pull/16583/commits/0ede3bfa3ab18e5edac01b66032f2ad11dace997#diff-3682229c1942d38b2fe0f6b5738731fc5efe9eb8905bcd9617303ae1ab9b8bb7R71-R88) (not yet released). While porting https://github.com/crate/crate/issues/16619 was also carried over. 

## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
