### PR TITLE
Fixed issue with parted tables and NOT on WHERE clause

### DIFF
--- a/docs/appendices/release-notes/5.8.4.rst
+++ b/docs/appendices/release-notes/5.8.4.rst
@@ -53,6 +53,19 @@ Fixes
     SELECT * FROM tbl ORDER BY ip_col;
     SELECT ip_col > '11.22.33.44' FROM tbl;
 
+- Fixed an issue that caused ``WHERE`` clause to wrongly filter out whole
+  partitions when there is a :ref:`NOT<sql_dql_not>` wrapping
+  :ref:`IS NULL<sql_dql_is_null>` or a complex expression::
+
+    CREATE TABLE tbl(a STRING, b STRING) PARTITIONED BY (a);
+    SELECT * FROM tbl
+    WHERE NOT (
+        CASE t1.c0
+            WHEN '' THEN TRUE
+            WHEN 'E' THEN ((t1.c1) IS NOT NULL)
+            ELSE t1.c0 > 'a'
+        END)
+
 - Fixed an issue that caused numeric values inside of ``OBJECT (IGNORED)``
   columns to be returned as text instead of number.
 

--- a/server/src/main/java/io/crate/analyze/where/WhereClauseAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/where/WhereClauseAnalyzer.java
@@ -61,7 +61,7 @@ public class WhereClauseAnalyzer {
                                                 CoordinatorTxnCtx coordinatorTxnCtx,
                                                 NodeContext nodeCtx,
                                                 Metadata metadata) {
-        if (!where.hasQuery() || !(tableRelation instanceof DocTableRelation) || where.query().equals(Literal.BOOLEAN_TRUE)) {
+        if (!where.hasQuery() || !(tableRelation instanceof DocTableRelation) || Literal.BOOLEAN_TRUE.equals(where.query())) {
             return where;
         }
         DocTableInfo table = ((DocTableRelation) tableRelation).tableInfo();
@@ -190,7 +190,7 @@ public class WhereClauseAnalyzer {
         for (Map.Entry<Symbol, List<Literal<?>>> entry : queryPartitionMap.entrySet()) {
             Symbol query = entry.getKey();
             List<Literal<?>> partitions = entry.getValue();
-            Symbol normalized = normalizer.normalize(ScalarsAndRefsToTrue.rewrite(query), coordinatorTxnCtx);
+            Symbol normalized = normalizer.normalize(ScalarsAndRefsToTrue.rewrite(normalizer, coordinatorTxnCtx, query), coordinatorTxnCtx);
             assert normalized instanceof Literal :
                 "after normalization and replacing all reference occurrences with true there must only be a literal left";
 

--- a/server/src/testFixtures/java/io/crate/testing/SqlExpressions.java
+++ b/server/src/testFixtures/java/io/crate/testing/SqlExpressions.java
@@ -46,6 +46,7 @@ import io.crate.metadata.NodeContext;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.Schemas;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.settings.CoordinatorSessionSettings;
 import io.crate.metadata.table.Operation;
 import io.crate.planner.optimizer.LoadedRules;
@@ -101,6 +102,14 @@ public class SqlExpressions {
         );
         normalizer = new EvaluatingNormalizer(nodeCtx, RowGranularity.DOC, null, fieldResolver);
         expressionAnalysisCtx = new ExpressionAnalysisContext(sessionSettings);
+    }
+
+    public EvaluatingNormalizer normalizer() {
+        return normalizer;
+    }
+
+    public TransactionContext txnCtx() {
+        return coordinatorTxnCtx;
     }
 
     public Symbol asSymbol(String expression) {


### PR DESCRIPTION
When executing a query on a partitioned table with a `WHERE` clause, we try to find out which partitions should be included in the execution plan (collect data from their shards). To achieve this, we break down the query to parts based on the `PARTITIONED BY` column and the available partitions of the table, and for each one of the parts we replace all references (table columns) with the value `TRUE` or `NULL` (pretending that there are indeed values for that column which satisfy the expression)

When `NOT` predicate is involved there though, we need to just skip it, since a `NOT TRUE` will lead to `false` and therefore filter out whole partitions. It's also important that the `NOT` is skipped and whatever it wraps underneath is returned, only if that wrapped expression can be normalized to a literal.

Fixes: #16614
