### PR TITLE
Suppress native access warning; enable use of incubator.vector

### DIFF
--- a/app/src/main/dist/bin/crate
+++ b/app/src/main/dist/bin/crate
@@ -161,6 +161,9 @@ JAVA_OPTS="$JAVA_OPTS -Dlog4j.shutdownHookEnabled=false -Dlog4j2.disable.jmx=tru
 # Disable netty recycler
 JAVA_OPTS="$JAVA_OPTS -Dio.netty.recycler.maxCapacityPerThread=0"
 
+# Lucene uses native access and vector module
+JAVA_OPTS="$JAVA_OPTS --enable-native-access=ALL-UNNAMED --add-modules jdk.incubator.vector"
+
 # Dump heap on OOM
 JAVA_OPTS="$JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError"
 if [ "x$CRATE_HEAP_DUMP_PATH" != "x" ]; then

--- a/app/src/main/dist/bin/crate.bat
+++ b/app/src/main/dist/bin/crate.bat
@@ -93,6 +93,10 @@ set JAVA_OPTS=%JAVA_OPTS% -Dlog4j.shutdownHookEnabled=false -Dlog4j2.disable.jmx
 REM Disable netty recycler
 set JAVA_OPTS=%JAVA_OPTS% -Dio.netty.recycler.maxCapacityPerThread=0
 
+REM Lucene uses native access
+set JAVA_OPTS=%JAVA_OPTS% --enable-native-access=ALL-UNNAMED --add-modules jdk.incubator.vector
+
+
 REM Dump heap on OOM
 set JAVA_OPTS=%JAVA_OPTS% -XX:+HeapDumpOnOutOfMemoryError
 if NOT "%CRATE_HEAP_DUMP_PATH%" == "" (

--- a/pom.xml
+++ b/pom.xml
@@ -255,6 +255,7 @@
             <addModule>jdk.management</addModule>
             <addModule>jdk.management.agent</addModule>
             <addModule>jdk.crypto.ec</addModule>
+            <addModule>jdk.incubator.vector</addModule>
 
             <!-- These are required to use https://github.com/crate/jmx_exporter -->
             <addModule>java.instrument</addModule>


### PR DESCRIPTION
Ensures bin/crate doesn't result in the following warning:

    WARNING: A restricted method in java.lang.foreign.Linker has been called
    WARNING: java.lang.foreign.Linker::downcallHandle has been called by org.apache.lucene.store.PosixNativeAccess in an unnamed module
    WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
    WARNING: Restricted methods will be blocked in a future release unless native access is enabled

And allows Lucene to make use of the jdk.incubator.vector module, which
should result in improved performance for operations around the
`float_vector` type - e.g. dot product calculations.
