### PR TITLE
Add DistinctFrom JMH benchmark (comparing DistinctFrom with Eq)

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -7,6 +7,7 @@
     <groupId>io.crate</groupId>
     <artifactId>crate</artifactId>
     <version>5.10.0</version>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>crate-benchmarks</artifactId>
@@ -73,6 +74,7 @@
       <groupId>io.crate</groupId>
       <artifactId>crate-server</artifactId>
       <version>${project.version}</version>
+      <type>jar</type>
     </dependency>
     <dependency>
       <groupId>io.crate</groupId>
@@ -90,5 +92,36 @@
       <version>${versions.jmh}</version>
       <scope>provided</scope>
     </dependency>
+
+    <dependency>
+      <groupId>io.crate</groupId>
+      <artifactId>crate-server</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <exclusions>
+        <exclusion>
+          <groupId>com.carrotsearch.randomizedtesting</groupId>
+          <artifactId>randomizedtesting-runner</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.lucene</groupId>
+      <artifactId>lucene-test-framework</artifactId>
+      <version>${versions.lucene}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.carrotsearch.randomizedtesting</groupId>
+          <artifactId>randomizedtesting-runner</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${versions.mockito}</version>
+    </dependency>
+
+
   </dependencies>
 </project>

--- a/benchmarks/src/main/java/io/crate/execution/engine/filter/DistinctFromBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/execution/engine/filter/DistinctFromBenchmark.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.engine.filter;
+
+
+import static org.elasticsearch.test.ClusterServiceUtils.createClusterStatePublisher;
+import static org.elasticsearch.test.ClusterServiceUtils.createNoOpNodeConnectionsService;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.lucene.search.Query;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlocks;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.service.ClusterApplierService;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.cluster.service.MasterService;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.node.Node;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+
+import io.crate.testing.QueryTester;
+
+
+@BenchmarkMode({Mode.AverageTime})
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Fork(value = 1)
+@Measurement(iterations = 4)
+@State(Scope.Benchmark)
+public class DistinctFromBenchmark {
+
+    public static final String NODE_ID = "n1";
+    public static final String NODE_NAME = "node-name";
+    protected ThreadPool threadPool;
+    protected ClusterService clusterService;
+    private QueryTester queryTester;
+
+    private Query distinctFromQuery;
+    private Query eqQuery;
+
+    @Setup
+    public void prepare() throws Exception {
+        threadPool = new TestThreadPool(Thread.currentThread().getName());
+        clusterService = createClusterService(Set.of(),
+            Metadata.EMPTY_METADATA,
+            Version.CURRENT);
+        QueryTester.Builder builder = new QueryTester.Builder(
+            threadPool,
+            clusterService,
+            Version.CURRENT,
+            "CREATE TABLE tbl (name text)");
+
+        for (int i = 0; i < 10_000_000; i++) {
+            builder.indexValue("name", "val_" + i);
+        }
+        queryTester = builder.build();
+        eqQuery = queryTester.toQuery("name = 'val_3000000'");
+        distinctFromQuery = queryTester.toQuery("name is not distinct from 'val_3000000'");
+    }
+
+    @TearDown
+    public void shutdownThreadPool() throws Exception {
+        queryTester.close();
+        clusterService.close();
+        ThreadPool.terminate(threadPool, 30, TimeUnit.SECONDS);
+    }
+
+    @Benchmark
+    public void benchmarkDistinctQueryBuilding() {
+        queryTester.toQuery("name is not distinct from 'val_3000000'");
+    }
+
+    @Benchmark
+    public void benchmarkEqualQueryBuilding() throws Exception {
+        queryTester.toQuery("name = 'val_3000000'");
+    }
+
+    @Benchmark
+    public void benchmarkDistinctFromQueryRun() throws Exception {
+        queryTester.runQuery("name", distinctFromQuery);
+    }
+
+    @Benchmark
+    public void benchmarkEqualQueryRun() throws Exception {
+        queryTester.runQuery("name", eqQuery);
+    }
+
+    public ClusterService createClusterService(
+        Collection<Setting<?>> additionalClusterSettings,
+        Metadata metaData,
+        Version version) {
+        Set<Setting<?>> clusterSettingsSet = new HashSet<>(ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
+        clusterSettingsSet.addAll(additionalClusterSettings);
+        ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, clusterSettingsSet);
+        ClusterService clusterService = new ClusterService(
+            Settings.builder()
+                .put("cluster.name", "ClusterServiceTests")
+                .put(Node.NODE_NAME_SETTING.getKey(), NODE_NAME)
+                .build(),
+            clusterSettings,
+            threadPool
+        );
+        clusterService.setNodeConnectionsService(createNoOpNodeConnectionsService());
+        DiscoveryNode discoveryNode = new DiscoveryNode(
+            NODE_NAME,
+            NODE_ID,
+            new TransportAddress(TransportAddress.META_ADDRESS, 0),
+            Collections.emptyMap(),
+            DiscoveryNodeRole.BUILT_IN_ROLES,
+            version
+        );
+        DiscoveryNodes nodes = DiscoveryNodes.builder()
+            .add(discoveryNode)
+            .localNodeId(NODE_ID)
+            .masterNodeId(NODE_ID)
+            .build();
+        ClusterState clusterState = ClusterState.builder(new ClusterName(this.getClass().getSimpleName()))
+            .nodes(nodes).metadata(metaData).blocks(ClusterBlocks.EMPTY_CLUSTER_BLOCK).build();
+
+        ClusterApplierService clusterApplierService = clusterService.getClusterApplierService();
+        clusterApplierService.setInitialState(clusterState);
+
+        MasterService masterService = clusterService.getMasterService();
+        masterService.setClusterStatePublisher(createClusterStatePublisher(clusterApplierService));
+        masterService.setClusterStateSupplier(clusterApplierService::state);
+
+        clusterService.start();
+        return clusterService;
+    }
+}

