### PR TITLE
Optimize sketch capacity for topk

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/TopKAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/TopKAggregation.java
@@ -176,7 +176,7 @@ public class TopKAggregation extends AggregationFunction<TopKAggregation.State, 
 
     private static int maxMapSize(int x) {
         // max map size should be 4 * the limit based on the power of 2 to avoid errors
-        return (int) Math.pow(2, Math.ceil(Math.log(x) / Math.log(2))) * 4;
+        return (int) Math.pow(2, Math.ceil(Math.log(x) / Math.log(2))) * 32;
     }
 
     private static long calculateRamUsage(long maxMapSize) {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

I played around with the nyc-taxi dataset and topk and did some profiling. It's worth optimizing the capacity size of the data sketch further because it can have a significant performance impact. More details on this: https://datasketches.apache.org/docs/Frequency/FrequentItemsPerformance.html

```
Q: select topk(pulocationid) from nyc_taxi
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |       85.169 ±   23.290 |     81.439 |     82.484 |     83.155 |    315.296 |
|   V2    |       46.046 ±   25.893 |     28.759 |     42.239 |     43.184 |    288.246 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  59.63%                           -  64.53%
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 59.63%
The test has statistical significance
```



```
Top frames (by count)
  V1
    ReversePurgeLongHashMap.purge(int) total=4601564458, count=2218
    ReversePurgeLongHashMap.adjustOrPutValue(long, long) total=944, count=944
    DocValuesAggregates.getRow(...) total=922, count=922
    ReversePurgeLongHashMap.keepOnlyPositiveCounts() total=262, count=262
    QuickSelect.partition(...) total=158, count=158
    AbstractMemorySegmentImpl.checkBounds(long, long) total=110, count=110
    ReversePurgeLongHashMap.hashDelete(int) total=90, count=90
    QuickSelect.select(...) total=49, count=49
    CompositeBatchIterator$AsyncCompositeBI.lambda$loadNextBatch$0(int, int) total=1906284128, count=18
    SingletonSortedNumericDocValues.nextValue() total=17, count=17
  V2
    DocValuesAggregates.getRow(...) total=546, count=546
    SingletonSortedNumericDocValues.nextValue() total=299, count=299
    ReversePurgeLongHashMap.adjustOrPutValue(long, long) total=237, count=237
    AbstractMemorySegmentImpl.checkBounds(long, long) total=129, count=129
    ParserATNSimulator.getEpsilonTarget(...) total=26216552, count=9
    ReversePurgeLongHashMap.purge(int) total=332351600, count=8
    ObjectName.construct(String) total=19064, count=8
    LinkedList.listIterator(int) total=14652848, count=6
    StreamSupport.stream(...) total=12304, count=6
    ObjectName.setCanonicalName(...) total=10344, count=5
```



## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
