### PR TITLE
Add undocumented retry count setting; use in test_decommission

### DIFF
--- a/blackbox/test_decommission.py
+++ b/blackbox/test_decommission.py
@@ -136,6 +136,7 @@ class GracefulStopTest(unittest.TestCase):
                     'cluster.name': self.__class__.__name__,
                     'node.name': self.node_name(i),
                     'transport.tcp.port': transport_port_range,
+                    'node.sql.num_temp_error_retries': 15,
                 },
                 env={
                     **os.environ.copy(),

--- a/server/src/main/java/io/crate/Constants.java
+++ b/server/src/main/java/io/crate/Constants.java
@@ -32,6 +32,4 @@ public class Constants {
     public static final String DEFAULT_MAPPING_TYPE = "default";
 
     public static final String DEFAULT_DATE_STYLE = "ISO";
-
-    public static final int MAX_SHARD_MISSING_RETRIES = 3;
 }

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -449,6 +449,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
         Sessions.NODE_READ_ONLY_SETTING,
         Sessions.STATEMENT_TIMEOUT,
         Sessions.MEMORY_LIMIT,
+        Sessions.TEMP_ERROR_RETRY_COUNT,
         PostgresNetty.PSQL_ENABLED_SETTING,
         PostgresNetty.PSQL_PORT_SETTING,
         AuthSettings.AUTH_HOST_BASED_ENABLED_SETTING,

--- a/server/src/test/java/io/crate/session/RetryOnFailureResultReceiverTest.java
+++ b/server/src/test/java/io/crate/session/RetryOnFailureResultReceiverTest.java
@@ -43,6 +43,7 @@ public class RetryOnFailureResultReceiverTest extends CrateDummyClusterServiceUn
         BaseResultReceiver baseResultReceiver = new BaseResultReceiver();
         ClusterState initialState = clusterService.state();
         RetryOnFailureResultReceiver<?> retryOnFailureResultReceiver = new RetryOnFailureResultReceiver<>(
+            3,
             clusterService,
             indexName -> true,
             baseResultReceiver,
@@ -65,6 +66,7 @@ public class RetryOnFailureResultReceiverTest extends CrateDummyClusterServiceUn
 
         ClusterState initialState = clusterService.state();
         RetryOnFailureResultReceiver<?> retryOnFailureResultReceiver = new RetryOnFailureResultReceiver<>(
+            3,
             clusterService,
             indexName -> true,
             resultReceiver,


### PR DESCRIPTION
The `test_decommission` blackbox tests are currently flaky and fail
sometimes with table not found errors.

This is due to index relocations, leading to IndexNotFoundExceptions
which are retried, but it can happen that the retry operations are
faster than the cluster state update/index relocation and the 3 default
attempts are not enough.
