### PR TITLE
Add array_overlap scalar

### DIFF
--- a/server/src/main/java/io/crate/expression/scalar/ArrayOverlapFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayOverlapFunction.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar;
+
+import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import io.crate.data.Input;
+import io.crate.metadata.FunctionType;
+import io.crate.metadata.Functions;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.functions.BoundSignature;
+import io.crate.metadata.functions.Signature;
+import io.crate.types.DataTypes;
+import io.crate.types.TypeSignature;
+
+public class ArrayOverlapFunction extends Scalar<Boolean, List<Object>> {
+
+    public static final String NAME = "array_overlap";
+
+    public static final Signature SIGNATURE = Signature.builder(NAME, FunctionType.SCALAR)
+        .argumentTypes(TypeSignature.parse("array(E)"),
+            TypeSignature.parse("array(E)"))
+        .returnType(DataTypes.BOOLEAN.getTypeSignature())
+        .typeVariableConstraints(typeVariable("E"))
+        .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.NOTNULL)
+        .build();
+
+    public static void register(Functions.Builder module) {
+        module.add(SIGNATURE, ArrayOverlapFunction::new);
+    }
+
+    ArrayOverlapFunction(Signature signature, BoundSignature boundSignature) {
+        super(signature, boundSignature);
+    }
+
+    @Override
+    @SafeVarargs
+    public final Boolean evaluate(TransactionContext txnCtx, NodeContext nodeContext, Input<List<Object>>... args) {
+        List<Object> firstList = args[0].value();
+        List<Object> secondList = args[1].value();
+        Set<Object> set = new HashSet<>(firstList);
+        for (Object o : secondList) {
+            if (set.contains(o)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/server/src/main/java/io/crate/expression/scalar/ScalarFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/ScalarFunctions.java
@@ -213,6 +213,7 @@ public class ScalarFunctions implements FunctionsProvider {
         ArrayPrependFunction.register(builder);
         ArrayUnnestFunction.register(builder);
         ArraySetFunction.register(builder);
+        ArrayOverlapFunction.register(builder);
 
         CoalesceFunction.register(builder);
         GreatestFunction.register(builder);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Implemented the array_overlap function, which takes two arrays and returns a Boolean value depending on if the arrays have common elements between them.
Fixes #16687 
 
## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
