### PR TITLE
Fix `<numeric> cmp <numeric>`

### DIFF
--- a/docs/appendices/release-notes/5.8.5.rst
+++ b/docs/appendices/release-notes/5.8.5.rst
@@ -119,3 +119,7 @@ Fixes
   generated ``geo_shape`` column with type ``Polygon``, ``MultiPolygon``,
   ``LineString`` or ``MultiLineString`` and a user provides a correct value for
   this generated column.
+
+- Fixed an issue that caused ``>``, ``<``, ``>=`` or ``<=`` on
+  :ref:`NUMERIC <type-numeric>` types with unmatched precisions and scales or
+  negative values to return invalid results.

--- a/docs/appendices/release-notes/5.9.1.rst
+++ b/docs/appendices/release-notes/5.9.1.rst
@@ -123,3 +123,7 @@ Fixes
   generated ``geo_shape`` column with type ``Polygon``, ``MultiPolygon``,
   ``LineString`` or ``MultiLineString`` and a user provides a correct value for
   this generated column.
+
+- Fixed an issue that caused ``>``, ``<``, ``>=`` or ``<=`` on
+  :ref:`NUMERIC <type-numeric>` types with unmatched precisions and scales or
+  negative values to return invalid results.

--- a/server/src/main/java/io/crate/expression/operator/GtOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/GtOperator.java
@@ -47,5 +47,18 @@ public final class GtOperator {
                 )
             );
         }
+        builder.add(
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.NUMERIC.getTypeSignature(),
+                    DataTypes.NUMERIC.getTypeSignature())
+                .returnType(Operator.RETURN_TYPE.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
+                .build(),
+            (signature, boundSignature) -> new CmpOperator(
+                signature,
+                boundSignature,
+                cmpResult -> cmpResult > 0
+            )
+        );
     }
 }

--- a/server/src/main/java/io/crate/expression/operator/GteOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/GteOperator.java
@@ -47,5 +47,18 @@ public final class GteOperator {
                 )
             );
         }
+        builder.add(
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.NUMERIC.getTypeSignature(),
+                    DataTypes.NUMERIC.getTypeSignature())
+                .returnType(Operator.RETURN_TYPE.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
+                .build(),
+            (signature, boundSignature) -> new CmpOperator(
+                signature,
+                boundSignature,
+                cmpResult -> cmpResult >= 0
+            )
+        );
     }
 }

--- a/server/src/main/java/io/crate/expression/operator/LtOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/LtOperator.java
@@ -44,5 +44,15 @@ public final class LtOperator {
                     new CmpOperator(signature, boundSignature, cmpResult -> cmpResult < 0)
             );
         }
+        builder.add(
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.NUMERIC.getTypeSignature(),
+                    DataTypes.NUMERIC.getTypeSignature())
+                .returnType(Operator.RETURN_TYPE.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
+                .build(),
+            (signature, boundSignature) ->
+                new CmpOperator(signature, boundSignature, cmpResult -> cmpResult < 0)
+        );
     }
 }

--- a/server/src/main/java/io/crate/expression/operator/LteOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/LteOperator.java
@@ -47,5 +47,18 @@ public final class LteOperator {
                 )
             );
         }
+        builder.add(
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.NUMERIC.getTypeSignature(),
+                    DataTypes.NUMERIC.getTypeSignature())
+                .returnType(Operator.RETURN_TYPE.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
+                .build(),
+            (signature, boundSignature) -> new CmpOperator(
+                signature,
+                boundSignature,
+                cmpResult -> cmpResult <= 0
+            )
+        );
     }
 }

