### PR TITLE
Support Azure Blob Storage in COPY TO/COPY FROM

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -134,6 +134,13 @@
     </dependency>
     <dependency>
       <groupId>io.crate</groupId>
+      <artifactId>crate-copy-azure</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.crate</groupId>
       <artifactId>crate-functions</artifactId>
       <version>${project.version}</version>
       <scope>runtime</scope>

--- a/app/src/assembly/src.xml
+++ b/app/src/assembly/src.xml
@@ -84,6 +84,10 @@
       <outputDirectory>plugins/copy-s3</outputDirectory>
     </file>
     <file>
+      <source>../plugins/crate-copy-azure/src/main/resources/plugin-descriptor.properties</source>
+      <outputDirectory>plugins/copy-azure</outputDirectory>
+    </file>
+    <file>
       <source>../plugins/es-analysis-common/src/main/resources/plugin-descriptor.properties</source>
       <outputDirectory>plugins/es-analysis-common</outputDirectory>
     </file>
@@ -113,6 +117,7 @@
       -->
       <excludes>
         <exclude>io.crate:crate-copy-s3</exclude>
+        <exclude>io.crate:crate-copy-azure</exclude>
         <exclude>io.crate:crate-functions</exclude>
         <exclude>io.crate:crate-lang-js</exclude>
         <exclude>io.crate:crate-jmx-monitoring</exclude>
@@ -137,6 +142,17 @@
         <includeDependencies>false</includeDependencies>
         <unpack>false</unpack>
         <outputDirectory>plugins/copy-s3</outputDirectory>
+      </binaries>
+    </moduleSet>
+    <moduleSet>
+      <useAllReactorProjects>true</useAllReactorProjects>
+      <includes>
+        <include>io.crate:crate-copy-azure</include>
+      </includes>
+      <binaries>
+        <includeDependencies>false</includeDependencies>
+        <unpack>false</unpack>
+        <outputDirectory>plugins/copy-azure</outputDirectory>
       </binaries>
     </moduleSet>
     <moduleSet>

--- a/docs/appendices/release-notes/5.9.0.rst
+++ b/docs/appendices/release-notes/5.9.0.rst
@@ -131,6 +131,9 @@ SQL Standard and PostgreSQL Compatibility
 - `Martin Stein <https://github.com/marstein>`_ added support for the
   IS DISTINCT FROM operator.
 
+- Added Azure Blob Storage support to the :ref:`COPY FROM <sql-copy-from>` and
+  :ref:`COPY TO <sql-copy-to>` statements.
+
 Data Types
 ----------
 

--- a/docs/sql/statements/copy-from.rst
+++ b/docs/sql/statements/copy-from.rst
@@ -215,8 +215,9 @@ Additionally, only the ``crate`` superuser is allowed to use the ``file://``
 scheme.
 
 By default, every node will attempt to import every file. If the file is
-accessible on multiple nodes, you can set the `shared`_ option to true in order
-to avoid importing duplicates.
+accessible on multiple nodes, you can set the
+:ref:`shared <sql-copy-from-shared>` option to true in order to avoid importing
+duplicates.
 
 Use :ref:`sql-copy-from-return-summary` to get information about what actions
 were performed on each node.
@@ -267,7 +268,8 @@ Here is a more concrete example:
 If no credentials are set the s3 client will operate in anonymous mode.
 See `AWS Java Documentation`_.
 
-Using the ``s3://`` scheme automatically sets the `shared`_ to true.
+Using the ``s3://`` scheme automatically sets the
+:ref:`shared <sql-copy-from-shared>` to true.
 
 .. TIP::
 
@@ -287,6 +289,38 @@ Using the ``s3://`` scheme automatically sets the `shared`_ to true.
    0.51.x these connections are using the HTTPS protocol. Please make sure you
    update your firewall rules to allow outgoing connections on port ``443``.
 
+.. _sql-copy-from-az:
+
+``az``
+''''''
+
+You can use the ``az://`` scheme to access files on the `Azure Blob Storage`_.
+
+URI must look like ``az:://<account>.<endpoint_suffix>/<container>/<blob_path>``.
+
+For example:
+
+.. code-block:: text
+
+    az://myaccount.blob.core.windows.net/my-container/dir1/dir2/file1.json
+
+One of the authentication parameters (:ref:`sql-copy-from-key` or :ref:`sql-copy-from-sas-token`)
+must be provided in the ``WITH`` clause.
+
+Protocol can be provided in the ``WITH`` clause, otherwise ``https`` is used by default.
+
+For example:
+
+.. code-block:: text
+
+    COPY source
+    TO DIRECTORY 'az://myaccount.blob.core.windows.net/my-container/dir1/dir2/file1.json'
+    WITH (
+        key = 'key'
+    )
+
+Using the ``az://`` scheme automatically sets the
+:ref:`shared <sql-copy-from-shared>` to ``true``.
 
 .. _sql-copy-from-other-schemes:
 
@@ -386,203 +420,255 @@ The ``WITH`` clause supports the following options:
 
 .. _sql-copy-from-bulk_size:
 
-``bulk_size``
-'''''''''''''
+**bulk_size**
+  | *Type:*    ``integer``
+  | *Default:* ``10000``
+  | *Optional*
 
-CrateDB will process the lines it reads from the ``path`` in bulks. This option
-specifies the size of one batch. The provided value must be greater than 0, the
-default value is 10000.
+  CrateDB will process the lines it reads from the ``path`` in bulks. This option
+  specifies the size of one batch. The provided value must be greater than 0.
 
 
 .. _sql-copy-from-fail_fast:
 
-``fail_fast``
-'''''''''''''
+**fail_fast**
+  | *Type:*    ``boolean``
+  | *Default:* ``false``
+  | *Optional*
 
-A boolean value indicating if the ``COPY FROM`` operation should abort early
-after an error. This is best effort and due to the distributed execution, it
-may continue processing some records before it aborts.
-Defaults to ``false``.
+  A boolean value indicating if the ``COPY FROM`` operation should abort early
+  after an error. This is best effort and due to the distributed execution, it
+  may continue processing some records before it aborts.
 
 .. _sql-copy-from-wait_for_completion:
 
-``wait_for_completion``
-'''''''''''''''''''''''
+**wait_for_completion**
+  | *Type:*    ``boolean``
+  | *Default:* ``true``
+  | *Optional*
 
-A boolean value indicating if the ``COPY FROM`` should wait for
-the copy operation to complete. If set to ``false`` the request
-returns at once and the copy operation runs in the background.
-Defaults to ``true``.
+  A boolean value indicating if the ``COPY FROM`` should wait for
+  the copy operation to complete. If set to ``false`` the request
+  returns at once and the copy operation runs in the background.
 
 .. _sql-copy-from-shared:
 
-``shared``
-''''''''''
+**shared**
+  | *Type:*    ``boolean``
+  | *Default:* Depends on the scheme of each URI.
+  | *Optional*
 
-This option should be set to true if the URIs location is accessible by more
-than one CrateDB node to prevent them from importing the same file.
+  This option should be set to true if the URIs location is accessible by more
+  than one CrateDB node to prevent them from importing the same file.
 
-The default value depends on the scheme of each URI.
-
-If an array of URIs is passed to ``COPY FROM`` this option will overwrite the
-default for *all* URIs.
+  If an array of URIs is passed to ``COPY FROM`` this option will overwrite the
+  default for *all* URIs.
 
 
 .. _sql-copy-from-node_filters:
 
