### PR TITLE
Fix column pruning for table function

### DIFF
--- a/docs/appendices/release-notes/5.8.4.rst
+++ b/docs/appendices/release-notes/5.8.4.rst
@@ -47,7 +47,12 @@ See the :ref:`version_5.8.0` release notes for a full list of changes in the
 Fixes
 =====
 
-- Fixed an issue that caused wrong results when ordering by an IP field or whehn
+- Fixed an issue that caused an error or wrong results when a table function was
+  combined with a UNION ALL in a sub-query e.g.::
+
+      SELECT a FROM (SELECT a, b FROM tbl UNION ALL SELECT 3 AS a, 3 AS b) t;
+
+- Fixed an issue that caused wrong results when ordering by an IP field or when
   comparing values of :ref:`IP type <type-ip>`, e.g.::
 
     SELECT * FROM tbl ORDER BY ip_col;

--- a/server/src/main/java/io/crate/planner/operators/TableFunction.java
+++ b/server/src/main/java/io/crate/planner/operators/TableFunction.java
@@ -136,7 +136,7 @@ public final class TableFunction implements LogicalPlan {
 
     @Override
     public LogicalPlan pruneOutputsExcept(SequencedCollection<Symbol> outputsToKeep) {
-        if (outputsToKeep.containsAll(toCollect)) {
+        if (toCollect.size() == outputsToKeep.size() && outputsToKeep.containsAll(toCollect)) {
             return this;
         }
         return new TableFunction(relation, List.copyOf(outputsToKeep), where);

--- a/server/src/test/java/io/crate/integrationtests/CorrelatedSubqueryITest.java
+++ b/server/src/test/java/io/crate/integrationtests/CorrelatedSubqueryITest.java
@@ -68,7 +68,7 @@ public class CorrelatedSubqueryITest extends IntegTestCase {
             "    └ SubPlan\n" +
             "      └ Eval[mountain]\n" +
             "        └ Limit[2::bigint;0::bigint]\n" +
-            "          └ TableFunction[empty_row | [] | true]\n"
+            "          └ TableFunction[empty_row | [mountain] | true]\n"
         );
         execute("SELECT 1, (SELECT t.mountain) FROM sys.summits t");
         Comparator<Object[]> compareMountain = Comparator.comparing((Object[] row) -> (String) row[1]);
@@ -121,7 +121,7 @@ public class CorrelatedSubqueryITest extends IntegTestCase {
             "        └ SubPlan\n" +
             "          └ Eval[mountain]\n" +
             "            └ Limit[2::bigint;0::bigint]\n" +
-            "              └ TableFunction[empty_row | [] | true]\n"
+            "              └ TableFunction[empty_row | [mountain] | true]\n"
         );
         execute(statement);
         assertThat(TestingHelpers.printedTable(response.rows())).isEqualTo(
@@ -230,7 +230,7 @@ public class CorrelatedSubqueryITest extends IntegTestCase {
             "      └ SubPlan\n" +
             "        └ Eval[x]\n" +
             "          └ Limit[1;0]\n" +
-            "            └ TableFunction[empty_row | [] | true]\n");
+            "            └ TableFunction[empty_row | [x] | true]\n");
         execute(stmt);
         assertThat(TestingHelpers.printedTable(response.rows())).isEqualTo(
             "1\n" +
@@ -254,7 +254,7 @@ public class CorrelatedSubqueryITest extends IntegTestCase {
             "          └ SubPlan\n" +
             "            └ Eval[mountain]\n" +
             "              └ Limit[2::bigint;0::bigint]\n" +
-            "                └ TableFunction[empty_row | [] | true]\n"
+            "                └ TableFunction[empty_row | [mountain] | true]\n"
         );
         execute(stmt);
         assertThat(TestingHelpers.printedTable(response.rows())).isEqualTo(
@@ -381,7 +381,7 @@ public class CorrelatedSubqueryITest extends IntegTestCase {
             "          └ SubPlan\n" +
             "            └ Eval[attrelid]\n" +
             "              └ Limit[2::bigint;0::bigint]\n" +
-            "                └ TableFunction[empty_row | [] | true]\n"
+            "                └ TableFunction[empty_row | [attrelid] | true]\n"
         );
         execute(stmt);
         assertThat(TestingHelpers.printedTable(response.rows())).isEqualTo(

--- a/server/src/test/java/io/crate/planner/CorrelatedJoinPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/CorrelatedJoinPlannerTest.java
@@ -60,7 +60,7 @@ public class CorrelatedJoinPlannerTest extends CrateDummyClusterServiceUnitTest 
             "        └ SubPlan\n" +
             "          └ Eval[mountain]\n" +
             "            └ Limit[2::bigint;0::bigint]\n" +
-            "              └ TableFunction[empty_row | [] | true]"
+            "              └ TableFunction[empty_row | [mountain] | true]"
         );
     }
 
@@ -77,7 +77,7 @@ public class CorrelatedJoinPlannerTest extends CrateDummyClusterServiceUnitTest 
             "    └ SubPlan\n" +
             "      └ Eval[mountain]\n" +
             "        └ Limit[2::bigint;0::bigint]\n" +
-            "          └ TableFunction[empty_row | [] | true]"
+            "          └ TableFunction[empty_row | [mountain] | true]"
         );
     }
 

--- a/server/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -24,7 +24,6 @@ package io.crate.planner;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.isReference;
 import static java.util.Collections.singletonList;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.HashSet;
@@ -1230,8 +1229,8 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             Eval[unnest, sum(unnest) OVER (ORDER BY power(unnest, 2.0) ASC RANGE BETWEEN 3 PRECEDING AND CURRENT ROW)]
               └ WindowAgg[unnest, power(unnest, 2.0), sum(unnest) OVER (ORDER BY power(unnest, 2.0) ASC RANGE BETWEEN 3 PRECEDING AND CURRENT ROW)]
                 └ Eval[unnest, power(unnest, 2.0)]
-                  └ Rename[unnest] AS t
-                    └ TableFunction[unnest | [unnest] | true]
+                  └ Rename[unnest, unnest] AS t
+                    └ TableFunction[unnest | [unnest, unnest] | true]
             """;
         assertThat(plan).isEqualTo(expectedPlan);
     }

--- a/server/src/test/java/io/crate/planner/UnionPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/UnionPlannerTest.java
@@ -201,8 +201,7 @@ public class UnionPlannerTest extends CrateDummyClusterServiceUnitTest {
         UnionExecutionPlan union = e.plan("SELECT null UNION ALL SELECT id FROM users");
         Collect left = (Collect) union.left();
         assertThat(left.collectPhase().projections()).satisfiesExactly(
-            p -> assertThat(p).isExactlyInstanceOf(EvalProjection.class), // returns NULL
-            p -> assertThat(p).isExactlyInstanceOf(EvalProjection.class)  // casts NULL to long to match `id`
+            p -> assertThat(p).isExactlyInstanceOf(EvalProjection.class) // returns NULL
         );
         Collect right = (Collect) union.right();
         assertThat(left.streamOutputs()).isEqualTo(right.streamOutputs());
@@ -215,8 +214,7 @@ public class UnionPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(left.streamOutputs()).isEqualTo(right.streamOutputs());
         assertThat(right.streamOutputs()).satisfiesExactly(o -> assertThat(o).isEqualTo(DataTypes.LONG));
         assertThat(right.collectPhase().projections()).satisfiesExactly(
-            p -> assertThat(p).isExactlyInstanceOf(EvalProjection.class), // returns NULL
-            p -> assertThat(p).isExactlyInstanceOf(EvalProjection.class)  // casts NULL to long to match `id`
+            p -> assertThat(p).isExactlyInstanceOf(EvalProjection.class) // returns NULL
         );
     }
 
@@ -262,8 +260,7 @@ public class UnionPlannerTest extends CrateDummyClusterServiceUnitTest {
                     │    │  └ Collect[doc.users | [id] | true]
                     │    └ Rename[id] AS y
                     │      └ Collect[doc.users | [id] | true]
-                    └ Eval[1, 1]
-                      └ TableFunction[empty_row | [] | true]
+                    └ TableFunction[empty_row | [1, 1] | true]
                 """
         );
     }

