### PR TITLE
Fix flaky testCancelRecoveryDuringPhase1

### DIFF
--- a/server/src/test/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
@@ -835,9 +835,12 @@ public class RecoverySourceHandlerTests extends ESTestCase {
             () -> 0,
             future
         );
-        assertThat(future).failsWithin(1, TimeUnit.SECONDS)
-            .withThrowableThat()
-            .withRootCauseExactlyInstanceOf(CancellableThreads.ExecutionCancelledException.class);
+        try {
+            future.get(5, TimeUnit.SECONDS);
+        } catch (Throwable t) {
+            assertThat(wasCancelled).isTrue();
+            assertThat(t).hasRootCauseExactlyInstanceOf(CancellableThreads.ExecutionCancelledException.class);
+        }
         store.close();
     }
 


### PR DESCRIPTION
Follow up to b3f728e60a33fe5885ddcd22ae8cf47c85e5bde0
The future can complete successfully.

    Expecting
      <FutureActionListener[Completed: org.elasticsearch.indices.recovery.RecoverySourceHandler$SendFileResult@314fd105]>
    to have failed within 1L SECONDS.
    Be aware that the state of the future in this message might not reflect the one at the time when the assertion was performed as it is evaluated later on
    	at __randomizedtesting.SeedInfo.seed([51B175CE4F30F291:3E116EFD63A564DD]:0)
    	at org.elasticsearch.indices.recovery.RecoverySourceHandlerTests.testCancelRecoveryDuringPhase1(RecoverySourceHandlerTests.java:838)