-``node_filters``
-''''''''''''''''
+**node_filters**
+  | *Type:* ``text``
+  | *Optional*
 
-A filter :ref:`expression <gloss-expression>` to select the nodes to run the
-*read* operation.
+  A filter :ref:`expression <gloss-expression>` to select the nodes to run the
+  *read* operation.
 
-It's an object in the form of::
+  It's an object in the form of::
 
-    {
-        name = '<node_name_regex>',
-        id = '<node_id_regex>'
-    }
+      {
+          name = '<node_name_regex>',
+          id = '<node_id_regex>'
+      }
 
-Only one of the keys is required.
+  Only one of the keys is required.
 
-The ``name`` :ref:`regular expression <gloss-regular-expression>` is applied on
-the ``name`` of all execution nodes, whereas the ``id`` regex is applied on the
-``node id``.
+  The ``name`` :ref:`regular expression <gloss-regular-expression>` is applied on
+  the ``name`` of all execution nodes, whereas the ``id`` regex is applied on the
+  ``node id``.
 
-If both keys are set, *both* regular expressions have to match for a node to be
-included.
+  If both keys are set, *both* regular expressions have to match for a node to be
+  included.
 
-If the `shared`_ option is false, a strict node filter might exclude nodes with
-access to the data leading to a partial import.
+  If the :ref:`shared <sql-copy-from-shared>` option is false, a strict node
+  filter might exclude nodes with access to the data leading to a partial import.
 
-To verify which nodes match the filter, run the statement with
-:ref:`EXPLAIN <ref-explain>`.
+  To verify which nodes match the filter, run the statement with
+  :ref:`EXPLAIN <ref-explain>`.
 
 
 .. _sql-copy-from-num_readers:
 
-``num_readers``
-'''''''''''''''
+**num_readers**
+  | *Type:*    ``integer``
+  | *Default:* Number of nodes available in the cluster.
+  | *Optional*
 
-The number of nodes that will read the resources specified in the URI. Defaults
-to the number of nodes available in the cluster. If the option is set to a
-number greater than the number of available nodes it will still use each node
-only once to do the import. However, the value must be an integer greater than
-0.
+  The number of nodes that will read the resources specified in the URI.
+  If the option is set to a
+  number greater than the number of available nodes it will still use each node
+  only once to do the import. However, the value must be an integer greater than
+  0.
 
-If `shared`_ is set to false this option has to be used with caution. It might
-exclude the wrong nodes, causing COPY FROM to read no files or only a subset of
-the files.
+  If :ref:`shared <sql-copy-from-shared>` is set to false this option has to be
+  used with caution. It might exclude the wrong nodes, causing COPY FROM to read
+  no files or only a subset of the files.
 
 
 .. _sql-copy-from-compression:
 
-``compression``
-'''''''''''''''
+**compression**
+  | *Type:* ``text``
+  | *Values:*  ``gzip``
+  | *Default:* By default the output is not compressed.
+  | *Optional*
 
-The default value is ``null``, set to ``gzip`` to read gzipped files.
+  Define if and how the exported data should be compressed.
 
 
 .. _sql-copy-from-protocol:
 
-``protocol``
-'''''''''''''''
+**protocol**
+  | *Type:*    ``text``
+  | *Values:*  ``http``, ``https``
+  | *Default:* ``https``
+  | *Optional*
 
-Used for :ref:`s3 <sql-copy-from-s3>` scheme only. It is set to HTTPS by
-default.
+  Protocol to use.
+  Used for :ref:`s3 <sql-copy-from-s3>` and :ref:`az <sql-copy-from-az>` schemes only.
 
 
 .. _sql-copy-from-overwrite_duplicates:
 
-``overwrite_duplicates``
-''''''''''''''''''''''''
+**overwrite_duplicates**
+  | *Type:*    ``boolean``
+  | *Default:* ``false``
+  | *Optional*
 
-Default: false
-
-``COPY FROM`` by default won't overwrite rows if a document with the same
-primary key already exists. Set to true to overwrite duplicate rows.
+  ``COPY FROM`` by default won't overwrite rows if a document with the same
+  primary key already exists. Set to true to overwrite duplicate rows.
 
 
 .. _sql-copy-from-empty_string_as_null:
 
-``empty_string_as_null``
-''''''''''''''''''''''''
+**empty_string_as_null**
+  | *Type:*    ``boolean``
+  | *Default:* ``false``
+  | *Optional*
 
-If set to ``true`` the ``empty_string_as_null`` option enables conversion of
-empty strings into ``NULL``. The default value is ``false`` meaning that no
-action will be taken on empty strings during the COPY FROM execution.
+  If set to ``true`` the ``empty_string_as_null`` option enables conversion of
+  empty strings into ``NULL``.
 
-The option is only supported when using the ``CSV`` format, otherwise, it will
-be ignored.
+  The option is only supported when using the ``CSV`` format, otherwise, it will
+  be ignored.
 
 
 .. _sql-copy-from-delimiter:
 
-``delimiter``
-'''''''''''''
+**delimiter**
+  | *Type:*    ``text``
+  | *Default:* ``,``
+  | *Optional*
 
-Specifies a single one-byte character that separates columns within each line
-of the file. The default delimiter is ``,``.
+  Specifies a single one-byte character that separates columns within each line
+  of the file.
 
-The option is only supported when using the ``CSV`` format, otherwise, it will
-be ignored.
+  The option is only supported when using the ``CSV`` format, otherwise, it will
+  be ignored.
 
 
 .. _sql-copy-from-format:
 
-``format``
-''''''''''
+**format**
+  | *Type:*    ``text``
+  | *Values:*  ``csv``, ``json``
+  | *Default:* ``json``
+  | *Optional*
 
-This option specifies the format of the input file. Available formats are
-``csv`` or ``json``. If a format is not specified and the format cannot be
-guessed from the file extension, the file will be processed as JSON.
+  This option specifies the format of the input file. Available formats are
+  ``csv`` or ``json``. If a format is not specified and the format cannot be
+  guessed from the file extension, the file will be processed as JSON.
 
 
 .. _sql-copy-from-header:
 
-``header``
-''''''''''
+**header**
+  | *Type:*    ``boolean``
+  | *Default:* ``true``
+  | *Optional*
 
-Used to indicate if the first line of a CSV file contains a header with the
-column names. Defaults to ``true``.
+  Used to indicate if the first line of a CSV file contains a header with the
+  column names.
 
-If set to ``false``, the CSV must not contain column names in the first line
-and instead the columns declared in the statement are used. If no columns are
-declared in the statement, it will default to all columns present in the table
-in their ``CREATE TABLE`` declaration order.
+  If set to ``false``, the CSV must not contain column names in the first line
+  and instead the columns declared in the statement are used. If no columns are
+  declared in the statement, it will default to all columns present in the table
+  in their ``CREATE TABLE`` declaration order.
 
-If set to ``true`` the first line in the CSV file must contain the column
-names. You can use the optional column declaration in addition to import only a
-subset of the data.
+  If set to ``true`` the first line in the CSV file must contain the column
+  names. You can use the optional column declaration in addition to import only a
+  subset of the data.
 
-If the statement contains no column declarations, all fields in the CSV are
-read and if it contains fields where there is no matching column in the table,
-the behavior depends on the ``column_policy`` table setting. If ``dynamic`` it
-implicitly adds new columns, if ``strict`` the operation will fail.
+  If the statement contains no column declarations, all fields in the CSV are
+  read and if it contains fields where there is no matching column in the table,
+  the behavior depends on the ``column_policy`` table setting. If ``dynamic`` it
+  implicitly adds new columns, if ``strict`` the operation will fail.
 
-An example of using input file with no header
+  An example of using input file with no header
 
-::
+  ::
 
-    cr> COPY quotes FROM 'file:///tmp/import_data/quotes.csv' with (format='csv', header=false);
-    COPY OK, 3 rows affected (... sec)
+      cr> COPY quotes FROM 'file:///tmp/import_data/quotes.csv' with (format='csv', header=false);
+      COPY OK, 3 rows affected (... sec)
 
 
 .. _sql-copy-from-skip:
 
