### PR TITLE
Fix issue with char type and implicit casts

### DIFF
--- a/server/src/main/java/io/crate/analyze/InsertAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/InsertAnalyzer.java
@@ -173,6 +173,8 @@ class InsertAnalyzer {
                 null
             );
             var selectAnalysis = SelectAnalyzer.analyzeSelectItems(
+                txnCtx,
+                nodeCtx,
                 insert.returningClause(),
                 sources,
                 sourceExprAnalyzer,

--- a/server/src/main/java/io/crate/analyze/UpdateAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/UpdateAnalyzer.java
@@ -138,6 +138,8 @@ public final class UpdateAnalyzer {
 
         Symbol normalizedQuery = normalizer.normalize(query, txnCtx);
         SelectAnalysis selectAnalysis = SelectAnalyzer.analyzeSelectItems(
+            txnCtx,
+            nodeCtx,
             update.returningClause(),
             relCtx.sources(),
             sourceExprAnalyzer,

--- a/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -409,6 +409,8 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
         expressionAnalysisContext.windows(node.getWindows());
 
         SelectAnalysis selectAnalysis = SelectAnalyzer.analyzeSelectItems(
+            coordinatorTxnCtx,
+            nodeCtx,
             node.getSelect().getSelectItems(),
             context.sources(),
             expressionAnalyzer,


### PR DESCRIPTION
`WHERE` clause gets optimized by symbol `Optimizer`, so that the casts are moved from the columns to the literals, but this logic is not applied to expressions in other place, e.g.: `SELECT` clause. Therefore we can end up with strange behaviour like:
```
CREATE TABLE tbl(c0 CHAR(3));
INSERT INTO tbl VALUES(' ');
SELECT c0 = '' FROM tbl WHERE c0 = '';
+-----------+
| (c0 = '') |
+-----------+
| FALSE     |
+-----------+
SELECT 1 row in set (0.138 sec)
```

PoC: apply the optmizeCasts() to SELECT expressions.

Fixes: #16689