--- a/server/src/test/java/io/crate/planner/operators/JoinTest.java
+++ b/server/src/test/java/io/crate/planner/operators/JoinTest.java
@@ -781,7 +781,7 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
                   └ Eval[1]
                     └ Limit[2::bigint;0::bigint]
                       └ Filter[(((x = 1) AND (x = 1)) AND (x = 1))]
-                        └ TableFunction[empty_row | [] | true]
+                        └ TableFunction[empty_row | [1] | true]
             """
         );
     }

--- a/server/src/test/java/io/crate/planner/operators/StatementClassifierTest.java
+++ b/server/src/test/java/io/crate/planner/operators/StatementClassifierTest.java
@@ -56,7 +56,7 @@ public class StatementClassifierTest extends CrateDummyClusterServiceUnitTest {
         LogicalPlan plan = e.logicalPlan("SELECT 1");
         StatementClassifier.Classification classification = StatementClassifier.classify(plan);
         assertThat(classification.type()).isEqualTo(Plan.StatementType.SELECT);
-        assertThat(classification.labels()).containsExactly("Eval", "TableFunction");
+        assertThat(classification.labels()).containsExactly("TableFunction");
 
         plan = e.logicalPlan("SELECT * FROM users WHERE id = 1");
         classification = StatementClassifier.classify(plan);

--- a/server/src/test/java/io/crate/planner/operators/TableFunctionTest.java
+++ b/server/src/test/java/io/crate/planner/operators/TableFunctionTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.operators;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.junit.Test;
+
+import io.crate.analyze.WhereClause;
+import io.crate.analyze.relations.TableFunctionRelation;
+import io.crate.expression.symbol.Symbol;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+
+public class TableFunctionTest extends CrateDummyClusterServiceUnitTest {
+
+    @Test
+    public void test_column_pruning_with_empty_outputs() throws IOException {
+        SQLExecutor e = SQLExecutor.of(clusterService).addTable("create table tbl (a int, b int)");
+
+        Symbol a = e.asSymbol("a");
+        Symbol b = e.asSymbol("b");
+
+        LogicalPlan tableFunction = TableFunction.create(mock(TableFunctionRelation.class), List.of(), WhereClause.MATCH_ALL);
+        assertThat(tableFunction.outputs()).isEmpty();
+        var prunedTableFunction = tableFunction.pruneOutputsExcept(List.of(a, b));
+        assertThat(prunedTableFunction.outputs()).containsExactly(a, b);
+    }
+
+    @Test
+    public void test_column_pruning_with_more_outputs() throws IOException {
+        SQLExecutor e = SQLExecutor.of(clusterService).addTable("create table tbl (a int, b int, c int)");
+
+        Symbol a = e.asSymbol("a");
+        Symbol b = e.asSymbol("b");
+        Symbol c = e.asSymbol("c");
+
+        LogicalPlan tableFunction = TableFunction.create(mock(TableFunctionRelation.class), List.of(a, b, c), WhereClause.MATCH_ALL);
+        assertThat(tableFunction.outputs()).containsExactly(a, b, c);
+        var prunedTableFunction = tableFunction.pruneOutputsExcept(List.of(a, b));
+        assertThat(prunedTableFunction.outputs()).containsExactly(a, b);
+    }
+
+}


### PR DESCRIPTION
This fixes the column pruning for table functions, in particular the case where no outputs are pre-defined because the source is an `empty-row`. This causes the table function logic to skip the pruning which results in incorrect outputs.

```
cr> select a from (select a,b from tbl union all select 'foo' as a, 'bar' b) t;
SQLParseException[Couldn't create execution plan from logical plan because of: Index 1 out of bounds for length 1:
Rename[a] AS t (rows=unknown)
  └ Union[a] (rows=unknown)
    ├ Collect[doc.tbl | [a] | true] (rows=unknown)
    └ Eval['foo' AS a, 'bar' AS b] (rows=unknown)
      └ TableFunction[empty_row | [] | true] (rows=unknown)]
```





## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