-``skip``
-''''''''
+**skip**
+  | *Type:*    ``integer``
+  | *Default:* ``0``
+  | *Optional*
 
-Default: ``0``
+  Setting this option to ``n`` skips the first ``n`` rows while copying.
 
-Setting this option to ``n`` skips the first ``n`` rows while copying.
+  .. NOTE::
 
-.. NOTE::
+      CrateDB by default expects a header in CSV files. If you're using the SKIP
+      option to skip the header, you have to set ``header = false`` as well. See
+      :ref:`header <sql-copy-from-header>`.
 
-    CrateDB by default expects a header in CSV files. If you're using the SKIP
-    option to skip the header, you have to set ``header = false`` as well. See
-    :ref:`header <sql-copy-from-header>`.
+.. _sql-copy-from-key:
 
+**key**
+  | *Type:*    ``text``
+  | *Optional*
+
+  Used for :ref:`az <sql-copy-from-az>` scheme only.
+  The Azure Storage `Account Key`_.
+
+  .. NOTE::
+
+      It must be provided if :ref:`sql-copy-from-sas-token` is not provided.
+
+.. _sql-copy-from-sas-token:
+
+**sas_token**
+  | *Type:*    ``text``
+  | *Optional*
+
+  Used for :ref:`az <sql-copy-from-az>` scheme only.
+  The Shared Access Signatures (`SAS`_) token used for authentication for the
+  Azure Storage account. This can be used as an alternative to the The Azure
+  Storage `Account Key`_.
+
+  The SAS token must have read, write, and list permissions for the
+  container base path and all its contents. These permissions need to be
+  granted for the blob service and apply to resource types service, container,
+  and object.
+
+  .. NOTE::
+
+      It must be provided if :ref:`sql-copy-from-key` is not provided.
 
 .. _sql-copy-from-return-summary:
 
@@ -636,6 +722,9 @@ inserted records.
 .. _Amazon Simple Storage Service: https://aws.amazon.com/s3/
 .. _AWS documentation: https://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html
 .. _AWS Java Documentation: https://docs.aws.amazon.com/AmazonS3/latest/dev/AuthUsingAcctOrUserCredJava.html
+.. _Azure Blob Storage: https://learn.microsoft.com/en-us/azure/storage/blobs/
+.. _Account Key: https://learn.microsoft.com/en-us/purview/sit-defn-azure-storage-account-key-generic#format
+.. _SAS: https://learn.microsoft.com/en-us/azure/storage/common/storage-sas-overview
 .. _Docker volume: https://docs.docker.com/storage/volumes/
 .. _GeoJSON: https://geojson.org/
 .. _globbing: https://en.wikipedia.org/wiki/Glob_(programming)

--- a/docs/sql/statements/copy-to.rst
+++ b/docs/sql/statements/copy-to.rst
@@ -281,6 +281,35 @@ See `AWS Java Documentation`_.
    0.51.x these connections are using the HTTPS protocol. Please make sure you
    update your firewall rules to allow outgoing connections on port ``443``.
 
+.. _sql-copy-to-az:
+
+``az``
+''''''
+
+You can use the ``az://`` scheme to access files on the `Azure Blob Storage`_.
+
+URI must look like ``az:://<account>.<endpoint_suffix>/<container>/<blob_path>``.
+
+For example:
+
+.. code-block:: text
+
+    az://myaccount.blob.core.windows.net/my-container/dir1/dir2/file1.json
+
+One of the authentication parameters (:ref:`sql-copy-to-key` or :ref:`sql-copy-to-sas-token`)
+must be provided in the ``WITH`` clause.
+
+Protocol can be provided in the ``WITH`` clause, otherwise ``https`` is used by default.
+
+For example:
+
+.. code-block:: text
+
+    COPY source
+    TO DIRECTORY 'az://myaccount.blob.core.windows.net/my-container/dir1/dir2/file1.json'
+    WITH (
+        key = 'key'
+    )
 
 .. _sql-copy-to-with:
 
@@ -303,63 +332,98 @@ The ``WITH`` clause supports the following copy parameters:
 
 .. _sql-copy-to-compression:
 
-``compression``
-'''''''''''''''
+**compression**
+  | *Type:*    ``text``
+  | *Values:*  ``gzip``
+  | *Default:* By default the output is not compressed.
+  | *Optional*
 
-Define if and how the exported data should be compressed.
-
-By default the output is not compressed.
-
-Possible values for the ``compression`` setting are:
-
-``gzip``
-  Use gzip_ to compress the data output.
-
+  Define if and how the exported data should be compressed.
 
 .. _sql-copy-to-protocol:
 
-``protocol``
-'''''''''''''''
+**protocol**
+  | *Type:*    ``text``
+  | *Values:*  ``http``, ``https``
+  | *Default:* ``https``
+  | *Optional*
 
-Used for :ref:`s3 <sql-copy-to-s3>` scheme only. It is set to HTTPS by
-default.
-
+  Protocol to use.
+  Used only by the :ref:`s3 <sql-copy-to-s3>` and :ref:`az <sql-copy-to-az>` schemes.
 
 .. _sql-copy-to-format:
 
-``format``
-''''''''''
+**format**
+  | *Type:*    ``text``
+  | *Values:*  ``json_object``, ``json_array``
+  | *Default:* Depends on defined columns. See description below.
+  | *Optional*
 
-Optional parameter to override default output behavior.
+  Possible values for the ``format`` settings are:
 
-Possible values for the ``format`` settings are:
+  ``json_object``
+    Each row in the result set is serialized as JSON object and written to an
+    output file where one line contains one object. This is the default behavior
+    if no columns are defined. Use this format to import with
+    :ref:`COPY FROM <sql-copy-from>`.
 
-``json_object``
-  Each row in the result set is serialized as JSON object and written to an
-  output file where one line contains one object. This is the default behavior
-  if no columns are defined. Use this format to import with
-  :ref:`COPY FROM <sql-copy-from>`.
-
-``json_array``
-  Each row in the result set is serialized as JSON array, storing one array per
-  line in an output file. This is the default behavior if columns are defined.
+  ``json_array``
+    Each row in the result set is serialized as JSON array, storing one array per
+    line in an output file. This is the default behavior if columns are defined.
 
 
 .. _sql-copy-to-wait_for_completion:
 
-``wait_for_completion``
-'''''''''''''''''''''''
+**wait_for_completion**
+  | *Type:*    ``boolean``
+  | *Default:* ``true``
+  | *Optional*
 
-A boolean value indicating if the ``COPY TO`` should wait for
-the copy operation to complete. If set to ``false`` the request
-returns at once and the copy operation runs in the background.
-Defaults to ``true``.
+  A boolean value indicating if the ``COPY TO`` should wait for
+  the copy operation to complete. If set to ``false`` the request
+  returns at once and the copy operation runs in the background.
+
+.. _sql-copy-to-key:
+
+**key**
+  | *Type:*    ``text``
+  | *Optional*
+
+  Used for :ref:`azblob <sql-copy-to-az>` scheme only.
+  The Azure Storage `Account Key`_.
+
+  .. NOTE::
+
+      It must be provided if :ref:`sql-copy-to-sas-token` is not provided.
+
+.. _sql-copy-to-sas-token:
+
+**sas_token**
+  | *Type:*    ``text``
+  | *Optional*
+
+  Used for :ref:`azblob <sql-copy-to-az>` scheme only.
+  The Shared Access Signatures (`SAS`_) token used for authentication for the
+  Azure Storage account. This can be used as an alternative to the The Azure
+  Storage `Account Key`_.
+
+  The SAS token must have read, write, and list permissions for the
+  container base path and all its contents. These permissions need to be
+  granted for the blob service and apply to resource types service, container,
+  and object.
+
+  .. NOTE::
+
+      It must be provided if :ref:`sql-copy-to-key` is not provided.
 
 
 .. _Amazon S3: https://aws.amazon.com/s3/
 .. _Amazon Simple Storage Service: https://aws.amazon.com/s3/
 .. _AWS documentation: https://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html
 .. _AWS Java Documentation: https://docs.aws.amazon.com/AmazonS3/latest/dev/AuthUsingAcctOrUserCredJava.html