--- a/server/src/testFixtures/java/io/crate/testing/IndexEnv.java
+++ b/server/src/testFixtures/java/io/crate/testing/IndexEnv.java
@@ -56,7 +56,6 @@ import org.elasticsearch.test.IndexSettingsModule;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import io.crate.expression.reference.doc.lucene.LuceneReferenceResolver;
-import io.crate.lucene.CrateLuceneTestCase;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.doc.DocTableInfo;
 
@@ -75,7 +74,7 @@ public final class IndexEnv implements AutoCloseable {
         String indexName = table.ident().indexNameOrAlias();
         assert clusterState.metadata().hasIndex(indexName) : "ClusterState must contain the index: " + indexName;
 
-        Path tempDir = CrateLuceneTestCase.createTempDir();
+        Path tempDir = TestingHelpers.createTempDir();
         Index index = new Index(indexName, UUIDs.randomBase64UUID());
         Settings nodeSettings = Settings.builder()
             .put(IndexMetadata.SETTING_VERSION_CREATED, indexVersion)

--- a/server/src/testFixtures/java/io/crate/testing/QueryTester.java
+++ b/server/src/testFixtures/java/io/crate/testing/QueryTester.java
@@ -240,6 +240,10 @@ public final class QueryTester implements AutoCloseable {
 
     public List<Object> runQuery(String resultColumn, String expression, Object ... params) throws Exception {
         Query query = toQuery(expression, params);
+        return runQuery(resultColumn, query);
+    }
+
+    public List<Object> runQuery(String resultColumn, Query query) throws Exception {
         LuceneBatchIterator batchIterator = getIterator.apply(ColumnIdent.fromPath(resultColumn), query);
         return batchIterator
             .map(row -> row.get(0))

--- a/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
@@ -95,9 +95,6 @@ import org.jetbrains.annotations.Nullable;
 import org.mockito.Answers;
 
 import io.crate.Constants;
-import io.crate.session.Cursors;
-import io.crate.session.Session;
-import io.crate.session.Sessions;
 import io.crate.analyze.Analysis;
 import io.crate.analyze.AnalyzedCreateBlobTable;
 import io.crate.analyze.AnalyzedCreateTable;
@@ -138,7 +135,6 @@ import io.crate.fdw.AddServerTask;
 import io.crate.fdw.CreateServerRequest;
 import io.crate.fdw.FdwAnalyzer;
 import io.crate.fdw.ForeignDataWrappers;
-import io.crate.lucene.CrateLuceneTestCase;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.FulltextAnalyzerResolver;
 import io.crate.metadata.Functions;
@@ -180,6 +176,9 @@ import io.crate.replication.logical.metadata.SubscriptionsMetadata;
 import io.crate.role.Role;
 import io.crate.role.RoleManager;
 import io.crate.role.StubRoleManager;
+import io.crate.session.Cursors;
+import io.crate.session.Session;
+import io.crate.session.Sessions;
 import io.crate.sql.parser.SqlParser;
 import io.crate.sql.tree.CreateBlobTable;
 import io.crate.sql.tree.CreateForeignTable;
@@ -322,7 +321,7 @@ public class SQLExecutor {
             var tableStats = new TableStats();
             var sessionSettingRegistry = new SessionSettingRegistry(Set.of(LoadedRules.INSTANCE));
             AtomicReference<RelationAnalyzer> relationAnalyzerRef = new AtomicReference<>(null);
-            Path homeDir = CrateLuceneTestCase.createTempDir();
+            Path homeDir = TestingHelpers.createTempDir();
             Environment environment = new Environment(
                 Settings.builder().put(PATH_HOME_SETTING.getKey(), homeDir.toAbsolutePath()).build(),
                 homeDir.resolve("config")


### PR DESCRIPTION
Relates to https://github.com/crate/crate/pull/16621#issuecomment-2355069537.

Results:

```
Benchmark                                             Mode  Cnt   Score   Error  Units
DistinctFromBenchmark.benchmarkDistinctQueryBuilding  avgt    4   4,142 ± 0,067  us/op
DistinctFromBenchmark.benchmarkEqualQueryBuilding     avgt    4   2,936 ± 0,017  us/op
DistinctFromBenchmark.benchmarkDistinctFromQueryRun   avgt    4  34,469 ± 0,157  us/op
DistinctFromBenchmark.benchmarkEqualQueryRun          avgt    4  33,810 ± 0,199  us/op
```

Benchmark runs with disabled query cache, and indicates that the variations we saw at https://github.com/crate/crate/pull/16621 seems to be purely related to the query building and not to the execution (a bit expected as both expressions will result in the same `TermQuery`).

Maybe still worth merging this benchmark as a blueprint on how to benchmark queries? 