### PR TITLE
Don't expose array_of_null as an addressable type

### DIFF
--- a/server/src/main/java/io/crate/types/DataTypes.java
+++ b/server/src/main/java/io/crate/types/DataTypes.java
@@ -456,8 +456,7 @@ public final class DataTypes {
         entry(BitStringType.INSTANCE_ONE.getName(), BitStringType.INSTANCE_ONE),
         entry(JsonType.INSTANCE.getName(), JsonType.INSTANCE),
         entry("decimal", NUMERIC),
-        entry(FloatVectorType.INSTANCE_ONE.getName(), FloatVectorType.INSTANCE_ONE),
-        entry(NullArrayType.NAME, NullArrayType.INSTANCE)
+        entry(FloatVectorType.INSTANCE_ONE.getName(), FloatVectorType.INSTANCE_ONE)
     );
 
     public static DataType<?> ofName(String typeName) {

--- a/server/src/main/java/io/crate/types/TypeSignature.java
+++ b/server/src/main/java/io/crate/types/TypeSignature.java
@@ -171,6 +171,8 @@ public class TypeSignature implements Writeable, Accountable {
             }
             DataType<?> innerType = parameters.get(0).createType();
             return new ArrayType<>(innerType);
+        } else if (baseTypeName.equalsIgnoreCase(NullArrayType.NAME)) {
+            return NullArrayType.INSTANCE;
         } else if (baseTypeName.equalsIgnoreCase(ObjectType.NAME)) {
             var builder = ObjectType.builder();
             // Only build typed objects if we receive parameter key-value pairs which may not exist on generic

--- a/server/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
@@ -25,7 +25,6 @@ import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.Locale;

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -2309,4 +2309,12 @@ public class TransportSQLActionTest extends IntegTestCase {
         execute("select x from tbl where y in ('123456789.123456789', '778941863531215726456187232788659941.79')");
         assertThat(response).hasRows("123456789.123456789");
     }
+
+    @Test
+    public void test_array_of_null_cannot_be_explicitly_added() {
+        Asserts.assertSQLError(() -> execute("create table tbl (x array_of_null)"))
+            .hasMessageContaining("Cannot find data type: array_of_null");
+        Asserts.assertSQLError(() -> execute("select 1::array_of_null"))
+            .hasMessageContaining("Cannot find data type: array_of_null");
+    }
 }


### PR DESCRIPTION
We can create an array_of_null internally via building a TypeSignature, 
but the SQL Parser doesn't know anything about it and will throw errors 
if a user tries to use it as a datatype in casts or schema definitions.