### PR TITLE
Avoid array copy in md5 scalar

### DIFF
--- a/server/src/main/java/io/crate/expression/scalar/string/HashFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/string/HashFunctions.java
@@ -22,7 +22,6 @@
 package io.crate.expression.scalar.string;
 
 import java.nio.charset.StandardCharsets;
-import java.security.DigestException;
 import java.security.MessageDigest;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
@@ -73,16 +72,8 @@ public final class HashFunctions {
 
         public String digest(String input) {
             MessageDigest messageDigest = messageDigestSupplier.get();
-            byte[] digest = new byte[messageDigest.getDigestLength()];
-            messageDigest.update(input.getBytes(StandardCharsets.UTF_8));
-            try {
-                messageDigest.digest(digest, 0, digest.length);
-            } catch (DigestException e) {
-                throw new RuntimeException("Error computing digest.", e);
-            }
-            return Hex.encodeHexString(digest);
+            byte[] result = messageDigest.digest(input.getBytes(StandardCharsets.UTF_8));
+            return Hex.encodeHexString(result);
         }
     }
-
-
 }


### PR DESCRIPTION
Looking at the underlying implementation the `digest` method doesn't use
the provided buffer directly but still does a copy:

    protected int engineDigest(byte[] buf, int offset, int len)
                                                    throws DigestException {
        byte[] digest = engineDigest();
        if (len < digest.length)
                throw new DigestException("partial digests not returned");
        if (buf.length - offset < digest.length)
                throw new DigestException("insufficient space in the output "
                                          + "buffer to store the digest");
        System.arraycopy(digest, 0, buf, offset, digest.length);
        return digest.length;
    }

So we can use instead use the other overload and use the return value
directly to avoid the copy.


---

(The change is not measurable impact in a end-to-end benchmark as it's impact is tiny compared to all the remaining work happening during query processing)

```
Q: select md5('crate')
C: 20
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |        3.555 ±   20.326 |      0.280 |      0.560 |      0.788 |    146.280 |
|   V2    |        3.279 ±   18.217 |      0.270 |      0.601 |      0.814 |    131.471 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -   8.08%                           +   6.98%
```