### PR TITLE
Docs: Remove CTEs from unsupported SQL features

### DIFF
--- a/docs/appendices/compatibility.rst
+++ b/docs/appendices/compatibility.rst
@@ -129,8 +129,6 @@ These *features* of `standard SQL`_ are not supported:
 
 - Triggers
 
-  - ``WITH`` Queries (Common Table Expressions)
-
 - Sequences
 
 - Inheritance


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

I'm not sure why CTEs were listed as a sub-item of Triggers, it looks misplaced, and CrateDB has supported CTEs for a few years already. 

## Checklist

 - [X] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [X] Updated documentation & `sql_features` table for user facing changes
 - [X] Touched code is covered by tests
 - [X] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
