### PR TITLE
Use Writable for cluster state persistance instead of xContent

### DIFF
--- a/libs/es-x-content/src/main/java/org/elasticsearch/common/xcontent/XContentBuilder.java
+++ b/libs/es-x-content/src/main/java/org/elasticsearch/common/xcontent/XContentBuilder.java
@@ -814,19 +814,11 @@ public final class XContentBuilder implements Closeable, Flushable {
         return field(name).value(value);
     }
 
-    public XContentBuilder field(String name, ToXContent value, ToXContent.Params params) throws IOException {
-        return field(name).value(value, params);
-    }
-
     private XContentBuilder value(ToXContent value) throws IOException {
-        return value(value, ToXContent.EMPTY_PARAMS);
-    }
-
-    private XContentBuilder value(ToXContent value, ToXContent.Params params) throws IOException {
         if (value == null) {
             return nullValue();
         }
-        value.toXContent(this, params);
+        value.toXContent(this, ToXContent.EMPTY_PARAMS);
         return this;
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -1289,17 +1289,10 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         }
     }
 
-    private static final ToXContent.Params FORMAT_PARAMS = new MapParams(Collections.singletonMap("binary", "true"));
-
     /**
      * State format for {@link IndexMetadata} to write to and load from disk
      */
     public static final MetadataStateFormat<IndexMetadata> FORMAT = new MetadataStateFormat<IndexMetadata>(INDEX_STATE_FILE_PREFIX) {
-
-        @Override
-        public void toXContent(XContentBuilder builder, IndexMetadata state) throws IOException {
-            Builder.toXContent(state, builder, FORMAT_PARAMS);
-        }
 
         @Override
         public IndexMetadata fromXContent(XContentParser parser) throws IOException {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -1305,6 +1305,11 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         public IndexMetadata fromXContent(XContentParser parser) throws IOException {
             return Builder.fromXContent(parser);
         }
+
+        @Override
+        public IndexMetadata readFrom(StreamInput in) throws IOException {
+            return IndexMetadata.readFrom(in);
+        }
     };
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Manifest.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Manifest.java
@@ -139,11 +139,6 @@ public class Manifest implements ToXContentFragment, Writeable {
     public static final MetadataStateFormat<Manifest> FORMAT = new MetadataStateFormat<Manifest>(MANIFEST_FILE_PREFIX) {
 
         @Override
-        public void toXContent(XContentBuilder builder, Manifest state) throws IOException {
-            state.toXContent(builder, MANIFEST_FORMAT_PARAMS);
-        }
-
-        @Override
         public Manifest fromXContent(XContentParser parser) throws IOException {
             return Manifest.fromXContent(parser);
         }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -1082,15 +1081,6 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
         }
     }
 
-    private static final ToXContent.Params FORMAT_PARAMS;
-
-    static {
-        Map<String, String> params = new HashMap<>(2);
-        params.put("binary", "true");
-        params.put(Metadata.CONTEXT_MODE_PARAM, Metadata.CONTEXT_MODE_GATEWAY);
-        FORMAT_PARAMS = new MapParams(params);
-    }
-
     /**
      * State format for {@link Metadata} to write to and load from disk
      */
@@ -1104,11 +1094,6 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
 
     private static MetadataStateFormat<Metadata> createMetadataStateFormat(boolean preserveUnknownCustoms) {
         return new MetadataStateFormat<Metadata>(GLOBAL_STATE_FILE_PREFIX) {
-
-            @Override
-            public void toXContent(XContentBuilder builder, Metadata state) throws IOException {
-                Builder.toXContent(state, builder, FORMAT_PARAMS);
-            }
 
             @Override
             public Metadata fromXContent(XContentParser parser) throws IOException {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -1114,6 +1114,11 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, To
             public Metadata fromXContent(XContentParser parser) throws IOException {
                 return Builder.fromXContent(parser, preserveUnknownCustoms);
             }
+
+            @Override
+            public Metadata readFrom(StreamInput in) throws IOException {
+                return Metadata.readFrom(in);
+            }
         };
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/routing/AllocationId.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/AllocationId.java
@@ -19,7 +19,9 @@
 
 package org.elasticsearch.cluster.routing;
 
-import org.jetbrains.annotations.Nullable;
+import java.io.IOException;
+import java.util.Objects;
+
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -29,9 +31,7 @@ import org.elasticsearch.common.xcontent.ParseField;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-
-import java.io.IOException;
-import java.util.Objects;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Uniquely identifies an allocation. An allocation is a shard moving from unassigned to initializing,
@@ -75,7 +75,7 @@ public class AllocationId implements ToXContentObject, Writeable {
     @Nullable
     private final String relocationId;
 
-    AllocationId(StreamInput in) throws IOException {
+    public AllocationId(StreamInput in) throws IOException {
         this.id = in.readString();
         this.relocationId = in.readOptionalString();
     }

--- a/server/src/main/java/org/elasticsearch/common/io/stream/NamedWriteableRegistry.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/NamedWriteableRegistry.java
@@ -34,6 +34,8 @@ import java.util.Objects;
  */
 public class NamedWriteableRegistry {
 
+    public static final NamedWriteableRegistry EMPTY = new NamedWriteableRegistry(List.of());
+
     /** An entry in the registry, made up of a category class and name, and a reader for that category class. */
     public static class Entry {
 

--- a/server/src/main/java/org/elasticsearch/env/NodeMetadata.java
+++ b/server/src/main/java/org/elasticsearch/env/NodeMetadata.java
@@ -20,7 +20,6 @@
 package org.elasticsearch.env;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Objects;
 
 import org.elasticsearch.Version;
@@ -29,9 +28,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.ParseField;
-import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.gateway.MetadataStateFormat;
 
 /**
@@ -151,19 +148,6 @@ public final class NodeMetadata implements Writeable {
             objectParser = new ObjectParser<>("node_meta_data", false, Builder::new);
             objectParser.declareString(Builder::setNodeId, new ParseField(NODE_ID_KEY));
             objectParser.declareInt(Builder::setNodeVersionId, new ParseField(NODE_VERSION_KEY));
-        }
-
-        @Override
-        protected XContentBuilder newXContentBuilder(XContentType type, OutputStream stream) throws IOException {
-            XContentBuilder xContentBuilder = super.newXContentBuilder(type, stream);
-            xContentBuilder.prettyPrint();
-            return xContentBuilder;
-        }
-
-        @Override
-        public void toXContent(XContentBuilder builder, NodeMetadata nodeMetadata) throws IOException {
-            builder.field(NODE_ID_KEY, nodeMetadata.nodeId);
-            builder.field(NODE_VERSION_KEY, nodeMetadata.nodeVersion.internalId);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/env/NodeMetadata.java
+++ b/server/src/main/java/org/elasticsearch/env/NodeMetadata.java
@@ -19,7 +19,14 @@
 
 package org.elasticsearch.env;
 
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Objects;
+
 import org.elasticsearch.Version;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ObjectParser;
 import org.elasticsearch.common.xcontent.ParseField;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -27,15 +34,11 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.gateway.MetadataStateFormat;
 
-import java.io.IOException;
-import java.io.OutputStream;
-import java.util.Objects;
-
 /**
  * Metadata associated with this node: its persistent node ID and its version.
  * The metadata is persisted in the data folder of this node and is reused across restarts.
  */
-public final class NodeMetadata {
+public final class NodeMetadata implements Writeable {
 
     static final String NODE_ID_KEY = "node_id";
     static final String NODE_VERSION_KEY = "node_version";
@@ -47,6 +50,17 @@ public final class NodeMetadata {
     public NodeMetadata(final String nodeId, final Version nodeVersion) {
         this.nodeId = Objects.requireNonNull(nodeId);
         this.nodeVersion = Objects.requireNonNull(nodeVersion);
+    }
+
+    public NodeMetadata(StreamInput in) throws IOException {
+        this.nodeId = in.readString();
+        this.nodeVersion = Version.readVersion(in);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(nodeId);
+        Version.writeVersion(nodeVersion, out);
     }
 
     @Override
@@ -155,6 +169,11 @@ public final class NodeMetadata {
         @Override
         public NodeMetadata fromXContent(XContentParser parser) throws IOException {
             return objectParser.apply(parser, null).build();
+        }
+
+        @Override
+        public NodeMetadata readFrom(StreamInput in) throws IOException {
+            return new NodeMetadata(in);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
+++ b/server/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
@@ -102,9 +102,13 @@ public class GatewayMetaState implements Closeable {
         return getPersistedState().getLastAcceptedState().metadata();
     }
 
-    public void start(Settings settings, TransportService transportService, ClusterService clusterService,
-                      MetaStateService metaStateService, MetadataIndexUpgradeService metadataIndexUpgradeService,
-                      MetadataUpgrader metadataUpgrader, PersistedClusterStateService persistedClusterStateService) {
+    public void start(Settings settings,
+                      TransportService transportService,
+                      ClusterService clusterService,
+                      MetaStateService metaStateService,
+                      MetadataIndexUpgradeService metadataIndexUpgradeService,
+                      MetadataUpgrader metadataUpgrader,
+                      PersistedClusterStateService persistedClusterStateService) {
         assert persistedState.get() == null : "should only start once, but already have " + persistedState.get();
 
         if (DiscoveryNode.isMasterEligibleNode(settings) || DiscoveryNode.isDataNode(settings)) {
@@ -145,7 +149,10 @@ public class GatewayMetaState implements Closeable {
                         metaStateService.deleteAll(); // delete legacy files
                     }
                     // write legacy node metadata to prevent accidental downgrades from spawning empty cluster state
-                    NodeMetadata.FORMAT.writeAndCleanup(new NodeMetadata(persistedClusterStateService.getNodeId(), Version.CURRENT), persistedClusterStateService.getDataPaths());
+                    NodeMetadata.FORMAT.writeAndCleanup(
+                        new NodeMetadata(persistedClusterStateService.getNodeId(), Version.CURRENT),
+                        persistedClusterStateService.getDataPaths()
+                    );
                     success = true;
                 } finally {
                     if (success == false) {
@@ -172,7 +179,10 @@ public class GatewayMetaState implements Closeable {
                     // delete legacy cluster state files
                     metaStateService.deleteAll();
                     // write legacy node metadata to prevent downgrades from spawning empty cluster state
-                    NodeMetadata.FORMAT.writeAndCleanup(new NodeMetadata(persistedClusterStateService.getNodeId(), Version.CURRENT), persistedClusterStateService.getDataPaths());
+                    NodeMetadata.FORMAT.writeAndCleanup(
+                        new NodeMetadata(persistedClusterStateService.getNodeId(), Version.CURRENT),
+                        persistedClusterStateService.getDataPaths()
+                    );
                 } catch (IOException e) {
                     throw new UncheckedIOException(e);
                 }

--- a/server/src/main/java/org/elasticsearch/gateway/MetadataStateFormat.java
+++ b/server/src/main/java/org/elasticsearch/gateway/MetadataStateFormat.java
@@ -21,7 +21,6 @@ package org.elasticsearch.gateway;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
@@ -57,8 +56,6 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.lucene.store.IndexOutputOutputStream;
 import org.elasticsearch.common.lucene.store.InputStreamIndexInput;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 
@@ -269,20 +266,13 @@ public abstract class MetadataStateFormat<T extends Writeable> {
         return newGenerationId;
     }
 
-    protected XContentBuilder newXContentBuilder(XContentType type, OutputStream stream) throws IOException {
-        return XContentFactory.builder(type, stream);
-    }
-
-    /**
-     * Writes the given state to the given XContentBuilder
-     * Subclasses need to implement this class for theirs specific state.
-     */
-    public abstract void toXContent(XContentBuilder builder, T state) throws IOException;
-
     /**
      * Reads a new instance of the state from the given XContentParser
      * Subclasses need to implement this class for theirs specific state.
+     *
+     * @deprecated used for BWC to read old formats
      */
+    @Deprecated
     public abstract T fromXContent(XContentParser parser) throws IOException;
 
     public abstract T readFrom(StreamInput in) throws IOException;

--- a/server/src/main/java/org/elasticsearch/gateway/MetadataStateFormat.java
+++ b/server/src/main/java/org/elasticsearch/gateway/MetadataStateFormat.java
@@ -47,6 +47,13 @@ import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.store.NIOFSDirectory;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.io.stream.InputStreamStreamInput;
+import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.OutputStreamStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.lucene.store.IndexOutputOutputStream;
 import org.elasticsearch.common.lucene.store.InputStreamIndexInput;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
@@ -65,14 +72,15 @@ import io.crate.server.xcontent.LoggingDeprecationHandler;
  * XContent based files to one or more directories in a standardized directory structure.
  * @param <T> the type of the XContent base data-structure
  */
-public abstract class MetadataStateFormat<T> {
+public abstract class MetadataStateFormat<T extends Writeable> {
     public static final XContentType FORMAT = XContentType.SMILE;
     public static final String STATE_DIR_NAME = "_state";
     public static final String STATE_FILE_EXTENSION = ".st";
 
     private static final String STATE_FILE_CODEC = "state";
     private static final int MIN_COMPATIBLE_STATE_FILE_VERSION = 1;
-    private static final int STATE_FILE_VERSION = 1;
+    private static final int XCONTENT_STATE_VERSION = 1;
+    private static final int STATE_FILE_VERSION = 2;
     private final String prefix;
     private final Pattern stateFilePattern;
 
@@ -103,24 +111,19 @@ public abstract class MetadataStateFormat<T> {
         }
     }
 
-    private void writeStateToFirstLocation(final T state, Path stateLocation, Directory stateDir, String tmpFileName)
+    private void writeStateToFirstLocation(final T state,
+                                           Path stateLocation,
+                                           Directory stateDir,
+                                           String tmpFileName)
             throws WriteStateException {
         try {
             deleteFileIfExists(stateLocation, stateDir, tmpFileName);
             try (IndexOutput out = EndiannessReverserUtil.createOutput(stateDir, tmpFileName, IOContext.DEFAULT)) {
                 CodecUtil.writeHeader(out, STATE_FILE_CODEC, STATE_FILE_VERSION);
                 out.writeInt(FORMAT.index());
-                try (XContentBuilder builder = newXContentBuilder(FORMAT, new IndexOutputOutputStream(out) {
-                    @Override
-                    public void close() {
-                        // this is important since some of the XContentBuilders write bytes on close.
-                        // in order to write the footer we need to prevent closing the actual index input.
-                    }
-                })) {
-                    builder.startObject();
-                    toXContent(builder, state);
-                    builder.endObject();
-                }
+                var streamOutput = new OutputStreamStreamOutput(new IndexOutputOutputStream(out));
+                Version.writeVersion(Version.CURRENT, streamOutput);
+                state.writeTo(streamOutput);
                 CodecUtil.writeFooter(out);
             }
 
@@ -282,16 +285,18 @@ public abstract class MetadataStateFormat<T> {
      */
     public abstract T fromXContent(XContentParser parser) throws IOException;
 
+    public abstract T readFrom(StreamInput in) throws IOException;
+
     /**
      * Reads the state from a given file and compares the expected version against the actual version of
      * the state.
      */
-    public final T read(NamedXContentRegistry namedXContentRegistry, Path file) throws IOException {
+    public final T read(NamedWriteableRegistry namedWritableRegistry, NamedXContentRegistry namedXContentRegistry, Path file) throws IOException {
         try (Directory dir = newDirectory(file.getParent())) {
             try (IndexInput indexInput = EndiannessReverserUtil.openInput(dir, file.getFileName().toString(), IOContext.DEFAULT)) {
                 // We checksum the entire file before we even go and parse it. If it's corrupted we barf right here.
                 CodecUtil.checksumEntireFile(indexInput);
-                CodecUtil.checkHeader(indexInput, STATE_FILE_CODEC, MIN_COMPATIBLE_STATE_FILE_VERSION, STATE_FILE_VERSION);
+                int stateVersion = CodecUtil.checkHeader(indexInput, STATE_FILE_CODEC, MIN_COMPATIBLE_STATE_FILE_VERSION, STATE_FILE_VERSION);
                 final XContentType xContentType = XContentType.values()[indexInput.readInt()];
                 if (xContentType != FORMAT) {
                     throw new IllegalStateException("expected state in " + file + " to be " + FORMAT + " format but was " + xContentType);
@@ -300,10 +305,18 @@ public abstract class MetadataStateFormat<T> {
                 long contentSize = indexInput.length() - CodecUtil.footerLength() - filePointer;
                 try (IndexInput slice = indexInput.slice("state_xcontent", filePointer, contentSize)) {
                     try (InputStreamIndexInput in = new InputStreamIndexInput(slice, contentSize)) {
-                        try (XContentParser parser = FORMAT.xContent()
-                                .createParser(namedXContentRegistry, LoggingDeprecationHandler.INSTANCE,
-                                    in)) {
-                            return fromXContent(parser);
+                        if (stateVersion == XCONTENT_STATE_VERSION) {
+                            try (XContentParser parser = FORMAT.xContent()
+                                    .createParser(namedXContentRegistry, LoggingDeprecationHandler.INSTANCE,
+                                        in)) {
+                                return fromXContent(parser);
+                            }
+                        } else {
+                            try (var streamInput = new NamedWriteableAwareStreamInput(new InputStreamStreamInput(in), namedWritableRegistry)) {
+                                Version version = Version.readVersion(streamInput);
+                                streamInput.setVersion(version);
+                                return readFrom(streamInput);
+                            }
                         }
                     }
                 }
@@ -400,13 +413,17 @@ public abstract class MetadataStateFormat<T> {
      * @param dataLocations the data-locations to try.
      * @return the state of asked generation or <code>null</code> if no state was found.
      */
-    public T loadGeneration(Logger logger, NamedXContentRegistry namedXContentRegistry, long generation, Path... dataLocations) {
+    public T loadGeneration(Logger logger,
+                            NamedWriteableRegistry namedWriteableRegistry,
+                            NamedXContentRegistry namedXContentRegistry,
+                            long generation,
+                            Path... dataLocations) {
         List<Path> stateFiles = findStateFilesByGeneration(generation, dataLocations);
 
         final List<Throwable> exceptions = new ArrayList<>();
         for (Path stateFile : stateFiles) {
             try {
-                T state = read(namedXContentRegistry, stateFile);
+                T state = read(namedWriteableRegistry, namedXContentRegistry, stateFile);
                 logger.trace("generation id [{}] read from [{}]", generation, stateFile.getFileName());
                 return state;
             } catch (Exception e) {
@@ -432,10 +449,12 @@ public abstract class MetadataStateFormat<T> {
      * @param dataLocations the data-locations to try.
      * @return tuple of the latest state and generation. (null, -1) if no state is found.
      */
-    public Tuple<T, Long> loadLatestStateWithGeneration(Logger logger, NamedXContentRegistry namedXContentRegistry, Path... dataLocations)
-            throws IOException {
+    public Tuple<T, Long> loadLatestStateWithGeneration(Logger logger,
+                                                        NamedWriteableRegistry namedWriteableRegistry,
+                                                        NamedXContentRegistry namedXContentRegistry,
+                                                        Path... dataLocations) throws IOException {
         long generation = findMaxGenerationId(prefix, dataLocations);
-        T state = loadGeneration(logger, namedXContentRegistry, generation, dataLocations);
+        T state = loadGeneration(logger, namedWriteableRegistry, namedXContentRegistry, generation, dataLocations);
 
         if (generation > -1 && state == null) {
             throw new IllegalStateException(
@@ -456,9 +475,9 @@ public abstract class MetadataStateFormat<T> {
      * @param dataLocations the data-locations to try.
      * @return the latest state or <code>null</code> if no state was found.
      */
-    public T loadLatestState(Logger logger, NamedXContentRegistry namedXContentRegistry, Path... dataLocations) throws
+    public T loadLatestState(Logger logger, NamedWriteableRegistry namedWriteableRegistry, NamedXContentRegistry namedXContentRegistry, Path... dataLocations) throws
             IOException {
-        return loadLatestStateWithGeneration(logger, namedXContentRegistry, dataLocations).v1();
+        return loadLatestStateWithGeneration(logger, namedWriteableRegistry, namedXContentRegistry, dataLocations).v1();
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/seqno/ReplicationTracker.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/ReplicationTracker.java
@@ -50,6 +50,7 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.routing.AllocationId;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -462,7 +463,7 @@ public class ReplicationTracker extends AbstractIndexShardComponent implements L
     public RetentionLeases loadRetentionLeases(final Path path) throws IOException {
         final RetentionLeases retentionLeases;
         synchronized (retentionLeasePersistenceLock) {
-            retentionLeases = RetentionLeases.FORMAT.loadLatestState(logger, NamedXContentRegistry.EMPTY, path);
+            retentionLeases = RetentionLeases.FORMAT.loadLatestState(logger, NamedWriteableRegistry.EMPTY, NamedXContentRegistry.EMPTY, path);
         }
 
         if (retentionLeases == null) {
@@ -498,7 +499,7 @@ public class ReplicationTracker extends AbstractIndexShardComponent implements L
     }
 
     public boolean assertRetentionLeasesPersisted(final Path path) throws IOException {
-        assert RetentionLeases.FORMAT.loadLatestState(logger, NamedXContentRegistry.EMPTY, path) != null;
+        assert RetentionLeases.FORMAT.loadLatestState(logger, NamedWriteableRegistry.EMPTY, NamedXContentRegistry.EMPTY, path) != null;
         return true;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeases.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeases.java
@@ -33,7 +33,6 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ConstructingObjectParser;
 import org.elasticsearch.common.xcontent.ParseField;
-import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -223,11 +222,6 @@ public class RetentionLeases implements ToXContentFragment, Writeable {
     }
 
     static final MetadataStateFormat<RetentionLeases> FORMAT = new MetadataStateFormat<>("retention-leases-") {
-
-        @Override
-        public void toXContent(final XContentBuilder builder, final RetentionLeases retentionLeases) throws IOException {
-            retentionLeases.toXContent(builder, ToXContent.EMPTY_PARAMS);
-        }
 
         @Override
         public RetentionLeases fromXContent(final XContentParser parser) {

--- a/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeases.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeases.java
@@ -234,6 +234,10 @@ public class RetentionLeases implements ToXContentFragment, Writeable {
             return RetentionLeases.fromXContent(parser);
         }
 
+        @Override
+        public RetentionLeases readFrom(StreamInput in) throws IOException {
+            return new RetentionLeases(in);
+        }
     };
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/shard/ShardPath.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/ShardPath.java
@@ -32,6 +32,7 @@ import java.util.Objects;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.util.Strings;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.env.ShardLock;
@@ -133,7 +134,7 @@ public final class ShardPath {
         Path loadedPath = null;
         for (Path path : availableShardPaths) {
             // EMPTY is safe here because we never call namedObject
-            ShardStateMetadata load = ShardStateMetadata.FORMAT.loadLatestState(logger, NamedXContentRegistry.EMPTY, path);
+            ShardStateMetadata load = ShardStateMetadata.FORMAT.loadLatestState(logger, NamedWriteableRegistry.EMPTY, NamedXContentRegistry.EMPTY, path);
             if (load != null) {
                 if (load.indexUUID.equals(indexUUID) == false && IndexMetadata.INDEX_UUID_NA_VALUE.equals(load.indexUUID) == false) {
                     logger.warn("{} found shard on path: [{}] with a different index UUID - this "
@@ -175,7 +176,7 @@ public final class ShardPath {
         final Path[] paths = env.availableShardPaths(lock.getShardId());
         for (Path path : paths) {
             // EMPTY is safe here because we never call namedObject
-            ShardStateMetadata load = ShardStateMetadata.FORMAT.loadLatestState(logger, NamedXContentRegistry.EMPTY, path);
+            ShardStateMetadata load = ShardStateMetadata.FORMAT.loadLatestState(logger, NamedWriteableRegistry.EMPTY, NamedXContentRegistry.EMPTY, path);
             if (load != null) {
                 if (load.indexUUID.equals(indexUUID) == false && IndexMetadata.INDEX_UUID_NA_VALUE.equals(load.indexUUID) == false) {
                     logger.warn("{} deleting leftover shard on path: [{}] with a different index UUID", lock.getShardId(), path);

--- a/server/src/main/java/org/elasticsearch/index/shard/ShardStateMetadata.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/ShardStateMetadata.java
@@ -19,19 +19,22 @@
 
 package org.elasticsearch.index.shard;
 
+import java.io.IOException;
+import java.io.OutputStream;
+
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.routing.AllocationId;
-import org.jetbrains.annotations.Nullable;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.gateway.CorruptStateException;
 import org.elasticsearch.gateway.MetadataStateFormat;
+import org.jetbrains.annotations.Nullable;
 
-import java.io.IOException;
-import java.io.OutputStream;
-
-public final class ShardStateMetadata {
+public final class ShardStateMetadata implements Writeable {
 
     private static final String SHARD_STATE_FILE_PREFIX = "state-";
     private static final String PRIMARY_KEY = "primary";
@@ -49,6 +52,19 @@ public final class ShardStateMetadata {
         this.primary = primary;
         this.indexUUID = indexUUID;
         this.allocationId = allocationId;
+    }
+
+    public ShardStateMetadata(StreamInput in) throws IOException {
+        this.primary = in.readBoolean();
+        this.indexUUID = in.readString();
+        this.allocationId = in.readOptionalWriteable(AllocationId::new);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeBoolean(primary);
+        out.writeString(indexUUID);
+        out.writeOptionalWriteable(allocationId);
     }
 
     @Override
@@ -143,6 +159,11 @@ public final class ShardStateMetadata {
                 throw new CorruptStateException("missing value for [primary] in shard state");
             }
             return new ShardStateMetadata(primary, indexUUID, allocationId);
+        }
+
+        @Override
+        public ShardStateMetadata readFrom(StreamInput in) throws IOException {
+            return new ShardStateMetadata(in);
         }
     };
 }

--- a/server/src/main/java/org/elasticsearch/index/shard/ShardStateMetadata.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/ShardStateMetadata.java
@@ -20,16 +20,13 @@
 package org.elasticsearch.index.shard;
 
 import java.io.IOException;
-import java.io.OutputStream;
 
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.routing.AllocationId;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.gateway.CorruptStateException;
 import org.elasticsearch.gateway.MetadataStateFormat;
 import org.jetbrains.annotations.Nullable;
@@ -105,22 +102,6 @@ public final class ShardStateMetadata implements Writeable {
     }
 
     public static final MetadataStateFormat<ShardStateMetadata> FORMAT = new MetadataStateFormat<ShardStateMetadata>(SHARD_STATE_FILE_PREFIX) {
-
-        @Override
-        protected XContentBuilder newXContentBuilder(XContentType type, OutputStream stream) throws IOException {
-            XContentBuilder xContentBuilder = super.newXContentBuilder(type, stream);
-            xContentBuilder.prettyPrint();
-            return xContentBuilder;
-        }
-
-        @Override
-        public void toXContent(XContentBuilder builder, ShardStateMetadata shardStateMetadata) throws IOException {
-            builder.field(PRIMARY_KEY, shardStateMetadata.primary);
-            builder.field(INDEX_UUID_KEY, shardStateMetadata.indexUUID);
-            if (shardStateMetadata.allocationId != null) {
-                builder.field(ALLOCATION_ID_KEY, shardStateMetadata.allocationId);
-            }
-        }
 
         @Override
         public ShardStateMetadata fromXContent(XContentParser parser) throws IOException {

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -488,8 +488,12 @@ public class Node implements Closeable {
                 MetadataModule.getNamedXContents(nodeContext).stream())
                 .flatMap(Function.identity()).collect(Collectors.toList()));
             final MetaStateService metaStateService = new MetaStateService(nodeEnvironment, xContentRegistry);
-            final PersistedClusterStateService persistedClusterStateService
-                = new PersistedClusterStateService(nodeEnvironment, xContentRegistry, bigArrays, clusterService.getClusterSettings(),
+            final PersistedClusterStateService persistedClusterStateService = new PersistedClusterStateService(
+                nodeEnvironment,
+                xContentRegistry,
+                namedWriteableRegistry,
+                bigArrays,
+                clusterService.getClusterSettings(),
                 threadPool::relativeTimeInMillis);
 
             // collect engine factory providers from server and from plugins

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -487,7 +487,7 @@ public class Node implements Closeable {
                 ClusterModule.getNamedXWriteables().stream(),
                 MetadataModule.getNamedXContents(nodeContext).stream())
                 .flatMap(Function.identity()).collect(Collectors.toList()));
-            final MetaStateService metaStateService = new MetaStateService(nodeEnvironment, xContentRegistry);
+            final MetaStateService metaStateService = new MetaStateService(nodeEnvironment, namedWriteableRegistry, xContentRegistry);
             final PersistedClusterStateService persistedClusterStateService = new PersistedClusterStateService(
                 nodeEnvironment,
                 xContentRegistry,
@@ -1059,8 +1059,12 @@ public class Node implements Closeable {
         if (Assertions.ENABLED) {
             try {
                 assert injector.getInstance(MetaStateService.class).loadFullState().v1().isEmpty();
-                final NodeMetadata nodeMetadata = NodeMetadata.FORMAT.loadLatestState(logger, NamedXContentRegistry.EMPTY,
-                                                                                      nodeEnvironment.nodeDataPaths());
+                final NodeMetadata nodeMetadata = NodeMetadata.FORMAT.loadLatestState(
+                    logger,
+                    NamedWriteableRegistry.EMPTY,
+                    NamedXContentRegistry.EMPTY,
+                    nodeEnvironment.nodeDataPaths()
+                );
                 assert nodeMetadata != null;
                 assert nodeMetadata.nodeVersion().equals(Version.CURRENT);
                 assert nodeMetadata.nodeId().equals(localNodeFactory.getNode().getId());

--- a/server/src/test/java/io/crate/role/metadata/CustomMetadataTest.java
+++ b/server/src/test/java/io/crate/role/metadata/CustomMetadataTest.java
@@ -30,6 +30,7 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.DeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
@@ -81,7 +82,7 @@ public class CustomMetadataTest {
     private String xContentFromMetadata(Metadata metadata) throws IOException {
         XContentBuilder builder = JsonXContent.builder();
         builder.startObject();
-        Metadata.FORMAT.toXContent(builder, metadata);
+        metadata.toXContent(builder, ToXContent.EMPTY_PARAMS);
         builder.endObject();
         return Strings.toString(builder);
     }

--- a/server/src/test/java/org/elasticsearch/env/NodeMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/env/NodeMetadataTests.java
@@ -50,7 +50,7 @@ public class NodeMetadataTests extends ESTestCase {
                                                        nodeMetadata -> {
                                                            final long generation = NodeMetadata.FORMAT.writeAndCleanup(nodeMetadata, tempDir);
                                                            final Tuple<NodeMetadata, Long> nodeMetadataLongTuple
-                                                               = NodeMetadata.FORMAT.loadLatestStateWithGeneration(logger, xContentRegistry(), tempDir);
+                                                               = NodeMetadata.FORMAT.loadLatestStateWithGeneration(logger, writableRegistry(), xContentRegistry(), tempDir);
                                                            assertThat(nodeMetadataLongTuple.v2()).isEqualTo(generation);
                                                            return nodeMetadataLongTuple.v1();
                                                        }, nodeMetadata -> {
@@ -74,7 +74,7 @@ public class NodeMetadataTests extends ESTestCase {
         final InputStream resource = this.getClass().getResourceAsStream("testReadsFormatWithoutVersion.binary");
         assertThat(resource).isNotNull();
         Files.copy(resource, stateDir.resolve(NodeMetadata.FORMAT.getStateFileName(between(0, Integer.MAX_VALUE))));
-        final NodeMetadata nodeMetadata = NodeMetadata.FORMAT.loadLatestState(logger, xContentRegistry(), tempDir);
+        final NodeMetadata nodeMetadata = NodeMetadata.FORMAT.loadLatestState(logger, writableRegistry(), xContentRegistry(), tempDir);
         assertThat(nodeMetadata.nodeId()).isEqualTo("y6VUVMSaStO4Tz-B5BxcOw");
         assertThat(nodeMetadata.nodeVersion()).isEqualTo(Version.V_EMPTY);
     }

--- a/server/src/test/java/org/elasticsearch/env/NodeRepurposeCommandTests.java
+++ b/server/src/test/java/org/elasticsearch/env/NodeRepurposeCommandTests.java
@@ -72,7 +72,8 @@ public class NodeRepurposeCommandTests extends ESTestCase {
             nodePaths = nodeEnvironment.nodeDataPaths();
             final String nodeId = randomAlphaOfLength(10);
             try (PersistedClusterStateService.Writer writer = new PersistedClusterStateService(nodePaths, nodeId,
-                xContentRegistry(), BigArrays.NON_RECYCLING_INSTANCE,
+                xContentRegistry(),
+                writableRegistry(), BigArrays.NON_RECYCLING_INSTANCE,
                 new ClusterSettings(dataMasterSettings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS), () -> 0L, true).createWriter()) {
                 writer.writeFullStateAndCommit(1L, ClusterState.EMPTY_STATE);
             }

--- a/server/src/test/java/org/elasticsearch/env/OverrideNodeVersionCommandTests.java
+++ b/server/src/test/java/org/elasticsearch/env/OverrideNodeVersionCommandTests.java
@@ -58,7 +58,7 @@ public class OverrideNodeVersionCommandTests extends ESTestCase {
             nodeId = nodeEnvironment.nodeId();
 
             try (PersistedClusterStateService.Writer writer = new PersistedClusterStateService(nodePaths, nodeId,
-                xContentRegistry(), BigArrays.NON_RECYCLING_INSTANCE,
+                xContentRegistry(), writableRegistry(), BigArrays.NON_RECYCLING_INSTANCE,
                 new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS), () -> 0L, true).createWriter()) {
                 writer.writeFullStateAndCommit(1L, ClusterState.builder(ClusterName.DEFAULT).metadata(Metadata.builder()
                     .persistentSettings(Settings.builder().put(Metadata.SETTING_READ_ONLY_SETTING.getKey(), true).build()).build())
@@ -71,7 +71,7 @@ public class OverrideNodeVersionCommandTests extends ESTestCase {
     @After
     public void checkClusterStateIntact() throws IOException {
         assertThat(Metadata.SETTING_READ_ONLY_SETTING.get(new PersistedClusterStateService(nodePaths, nodeId,
-            xContentRegistry(), BigArrays.NON_RECYCLING_INSTANCE,
+            xContentRegistry(), writableRegistry(), BigArrays.NON_RECYCLING_INSTANCE,
             new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS), () -> 0L, true)
             .loadBestOnDiskState().metadata.persistentSettings())).isTrue();
     }

--- a/server/src/test/java/org/elasticsearch/gateway/DanglingIndicesStateTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/DanglingIndicesStateTests.java
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.elasticsearch.gateway;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -58,7 +59,7 @@ public class DanglingIndicesStateTests extends ESTestCase {
 
     public void testCleanupWhenEmpty() throws Exception {
         try (NodeEnvironment env = newNodeEnvironment()) {
-            MetaStateService metaStateService = new MetaStateService(env, xContentRegistry());
+            MetaStateService metaStateService = new MetaStateService(env, writableRegistry(), xContentRegistry());
             DanglingIndicesState danglingState = createDanglingIndicesState(env, metaStateService);
 
             assertThat(danglingState.getDanglingIndices().isEmpty()).isTrue();
@@ -70,7 +71,7 @@ public class DanglingIndicesStateTests extends ESTestCase {
 
     public void testDanglingIndicesDiscovery() throws Exception {
         try (NodeEnvironment env = newNodeEnvironment()) {
-            MetaStateService metaStateService = new MetaStateService(env, xContentRegistry());
+            MetaStateService metaStateService = new MetaStateService(env, writableRegistry(), xContentRegistry());
             DanglingIndicesState danglingState = createDanglingIndicesState(env, metaStateService);
             assertThat(danglingState.getDanglingIndices().isEmpty()).isTrue();
             Metadata metadata = Metadata.builder().build();
@@ -87,7 +88,7 @@ public class DanglingIndicesStateTests extends ESTestCase {
 
     public void testInvalidIndexFolder() throws Exception {
         try (NodeEnvironment env = newNodeEnvironment()) {
-            MetaStateService metaStateService = new MetaStateService(env, xContentRegistry());
+            MetaStateService metaStateService = new MetaStateService(env, writableRegistry(), xContentRegistry());
             DanglingIndicesState danglingState = createDanglingIndicesState(env, metaStateService);
 
             Metadata metadata = Metadata.builder().build();
@@ -111,7 +112,7 @@ public class DanglingIndicesStateTests extends ESTestCase {
 
     public void testDanglingProcessing() throws Exception {
         try (NodeEnvironment env = newNodeEnvironment()) {
-            MetaStateService metaStateService = new MetaStateService(env, xContentRegistry());
+            MetaStateService metaStateService = new MetaStateService(env, writableRegistry(), xContentRegistry());
             DanglingIndicesState danglingState = createDanglingIndicesState(env, metaStateService);
 
             Metadata metadata = Metadata.builder().build();
@@ -152,7 +153,7 @@ public class DanglingIndicesStateTests extends ESTestCase {
 
     public void testDanglingIndicesNotImportedWhenTombstonePresent() throws Exception {
         try (NodeEnvironment env = newNodeEnvironment()) {
-            MetaStateService metaStateService = new MetaStateService(env, xContentRegistry());
+            MetaStateService metaStateService = new MetaStateService(env, writableRegistry(), xContentRegistry());
             DanglingIndicesState danglingState = createDanglingIndicesState(env, metaStateService);
 
             final Settings.Builder settings = Settings.builder().put(indexSettings).put(IndexMetadata.SETTING_INDEX_UUID, "test1UUID");
@@ -167,7 +168,7 @@ public class DanglingIndicesStateTests extends ESTestCase {
 
     public void testDanglingIndicesAreNotAllocatedWhenDisabled() throws Exception {
         try (NodeEnvironment env = newNodeEnvironment()) {
-            MetaStateService metaStateService = new MetaStateService(env, xContentRegistry());
+            MetaStateService metaStateService = new MetaStateService(env, writableRegistry(), xContentRegistry());
             LocalAllocateDangledIndices localAllocateDangledIndices = mock(LocalAllocateDangledIndices.class);
 
             final Settings allocateSettings = Settings.builder().put(AUTO_IMPORT_DANGLING_INDICES_SETTING.getKey(), false).build();
@@ -187,7 +188,7 @@ public class DanglingIndicesStateTests extends ESTestCase {
 
     public void testDanglingIndicesAreAllocatedWhenEnabled() throws Exception {
         try (NodeEnvironment env = newNodeEnvironment()) {
-            MetaStateService metaStateService = new MetaStateService(env, xContentRegistry());
+            MetaStateService metaStateService = new MetaStateService(env, writableRegistry(), xContentRegistry());
             LocalAllocateDangledIndices localAllocateDangledIndices = mock(LocalAllocateDangledIndices.class);
             final Settings allocateSettings = Settings.builder().put(AUTO_IMPORT_DANGLING_INDICES_SETTING.getKey(), true).build();
 

--- a/server/src/test/java/org/elasticsearch/gateway/GatewayMetaStatePersistedStateTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/GatewayMetaStatePersistedStateTests.java
@@ -92,7 +92,7 @@ public class GatewayMetaStatePersistedStateTests extends ESTestCase {
 
     private CoordinationState.PersistedState newGatewayPersistedState() {
         final MockGatewayMetaState gateway = new MockGatewayMetaState(localNode, bigArrays);
-        gateway.start(settings, nodeEnvironment, xContentRegistry());
+        gateway.start(settings, nodeEnvironment, xContentRegistry(), writableRegistry());
         final CoordinationState.PersistedState persistedState = gateway.getPersistedState();
         assertThat(persistedState).isExactlyInstanceOf(GatewayMetaState.LucenePersistedState.class);
         return persistedState;
@@ -299,7 +299,7 @@ public class GatewayMetaStatePersistedStateTests extends ESTestCase {
     public void testStatePersistedOnLoad() throws IOException {
         // open LucenePersistedState to make sure that cluster state is written out to each data path
         final PersistedClusterStateService persistedClusterStateService =
-            new PersistedClusterStateService(nodeEnvironment, xContentRegistry(), getBigArrays(),
+            new PersistedClusterStateService(nodeEnvironment, xContentRegistry(), writableRegistry(), getBigArrays(),
                 new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS), () -> 0L);
         final ClusterState state = createClusterState(randomNonNegativeLong(),
                                                       Metadata.builder().clusterUUID(randomAlphaOfLength(10)).build());
@@ -318,7 +318,7 @@ public class GatewayMetaStatePersistedStateTests extends ESTestCase {
                 .put(Environment.PATH_DATA_SETTING.getKey(), path.getParent().getParent().toString()).build();
             try (NodeEnvironment nodeEnvironment = new NodeEnvironment(settings, TestEnvironment.newEnvironment(settings))) {
                 final PersistedClusterStateService newPersistedClusterStateService =
-                    new PersistedClusterStateService(nodeEnvironment, xContentRegistry(), getBigArrays(),
+                    new PersistedClusterStateService(nodeEnvironment, xContentRegistry(), writableRegistry(), getBigArrays(),
                         new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS), () -> 0L);
                 final PersistedClusterStateService.OnDiskState onDiskState = newPersistedClusterStateService.loadBestOnDiskState();
                 assertThat(onDiskState.empty()).as("Path should not be empty: " + path.toAbsolutePath()).isFalse();
@@ -344,7 +344,7 @@ public class GatewayMetaStatePersistedStateTests extends ESTestCase {
         when(clusterService.getClusterSettings()).thenReturn(
             new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS));
         final PersistedClusterStateService persistedClusterStateService =
-            new PersistedClusterStateService(nodeEnvironment, xContentRegistry(), BigArrays.NON_RECYCLING_INSTANCE,
+            new PersistedClusterStateService(nodeEnvironment, xContentRegistry(), writableRegistry(), BigArrays.NON_RECYCLING_INSTANCE,
                 new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS), () -> 0L);
         gateway.start(settings, transportService, clusterService,
                       new MetaStateService(nodeEnvironment, xContentRegistry()), null, null, persistedClusterStateService);
@@ -422,7 +422,7 @@ public class GatewayMetaStatePersistedStateTests extends ESTestCase {
         final AtomicReference<Double> ioExceptionRate = new AtomicReference<>(0.01d);
         final List<MockDirectoryWrapper> list = new ArrayList<>();
         final PersistedClusterStateService persistedClusterStateService =
-            new PersistedClusterStateService(nodeEnvironment, xContentRegistry(), getBigArrays(),
+            new PersistedClusterStateService(nodeEnvironment, xContentRegistry(), writableRegistry(), getBigArrays(),
                 new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS), () -> 0L) {
                 @Override
                 Directory createDirectory(Path path) {
@@ -499,7 +499,7 @@ public class GatewayMetaStatePersistedStateTests extends ESTestCase {
                 .put(Environment.PATH_DATA_SETTING.getKey(), path.getParent().getParent().toString()).build();
             try (NodeEnvironment nodeEnvironment = new NodeEnvironment(settings, TestEnvironment.newEnvironment(settings))) {
                 final PersistedClusterStateService newPersistedClusterStateService =
-                    new PersistedClusterStateService(nodeEnvironment, xContentRegistry(), getBigArrays(),
+                    new PersistedClusterStateService(nodeEnvironment, xContentRegistry(), writableRegistry(), getBigArrays(),
                         new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS), () -> 0L);
                 final PersistedClusterStateService.OnDiskState onDiskState = newPersistedClusterStateService.loadBestOnDiskState();
                 assertThat(onDiskState.empty()).isFalse();

--- a/server/src/test/java/org/elasticsearch/gateway/GatewayMetaStatePersistedStateTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/GatewayMetaStatePersistedStateTests.java
@@ -347,7 +347,7 @@ public class GatewayMetaStatePersistedStateTests extends ESTestCase {
             new PersistedClusterStateService(nodeEnvironment, xContentRegistry(), writableRegistry(), BigArrays.NON_RECYCLING_INSTANCE,
                 new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS), () -> 0L);
         gateway.start(settings, transportService, clusterService,
-                      new MetaStateService(nodeEnvironment, xContentRegistry()), null, null, persistedClusterStateService);
+                      new MetaStateService(nodeEnvironment, writableRegistry(), xContentRegistry()), null, null, persistedClusterStateService);
         final CoordinationState.PersistedState persistedState = gateway.getPersistedState();
         assertThat(persistedState).isExactlyInstanceOf(GatewayMetaState.AsyncLucenePersistedState.class);
 

--- a/server/src/test/java/org/elasticsearch/gateway/IncrementalClusterStateWriterTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/IncrementalClusterStateWriterTests.java
@@ -63,7 +63,6 @@ import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
-import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.index.Index;
@@ -311,10 +310,6 @@ public class IncrementalClusterStateWriterTests extends ESAllocationTestCase {
 
         private <T extends Writeable> MetadataStateFormat<T> wrap(MetadataStateFormat<T> format) {
             return new MetadataStateFormat<T>(format.getPrefix()) {
-                @Override
-                public void toXContent(XContentBuilder builder, T state) throws IOException {
-                    format.toXContent(builder, state);
-                }
 
                 @Override
                 public T fromXContent(XContentParser parser) throws IOException {

--- a/server/src/test/java/org/elasticsearch/gateway/MockGatewayMetaState.java
+++ b/server/src/test/java/org/elasticsearch/gateway/MockGatewayMetaState.java
@@ -30,6 +30,7 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.MetadataIndexUpgradeService;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
@@ -69,7 +70,7 @@ public class MockGatewayMetaState extends GatewayMetaState {
         return ClusterStateUpdaters.setLocalNode(clusterState, localNode);
     }
 
-    public void start(Settings settings, NodeEnvironment nodeEnvironment, NamedXContentRegistry xContentRegistry) {
+    public void start(Settings settings, NodeEnvironment nodeEnvironment, NamedXContentRegistry namedXContentRegistry, NamedWriteableRegistry namedWritableRegistry) {
         final TransportService transportService = mock(TransportService.class);
         when(transportService.getThreadPool()).thenReturn(mock(ThreadPool.class));
         final ClusterService clusterService = mock(ClusterService.class);
@@ -81,8 +82,22 @@ public class MockGatewayMetaState extends GatewayMetaState {
         } catch (IOException e) {
             throw new AssertionError(e);
         }
-        start(settings, transportService, clusterService, metaStateService,
-            null, null, new PersistedClusterStateService(nodeEnvironment, xContentRegistry, bigArrays,
-                new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS), () -> 0L));
+        PersistedClusterStateService persistedClusterStateService = new PersistedClusterStateService(
+            nodeEnvironment,
+            namedXContentRegistry,
+            namedWritableRegistry,
+            bigArrays,
+            new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
+            () -> 0L
+        );
+        start(
+            settings,
+            transportService,
+            clusterService,
+            metaStateService,
+            null,
+            null,
+            persistedClusterStateService
+        );
     }
 }

--- a/server/src/test/java/org/elasticsearch/gateway/PersistedClusterStateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/PersistedClusterStateServiceTests.java
@@ -74,9 +74,14 @@ import io.crate.common.io.IOUtils;
 public class PersistedClusterStateServiceTests extends ESTestCase {
 
     private PersistedClusterStateService newPersistedClusterStateService(NodeEnvironment nodeEnvironment) {
-        return new PersistedClusterStateService(nodeEnvironment, xContentRegistry(), getBigArrays(),
+        return new PersistedClusterStateService(
+            nodeEnvironment,
+            xContentRegistry(),
+            writableRegistry(),
+            getBigArrays(),
             new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
-            () -> 0L);
+            () -> 0L
+        );
     }
 
     public void testPersistsAndReloadsTerm() throws IOException {
@@ -346,7 +351,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
 
         try (NodeEnvironment nodeEnvironment = newNodeEnvironment(createDataPaths())) {
             final PersistedClusterStateService persistedClusterStateService
-                = new PersistedClusterStateService(nodeEnvironment, xContentRegistry(), getBigArrays(),
+                = new PersistedClusterStateService(nodeEnvironment, xContentRegistry(), writableRegistry(), getBigArrays(),
                 new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS), () -> 0L) {
                 @Override
                 Directory createDirectory(Path path) throws IOException {
@@ -384,7 +389,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
 
         try (NodeEnvironment nodeEnvironment = newNodeEnvironment(createDataPaths())) {
             final PersistedClusterStateService persistedClusterStateService
-                = new PersistedClusterStateService(nodeEnvironment, xContentRegistry(), getBigArrays(),
+                = new PersistedClusterStateService(nodeEnvironment, xContentRegistry(), writableRegistry(), getBigArrays(),
                 new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS), () -> 0L) {
                 @Override
                 Directory createDirectory(Path path) throws IOException {
@@ -430,7 +435,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
 
         try (NodeEnvironment nodeEnvironment = newNodeEnvironment(createDataPaths())) {
             final PersistedClusterStateService persistedClusterStateService
-                = new PersistedClusterStateService(nodeEnvironment, xContentRegistry(), getBigArrays(),
+                = new PersistedClusterStateService(nodeEnvironment, xContentRegistry(), writableRegistry(), getBigArrays(),
                 new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS), () -> 0L) {
                 @Override
                 Directory createDirectory(Path path) throws IOException {
@@ -812,7 +817,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
         final ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
         try (NodeEnvironment nodeEnvironment = newNodeEnvironment(createDataPaths())) {
             PersistedClusterStateService persistedClusterStateService = new PersistedClusterStateService(nodeEnvironment,
-                    xContentRegistry(), getBigArrays(), clusterSettings, () -> currentTime.getAndAdd(writeDurationMillis.get()));
+                    xContentRegistry(), writableRegistry(), getBigArrays(), clusterSettings, () -> currentTime.getAndAdd(writeDurationMillis.get()));
 
             try (Writer writer = persistedClusterStateService.createWriter()) {
                 assertExpectedLogs(1L, null, clusterState, writer, new MockLogAppender.SeenEventExpectation(

--- a/server/src/test/java/org/elasticsearch/index/seqno/ReplicationTrackerRetentionLeaseTests.java
+++ b/server/src/test/java/org/elasticsearch/index/seqno/ReplicationTrackerRetentionLeaseTests.java
@@ -623,11 +623,11 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
         replicationTracker.persistRetentionLeases(path);
 
         final Tuple<RetentionLeases, Long> retentionLeasesWithGeneration =
-                RetentionLeases.FORMAT.loadLatestStateWithGeneration(logger, NamedXContentRegistry.EMPTY, path);
+                RetentionLeases.FORMAT.loadLatestStateWithGeneration(logger, writableRegistry(), NamedXContentRegistry.EMPTY, path);
 
         replicationTracker.persistRetentionLeases(path);
         final Tuple<RetentionLeases, Long> retentionLeasesWithGenerationAfterUnnecessaryPersistence =
-                RetentionLeases.FORMAT.loadLatestStateWithGeneration(logger, NamedXContentRegistry.EMPTY, path);
+                RetentionLeases.FORMAT.loadLatestStateWithGeneration(logger, writableRegistry(), NamedXContentRegistry.EMPTY, path);
 
         assertThat(retentionLeasesWithGenerationAfterUnnecessaryPersistence.v1()).isEqualTo(retentionLeasesWithGeneration.v1());
         assertThat(retentionLeasesWithGenerationAfterUnnecessaryPersistence.v2()).isEqualTo(retentionLeasesWithGeneration.v2());

--- a/server/src/test/java/org/elasticsearch/index/seqno/RetentionLeasesTests.java
+++ b/server/src/test/java/org/elasticsearch/index/seqno/RetentionLeasesTests.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.test.ESTestCase;
 
@@ -96,7 +97,7 @@ public class RetentionLeasesTests extends ESTestCase {
         final Path path = createTempDir();
         final RetentionLeases retentionLeases = randomRetentionLeases(true);
         RetentionLeases.FORMAT.writeAndCleanup(retentionLeases, path);
-        assertThat(RetentionLeases.FORMAT.loadLatestState(logger, NamedXContentRegistry.EMPTY, path)).isEqualTo(retentionLeases);
+        assertThat(RetentionLeases.FORMAT.loadLatestState(logger, NamedWriteableRegistry.EMPTY, NamedXContentRegistry.EMPTY, path)).isEqualTo(retentionLeases);
     }
 
     private RetentionLeases randomRetentionLeases(boolean allowEmpty) {

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -97,6 +97,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.lease.Releasables;
@@ -188,19 +189,19 @@ public class IndexShardTests extends IndexShardTestCase {
             ShardStateMetadata state1 = new ShardStateMetadata(primary, "fooUUID", allocationId);
             ShardStateMetadata.FORMAT.writeAndCleanup(state1, env.availableShardPaths(id));
             ShardStateMetadata shardStateMetadata = ShardStateMetadata.FORMAT
-                .loadLatestState(logger, NamedXContentRegistry.EMPTY, env.availableShardPaths(id));
+                .loadLatestState(logger, NamedWriteableRegistry.EMPTY, NamedXContentRegistry.EMPTY, env.availableShardPaths(id));
             assertThat(shardStateMetadata).isEqualTo(state1);
 
             ShardStateMetadata state2 = new ShardStateMetadata(primary, "fooUUID", allocationId);
             ShardStateMetadata.FORMAT.writeAndCleanup(state2, env.availableShardPaths(id));
             shardStateMetadata = ShardStateMetadata.FORMAT
-                .loadLatestState(logger, NamedXContentRegistry.EMPTY, env.availableShardPaths(id));
+                .loadLatestState(logger, NamedWriteableRegistry.EMPTY, NamedXContentRegistry.EMPTY, env.availableShardPaths(id));
             assertThat(shardStateMetadata).isEqualTo(state1);
 
             ShardStateMetadata state3 = new ShardStateMetadata(primary, "fooUUID", allocationId);
             ShardStateMetadata.FORMAT.writeAndCleanup(state3, env.availableShardPaths(id));
             shardStateMetadata = ShardStateMetadata.FORMAT
-                .loadLatestState(logger, NamedXContentRegistry.EMPTY, env.availableShardPaths(id));
+                .loadLatestState(logger, NamedWriteableRegistry.EMPTY, NamedXContentRegistry.EMPTY, env.availableShardPaths(id));
             assertThat(shardStateMetadata).isEqualTo(state3);
             assertThat("fooUUID").isEqualTo(state3.indexUUID);
         }
@@ -211,13 +212,13 @@ public class IndexShardTests extends IndexShardTestCase {
         IndexShard shard = newStartedShard();
         Path shardStatePath = shard.shardPath().getShardStatePath();
         ShardStateMetadata shardStateMetadata  = ShardStateMetadata.FORMAT
-            .loadLatestState(logger, NamedXContentRegistry.EMPTY, shardStatePath);
+            .loadLatestState(logger, NamedWriteableRegistry.EMPTY, NamedXContentRegistry.EMPTY, shardStatePath);
         assertThat(getShardStateMetadata(shard)).isEqualTo(shardStateMetadata);
         ShardRouting routing = shard.shardRouting;
         IndexShardTestCase.updateRoutingEntry(shard, routing);
 
         shardStateMetadata  = ShardStateMetadata.FORMAT
-            .loadLatestState(logger, NamedXContentRegistry.EMPTY, shardStatePath);
+            .loadLatestState(logger, NamedWriteableRegistry.EMPTY, NamedXContentRegistry.EMPTY, shardStatePath);
         assertThat(shardStateMetadata).isEqualTo(getShardStateMetadata(shard));
         assertThat(shardStateMetadata).isEqualTo(
             new ShardStateMetadata(
@@ -229,7 +230,7 @@ public class IndexShardTests extends IndexShardTestCase {
         routing = TestShardRouting.relocate(shard.shardRouting, "some node", 42L);
         IndexShardTestCase.updateRoutingEntry(shard, routing);
         shardStateMetadata  = ShardStateMetadata.FORMAT
-            .loadLatestState(logger, NamedXContentRegistry.EMPTY, shardStatePath);
+            .loadLatestState(logger, NamedWriteableRegistry.EMPTY, NamedXContentRegistry.EMPTY, shardStatePath);
         assertThat(shardStateMetadata).isEqualTo(getShardStateMetadata(shard));
         assertThat(shardStateMetadata).isEqualTo(
             new ShardStateMetadata(
@@ -252,7 +253,7 @@ public class IndexShardTests extends IndexShardTestCase {
         shard.store().close();
         // check state file still exists
         ShardStateMetadata shardStateMetadata  = ShardStateMetadata.FORMAT
-            .loadLatestState(logger, NamedXContentRegistry.EMPTY, shardPath.getShardStatePath());
+            .loadLatestState(logger, NamedWriteableRegistry.EMPTY, NamedXContentRegistry.EMPTY, shardPath.getShardStatePath());
 
         assertThat(shardStateMetadata).isEqualTo(getShardStateMetadata(shard));
         // but index can't be opened for a failed shard


### PR DESCRIPTION
Currently ClusterState/Metadata and any custom metadata needs to
implement serialization via xContent for persisted storage and
writeTo/readFrom for communication between nodes.

Having two different serializations adds complexity.

Of the two writeTo/readFrom is more convenient to implement, and has
more surface area. We can use that for storage too.

This will allow us to:

- Add new metadata components with only wirteTo/readFrom, without
  xContent implementations
- Drop the xContent implementations/registry once we no longer need to
  keep them for BWC (probably in 7.0)
- Re-use existing writeTo/readFrom implementations to store structures
  like `Reference` without special mapping representations

Relates to:

- https://github.com/crate/crate/issues/11939

---

I gave the crate-qa bwc tests (storageCompatibility and rolling upgrades) a short try against the branch and it seemed to work.
