### PR TITLE
Fix Rename prune handling for duplicate parent expressions

### DIFF
--- a/docs/appendices/release-notes/5.8.5.rst
+++ b/docs/appendices/release-notes/5.8.5.rst
@@ -47,6 +47,20 @@ See the :ref:`version_5.8.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that led to a ``NullPointerException`` when the same filter
+  expression was used multiple times in an aggregation on an aliased table. For
+  example::
+
+      SELECT
+          alias1.country,
+          MAX(height) FILTER (WHERE height>0) as max_height,
+          MAX(prominence) FILTER (WHERE height>0) as max_prominence
+      FROM
+          sys.summits alias1
+      GROUP BY
+          alias1.country
+      LIMIT 100;
+
 - Fixed an issue that would cause users and roles to loose irrelevant
   privileges, like: ``Administration Language (AL)``, when a table or a view
   is dropped.

--- a/docs/appendices/release-notes/5.9.1.rst
+++ b/docs/appendices/release-notes/5.9.1.rst
@@ -47,6 +47,20 @@ See the :ref:`version_5.9.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that led to a ``NullPointerException`` when the same filter
+  expression was used multiple times in an aggregation on an aliased table. For
+  example::
+
+      SELECT
+          alias1.country,
+          MAX(height) FILTER (WHERE height>0) as max_height,
+          MAX(prominence) FILTER (WHERE height>0) as max_prominence
+      FROM
+          sys.summits alias1
+      GROUP BY
+          alias1.country
+      LIMIT 100;
+
 - Fixed an issue that would cause users and roles to loose irrelevant
   privileges, like: ``Administration Language (AL)``, when a table or a view
   is dropped.

--- a/server/src/main/java/io/crate/planner/operators/Rename.java
+++ b/server/src/main/java/io/crate/planner/operators/Rename.java
@@ -25,7 +25,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.IdentityHashMap;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.SequencedCollection;
@@ -98,11 +98,8 @@ public final class Rename extends ForwardingLogicalPlan implements FieldResolver
 
     @Override
     public LogicalPlan pruneOutputsExcept(SequencedCollection<Symbol> outputsToKeep) {
-        /* In `SELECT * FROM (SELECT t1.*, t2.* FROM tbl AS t1, tbl AS t2) AS tjoin`
-         * The `ScopedSymbol`s are ambiguous; To map them correctly this uses a IdentityHashMap
-         */
-        IdentityHashMap<Symbol, Symbol> parentToChildMap = new IdentityHashMap<>(outputs.size());
-        IdentityHashMap<Symbol, Symbol> childToParentMap = new IdentityHashMap<>(outputs.size());
+        HashMap<Symbol, Symbol> parentToChildMap = HashMap.newHashMap(outputs.size());
+        HashMap<Symbol, Symbol> childToParentMap = HashMap.newHashMap(outputs.size());
         for (int i = 0; i < outputs.size(); i++) {
             parentToChildMap.put(outputs.get(i), source.outputs().get(i));
             childToParentMap.put(source.outputs().get(i), outputs.get(i));
@@ -134,8 +131,8 @@ public final class Rename extends ForwardingLogicalPlan implements FieldResolver
     @Nullable
     @Override
     public FetchRewrite rewriteToFetch(Collection<Symbol> usedColumns) {
-        IdentityHashMap<Symbol, Symbol> parentToChildMap = new IdentityHashMap<>(outputs.size());
-        IdentityHashMap<Symbol, Symbol> childToParentMap = new IdentityHashMap<>(outputs.size());
+        HashMap<Symbol, Symbol> parentToChildMap = HashMap.newHashMap(outputs.size());
+        HashMap<Symbol, Symbol> childToParentMap = HashMap.newHashMap(outputs.size());
         for (int i = 0; i < outputs.size(); i++) {
             parentToChildMap.put(outputs.get(i), source.outputs().get(i));
             childToParentMap.put(source.outputs().get(i), outputs.get(i));


### PR DESCRIPTION
In a query like:

    SELECT
        alias1.country,
        MAX(height) FILTER (WHERE height>0) as max_height,
        MAX(prominence) FILTER (WHERE height>0) as max_prominence
    FROM
        sys.summits alias1
    GROUP BY
        alias1.country
    LIMIT 100;

The `Rename` operator was built with a single `height > 0` output
because the `SplitPoints` detection de-duplicated them, but later on the
column pruning provided two different `Function` instances for both
`height > 0` expressions, which failed due to the `IdentityHashMap` only
containing a single function - based on the rename's `outputs()`

Due to the change in https://github.com/crate/crate/pull/16558
`SelectSymbol` should no longer be ambigous and we can replace the
`IdentityHashMap` with a `HashMap`, which means the `height > 0` lookup
will work.
