### PR TITLE
Fix issue with PG de-/serialization of BigDecimal.ZERO

### DIFF
--- a/docs/appendices/release-notes/5.8.5.rst
+++ b/docs/appendices/release-notes/5.8.5.rst
@@ -47,6 +47,12 @@ See the :ref:`version_5.8.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that would cause an error to be thrown when trying to get ``0``
+  numeric value from a query when using
+  :ref:`PostgreSQL wire protocol<interface-postgresql>`,  e.g.::
+
+      SELECT 0::numeric;
+
 - Fixed behavior of comparing (``=``, ``>``, etc. ) a column of type
   :ref:`CHAR<type-char>` with string literals, so that any trailing whitespaces
   are ignored for both sides of the comparison, thus matching PostgreSQL

--- a/docs/appendices/release-notes/5.9.1.rst
+++ b/docs/appendices/release-notes/5.9.1.rst
@@ -47,6 +47,13 @@ See the :ref:`version_5.9.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that would cause an error to be thrown when using
+  :ref:`PostgreSQL wire protocol<interface-postgresql>` and attempting to
+  insert ``0`` value for a numeric :ref:`NUMERIC<type-numeric>`, or trying to
+  get ``0`` numeric value from a query, e.g.::
+
+      SELECT 0::numeric;
+
 - Fixed behavior of comparing (``=``, ``>``, etc. ) a column of type
   :ref:`CHAR<type-char>` with string literals, so that any trailing whitespaces
   are ignored for both sides of the comparison, thus matching PostgreSQL

--- a/server/src/test/java/io/crate/protocols/postgres/types/NumericTypeTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/types/NumericTypeTest.java
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigDecimal;
 import java.math.MathContext;
-import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.Test;
 
@@ -38,39 +38,39 @@ public class NumericTypeTest extends BasePGTypeTest<BigDecimal> {
         super(NumericType.INSTANCE);
     }
 
+    private static final List<BigDecimal> TEST_NUMBERS = List.of(
+        new BigDecimal(0),
+        new BigDecimal("-123"),
+        new BigDecimal("12345.1"),
+        new BigDecimal("-12.12"),
+        new BigDecimal("00123"),
+        new BigDecimal("12.123").setScale(2, MathContext.DECIMAL64.getRoundingMode()),
+        new BigDecimal("1234.0"),
+        new BigDecimal("1234.0000").setScale(1, MathContext.DECIMAL64.getRoundingMode())
+    );
+
     @Test
     public void test_read_and_write_numeric_text_value() {
-        var expected = new BigDecimal("12.123", MathContext.DECIMAL64)
-            .setScale(2, MathContext.DECIMAL64.getRoundingMode());
-        ByteBuf buffer = Unpooled.buffer();
-        try {
-            //noinspection unchecked
-            pgType.writeAsText(buffer, expected);
-            var actual = pgType.readTextValue(buffer, buffer.readInt());
-            assertThat(actual).isEqualTo(expected);
-            assertThat(actual.toString()).isEqualTo(expected.toString());
-        } finally {
-            buffer.release();
+        for (var expected : TEST_NUMBERS) {
+            ByteBuf buffer = Unpooled.buffer();
+            try {
+                pgType.writeAsText(buffer, expected);
+                var actual = pgType.readTextValue(buffer, buffer.readInt());
+                assertThat(actual).isEqualTo(expected);
+                assertThat(actual.toString()).isEqualTo(expected.toString());
+            } finally {
+                buffer.release();
+            }
         }
     }
 
     @Test
     public void test_read_and_write_numeric_binary_value() {
-        ArrayList<BigDecimal> testNumbers = new ArrayList<>();
-        testNumbers.add(new BigDecimal("-123"));
-        testNumbers.add(new BigDecimal("12345.1"));
-        testNumbers.add(new BigDecimal("-12.12"));
-        testNumbers.add(new BigDecimal("00123"));
-        testNumbers.add(new BigDecimal("12.123").setScale(2, MathContext.DECIMAL64.getRoundingMode()));
-        testNumbers.add(new BigDecimal("1234.0"));
-        testNumbers.add(new BigDecimal("1234.0000").setScale(1, MathContext.DECIMAL64.getRoundingMode()));
-
-        for (var expected : testNumbers) {
+        for (var expected : TEST_NUMBERS) {
             ByteBuf buffer = Unpooled.buffer();
             try {
-                //noinspection unchecked
                 pgType.writeAsBinary(buffer, expected);
-                BigDecimal actual = (BigDecimal) pgType.readBinaryValue(buffer, buffer.readInt());
+                BigDecimal actual = pgType.readBinaryValue(buffer, buffer.readInt());
                 assertThat(actual.scale()).isEqualTo(expected.scale());
                 assertThat(actual.toString()).isEqualTo(expected.toString());
             } finally {


### PR DESCRIPTION
Fix BigDecimal.ZERO, which has zero digits, to be handled correctly in PG binary serialization and deserialization.

Additionally, BigDecimal cannot take values of NaN or infinity, for example `new BigDecimal(Double.NaN)` throws an error. Also, it's not allowed to try to set directly a value like that to a numeric column when using JDBC:

```
PreparedStatement preparedStatement =
    conn.prepareStatement( "INSERT INTO t (l) VALUES (?)");
preparedStatement.setDouble(1, Double.POSITIVE_INFINITY);
```

as it throws:
```
org.postgresql.util.PSQLException: ERROR: Cannot cast value `Infinity` to type `numeric`
```

Therefore, simplify the logic and remove code that handles
`NaN` and `Infinities`.

Fixes: #16797