+.. _Azure Blob Storage: https://learn.microsoft.com/en-us/azure/storage/blobs/
+.. _SAS: https://learn.microsoft.com/en-us/azure/storage/common/storage-sas-overview
+.. _Account Key: https://learn.microsoft.com/en-us/purview/sit-defn-azure-storage-account-key-generic#format
 .. _Docker volume: https://docs.docker.com/storage/volumes/
 .. _gzip: https://www.gzip.org/
 .. _NFS: https://en.wikipedia.org/wiki/Network_File_System

--- a/plugins/crate-copy-azure/pom.xml
+++ b/plugins/crate-copy-azure/pom.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.crate</groupId>
+        <artifactId>crate</artifactId>
+        <version>5.9.0</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>crate-copy-azure</artifactId>
+
+
+    <dependencies>
+        <dependency>
+            <groupId>io.crate</groupId>
+            <artifactId>crate-server</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>${versions.annotations}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.opendal</groupId>
+            <artifactId>opendal-java</artifactId>
+            <version>${versions.opendal}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.opendal</groupId>
+            <artifactId>opendal-java</artifactId>
+            <version>${versions.opendal}</version>
+            <classifier>${os.detected.classifier}</classifier>
+        </dependency>
+
+        <dependency>
+            <groupId>io.crate</groupId>
+            <artifactId>crate-server</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+            <classifier>tests</classifier>
+        </dependency>
+        <dependency>
+            <groupId>io.crate</groupId>
+            <artifactId>crate-libs-dex</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+            <classifier>tests</classifier>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${versions.assertj}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${versions.junit5}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>${versions.junit5}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${versions.mockito}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.carrotsearch.randomizedtesting</groupId>
+            <artifactId>randomizedtesting-runner</artifactId>
+            <version>${versions.randomizedrunner}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-test-framework</artifactId>
+            <version>${versions.lucene}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.crate</groupId>
+            <artifactId>crate-libs-azure-testing</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+            <classifier>tests</classifier>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>${versions.plugin.os}</version>
+            </extension>
+        </extensions>
+    </build>
+</project>

--- a/plugins/crate-copy-azure/src/main/java/io/crate/copy/azure/AzureBlobStorageSettings.java
+++ b/plugins/crate-copy-azure/src/main/java/io/crate/copy/azure/AzureBlobStorageSettings.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.copy.azure;
+
+import static io.crate.analyze.CopyStatementSettings.COMMON_COPY_FROM_SETTINGS;
+import static io.crate.analyze.CopyStatementSettings.COMMON_COPY_TO_SETTINGS;
+
+import java.util.List;
+import java.util.Locale;
+
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Setting.Property;
+import org.elasticsearch.common.settings.Settings;
+
+import io.crate.common.collections.Lists;
+import io.crate.types.DataTypes;
+
+public class AzureBlobStorageSettings {
+
+    private static List<String> SUPPORTED_PROTOCOLS = List.of("https", "http");
+
+    public static final Setting<String> KEY_SETTING = Setting.simpleString("key", Property.NodeScope);
+    public static final Setting<String> SAS_TOKEN_SETTING = Setting.simpleString("sas_token");
+    public static final Setting<String> PROTOCOL_SETTING = new Setting<>(
+        "protocol",
+        "https",
+        s -> {
+            if (SUPPORTED_PROTOCOLS.contains(s) == false) {
+                throw new IllegalArgumentException(
+                    String.format(Locale.ENGLISH,"Invalid protocol `%s`. Expected HTTP or HTTPS", s)
+                );
+            }
+            return s;
+
+        },
+        DataTypes.STRING);
+
+    public static final List<Setting<String>> SUPPORTED_SETTINGS = List.of(
+        KEY_SETTING,
+        SAS_TOKEN_SETTING,
+        PROTOCOL_SETTING
+    );
+
+    static void validate(Settings settings, boolean read) {
+        List<String> validSettings = Lists.concat(
+            SUPPORTED_SETTINGS.stream().map(Setting::getKey).toList(),
+            read ? COMMON_COPY_FROM_SETTINGS : COMMON_COPY_TO_SETTINGS
+        );
+        for (String key : settings.keySet()) {
+            if (validSettings.contains(key) == false) {
+                throw new IllegalArgumentException("Setting '" + key + "' is not supported");
+            }
+        }
+        if (settings.get(SAS_TOKEN_SETTING.getKey()) == null && settings.get(KEY_SETTING.getKey()) == null) {
+            throw new IllegalArgumentException("Authentication setting must be provided: either sas_token or key");
+        }
+    }
+
+
+}

--- a/plugins/crate-copy-azure/src/main/java/io/crate/copy/azure/AzureCopyPlugin.java
+++ b/plugins/crate-copy-azure/src/main/java/io/crate/copy/azure/AzureCopyPlugin.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.copy.azure;
+
+import io.crate.execution.engine.collect.files.FileInputFactory;
+import io.crate.execution.engine.export.FileOutputFactory;
+import io.crate.plugin.CopyPlugin;
+
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.repositories.RepositoriesService;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Supplier;
+
+public class AzureCopyPlugin extends Plugin implements CopyPlugin {
+
+    public static final String OPEN_DAL_SCHEME = "azblob";
+    public static final String USER_FACING_SCHEME = "az";
+
+    private final SharedAsyncExecutor sharedAsyncExecutor;
+
+    @Inject
+    public AzureCopyPlugin(Settings settings) {
+        this.sharedAsyncExecutor = new SharedAsyncExecutor(settings);
+    }
+
+    public Map<String, FileInputFactory> getFileInputFactories() {
+        return Map.of(USER_FACING_SCHEME, new AzureFileInputFactory(sharedAsyncExecutor));
+    }
+
+    public Map<String, FileOutputFactory> getFileOutputFactories() {
+        return Map.of(USER_FACING_SCHEME, new AzureFileOutputFactory(sharedAsyncExecutor));
+    }
+
+    @Override
+    public Collection<Object> createComponents(Client client,
+                                               ClusterService clusterService,
+                                               ThreadPool threadPool,
+                                               NamedXContentRegistry xContentRegistry,
+                                               Environment environment,
+                                               NodeEnvironment nodeEnvironment,
+                                               NamedWriteableRegistry namedWriteableRegistry,
+                                               Supplier<RepositoriesService> repositoriesServiceSupplier) {
+        return Collections.singletonList(sharedAsyncExecutor);
+    }
+}

