### PR TITLE
Add debug logging statements to ReservoirSampler

### DIFF
--- a/server/src/main/java/io/crate/statistics/ReservoirSampler.java
+++ b/server/src/main/java/io/crate/statistics/ReservoirSampler.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.function.IntFunction;
+import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -166,6 +167,12 @@ public final class ReservoirSampler {
                                Random random,
                                Metadata metadata) throws IOException {
 
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Start collecting samples for table: {}({}),",
+                docTable.ident().fqn(),
+                columns.stream().map(r -> r.column().fqn()).collect(Collectors.joining(", ")));
+        }
+
         Reservoir fetchIdSamples = new Reservoir(random);
         long totalNumDocs = 0;
         long totalSizeInBytes = 0;
@@ -296,7 +303,6 @@ public final class ReservoirSampler {
                 collectors.get(i).setShard(expressions.get(i));
             }
         }
-
     }
 
     private static class ColumnSampler {


### PR DESCRIPTION
Add some debug logging, to help investigate issues when gathering statistics for tables during `ANALYZE`.

e.g. output:
```
[2024-10-14T13:36:19,295][INFO ][o.e.c.m.MetadataDeleteIndexService] [Cima dell'Uomo] [test/aItevvVMQGmXx9kmDUPckw] deleting index
[2024-10-14T13:36:20,619][DEBUG][i.c.s.ReservoirSampler   ] [Cima dell'Uomo] Start collecting samples for table: doc.t
[2024-10-14T13:36:20,619][DEBUG][i.c.s.ReservoirSampler   ] [Cima dell'Uomo] Start collecting samples for table: doc.tbl
[2024-10-14T13:36:20,619][DEBUG][i.c.s.ReservoirSampler   ] [Cima dell'Uomo] Start collecting samples for table: doc.t0
[2024-10-14T13:36:20,619][DEBUG][i.c.s.ReservoirSampler   ] [Cima dell'Uomo] Start collecting samples for table: doc.t1
[2024-10-14T13:36:20,620][DEBUG][i.c.s.ReservoirSampler   ] [Cima dell'Uomo] Iterating over docs of table: doc.t
[2024-10-14T13:36:20,620][DEBUG][i.c.s.ReservoirSampler   ] [Cima dell'Uomo] Iterating over docs of table: doc.t0
[2024-10-14T13:36:20,620][DEBUG][i.c.s.ReservoirSampler   ] [Cima dell'Uomo] Iterating over docs of table: doc.tbl
[2024-10-14T13:36:20,620][DEBUG][i.c.s.ReservoirSampler   ] [Cima dell'Uomo] Iterating over docs of table: doc.t1
[2024-10-14T13:36:20,620][DEBUG][i.c.s.ReservoirSampler   ] [Cima dell'Uomo] Collecting stats for table: doc.t column: c1 and docId: 0
[2024-10-14T13:36:20,620][DEBUG][i.c.s.ReservoirSampler   ] [Cima dell'Uomo] Collecting stats for table: doc.t0 column: c0 and docId: 0
[2024-10-14T13:36:20,620][DEBUG][i.c.s.ReservoirSampler   ] [Cima dell'Uomo] Collecting stats for table: doc.t1 column: c0 and docId: 0
[2024-10-14T13:36:20,620][DEBUG][i.c.s.ReservoirSampler   ] [Cima dell'Uomo] Collecting stats for table: doc.t column: c2 and docId: 0
[2024-10-14T13:36:20,620][DEBUG][i.c.s.ReservoirSampler   ] [Cima dell'Uomo] Collecting stats for table: doc.t column: c1 and docId: 0
[2024-10-14T13:36:20,620][DEBUG][i.c.s.ReservoirSampler   ] [Cima dell'Uomo] Collecting stats for table: doc.t column: c2 and docId: 0
[2024-10-14T13:36:20,620][DEBUG][i.c.s.ReservoirSampler   ] [Cima dell'Uomo] Collecting stats for table: doc.t column: c1 and docId: 0
[2024-10-14T13:36:20,620][DEBUG][i.c.s.ReservoirSampler   ] [Cima dell'Uomo] Collecting stats for table: doc.t column: c2 and docId: 0
[2024-10-14T13:36:20,620][DEBUG][i.c.s.ReservoirSampler   ] [Cima dell'Uomo] Collecting stats for table: doc.t column: c1 and docId: 0
[2024-10-14T13:36:20,620][DEBUG][i.c.s.ReservoirSampler   ] [Cima dell'Uomo] Collecting stats for table: doc.t column: c2 and docId: 0
```
