### PR TITLE
Don't convert numbers or booleans to text for undefined type in SourceParser

### DIFF
--- a/docs/appendices/release-notes/5.8.4.rst
+++ b/docs/appendices/release-notes/5.8.4.rst
@@ -47,6 +47,9 @@ See the :ref:`version_5.8.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that caused numeric values inside of ``OBJECT (IGNORED)``
+  columns to be returned as text instead of number.
+
 - Fixed an issue causing an object column definition with duplicate child
   column names to be accepted (last definition was used) instead of throwing an
   error. E.g.::

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/SourceParser.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/SourceParser.java
@@ -60,6 +60,7 @@ import io.crate.types.BitStringType;
 import io.crate.types.BooleanType;
 import io.crate.types.ByteType;
 import io.crate.types.DataType;
+import io.crate.types.DataTypes;
 import io.crate.types.DoubleType;
 import io.crate.types.FloatType;
 import io.crate.types.FloatVectorType;
@@ -297,13 +298,17 @@ public final class SourceParser {
                 colPath);
             case START_OBJECT -> parseObject(parser, requiredColumns, droppedColumns, lookupNameBySourceKey,
                 colPath, includeUnknown);
-            case VALUE_STRING -> type == null ? parser.text() : parseByType(parser, type);
-            case VALUE_NUMBER -> type == null ? parser.numberValue() : parseByType(parser, type);
-            case VALUE_BOOLEAN -> type == null ? parser.booleanValue() : parseByType(parser, type);
-            case VALUE_EMBEDDED_OBJECT -> type == null ? parser.binaryValue() : parseByType(parser, type);
+            case VALUE_STRING -> isUndefined(type) ? parser.text() : parseByType(parser, type);
+            case VALUE_NUMBER -> isUndefined(type) ? parser.numberValue() : parseByType(parser, type);
+            case VALUE_BOOLEAN -> isUndefined(type) ? parser.booleanValue() : parseByType(parser, type);
+            case VALUE_EMBEDDED_OBJECT -> isUndefined(type) ? parser.binaryValue() : parseByType(parser, type);
             default -> throw new UnsupportedOperationException("Unsupported token encountered, expected a value, got "
                 + parser.currentToken());
         };
+    }
+
+    private static boolean isUndefined(@Nullable DataType<?> type) {
+        return type == null || type.id() == DataTypes.UNDEFINED.id();
     }
 
     private static Object parseByType(XContentParser parser, DataType<?> type) throws IOException {

--- a/server/src/test/java/io/crate/expression/reference/doc/lucene/SourceParserTest.java
+++ b/server/src/test/java/io/crate/expression/reference/doc/lucene/SourceParserTest.java
@@ -308,7 +308,7 @@ public class SourceParserTest extends ESTestCase {
                     }
                     """
             ));
-        assertThat(result).isEqualTo(Map.of("obj", Map.of("x", List.of(List.of("1", "2"), List.of("3", "4")))));
+        assertThat(result).isEqualTo(Map.of("obj", Map.of("x", List.of(List.of(1, 2), List.of(3, 4)))));
     }
 
     @Test


### PR DESCRIPTION
In

    CREATE TABLE obj_ignored (obj OBJECT(IGNORED));
    INSERT INTO obj_ignored VALUES
            ('{"x":[1,2,3]}'),
            ('{"x":"a"}');

The values for `obj['x']` in the first row were returned as `["1", "2",
"3"]` instead of preserving the numbers.

Relates to https://github.com/crate/crate/issues/11714
