### PR TITLE
Add hash-join execution for left-outer-joins

### DIFF
--- a/benchmarks/src/main/java/io/crate/data/join/RowsBatchIteratorBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/data/join/RowsBatchIteratorBenchmark.java
@@ -53,7 +53,7 @@ import io.crate.data.SkippingBatchIterator;
 import io.crate.data.breaker.RamAccounting;
 import io.crate.data.breaker.RowAccounting;
 import io.crate.execution.engine.collect.RowCollectExpression;
-import io.crate.execution.engine.join.HashInnerJoinBatchIterator;
+import io.crate.execution.engine.join.HashJoinBatchIterator;
 import io.crate.execution.engine.window.WindowFunction;
 import io.crate.execution.engine.window.WindowFunctionBatchIterator;
 import io.crate.metadata.FunctionType;
@@ -156,7 +156,7 @@ public class RowsBatchIteratorBenchmark {
 
     @Benchmark
     public void measureConsumeHashInnerJoin(Blackhole blackhole) {
-        BatchIterator<Row> leftJoin = new HashInnerJoinBatchIterator(
+        BatchIterator<Row> leftJoin = new HashJoinBatchIterator(
             InMemoryBatchIterator.of(oneThousandRows, SENTINEL, true),
             InMemoryBatchIterator.of(tenThousandRows, SENTINEL, true),
             rowAccounting,
@@ -164,7 +164,8 @@ public class RowsBatchIteratorBenchmark {
             row -> Objects.equals(row.get(0), row.get(1)),
             row -> Objects.hash(row.get(0)),
             row -> Objects.hash(row.get(0)),
-            ignored -> 1000
+            ignored -> 1000,
+            false
         );
         while (leftJoin.moveNext()) {
             blackhole.consume(leftJoin.currentElement().get(0));
@@ -173,7 +174,7 @@ public class RowsBatchIteratorBenchmark {
 
     @Benchmark
     public void measureConsumeHashInnerJoinWithHashCollisions(Blackhole blackhole) {
-        BatchIterator<Row> leftJoin = new HashInnerJoinBatchIterator(
+        BatchIterator<Row> leftJoin = new HashJoinBatchIterator(
             InMemoryBatchIterator.of(oneThousandRows, SENTINEL, true),
             InMemoryBatchIterator.of(tenThousandRows, SENTINEL, true),
             rowAccounting,
@@ -186,7 +187,8 @@ public class RowsBatchIteratorBenchmark {
                 return value < 500 ? value : (value % 100) + 500;
             },
             row -> (Integer) row.get(0) % 500,
-            ignored -> 1000
+            ignored -> 1000,
+            false
         );
         while (leftJoin.moveNext()) {
             blackhole.consume(leftJoin.currentElement().get(0));

--- a/docs/appendices/release-notes/5.10.0.rst
+++ b/docs/appendices/release-notes/5.10.0.rst
@@ -88,7 +88,17 @@ None
 Performance and Resilience Improvements
 ---------------------------------------
 
-None
+- Added hash-join execution for left-outer-equi-joins. This improves performance
+  for left-outer-join with an equi-join condition significantly with the cost of
+  higher memory consumption e.g.::
+
+    SELECT * FROM t1 LEFT JOIN t2 OM t1.id = t2.id;
+
+  This optimization can be disabled, with the session setting::
+
+    SET rewrite_left_outer_join_to_hash_join = false
+
+  Note that this setting is experimental, and may change in the future.
 
 Administration and Operations
 -----------------------------

--- a/docs/general/dql/joins.rst
+++ b/docs/general/dql/joins.rst
@@ -260,8 +260,8 @@ available memory, only a certain block size of a relation is loaded at
 once. The whole operation will be repeated with the next block of the first
 relation once scanning the second relation has finished.
 
-This optimisation cannot be applied unless the join is an ``INNER`` join and
-the join condition satisfies the following rules:
+This optimisation can be applied if the join is an ``INNER`` or ``LEFT OUTER``
+join and the join condition satisfies the following rules:
 
 - Contains at least one ``EQUAL`` :ref:`operator <gloss-operator>`
 

--- a/docs/sql/statements/explain.rst
+++ b/docs/sql/statements/explain.rst
@@ -61,16 +61,16 @@ optimizer. An example output looks like this::
     |                                    |     └ Filter[(name = 'IT')] (rows=1)                                 |
     |                                    |       └ Collect[doc.departments | [id, name] | true] (rows=6)        |
     | optimizer_rewrite_join_plan        | Eval[id] (rows=3)                                                    |
-    |                                    |   └ HashJoin[(dept_id = id)] (rows=3)                                |
+    |                                    |   └ HashJoin[INNER | (dept_id = id)] (rows=3)                        |
     |                                    |     ├ Collect[doc.employees | [id, dept_id] | true] (rows=18)        |
     |                                    |     └ Filter[(name = 'IT')] (rows=1)                                 |
     |                                    |       └ Collect[doc.departments | [id, name] | true] (rows=6)        |
     | optimizer_merge_filter_and_collect | Eval[id] (rows=3)                                                    |
-    |                                    |   └ HashJoin[(dept_id = id)] (rows=3)                                |
+    |                                    |   └ HashJoin[INNER | (dept_id = id)] (rows=3)                        |
     |                                    |     ├ Collect[doc.employees | [id, dept_id] | true] (rows=18)        |
     |                                    |     └ Collect[doc.departments | [id, name] | (name = 'IT')] (rows=1) |
     | Final logical plan                 | Eval[id] (rows=3)                                                    |
-    |                                    |   └ HashJoin[(dept_id = id)] (rows=3)                                |
+    |                                    |   └ HashJoin[INNER | (dept_id = id)] (rows=3)                        |
     |                                    |     ├ Collect[doc.employees | [id, dept_id] | true] (rows=18)        |
     |                                    |     └ Collect[doc.departments | [id] | (name = 'IT')] (rows=1)       |
     +------------------------------------+----------------------------------------------------------------------+

--- a/server/src/main/java/io/crate/breaker/TypedCellsAccounting.java
+++ b/server/src/main/java/io/crate/breaker/TypedCellsAccounting.java
@@ -25,7 +25,7 @@ import java.util.List;
 
 import io.crate.data.breaker.RamAccounting;
 import io.crate.data.breaker.RowAccounting;
-import io.crate.execution.engine.join.HashInnerJoinBatchIterator;
+import io.crate.execution.engine.join.HashJoinBatchIterator;
 import io.crate.types.DataType;
 
 /**
@@ -41,7 +41,7 @@ public class TypedCellsAccounting implements RowAccounting<Object[]> {
     /**
      * @param columnTypes     Column types to use for size estimation
      * @param ramAccounting   {@link RamAccounting} implementing the CircuitBreaker logic
-     * @param extraSizePerRow Extra size that need to be calculated per row. E.g. {@link HashInnerJoinBatchIterator}
+     * @param extraSizePerRow Extra size that need to be calculated per row. E.g. {@link HashJoinBatchIterator}
      *                        might instantiate an ArrayList per row used for the internal hash->row buffer
      */
     public TypedCellsAccounting(List<? extends DataType<?>> columnTypes,

--- a/server/src/main/java/io/crate/breaker/TypedRowAccounting.java
+++ b/server/src/main/java/io/crate/breaker/TypedRowAccounting.java
@@ -26,7 +26,7 @@ import java.util.List;
 import io.crate.data.Row;
 import io.crate.data.breaker.RamAccounting;
 import io.crate.data.breaker.RowAccounting;
-import io.crate.execution.engine.join.HashInnerJoinBatchIterator;
+import io.crate.execution.engine.join.HashJoinBatchIterator;
 import io.crate.types.DataType;
 
 /**
@@ -52,7 +52,7 @@ public class TypedRowAccounting implements RowAccounting<Row> {
      *
      * @param columnTypes     The column types to use for size estimation
      * @param ramAccounting   {@link RamAccounting} implementing the CircuitBreaker logic
-     * @param extraSizePerRow Extra size that need to be calculated per row. E.g. {@link HashInnerJoinBatchIterator}
+     * @param extraSizePerRow Extra size that need to be calculated per row. E.g. {@link HashJoinBatchIterator}
      *                        might instantiate an ArrayList per row used for the internal hash->row buffer
      */
     public TypedRowAccounting(List<? extends DataType<?>> columnTypes,

--- a/server/src/main/java/io/crate/execution/dsl/phases/HashJoinPhase.java
+++ b/server/src/main/java/io/crate/execution/dsl/phases/HashJoinPhase.java
@@ -59,7 +59,8 @@ public class HashJoinPhase extends JoinPhase {
                          List<Symbol> leftJoinConditionInputs,
                          List<Symbol> rightJoinConditionInputs,
                          List<DataType<?>> leftOutputTypes,
-                         long estimatedRowSizeForLeft) {
+                         long estimatedRowSizeForLeft,
+                         JoinType joinType) {
         super(
             jobId,
             executionNodeId,
@@ -70,7 +71,7 @@ public class HashJoinPhase extends JoinPhase {
             numLeftOutputs,
             numRightOutputs,
             executionNodes,
-            JoinType.INNER,
+            joinType,
             joinCondition);
         assert joinCondition != null : "JoinCondition for HashJoin cannot be null";
         this.leftJoinConditionInputs = leftJoinConditionInputs;

--- a/server/src/main/java/io/crate/execution/engine/join/HashJoinOperation.java
+++ b/server/src/main/java/io/crate/execution/engine/join/HashJoinOperation.java
@@ -57,7 +57,8 @@ public class HashJoinOperation implements CompletionListenable {
                              TransactionContext txnCtx,
                              InputFactory inputFactory,
                              CircuitBreaker circuitBreaker,
-                             long estimatedRowSizeForLeft) {
+                             long estimatedRowSizeForLeft,
+                             boolean emitNullValues) {
 
         this.resultConsumer = nlResultConsumer;
         this.leftConsumer = new CapturingRowConsumer(nlResultConsumer.requiresScroll(), nlResultConsumer.completionFuture());
@@ -80,7 +81,8 @@ public class HashJoinOperation implements CompletionListenable {
                                 Paging.PAGE_SIZE,
                                 circuitBreaker,
                                 estimatedRowSizeForLeft
-                            )
+                            ),
+                            emitNullValues
                         );
                         nlResultConsumer.accept(joinIterator, null);
                     } catch (Exception e) {
@@ -132,9 +134,10 @@ public class HashJoinOperation implements CompletionListenable {
                                                              ToIntFunction<Row> hashBuilderForLeft,
                                                              ToIntFunction<Row> hashBuilderForRight,
                                                              RowAccounting<Object[]> rowAccounting,
-                                                             RamBlockSizeCalculator blockSizeCalculator) {
+                                                             RamBlockSizeCalculator blockSizeCalculator,
+                                                             boolean emitNullValues) {
         CombinedRow combiner = new CombinedRow(leftNumCols, rightNumCols);
-        return new HashInnerJoinBatchIterator(
+        return new HashJoinBatchIterator(
             left,
             right,
             rowAccounting,
@@ -142,6 +145,7 @@ public class HashJoinOperation implements CompletionListenable {
             joinCondition,
             hashBuilderForLeft,
             hashBuilderForRight,
-            blockSizeCalculator);
+            blockSizeCalculator,
+            emitNullValues);
     }
 }

--- a/server/src/main/java/io/crate/execution/jobs/JobSetup.java
+++ b/server/src/main/java/io/crate/execution/jobs/JobSetup.java
@@ -122,6 +122,7 @@ import io.crate.metadata.TransactionContext;
 import io.crate.metadata.settings.SessionSettings;
 import io.crate.planner.distribution.DistributionType;
 import io.crate.planner.operators.PKAndVersion;
+import io.crate.sql.tree.JoinType;
 import io.crate.types.DataTypes;
 
 @Singleton
@@ -933,7 +934,6 @@ public class JobSetup {
                 projectorFactory
             );
             Predicate<Row> joinCondition = RowFilter.create(context.transactionContext, inputFactory, phase.joinCondition());
-
             HashJoinOperation joinOperation = new HashJoinOperation(
                 phase.numLeftOutputs(),
                 phase.numRightOutputs(),
@@ -949,7 +949,8 @@ public class JobSetup {
                 context.transactionContext,
                 inputFactory,
                 breaker(),
-                phase.estimatedRowSizeForLeft()
+                phase.estimatedRowSizeForLeft(),
+                phase.joinType() == JoinType.LEFT
             );
             DistResultRXTask left = pageDownstreamContextForNestedLoop(
                 phase.phaseId(),

--- a/server/src/main/java/io/crate/planner/operators/EquiJoinDetector.java
+++ b/server/src/main/java/io/crate/planner/operators/EquiJoinDetector.java
@@ -51,15 +51,10 @@ public class EquiJoinDetector {
 
     private static final Visitor VISITOR = new Visitor();
 
-    public static boolean isHashJoinPossible(JoinType joinType, Symbol joinCondition) {
-        if (joinType != JoinType.INNER) {
+    public static boolean isEquiJoin(Symbol joinCondition) {
+        if (joinCondition == null) {
             return false;
         }
-        return isEquiJoin(joinCondition);
-    }
-
-    public static boolean isEquiJoin(Symbol joinCondition) {
-        assert joinCondition != null : "join condition must not be null on inner joins";
         Context context = new Context();
         joinCondition.accept(VISITOR, context);
         return context.isHashJoinPossible;

--- a/server/src/main/java/io/crate/planner/operators/HashJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/HashJoin.java
@@ -61,15 +61,17 @@ public class HashJoin extends AbstractJoinPlan {
 
     public HashJoin(LogicalPlan lhs,
                     LogicalPlan rhs,
-                    Symbol joinCondition) {
-        super(lhs, rhs, joinCondition, JoinType.INNER, LookUpJoin.NONE);
+                    Symbol joinCondition,
+                    JoinType joinType) {
+        super(lhs, rhs, joinCondition, joinType, LookUpJoin.NONE);
     }
 
     public HashJoin(LogicalPlan lhs,
                     LogicalPlan rhs,
                     Symbol joinCondition,
+                    JoinType joinType,
                     LookUpJoin lookUpJoin) {
-        super(lhs, rhs, joinCondition, JoinType.INNER, lookUpJoin);
+        super(lhs, rhs, joinCondition, joinType, lookUpJoin);
     }
 
     @Override
@@ -156,7 +158,8 @@ public class HashJoin extends AbstractJoinPlan {
             InputColumns.create(lhsHashSymbols, new InputColumns.SourceSymbols(leftOutputs)),
             InputColumns.create(rhsHashSymbols, new InputColumns.SourceSymbols(rightOutputs)),
             Symbols.typeView(leftOutputs),
-            lhStats.estimateSizeForColumns(leftOutputs)
+            lhStats.estimateSizeForColumns(leftOutputs),
+            joinType
         );
         return new Join(
             joinPhase,
@@ -175,6 +178,7 @@ public class HashJoin extends AbstractJoinPlan {
             sources.get(0),
             sources.get(1),
             joinCondition,
+            joinType,
             lookupJoin
         );
     }
@@ -207,6 +211,7 @@ public class HashJoin extends AbstractJoinPlan {
                 newLhs,
                 newRhs,
                 joinCondition,
+                joinType,
                 lookupJoin
             );
         }
@@ -237,6 +242,7 @@ public class HashJoin extends AbstractJoinPlan {
                 lhsFetchRewrite == null ? lhs : lhsFetchRewrite.newPlan(),
                 rhsFetchRewrite == null ? rhs : rhsFetchRewrite.newPlan(),
                 joinCondition,
+                joinType,
                 lookupJoin
             )
         );
@@ -251,6 +257,8 @@ public class HashJoin extends AbstractJoinPlan {
     public void print(PrintContext printContext) {
         printContext
             .text("HashJoin[")
+            .text(joinType.toString())
+            .text(" | ")
             .text(joinCondition.toString())
             .text("]");
         printStats(printContext);

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -121,6 +121,7 @@ import io.crate.planner.optimizer.rule.ReorderNestedLoopJoin;
 import io.crate.planner.optimizer.rule.RewriteFilterOnOuterJoinToInnerJoin;
 import io.crate.planner.optimizer.rule.RewriteGroupByKeysLimitToLimitDistinct;
 import io.crate.planner.optimizer.rule.RewriteJoinPlan;
+import io.crate.planner.optimizer.rule.RewriteLeftOuterJoinToHashJoin;
 import io.crate.planner.optimizer.rule.RewriteToQueryThenFetch;
 import io.crate.planner.optimizer.tracer.OptimizerTracer;
 import io.crate.role.Role;
@@ -169,6 +170,7 @@ public class LogicalPlanner {
         new MoveConstantJoinConditionsBeneathJoin(),
         new EliminateCrossJoin(),
         new EquiJoinToLookupJoin(),
+        new RewriteLeftOuterJoinToHashJoin(),
         new RewriteJoinPlan()
     );
 

--- a/server/src/main/java/io/crate/planner/optimizer/rule/ReorderHashJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/ReorderHashJoin.java
@@ -29,10 +29,11 @@ import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.optimizer.Rule;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
+import io.crate.sql.tree.JoinType;
 
 public class ReorderHashJoin implements Rule<HashJoin> {
 
-    private final Pattern<HashJoin> pattern = typeOf(HashJoin.class);
+    private final Pattern<HashJoin> pattern = typeOf(HashJoin.class).with(j -> j.joinType() == JoinType.INNER);
 
     @Override
     public Pattern<HashJoin> pattern() {
@@ -57,6 +58,7 @@ public class ReorderHashJoin implements Rule<HashJoin> {
                     plan.rhs(),
                     plan.lhs(),
                     plan.joinCondition(),
+                    plan.joinType(),
                     plan.lookUpJoin().invert()
                 ),
                 plan.outputs()

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteLeftOuterJoinToHashJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteLeftOuterJoinToHashJoin.java
@@ -27,15 +27,17 @@ import io.crate.planner.operators.EquiJoinDetector;
 import io.crate.planner.operators.HashJoin;
 import io.crate.planner.operators.JoinPlan;
 import io.crate.planner.operators.LogicalPlan;
-import io.crate.planner.operators.NestedLoopJoin;
 import io.crate.planner.optimizer.Rule;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
 import io.crate.sql.tree.JoinType;
 
-public class RewriteJoinPlan implements Rule<JoinPlan> {
+public class RewriteLeftOuterJoinToHashJoin implements Rule<JoinPlan> {
 
-    private final Pattern<JoinPlan> pattern = typeOf(JoinPlan.class);
+    private final Pattern<JoinPlan> pattern =
+        typeOf(JoinPlan.class)
+            .with(j -> j.joinType() == JoinType.LEFT &&
+                EquiJoinDetector.isEquiJoin(j.joinCondition()));
 
     @Override
     public Pattern<JoinPlan> pattern() {
@@ -43,19 +45,10 @@ public class RewriteJoinPlan implements Rule<JoinPlan> {
     }
 
     @Override
-    public boolean mandatory() {
-        // this rule is currently mandatory to convert JoinPlan to NestedLoop/HashJoin
-        // and apply further optimizations
-        return true;
-    }
-
-    @Override
     public LogicalPlan apply(JoinPlan join,
                              Captures captures,
                              Rule.Context context) {
-        if (context.txnCtx().sessionSettings().hashJoinsEnabled() &&
-            join.joinType() == JoinType.INNER &&
-            EquiJoinDetector.isEquiJoin(join.joinCondition())) {
+        if (context.txnCtx().sessionSettings().hashJoinsEnabled()) {
             return new HashJoin(
                 join.lhs(),
                 join.rhs(),
@@ -63,18 +56,7 @@ public class RewriteJoinPlan implements Rule<JoinPlan> {
                 join.joinType(),
                 join.lookUpJoin()
             );
-        } else {
-            return new NestedLoopJoin(
-                join.lhs(),
-                join.rhs(),
-                join.joinType(),
-                join.joinCondition(),
-                join.isFiltered(),
-                false,
-                false,
-                join.lookUpJoin()
-            );
         }
+        return null;
     }
-
 }

--- a/server/src/test/java/io/crate/execution/engine/join/HashJoinBatchIteratorBehaviouralTest.java
+++ b/server/src/test/java/io/crate/execution/engine/join/HashJoinBatchIteratorBehaviouralTest.java
@@ -41,7 +41,7 @@ import io.crate.data.testing.BatchSimulatingIterator;
 import io.crate.data.testing.TestingBatchIterators;
 import io.crate.data.testing.TestingRowConsumer;
 
-public class HashInnerJoinBatchIteratorBehaviouralTest {
+public class HashJoinBatchIteratorBehaviouralTest {
 
     private int originalPageSize = Paging.PAGE_SIZE;
 
@@ -56,13 +56,13 @@ public class HashInnerJoinBatchIteratorBehaviouralTest {
     }
 
     @Test
-    public void testDistributed_SwitchToRightEvenIfLeftBatchDoesNotDeliverAllRowsExpectedByOneBatch() throws Exception {
+    public void test_inner_Distributed_SwitchToRightEvenIfLeftBatchDoesNotDeliverAllRowsExpectedByOneBatch() throws Exception {
         BatchSimulatingIterator<Row> leftIterator = new BatchSimulatingIterator<>(
             TestingBatchIterators.ofValues(Arrays.asList(1, 2, 4)), 1, 2, null);
         BatchSimulatingIterator<Row> rightIterator = new BatchSimulatingIterator<>(
             TestingBatchIterators.ofValues(Arrays.asList(2, 0, 4, 5)), 2, 1, null);
 
-        BatchIterator<Row> batchIterator = new HashInnerJoinBatchIterator(
+        BatchIterator<Row> batchIterator = new HashJoinBatchIterator(
                 leftIterator,
                 rightIterator,
                 mock(RowAccounting.class),
@@ -70,7 +70,8 @@ public class HashInnerJoinBatchIteratorBehaviouralTest {
                 row -> Objects.equals(row.get(0), row.get(1)),
                 row -> Objects.hash(row.get(0)),
                 row -> Objects.hash(row.get(0)),
-                ignored -> 2
+                ignored -> 2,
+                false
             );
 
         TestingRowConsumer consumer = new TestingRowConsumer();
@@ -86,13 +87,13 @@ public class HashInnerJoinBatchIteratorBehaviouralTest {
     }
 
     @Test
-    public void test_SwitchToRightWhenLeftExhausted() throws Exception {
+    public void test_inner_SwitchToRightWhenLeftExhausted() throws Exception {
         BatchSimulatingIterator<Row> leftIterator = new BatchSimulatingIterator<>(
             TestingBatchIterators.ofValues(Arrays.asList(1, 2, 3, 4)), 2, 1, null);
         BatchSimulatingIterator<Row> rightIterator = new BatchSimulatingIterator<>(
             TestingBatchIterators.ofValues(Arrays.asList(2, 0, 4, 5)), 2, 1, null);
 
-        BatchIterator<Row> batchIterator = new HashInnerJoinBatchIterator(
+        BatchIterator<Row> batchIterator = new HashJoinBatchIterator(
             leftIterator,
             rightIterator,
             mock(RowAccounting.class),
@@ -100,12 +101,69 @@ public class HashInnerJoinBatchIteratorBehaviouralTest {
             row -> Objects.equals(row.get(0), row.get(1)),
             row -> Objects.hash(row.get(0)),
             row -> Objects.hash(row.get(0)),
-            ignored -> 500000
+            ignored -> 500000,
+            false
         );
 
         TestingRowConsumer consumer = new TestingRowConsumer();
         consumer.accept(batchIterator, null);
         List<Object[]> result = consumer.getResult();
         assertThat(result).containsExactly(new Object[]{2, 2}, new Object[]{4, 4});
+    }
+
+    @Test
+    public void test_left_Distributed_SwitchToRightEvenIfLeftBatchDoesNotDeliverAllRowsExpectedByOneBatch() throws Exception {
+        BatchSimulatingIterator<Row> leftIterator = new BatchSimulatingIterator<>(
+            TestingBatchIterators.ofValues(Arrays.asList(1, 2, 4)), 1, 2, null);
+        BatchSimulatingIterator<Row> rightIterator = new BatchSimulatingIterator<>(
+            TestingBatchIterators.ofValues(Arrays.asList(2, 0, 4, 5)), 2, 1, null);
+
+        BatchIterator<Row> batchIterator = new HashJoinBatchIterator(
+            leftIterator,
+            rightIterator,
+            mock(RowAccounting.class),
+            new CombinedRow(1, 1),
+            row -> Objects.equals(row.get(0), row.get(1)),
+            row -> Objects.hash(row.get(0)),
+            row -> Objects.hash(row.get(0)),
+            ignored -> 2,
+            true
+        );
+
+        TestingRowConsumer consumer = new TestingRowConsumer();
+        consumer.accept(batchIterator, null);
+        List<Object[]> result = consumer.getResult();
+        assertThat(result).containsExactly(new Object[]{2, 2}, new Object[]{1, null}, new Object[]{4, 4});
+
+        // as the blocksize is defined of 2 but the left batch size 1, normally it would call left loadNextBatch until
+        // the blocksize is reached. we don't want that as parallel running hash iterators must call loadNextBatch always
+        // on the same side synchronously as the upstreams will only send new data after all downstreams responded.
+        // to validate this, the right must be repeated 3 times
+        assertThat(rightIterator.getMovetoStartCalls()).isEqualTo(2);
+    }
+
+    @Test
+    public void test_left_SwitchToRightWhenLeftExhausted() throws Exception {
+        BatchSimulatingIterator<Row> leftIterator = new BatchSimulatingIterator<>(
+            TestingBatchIterators.ofValues(List.of(1, 2, 3, 4)), 2, 1, null);
+        BatchSimulatingIterator<Row> rightIterator = new BatchSimulatingIterator<>(
+            TestingBatchIterators.ofValues(List.of(2, 0, 4, 5)), 2, 1, null);
+
+        BatchIterator<Row> batchIterator = new HashJoinBatchIterator(
+            leftIterator,
+            rightIterator,
+            mock(RowAccounting.class),
+            new CombinedRow(1, 1),
+            row -> Objects.equals(row.get(0), row.get(1)),
+            row -> Objects.hash(row.get(0)),
+            row -> Objects.hash(row.get(0)),
+            ignored -> 500000,
+            true
+        );
+
+        TestingRowConsumer consumer = new TestingRowConsumer();
+        consumer.accept(batchIterator, null);
+        List<Object[]> result = consumer.getResult();
+        assertThat(result).containsExactly(new Object[]{2, 2}, new Object[]{4, 4}, new Object[]{1, null}, new Object[]{3, null});
     }
 }

--- a/server/src/test/java/io/crate/execution/engine/join/LeftOuterHashJoinBatchIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/join/LeftOuterHashJoinBatchIteratorTest.java
@@ -52,7 +52,7 @@ import io.crate.data.testing.TestingBatchIterators;
 
 @RunWith(RandomizedRunner.class)
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
-public class HashInnerJoinBatchIteratorTest {
+public class LeftOuterHashJoinBatchIteratorTest {
 
     private final CircuitBreaker circuitBreaker = mock(CircuitBreaker.class);
     private final List<Object[]> expectedResult;
@@ -75,60 +75,45 @@ public class HashInnerJoinBatchIteratorTest {
         return row -> (Integer) row.get(0) % 3;
     }
 
-    public HashInnerJoinBatchIteratorTest(@SuppressWarnings("unused") @Name("dataSetName") String testName,
-                                          @Name("dataForLeft") Supplier<BatchIterator<Row>> leftIterator,
-                                          @Name("dataForRight") Supplier<BatchIterator<Row>> rightIterator,
-                                          @Name("expectedResult") List<Object[]> expectedResult) {
+    public LeftOuterHashJoinBatchIteratorTest(@SuppressWarnings("unused") @Name("dataSetName") String testName,
+                                              @Name("dataForLeft") Supplier<BatchIterator<Row>> leftIterator,
+                                              @Name("dataForRight") Supplier<BatchIterator<Row>> rightIterator,
+                                              @Name("expectedResulWithoutNulls") List<Object[]> expectedResulWithoutNulls) {
         this.leftIterator = leftIterator;
         this.rightIterator = rightIterator;
-        this.expectedResult = expectedResult;
+        this.expectedResult = expectedResulWithoutNulls;
         when(circuitBreaker.getLimit()).thenReturn(110L);
         when(circuitBreaker.getUsed()).thenReturn(10L);
     }
 
     @ParametersFactory
     public static Iterable<Object[]> testParameters() {
-        List<Object[]> resultForUniqueValues = Arrays.asList(
-            new Object[] { 2, 2 }, new Object[] { 3, 3 }, new Object[] { 4, 4 });
-        List<Object[]> resultForDuplicateValues = Arrays.asList(
-            new Object[] { 1, 1 }, new Object[] { 1, 1 },
-            new Object[] { 2, 2 }, new Object[] { 2, 2 },
-            new Object[] { 3, 3 },
-            new Object[] { 4, 4 }, new Object[] { 4, 4 }, new Object[] { 4, 4 }, new Object[] { 4, 4 }
-        );
 
-        return Arrays.asList(
+        return List.of(
             $("UniqueValues-plain",
-              (Supplier<BatchIterator<Row>>) () -> TestingBatchIterators.range(0, 5),
-              (Supplier<BatchIterator<Row>>) () -> TestingBatchIterators.range(2, 6),
-              resultForUniqueValues),
+                (Supplier<BatchIterator<Row>>) () -> TestingBatchIterators.range(0, 5),
+                (Supplier<BatchIterator<Row>>) () -> TestingBatchIterators.range(2, 6),
+                List.of($(0, null), $(1, null), $(2, 2), $(3, 3), $(4, 4))),
             $("UniqueValues-batchedSource",
-              (Supplier<BatchIterator<Row>>) () ->
-                  new BatchSimulatingIterator<>(TestingBatchIterators.range(0, 5), 2, 2, null),
-              (Supplier<BatchIterator<Row>>) () ->
-                  new BatchSimulatingIterator<>(TestingBatchIterators.range(2, 6), 2, 2, null),
-              resultForUniqueValues),
+                (Supplier<BatchIterator<Row>>) () -> new BatchSimulatingIterator<>(TestingBatchIterators.range(0, 5), 2, 2, null),
+                (Supplier<BatchIterator<Row>>) () -> new BatchSimulatingIterator<>(TestingBatchIterators.range(2, 6), 2, 2, null),
+                List.of($(0, null), $(1, null), $(2, 2), $(3, 3), $(4, 4))),
             $("DuplicateValues-plain",
-              (Supplier<BatchIterator<Row>>) () -> TestingBatchIterators.ofValues(Arrays.asList(0, 0, 1, 2, 2, 3, 4, 4)),
-              (Supplier<BatchIterator<Row>>) () ->
-                  TestingBatchIterators.ofValues(Arrays.asList(1, 1, 2, 3, 4, 4, 5, 5, 6)),
-              resultForDuplicateValues),
+                (Supplier<BatchIterator<Row>>) () -> TestingBatchIterators.ofValues(List.of(0, 0, 1, 2, 2, 3, 4, 4)),
+                (Supplier<BatchIterator<Row>>) () -> TestingBatchIterators.ofValues(List.of(1, 1, 2, 3, 4, 4, 5, 5, 6)),
+                List.of($(0, null), $(0, null), $(1, 1), $(1, 1), $(2, 2), $(2, 2), $(3, 3), $(4, 4), $(4, 4), $(4, 4), $(4, 4))),
             $("DuplicateValues-batchedSource",
-              (Supplier<BatchIterator<Row>>) () ->
-                  new BatchSimulatingIterator<>(
-                      TestingBatchIterators.ofValues(Arrays.asList(0, 0, 1, 2, 2, 3, 4, 4)), 2, 4, null),
-              (Supplier<BatchIterator<Row>>) () -> new BatchSimulatingIterator<>(
-                TestingBatchIterators.ofValues(Arrays.asList(1, 1, 2, 3, 4, 4, 5, 5, 6)), 2, 4, null),
-              resultForDuplicateValues),
+                (Supplier<BatchIterator<Row>>) () -> new BatchSimulatingIterator<>(TestingBatchIterators.ofValues(Arrays.asList(0, 0, 1, 2, 2, 3, 4, 4)), 2, 4, null),
+                (Supplier<BatchIterator<Row>>) () -> new BatchSimulatingIterator<>(TestingBatchIterators.ofValues(Arrays.asList(1, 1, 2, 3, 4, 4, 5, 5, 6)), 2, 4, null),
+                List.of($(0, null), $(0, null), $(1, 1), $(1, 1), $(2, 2), $(2, 2), $(3, 3), $(4, 4), $(4, 4), $(4, 4), $(4, 4))),
             $("DuplicateValues-leftLoadedRightBatched",
-              (Supplier<BatchIterator<Row>>) () -> TestingBatchIterators.ofValues(Arrays.asList(0, 0, 1, 2, 2, 3, 4, 4)),
-              (Supplier<BatchIterator<Row>>) () -> new BatchSimulatingIterator<>(
-              TestingBatchIterators.ofValues(Arrays.asList(1, 1, 2, 3, 4, 4, 5, 5, 6)), 2, 4, null),
-              resultForDuplicateValues));
+                (Supplier<BatchIterator<Row>>) () -> TestingBatchIterators.ofValues(Arrays.asList(0, 0, 1, 2, 2, 3, 4, 4)),
+                (Supplier<BatchIterator<Row>>) () -> new BatchSimulatingIterator<>(TestingBatchIterators.ofValues(Arrays.asList(1, 1, 2, 3, 4, 4, 5, 5, 6)), 2, 4, null),
+                List.of($(0, null), $(0, null), $(1, 1), $(1, 1), $(2, 2), $(2, 2), $(3, 3), $(4, 4), $(4, 4), $(4, 4), $(4, 4))));
     }
 
     @Test
-    public void testInnerHashJoin() throws Exception {
+    public void test_left_outer_join() throws Exception {
         Supplier<BatchIterator<Row>> batchIteratorSupplier = () -> new HashJoinBatchIterator(
             leftIterator.get(),
             rightIterator.get(),
@@ -138,31 +123,14 @@ public class HashInnerJoinBatchIteratorTest {
             getHashForLeft(),
             getHashForRight(),
             ignored -> 5,
-            false
+            true
         );
-        var tester = BatchIteratorTester.forRows(batchIteratorSupplier, ResultOrder.EXACT);
+        var tester = BatchIteratorTester.forRows(batchIteratorSupplier, ResultOrder.ANY);
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
     }
 
     @Test
-    public void testInnerHashJoinWithHashCollisions() throws Exception {
-        Supplier<BatchIterator<Row>> batchIteratorSupplier = () -> new HashJoinBatchIterator(
-            leftIterator.get(),
-            rightIterator.get(),
-            mock(RowAccounting.class),
-            new CombinedRow(1, 1),
-            getCol0EqCol1JoinCondition(),
-            getHashWithCollisions(),
-            getHashWithCollisions(),
-            ignored -> 5,
-            false
-        );
-        var tester = BatchIteratorTester.forRows(batchIteratorSupplier, ResultOrder.EXACT);
-        tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
-    }
-
-    @Test
-    public void testInnerHashJoinWithBlockSizeSmallerThanDataSet() throws Exception {
+    public void test_left_outer_join_with_blocksize_smaller_than_dataset() throws Exception {
         Supplier<BatchIterator<Row>> batchIteratorSupplier = () -> new HashJoinBatchIterator(
             leftIterator.get(),
             rightIterator.get(),
@@ -172,14 +140,14 @@ public class HashInnerJoinBatchIteratorTest {
             getHashForLeft(),
             getHashForRight(),
             ignored -> 1,
-            false
+            true
         );
-        var tester = BatchIteratorTester.forRows(batchIteratorSupplier, ResultOrder.EXACT);
+        var tester = BatchIteratorTester.forRows(batchIteratorSupplier, ResultOrder.ANY);
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
     }
 
     @Test
-    public void testInnerHashJoinWithBlockSizeBiggerThanIteratorBatchSize() throws Exception {
+    public void test_left_outer_join_with_blocksize_bigger_than_tterator_batchsize() throws Exception {
         Supplier<BatchIterator<Row>> batchIteratorSupplier = () -> new HashJoinBatchIterator(
             leftIterator.get(),
             rightIterator.get(),
@@ -189,9 +157,26 @@ public class HashInnerJoinBatchIteratorTest {
             getHashForLeft(),
             getHashForRight(),
             ignored -> 3,
-            false
+            true
         );
-        var tester = BatchIteratorTester.forRows(batchIteratorSupplier, ResultOrder.EXACT);
+        var tester = BatchIteratorTester.forRows(batchIteratorSupplier, ResultOrder.ANY);
+        tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
+    }
+
+    @Test
+    public void test_left_outer_join_with_collisions() throws Exception {
+        Supplier<BatchIterator<Row>> batchIteratorSupplier = () -> new HashJoinBatchIterator(
+            leftIterator.get(),
+            rightIterator.get(),
+            mock(RowAccounting.class),
+            new CombinedRow(1, 1),
+            getCol0EqCol1JoinCondition(),
+            getHashWithCollisions(),
+            getHashWithCollisions(),
+            ignored -> 3,
+            true
+        );
+        var tester = BatchIteratorTester.forRows(batchIteratorSupplier, ResultOrder.ANY);
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/LookupJoinIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/LookupJoinIntegrationTest.java
@@ -49,7 +49,7 @@ public class LookupJoinIntegrationTest extends IntegTestCase {
             var query = "select t1.id, t2.id from doc.t1 join doc.t2 on t1.id = t2.id";
             execute("explain (costs false)" + query, session);
             assertThat(response).hasLines(
-                "HashJoin[(id = id)]",
+                "HashJoin[INNER | (id = id)]",
                 "  ├ MultiPhase",
                 "  │  └ Collect[doc.t1 | [id] | (id = ANY((doc.t2)))]",
                 "  │  └ Collect[doc.t2 | [id] | true]",
@@ -113,7 +113,7 @@ public class LookupJoinIntegrationTest extends IntegTestCase {
             execute("explain (costs false)" + query, session);
             assertThat(response).hasLines(
                 "HashAggregate[count(name)]",
-                "  └ HashJoin[(id = id)]",
+                "  └ HashJoin[INNER | (id = id)]",
                 "    ├ MultiPhase",
                 "    │  └ Collect[doc.t1 | [id] | (id = ANY((x)))]",
                 "    │  └ Rename[id] AS x",
@@ -146,7 +146,7 @@ public class LookupJoinIntegrationTest extends IntegTestCase {
             assertThat(response).hasLines(
                 "HashAggregate[count(name)]",
                 "  └ Eval[name, id, id]",
-                "    └ HashJoin[(id = id)]",
+                "    └ HashJoin[INNER | (id = id)]",
                 "      ├ MultiPhase",
                 "      │  └ Collect[doc.t1 | [id] | (id = ANY((x)))]",
                 "      │  └ Eval[id]",

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -262,6 +262,7 @@ public class PgCatalogITest extends IntegTestCase {
             "optimizer_reorder_nested_loop_join| true| Indicates if the optimizer rule ReorderNestedLoopJoin is activated.| NULL| NULL",
             "optimizer_rewrite_filter_on_outer_join_to_inner_join| true| Indicates if the optimizer rule RewriteFilterOnOuterJoinToInnerJoin is activated.| NULL| NULL",
             "optimizer_rewrite_group_by_keys_limit_to_limit_distinct| true| Indicates if the optimizer rule RewriteGroupByKeysLimitToLimitDistinct is activated.| NULL| NULL",
+            "optimizer_rewrite_left_outer_join_to_hash_join| true| Indicates if the optimizer rule RewriteLeftOuterJoinToHashJoin is activated.| NULL| NULL",
             "optimizer_rewrite_to_query_then_fetch| true| Indicates if the optimizer rule RewriteToQueryThenFetch is activated.| NULL| NULL",
             "search_path| doc| Sets the schema search order.| NULL| NULL",
             "server_version| 14.0| Reports the emulated PostgreSQL version number| NULL| NULL",

--- a/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
@@ -437,6 +437,7 @@ public class ShowIntegrationTest extends IntegTestCase {
             "optimizer_reorder_nested_loop_join| true| Indicates if the optimizer rule ReorderNestedLoopJoin is activated.",
             "optimizer_rewrite_filter_on_outer_join_to_inner_join| true| Indicates if the optimizer rule RewriteFilterOnOuterJoinToInnerJoin is activated.",
             "optimizer_rewrite_group_by_keys_limit_to_limit_distinct| true| Indicates if the optimizer rule RewriteGroupByKeysLimitToLimitDistinct is activated.",
+            "optimizer_rewrite_left_outer_join_to_hash_join| true| Indicates if the optimizer rule RewriteLeftOuterJoinToHashJoin is activated.",
             "optimizer_rewrite_to_query_then_fetch| true| Indicates if the optimizer rule RewriteToQueryThenFetch is activated.",
             "search_path| doc| Sets the schema search order.",
             "server_version| 14.0| Reports the emulated PostgreSQL version number",

--- a/server/src/test/java/io/crate/planner/ExplainPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/ExplainPlannerTest.java
@@ -228,7 +228,7 @@ public class ExplainPlannerTest extends CrateDummyClusterServiceUnitTest {
         var printedPlan = ExplainPlan.printLogicalPlan((LogicalPlan) plan.subPlan(), e.getPlannerContext(), plan.showCosts());
         assertThat(printedPlan).isEqualTo(
             "HashAggregate[count(x)] (rows=1)\n" +
-            "  └ HashJoin[(x = x)] (rows=0)\n" +
+            "  └ HashJoin[INNER | (x = x)] (rows=0)\n" +
             "    ├ Collect[doc.a | [x] | true] (rows=100)\n" +
             "    └ Collect[doc.b | [x] | true] (rows=100)"
         );
@@ -236,7 +236,7 @@ public class ExplainPlannerTest extends CrateDummyClusterServiceUnitTest {
         printedPlan = ExplainPlan.printLogicalPlan((LogicalPlan) plan.subPlan(), e.getPlannerContext(), plan.showCosts());
         assertThat(printedPlan).isEqualTo(
             "HashAggregate[count(x)] (rows=1)\n" +
-            "  └ HashJoin[(x = x)] (rows=0)\n" +
+            "  └ HashJoin[INNER | (x = x)] (rows=0)\n" +
             "    ├ Collect[doc.a | [x] | true] (rows=100)\n" +
             "    └ Collect[doc.b | [x] | true] (rows=100)"
         );
@@ -244,7 +244,7 @@ public class ExplainPlannerTest extends CrateDummyClusterServiceUnitTest {
         printedPlan = ExplainPlan.printLogicalPlan((LogicalPlan) plan.subPlan(), e.getPlannerContext(), plan.showCosts());
         assertThat(printedPlan).isEqualTo(
             "HashAggregate[count(x)]\n" +
-            "  └ HashJoin[(x = x)]\n" +
+            "  └ HashJoin[INNER | (x = x)]\n" +
             "    ├ Collect[doc.a | [x] | true]\n" +
             "    └ Collect[doc.b | [x] | true]"
         );
@@ -294,14 +294,14 @@ public class ExplainPlannerTest extends CrateDummyClusterServiceUnitTest {
                 "optimizer_rewrite_join_plan",
                 """
                 HashAggregate[count(x)] (rows=1)
-                  └ HashJoin[(x = x)] (rows=0)
+                  └ HashJoin[INNER | (x = x)] (rows=0)
                     ├ Collect[doc.a | [x] | true] (rows=100)
                     └ Collect[doc.b | [x] | true] (rows=100)"""},
             new Object[]{
                 "Final logical plan",
                 """
                 HashAggregate[count(x)] (rows=1)
-                  └ HashJoin[(x = x)] (rows=0)
+                  └ HashJoin[INNER | (x = x)] (rows=0)
                     ├ Collect[doc.a | [x] | true] (rows=100)
                     └ Collect[doc.b | [x] | true] (rows=100)"""}
         );
@@ -320,14 +320,14 @@ public class ExplainPlannerTest extends CrateDummyClusterServiceUnitTest {
                 "optimizer_rewrite_join_plan",
                 """
                 HashAggregate[count(x)] (rows=1)
-                  └ HashJoin[(x = x)] (rows=0)
+                  └ HashJoin[INNER | (x = x)] (rows=0)
                     ├ Collect[doc.a | [x] | true] (rows=100)
                     └ Collect[doc.b | [x] | true] (rows=100)"""},
             new Object[]{
                 "Final logical plan",
                 """
                 HashAggregate[count(x)] (rows=1)
-                  └ HashJoin[(x = x)] (rows=0)
+                  └ HashJoin[INNER | (x = x)] (rows=0)
                     ├ Collect[doc.a | [x] | true] (rows=100)
                     └ Collect[doc.b | [x] | true] (rows=100)"""}
         );
@@ -346,14 +346,14 @@ public class ExplainPlannerTest extends CrateDummyClusterServiceUnitTest {
                 "optimizer_rewrite_join_plan",
                 """
                 HashAggregate[count(x)]
-                  └ HashJoin[(x = x)]
+                  └ HashJoin[INNER | (x = x)]
                     ├ Collect[doc.a | [x] | true]
                     └ Collect[doc.b | [x] | true]"""},
             new Object[]{
                 "Final logical plan",
                 """
                 HashAggregate[count(x)]
-                  └ HashJoin[(x = x)]
+                  └ HashJoin[INNER | (x = x)]
                     ├ Collect[doc.a | [x] | true]
                     └ Collect[doc.b | [x] | true]"""}
         );

--- a/server/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -1313,7 +1313,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         String expectedPlan =
             """
             Eval[name]
-              └ HashJoin[(name = (name || $1))]
+              └ HashJoin[INNER | (name = (name || $1))]
                 ├ Rename[name] AS u1
                 │  └ Collect[doc.users | [name] | true]
                 └ Rename[name] AS u2
@@ -1367,7 +1367,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         LogicalPlan plan = e.logicalPlan(stmt);
         String expectedPlan =
             """
-            HashJoin[(a = b)]
+            HashJoin[INNER | (a = b)]
               ├ Rename[a] AS v1
               │  └ Rename[a] AS a1
               │    └ Collect[doc.t1 | [a] | true]

--- a/server/src/test/java/io/crate/planner/ViewPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/ViewPlannerTest.java
@@ -52,7 +52,7 @@ public class ViewPlannerTest extends CrateDummyClusterServiceUnitTest {
             Eval[id]
               └ Rename[id, o['i']] AS doc.v1
                 └ Eval[id, o['i']]
-                  └ NestedLoopJoin[LEFT | (o['i'] = o['i'])]
+                  └ HashJoin[LEFT | (o['i'] = o['i'])]
                     ├ Rename[o['i']] AS g1
                     │  └ Collect[doc.t1 | [o['i']] | true]
                     └ Rename[id, o['i']] AS b

--- a/server/src/test/java/io/crate/planner/node/dql/JoinPhaseTest.java
+++ b/server/src/test/java/io/crate/planner/node/dql/JoinPhaseTest.java
@@ -148,7 +148,9 @@ public class JoinPhaseTest extends ESTestCase {
             List.of(Literal.of("testLeft"), Literal.of(10)),
             List.of(Literal.of("testRight"), Literal.of(20)),
             List.of(DataTypes.STRING, DataTypes.INTEGER),
-            111);
+            111,
+            JoinType.INNER
+        );
 
         BytesStreamOutput output = new BytesStreamOutput();
         node.writeTo(output);

--- a/server/src/test/java/io/crate/planner/operators/EquiJoinDetectorTest.java
+++ b/server/src/test/java/io/crate/planner/operators/EquiJoinDetectorTest.java
@@ -27,7 +27,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import io.crate.expression.symbol.Symbol;
-import io.crate.sql.tree.JoinType;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SqlExpressions;
 import io.crate.testing.T3;
@@ -44,116 +43,104 @@ public class EquiJoinDetectorTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testPossibleOnInnerContainingEqCondition() {
         Symbol joinCondition = sqlExpressions.asSymbol("t1.x = t2.y");
-        assertThat(EquiJoinDetector.isHashJoinPossible(JoinType.INNER, joinCondition)).isTrue();
+        assertThat(EquiJoinDetector.isEquiJoin(joinCondition)).isTrue();
     }
 
     @Test
     public void testPossibleOnInnerContainingEqAndAnyCondition() {
         Symbol joinCondition = sqlExpressions.asSymbol("t1.x > t2.y and t1.a = t2.b and not(t1.i = t2.i)");
-        assertThat(EquiJoinDetector.isHashJoinPossible(JoinType.INNER, joinCondition)).isTrue();
+        assertThat(EquiJoinDetector.isEquiJoin(joinCondition)).isTrue();
     }
 
     @Test
     public void testNotPossibleOnInnerWithoutAnyEqCondition() {
         Symbol joinCondition = sqlExpressions.asSymbol("t1.x > t2.y and t1.a > t2.b");
-        assertThat(EquiJoinDetector.isHashJoinPossible(JoinType.INNER, joinCondition)).isFalse();
+        assertThat(EquiJoinDetector.isEquiJoin(joinCondition)).isFalse();
     }
 
     @Test
     public void testPossibleOnInnerWithEqAndScalarOnOneRelation() {
         Symbol joinCondition = sqlExpressions.asSymbol("t1.x + t1.i = t2.b");
-        assertThat(EquiJoinDetector.isHashJoinPossible(JoinType.INNER, joinCondition)).isTrue();
+        assertThat(EquiJoinDetector.isEquiJoin(joinCondition)).isTrue();
     }
 
     @Test
     public void testNotPossibleOnInnerWithEqAndScalarOnMultipleRelations() {
         Symbol joinCondition = sqlExpressions.asSymbol("t1.x + t2.y = 4");
-        assertThat(EquiJoinDetector.isHashJoinPossible(JoinType.INNER, joinCondition)).isFalse();
+        assertThat(EquiJoinDetector.isEquiJoin(joinCondition)).isFalse();
     }
 
     @Test
     public void testNotPossibleOnInnerContainingEqOrAnyCondition() {
         Symbol joinCondition = sqlExpressions.asSymbol("t1.x = t2.y and t1.a = t2.b or t1.i = t2.i");
-        assertThat(EquiJoinDetector.isHashJoinPossible(JoinType.INNER, joinCondition)).isFalse();
+        assertThat(EquiJoinDetector.isEquiJoin(joinCondition)).isFalse();
 
         joinCondition = sqlExpressions.asSymbol("(t1.a = t2.b or t1.x = t2.y) and t1.i = t2.i");
-        assertThat(EquiJoinDetector.isHashJoinPossible(JoinType.INNER, joinCondition)).isFalse();
-    }
-
-    @Test
-    public void testNotPossibleIfNotAnInnerJoin() {
-        assertThat(EquiJoinDetector.isHashJoinPossible(JoinType.CROSS, null)).isFalse();
-
-        Symbol joinCondition = sqlExpressions.asSymbol("t1.x = t2.y");
-        assertThat(EquiJoinDetector.isHashJoinPossible(JoinType.LEFT, joinCondition)).isFalse();
-        assertThat(EquiJoinDetector.isHashJoinPossible(JoinType.RIGHT, joinCondition)).isFalse();
-        assertThat(EquiJoinDetector.isHashJoinPossible(JoinType.FULL, joinCondition)).isFalse();
-        assertThat(EquiJoinDetector.isHashJoinPossible(JoinType.ANTI, joinCondition)).isFalse();
-        assertThat(EquiJoinDetector.isHashJoinPossible(JoinType.SEMI, joinCondition)).isFalse();
+        assertThat(EquiJoinDetector.isEquiJoin(joinCondition)).isFalse();
     }
 
     @Test
     public void testNotPossibleOnEqWithoutRelationFieldsOnBothSides() {
         Symbol joinCondition = sqlExpressions.asSymbol("t1.x = 4");
-        assertThat(EquiJoinDetector.isHashJoinPossible(JoinType.INNER, joinCondition)).isFalse();
+        assertThat(EquiJoinDetector.isEquiJoin(joinCondition)).isFalse();
     }
 
     @Test
     public void testNotPossibleOnNotWrappingEq() {
         Symbol joinCondition = sqlExpressions.asSymbol("NOT (t1.a = t2.b)");
-        assertThat(EquiJoinDetector.isHashJoinPossible(JoinType.INNER, joinCondition)).isFalse();
+        assertThat(EquiJoinDetector.isEquiJoin(joinCondition)).isFalse();
     }
 
     @Test
     public void test_not_hash_join_possible_if_join_condition_refers_to_columns_from_a_single_relation() {
         Symbol joinCondition = sqlExpressions.asSymbol("t1.a + t1.a = t1.a + t1.a");
-        assertThat(EquiJoinDetector.isHashJoinPossible(JoinType.INNER, joinCondition)).isFalse();
+        assertThat(EquiJoinDetector.isEquiJoin(joinCondition)).isFalse();
 
         joinCondition = sqlExpressions.asSymbol("t1.x = t1.i");
-        assertThat(EquiJoinDetector.isHashJoinPossible(JoinType.INNER, joinCondition)).isFalse();
+        assertThat(EquiJoinDetector.isEquiJoin(joinCondition)).isFalse();
     }
 
     // tracks a bug : https://github.com/crate/crate/issues/15613
     @Test
     public void test_equality_expression_followed_by_case_expression() {
         Symbol joinCondition = sqlExpressions.asSymbol("t1.a = t1.a AND CASE 1 WHEN t1.a THEN false ELSE t2.b in (t2.b) END");
-        assertThat(EquiJoinDetector.isHashJoinPossible(JoinType.INNER, joinCondition)).isFalse();
+        assertThat(EquiJoinDetector.isEquiJoin(joinCondition)).isFalse();
     }
 
     @Test
     public void test_equality_and_many_relations_in_boolean_join_condition_hash_join_not_possible() {
         // Nested EQ operator.
         Symbol joinCondition = sqlExpressions.asSymbol("(t1.a >= 1) = ((t1.a = t1.a) AND (t2.b <= t2.b))");
-        assertThat(EquiJoinDetector.isHashJoinPossible(JoinType.INNER, joinCondition)).isFalse();
+        assertThat(EquiJoinDetector.isEquiJoin(joinCondition)).isFalse();
 
         // Deep nested EQ operator.
         joinCondition = sqlExpressions.asSymbol("(t1.a >= 1) = " +
             " (t2.b < 10 AND ((t2.b < 10) = (t1.a = t1.a + 10) AND (t2.b < 7) = (t1.a = (t1.a - 5))))");
-        assertThat(EquiJoinDetector.isHashJoinPossible(JoinType.INNER, joinCondition)).isFalse();
+        assertThat(EquiJoinDetector.isEquiJoin(joinCondition)).isFalse();
 
         // Nested NOT operator
         joinCondition = sqlExpressions.asSymbol("(((t1.a != t1.a) > (t2.b = t2.b)) = t1.a)");
-        assertThat(EquiJoinDetector.isHashJoinPossible(JoinType.INNER, joinCondition)).isFalse();
+        assertThat(EquiJoinDetector.isEquiJoin(joinCondition)).isFalse();
     }
 
     @Test
     public void test_inequality_in_boolean_join_condition_hash_join_possible() {
         // Compare column with column
         Symbol joinCondition = sqlExpressions.asSymbol("(t1.a >= 1) = (t2.b <= t2.b)");
-        assertThat(EquiJoinDetector.isHashJoinPossible(JoinType.INNER, joinCondition)).isTrue();
+        assertThat(EquiJoinDetector.isEquiJoin(joinCondition)).isTrue();
 
         // Compare column with constant
         joinCondition = sqlExpressions.asSymbol("(t1.a >= 1) = (t2.b < 10)");
-        assertThat(EquiJoinDetector.isHashJoinPossible(JoinType.INNER, joinCondition)).isTrue();
+        assertThat(EquiJoinDetector.isEquiJoin(joinCondition)).isTrue();
 
         // Compare with column AND compare with constant.
         joinCondition = sqlExpressions.asSymbol("(t1.a >= 1) = (t2.b <= t2.b AND t2.b < 10)");
-        assertThat(EquiJoinDetector.isHashJoinPossible(JoinType.INNER, joinCondition)).isTrue();
+        assertThat(EquiJoinDetector.isEquiJoin(joinCondition)).isTrue();
     }
 
     @Test
     public void test_or_in_boolean_join_condition_hash_join_possible() {
         Symbol joinCondition = sqlExpressions.asSymbol("(t1.a > 1) = (t2.b < 5 OR t2.b > 10)");
-        assertThat(EquiJoinDetector.isHashJoinPossible(JoinType.INNER, joinCondition)).isTrue();
+        assertThat(EquiJoinDetector.isEquiJoin(joinCondition)).isTrue();
     }
 }

--- a/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -263,7 +263,7 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(plan).isEqualTo(
             """
             Eval[i, cnt]
-              └ HashJoin[(cnt = cast(i AS bigint))]
+              └ HashJoin[INNER | (cnt = cast(i AS bigint))]
                 ├ Rename[cnt] AS t1
                 │  └ Eval[count(*) AS cnt]
                 │    └ Count[doc.t1 | true]
@@ -289,7 +289,7 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
             Fetch[x, a, y]
               └ Limit[10::bigint;0]
                 └ OrderBy[x ASC]
-                  └ HashJoin[(x = y)]
+                  └ HashJoin[INNER | (x = y)]
                     ├ Collect[doc.t1 | [_fetchid, x] | true]
                     └ Collect[doc.t2 | [y] | true]
             """);
@@ -361,7 +361,7 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
             """
             Fetch[a, i, b, i]
               └ Limit[10::bigint;0]
-                └ HashJoin[(i = i)]
+                └ HashJoin[INNER | (i = i)]
                   ├ Rename[a, i] AS t1
                   │  └ Filter[(a > '50')]
                   │    └ Fetch[a, i]
@@ -385,7 +385,7 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(plan).isEqualTo(
             """
             Eval[x, a, x, a]
-              └ HashJoin[(x = x)]
+              └ HashJoin[INNER | (x = x)]
                 ├ Rename[a, x] AS doc.v2
                 │  └ Collect[doc.t1 | [a, x] | true]
                 └ Rename[a, x] AS doc.v3
@@ -447,7 +447,7 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
             """
             Fetch[a, x, i, b, y, i]
               └ Limit[3::bigint;0]
-                └ HashJoin[(a = b)]
+                └ HashJoin[INNER | (a = b)]
                   ├ Collect[doc.t1 | [_fetchid, a] | true]
                   └ Collect[doc.t2 | [_fetchid, b] | true]
             """
@@ -513,7 +513,7 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
             """
             Fetch[name, a, x, i]
               └ Limit[10::bigint;0]
-                └ HashJoin[(a = name)]
+                └ HashJoin[INNER | (a = name)]
                   ├ Rename[name] AS u
                   │  └ GroupHashAggregate[name]
                   │    └ Collect[doc.users | [name] | true]
@@ -560,7 +560,7 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
                   ├ TableFunction[generate_series | [generate_series] | true]
                   └ Rename[v._fetchid, aliased] AS v
                     └ Eval[_fetchid, y AS aliased]
-                      └ HashJoin[(x = y)]
+                      └ HashJoin[INNER | (x = y)]
                         ├ Collect[doc.t1 | [_fetchid, x] | true]
                         └ Collect[doc.t2 | [y] | true]
             """

--- a/server/src/test/java/io/crate/planner/operators/OuterJoinRewriteTest.java
+++ b/server/src/test/java/io/crate/planner/operators/OuterJoinRewriteTest.java
@@ -50,7 +50,7 @@ public class OuterJoinRewriteTest extends CrateDummyClusterServiceUnitTest {
         );
         var expectedPlan =
             """
-            HashJoin[(x = x)]
+            HashJoin[INNER | (x = x)]
               ├ Collect[doc.t1 | [x] | true]
               └ Collect[doc.t2 | [x] | (x = 10)]
             """;
@@ -66,7 +66,7 @@ public class OuterJoinRewriteTest extends CrateDummyClusterServiceUnitTest {
         var expectedPlan =
             """
             Filter[(coalesce(x, 10) = 10)]
-              └ NestedLoopJoin[LEFT | (x = x)]
+              └ HashJoin[LEFT | (x = x)]
                 ├ Collect[doc.t1 | [x] | true]
                 └ Collect[doc.t2 | [x] | true]
             """;
@@ -82,7 +82,7 @@ public class OuterJoinRewriteTest extends CrateDummyClusterServiceUnitTest {
         var expectedPlan =
             """
             Filter[(coalesce(x, 10) = 10)]
-              └ NestedLoopJoin[LEFT | (x = x)]
+              └ HashJoin[LEFT | (x = x)]
                 ├ Collect[doc.t1 | [x] | (x > 5)]
                 └ Collect[doc.t2 | [x] | true]
             """;

--- a/server/src/test/java/io/crate/planner/operators/PushDownTest.java
+++ b/server/src/test/java/io/crate/planner/operators/PushDownTest.java
@@ -214,7 +214,7 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
         assertThat(plan).isEqualTo(
             """
             OrderBy[a ASC]
-              └ HashJoin[(a = b)]
+              └ HashJoin[INNER | (a = b)]
                 ├ Collect[doc.t1 | [a] | true]
                 └ Collect[doc.t2 | [b] | true]
             """
@@ -265,7 +265,7 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
         var expectedPlan =
             """
             Rename[a, x, i, b, y, i] AS tjoin
-              └ HashJoin[(x = y)]
+              └ HashJoin[INNER | (x = y)]
                 ├ Collect[doc.t1 | [a, x, i] | (x = 10)]
                 └ Collect[doc.t2 | [b, y, i] | true]
             """;
@@ -305,7 +305,7 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
             """
             Rename[a, x, i, b, y, i] AS tjoin
               └ Filter[((a || b) = '')]
-                └ HashJoin[(x = y)]
+                └ HashJoin[INNER | (x = y)]
                   ├ Collect[doc.t1 | [a, x, i] | (x = 10)]
                   └ Collect[doc.t2 | [b, y, i] | (y = 20)]
             """;

--- a/server/src/test/java/io/crate/planner/operators/RelationNamesInLogicalPlanTest.java
+++ b/server/src/test/java/io/crate/planner/operators/RelationNamesInLogicalPlanTest.java
@@ -85,7 +85,7 @@ public class RelationNamesInLogicalPlanTest extends CrateDummyClusterServiceUnit
 
     @Test
     public void test_relationnames_are_based_on_sources_in_hashjoin() throws Exception {
-        var hashJoin = new HashJoin(t1Rename, t2Rename, e.asSymbol("x = y"));
+        var hashJoin = new HashJoin(t1Rename, t2Rename, e.asSymbol("x = y"), JoinType.INNER);
         assertThat(hashJoin.relationNames()).containsExactlyInAnyOrder(t1RenamedRelationName, t2RenamedRelationName);
     }
 

--- a/server/src/test/java/io/crate/planner/operators/SelectDistinctLogicalPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/operators/SelectDistinctLogicalPlannerTest.java
@@ -98,7 +98,7 @@ public class SelectDistinctLogicalPlannerTest extends CrateDummyClusterServiceUn
             """
             GroupHashAggregate[count(id)]
               └ GroupHashAggregate[name | count(id)]
-                └ HashJoin[(department_id = id)]
+                └ HashJoin[INNER | (department_id = id)]
                   ├ Collect[doc.users | [id, department_id] | true]
                   └ Collect[doc.departments | [name, id] | true]
             """
@@ -118,7 +118,7 @@ public class SelectDistinctLogicalPlannerTest extends CrateDummyClusterServiceUn
             """
             OrderBy[name ASC]
               └ GroupHashAggregate[name]
-                └ HashJoin[(department_id = id)]
+                └ HashJoin[INNER | (department_id = id)]
                   ├ Collect[doc.users | [department_id] | true]
                   └ Collect[doc.departments | [name, id] | true]
             """

--- a/server/src/test/java/io/crate/planner/optimizer/costs/PlanStatsTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/costs/PlanStatsTest.java
@@ -215,7 +215,7 @@ public class PlanStatsTest extends CrateDummyClusterServiceUnitTest {
             )
         );
 
-        var hashjoin = new HashJoin(lhs, rhs, joinCondition);
+        var hashjoin = new HashJoin(lhs, rhs, joinCondition, JoinType.INNER);
 
         var memo = new Memo(hashjoin);
         PlanStats planStats = new PlanStats(nodeContext, txnCtx, tableStats, memo);

--- a/server/src/testFixtures/java/io/crate/testing/SQLResponseAssert.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLResponseAssert.java
@@ -66,6 +66,16 @@ public final class SQLResponseAssert extends AbstractAssert<SQLResponseAssert, S
         return this;
     }
 
+    public SQLResponseAssert hasRowsInAnyOrder(String ... rows) {
+        String[] resultRows = new String[actual.rows().length];
+        for (int i = 0; i < actual.rows().length; i++) {
+            Object[] row = actual.rows()[i];
+            resultRows[i] = TestingHelpers.printRow(row);
+        }
+        assertThat(resultRows).containsExactlyInAnyOrder(rows);
+        return this;
+    }
+
     public SQLResponseAssert hasRows(Object[] ... rows) {
         assertThat(List.of(actual.rows())).containsExactly(rows);
         return this;


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This implements hash-join execution for left-outer-joins according to https://github.com/crate/crate/issues/15147 by the following steps:

- Extend `HashInnerJoinBatchIterator` to `HashJoinBatchIterator` with an additional option to emit non-matching join pairs with null values to support left-outer-join behaviour 
- Extend the planning pipeline to support `Left` Join-Type for Hash-Joins


## Performance Improvements:
This is a comparison between the hash-join and nested-loop join execution on a table having 50 % matches and 50 % non-matches with different sizes running each time 100 iterations:
```
select count(*) from t1 left join t2 on t1.id = t2.id
```


| Table sizes | Nestedloop (ms mean) | Hash-Join (ms mean)| 
| ------------- | ------------- | ------------- | 
| 10 / 10  | 2.045 ± 1.229 |  0.555 ± 0.110  | 
| 100 / 100  | 4.455 ± 0.271  |  0.438 ± 0.028 | 
| 1000 / 1000  | 169.494 ± 0.286  | 1.058 ± 0.018  | 
| 10.000 / 10.000  | 21919.926 ± 653.076  | 7.955 ± 0.050  | 
| 100.000 / 100.000  | n/a  | 178.404 ± 4.188  | 

Fixes https://github.com/crate/crate/issues/15147