### PR TITLE
Use ColumnIdent instead of String for routing in CreateTableRequest

### DIFF
--- a/server/src/main/java/io/crate/execution/ddl/tables/MappingUtil.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/MappingUtil.java
@@ -105,7 +105,7 @@ public final class MappingUtil {
                                                     Map<String, String> checkConstraints,
                                                     List<List<String>> partitionedBy,
                                                     @Nullable ColumnPolicy tableColumnPolicy,
-                                                    @Nullable String routingColumn) {
+                                                    @Nullable ColumnIdent routingColumn) {
 
         HashMap<ColumnIdent, List<Reference>> tree = buildTree(columns);
         Map<String, Map<String, Object>> propertiesMap = toProperties(allocPosition, null, tree);
@@ -118,7 +118,7 @@ public final class MappingUtil {
         }
         mergeConstraints(meta, columns, pKeyIndices, checkConstraints);
         if (routingColumn != null) {
-            meta.put("routing", routingColumn);
+            meta.put("routing", routingColumn.fqn());
         }
 
         if (tableColumnPolicy != null) {

--- a/server/src/main/java/io/crate/execution/ddl/tables/TableCreator.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TableCreator.java
@@ -61,7 +61,7 @@ public class TableCreator {
         var policy = createTable.tableParameter().mappings().get(ColumnPolicy.MAPPING_KEY);
         var tableColumnPolicy = policy != null ? ColumnPolicy.fromMappingValue(policy) : ColumnPolicy.STRICT;
 
-        String routingColumn = createTable.routingColumn().equals(SysColumns.ID.COLUMN) ? null : createTable.routingColumn().fqn();
+        ColumnIdent routingColumn = createTable.routingColumn().equals(SysColumns.ID.COLUMN) ? null : createTable.routingColumn();
         if (minNodeVersion.onOrAfter(Version.V_5_4_0)) {
             createTableRequest = new CreateTableRequest(
                 relationName,

--- a/server/src/main/java/io/crate/metadata/ColumnIdent.java
+++ b/server/src/main/java/io/crate/metadata/ColumnIdent.java
@@ -35,6 +35,7 @@ import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -50,7 +51,7 @@ import io.crate.sql.tree.QualifiedNameReference;
 import io.crate.sql.tree.SubscriptExpression;
 
 public abstract sealed class ColumnIdent
-    implements Comparable<ColumnIdent>, Accountable
+    implements Comparable<ColumnIdent>, Accountable, Writeable
     permits ColumnIdent.Col0, ColumnIdent.ColN {
 
     private static final Comparator<ColumnIdent> COMPARATOR = Comparator.comparing(ColumnIdent::name)
@@ -523,6 +524,7 @@ public abstract sealed class ColumnIdent
         return COMPARATOR.compare(this, o);
     }
 
+    @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(name());
         out.writeVInt(path().size());

--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
@@ -1044,7 +1044,7 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
             checkConstraintMap,
             Lists.map(partitionedByColumns, BoundCreateTable::toPartitionMapping),
             columnPolicy,
-            clusteredBy == SysColumns.ID.COLUMN ? null : clusteredBy.fqn()
+            clusteredBy == SysColumns.ID.COLUMN ? null : clusteredBy
         ));
         for (String indexName : concreteIndices(metadata)) {
             IndexMetadata indexMetadata = metadata.index(indexName);

--- a/server/src/testFixtures/java/io/crate/testing/TestingHelpers.java
+++ b/server/src/testFixtures/java/io/crate/testing/TestingHelpers.java
@@ -370,7 +370,7 @@ public class TestingHelpers {
             tableColumnPolicy,
             boundCreateTable.routingColumn().equals(SysColumns.ID.COLUMN)
                 ? null
-                : boundCreateTable.routingColumn().fqn()
+                : boundCreateTable.routingColumn()
         );
 
     }


### PR DESCRIPTION
Doesn't change the storage format yet, but ensures we keep the parsed
structure for longer.

Relates to:

- https://github.com/crate/crate/issues/16063
- https://github.com/crate/crate/issues/11939
