### PR TITLE
Fix filtering by `<array-literal> != any(<array-ref>)`

### DIFF
--- a/docs/appendices/release-notes/5.8.4.rst
+++ b/docs/appendices/release-notes/5.8.4.rst
@@ -78,3 +78,6 @@ Fixes
 
 - Fixed an integer overflow issue when the total shards (shards and replicas)
   configured for a table are greater than ``Integer.MAX_VALUE``.
+
+- Fixed an issue that caused :ref:`ANY <sql_any_array_comparison>` operator to
+  throw a ``ClassCastException`` when the arguments were nested arrays.

--- a/docs/appendices/release-notes/5.8.4.rst
+++ b/docs/appendices/release-notes/5.8.4.rst
@@ -68,7 +68,7 @@ Fixes
   array typed column on left hand side of the arguments to return invalid
   results.
 
-- Fixed an issue that caused ``=`` :ref:`ANY <sql_any_array_comparison>`
+- Fixed an issue that caused ``=`` or ``!=`` :ref:`ANY <sql_any_array_comparison>`
   operator to throw a ``ClassCastException`` when the right hand side argument
   was more than 1 dimensions higher than the left hand side argument.
 

--- a/server/src/main/java/io/crate/expression/operator/any/AnyNeqOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/any/AnyNeqOperator.java
@@ -39,6 +39,7 @@ import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 import io.crate.sql.tree.ComparisonExpression;
 import io.crate.types.ArrayType;
+import io.crate.types.DataTypes;
 import io.crate.types.EqQuery;
 import io.crate.types.StorageSupport;
 
@@ -89,6 +90,9 @@ public final class AnyNeqOperator extends AnyOperator<Object> {
     @Override
     @SuppressWarnings({"unchecked", "rawtypes"})
     protected Query literalMatchesAnyArrayRef(Function any, Literal<?> probe, Reference candidates, Context context) {
+        if (DataTypes.isArray(probe.valueType())) {
+            return null;
+        }
         // 1 != any ( col ) -->  gt 1 or lt 1
         String columnName = candidates.storageIdent();
         StorageSupport<?> storageSupport = probe.valueType().storageSupport();

--- a/server/src/test/java/io/crate/lucene/NestedArrayLuceneQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/NestedArrayLuceneQueryBuilderTest.java
@@ -32,7 +32,8 @@ public class NestedArrayLuceneQueryBuilderTest extends LuceneQueryBuilderTest {
         return """
             create table t (
                 a int[][],
-                b int[]
+                b int[],
+                c int[][][]
             )
             """;
     }
@@ -69,5 +70,11 @@ public class NestedArrayLuceneQueryBuilderTest extends LuceneQueryBuilderTest {
         var query = convert("b = any([ [ [1], [1, 2] ], [ [3], [4, 5] ] ])");
         // pre-filter by a terms query with 1, 2, 3, 4, 5 then a generic function query to make sure an exact match
         assertThat(query.toString()).isEqualTo("+b:{1 2 3 4 5} #(b = ANY([[1], [1, 2], [3], [4, 5]]))");
+    }
+
+    @Test
+    public void test_any_not_equals_on_array_literal_and_nested_array_ref_with_automatic_array_dimension_leveling() {
+        var query = convert("[1] != any(c)");
+        assertThat(query.toString()).isEqualTo("([1] <> ANY(array_unnest(c)))");
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
```
cr> create table t (a int[][][]);
CREATE OK, 1 row affected (1.962 sec)

-- before fix:
cr> select * from t where [1] != any(a);
ClassCastException[class java.util.ArrayList cannot be cast to class java.lang.Number (java.util.ArrayList and java.lang.Number are in module java.base of loader 'bootstrap')]

-- after:
cr> select * from t where [1] != any(a);
+---+
| a |
+---+
+---+
SELECT 0 rows in set (2.373 sec)
```

The second commit is for https://github.com/crate/crate/pull/16553#discussion_r1774230036.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