--- a/server/src/main/java/io/crate/types/NumericStorage.java
+++ b/server/src/main/java/io/crate/types/NumericStorage.java
@@ -64,8 +64,8 @@ import io.crate.metadata.doc.SysColumns;
 public final class NumericStorage extends StorageSupport<BigDecimal> {
 
     public static final int COMPACT_PRECISION = 18;
-    public static long COMPACT_MIN_VALUE = -999999999999999999L;
-    public static long COMPACT_MAX_VALUE = 999999999999999999L;
+    public static final long COMPACT_MIN_VALUE = -999999999999999999L;
+    public static final long COMPACT_MAX_VALUE = 999999999999999999L;
 
     public NumericStorage(NumericType numericType) {
         super(true, true, NumericEqQuery.of(numericType));

--- a/server/src/test/java/io/crate/lucene/NumericEqQueryTest.java
+++ b/server/src/test/java/io/crate/lucene/NumericEqQueryTest.java
@@ -55,6 +55,67 @@ public class NumericEqQueryTest extends LuceneQueryBuilderTest {
     }
 
     @Test
+    public void test_numeric_comparisions_with_different_precision() {
+        String col = randomBoolean() ? "x" : "y";
+        assertThat(convert(col + " > 1.111")).isEqualTo(convert(col + " > 1.11"));
+        assertThat(convert(col + " > 1.119")).isEqualTo(convert(col + " > 1.11"));
+        assertThat(convert(col + " > 1.1100")).isEqualTo(convert(col + " > 1.11"));
+        assertThat(convert(col + " > 1.105")).isEqualTo(convert(col + " > 1.10"));
+        assertThat(convert(col + " > 1.1")).isEqualTo(convert(col + " > 1.10"));
+        assertThat(convert(col + " > 1")).isEqualTo(convert(col + " > 1.00"));
+
+        assertThat(convert(col + " >= 1.111")).isEqualTo(convert(col + " > 1.11"));
+        assertThat(convert(col + " >= 1.119")).isEqualTo(convert(col + " > 1.11"));
+        assertThat(convert(col + " >= 1.1100")).isEqualTo(convert(col + " > 1.10"));
+        assertThat(convert(col + " >= 1.105")).isEqualTo(convert(col + " > 1.10"));
+        assertThat(convert(col + " >= 1.1")).isEqualTo(convert(col + " > 1.09"));
+        assertThat(convert(col + " >= 1")).isEqualTo(convert(col + " > 0.99"));
+
+        assertThat(convert(col + " < 1.111")).isEqualTo(convert(col + " < 1.12"));
+        assertThat(convert(col + " < 1.119")).isEqualTo(convert(col + " < 1.12"));
+        assertThat(convert(col + " < 1.1100")).isEqualTo(convert(col + " < 1.11"));
+        assertThat(convert(col + " < 1.105")).isEqualTo(convert(col + " < 1.11"));
+        assertThat(convert(col + " < 1.1")).isEqualTo(convert(col + " < 1.10"));
+        assertThat(convert(col + " < 1")).isEqualTo(convert(col + " < 1.00"));
+
+        assertThat(convert(col + " <= 1.111")).isEqualTo(convert(col + " < 1.12"));
+        assertThat(convert(col + " <= 1.119")).isEqualTo(convert(col + " < 1.12"));
+        assertThat(convert(col + " <= 1.1100")).isEqualTo(convert(col + " < 1.12"));
+        assertThat(convert(col + " <= 1.105")).isEqualTo(convert(col + " < 1.11"));
+        assertThat(convert(col + " <= 1.1")).isEqualTo(convert(col + " < 1.11"));
+        assertThat(convert(col + " <= 1")).isEqualTo(convert(col + " < 1.01"));
+
+        // negative values
+        assertThat(convert(col + " > -1.111")).isEqualTo(convert(col + " > -1.12"));
+        assertThat(convert(col + " > -1.119")).isEqualTo(convert(col + " > -1.12"));
+        assertThat(convert(col + " > -1.1100")).isEqualTo(convert(col + " > -1.11"));
+        assertThat(convert(col + " > -1.105")).isEqualTo(convert(col + " > -1.11"));
+        assertThat(convert(col + " > -1.1")).isEqualTo(convert(col + " > -1.10"));
+        assertThat(convert(col + " > -1")).isEqualTo(convert(col + " > -1.00"));
+
+        assertThat(convert(col + " >= -1.111")).isEqualTo(convert(col + " > -1.12"));
+        assertThat(convert(col + " >= -1.119")).isEqualTo(convert(col + " > -1.12"));
+        assertThat(convert(col + " >= -1.1100")).isEqualTo(convert(col + " > -1.12"));
+        assertThat(convert(col + " >= -1.105")).isEqualTo(convert(col + " > -1.11"));
+        assertThat(convert(col + " >= -1.1")).isEqualTo(convert(col + " > -1.11"));
+        assertThat(convert(col + " >= -1")).isEqualTo(convert(col + " > -1.01"));
+
+        assertThat(convert(col + " < -1.111")).isEqualTo(convert(col + " < -1.11"));
+        assertThat(convert(col + " < -1.119")).isEqualTo(convert(col + " < -1.11"));
+        assertThat(convert(col + " < -1.1100")).isEqualTo(convert(col + " < -1.11"));
+        assertThat(convert(col + " < -1.105")).isEqualTo(convert(col + " < -1.10"));
+        assertThat(convert(col + " < -1.1")).isEqualTo(convert(col + " < -1.10"));
+        assertThat(convert(col + " < -1")).isEqualTo(convert(col + " < -1.00"));
+
+        assertThat(convert(col + " <= -1.111")).isEqualTo(convert(col + " < -1.11"));
+        assertThat(convert(col + " <= -1.119")).isEqualTo(convert(col + " < -1.11"));
+        assertThat(convert(col + " <= -1.1100")).isEqualTo(convert(col + " < -1.10"));
+        assertThat(convert(col + " <= -1.105")).isEqualTo(convert(col + " < -1.10"));
+        assertThat(convert(col + " <= -1.1")).isEqualTo(convert(col + " < -1.09"));
+        assertThat(convert(col + " <= -1")).isEqualTo(convert(col + " < -0.99"));
+    }
+
+    @Test
     public void test_uses_binary_encoded_range_queries_for_large_numeric() throws Exception {
         Query query = convert("y = '2746799837116176.76'");
         assertThat(query).isInstanceOf(PointRangeQuery.class);

--- a/server/src/test/java/io/crate/types/NumericTypeTest.java
+++ b/server/src/test/java/io/crate/types/NumericTypeTest.java
@@ -242,4 +242,11 @@ public class NumericTypeTest extends DataTypeTestCase<BigDecimal> {
         assertThat(e.asSymbol("1.11::numeric(3, 1) = 1.11::numeric")).isEqualTo(BOOLEAN_FALSE);
         assertThat(e.asSymbol("1.1::numeric(5,1) = 1.11::numeric(4,2)")).isEqualTo(BOOLEAN_FALSE);
     }
+
+    @Test
+    public void test_comparisons_operators_with_different_precision_and_negative_values() {
+        SQLExecutor e = SQLExecutor.of(clusterService);
+        assertThat(e.asSymbol("1.11::numeric(3, 1) >= 1.10::numeric(3, 2)")).isEqualTo(BOOLEAN_TRUE);
+        assertThat(e.asSymbol("-2.1::numeric(5, 1) > -3.1::numeric(4, 2)")).isEqualTo(BOOLEAN_TRUE);
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Currently we depend on text variant of the comparison operators resulting in invalid results:
```
cr> create table t (a numeric(3,1), b numeric(3,1));
CREATE OK, 1 row affected (1.736 sec)
cr> insert into t values (-2.1, -1.1);
INSERT OK, 1 row affected (0.045 sec)
cr> select a > b from t;
+---------+
| (a > b) |
+---------+
| TRUE    | -- should be false
+---------+
SELECT 1 row in set (0.006 sec)

-- Even simpler cases:
cr> select 1.11::numeric(3, 1) >= 1.10::numeric(3, 2);
+-------+
| false |
+-------+
| FALSE |
+-------+
SELECT 1 row in set (0.005 sec)
cr> select -2.1::numeric(5, 1) > -3.1::numeric(4, 2);
+-------+
| false |
+-------+
| FALSE |
+-------+
SELECT 1 row in set (0.006 sec)
```

Storage support for numeric type is added recently, so only `master` is affected.


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
