### PR TITLE
Set language level to 22

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -22,9 +22,8 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_23" default="true" project-jdk-name="temurin-23" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_22" project-jdk-name="temurin-23" project-jdk-type="JavaSDK" />
   <component name="SuppressionsComponent">
     <option name="suppComments" value="[]" />
   </component>
 </project>
-


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Because there is no language jdk-23 on the current version on intellij on a mac.


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
