### PR TITLE
Fix issue with correlated join on primary key

### DIFF
--- a/docs/appendices/release-notes/5.8.5.rst
+++ b/docs/appendices/release-notes/5.8.5.rst
@@ -47,6 +47,15 @@ See the :ref:`version_5.8.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed and issue that would cause error to be thrown when using correlated
+  subquery with join on a primary key column, e.g.::
+
+      CREATE TABLE tbl(x int PRIMARY KEY);
+      SELECT (
+          SELECT x FROM tbl a WHERE a.x = b.x LIMIT 1
+      ) AS t
+      FROM (SELECT x FROM tbl) as b;
+
 - Fixed an issue that would cause an error to be thrown when trying to get ``0``
   numeric value from a query when using
   :ref:`PostgreSQL wire protocol<interface-postgresql>`,  e.g.::

--- a/docs/appendices/release-notes/5.9.1.rst
+++ b/docs/appendices/release-notes/5.9.1.rst
@@ -47,6 +47,15 @@ See the :ref:`version_5.9.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed and issue that would cause error to be thrown when using correlated
+  subquery with join on a primary key column, e.g.::
+
+      CREATE TABLE tbl(x int PRIMARY KEY);
+      SELECT (
+          SELECT x FROM tbl a WHERE a.x = b.x LIMIT 1
+      ) AS t
+      FROM (SELECT x FROM tbl) as b;
+
 - Fixed an issue that would cause an error to be thrown when using
   :ref:`PostgreSQL wire protocol<interface-postgresql>` and attempting to
   insert ``0`` value for a numeric :ref:`NUMERIC<type-numeric>`, or trying to

--- a/server/src/main/java/io/crate/analyze/SymbolEvaluator.java
+++ b/server/src/main/java/io/crate/analyze/SymbolEvaluator.java
@@ -30,6 +30,7 @@ import io.crate.expression.BaseImplementationSymbolVisitor;
 import io.crate.expression.InputFactory;
 import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.expression.symbol.Literal;
+import io.crate.expression.symbol.OuterColumn;
 import io.crate.expression.symbol.ParameterSymbol;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
@@ -88,6 +89,12 @@ public final class SymbolEvaluator extends BaseImplementationSymbolVisitor<Row> 
     public Input<?> visitSelectSymbol(SelectSymbol selectSymbol, Row context) {
         DataType type = selectSymbol.valueType();
         return Literal.of(type, type.sanitizeValue(subQueryResults.getSafe(selectSymbol)));
+    }
+
+    @Override
+    public Input<?> visitOuterColumn(OuterColumn outerColumn, Row context) {
+        DataType<?> valueType = outerColumn.valueType();
+        return Literal.ofUnchecked(valueType, valueType.sanitizeValue(subQueryResults.get(outerColumn)));
     }
 
     public Function<Symbol, Object> bind(Row params) {

--- a/server/src/test/java/io/crate/integrationtests/CorrelatedSubqueryITest.java
+++ b/server/src/test/java/io/crate/integrationtests/CorrelatedSubqueryITest.java
@@ -498,4 +498,26 @@ public class CorrelatedSubqueryITest extends IntegTestCase {
 
         assertThat(response).hasRows("1abc");
     }
+
+    /*
+     * https://github.com/crate/crate/issues/16793
+     */
+    @Test
+    public void test_correlated_subquery_with_join_on_primary_key() {
+        execute("CREATE TABLE tbl (x INT PRIMARY KEY)");
+        execute("INSERT INTO tbl(x) VALUES(111)");
+        execute("REFRESH TABLE tbl");
+        execute("""
+            SELECT (
+              SELECT x
+              FROM tbl a
+              WHERE a.x = b.x
+              LIMIT 1
+            ) AS t
+            FROM (
+              SELECT x FROM tbl
+            ) as b"""
+        );
+        assertThat(response).hasRows("111");
+    }
 }


### PR DESCRIPTION
When there is a correlated join on a table's primary key, then `DocKeys#getId()` is used, which in turn uses `SymbolEvaluator`, which previously, didn't implement `visitOuterColumn`, which in turn threw an error for unhandled symbol (the OuterColumn symbol).

Fixes: #16793