### PR TITLE
Refactor StorageSupport.eqQuery to be notnull

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/collect/collectors/OptimizeQueryForSearchAfter.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/collectors/OptimizeQueryForSearchAfter.java
@@ -65,11 +65,11 @@ public class OptimizeQueryForSearchAfter implements Function<FieldDoc, Query> {
                     return null;
                 }
                 StorageSupport<?> storageSupport = ref.valueType().storageSupport();
-                //noinspection unchecked
-                EqQuery<Object> eqQuery = storageSupport == null ? null : (EqQuery<Object>) storageSupport.eqQuery();
-                if (eqQuery == null) {
+                if (storageSupport == null) {
                     return null;
                 }
+                //noinspection unchecked
+                EqQuery<Object> eqQuery = (EqQuery<Object>) storageSupport.eqQuery();
                 boolean nullsFirst = orderBy.nullsFirst()[i];
                 value = value == null || value.equals(missingValues[i]) ? null : value;
                 if (nullsFirst && value == null) {

--- a/server/src/main/java/io/crate/expression/operator/CIDROperator.java
+++ b/server/src/main/java/io/crate/expression/operator/CIDROperator.java
@@ -111,9 +111,6 @@ public final class CIDROperator {
             assert ref.valueType().id() == DataTypes.IP.id()
                 : "In <ref> << <literal> the ref must have type IP due to function registration";
             EqQuery<? super String> eqQuery = DataTypes.IP.storageSupportSafe().eqQuery();
-            if (eqQuery == null) {
-                return null;
-            }
             return eqQuery.rangeQuery(
                 ref.storageIdent(),
                 bounds[0].getHostAddress(),

--- a/server/src/main/java/io/crate/expression/operator/CmpOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/CmpOperator.java
@@ -23,7 +23,6 @@ package io.crate.expression.operator;
 
 import java.util.function.IntPredicate;
 
-import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 
 import io.crate.data.Input;
@@ -75,9 +74,6 @@ public final class CmpOperator extends Operator<Object> {
             return null;
         }
         EqQuery eqQuery = storageSupport.eqQuery();
-        if (eqQuery == null) {
-            return new MatchNoDocsQuery("For types that do not support EqQuery, a `x [>, >=, <, <=] <value>` is always considered a no-match");
-        }
         String field = ref.storageIdent();
         return switch (functionName) {
             case GtOperator.NAME -> eqQuery.rangeQuery(

--- a/server/src/main/java/io/crate/expression/operator/LikeOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/LikeOperator.java
@@ -133,10 +133,10 @@ public class LikeOperator extends Operator<String> {
                 : "LikeOperator is registered for string types. Value must be a string";
             if (((String) value).isEmpty()) {
                 StorageSupport<?> storageSupport = ref.valueType().storageSupport();
-                EqQuery<?> eqQuery = storageSupport == null ? null : storageSupport.eqQuery();
-                if (eqQuery == null) {
+                if (storageSupport == null) {
                     return null;
                 }
+                EqQuery<?> eqQuery = storageSupport.eqQuery();
                 return ((EqQuery<Object>) eqQuery).termQuery(
                     ref.storageIdent(), value, ref.hasDocValues(), ref.indexType() != IndexType.NONE);
             }

--- a/server/src/main/java/io/crate/expression/operator/any/AnyNeqOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/any/AnyNeqOperator.java
@@ -100,9 +100,6 @@ public final class AnyNeqOperator extends AnyOperator<Object> {
             return null;
         }
         EqQuery eqQuery = storageSupport.eqQuery();
-        if (eqQuery == null) {
-            return null;
-        }
         Object value = probe.value();
         BooleanQuery.Builder query = new BooleanQuery.Builder();
         query.setMinimumNumberShouldMatch(1);

--- a/server/src/main/java/io/crate/expression/scalar/SubscriptFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/SubscriptFunction.java
@@ -265,11 +265,11 @@ public class SubscriptFunction extends Scalar<Object, Object> {
             }
             DataType<?> innerType = unnest(ref.valueType());
             StorageSupport<?> storageSupport = innerType.storageSupport();
-            //noinspection unchecked
-            EqQuery<Object> eqQuery = storageSupport == null ? null : (EqQuery<Object>) storageSupport.eqQuery();
-            if (eqQuery == null) {
+            if (storageSupport == null) {
                 return null;
             }
+            //noinspection unchecked
+            EqQuery<Object> eqQuery = (EqQuery<Object>) storageSupport.eqQuery();
             BooleanQuery.Builder builder = new BooleanQuery.Builder();
             var preFilterQuery = preFilterQueryBuilder.buildQuery(ref, eqQuery, cmpLiteral.value());
             if (preFilterQuery == null) {

--- a/server/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
+++ b/server/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
@@ -338,10 +338,8 @@ public class LuceneQueryBuilder {
             // called for queries like: where boolColumn
             if (type == DataTypes.BOOLEAN) {
                 EqQuery<? super Boolean> eqQuery = DataTypes.BOOLEAN.storageSupportSafe().eqQuery();
-                if (eqQuery != null) {
-                    return eqQuery.termQuery(
-                        ref.storageIdent(), Boolean.TRUE, ref.hasDocValues(), ref.indexType() != IndexType.NONE);
-                }
+                return eqQuery.termQuery(
+                    ref.storageIdent(), Boolean.TRUE, ref.hasDocValues(), ref.indexType() != IndexType.NONE);
             }
             return super.visitReference(ref, context);
         }

--- a/server/src/main/java/io/crate/types/EqQuery.java
+++ b/server/src/main/java/io/crate/types/EqQuery.java
@@ -73,4 +73,23 @@ public interface EqQuery<T> {
             }
         };
     }
+
+    static <T> EqQuery<T> nullEqQuery() {
+        return new EqQuery<>() {
+            @Override
+            public Query termQuery(String field, T value, boolean hasDocValues, boolean isIndexed) {
+                return null;
+            }
+
+            @Override
+            public Query rangeQuery(String field, T lowerTerm, T upperTerm, boolean includeLower, boolean includeUpper, boolean hasDocValues, boolean isIndexed) {
+                return null;
+            }
+
+            @Override
+            public Query termsQuery(String field, List<T> nonNullValues, boolean hasDocValues, boolean isIndexed) {
+                return null;
+            }
+        };
+    }
 }

--- a/server/src/main/java/io/crate/types/FloatVectorType.java
+++ b/server/src/main/java/io/crate/types/FloatVectorType.java
@@ -29,7 +29,6 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.apache.lucene.index.VectorSimilarityFunction;
-import org.apache.lucene.search.Query;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -54,34 +53,10 @@ public class FloatVectorType extends DataType<float[]> implements Streamer<float
     public static final VectorSimilarityFunction SIMILARITY_FUNC = VectorSimilarityFunction.EUCLIDEAN;
     public static final int MAX_DIMENSIONS = 2048;
 
-    private static final EqQuery<float[]> EQ_QUERY = new EqQuery<>() {
-
-        @Override
-        public Query termQuery(String field, float[] value, boolean hasDocValues, boolean isIndexed) {
-            return null;
-        }
-
-        @Override
-        public Query rangeQuery(String field,
-                                float[] lowerTerm,
-                                float[] upperTerm,
-                                boolean includeLower,
-                                boolean includeUpper,
-                                boolean hasDocValues,
-                                boolean isIndexed) {
-            return null;
-        }
-
-        @Override
-        public Query termsQuery(String field, List<float[]> nonNullValues, boolean hasDocValues, boolean isIndexed) {
-            return null;
-        }
-    };
-
     private static final StorageSupport<? super float[]> STORAGE_SUPPORT = new StorageSupport<>(
-            true,
-            true,
-            EQ_QUERY) {
+        true,
+        true,
+        EqQuery.nullEqQuery()) {
 
         @Override
         public ValueIndexer<? super float[]> valueIndexer(RelationName table,

--- a/server/src/main/java/io/crate/types/GeoPointType.java
+++ b/server/src/main/java/io/crate/types/GeoPointType.java
@@ -46,15 +46,16 @@ public class GeoPointType extends DataType<Point> implements Streamer<Point>, Fi
 
     public static final int ID = 13;
     public static final GeoPointType INSTANCE = new GeoPointType();
-    private static StorageSupport<Point> STORAGE = new StorageSupport<>(true, false, null) {
+    private static final StorageSupport<Point> STORAGE =
+        new StorageSupport<>(true, false, EqQuery.nullEqQuery()) {
 
-        @Override
-        public ValueIndexer<Point> valueIndexer(RelationName table,
-                                                Reference ref,
-                                                Function<ColumnIdent, Reference> getRef) {
-            return new GeoPointIndexer(ref);
-        }
-    };
+            @Override
+            public ValueIndexer<Point> valueIndexer(RelationName table,
+                                                    Reference ref,
+                                                    Function<ColumnIdent, Reference> getRef) {
+                return new GeoPointIndexer(ref);
+            }
+        };
 
     private GeoPointType() {
     }

--- a/server/src/main/java/io/crate/types/GeoShapeType.java
+++ b/server/src/main/java/io/crate/types/GeoShapeType.java
@@ -56,15 +56,16 @@ public class GeoShapeType extends DataType<Map<String, Object>> implements Strea
     }
 
 
-    private static final StorageSupport<Map<String, Object>> STORAGE = new StorageSupport<>(false, false, null) {
+    private static final StorageSupport<Map<String, Object>> STORAGE =
+        new StorageSupport<>(false, false, EqQuery.nullEqQuery()) {
 
-        @Override
-        public ValueIndexer<Map<String, Object>> valueIndexer(RelationName table,
-                                                              Reference ref,
-                                                              Function<ColumnIdent, Reference> getRef) {
-            return new GeoShapeIndexer(ref);
-        }
-    };
+            @Override
+            public ValueIndexer<Map<String, Object>> valueIndexer(RelationName table,
+                                                                  Reference ref,
+                                                                  Function<ColumnIdent, Reference> getRef) {
+                return new GeoShapeIndexer(ref);
+            }
+        };
 
     private GeoShapeType() {
     }

--- a/server/src/main/java/io/crate/types/ObjectType.java
+++ b/server/src/main/java/io/crate/types/ObjectType.java
@@ -66,15 +66,16 @@ public class ObjectType extends DataType<Map<String, Object>> implements Streame
     public static final ObjectType UNTYPED = new ObjectType(Map.of());
     public static final int ID = 12;
     public static final String NAME = "object";
-    private static final StorageSupport<Map<String, Object>> STORAGE = new StorageSupport<>(false, false, null) {
+    private static final StorageSupport<Map<String, Object>> STORAGE =
+        new StorageSupport<>(false, false, EqQuery.nullEqQuery()) {
 
-        @Override
-        public ValueIndexer<Map<String, Object>> valueIndexer(RelationName table,
-                                                              Reference ref,
-                                                              Function<ColumnIdent, Reference> getRef) {
-            return new ObjectIndexer(table, ref, getRef);
-        }
-    };
+            @Override
+            public ValueIndexer<Map<String, Object>> valueIndexer(RelationName table,
+                                                                  Reference ref,
+                                                                  Function<ColumnIdent, Reference> getRef) {
+                return new ObjectIndexer(table, ref, getRef);
+            }
+        };
 
     public static class Builder {
 

--- a/server/src/main/java/io/crate/types/StorageSupport.java
+++ b/server/src/main/java/io/crate/types/StorageSupport.java
@@ -24,6 +24,7 @@ package io.crate.types;
 
 import java.util.function.Function;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import io.crate.execution.dml.ValueIndexer;
@@ -37,12 +38,12 @@ public abstract class StorageSupport<T> {
     private final boolean docValuesDefault;
     private final boolean supportsDocValuesOff;
 
-    @Nullable
+    @NotNull
     private final EqQuery<T> eqQuery;
 
     StorageSupport(boolean docValuesDefault,
                    boolean supportsDocValuesOff,
-                   @Nullable EqQuery<T> eqQuery) {
+                   @NotNull EqQuery<T> eqQuery) {
         this.docValuesDefault = docValuesDefault;
         this.supportsDocValuesOff = supportsDocValuesOff;
         this.eqQuery = eqQuery;
@@ -70,7 +71,7 @@ public abstract class StorageSupport<T> {
         return supportsDocValuesOff;
     }
 
-    @Nullable
+    @NotNull
     public EqQuery<T> eqQuery() {
         return eqQuery;
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
There are 3 storageSupport types(GeoShape, GeoPoint, Object) that carry `null` eqQuery. And when eqQuery == null, we fall back to GenericFunctionQuery. We can implement EqQuery that returns null and remove null checks.

## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
