### PR TITLE
Fix issues with CHAR comparisons

### DIFF
--- a/docs/appendices/release-notes/5.8.5.rst
+++ b/docs/appendices/release-notes/5.8.5.rst
@@ -47,6 +47,16 @@ See the :ref:`version_5.8.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed behavior of comparing (``=``, ``>``, etc. ) a column of type
+  :ref:`CHAR<type-char>` with string literals, so that any trailing whitespaces
+  are ignored for both sides of the comparison, thus matching PostgreSQL
+  behavior.
+
+- Fixed an issue that could cause comparisons (``=``, ``>``, etc. ) of columns
+  of :ref:`CHAR<type-char>` type to yield different results when in the
+  ``WHERE`` clause, than in any other part of a query, e.g. in the ``SELECT``
+  clause.
+
 - Fixed an issue that led to a ``NullPointerException`` when the same filter
   expression was used multiple times in an aggregation on an aliased table. For
   example::

--- a/docs/appendices/release-notes/5.9.1.rst
+++ b/docs/appendices/release-notes/5.9.1.rst
@@ -47,6 +47,16 @@ See the :ref:`version_5.9.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed behavior of comparing (``=``, ``>``, etc. ) a column of type
+  :ref:`CHAR<type-char>` with string literals, so that any trailing whitespaces
+  are ignored for both sides of the comparison, thus matching PostgreSQL
+  behavior.
+
+- Fixed an issue that could cause comparisons (``=``, ``>``, etc. ) of columns
+  of :ref:`CHAR<type-char>` type to yield different results when in the
+  ``WHERE`` clause, than in any other part of a query, e.g. in the ``SELECT``
+  clause.
+
 - Fixed an issue that led to a ``NullPointerException`` when the same filter
   expression was used multiple times in an aggregation on an aliased table. For
   example::