--- a/plugins/crate-copy-azure/src/main/java/io/crate/copy/azure/AzureFileInput.java
+++ b/plugins/crate-copy-azure/src/main/java/io/crate/copy/azure/AzureFileInput.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.copy.azure;
+
+import static io.crate.copy.azure.AzureCopyPlugin.OPEN_DAL_SCHEME;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.opendal.AsyncOperator;
+import org.apache.opendal.Entry;
+import org.apache.opendal.Operator;
+import org.elasticsearch.common.settings.Settings;
+
+import io.crate.execution.engine.collect.files.FileInput;
+
+/**
+ * File reading components operate with URI.
+ * All URI-s in the public API follow the contract "outgoing/incoming" URI is Azure compatible.
+ * This is accomplished by transforming user provided URI to the Azure compatible format only once.
+ * Outgoing URI-s are then used by other components and sent back to this component,
+ * so outgoing format (expandURI) implicitly dictates incoming URI-s format (getStream).
+ */
+public class AzureFileInput implements FileInput {
+
+    private final Map<String, String> config;
+    private final AzureURI azureURI;
+    private final URI uri;
+    private final Operator operator;
+
+    public AzureFileInput(SharedAsyncExecutor sharedAsyncExecutor,
+                          URI uri,
+                          Settings settings) {
+
+        this.azureURI = AzureURI.of(uri);
+        this.config = OperatorHelper.config(azureURI, settings, true);
+
+        this.operator = AsyncOperator.of(OPEN_DAL_SCHEME, config, sharedAsyncExecutor.asyncExecutor()).blocking();
+
+        String resourceURI = azureURI.resourcePath();
+        this.uri = URI.create(resourceURI);
+    }
+
+    /**
+     * @return List<URI> in Azure compatible format.
+     */
+    @Override
+    public List<URI> expandUri() throws IOException {
+        if (isGlobbed() == false) {
+            return List.of(uri);
+        }
+        List<URI> uris = new ArrayList<>();
+        var preGlobPath = azureURI.preGlobPath();
+        assert preGlobPath != null : "List API must be used only for a globbed URI.";
+        List<Entry> entries = operator.list(preGlobPath);
+        for (Entry entry : entries) {
+            var path = entry.getPath();
+            if (azureURI.matchesGlob(path)) {
+                uris.add(URI.create(path));
+            }
+        }
+        return uris;
+    }
+
+    /**
+     * @param uri is resource path without "azblob" schema.
+     */
+    @Override
+    public InputStream getStream(URI uri) throws IOException {
+        return operator.createInputStream(uri.getPath());
+    }
+
+    @Override
+    public boolean isGlobbed() {
+        return azureURI.preGlobPath() != null;
+    }
+
+    @Override
+    public URI uri() {
+        return uri;
+    }
+
+    @Override
+    public boolean sharedStorageDefault() {
+        return true;
+    }
+
+    @Override
+    public void close() {
+        assert operator != null : "Operator must be created before FileInput is closed";
+        operator.close();
+    }
+}

--- a/plugins/crate-copy-azure/src/main/java/io/crate/copy/azure/AzureFileInputFactory.java
+++ b/plugins/crate-copy-azure/src/main/java/io/crate/copy/azure/AzureFileInputFactory.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.copy.azure;
+
+import io.crate.execution.engine.collect.files.FileInput;
+import io.crate.execution.engine.collect.files.FileInputFactory;
+
+import org.elasticsearch.common.settings.Settings;
+
+import java.net.URI;
+
+public class AzureFileInputFactory implements FileInputFactory {
+
+    private final SharedAsyncExecutor sharedAsyncExecutor;
+
+    public AzureFileInputFactory(SharedAsyncExecutor sharedAsyncExecutor) {
+        this.sharedAsyncExecutor = sharedAsyncExecutor;
+    }
+
+    @Override
+    public FileInput create(URI uri, Settings withClauseOptions) {
+        return new AzureFileInput(sharedAsyncExecutor, uri, withClauseOptions);
+    }
+}

--- a/plugins/crate-copy-azure/src/main/java/io/crate/copy/azure/AzureFileOutput.java
+++ b/plugins/crate-copy-azure/src/main/java/io/crate/copy/azure/AzureFileOutput.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.copy.azure;
+
+import static io.crate.copy.azure.AzureCopyPlugin.OPEN_DAL_SCHEME;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URI;
+import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.zip.GZIPOutputStream;
+
+import org.apache.opendal.AsyncOperator;
+import org.apache.opendal.Operator;
+import org.elasticsearch.common.settings.Settings;
+
+import io.crate.execution.dsl.projection.WriterProjection;
+import io.crate.execution.engine.export.FileOutput;
+
+public class AzureFileOutput implements FileOutput {
+
+    private final Map<String, String> config;
+    private final Operator operator;
+    private final String resourcePath;
+
+    public AzureFileOutput(URI uri, SharedAsyncExecutor sharedAsyncExecutor, Settings settings) {
+        AzureURI azureURI = AzureURI.of(uri);
+        this.config = OperatorHelper.config(azureURI, settings, false);
+        this.resourcePath = azureURI.resourcePath();
+        this.operator = AsyncOperator.of(OPEN_DAL_SCHEME, config, sharedAsyncExecutor.asyncExecutor()).blocking();
+    }
+
+    @Override
+    public OutputStream acquireOutputStream(Executor executor, WriterProjection.CompressionType compressionType) throws IOException {
+        OutputStream outputStream = operator.createOutputStream(resourcePath);
+        if (compressionType != null) {
+            outputStream = new GZIPOutputStream(outputStream);
+        }
+        return outputStream;
+    }
+
+    @Override
+    public void close() {
+        assert operator != null : "Operator must be created before FileOutput is closed";
+        operator.close();
+    }
+
+}

--- a/plugins/crate-copy-azure/src/main/java/io/crate/copy/azure/AzureFileOutputFactory.java
+++ b/plugins/crate-copy-azure/src/main/java/io/crate/copy/azure/AzureFileOutputFactory.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.copy.azure;
+
+import java.net.URI;
+
+import org.elasticsearch.common.settings.Settings;
+
+import io.crate.execution.engine.export.FileOutput;
+import io.crate.execution.engine.export.FileOutputFactory;
+
+public class AzureFileOutputFactory implements FileOutputFactory {
+
+    private final SharedAsyncExecutor sharedAsyncExecutor;
+
+    public AzureFileOutputFactory(SharedAsyncExecutor sharedAsyncExecutor) {
+        this.sharedAsyncExecutor = sharedAsyncExecutor;
+    }
+
+    @Override
+    public FileOutput create(URI uri, Settings withClauseOptions) {
+        return new AzureFileOutput(uri, sharedAsyncExecutor, withClauseOptions);
+    }
+}

