### PR TITLE
Narrow range of bigint to account for null-sentinel

### DIFF
--- a/docs/appendices/release-notes/5.9.0.rst
+++ b/docs/appendices/release-notes/5.9.0.rst
@@ -50,6 +50,10 @@ Version 5.9.0 - Unreleased
 Breaking Changes
 ================
 
+- Narrowed the allowed min and max values for ``bigint`` by one to solve an
+  issue where a query using ``ORDER BY`` would return ``NULL`` instead of the
+  inserted value.
+
 - Removed deprecated ``validation`` parameter from ``COPY FROM``.
 
 - Added validation of unknown or irrelevant for the ``file`` scheme properties

--- a/docs/general/builtins/aggregation.rst
+++ b/docs/general/builtins/aggregation.rst
@@ -765,7 +765,7 @@ the :ref:`function <gloss-function>` argument to the :ref:`numeric type
 
 .. Hidden: insert into uservisits table
 
-    cr> INSERT INTO uservisits VALUES (1, 9223372036854775807), (2, 10);
+    cr> INSERT INTO uservisits VALUES (1, 9223372036854775806), (2, 10);
     INSERT OK, 2 rows affected  (... sec)
 
 .. Hidden: refresh uservisits table
@@ -788,7 +788,7 @@ the aggregation column to the ``numeric`` data type::
     +-----------------------------+
     | sum(cast(count AS numeric)) |
     +-----------------------------+
-    |         9223372036854775817 |
+    |         9223372036854775816 |
     +-----------------------------+
     SELECT 1 row in set (... sec)
 

--- a/docs/general/ddl/data-types.rst
+++ b/docs/general/ddl/data-types.rst
@@ -953,7 +953,7 @@ Example::
 
 A large integer.
 
-Limited to eight bytes, with a range from -2^63 to 2^63-1.
+Limited to eight bytes, with a range from -2^63 + 1 to 2^63-2.
 
 Example:
 
@@ -969,7 +969,7 @@ Example:
     cr> INSERT INTO my_table (
     ...     number
     ... ) VALUES (
-    ...     9223372036854775807
+    ...     9223372036854775806
     ... );
     INSERT OK, 1 row affected (... sec)
 
@@ -984,7 +984,7 @@ Example:
     +---------------------+
     | number              |
     +---------------------+
-    | 9223372036854775807 |
+    | 9223372036854775806 |
     +---------------------+
     SELECT 1 row in set (... sec)
 

--- a/extensions/functions/src/test/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationTest.java
+++ b/extensions/functions/src/test/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationTest.java
@@ -147,7 +147,7 @@ public class HyperLogLogDistinctAggregationTest extends AggregationTestCase {
         // They return different result for Long.MIN_VALUE (and all close numbers with same 63-th bit)
         // but providing 1 Long.MIN_VALUE as input is still not enough.
         // The difference is revealed only when input data consists of many tricky values i.e values, close to Long.MIN_VALUE.
-        Object result = executeAggregation(DataTypes.LONG, createTestData(10_000, i -> Long.MIN_VALUE + i, null));
+        Object result = executeAggregation(DataTypes.LONG, createTestData(10_000, i -> Long.MIN_VALUE + 1 + i, null));
         assertThat(result).isEqualTo(9925L);
     }
 

--- a/server/src/main/java/io/crate/execution/dml/LongIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/LongIndexer.java
@@ -46,6 +46,10 @@ public class LongIndexer implements ValueIndexer<Long> {
     @Override
     public void indexValue(@NotNull Long value, IndexDocumentBuilder docBuilder) throws IOException {
         long longValue = value;
+        if (longValue == Long.MAX_VALUE || longValue == Long.MIN_VALUE) {
+            throw new IllegalArgumentException(
+                "Value " + longValue + " exceeds allowed range for column of type bigint");
+        }
         if (ref.hasDocValues() && ref.indexType() != IndexType.NONE) {
             docBuilder.addField(new LongField(name, longValue, Field.Store.NO));
         } else {

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/CmpByAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/CmpByAggregationTest.java
@@ -196,7 +196,7 @@ public class CmpByAggregationTest extends AggregationTestCase {
             new Object[][] {
                 new Object[] { "a", 1L },
                 new Object[] { "b", 2L },
-                new Object[] { "c", Long.MIN_VALUE},
+                new Object[] { "c", Long.MIN_VALUE + 1},
             },
             List.of()
         );

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/MaximumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/MaximumAggregationTest.java
@@ -102,8 +102,13 @@ public class MaximumAggregationTest extends AggregationTestCase {
 
     @Test
     public void test_aggregate_min_long() throws Exception {
-        Object result = executeAggregation(DataTypes.LONG, new Object[][]{{Long.MIN_VALUE}, {Long.MIN_VALUE}});
-        assertThat(result).isEqualTo((Long.MIN_VALUE));
+        Object result = executeAggregation(
+            DataTypes.LONG,
+            new Object[][] {
+                {Long.MIN_VALUE + 1},
+                {Long.MIN_VALUE + 1}
+            });
+        assertThat(result).isEqualTo((Long.MIN_VALUE + 1));
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/AggregateExpressionIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/AggregateExpressionIntegrationTest.java
@@ -22,6 +22,7 @@
 package io.crate.integrationtests;
 
 import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.Map;
@@ -86,8 +87,8 @@ public class AggregateExpressionIntegrationTest extends IntegTestCase {
                 "WITH (number_of_replicas=0)");
         execute(
             "INSERT INTO tbl VALUES (?, ?, ?)", new Object[][]{
-                new Object[]{1.0d, 1f, 9223372036854775807L},
-                new Object[]{1.56d, 2.12f, 2L}});
+                new Object[]{1.0d, 1f, 9223372036854775806L},
+                new Object[]{1.56d, 2.12f, 3L}});
         execute("refresh table tbl");
 
         execute("SELECT sum(x::numeric(16, 1))," +
@@ -122,15 +123,15 @@ public class AggregateExpressionIntegrationTest extends IntegTestCase {
             "WITH (number_of_replicas=0)");
         execute(
             "INSERT INTO tbl VALUES (?, ?, ?)", new Object[][]{
-                new Object[]{0.3f, 2.251d, 9223372036854775807L},
-                new Object[]{0.7f, 2.251d, 9223372036854775807L}});
+                new Object[]{0.3f, 2.251d, 9223372036854775806L},
+                new Object[]{0.7f, 2.251d, 9223372036854775806L}});
         execute("refresh table tbl");
 
         execute("SELECT avg(x::numeric(16, 1)), " +
                 "       avg(y::numeric(16, 2))," +
                 "       avg(z::numeric) " + // Handle precision error by casting.
             "FROM tbl");
-        assertThat(response).hasRows("0.5| 2.25| 9223372036854775807");
+        assertThat(response).hasRows("0.5| 2.25| 9223372036854775806");
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
@@ -104,9 +104,9 @@ public class InsertIntoIntegrationTest extends IntegTestCase {
                 "   string text" +
                 ")");
 
-        execute("insert into test values(true, '2013-09-10T21:51:43', 1.79769313486231570e+308, 3.402, 2147483647, 9223372036854775807, 32767, 'Youri')");
+        execute("insert into test values(true, '2013-09-10T21:51:43', 1.79769313486231570e+308, 3.402, 2147483647, 9223372036854775806, 32767, 'Youri')");
         execute("insert into test values(?, ?, ?, ?, ?, ?, ?, ?)",
-            new Object[]{true, "2013-09-10T21:51:43", 1.79769313486231570e+308, 3.402, 2147483647, 9223372036854775807L, 32767, "Youri"});
+            new Object[]{true, "2013-09-10T21:51:43", 1.79769313486231570e+308, 3.402, 2147483647, 9223372036854775806L, 32767, "Youri"});
         assertThat(response).hasRowCount(1);
         refresh();
 
@@ -118,7 +118,7 @@ public class InsertIntoIntegrationTest extends IntegTestCase {
         assertThat(response.rows()[0][2]).isEqualTo(1.79769313486231570e+308);
         assertThat(((Number) response.rows()[0][3]).floatValue()).isCloseTo(3.402f, offset(0.002f));
         assertThat(response.rows()[0][4]).isEqualTo(2147483647);
-        assertThat(response.rows()[0][5]).isEqualTo(9223372036854775807L);
+        assertThat(response.rows()[0][5]).isEqualTo(9223372036854775806L);
         assertThat(response.rows()[0][6]).isEqualTo((short) 32767);
         assertThat(response.rows()[0][7]).isEqualTo("Youri");
 
@@ -127,7 +127,7 @@ public class InsertIntoIntegrationTest extends IntegTestCase {
         assertThat(response.rows()[1][2]).isEqualTo(1.79769313486231570e+308);
         assertThat(((Number) response.rows()[1][3]).floatValue()).isCloseTo(3.402f, offset(0.002f));
         assertThat(response.rows()[1][4]).isEqualTo(2147483647);
-        assertThat(response.rows()[1][5]).isEqualTo(9223372036854775807L);
+        assertThat(response.rows()[1][5]).isEqualTo(9223372036854775806L);
         assertThat(response.rows()[1][6]).isEqualTo((short) 32767);
         assertThat(response.rows()[1][7]).isEqualTo("Youri");
     }
@@ -155,7 +155,7 @@ public class InsertIntoIntegrationTest extends IntegTestCase {
                 new Double[]{1.79769313486231570e+308, 1.69769313486231570e+308},
                 new Float[]{3.402f, 3.403f, null},
                 new Integer[]{2147483647, 234583},
-                new Long[]{9223372036854775807L, 4L},
+                new Long[]{9223372036854775806L, 4L},
                 new Short[]{32767, 2},
                 new String[]{"Youri", "Juri"}
             }
@@ -183,7 +183,7 @@ public class InsertIntoIntegrationTest extends IntegTestCase {
         assertThat(((List<?>) row[4]).get(0)).isEqualTo(2147483647);
         assertThat(((List<?>) row[4]).get(1)).isEqualTo(234583);
 
-        assertThat(((List<?>) row[5]).get(0)).isEqualTo(9223372036854775807L);
+        assertThat(((List<?>) row[5]).get(0)).isEqualTo(9223372036854775806L);
         assertThat(((List<?>) row[5]).get(1)).isEqualTo(4L);
 
         assertThat(((List<?>) row[6]).get(0)).isEqualTo((short) 32767);

--- a/server/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
@@ -25,6 +25,7 @@ import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.Locale;
@@ -227,7 +228,7 @@ public class SQLTypeMappingTest extends IntegTestCase {
                 "ip_field=? " +
                 "where id=0",
                 new Object[]{
-                    Byte.MAX_VALUE, Short.MIN_VALUE, Integer.MAX_VALUE, Long.MIN_VALUE,
+                    Byte.MAX_VALUE, Short.MIN_VALUE, Integer.MAX_VALUE, Long.MIN_VALUE + 1,
                     1.0f, Math.PI, true, "a string", "2013-11-20",
                     Map.of("inner", "2013-11-20"), "127.0.0.1"
                 });
@@ -241,7 +242,7 @@ public class SQLTypeMappingTest extends IntegTestCase {
         assertThat(response.rows()[0][1]).isEqualTo((byte) 127);
         assertThat(response.rows()[0][2]).isEqualTo((short) -32768);
         assertThat(response.rows()[0][3]).isEqualTo(0x7fffffff);
-        assertThat(response.rows()[0][4]).isEqualTo(0x8000000000000000L);
+        assertThat(response.rows()[0][4]).isEqualTo(Long.MIN_VALUE + 1);
         assertThat(((Number) response.rows()[0][5]).floatValue()).isCloseTo(1.0f, Offset.offset(0.01f));
         assertThat(response.rows()[0][6]).isEqualTo(Math.PI);
         assertThat(response.rows()[0][7]).isEqualTo(true);
@@ -300,7 +301,7 @@ public class SQLTypeMappingTest extends IntegTestCase {
                     Map.of(
                         "a_date", "1970-01-01",
                         "an_int", 127,
-                        "a_long", Long.MAX_VALUE,
+                        "a_long", Long.MAX_VALUE - 1,
                         "a_boolean", true)
                     });
         refresh();
@@ -309,7 +310,7 @@ public class SQLTypeMappingTest extends IntegTestCase {
         @SuppressWarnings("unchecked")
         Map<String, Object> mapped = (Map<String, Object>) response.rows()[0][1];
         assertThat(mapped.get("a_date")).isEqualTo("1970-01-01");
-        assertThat(mapped.get("a_long")).isEqualTo(0x7fffffffffffffffL);
+        assertThat(mapped.get("a_long")).isEqualTo(Long.MAX_VALUE - 1);
         assertThat(mapped.get("a_boolean")).isEqualTo(true);
 
         // The inner value will result in an Long type as we rely on ES mappers here and the dynamic ES parsing


### PR DESCRIPTION
To be able to work with `long` primitive values using doc-values ORDER
BY operations use Long.MIN_VALUE and Long.MAX_VALUE as sentinel value in
place for `NULL` values.

If you inserted these values and selected them with a query using ORDER
BY you therefore got `NULL` as result instead of the actual values.

To address that, this restricts the supported range for these types.