--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfoFactory.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfoFactory.java
@@ -723,7 +723,7 @@ public class DocTableInfoFactory {
                 Integer lengthLimit = (Integer) columnProperties.get("length_limit");
                 var blankPadding = columnProperties.get("blank_padding");
                 if (blankPadding != null && (Boolean) blankPadding) {
-                    yield new CharacterType(lengthLimit);
+                    yield CharacterType.of(lengthLimit);
                 }
                 yield lengthLimit != null
                     ? StringType.of(lengthLimit)

--- a/server/src/main/java/io/crate/types/CharacterType.java
+++ b/server/src/main/java/io/crate/types/CharacterType.java
@@ -27,12 +27,20 @@ import static io.crate.common.StringUtils.padEnd;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.jetbrains.annotations.Nullable;
 
+import io.crate.execution.dml.FulltextIndexer;
+import io.crate.execution.dml.StringIndexer;
+import io.crate.execution.dml.ValueIndexer;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.Reference;
+import io.crate.metadata.RelationName;
 import io.crate.metadata.settings.SessionSettings;
 import io.crate.sql.tree.ColumnDefinition;
 import io.crate.sql.tree.ColumnPolicy;
@@ -44,6 +52,35 @@ public class CharacterType extends StringType {
     public static final String NAME = "character";
     public static final int ID = 27;
     public static final CharacterType INSTANCE = new CharacterType();
+
+    private StorageSupport<Object> storageSupport(int lengthLimit) {
+        return new StorageSupport<>(
+            true,
+            true,
+            new StringEqQuery(value -> {
+                // strip trailing whitespaces and pad to reach the {@param lengthLimit},
+                // to match the value stored on disk.
+                if (value == null) {
+                    return null;
+                }
+                if (value instanceof String s) {
+                    return padEnd(s.stripTrailing(), lengthLimit, ' ');
+                }
+                return padEnd(((BytesRef) value).utf8ToString().stripTrailing(), lengthLimit, ' ');
+            })
+        ) {
+            @Override
+            @SuppressWarnings({"rawtypes"})
+            public ValueIndexer<Object> valueIndexer(RelationName table,
+                                                     Reference ref,
+                                                     Function<ColumnIdent, Reference> getRef) {
+                return switch (ref.indexType()) {
+                    case FULLTEXT -> (ValueIndexer) new FulltextIndexer(ref);
+                    case NONE, PLAIN -> (ValueIndexer) new StringIndexer(ref);
+                };
+            }
+        };
+    }
 
     public static CharacterType of(List<Integer> parameters) {
         if (parameters.size() != 1) {
@@ -63,14 +100,15 @@ public class CharacterType extends StringType {
         return new CharacterType(lengthLimit);
     }
 
-    private final int lengthLimit;
+    private final StorageSupport<Object> storageSupport;
 
     public CharacterType(StreamInput in) throws IOException {
-        lengthLimit = in.readInt();
+        this(in.readInt());
     }
 
-    public CharacterType(int lengthLimit) {
-        this.lengthLimit = lengthLimit;
+    private CharacterType(int lengthLimit) {
+        super(lengthLimit);
+        storageSupport = storageSupport(lengthLimit);
     }
 
     private CharacterType() {
@@ -85,11 +123,6 @@ public class CharacterType extends StringType {
     @Override
     public int id() {
         return ID;
-    }
-
-    @Override
-    public int lengthLimit() {
-        return lengthLimit;
     }
 
     @Override
@@ -134,10 +167,10 @@ public class CharacterType extends StringType {
             return null;
         }
         var string = cast(value);
-        if (string.length() <= lengthLimit()) {
+        if (string.length() <= lengthLimit) {
             return string;
         } else {
-            return string.substring(0, lengthLimit());
+            return string.substring(0, lengthLimit);
         }
     }
 
@@ -179,5 +212,15 @@ public class CharacterType extends StringType {
     public void addMappingOptions(Map<String, Object> mapping) {
         mapping.put("length_limit", lengthLimit);
         mapping.put("blank_padding", true);
+    }
+
+    @Override
+    public int compare(String val1, String val2) {
+        return val1.stripTrailing().compareTo(val2.stripTrailing());
+    }
+
+    @Override
+    public StorageSupport<Object> storageSupport() {
+        return storageSupport;
     }
 }

--- a/server/src/main/java/io/crate/types/DataType.java
+++ b/server/src/main/java/io/crate/types/DataType.java
@@ -64,8 +64,8 @@ public abstract class DataType<T> implements Comparable<DataType<?>>, Writeable,
     public enum Precedence {
         NOT_SUPPORTED,
         UNDEFINED,
-        CHARACTER,
         STRING,
+        CHARACTER,
         BYTE,
         BOOLEAN,
         SHORT,
@@ -169,7 +169,7 @@ public abstract class DataType<T> implements Comparable<DataType<?>>, Writeable,
 
     /**
      * Returns true if this DataType precedes the supplied DataType.
-     * @param other The other type to compare against.
+     * @param that The other type to compare against.
      * @return True if the current type precedes, false otherwise.
      */
     public boolean precedes(DataType<?> that) {

--- a/server/src/main/java/io/crate/types/StringType.java
+++ b/server/src/main/java/io/crate/types/StringType.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
 
 import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.index.Term;
@@ -79,77 +80,91 @@ public class StringType extends DataType<String> implements Streamer<String> {
         */
     public static final int POSITION_INCREMENT_GAP = 100;
 
+    /**
+     * We cannot use {@code EqQuery<String>} because it's also used in OptimizeQueryForSearchAfter
+     * where the value is {@link BytesRef} and not {@link String}.
+     */
+    protected static final class StringEqQuery implements EqQuery<Object> {
+
+        private final UnaryOperator<Object> preProcess;
+
+        StringEqQuery(UnaryOperator<Object> preprocess) {
+            this.preProcess = preprocess;
+        }
+
+        @Override
+        public Query termQuery(String field, Object value, boolean hasDocValues, boolean isIndexed) {
+            if (isIndexed) {
+                return new TermQuery(new Term(field, BytesRefs.toBytesRef(preProcess.apply(value))));
+            }
+            if (hasDocValues) {
+                return SortedSetDocValuesField.newSlowExactQuery(
+                    field, BytesRefs.toBytesRef(preProcess.apply(value)));
+            }
+            return null;
+        }
+
+        @Override
+        public Query rangeQuery(String field,
+                                Object lowerTerm,
+                                Object upperTerm,
+                                boolean includeLower,
+                                boolean includeUpper,
+                                boolean hasDocValues,
+                                boolean isIndexed) {
+            if (isIndexed) {
+                return new TermRangeQuery(
+                    field,
+                    BytesRefs.toBytesRef(preProcess.apply(lowerTerm)),
+                    BytesRefs.toBytesRef(preProcess.apply(upperTerm)),
+                    includeLower,
+                    includeUpper
+                );
+            }
+            if (hasDocValues) {
+                return SortedSetDocValuesField.newSlowRangeQuery(
+                    field,
+                    BytesRefs.toBytesRef(preProcess.apply(lowerTerm)),
+                    BytesRefs.toBytesRef(preProcess.apply(upperTerm)),
+                    includeLower,
+                    includeUpper
+                );
+            }
+            return null;
+        }
+
+        @Override
+        public Query termsQuery(String field, List<Object> nonNullValues, boolean hasDocValues, boolean isIndexed) {
+            if (isIndexed) {
+                return new TermInSetQuery(field, nonNullValues.stream().map(
+                    c -> BytesRefs.toBytesRef(preProcess.apply(c))).toList());
+            }
+            if (hasDocValues) {
+                return SortedSetDocValuesField.newSlowSetQuery(
+                    field, Lists.map(nonNullValues, c -> BytesRefs.toBytesRef(preProcess.apply(c))));
+            }
+            return null;
+        }
+    }
+
     private static final StorageSupport<Object> STORAGE = new StorageSupport<>(
         true,
         true,
-        new EqQuery<Object>() {
+        new StringEqQuery(UnaryOperator.identity())) {
 
             @Override
-            public Query termQuery(String field, Object value, boolean hasDocValues, boolean isIndexed) {
-                if (isIndexed) {
-                    return new TermQuery(new Term(field, BytesRefs.toBytesRef(value)));
-                }
-                if (hasDocValues) {
-                    return SortedSetDocValuesField.newSlowExactQuery(field, BytesRefs.toBytesRef(value));
-                }
-                return null;
+            @SuppressWarnings({"rawtypes"})
+            public ValueIndexer<Object> valueIndexer(RelationName table,
+                                                     Reference ref,
+                                                     Function<ColumnIdent, Reference> getRef) {
+                return switch (ref.indexType()) {
+                    case FULLTEXT -> (ValueIndexer) new FulltextIndexer(ref);
+                    case NONE, PLAIN -> (ValueIndexer) new StringIndexer(ref);
+                };
             }
-
-            @Override
-            public Query rangeQuery(String field,
-                                    Object lowerTerm,
-                                    Object upperTerm,
-                                    boolean includeLower,
-                                    boolean includeUpper,
-                                    boolean hasDocValues,
-                                    boolean isIndexed) {
-                if (isIndexed) {
-                    return new TermRangeQuery(
-                        field,
-                        BytesRefs.toBytesRef(lowerTerm),
-                        BytesRefs.toBytesRef(upperTerm),
-                        includeLower,
-                        includeUpper
-                    );
-                }
-                if (hasDocValues) {
-                    return SortedSetDocValuesField.newSlowRangeQuery(
-                        field,
-                        BytesRefs.toBytesRef(lowerTerm),
-                        BytesRefs.toBytesRef(upperTerm),
-                        includeLower,
-                        includeUpper
-                    );
-                }
-                return null;
-            }
-
-            @Override
-            public Query termsQuery(String field, List<Object> nonNullValues, boolean hasDocValues, boolean isIndexed) {
-                if (isIndexed) {
-                    return new TermInSetQuery(field, nonNullValues.stream().map(BytesRefs::toBytesRef).toList());
-                }
-                if (hasDocValues) {
-                    return SortedSetDocValuesField.newSlowSetQuery(field, Lists.map(nonNullValues, BytesRefs::toBytesRef));
-                }
-                return null;
-            }
-        }
-    ) {
-
-        @Override
-        @SuppressWarnings({"rawtypes"})
-        public ValueIndexer<Object> valueIndexer(RelationName table,
-                                                 Reference ref,
-                                                 Function<ColumnIdent, Reference> getRef) {
-            return switch (ref.indexType()) {
-                case FULLTEXT -> (ValueIndexer) new FulltextIndexer(ref);
-                case NONE, PLAIN -> (ValueIndexer) new StringIndexer(ref);
-            };
-        }
     };
 
-    private final int lengthLimit;
+    protected final int lengthLimit;
 
     public static StringType of(List<Integer> parameters) {
         if (parameters.size() != 1) {
@@ -169,7 +184,7 @@ public class StringType extends DataType<String> implements Streamer<String> {
         return new StringType(lengthLimit);
     }
 
-    private StringType(int lengthLimit) {
+    protected StringType(int lengthLimit) {
         this.lengthLimit = lengthLimit;
     }
 

--- a/server/src/test/java/io/crate/execution/engine/collect/collectors/OptimizeQueryForSearchAfterTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/collectors/OptimizeQueryForSearchAfterTest.java
@@ -41,6 +41,7 @@ import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.SimpleReference;
 import io.crate.sql.tree.ColumnPolicy;
+import io.crate.types.CharacterType;
 import io.crate.types.DataTypes;
 
 public class OptimizeQueryForSearchAfterTest {
@@ -50,6 +51,18 @@ public class OptimizeQueryForSearchAfterTest {
         ReferenceIdent referenceIdent = new ReferenceIdent(new RelationName("doc", "dummy"), "x");
         OrderBy orderBy = new OrderBy(List.of(
             new SimpleReference(referenceIdent, RowGranularity.DOC, DataTypes.STRING, 1, null)
+        ));
+        var optimize = new OptimizeQueryForSearchAfter(orderBy);
+        FieldDoc lastCollected = new FieldDoc(1, 1.0f, new Object[] { new BytesRef("foobar") });
+        Query query = optimize.apply(lastCollected);
+        assertThat(query).hasToString("+x:{* TO foobar}");
+    }
+
+    @Test
+    public void test_char_range_query_can_handle_byte_ref_values() {
+        ReferenceIdent referenceIdent = new ReferenceIdent(new RelationName("doc", "dummy"), "x");
+        OrderBy orderBy = new OrderBy(List.of(
+            new SimpleReference(referenceIdent, RowGranularity.DOC, CharacterType.of(3), 1, null)
         ));
         var optimize = new OptimizeQueryForSearchAfter(orderBy);
         FieldDoc lastCollected = new FieldDoc(1, 1.0f, new Object[] { new BytesRef("foobar") });

--- a/server/src/test/java/io/crate/lucene/CharacterEqQueryTest.java
+++ b/server/src/test/java/io/crate/lucene/CharacterEqQueryTest.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.lucene;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.MultiTermQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermInSetQuery;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.TermRangeQuery;
+import org.junit.Test;
+
+public class CharacterEqQueryTest extends LuceneQueryBuilderTest {
+    @Override
+    protected String createStmt() {
+        return """
+                create table m (
+                c1 char(3),
+                c2 char(3) index off,
+                c3 char(3) storage with (columnstore = false),
+                c4 char(3) index off storage with (columnstore = false),
+                arr1 array(char(3)),
+                arr2 array(char(3)) index off,
+                arr3 array(char(3)) storage with (columnstore = false),
+                arr4 array(char(3)) index off storage with (columnstore = false)
+            )
+            """;
+    }
+
+    @Test
+    public void test_StringEqQuery_termQuery() {
+        Query query = convert("c1 = 'abc   '");
+        assertThat(query)
+            .isExactlyInstanceOf(TermQuery.class)
+            .hasToString("c1:abc");
+
+        query = convert("c2 = 'ab  c  '");
+        // SortedSetDocValuesRangeQuery.class is not public
+        assertThat(query.getClass().getName()).endsWith("SortedSetDocValuesRangeQuery");
+        assertThat(query).hasToString("c2:[[61 62 20 20 63] TO [61 62 20 20 63]]");
+
+        query = convert("c3 = 'ab'");
+        assertThat(query)
+            .isExactlyInstanceOf(TermQuery.class)
+            .hasToString("c3:ab ");
+
+        query = convert("c4 = 'abc  '");
+        assertThat(query)
+            .isExactlyInstanceOf(GenericFunctionQuery.class)
+            .hasToString("(c4 = 'abc  ')"); // trailing whitespace are stripped in CharacterType#compare()
+    }
+
+    @Test
+    public void test_StringEqQuery_rangeQuery() {
+        Query query = convert("c1 > 'ab   '");
+        assertThat(query)
+            .isExactlyInstanceOf(TermRangeQuery.class)
+            .hasToString("c1:{ab  TO *}");
+
+        query = convert("c2 < 'ab  c  '");
+        // SortedSetDocValuesRangeQuery.class is not public
+        assertThat(query.getClass().getName()).endsWith("SortedSetDocValuesRangeQuery");
+        assertThat(query).hasToString("c2:{* TO [61 62 20 20 63]}");
+
+        query = convert("c3 >= 'abc  '");
+        assertThat(query)
+            .isExactlyInstanceOf(TermRangeQuery.class)
+            .hasToString("c3:[abc TO *}");
+
+        query = convert("c4 <= 'abc  '");
+        assertThat(query)
+            .isExactlyInstanceOf(GenericFunctionQuery.class)
+            .hasToString("(c4 <= 'abc  ')"); // trailing whitespace are stripped in CharacterType#compare()
+    }
+
+    @Test
+    public void test_StringEqQuery_termsQuery() {
+        Query query = convert("arr1 = ['abc  ']");
+        assertThat(query).isExactlyInstanceOf(BooleanQuery.class);
+        BooleanClause clause = ((BooleanQuery) query).clauses().getFirst();
+        query = clause.getQuery();
+        assertThat(query)
+            .isExactlyInstanceOf(TermInSetQuery.class)
+            .hasToString("arr1:(abc)");
+
+        query = convert("arr2 = ['ab  c  ']");
+        assertThat(query).isExactlyInstanceOf(BooleanQuery.class);
+        clause = ((BooleanQuery) query).clauses().getFirst();
+        query = clause.getQuery();
+        // SortedSetDocValuesField.newSlowSetQuery is equal to TermInSetQuery + MultiTermQuery.DOC_VALUES_REWRITE
+        assertThat(query).isExactlyInstanceOf(TermInSetQuery.class);
+        assertThat(((TermInSetQuery) query).getRewriteMethod()).isEqualTo(MultiTermQuery.DOC_VALUES_REWRITE);
+        assertThat(query).hasToString("arr2:(ab  c)");
+
+        query = convert("arr3 = ['abc   ']");
+        assertThat(query).isExactlyInstanceOf(BooleanQuery.class);
+        clause = ((BooleanQuery) query).clauses().getFirst();
+        query = clause.getQuery();
+        assertThat(query)
+            .isExactlyInstanceOf(TermInSetQuery.class)
+            .hasToString("arr3:(abc)");
+
+        query = convert("arr4 = ['abc  ']");
+        assertThat(query)
+            .isExactlyInstanceOf(GenericFunctionQuery.class)
+            .hasToString("(arr4 = ['abc  '])"); // trailing whitespace are stripped in CharacterType#compare()
+    }
+}

--- a/server/src/test/java/io/crate/types/CharacterTypeTest.java
+++ b/server/src/test/java/io/crate/types/CharacterTypeTest.java
@@ -23,10 +23,13 @@ package io.crate.types;
 
 import static io.crate.testing.Asserts.assertThat;
 
+import java.util.Map;
+
 import org.junit.Test;
 
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.settings.SessionSettings;
+import io.crate.testing.SqlExpressions;
 
 public class CharacterTypeTest extends DataTypeTestCase<String> {
 
@@ -58,5 +61,18 @@ public class CharacterTypeTest extends DataTypeTestCase<String> {
         assertThat(CharacterType.of(1).explicitCast(true, SESSION_SETTINGS)).isEqualTo("t");
         assertThat(CharacterType.of(1).explicitCast(12, SESSION_SETTINGS)).isEqualTo("1");
         assertThat(CharacterType.of(1).explicitCast(-12, SESSION_SETTINGS)).isEqualTo("-");
+    }
+
+    @Test
+    public void test_comparison() {
+        assertThat(CharacterType.of(3).compare(" a  ", " a       ")).isEqualTo(0);
+        assertThat(CharacterType.of(3).compare("  a", " a")).isLessThan(0);
+        assertThat(CharacterType.of(3).compare(" b          ", " a  ")).isGreaterThan(0);
+    }
+
+    @Test
+    public void test_precedence_with_string_type() {
+        var sqlExpressions = new SqlExpressions(Map.of());
+        assertThat(sqlExpressions.normalize(sqlExpressions.asSymbol("'ab'::char(3) = 'ab  '"))).isLiteral(true);
     }
 }


### PR DESCRIPTION
Previously, comparisons of CHAR values in the WHERE clause could yield different results from the same comparison in another part of the query (e.g. in the SELECT). That was because of the implicit casts that are added, and the fact that the comparisons in the WHERE clause are later on optimized with `Optimizer.optimizeCasts`, which removes casts from columns and pass them to the literals (text literals are always of type `STRING`. As a consequence the WHERE clause would behave correctly, but in the SELECT not, because of the missing cast optmization. To fix this, we simply change the CHAR type to have higher precedence from the STRING, so that the STRING literals are implicitly casted to CHAR, and not the other way around, without the need of the `optimizeCasts` logic.

Additionally, to match Postgres behavior for comparisons, both in the WHERE clause but also everywhere else, we ignore trailing whitespaces from both sides of the comparison when a value of `CHAR` type is involved.

Fixes: #16689
