### PR TITLE
Fix array related cast optimization, do not apply on explicit casts

### DIFF
--- a/docs/appendices/release-notes/5.8.5.rst
+++ b/docs/appendices/release-notes/5.8.5.rst
@@ -62,3 +62,12 @@ Fixes
 - Fixed an issue resulting in different (and partly wrong)
   ``sys.allocations.decisions`` results when querying the table on different
   nodes.
+
+- Fixed an incorrect optimization of comparison operators in combination with
+  array subscript expression, :ref:`ANY <sql_any_array_comparison>`,
+  :ref:`ARRAY_UPPER <scalar-array_upper>` and
+  :ref:`ARRAY_LENGTH <scalar-array_length>` function argument whereas the array
+  (or array element) column has an explicit cast. Such queries may return wrong
+  results as the explicit cast was removed. Example:
+
+  ``WHERE my_array[1]::timestamptz > 3::timestamptz``

--- a/docs/appendices/release-notes/5.9.1.rst
+++ b/docs/appendices/release-notes/5.9.1.rst
@@ -65,3 +65,12 @@ Fixes
 
 - Fixed a BWC issue resulting in an exception when querying the ``sys.users``
   table on an older node (< :ref:`version_5.9.0`) during a rolling upgrade.
+
+- Fixed an incorrect optimization of comparison operators in combination with
+  array subscript expression, :ref:`ANY <sql_any_array_comparison>`,
+  :ref:`ARRAY_UPPER <scalar-array_upper>` and
+  :ref:`ARRAY_LENGTH <scalar-array_length>` function argument whereas the array
+  (or array element) column has an explicit cast. Such queries may return wrong
+  results as the explicit cast was removed. Example:
+
+  ``WHERE my_array[1]::timestamptz > 3::timestamptz``

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveArrayLengthOnReferenceCastToLiteralCastInsideOperators.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveArrayLengthOnReferenceCastToLiteralCastInsideOperators.java
@@ -27,6 +27,7 @@ import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 import java.util.List;
 
 import io.crate.expression.scalar.ArrayUpperFunction;
+import io.crate.expression.scalar.cast.ImplicitCastFunction;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolType;
@@ -50,7 +51,7 @@ public class MoveArrayLengthOnReferenceCastToLiteralCastInsideOperators implemen
             .with(f -> COMPARISON_OPERATORS.contains(f.name()))
             .with(f -> f.arguments().get(1).symbolType().isValueOrParameterSymbol())
             .with(f -> f.arguments().get(0), typeOf(Function.class).capturedAs(castCapture)
-                .with(f -> f.isCast())
+                .with(f -> f.name().equals(ImplicitCastFunction.NAME))
                 .with(f -> f.arguments().get(0), typeOf(Function.class)
                     .with(f -> f.name().equals(ArrayUpperFunction.ARRAY_LENGTH)
                                || f.name().equals(ArrayUpperFunction.ARRAY_UPPER))

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveSubscriptOnReferenceCastToLiteralCastInsideOperators.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/rule/MoveSubscriptOnReferenceCastToLiteralCastInsideOperators.java
@@ -27,6 +27,7 @@ import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 import java.util.List;
 
 import io.crate.expression.scalar.SubscriptFunction;
+import io.crate.expression.scalar.cast.ImplicitCastFunction;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolType;
@@ -50,7 +51,7 @@ public class MoveSubscriptOnReferenceCastToLiteralCastInsideOperators implements
             .with(f -> COMPARISON_OPERATORS.contains(f.name()))
             .with(f -> f.arguments().get(1).symbolType().isValueOrParameterSymbol())
             .with(f -> f.arguments().get(0), typeOf(Function.class).capturedAs(castCapture)
-                .with(f -> f.isCast())
+                .with(f -> f.name().equals(ImplicitCastFunction.NAME))
                 .with(f -> f.arguments().get(0), typeOf(Function.class)
                     .with(f -> f.name().equals(SubscriptFunction.NAME))
                     .with(f -> f.arguments().get(0).symbolType() == SymbolType.REFERENCE)

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/rule/SwapCastsInComparisonOperators.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/rule/SwapCastsInComparisonOperators.java
@@ -28,7 +28,6 @@ import java.util.List;
 
 import io.crate.expression.scalar.cast.CastMode;
 import io.crate.expression.scalar.cast.ImplicitCastFunction;
-import io.crate.expression.scalar.cast.TryCastFunction;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolType;
@@ -53,7 +52,7 @@ public class SwapCastsInComparisonOperators implements Rule<Function> {
             .with(f -> f.arguments().get(1).symbolType().isValueOrParameterSymbol())
             .with(f -> f.arguments().get(0), typeOf(Function.class).capturedAs(castCapture)
                 // We have to respect explicit casts, see https://github.com/crate/crate/issues/12135
-                .with(f -> f.name().equals(ImplicitCastFunction.NAME) || f.name().equals(TryCastFunction.NAME))
+                .with(f -> f.name().equals(ImplicitCastFunction.NAME))
                 .with(f -> f.arguments().get(0).symbolType() == SymbolType.REFERENCE)
             );
     }


### PR DESCRIPTION
Explicit casts must be honored and should not be removed or exchanged.

Relates to #12155.
Fixes #16771.