### PR TITLE
WIP: modify DataType.precedes to return null

### DIFF
--- a/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -828,7 +828,7 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
                         "The types of the columns within VALUES lists must match. " +
                         "Found `" + targetType + "` and `" + cellType + "` at position: " + c);
                 }
-                if (usePrecedence && cellType.precedes(targetType)) {
+                if (usePrecedence && Boolean.TRUE.equals(cellType.precedes(targetType))) {
                     targetType = cellType;
                 } else if (targetType == DataTypes.UNDEFINED) {
                     targetType = cellType;

--- a/server/src/main/java/io/crate/metadata/functions/SignatureBinder.java
+++ b/server/src/main/java/io/crate/metadata/functions/SignatureBinder.java
@@ -470,7 +470,7 @@ public class SignatureBinder {
                 }
                 return fromType.equals(toType)
                        || (fromType.isConvertableTo(toTypeSignature.createType(), false)
-                          && toType.precedes(fromType));
+                          && Boolean.TRUE.equals(toType.precedes(fromType)));
             case NONE:
             default:
                 var fromTypeSignature = fromType.getTypeSignature();

--- a/server/src/main/java/io/crate/types/DataType.java
+++ b/server/src/main/java/io/crate/types/DataType.java
@@ -169,10 +169,12 @@ public abstract class DataType<T> implements Comparable<DataType<?>>, Writeable,
 
     /**
      * Returns true if this DataType precedes the supplied DataType.
+     *
      * @param other The other type to compare against.
      * @return True if the current type precedes, false otherwise.
      */
-    public boolean precedes(DataType<?> that) {
+    @Nullable
+    public Boolean precedes(DataType<?> that) {
         int thisOrdinal = this.precedence().ordinal();
         int thatOrdinal = that.precedence().ordinal();
         if (thisOrdinal == thatOrdinal) {

--- a/server/src/main/java/io/crate/types/DataTypes.java
+++ b/server/src/main/java/io/crate/types/DataTypes.java
@@ -377,7 +377,7 @@ public final class DataTypes {
                 throw new IllegalArgumentException(
                     "Mixed dataTypes inside a list are not supported. Found " + highest + " and " + current);
             }
-            if (current.precedes(highest)) {
+            if (Boolean.TRUE.equals(current.precedes(highest))) {
                 highest = current;
             }
         }
@@ -390,7 +390,11 @@ public final class DataTypes {
     private static boolean safeConversionPossible(DataType<?> type1, DataType<?> type2) {
         final DataType<?> source;
         final DataType<?> target;
-        if (type1.precedes(type2)) {
+        Boolean type1PrecedesType2 = type1.precedes(type2);
+        if (type1PrecedesType2 == null) {
+            return false;
+        }
+        if (type1PrecedesType2) {
             source = type2;
             target = type1;
         } else {
@@ -638,7 +642,13 @@ public final class DataTypes {
         } else if (leftType.id() == ArrayType.ID && rightType.id() == ArrayType.ID) {
             type = new ArrayType<>(merge(((ArrayType<?>) leftType).innerType(), ((ArrayType<?>) rightType).innerType()));
         } else {
-            if (leftType.precedes(rightType)) {
+            Boolean leftPrecedesRight = leftType.precedes(rightType);
+            if (leftPrecedesRight == null) {
+                if (leftType.id() == NumericType.ID && rightType.id() == NumericType.ID) {
+                    return NUMERIC;
+                }
+                throw new IllegalArgumentException("Cannot merge " + leftType + " and " + rightType);
+            } else if (leftPrecedesRight) {
                 if (rightType.isConvertableTo(leftType, false)) {
                     return leftType;
                 }

--- a/server/src/main/java/io/crate/types/NumericType.java
+++ b/server/src/main/java/io/crate/types/NumericType.java
@@ -107,6 +107,16 @@ public class NumericType extends DataType<BigDecimal> implements Streamer<BigDec
         return Precedence.NUMERIC;
     }
 
+    @Nullable
+    @Override
+    public Boolean precedes(DataType<?> that) {
+        if (that instanceof NumericType) {
+            return null;
+        } else {
+            return super.precedes(that);
+        }
+    }
+
     @Override
     public String getName() {
         return NAME;

--- a/server/src/main/java/io/crate/types/TypeCompatibility.java
+++ b/server/src/main/java/io/crate/types/TypeCompatibility.java
@@ -56,7 +56,10 @@ public final class TypeCompatibility {
     private static DataType<?> convertTypeByPrecedence(DataType<?> type1, DataType<?> type2) {
         final DataType<?> higherPrecedenceArg;
         final DataType<?> lowerPrecedenceArg;
-        if (type1.precedes(type2)) {
+        Boolean type1PrecedesType2 = type1.precedes(type2);
+        if (type1PrecedesType2 == null) {
+            return null;
+        } else if (type1PrecedesType2) {
             higherPrecedenceArg = type1;
             lowerPrecedenceArg = type2;
         } else {

--- a/server/src/test/java/io/crate/types/TypeCompatibilityTest.java
+++ b/server/src/test/java/io/crate/types/TypeCompatibilityTest.java
@@ -39,9 +39,9 @@ public class TypeCompatibilityTest {
 
     @Test
     public void test_numeric_highest_precision_wins() {
-        assertCommonType(NumericType.INSTANCE, new NumericType(2, 1), new NumericType(2, 1));
-        assertCommonType(new NumericType(2, 1), NumericType.INSTANCE, new NumericType(2, 1));
-        assertCommonType(new NumericType(2, 1), new NumericType(3, 1), new NumericType(3, 1));
+        assertCommonType(NumericType.INSTANCE, new NumericType(2, 1), NumericType.INSTANCE);
+        assertCommonType(new NumericType(2, 1), NumericType.INSTANCE, NumericType.INSTANCE);
+        assertCommonType(new NumericType(2, 1), new NumericType(3, 1), NumericType.INSTANCE);
     }
 
     private static void assertCommonType(DataType<?> first, DataType<?> second, DataType<?> expected) {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
