### PR TITLE
Don't prepend localhost with account name when creating test server; remove URI validation

### DIFF
--- a/plugins/crate-copy-azure/src/main/java/io/crate/copy/azure/AzureURI.java
+++ b/plugins/crate-copy-azure/src/main/java/io/crate/copy/azure/AzureURI.java
@@ -24,7 +24,6 @@ package io.crate.copy.azure;
 import static io.crate.copy.azure.AzureCopyPlugin.USER_FACING_SCHEME;
 
 import java.net.URI;
-import java.util.regex.Pattern;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -45,10 +44,6 @@ public record AzureURI(
     Globs.GlobPredicate globPredicate
 ) {
 
-
-    private static final Pattern ACCOUNT_PATTERN = Pattern.compile("[a-z0-9]{3,24}");
-    private static final Pattern CONTAINER_PATTERN = Pattern.compile("[a-z0-9-]{3,63}");
-
     public static AzureURI of(URI uri) {
 
         if (uri.getScheme().equals(USER_FACING_SCHEME) == false) {
@@ -62,11 +57,6 @@ public record AzureURI(
             throw new IllegalArgumentException("Invalid URI. URI must look like 'az://account.endpoint_suffix/container/path/to/file'");
         }
         String account = endpoint.substring(0, dotIndex);
-        if (ACCOUNT_PATTERN.matcher(account).matches() == false) {
-            throw new IllegalArgumentException(
-                "Invalid URI. Account length must be between 3 and 24 characters and contain only lowercase characters and numbers"
-            );
-        }
 
         assert path.charAt(0) == '/' : "URI path starts with /";
         int secondSlashIndex = path.indexOf('/', 1); // Skip first slash;
@@ -81,11 +71,6 @@ public record AzureURI(
         }
 
         String container = path.substring(1, secondSlashIndex);
-        if (CONTAINER_PATTERN.matcher(container).matches() == false) {
-            throw new IllegalArgumentException(
-                "Invalid URI. Container length must be between 3 and 63 characters and contain only lowercase characters, numbers and hyphens"
-            );
-        }
 
         String resourcePath = path.substring(secondSlashIndex); // At least one symbol as path cannot be empty.
         // List API returns entries without leading backslash.

--- a/plugins/crate-copy-azure/src/test/java/io/crate/copy/azure/AzureCopyIntegrationTest.java
+++ b/plugins/crate-copy-azure/src/test/java/io/crate/copy/azure/AzureCopyIntegrationTest.java
@@ -92,7 +92,7 @@ public class AzureCopyIntegrationTest extends IntegTestCase {
     public void setUp() throws Exception {
         super.setUp();
         var handler = new AzureHttpHandler(CONTAINER_NAME, true);
-        httpServer = HttpServer.create(new InetSocketAddress(AZURE_ACCOUNT + "." + "localhost", 0), 0);
+        httpServer = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
         httpServer.createContext("/" + CONTAINER_NAME , handler);
         httpServer.start();
         InetSocketAddress address = httpServer.getAddress();

--- a/plugins/crate-copy-azure/src/test/java/io/crate/copy/azure/AzureURITest.java
+++ b/plugins/crate-copy-azure/src/test/java/io/crate/copy/azure/AzureURITest.java
@@ -51,22 +51,6 @@ public class AzureURITest {
     }
 
     @Test
-    public void test_account_has_uppercase_letter_throws_exception() throws Exception {
-        URI uri = URI.create("az://myAccount.blob.core.windows.net/container/dir");
-        assertThatThrownBy(() -> AzureURI.of(uri))
-            .isExactlyInstanceOf(IllegalArgumentException.class)
-            .hasMessage("Invalid URI. Account length must be between 3 and 24 characters and contain only lowercase characters and numbers");
-    }
-
-    @Test
-    public void test_account_has_invalid_length_throws_exception() throws Exception {
-        URI uri = URI.create("az://ac.blob.core.windows.net/container/dir");
-        assertThatThrownBy(() -> AzureURI.of(uri))
-            .isExactlyInstanceOf(IllegalArgumentException.class)
-            .hasMessage("Invalid URI. Account length must be between 3 and 24 characters and contain only lowercase characters and numbers");
-    }
-
-    @Test
     public void test_no_container_throws_exception() throws Exception {
         URI uri = URI.create("az://myaccount.blob.core.windows.net/dir");
         assertThatThrownBy(() -> AzureURI.of(uri))


### PR DESCRIPTION
Server created with "localhost" can still serve requests on "account.localhost..."

Also don't do validation of account and container names - let Azure do it. 

For example, Azurite doesn't even allow creating a container with invalid name.