--- a/plugins/crate-copy-azure/src/main/java/io/crate/copy/azure/AzureURI.java
+++ b/plugins/crate-copy-azure/src/main/java/io/crate/copy/azure/AzureURI.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.copy.azure;
+
+import static io.crate.copy.azure.AzureCopyPlugin.USER_FACING_SCHEME;
+
+import java.net.URI;
+import java.util.regex.Pattern;
+
+import org.jetbrains.annotations.Nullable;
+
+import io.crate.execution.engine.collect.files.Globs;
+
+/**
+ * Represents URI provided by a user.
+ * @param account must be between 3 and 24 characters in length and may contain only numbers and lowercase letters.
+ * @param container must be between 3 and 63 characters in length  and may contain only numbers, lowercase letters and the hyphen character.
+ * @param endpoint which includes account name (for example, myaccount.blob.core.windows.net) without protocol (protocol is extracted from the setting).
+ * @param resourcePath path to the file
+ */
+public record AzureURI(
+    String account,
+    String container,
+    String endpoint,
+    String resourcePath,
+    Globs.GlobPredicate globPredicate
+) {
+
+
+    private static final Pattern ACCOUNT_PATTERN = Pattern.compile("[a-z0-9]{3,24}");
+    private static final Pattern CONTAINER_PATTERN = Pattern.compile("[a-z0-9-]{3,63}");
+
+    public static AzureURI of(URI uri) {
+
+        if (uri.getScheme().equals(USER_FACING_SCHEME) == false) {
+            throw new IllegalArgumentException("Invalid URI. URI must look like 'az://account.endpoint_suffix/container/path/to/file'");
+        }
+        String endpoint = uri.getHost() + ":" + uri.getPort();
+        String path = uri.getPath();
+
+        int dotIndex = endpoint.indexOf(".");
+        if (dotIndex < 0) {
+            throw new IllegalArgumentException("Invalid URI. URI must look like 'az://account.endpoint_suffix/container/path/to/file'");
+        }
+        String account = endpoint.substring(0, dotIndex);
+        if (ACCOUNT_PATTERN.matcher(account).matches() == false) {
+            throw new IllegalArgumentException(
+                "Invalid URI. Account length must be between 3 and 24 characters and contain only lowercase characters and numbers"
+            );
+        }
+
+        assert path.charAt(0) == '/' : "URI path starts with /";
+        int secondSlashIndex = path.indexOf('/', 1); // Skip first slash;
+        if (secondSlashIndex < 0) {
+            throw new IllegalArgumentException("Invalid URI. URI must look like 'az://account.endpoint_suffix/container/path/to/file'");
+        }
+
+        if (path.length() - secondSlashIndex < 2) {
+            // Impossible for COPY TO because even specifying root of the container leads to effective URI having also file name appended.
+            // Impossible for COPY FROM because even specifying root of the container must be followed by '*'.
+            throw new IllegalArgumentException("Invalid URI. Path after container cannot be empty");
+        }
+
+        String container = path.substring(1, secondSlashIndex);
+        if (CONTAINER_PATTERN.matcher(container).matches() == false) {
+            throw new IllegalArgumentException(
+                "Invalid URI. Container length must be between 3 and 63 characters and contain only lowercase characters, numbers and hyphens"
+            );
+        }
+
+        String resourcePath = path.substring(secondSlashIndex); // At least one symbol as path cannot be empty.
+        // List API returns entries without leading backslash.
+        var globPredicate = new Globs.GlobPredicate(resourcePath.substring(1));
+        return new AzureURI(account, container, endpoint, resourcePath, globPredicate);
+    }
+
+    /**
+     * This is directory-only path (without host/bucket/container or any storage specific part of the user provided URI.
+     * @return String as it's used by OpenDAL list/write/read API-s which work with String.
+     */
+    public String resourcePath() {
+        return resourcePath;
+    }
+
+    @Nullable
+    public String preGlobPath() {
+        int asteriskIndex = resourcePath.indexOf("*");
+        if (asteriskIndex < 0) {
+            return null;
+        }
+        int lastBeforeAsterisk = 0;
+        for (int i = asteriskIndex; i >= 0; i--) {
+            if (resourcePath.charAt(i) == '/') {
+                lastBeforeAsterisk = i;
+                break;
+            }
+        }
+        assert resourcePath.charAt(0) == '/' : "Resource path must start with the forwarding slash.";
+        return resourcePath.substring(0, lastBeforeAsterisk + 1); // Returns "/" if glob matches the whole container.
+    }
+
+    public boolean matchesGlob(String path) {
+        return globPredicate.test(path);
+    }
+}

--- a/plugins/crate-copy-azure/src/main/java/io/crate/copy/azure/OperatorHelper.java
+++ b/plugins/crate-copy-azure/src/main/java/io/crate/copy/azure/OperatorHelper.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.copy.azure;
+
+import static io.crate.copy.azure.AzureBlobStorageSettings.KEY_SETTING;
+import static io.crate.copy.azure.AzureBlobStorageSettings.PROTOCOL_SETTING;
+import static io.crate.copy.azure.AzureBlobStorageSettings.SAS_TOKEN_SETTING;
+import static io.crate.copy.azure.AzureBlobStorageSettings.validate;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+
+/**
+ * Helper class to build OpenDAL config.
+ */
+public class OperatorHelper {
+
+    /**
+     * OpenDAL specific settings.
+     * Not same with SUPPORTED_SETTINGS since protocol is not related and required only to construct endpoint.
+     */
+    public static final List<Setting<String>> SETTINGS_TO_REWRITE = List.of(
+        KEY_SETTING,
+        SAS_TOKEN_SETTING
+    );
+
+    /**
+     * Mapping of the user provided setting names,
+     * which are aligned with 'CREATE REPOSITORY ... TYPE AZURE',
+     * to OpenDAL supported names, listed in https://docs.rs/opendal/latest/opendal/services/struct.Azblob.html.
+     */
+    private static Map<String, String> AZURE_TO_OPEN_DAL = Map.of(
+        KEY_SETTING.getKey(), "account_key",
+        SAS_TOKEN_SETTING.getKey(), "sas_token"
+    );
+
+    /**
+     * @param settings represents WITH clause parameters in COPY... operation.
+     * @param read is 'true' for COPY FROM and 'false' for COPY TO.
+     */
+    public static Map<String, String> config(AzureURI azureURI, Settings settings, boolean read) {
+        validate(settings, read);
+
+        Map<String, String> config = new HashMap<>();
+        for (Setting<String> setting : SETTINGS_TO_REWRITE) {
+            var value = setting.get(settings);
+            var key = setting.getKey();
+            var mappedKey = AZURE_TO_OPEN_DAL.get(key);
+            assert mappedKey != null : "All known settings must have their OpenDAL counterpart specified.";
+            if (value != null) {
+                config.put(mappedKey, value);
+            }
+        }
+        String endpoint = String.format(
+            Locale.ENGLISH,
+            "%s://%s",
+            PROTOCOL_SETTING.get(settings),
+            azureURI.endpoint()
+        );
+        config.put("account_name", azureURI.account());
+        config.put("container", azureURI.container());
+        config.put("endpoint", endpoint);
+        return config;
+    }
+}

--- a/plugins/crate-copy-azure/src/main/java/io/crate/copy/azure/SharedAsyncExecutor.java
+++ b/plugins/crate-copy-azure/src/main/java/io/crate/copy/azure/SharedAsyncExecutor.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.copy.azure;
+
+import java.io.IOException;
+
+import org.apache.opendal.AsyncExecutor;
+import org.elasticsearch.common.component.AbstractLifecycleComponent;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+
+/**
+ * Wrapper around OpenDAL AsyncExecutor.
+ * Holds a singleton instance and manages its lifecycle.
+ */
+public class SharedAsyncExecutor extends AbstractLifecycleComponent {
+
+    private final AsyncExecutor asyncExecutor;
+
+    public SharedAsyncExecutor(Settings settings) {
+        int numOfProcessors = EsExecutors.numberOfProcessors(settings);
+        this.asyncExecutor = AsyncExecutor.createTokioExecutor(numOfProcessors);
+    }
+
+    public AsyncExecutor asyncExecutor() {
+        return asyncExecutor;
+    }
+
+    @Override
+    protected void doStart() {
+        // No-op.
+    }
+
+    @Override
+    protected void doStop() {
+        // No-op.
+    }
+
+    @Override
+    protected void doClose() throws IOException {
+        asyncExecutor.close();
+    }
+}

--- a/plugins/crate-copy-azure/src/main/resources/plugin-descriptor.properties
+++ b/plugins/crate-copy-azure/src/main/resources/plugin-descriptor.properties
@@ -1,0 +1,3 @@
+name=crate-copy-azure
+description="CrateDB Azure Copy Plugin"
+classname=io.crate.copy.azure.AzureCopyPlugin

--- a/plugins/crate-copy-azure/src/test/java/io/crate/copy/azure/AzureBlobStorageSettingsTest.java
+++ b/plugins/crate-copy-azure/src/test/java/io/crate/copy/azure/AzureBlobStorageSettingsTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.copy.azure;
+
+import static io.crate.copy.azure.AzureBlobStorageSettings.PROTOCOL_SETTING;
+import static io.crate.copy.azure.AzureBlobStorageSettings.validate;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.elasticsearch.common.settings.Settings;
+import org.junit.Test;
+
+public class AzureBlobStorageSettingsTest {
+
+    @Test
+    public void test_unknown_setting_is_rejected() throws Exception {
+        Settings settings = Settings.builder().put("dummy", "dummy").build();
+        assertThatThrownBy(() -> validate(settings, true))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Setting 'dummy' is not supported");
+    }
+
+    @Test
+    public void test_auth_param_is_required() throws Exception {
+        assertThatThrownBy(() -> validate(Settings.EMPTY, true))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Authentication setting must be provided: either sas_token or key");
+    }
+
+    @Test
+    public void test_unknown_protocol_is_rejected() throws Exception {
+        Settings settings = Settings.builder().put(PROTOCOL_SETTING.getKey(), "pg").build();
+        assertThatThrownBy(() -> PROTOCOL_SETTING.get(settings))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Invalid protocol `pg`. Expected HTTP or HTTPS");
+    }
+}

