### PR TITLE
Do not index array lengths for inner arrays

### DIFF
--- a/server/src/main/java/io/crate/expression/scalar/ArrayUpperFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayUpperFunction.java
@@ -169,6 +169,9 @@ public class ArrayUpperFunction extends Scalar<Integer, Object> {
             return null;
         }
         int dimension = ((Number) ((Input<?>) dimensionSymbol).value()).intValue();
+        if (dimension <= 0 || dimension > ArrayType.dimensions(arrayRef.valueType())) {
+            return new MatchNoDocsQuery("Dimension argument <= 0 or exceeding the dimension of the array cannot match");
+        }
         if (dimension != 1) {
             // Storage of the multidimensional arrays is not supported.
             return null;

--- a/server/src/main/java/io/crate/types/ArrayType.java
+++ b/server/src/main/java/io/crate/types/ArrayType.java
@@ -99,7 +99,10 @@ public class ArrayType<T> extends DataType<List<T>> {
                 public ValueIndexer<T> valueIndexer(RelationName table,
                                                     Reference ref,
                                                     Function<ColumnIdent, Reference> getRef) {
-                    return new ArrayIndexer<>(innerStorage.valueIndexer(table, ref, getRef), getRef, ref);
+                    int topMostArrayDimensions = ArrayType.dimensions(innerType) + 1;
+                    assert topMostArrayDimensions == ArrayType.dimensions(ref.valueType()) :
+                        "Must not retrieve value indexer of the child array of a multi dimensional array";
+                    return ArrayIndexer.of(ref, getRef);
                 }
             };
         }

--- a/server/src/test/java/io/crate/lucene/ArrayLengthQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/ArrayLengthQueryBuilderTest.java
@@ -79,6 +79,17 @@ public class ArrayLengthQueryBuilderTest extends LuceneQueryBuilderTest {
     }
 
     @Test
+    public void test_array_length_with_dimension_arg_exceeding_array_dimension_is_no_match() {
+        Query query = convert("array_length(y_array, 2) = 3");
+        assertThat(query).hasToString(
+            "MatchNoDocsQuery(\"Dimension argument <= 0 or exceeding the dimension of the array cannot match\")");
+
+        query = convert("array_length(y_array, 0) = 3");
+        assertThat(query).hasToString(
+            "MatchNoDocsQuery(\"Dimension argument <= 0 or exceeding the dimension of the array cannot match\")");
+    }
+
+    @Test
     public void test_NumTermsPerDocQuery_maps_column_idents_to_oids() throws Exception {
         final long oid = 123;
         try (QueryTester tester = new QueryTester.Builder(

--- a/server/src/test/java/io/crate/lucene/NestedArrayLuceneQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/NestedArrayLuceneQueryBuilderTest.java
@@ -49,6 +49,30 @@ public class NestedArrayLuceneQueryBuilderTest extends LuceneQueryBuilderTest {
     public void test_empty_nested_array_equals() {
         var query = convert("a = [[]]");
         assertThat(query.toString()).isEqualTo("+_array_length_a:[0 TO 0] +(a = [[]])");
+
+        query = convert("a[1] = []");
+        assertThat(query.toString()).isEqualTo("(a[1] = [])");
+    }
+
+    @Test
+    public void test_array_length_scalar_on_nested_array() {
+        var query = convert("array_length(a, 1) = 1");
+        assertThat(query.toString()).isEqualTo("_array_length_a:[1 TO 1]");
+
+        query = convert("array_length(a[1], 1) = 1");
+        assertThat(query.toString()).isEqualTo("(array_length(a[1], 1) = 1)");
+
+        query = convert("array_length(a, 2) = 1");
+        assertThat(query.toString()).isEqualTo("(array_length(a, 2) = 1)");
+    }
+
+    @Test
+    public void test_is_null_predicate_on_nested_array() {
+        var query = convert("a is null");
+        assertThat(query.toString()).isEqualTo("+*:* -FieldExistsQuery [field=_array_length_a]");
+
+        query = convert("a[1] is null");
+        assertThat(query.toString()).isEqualTo("(a[1] IS NULL)");
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes:
```
cr> create table t (a int[][]);
CREATE OK, 1 row affected (1.774 sec)
cr> insert into t values ([ [1], [1,1], null ]);
INSERT OK, 1 row affected (0.049 sec)
cr> select * from t where array_length(a, 1) = 1;
+---------------------+
| a                   |
+---------------------+
| [[1], [1, 1], null] | -- not expected
+---------------------+
SELECT 1 row in set (0.004 sec)
cr> select * from t where array_length(a, 1) = 2;
+---------------------+
| a                   |
+---------------------+
| [[1], [1, 1], null] | -- not expected
+---------------------+
SELECT 1 row in set (0.007 sec)
cr> select * from t where array_length(a, 1) = 3;
+---------------------+
| a                   |
+---------------------+
| [[1], [1, 1], null] | -- expected
+---------------------+
SELECT 1 row in set (0.004 sec)
```
Current ArrayIndexer indexes inner array lengths of a nested array but with the same field name(of the top most array).

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
