### PR TITLE
Documentation: Update to crate-docs-theme 0.35.0

### DIFF
--- a/blackbox/requirements.txt
+++ b/blackbox/requirements.txt
@@ -14,9 +14,8 @@ minio>=5.0.0
 dnslib
 
 # Documentation
-sphinx>=4.6
+crate-docs-theme>=0.35.0
 sphinx-csv-filter==0.4.0
-crate-docs-theme>=0.30.0
 
 # Documentation: local development
 sphinx-autobuild<2024

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 # packages for RTD to pick up (not used for local dev)
-crate-docs-theme>=0.30.0
+crate-docs-theme>=0.35.0
 sphinx-csv-filter==0.4.0
 Pygments>=2.7.4,<3


### PR DESCRIPTION
## About
This compensates for upstream changes introduced by Read The Docs.

> [...] introduction of [Read the Docs Addons](https://about.readthedocs.com/blog/2024/04/enable-beta-addons/) to **all the projects by default starting on October 7, 2024**.
>
> --https://about.readthedocs.com/blog/2024/07/addons-by-default/

## Preview
- https://crate--16732.org.readthedocs.build/en/16732/

## References
- https://github.com/crate/crate-docs-theme/issues/536

## Remarks
_Please commandeer into backports how you see applicable. Thanks!_