--- a/plugins/crate-copy-azure/src/test/java/io/crate/copy/azure/AzureCopyIntegrationTest.java
+++ b/plugins/crate-copy-azure/src/test/java/io/crate/copy/azure/AzureCopyIntegrationTest.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.copy.azure;
+
+import static io.crate.testing.Asserts.assertThat;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Locale;
+
+import org.apache.lucene.tests.util.QuickPatchThreadsFilter;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.IntegTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import com.carrotsearch.randomizedtesting.ThreadFilter;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+import com.sun.net.httpserver.HttpServer;
+
+import io.crate.azure.testing.AzureHttpHandler;
+import io.crate.lucene.CrateLuceneTestCase;
+
+@ThreadLeakFilters(
+        defaultFilters = true,
+        filters = {
+            QuickPatchThreadsFilter.class,
+            AzureCopyIntegrationTest.OpenDALFilter.class,
+            CrateLuceneTestCase.CommonPoolFilter.class})
+public class AzureCopyIntegrationTest extends IntegTestCase {
+
+    private static final String CONTAINER_NAME = "test";
+    public static final String AZURE_ACCOUNT = "devstoreaccount1";
+    private static final String AZURE_KEY = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
+
+    /**
+     * Generated via
+     * az storage container generate-sas
+     * --account-key Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==
+     * --account-name devstoreaccount1
+     * --expiry 2025-01-01 --name test --permissions dlrw
+     */
+    private static final String SAS_TOKEN =
+        "se=2025-01-01&sp=rwdl&sv=2022-11-02&sr=c&sig=E3VL9JiO78xUQsqzBoqDStPliSoGnguHcGvs%2BE9o8h8%3D";
+
+    private String containerUri;
+    private HttpServer httpServer;
+
+    /**
+     * OpenDAL uses shared singleton async tokio executor with configured number of threads.
+     * They are re-used throughout the app lifetime and cleaned up on executor disposal on node shutdown.
+     **/
+    public static class OpenDALFilter implements ThreadFilter {
+
+        @Override
+        public boolean reject(Thread t) {
+            // TODO: Used more reliable/less common pattern once https://github.com/apache/opendal/issues/5088 is implemented.
+            return t.getName().startsWith("Thread-");
+        }
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        var plugins = new ArrayList<>(super.nodePlugins());
+        plugins.add(AzureCopyPlugin.class);
+        return plugins;
+    }
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        var handler = new AzureHttpHandler(CONTAINER_NAME, true);
+        httpServer = HttpServer.create(new InetSocketAddress(AZURE_ACCOUNT + "." + "localhost", 0), 0);
+        httpServer.createContext("/" + CONTAINER_NAME , handler);
+        httpServer.start();
+        InetSocketAddress address = httpServer.getAddress();
+
+        String host = String.format(
+            Locale.ENGLISH,
+            "%s:%d",
+            address.getAddress().getCanonicalHostName(),
+            address.getPort()
+        );
+        containerUri = String.format(
+            Locale.ENGLISH,
+            "az://%s.%s/%s",
+            AZURE_ACCOUNT,
+            host,
+            CONTAINER_NAME
+        );
+    }
+
+    @Override
+    @After
+    public void tearDown() throws Exception {
+        super.tearDown();
+        httpServer.stop(1);
+    }
+
+    @Test
+    public void test_copy_to_and_copy_from_azure_blob_storage_auth_via_key() throws IOException, InterruptedException {
+        execute("CREATE TABLE source (x int)");
+        execute("INSERT INTO source(x) values (1), (2), (3)");
+        execute("REFRESH TABLE source");
+
+        String fullURI = containerUri;
+        execute("""
+            COPY source TO DIRECTORY ?
+            WITH (
+                protocol = 'http',
+                key = ?
+            )
+            """,
+            new Object[]{fullURI, AZURE_KEY}
+        );
+
+        execute("CREATE TABLE target (x int)");
+        execute("""
+            COPY target FROM ?
+            WITH (
+                protocol = 'http',
+                key = ?
+            )
+            """,
+            new Object[]{fullURI + "/*", AZURE_KEY}
+        );
+
+        execute("REFRESH TABLE target");
+        execute("select x from target order by x");
+        assertThat(response).hasRows("1", "2", "3");
+    }
+
+    @Test
+    public void test_copy_to_and_copy_from_azure_blob_storage_auth_via_token() throws IOException, InterruptedException {
+        execute("CREATE TABLE source (x int)");
+        execute("INSERT INTO source(x) values (1), (2), (3)");
+        execute("REFRESH TABLE source");
+
+        String fullURI = containerUri + "/dir/dir2";
+        execute("""
+            COPY source TO DIRECTORY ?
+            WITH (
+                protocol = 'http',
+                sas_token = ?
+            )
+            """,
+            new Object[]{fullURI, SAS_TOKEN}
+        );
+
+        execute("CREATE TABLE target (x int)");
+        execute("""
+            COPY target FROM ?
+            WITH (
+                protocol = 'http',
+                sas_token = ?
+            )
+            """,
+            new Object[]{fullURI + "/*", SAS_TOKEN}
+        );
+
+        execute("REFRESH TABLE target");
+        execute("select x from target order by x");
+        assertThat(response).hasRows("1", "2", "3");
+    }
+}

