### PR TITLE
Introduce capacity parameter for topk

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/AggregateExpressionIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/AggregateExpressionIntegrationTest.java
@@ -22,9 +22,6 @@
 package io.crate.integrationtests;
 
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.util.List;
 import java.util.Map;
 
 import org.elasticsearch.test.IntegTestCase;
@@ -319,23 +316,15 @@ public class AggregateExpressionIntegrationTest extends IntegTestCase {
         // Use this very verbose style of assertion, since the return type is an Array<Object(UNDEFINED)>,
         // and while HTTP returns Long for the item and frequency values, PG converts them to Integer
         execute("select topk(l) tl from tbl");
-        List<Map<String, Number>> resultRows = (List<Map<String, Number>>) response.rows()[0][0];
-        assertThat(resultRows).hasSize(2);
-        assertThat(resultRows.get(0)).containsOnlyKeys("item", "frequency");
-        assertThat(resultRows.get(0).get("item").longValue()).isEqualTo(1L);
-        assertThat(resultRows.get(0).get("frequency").longValue()).isEqualTo(3L);
-        assertThat(resultRows.get(1)).containsOnlyKeys("item", "frequency");
-        assertThat(resultRows.get(1).get("item").longValue()).isEqualTo(2L);
-        assertThat(resultRows.get(1).get("frequency").longValue()).isEqualTo(2L);
+        Map<String, Object> resultRows = (Map<String, Object>) response.rows()[0][0];
+        assertThat(resultRows).containsOnlyKeys("maximum_error", "frequencies");
+        assertThat(resultRows.get("maximum_error")).isNotNull();
+        assertThat(resultRows.get("frequencies")).isNotNull();
 
         execute("select topk(l_no_doc_values) tl from tbl");
-        resultRows = (List<Map<String, Number>>) response.rows()[0][0];
-        assertThat(resultRows).hasSize(2);
-        assertThat(resultRows.get(0)).containsOnlyKeys("item", "frequency");
-        assertThat(resultRows.get(0).get("item").longValue()).isEqualTo(2L);
-        assertThat(resultRows.get(0).get("frequency").longValue()).isEqualTo(3L);
-        assertThat(resultRows.get(1)).containsOnlyKeys("item", "frequency");
-        assertThat(resultRows.get(1).get("item").longValue()).isEqualTo(1L);
-        assertThat(resultRows.get(1).get("frequency").longValue()).isEqualTo(2L);
+        resultRows = (Map<String, Object>) response.rows()[0][0];
+        assertThat(resultRows).containsOnlyKeys("maximum_error", "frequencies");
+        assertThat(resultRows.get("maximum_error")).isNotNull();
+        assertThat(resultRows.get("frequencies")).isNotNull();
     }
 }

--- a/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
+++ b/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
@@ -318,7 +318,8 @@ public abstract class AggregationTestCase extends ESTestCase {
                                                           IndexShard shard,
                                                           Version minNodeVersion,
                                                           List<Literal<?>> optionalParams) throws Exception {
-        List<Symbol> inputs = InputColumn.mapToInputColumns(argumentTypes);
+        // Make sure optional parameters do not become references
+        List<Symbol> inputs = InputColumn.mapToInputColumns(argumentTypes.subList(0, argumentTypes.size() - optionalParams.size()));
         inputs.addAll(optionalParams);
         var aggregation = new Aggregation(
             signature,


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This changes the topk max limit to 5000 with capacity 8192 so the limit is less than 0.75 % of the capacity to have a better default behaviour for performance reasons. It also make the capacity configurable for the user.

### Background:
I tried out the nyc taxi datset with topk and found out that there is potential to improve performance significant by increasing the capacity of number of tracked items. Initializing an item is expensive while increasing a counter is cheap on the sketch datastructure. Small capacity means a small memory footprint, but If the capacity is too small items get dropped out and recreated which is slow because it requires multiple hashings. We should increase the default capacity size and make the parameter configurable for users like Spark does. On the nyc-taxi dataset this variant is much faster, and the other benchmarks are not slower.

```
V1: 5.9.0-9c2b7637a90c1271858560e0ce4288c569e7ade5
V2: 5.9.0-00be8919e533067034a1733d1c799101e57ce993

Q: select topk(pulocationid) from nyc_taxi
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |       84.861 ±   21.829 |     81.305 |     82.471 |     82.880 |    300.588 |
|   V2    |       42.820 ±   20.812 |     26.345 |     40.736 |     41.025 |    247.978 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  65.85%                           -  67.75%
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 65.85%
The test has statistical significance


System/JVM Metrics (durations in ms, byte-values in MB)
    |    YOUNG GC            |       OLD GC           |      HEAP         |     ALLOC
    |  cnt      avg      max |  cnt      avg      max |  initial     used |     rate      total
 V1 |    2     3.04     3.14 |    0     0.00     0.00 |      268     2001 |  3049.95      23119
 V2 |    0     0.00     0.00 |    0     0.00     0.00 |      268        0 |  5657.67      17064
```

```
Top frames (by count)
  V1
    ReversePurgeLongHashMap.purge(int) total=4601564458, count=2218
    ReversePurgeLongHashMap.adjustOrPutValue(long, long) total=944, count=944
    DocValuesAggregates.getRow(...) total=922, count=922
    ReversePurgeLongHashMap.keepOnlyPositiveCounts() total=262, count=262
    QuickSelect.partition(...) total=158, count=158
    AbstractMemorySegmentImpl.checkBounds(long, long) total=110, count=110
    ReversePurgeLongHashMap.hashDelete(int) total=90, count=90
    QuickSelect.select(...) total=49, count=49
    CompositeBatchIterator$AsyncCompositeBI.lambda$loadNextBatch$0(int, int) total=1906284128, count=18
    SingletonSortedNumericDocValues.nextValue() total=17, count=17
  V2
    DocValuesAggregates.getRow(...) total=546, count=546
    SingletonSortedNumericDocValues.nextValue() total=299, count=299
    ReversePurgeLongHashMap.adjustOrPutValue(long, long) total=237, count=237
    AbstractMemorySegmentImpl.checkBounds(long, long) total=129, count=129
    ParserATNSimulator.getEpsilonTarget(...) total=26216552, count=9
    ReversePurgeLongHashMap.purge(int) total=332351600, count=8
    ObjectName.construct(String) total=19064, count=8
    LinkedList.listIterator(int) total=14652848, count=6
    StreamSupport.stream(...) total=12304, count=6
    ObjectName.setCanonicalName(...) total=10344, count=5
```

For the implementation, there are a few options:

- Let the user use any value for capacity and convert internally to a power of number (@proddata favourite)
- Make it explicit, so capacity must be a value in the power of two (current approach)
- Use a load factor like clickhouse, this may be difficult to fine-tune for large datasets where you want a small topk.


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
