### PR TITLE
Fix array length fields for dynamic null arrays

### DIFF
--- a/server/src/main/java/io/crate/types/NullArrayType.java
+++ b/server/src/main/java/io/crate/types/NullArrayType.java
@@ -29,8 +29,6 @@ import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import org.apache.lucene.document.Field;
-import org.apache.lucene.document.IntField;
 import org.elasticsearch.Version;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -117,7 +115,6 @@ public class NullArrayType extends DataType<List<Object>> {
         return new StorageSupport<>(false, false, EqQuery.nonMatchingEqQuery()) {
             @Override
             public ValueIndexer<? super List<Object>> valueIndexer(RelationName table, Reference ref, Function<ColumnIdent, Reference> getRef) {
-                String arrayLengthFieldName = ArrayIndexer.ARRAY_LENGTH_FIELD_PREFIX + ref.column().leafName();
                 return new ValueIndexer<>() {
                     @Override
                     public void indexValue(@NotNull List<Object> value, IndexDocumentBuilder docBuilder) {
@@ -126,7 +123,7 @@ public class NullArrayType extends DataType<List<Object>> {
                             // map '[]' to '_array_length_ = 0'
                             // map '[null]' to '_array_length_ = 1'
                             // 'null' is not mapped; can utilize 'FieldExistsQuery' for 'IS NULL' filtering
-                            docBuilder.addField(new IntField(arrayLengthFieldName, value.size(), Field.Store.NO));
+                            docBuilder.addField(ArrayIndexer.arrayLengthField(ref, getRef, value.size()));
                         }
                     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Follows https://github.com/crate/crate/pull/16630.

```
cr> create table t (a int) with (column_policy= 'dynamic');
CREATE OK, 1 row affected (1.706 sec)
cr> insert into t(a,b) values (null, []);
INSERT OK, 1 row affected (0.259 sec)
cr> select * from t where b = [];
+---+---+
| a | b |
+---+---+  <-- missing the empty array which is a separate issue not to be handled here.
+---+---+
SELECT 0 rows in set (0.115 sec)
cr> insert into t(a,b) values (null, [1]);
INSERT OK, 1 row affected (0.162 sec)
cr> select * from t where b = [];
+------+----+
| a    | b  |
+------+----+
| NULL | [] | <-- this did not return because the array field name was wrong which is being fixed by this PR.
+------+----+
SELECT 1 row in set (0.017 sec)
```

## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
