### PR TITLE
Route `sys.allocations` to the master node to get correct decisions

### DIFF
--- a/docs/appendices/release-notes/5.8.5.rst
+++ b/docs/appendices/release-notes/5.8.5.rst
@@ -58,3 +58,7 @@ Fixes
 - Fixed a regression introduced in 5.8.4 leading to a rejection of writes into
   a column of the ``OBJECT(IGNORED)`` type if it had an array sub-column with
   mixed types.
+
+- Fixed an issue resulting in different (and partly wrong)
+  ``sys.allocations.decisions`` results when querying the table on different
+  nodes.

--- a/docs/appendices/release-notes/5.9.1.rst
+++ b/docs/appendices/release-notes/5.9.1.rst
@@ -58,3 +58,7 @@ Fixes
 - Fixed a regression introduced in 5.8.4 leading to a rejection of writes into
   a column of the ``OBJECT(IGNORED)`` type if it had an array sub-column with
   mixed types.
+
+- Fixed an issue resulting in different (and partly wrong)
+  ``sys.allocations.decisions`` results when querying the table on different
+  nodes.

--- a/server/src/main/java/io/crate/metadata/sys/SysAllocationsTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/sys/SysAllocationsTableInfo.java
@@ -29,6 +29,7 @@ import static io.crate.types.DataTypes.STRING_ARRAY;
 import io.crate.expression.reference.sys.shard.SysAllocation;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.RelationName;
+import io.crate.metadata.Routing;
 import io.crate.metadata.SystemTable;
 
 public class SysAllocationsTableInfo {
@@ -55,5 +56,6 @@ public class SysAllocationsTableInfo {
             ColumnIdent.of("partition_ident"),
             ColumnIdent.of("shard_id")
         )
+        .withRouting((state, ignored, ignored2) -> Routing.forTableOnSingleNode(IDENT, state.nodes().getMasterNodeId()))
         .build();
 }

--- a/server/src/test/java/io/crate/metadata/sys/SysAllocationsTableInfoTest.java
+++ b/server/src/test/java/io/crate/metadata/sys/SysAllocationsTableInfoTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.metadata.sys;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.elasticsearch.cluster.node.DiscoveryNodeRole.DATA_ROLE;
+import static org.elasticsearch.test.ClusterServiceUtils.setState;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+
+public class SysAllocationsTableInfoTest extends CrateDummyClusterServiceUnitTest {
+
+    @Before
+    public void add_non_data_node() {
+        var discoveryNode = new DiscoveryNode(
+            "data_only_node",
+            "d1",
+            buildNewFakeTransportAddress(),
+            Collections.emptyMap(),
+            Set.of(DATA_ROLE),
+            Version.CURRENT
+        );
+        var nodes = DiscoveryNodes.builder(clusterService.state().nodes())
+            .add(discoveryNode)
+            .localNodeId("d1")
+            .build();
+        var builder = ClusterState.builder(clusterService.state()).nodes(nodes);
+        setState(clusterService, builder);
+    }
+
+    @Test
+    public void test_table_is_routed_to_master_node() {
+        var allocationsTable = SysAllocationsTableInfo.INSTANCE;
+        var routing = allocationsTable.getRouting(clusterService.state(), null, null, null, null);
+        assertThat(routing.nodes()).contains(NODE_ID);
+    }
+}


### PR DESCRIPTION
Only the master node is collecting all cluster information values like disk usages of all nodes.
Thus, only the master node can give the correct allocation decisions, e.g. when a node reaches disk watermark thresholds.

Fixes #16730.