### PR TITLE
Check whether port is defined before adding it to the Azure endpoint

### DIFF
--- a/plugins/crate-copy-azure/src/main/java/io/crate/copy/azure/AzureURI.java
+++ b/plugins/crate-copy-azure/src/main/java/io/crate/copy/azure/AzureURI.java
@@ -49,7 +49,11 @@ public record AzureURI(
         if (uri.getScheme().equals(USER_FACING_SCHEME) == false) {
             throw new IllegalArgumentException("Invalid URI. URI must look like 'az://account.endpoint_suffix/container/path/to/file'");
         }
-        String endpoint = uri.getHost() + ":" + uri.getPort();
+        String endpoint = uri.getHost();
+        var port = uri.getPort();
+        if (port != -1) {
+            endpoint += ":" + port;
+        }
         String path = uri.getPath();
 
         int dotIndex = endpoint.indexOf(".");

--- a/plugins/crate-copy-azure/src/test/java/io/crate/copy/azure/AzureURITest.java
+++ b/plugins/crate-copy-azure/src/test/java/io/crate/copy/azure/AzureURITest.java
@@ -68,22 +68,6 @@ public class AzureURITest {
     }
 
     @Test
-    public void test_container_has_uppercase_letter_throws_exception() throws Exception {
-        URI uri = URI.create("dummy://myaccount.blob.core.windows.net/Container/dir");
-        assertThatThrownBy(() -> AzureURI.of(uri))
-            .isExactlyInstanceOf(IllegalArgumentException.class)
-            .hasMessage("Invalid URI. URI must look like 'az://account.endpoint_suffix/container/path/to/file'");
-    }
-
-    @Test
-    public void test_container_has_invalid_length_throws_exception() throws Exception {
-        URI uri = URI.create("dummy://myaccount.blob.core.windows.net/co/dir");
-        assertThatThrownBy(() -> AzureURI.of(uri))
-            .isExactlyInstanceOf(IllegalArgumentException.class)
-            .hasMessage("Invalid URI. URI must look like 'az://account.endpoint_suffix/container/path/to/file'");
-    }
-
-    @Test
     public void test_invalid_scheme_throws_exception() throws Exception {
         URI uri = URI.create("dummy://myaccount.blob.core.windows.net/container/dir");
         assertThatThrownBy(() -> AzureURI.of(uri))

--- a/plugins/crate-copy-azure/src/test/java/io/crate/copy/azure/AzureURITest.java
+++ b/plugins/crate-copy-azure/src/test/java/io/crate/copy/azure/AzureURITest.java
@@ -33,6 +33,15 @@ public class AzureURITest {
 
     private static final String COMMON_PREFIX = "az://myaccount.blob.core.windows.net/my-container";
 
+    @Test
+    public void test_port_is_added_when_defined() throws Exception {
+        AzureURI azureURI = AzureURI.of(URI.create("az://myaccount.blob.core.windows.net:1234/container/file.json"));
+        assertThat(azureURI.endpoint()).isEqualTo("myaccount.blob.core.windows.net:1234");
+
+        // No port
+        azureURI = AzureURI.of(URI.create("az://myaccount.blob.core.windows.net/container/file.json"));
+        assertThat(azureURI.endpoint()).isEqualTo("myaccount.blob.core.windows.net");
+    }
 
     @Test
     public void test_empty_path_after_container_throws_exception() throws Exception {


### PR DESCRIPTION
Bug: on real instance we don't have ports specified(at least by default) and endpoint used to look like "host:-1"
