### PR TITLE
Fix issue with DROP view/table, dropping irrelevant user privileges

### DIFF
--- a/docs/appendices/release-notes/5.8.5.rst
+++ b/docs/appendices/release-notes/5.8.5.rst
@@ -47,6 +47,10 @@ See the :ref:`version_5.8.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that would cause users and roles to loose irrelevant
+  privileges, like: ``Administration Language (AL)``, when a table or a view
+  is dropped.
+
 - Improved the memory accounting for values of type ``geo_shape`` to avoid
   running into out of memory errors or higher than expected GC load when running
   queries like ``INSERT INTO ... (query)``.

--- a/docs/appendices/release-notes/5.9.1.rst
+++ b/docs/appendices/release-notes/5.9.1.rst
@@ -47,6 +47,10 @@ See the :ref:`version_5.9.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that would cause users and roles to loose irrelevant
+  privileges, like: ``Administration Language (AL)``, when a table or a view
+  is dropped.
+
 - Improved the memory accounting for values of type ``geo_shape`` to avoid
   running into out of memory errors or higher than expected GC load when running
   queries like ``INSERT INTO ... (query)``.

--- a/server/src/main/java/io/crate/role/PrivilegesModifier.java
+++ b/server/src/main/java/io/crate/role/PrivilegesModifier.java
@@ -159,13 +159,8 @@ public final class PrivilegesModifier {
             for (Privilege privilege : role.privileges()) {
                 Subject subject = privilege.subject();
                 Securable securable = subject.securable();
-                if (securable != Securable.TABLE && securable != Securable.VIEW) {
-                    continue;
-                }
-
-                String ident = subject.ident();
-                assert ident != null : "ident must not be null for securable 'TABLE'";
-                if (ident.equals(tableOrViewIdent)) {
+                if ((securable == Securable.TABLE || securable == Securable.VIEW) &&
+                    tableOrViewIdent.equals(subject.ident())) {
                     affectedPrivileges++;
                 } else {
                     updatedPrivileges.add(privilege);

--- a/server/src/test/java/io/crate/role/metadata/UsersPrivilegesMetadataTest.java
+++ b/server/src/test/java/io/crate/role/metadata/UsersPrivilegesMetadataTest.java
@@ -22,6 +22,7 @@
 package io.crate.role.metadata;
 
 import static io.crate.role.PrivilegesModifierTest.DENY_DQL;
+import static io.crate.role.PrivilegesModifierTest.GRANT_AL;
 import static io.crate.role.PrivilegesModifierTest.GRANT_SCHEMA_DML;
 import static io.crate.role.PrivilegesModifierTest.GRANT_TABLE_DDL;
 import static io.crate.role.PrivilegesModifierTest.GRANT_TABLE_DQL;
@@ -32,7 +33,7 @@ import static io.crate.role.PrivilegesModifierTest.PRIVILEGES;
 import static io.crate.role.PrivilegesModifierTest.USERNAMES;
 import static io.crate.role.PrivilegesModifierTest.USER_WITHOUT_PRIVILEGES;
 import static io.crate.role.PrivilegesModifierTest.USER_WITH_DENIED_DQL;
-import static io.crate.role.PrivilegesModifierTest.USER_WITH_SCHEMA_AND_TABLE_PRIVS;
+import static io.crate.role.PrivilegesModifierTest.USER_WITH_TABLE_VIEW_SCHEMA_AL_PRIVS;
 import static io.crate.testing.Asserts.assertThat;
 
 import java.io.IOException;
@@ -68,8 +69,13 @@ public class UsersPrivilegesMetadataTest extends ESTestCase {
         }
         usersPrivileges.put(USER_WITHOUT_PRIVILEGES, new HashSet<>());
         usersPrivileges.put(USER_WITH_DENIED_DQL, new HashSet<>(Collections.singletonList(DENY_DQL)));
-        usersPrivileges.put(USER_WITH_SCHEMA_AND_TABLE_PRIVS, new HashSet<>(
-            Arrays.asList(GRANT_SCHEMA_DML, GRANT_TABLE_DQL, GRANT_TABLE_DDL, GRANT_VIEW_DQL, GRANT_VIEW_DML, GRANT_VIEW_DDL)));
+        usersPrivileges.put(USER_WITH_TABLE_VIEW_SCHEMA_AL_PRIVS, new HashSet<>(
+            Arrays.asList(
+                GRANT_SCHEMA_DML,
+                GRANT_TABLE_DQL, GRANT_TABLE_DDL,
+                GRANT_VIEW_DQL, GRANT_VIEW_DML, GRANT_VIEW_DDL,
+                GRANT_AL)
+        ));
 
         return new UsersPrivilegesMetadata(usersPrivileges);
     }


### PR DESCRIPTION
Fixed the logic in `PrivilegesModifier` which caused all existing users and roles to loose their assigned privileges when a table or view is dropped.

Fixes: #16749