--- a/plugins/crate-copy-azure/src/test/java/io/crate/copy/azure/AzureURITest.java
+++ b/plugins/crate-copy-azure/src/test/java/io/crate/copy/azure/AzureURITest.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.copy.azure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.net.URI;
+import java.util.List;
+
+import org.junit.Test;
+
+public class AzureURITest {
+
+    private static final String COMMON_PREFIX = "az://myaccount.blob.core.windows.net/my-container";
+
+
+    @Test
+    public void test_empty_path_after_container_throws_exception() throws Exception {
+        URI uri = URI.create("az://myaccount.blob.core.windows.net/container/");
+        assertThatThrownBy(() -> AzureURI.of(uri))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Invalid URI. Path after container cannot be empty");
+    }
+
+    @Test
+    public void test_host_contains_only_account_throws_exception() throws Exception {
+        URI uri = URI.create("az://myaccount/my-container/dir");
+        assertThatThrownBy(() -> AzureURI.of(uri))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Invalid URI. URI must look like 'az://account.endpoint_suffix/container/path/to/file'");
+    }
+
+    @Test
+    public void test_account_has_uppercase_letter_throws_exception() throws Exception {
+        URI uri = URI.create("az://myAccount.blob.core.windows.net/container/dir");
+        assertThatThrownBy(() -> AzureURI.of(uri))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Invalid URI. Account length must be between 3 and 24 characters and contain only lowercase characters and numbers");
+    }
+
+    @Test
+    public void test_account_has_invalid_length_throws_exception() throws Exception {
+        URI uri = URI.create("az://ac.blob.core.windows.net/container/dir");
+        assertThatThrownBy(() -> AzureURI.of(uri))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Invalid URI. Account length must be between 3 and 24 characters and contain only lowercase characters and numbers");
+    }
+
+    @Test
+    public void test_no_container_throws_exception() throws Exception {
+        URI uri = URI.create("az://myaccount.blob.core.windows.net/dir");
+        assertThatThrownBy(() -> AzureURI.of(uri))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Invalid URI. URI must look like 'az://account.endpoint_suffix/container/path/to/file'");
+    }
+
+    @Test
+    public void test_container_has_uppercase_letter_throws_exception() throws Exception {
+        URI uri = URI.create("dummy://myaccount.blob.core.windows.net/Container/dir");
+        assertThatThrownBy(() -> AzureURI.of(uri))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Invalid URI. URI must look like 'az://account.endpoint_suffix/container/path/to/file'");
+    }
+
+    @Test
+    public void test_container_has_invalid_length_throws_exception() throws Exception {
+        URI uri = URI.create("dummy://myaccount.blob.core.windows.net/co/dir");
+        assertThatThrownBy(() -> AzureURI.of(uri))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Invalid URI. URI must look like 'az://account.endpoint_suffix/container/path/to/file'");
+    }
+
+    @Test
+    public void test_invalid_scheme_throws_exception() throws Exception {
+        URI uri = URI.create("dummy://myaccount.blob.core.windows.net/container/dir");
+        assertThatThrownBy(() -> AzureURI.of(uri))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Invalid URI. URI must look like 'az://account.endpoint_suffix/container/path/to/file'");
+    }
+
+    @Test
+    public void test_match_glob_pattern() throws Exception {
+        List<String> entries = List.of(
+            "dir1/dir2/match1.json",
+             // Too many subdirectories, see https://cratedb.com/docs/crate/reference/en/latest/sql/statements/copy-from.html#uri-globbing
+            "dir1/dir2/dir3/no_match.json",
+            "dir2/dir1/no_match.json",
+            "dir1/dir0/dir2/no_match.json"
+        );
+
+        AzureURI azureURI = AzureURI.of(URI.create(COMMON_PREFIX + "/dir1/dir2/*"));
+
+        assertThat(azureURI.preGlobPath()).isNotNull();
+
+        List<String> matches = entries.stream().filter(azureURI::matchesGlob).toList();
+        assertThat(matches).containsExactly("dir1/dir2/match1.json");
+    }
+
+    @Test
+    public void test_to_pre_glob_path() {
+        var uris =
+            List.of(
+                COMMON_PREFIX + "/dir1/prefix*/*.json",
+                COMMON_PREFIX + "/dir1/*/prefix2/prefix3/a.json",
+                COMMON_PREFIX + "/dir1/prefix/p*x/*/*.json",
+                COMMON_PREFIX + "/dir1.1/prefix/key*",
+                COMMON_PREFIX + "/*" // Glob matches the whole container
+            );
+        var preGlobURIs = uris.stream()
+            .map(URI::create)
+            .map(AzureURI::of)
+            .map(AzureURI::preGlobPath)
+            .toList();
+        assertThat(preGlobURIs).isEqualTo(List.of(
+            "/dir1/",
+            "/dir1/",
+            "/dir1/prefix/",
+            "/dir1.1/prefix/",
+            "/"
+        ));
+
+    }
+}

--- a/plugins/es-repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureSnapshotIntegrationTest.java
+++ b/plugins/es-repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureSnapshotIntegrationTest.java
@@ -60,7 +60,7 @@ public class AzureSnapshotIntegrationTest extends IntegTestCase {
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        handler = new AzureHttpHandler(CONTAINER_NAME);
+        handler = new AzureHttpHandler(CONTAINER_NAME, false);
         httpServer = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
         httpServer.createContext("/" + CONTAINER_NAME, handler);
         httpServer.start();

--- a/pom.xml
+++ b/pom.xml
@@ -329,6 +329,7 @@
     <versions.caffeine>3.1.8</versions.caffeine>
     <versions.jodatime>2.12.7</versions.jodatime>
     <versions.aws>1.12.353</versions.aws>
+    <versions.opendal>0.46.3</versions.opendal>
     <versions.commonsmath>3.6.1</versions.commonsmath>
     <versions.commonscodec>1.17.1</versions.commonscodec>
     <versions.jaxb_api>2.3.1</versions.jaxb_api>
@@ -383,6 +384,7 @@
     <versions.plugin.jar>3.4.2</versions.plugin.jar>
     <versions.plugin.build-helper>3.6.0</versions.plugin.build-helper>
     <versions.plugin.antlr>4.13.2</versions.plugin.antlr>
+    <versions.plugin.os>1.7.0</versions.plugin.os>
   </properties>
 
   <modules>
@@ -404,6 +406,7 @@
     <module>plugins/repository-gcs</module>
     <module>plugins/dns-discovery</module>
     <module>plugins/cr8-copy-s3</module>
+    <module>plugins/crate-copy-azure</module>
     <module>extensions/functions</module>
     <module>extensions/lang-js</module>
     <module>extensions/jmx-monitoring</module>

--- a/server/src/main/java/io/crate/analyze/CopyStatementSettings.java
+++ b/server/src/main/java/io/crate/analyze/CopyStatementSettings.java
@@ -121,13 +121,13 @@ public final class CopyStatementSettings {
         return Enum.valueOf(settingsEnum, settingValue.toUpperCase(Locale.ENGLISH));
     }
 
-    public static List<String> commonCopyToSettings = List.of(
+    public static List<String> COMMON_COPY_TO_SETTINGS = List.of(
         COMPRESSION_SETTING.getKey(),
         OUTPUT_FORMAT_SETTING.getKey(),
         WAIT_FOR_COMPLETION_SETTING.getKey()
     );
 
-    public static List<String> commonCopyFromSettings = List.of(
+    public static List<String> COMMON_COPY_FROM_SETTINGS = List.of(
         COMPRESSION_SETTING.getKey(),
         INPUT_FORMAT_SETTING.getKey(),
         WAIT_FOR_COMPLETION_SETTING.getKey(),

--- a/server/src/main/java/io/crate/planner/statement/CopyFromPlan.java
+++ b/server/src/main/java/io/crate/planner/statement/CopyFromPlan.java
@@ -436,7 +436,7 @@ public final class CopyFromPlan implements Plan {
         if (uri instanceof String) {
             String uriAsString = DataTypes.STRING.sanitizeValue(uri);
             if (uriAsString.startsWith("/") || uriAsString.startsWith("file:")) {
-                properties.ensureContainsOnly(CopyStatementSettings.commonCopyFromSettings);
+                properties.ensureContainsOnly(CopyStatementSettings.COMMON_COPY_FROM_SETTINGS);
             }
             return Literal.of(uriAsString);
         } else if (uri instanceof List<?> uris) {
@@ -445,7 +445,7 @@ public final class CopyFromPlan implements Plan {
                 throw AnalyzedCopyFrom.raiseInvalidType(DataTypes.guessType(uri));
             }
             if (uriAsString.startsWith("/") || uriAsString.startsWith("file:")) {
-                properties.ensureContainsOnly(CopyStatementSettings.commonCopyFromSettings);
+                properties.ensureContainsOnly(CopyStatementSettings.COMMON_COPY_FROM_SETTINGS);
             }
             return Literal.of(DataTypes.STRING_ARRAY, DataTypes.STRING_ARRAY.sanitizeValue(uri));
         }

--- a/server/src/main/java/io/crate/planner/statement/CopyToPlan.java
+++ b/server/src/main/java/io/crate/planner/statement/CopyToPlan.java
@@ -255,7 +255,7 @@ public final class CopyToPlan implements Plan {
         if (uri.startsWith("/") || uri.startsWith("file:")) {
             // Settings of other schemes are validated later in plugins
             // as only plugins are aware of scheme specific properties.
-            properties.ensureContainsOnly(CopyStatementSettings.commonCopyToSettings);
+            properties.ensureContainsOnly(CopyStatementSettings.COMMON_COPY_TO_SETTINGS);
         }
         return new BoundCopyTo(
             outputs,


### PR DESCRIPTION
Closes https://github.com/crate/crate/issues/13852


Supersedes https://github.com/crate/crate/pull/16468 (review comments are taken into account here). 

Main difference from the old PR is parsing URI and extracting account/container and endpoint from there. `AzureURI` is the core change comparing to the old PR, otherwise it's roughly old PR + comments.