### PR TITLE
Try fix flaky testIteratorDoesNotHandleRejectedExecutionException

### DIFF
--- a/libs/dex/src/test/java/io/crate/data/AsyncCompositeBatchIteratorTest.java
+++ b/libs/dex/src/test/java/io/crate/data/AsyncCompositeBatchIteratorTest.java
@@ -21,7 +21,7 @@
 
 package io.crate.data;
 
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -101,10 +101,11 @@ class AsyncCompositeBatchIteratorTest {
 
             TestingRowConsumer consumer = new TestingRowConsumer();
             consumer.accept(batchIterator, null);
-            consumer.getResult();
-            fail("The AsyncBatchIterator should not handle the case when the executor rejects new tasks");
-        } catch (RejectedExecutionException ignored) {
-            // expected
+            assertThat(consumer.completionFuture())
+                .failsWithin(100, TimeUnit.MILLISECONDS)
+                .withThrowableThat()
+                    .havingCause()
+                    .isExactlyInstanceOf(RejectedExecutionException.class);
         } finally {
             executorService.shutdown();
             executorService.awaitTermination(10, TimeUnit.SECONDS);


### PR DESCRIPTION
I think there might have been a race where the `TestingRowConsumer`
future didn't complete immediately, leading to the following failure:

    java.lang.AssertionError: The AsyncBatchIterator should not handle the case when the executor rejects new tasks
    	at io.crate.data.AsyncCompositeBatchIteratorTest.testIteratorDoesNotHandleRejectedExecutionException(AsyncCompositeBatchIteratorTest.java:105)
    	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
