### PR TITLE
Don't use type guessing for estimation of object size.

### DIFF
--- a/docs/appendices/release-notes/5.8.5.rst
+++ b/docs/appendices/release-notes/5.8.5.rst
@@ -47,4 +47,6 @@ See the :ref:`version_5.8.0` release notes for a full list of changes in the
 Fixes
 =====
 
-None
+- Fixed a regression introduced in 5.8.4 leading to a rejection of writes into
+  a column of the ``OBJECT(IGNORED)`` type if it had an array sub-column with
+  mixed types.

--- a/docs/appendices/release-notes/5.9.1.rst
+++ b/docs/appendices/release-notes/5.9.1.rst
@@ -47,4 +47,6 @@ See the :ref:`version_5.9.0` release notes for a full list of changes in the
 Fixes
 =====
 
-None
+- Fixed a regression introduced in 5.8.4 leading to a rejection of writes into
+  a column of the ``OBJECT(IGNORED)`` type if it had an array sub-column with
+  mixed types.

--- a/server/src/main/java/io/crate/types/ObjectType.java
+++ b/server/src/main/java/io/crate/types/ObjectType.java
@@ -26,6 +26,7 @@ import static io.crate.types.DataTypes.UNDEFINED;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -37,6 +38,8 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import org.apache.lucene.search.Query;
+import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -388,20 +391,94 @@ public class ObjectType extends DataType<Map<String, Object>> implements Streame
         if (map == null) {
             return RamUsageEstimator.NUM_BYTES_OBJECT_HEADER;
         }
-        long bytes = RamUsageEstimator.shallowSizeOf(map);
-        long entrySize = -1;
-        for (var entry : map.entrySet()) {
-            if (entrySize == -1) {
-                entrySize = RamUsageEstimator.shallowSizeOf(entry);
-            }
-            bytes += entrySize;
-            bytes += RamUsageEstimator.sizeOf(entry.getKey());
+        return sizeOfMap(map);
+    }
 
-            Object value = entry.getValue();
-            DataType<?> innerType = DataTypes.guessType(value);
-            bytes += ((DataType<Object>) innerType).valueBytes(value);
+    /**
+     * Similar to {@link RamUsageEstimator#sizeOfMap(Map)}
+     * but not limited with depth = 1.
+     */
+    private static long sizeOfMap(Map<?, ?> map) {
+        if (map == null) {
+            return 0;
         }
-        return RamUsageEstimator.alignObjectSize(bytes);
+        long size = RamUsageEstimator.shallowSizeOf(map);
+        long sizeOfEntry = -1;
+        for (Map.Entry<?, ?> entry : map.entrySet()) {
+            if (sizeOfEntry == -1) {
+                sizeOfEntry = RamUsageEstimator.shallowSizeOf(entry);
+            }
+            size += sizeOfEntry;
+
+            // In most cases key has type String but for ignored object can be another type.
+            size += sizeOfObject(entry.getKey());
+            size += sizeOfObject(entry.getValue());
+        }
+        return RamUsageEstimator.alignObjectSize(size);
+    }
+
+    /**
+     * Similar to {@link RamUsageEstimator#sizeOfObject(Object)}
+     * but sizeOfMap and sizeOfCollection are replaced by custom methods without depth limitation
+     */
+    private static long sizeOfObject(Object o) {
+        if (o == null) {
+            return 0;
+        }
+        long size;
+        if (o instanceof Accountable) {
+            size = ((Accountable) o).ramBytesUsed();
+        } else if (o instanceof String) {
+            size = RamUsageEstimator.sizeOf((String) o);
+        } else if (o instanceof boolean[]) {
+            size = RamUsageEstimator.sizeOf((boolean[]) o);
+        } else if (o instanceof byte[]) {
+            size = RamUsageEstimator.sizeOf((byte[]) o);
+        } else if (o instanceof char[]) {
+            size = RamUsageEstimator.sizeOf((char[]) o);
+        } else if (o instanceof double[]) {
+            size = RamUsageEstimator.sizeOf((double[]) o);
+        } else if (o instanceof float[]) {
+            size = RamUsageEstimator.sizeOf((float[]) o);
+        } else if (o instanceof int[]) {
+            size = RamUsageEstimator.sizeOf((int[]) o);
+        } else if (o instanceof Integer) {
+            size = RamUsageEstimator.sizeOf((Integer) o);
+        } else if (o instanceof Long) {
+            size = RamUsageEstimator.sizeOf((Long) o);
+        } else if (o instanceof long[]) {
+            size = RamUsageEstimator.sizeOf((long[]) o);
+        } else if (o instanceof short[]) {
+            size = RamUsageEstimator.sizeOf((short[]) o);
+        } else if (o instanceof String[]) {
+            size = RamUsageEstimator.sizeOf((String[]) o);
+        } else if (o instanceof Query) {
+            size = RamUsageEstimator.sizeOf((Query) o, RamUsageEstimator.UNKNOWN_DEFAULT_RAM_BYTES_USED);
+        } else if (o instanceof Map<?, ?> map) {
+            size = sizeOfMap(map);
+        } else if (o instanceof Collection<?> collection) {
+            size = sizeOfCollection(collection);
+        } else {
+            size = RamUsageEstimator.UNKNOWN_DEFAULT_RAM_BYTES_USED;
+        }
+        return size;
+    }
+
+    /**
+     * Similar to {@link RamUsageEstimator#sizeOfCollection(Collection)}
+     * but not limited with depth = 1.
+     */
+    private static long sizeOfCollection(Collection<?> collection) {
+        if (collection == null) {
+            return 0;
+        }
+        long size = RamUsageEstimator.shallowSizeOf(collection);
+        // assume array-backed collection and add per-object references
+        size += RamUsageEstimator.NUM_BYTES_ARRAY_HEADER + (long) collection.size() * RamUsageEstimator.NUM_BYTES_OBJECT_REF;
+        for (Object o : collection) {
+            size += sizeOfObject(o);
+        }
+        return RamUsageEstimator.alignObjectSize(size);
     }
 
     @Override

--- a/server/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
@@ -2070,4 +2070,13 @@ public class InsertIntoIntegrationTest extends IntegTestCase {
         execute("insert into tdst (x, y) (select x, y from tsrc order by y)");
         assertThat(response).hasRowCount(3);
     }
+
+    @Test
+    public void test_can_write_ignored_object_with_array_column_with_mixed_types() throws Exception {
+        execute("CREATE TABLE t (data OBJECT(IGNORED))");
+        execute("insert into t (data) VALUES ('{\"items\": [42.42, \"foo\"]}'::json)");
+        execute("refresh table t");
+        execute("select * from t");
+        assertThat(response).hasRows("{items=[42.42, foo]}");
+    }
 }


### PR DESCRIPTION
Type guessing logic have casting checks which are redundant for estimating size of OBJECT(IGNORED),
it can have mixed types.

Also, picking up higher precedence doesn't fit estimation logic: (byte) 123 has higher precedence than "123" and guessed type would be "byte" but for estimation aspect we need to pick up string as it's "heavier".

Hence, inlining Lucene's estimation logic but without depth limitation.

Fixes https://github.com/crate/crate/issues/16734