### PR TITLE
Allow INSERT FROM VALUES to consume null arrays

### DIFF
--- a/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -823,7 +823,7 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
                 var cellType = cell.valueType();
                 if (r > 0 // skip first cell, we don't have to check for self-conversion
                     && !cellType.isConvertableTo(targetType, false)
-                    && targetType.id() != DataTypes.UNDEFINED.id()) {
+                    && ArrayType.unnest(targetType).id() != DataTypes.UNDEFINED.id()) {
                     throw new IllegalArgumentException(
                         "The types of the columns within VALUES lists must match. " +
                         "Found `" + targetType + "` and `" + cellType + "` at position: " + c);

--- a/server/src/test/java/io/crate/analyze/ValuesAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/ValuesAnalyzerTest.java
@@ -33,6 +33,7 @@ import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.exceptions.ConversionException;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
+import io.crate.types.ArrayType;
 import io.crate.types.DataTypes;
 
 public class ValuesAnalyzerTest extends CrateDummyClusterServiceUnitTest {
@@ -84,5 +85,11 @@ public class ValuesAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     public void test_highest_precedence_type_is_chosen_as_target_column_type() {
         AnalyzedRelation relation = e.analyze("VALUES (null), (1.0), (1), ('1')");
         assertThat(relation.outputs()).satisfiesExactly(isReference("col1", DataTypes.DOUBLE));
+    }
+
+    @Test
+    public void test_empty_array_and_int_array_can_be_resolved_to_int_array() {
+        AnalyzedRelation relation = e.analyze("VALUES ([]), ([null]), ([1])");
+        assertThat(relation.outputs()).satisfiesExactly(isReference("col1", new ArrayType<>(DataTypes.INTEGER)));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes:
```
cr> create table t (a int) with (column_policy= 'dynamic');
CREATE OK, 1 row affected (1.573 sec)
cr> insert into t(c) values ([]), ([null]), ([1]);
SQLParseException[The types of the columns within VALUES lists must match. Found `undefined_array` and `integer_array` at position: 0]
```

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
