### PR TITLE
Fix comparison and ORDER BY of IPs

### DIFF
--- a/docs/appendices/release-notes/5.8.4.rst
+++ b/docs/appendices/release-notes/5.8.4.rst
@@ -47,6 +47,12 @@ See the :ref:`version_5.8.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that caused wrong results when ordering by an IP field or whehn
+  comparing values of :ref:`IP type <type-ip>`, e.g.::
+
+    SELECT * FROM tbl ORDER BY ip_col;
+    SELECT ip_col > '11.22.33.44' FROM tbl;
+
 - Fixed an issue that caused numeric values inside of ``OBJECT (IGNORED)``
   columns to be returned as text instead of number.
 

--- a/server/src/main/java/io/crate/types/IpType.java
+++ b/server/src/main/java/io/crate/types/IpType.java
@@ -23,6 +23,7 @@ package io.crate.types;
 
 import java.io.IOException;
 import java.net.InetAddress;
+import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
 
@@ -188,7 +189,9 @@ public class IpType extends DataType<String> implements Streamer<String> {
 
     @Override
     public int compare(String val1, String val2) {
-        return val1.compareTo(val2);
+        byte[] ip1 = InetAddresses.ipStringToBytes(val1);
+        byte[] ip2 = InetAddresses.ipStringToBytes(val2);
+        return Arrays.compareUnsigned(ip1, ip2);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/network/InetAddresses.java
+++ b/server/src/main/java/org/elasticsearch/common/network/InetAddresses.java
@@ -34,7 +34,7 @@ public final class InetAddresses {
         return ipStringToBytes(ipString) != null;
     }
 
-    private static byte[] ipStringToBytes(String ipString) {
+    public static byte[] ipStringToBytes(String ipString) {
         // Make a first pass to categorize the characters in this string.
         boolean hasColon = false;
         boolean hasDot = false;

--- a/server/src/test/java/io/crate/expression/operator/CmpOperatorTest.java
+++ b/server/src/test/java/io/crate/expression/operator/CmpOperatorTest.java
@@ -49,6 +49,8 @@ public class CmpOperatorTest extends ScalarTestCase {
         assertNormalize("'987 years 567 months 482 days 127 hours 185 mins 31214 seconds'::interval <= " +
                         "'1035 years 7 months 2 days 18 hours 45 mins 13 seconds'::interval",
                         isLiteral(false)); // manual normalize up to years
+        assertNormalize("'::1'::ip <= '11.22.33.44'::ip",
+            isLiteral(true));
         assertEvaluateNull("true <= null");
         assertEvaluateNull("null <= 1");
         assertEvaluateNull("null <= 'abc'");
@@ -69,6 +71,8 @@ public class CmpOperatorTest extends ScalarTestCase {
         assertNormalize("'987 years 567 months 482 days 127 hours 185 mins 31214 seconds'::interval < " +
                         "'1035 years 7 months 2 days 18 hours 45 mins 14 seconds'::interval",
                         isLiteral(false)); // manual normalize up to years
+        assertNormalize("'11.22.33.44'::ip < '11.99.33.44'::ip",
+            isLiteral(true));
         assertEvaluateNull("true < null");
         assertEvaluateNull("null < 1");
         assertEvaluateNull("null < name", Literal.of("foo"));
@@ -86,6 +90,8 @@ public class CmpOperatorTest extends ScalarTestCase {
         assertNormalize("'0.002 secs'::interval >= '2 ms'::interval", isLiteral(true));
         assertNormalize("'12 hour'::interval >= '2 hour'::interval", isLiteral(true));
         assertNormalize("'1 month 1 hour'::interval >= '1 month 2 hour'::interval", isLiteral(false));
+        assertNormalize("'2001:4f8:3:ba:2e0:81ff:fe22:d1f2'::ip >= '2001:4f8:3:ba:2e0:81ff:fe22:d1f1'::ip",
+            isLiteral(true));
         assertEvaluateNull("true >= null");
         assertEvaluateNull("null >= 1");
         assertEvaluateNull("null >= 'abc'");
@@ -100,6 +106,8 @@ public class CmpOperatorTest extends ScalarTestCase {
         assertNormalize("'abd' > 'abc'", isLiteral(true));
         assertNormalize("'10 hour'::interval > '2 hour'::interval", isLiteral(true));
         assertNormalize("'1 month 1 hour'::interval > '1 month 2 hour'::interval", isLiteral(false));
+        assertNormalize("'2002:4f8:3:ba:2e0:81ff:fe22:d1f1'::ip > '2001:4f8:3:ba:2e0:81ff:fe22:d1f1'::ip",
+            isLiteral(true));
         assertEvaluateNull("true > null");
         assertEvaluateNull("null > 1");
         assertEvaluateNull("name > null", Literal.of("foo"));
@@ -111,6 +119,7 @@ public class CmpOperatorTest extends ScalarTestCase {
         assertNormalize("0.1 between 0.01 and 0.2", isLiteral(true));
         assertNormalize("10 between 1 and 2", isLiteral(false));
         assertNormalize("'abd' between 'abc' and 'abe'", isLiteral(true));
+        assertNormalize("'11.22.33.44'::ip between '11.22.33.44'::ip and '11.22.33.45'::ip", isLiteral(true));
         assertEvaluateNull("1 between 0 and null");
         assertEvaluateNull("1 between null and 10");
         assertEvaluateNull("1 between null and null");

--- a/server/src/test/java/io/crate/integrationtests/OrderByITest.java
+++ b/server/src/test/java/io/crate/integrationtests/OrderByITest.java
@@ -47,8 +47,8 @@ public class OrderByITest extends IntegTestCase {
         assertThat(response).hasRows(
             "10.0.0.1",
             "10.200.1.100",
-            "10.220.1.120",
             "10.220.1.20",
+            "10.220.1.120",
             "127.0.0.1",
             "NULL");
 
@@ -56,8 +56,8 @@ public class OrderByITest extends IntegTestCase {
         assertThat(response).hasRows(
             "NULL",
             "127.0.0.1",
-            "10.220.1.20",
             "10.220.1.120",
+            "10.220.1.20",
             "10.200.1.100",
             "10.0.0.1");
     }


### PR DESCRIPTION
When two IP values are compared, not with a LuceneQuery, so for example
in the select clause, or when ORDERing BY an IP field, `IpType#compare()`
is used, which previously was yielding wrong results, as it was comparing
the 2 IPs as strings. To fix it, convert the IPs to `BigInteger`s and compare
those instead. This also solves the issue of comparing IPv4 and IPv6 addresses.

Fixes: #16690
