### PR TITLE
Fix rename column pruning

### DIFF
--- a/docs/appendices/release-notes/5.8.5.rst
+++ b/docs/appendices/release-notes/5.8.5.rst
@@ -47,6 +47,12 @@ See the :ref:`version_5.8.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that caused an error when the same filter expression was applied
+  multiple times in an aggregation on an aliased table e.g.::
+      
+      SELECT alias.a ,MAX(b) FILTER (WHERE c>0) ,MAX(c) FILTER (WHERE c>0)
+      FROM tbl alias GROUP BY alias.a
+
 - Fixed an issue that would cause users and roles to loose irrelevant
   privileges, like: ``Administration Language (AL)``, when a table or a view
   is dropped.

--- a/docs/appendices/release-notes/5.9.1.rst
+++ b/docs/appendices/release-notes/5.9.1.rst
@@ -47,6 +47,12 @@ See the :ref:`version_5.9.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that caused an error when the same filter expression was applied
+  multiple times in an aggregation on an aliased table e.g.::
+
+      SELECT alias.a ,MAX(b) FILTER (WHERE c>0) ,MAX(c) FILTER (WHERE c>0)
+      FROM tbl alias GROUP BY alias.a
+
 - Fixed an issue that would cause users and roles to loose irrelevant
   privileges, like: ``Administration Language (AL)``, when a table or a view
   is dropped.

--- a/server/src/main/java/io/crate/planner/operators/Rename.java
+++ b/server/src/main/java/io/crate/planner/operators/Rename.java
@@ -111,11 +111,9 @@ public final class Rename extends ForwardingLogicalPlan implements FieldResolver
         for (Symbol outputToKeep : outputsToKeep) {
             Symbols.intersection(outputToKeep, outputs, s -> {
                 Symbol childSymbol = parentToChildMap.get(s);
-                if (childSymbol == null) {
-                    childSymbol = childToParentMap.get(s);
+                if (childSymbol != null) {
+                    mappedToKeep.add(childSymbol);
                 }
-                assert childSymbol != null : "There must be a mapping available for symbol " + s;
-                mappedToKeep.add(childSymbol);
             });
         }
         LogicalPlan newSource = source.pruneOutputsExcept(mappedToKeep);

--- a/server/src/main/java/io/crate/planner/operators/Rename.java
+++ b/server/src/main/java/io/crate/planner/operators/Rename.java
@@ -111,6 +111,9 @@ public final class Rename extends ForwardingLogicalPlan implements FieldResolver
         for (Symbol outputToKeep : outputsToKeep) {
             Symbols.intersection(outputToKeep, outputs, s -> {
                 Symbol childSymbol = parentToChildMap.get(s);
+                if (childSymbol == null) {
+                    childSymbol = childToParentMap.get(s);
+                }
                 assert childSymbol != null : "There must be a mapping available for symbol " + s;
                 mappedToKeep.add(childSymbol);
             });

--- a/server/src/test/java/io/crate/planner/operators/RenameTest.java
+++ b/server/src/test/java/io/crate/planner/operators/RenameTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.operators;
+
+import static io.crate.testing.Asserts.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.junit.Test;
+
+import io.crate.analyze.WhereClause;
+import io.crate.analyze.relations.AbstractTableRelation;
+import io.crate.analyze.relations.FieldResolver;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.RelationName;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+
+public class RenameTest extends CrateDummyClusterServiceUnitTest {
+
+    /**
+     * https://github.com/crate/crate/issues/16754
+     */
+    @Test
+    public void test_parent_child_column_prunning() throws IOException {
+        SQLExecutor e = SQLExecutor.of(clusterService).addTable("create table tbl (a int, b int)");
+
+        Symbol a = e.asSymbol("a");
+        Symbol b = e.asSymbol("b");
+        Symbol childSymbol = e.asSymbol("b > 1");
+        Symbol parentSymbol = e.asSymbol("b > 1");
+
+        Collect source = new Collect(mock(AbstractTableRelation.class), List.of(a, b, childSymbol), WhereClause.MATCH_ALL);
+        Rename rename = new Rename(List.of(a, b, parentSymbol), mock(RelationName.class), mock(FieldResolver.class), source);
+        assertThat(rename.outputs()).containsExactly(a, b, parentSymbol);
+
+        var pruned = rename.pruneOutputsExcept(List.of(a, b, parentSymbol));
+        assertThat(pruned.outputs()).containsExactly(a, b, parentSymbol);
+
+        pruned = rename.pruneOutputsExcept(List.of(a, b, childSymbol));
+        assertThat(pruned.outputs()).containsExactly(a, b, parentSymbol);
+
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes https://github.com/crate/crate/issues/16754

```
cr> SELECT alias1.country
    ,MAX(height) FILTER (WHERE height>0) as max_height
    ,MAX(prominence) FILTER (WHERE height>0) as max_prominence
    FROM sys.summits alias1
    GROUP BY alias1.country limit 100;

NullPointerException[Cannot invoke "io.crate.expression.symbol.Symbol.accept(io.crate.expression.symbol.SymbolVisitor, Object)" because "needle" is null]
```




## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
