### PR TITLE
 Avoid double negation when negating a lucene query by `Queries.not`

### DIFF
--- a/server/src/main/java/io/crate/expression/predicate/NotPredicate.java
+++ b/server/src/main/java/io/crate/expression/predicate/NotPredicate.java
@@ -222,7 +222,7 @@ public class NotPredicate extends Scalar<Boolean, Boolean> {
                 .add(notX, Occur.MUST)
                 .add(LuceneQueryBuilder.genericFunctionFilter(input, context), Occur.FILTER)
                 .build();
-        } else {
+        } else if (ctx.nullableReferences().isEmpty() == false) {
             BooleanQuery.Builder builder = new BooleanQuery.Builder();
             builder.add(notX, BooleanClause.Occur.MUST);
             for (Reference nullableRef : ctx.nullableReferences()) {
@@ -244,6 +244,7 @@ public class NotPredicate extends Scalar<Boolean, Boolean> {
             }
             return builder.build();
         }
+        return notX;
     }
 
     /**

--- a/server/src/test/java/io/crate/expression/predicate/DistinctFromTest.java
+++ b/server/src/test/java/io/crate/expression/predicate/DistinctFromTest.java
@@ -118,6 +118,10 @@ public class DistinctFromTest extends ScalarTestCase {
             assertThat(query)
                 .hasToString("+*:* -str:hello");
 
+            query = tester.toQuery("str IS NOT DISTINCT FROM 'hello'");
+            assertThat(query)
+                .hasToString("+str:hello");
+
             assertThat(tester.runQuery("str", "str IS DISTINCT FROM 'hello'"))
                 .containsExactly("Duke", "rules", null);
             assertThat(tester.runQuery("str", "str IS DISTINCT FROM null"))

--- a/server/src/test/java/io/crate/expression/predicate/DistinctFromTest.java
+++ b/server/src/test/java/io/crate/expression/predicate/DistinctFromTest.java
@@ -120,7 +120,7 @@ public class DistinctFromTest extends ScalarTestCase {
 
             query = tester.toQuery("str IS NOT DISTINCT FROM 'hello'");
             assertThat(query)
-                .hasToString("+str:hello");
+                .hasToString("str:hello");
 
             assertThat(tester.runQuery("str", "str IS DISTINCT FROM 'hello'"))
                 .containsExactly("Duke", "rules", null);
@@ -302,6 +302,19 @@ public class DistinctFromTest extends ScalarTestCase {
                 List.of(1, 2), null
             );
         }
+    }
 
+    @Test
+    public void test_not_is_distinct_on_primitive_results_in_same_query_than_eq() throws Exception {
+        QueryTester.Builder builder = new QueryTester.Builder(
+            THREAD_POOL,
+            clusterService,
+            Version.CURRENT,
+            "CREATE TABLE tbl (name text)");
+        try (QueryTester tester = builder.build()) {
+            var query1 = tester.toQuery("name is not distinct from 'foo'");
+            var query2 = tester.toQuery("name = 'foo'");
+            assertThat(query1.toString()).isEqualTo(query2.toString());
+        }
     }
 }

--- a/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -138,12 +138,12 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
         Query query = convert("x != 10");
         assertThat(query)
             .isExactlyInstanceOf(BooleanQuery.class)
-            .hasToString("+(+*:* -x:[10 TO 10])");
+            .hasToString("+*:* -x:[10 TO 10]");
 
         query = convert("not x = 10");
         assertThat(query)
             .isExactlyInstanceOf(BooleanQuery.class)
-            .hasToString("+(+*:* -x:[10 TO 10])");
+            .hasToString("+*:* -x:[10 TO 10]");
     }
 
     @Test
@@ -797,7 +797,7 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
     @Test
     public void test_nested_not_operators() {
         Query query = convert("not (y is not null)");
-        assertThat(query).hasToString("+(+*:* -FieldExistsQuery [field=y])");
+        assertThat(query).hasToString("+*:* -FieldExistsQuery [field=y]");
     }
 
     @Test

--- a/server/src/test/java/io/crate/lucene/ThreeValuedLogicQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/ThreeValuedLogicQueryBuilderTest.java
@@ -39,15 +39,15 @@ public class ThreeValuedLogicQueryBuilderTest extends LuceneQueryBuilderTest {
     @Test
     public void testNotAnyEqWithout3vl() {
         assertThat(convert("NOT ignore3vl(20 = ANY(y_array))")).hasToString(
-            "+(+*:* -y_array:[20 TO 20])");
+            "+*:* -y_array:[20 TO 20]");
         assertThat(convert("NOT ignore3vl(d = ANY([1,2,3]))")).hasToString(
-            "+(+*:* -d:{1.0 2.0 3.0})");
+            "+*:* -d:{1.0 2.0 3.0}");
     }
 
     @Test
     public void testComplexOperatorTreeWith3vlAndIgnore3vl() {
         assertThat(convert("NOT name = 'foo' AND NOT ignore3vl(name = 'bar')")).hasToString(
-            "+(+(+*:* -name:foo) +FieldExistsQuery [field=name]) +(+(+*:* -name:bar))");
+            "+(+(+*:* -name:foo) +FieldExistsQuery [field=name]) +(+*:* -name:bar)");
     }
 
     @Test
@@ -70,7 +70,7 @@ public class ThreeValuedLogicQueryBuilderTest extends LuceneQueryBuilderTest {
     @Test
     public void test_negated_concat_with_three_valued_logic() {
         assertThat(convert("NOT (x || 1) < -1")).hasToString(
-            "+(+*:* -((x || '1') < -1))");
+            "+*:* -((x || '1') < -1)");
     }
 
     @Test


### PR DESCRIPTION
Relates to queries which negates inner queries twice like e.g. `IS NOT DISTINCT` -> not(not(eqQuery).
Second commit avoids an unnecessary ` BooleanQuery` at the `NotPredicate`,

Both changes seems not to have a performance impact but at least improves readability of query string representation.

Relates to a discussion at https://github.com/crate/crate/pull/16621