### PR TITLE
Implement `NUMERIC` overload for arithmetic functions

### DIFF
--- a/docs/appendices/release-notes/5.10.0.rst
+++ b/docs/appendices/release-notes/5.10.0.rst
@@ -69,7 +69,10 @@ None
 Data Types
 ----------
 
-None
+- Added support for :ref:`NUMERIC type<type-numeric>` to the following
+  arithmetic scalar functions: :ref:`ABS<scalar-abs>`, :ref:`CEIL<scalar-ceil>`,
+  :ref:`FLOOR<scalar-floor>`, :ref:`EXP<scalar-exp>`, :ref:`SQRT<scalar-sqrt>`
+  and :ref:`ROUND<scalar-round>` (for the variation of only one argument).
 
 Scalar and Aggregation Functions
 --------------------------------

--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -2073,13 +2073,14 @@ For example::
 ``ceil(number)``
 ----------------
 
-Returns the smallest integer or long value that is not less than the argument.
+Returns the smallest integral value that is not less than the argument.
 
-Returns: ``bigint`` or ``integer``
+Returns: ``numeric``, ``bigint`` or ``integer``
 
-Return value will be of type ``integer`` if the input value is an integer or
-float. If the input value is of type ``bigint`` or ``double precision`` the
-return value will be of type ``bigint``::
+Return value will be of type ``numeric`` if the input value is of ``numeric``
+type. It will be of ``integer`` if the input value is an ``integer``` or
+``float```.  If the input value is of type ``bigint`` or ``double precision``
+the return value will be of type ``bigint``::
 
     cr> select ceil(29.9) AS col;
     +-----+
@@ -2124,10 +2125,11 @@ Returns: ``double precision``
 ---------------
 
 Returns Euler's number ``e`` raised to the power of the given numeric value.
-The output will be cast to the given input type and thus may loose precision.
 
-Returns: ``double precision``
+Returns: ``numeric`` or ``double precision``
 
+Return value will be of type ``numeric`` if the input value is of ``numeric``
+type, and ``double precision`` for any other arithmetic type.
 ::
 
     > select exp(1.0) AS exp;
@@ -2146,14 +2148,14 @@ Returns: ``double precision``
 ``floor(number)``
 -----------------
 
-Returns the largest integer or long value that is not greater than the
-argument.
+Returns the largest integral value that is not less than the argument.
 
-Returns: ``bigint`` or ``integer``
+Returns: ``numeric``, ``bigint`` or ``integer``
 
-Return value will be an integer if the input value is an integer or a float. If
-the input value is of type ``bigint`` or ``double precision`` the return value
-will be of type ``bigint``.
+Return value will be of type ``numeric`` if the input value is of ``numeric``
+type. It will be of type ``integer`` if the input value is an ``integer``` or
+``float```.  If the input value is of type ``bigint`` or ``double precision``
+the return value will be of type ``bigint``.
 
 See below for an example::
 
@@ -2339,10 +2341,12 @@ Returns ``number`` rounded to the specified ``precision`` (decimal places).
 When ``precision`` is not specified, the ``round`` function rounds the input
 value to the closest integer for ``real`` and ``integer`` data types with ties
 rounding up, and to the closest ``bigint`` value for ``double precision`` and
-``bigint`` data types with ties rounding up.
+``bigint`` data types with ties rounding up. When the data type of the argument
+is ``numeric``, then it returns the closest ``numeric`` value, with all decimal
+digits zeroed out, and with thies rounding up.
 
 When it is specified, the result's type is ``numeric``. Notice that
-``round(number)`` and ``round(number, 0)`` return different result types.
+``round(number)`` and ``round(number, 0)`` may return different result types.
 
 
 See below for examples::
@@ -2402,7 +2406,8 @@ See below for examples::
 
 Returns the square root of the argument.
 
-Returns: ``double precision``
+Returns: ``numeric`` for argument of type ``numeric`` and ``double precision``
+for any other arithmetic type.
 
 See below for an example::
 

--- a/pom.xml
+++ b/pom.xml
@@ -333,6 +333,7 @@
     <versions.opendal>0.46.3</versions.opendal>
     <versions.commonsmath>3.6.1</versions.commonsmath>
     <versions.commonscodec>1.17.1</versions.commonscodec>
+    <versions.bigmath>2.3.2</versions.bigmath>
     <versions.jaxb_api>2.3.1</versions.jaxb_api>
     <versions.graalvm>24.0.2</versions.graalvm>
     <versions.jwt>4.4.0</versions.jwt>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -283,6 +283,11 @@
       <version>${versions.commonsmath}</version>
     </dependency>
     <dependency>
+      <groupId>ch.obermuhlner</groupId>
+      <artifactId>big-math</artifactId>
+      <version>${versions.bigmath}</version>
+    </dependency>
+    <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
       <version>${versions.commonscodec}</version>

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/AbsFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/AbsFunction.java
@@ -21,6 +21,8 @@
 
 package io.crate.expression.scalar.arithmetic;
 
+import java.math.MathContext;
+
 import io.crate.expression.scalar.UnaryScalar;
 import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
@@ -32,6 +34,8 @@ import io.crate.types.DataTypes;
 public final class AbsFunction {
 
     public static final String NAME = "abs";
+
+    private AbsFunction() {}
 
     public static void register(Functions.Builder builder) {
         for (var type : DataTypes.NUMERIC_PRIMITIVE_TYPES) {
@@ -53,5 +57,18 @@ public final class AbsFunction {
                 }
             );
         }
+        builder.add(
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.NUMERIC.getTypeSignature())
+                .returnType(DataTypes.NUMERIC.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
+                .build(),
+            (signature, boundSignature) -> new UnaryScalar<>(
+                signature,
+                boundSignature,
+                DataTypes.NUMERIC,
+                x -> x.abs(MathContext.DECIMAL128)
+            )
+        );
     }
 }

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/ExpFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/ExpFunction.java
@@ -21,6 +21,9 @@
 
 package io.crate.expression.scalar.arithmetic;
 
+import java.math.MathContext;
+
+import ch.obermuhlner.math.big.BigDecimalMath;
 import io.crate.expression.scalar.UnaryScalar;
 import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
@@ -32,10 +35,12 @@ public class ExpFunction {
 
     public static final String NAME = "exp";
 
-    public static void register(Functions.Builder module) {
+    private ExpFunction() {}
+
+    public static void register(Functions.Builder builder) {
         var type = DataTypes.DOUBLE;
         var signature = type.getTypeSignature();
-        module.add(
+        builder.add(
             Signature.builder(NAME, FunctionType.SCALAR)
                 .argumentTypes(signature)
                 .returnType(signature)
@@ -48,6 +53,18 @@ public class ExpFunction {
                     type,
                     x -> type.sanitizeValue(Math.exp(((Number) x).doubleValue()))
                 )
+        );
+        builder.add(
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.NUMERIC.getTypeSignature())
+                .returnType(DataTypes.NUMERIC.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
+                .build(),
+            (declaredSignature, boundSignature) -> new UnaryScalar<>(
+                declaredSignature,
+                boundSignature,
+                DataTypes.NUMERIC,
+                x -> BigDecimalMath.exp(x, MathContext.DECIMAL128))
         );
     }
 }

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/SquareRootFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/SquareRootFunction.java
@@ -21,7 +21,12 @@
 
 package io.crate.expression.scalar.arithmetic;
 
+import java.math.BigDecimal;
+import java.math.MathContext;
+
+import ch.obermuhlner.math.big.BigDecimalMath;
 import io.crate.expression.scalar.DoubleScalar;
+import io.crate.expression.scalar.UnaryScalar;
 import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
@@ -32,10 +37,12 @@ public final class SquareRootFunction {
 
     public static final String NAME = "sqrt";
 
-    public static void register(Functions.Builder module) {
+    private SquareRootFunction() {}
+
+    public static void register(Functions.Builder builder) {
         for (var type : DataTypes.NUMERIC_PRIMITIVE_TYPES) {
             var typeSignature = type.getTypeSignature();
-            module.add(
+            builder.add(
                 Signature.builder(NAME, FunctionType.SCALAR)
                     .argumentTypes(typeSignature)
                     .returnType(DataTypes.DOUBLE.getTypeSignature())
@@ -45,6 +52,19 @@ public final class SquareRootFunction {
                     new DoubleScalar(signature, boundSignature, SquareRootFunction::sqrt)
             );
         }
+        builder.add(
+            Signature.builder(NAME, FunctionType.SCALAR)
+                .argumentTypes(DataTypes.NUMERIC.getTypeSignature())
+                .returnType(DataTypes.NUMERIC.getTypeSignature())
+                .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
+                .build(),
+            (signature, boundSignature) -> new UnaryScalar<>(
+                signature,
+                boundSignature,
+                DataTypes.NUMERIC,
+                SquareRootFunction::sqrt
+            )
+        );
     }
 
     private static double sqrt(double value) {
@@ -52,5 +72,12 @@ public final class SquareRootFunction {
             throw new IllegalArgumentException("cannot take square root of a negative number");
         }
         return Math.sqrt(value);
+    }
+
+    private static BigDecimal sqrt(BigDecimal value) {
+        if (value.signum() < 0) {
+            throw new IllegalArgumentException("cannot take square root of a negative number");
+        }
+        return BigDecimalMath.sqrt(value, MathContext.DECIMAL128);
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/AbsFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/AbsFunctionTest.java
@@ -25,6 +25,8 @@ import static io.crate.testing.Asserts.isFunction;
 import static io.crate.testing.Asserts.isLiteral;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.math.BigDecimal;
+
 import org.junit.Test;
 
 import io.crate.exceptions.ConversionException;
@@ -39,6 +41,7 @@ public class AbsFunctionTest extends ScalarTestCase {
         assertEvaluate("abs(-2.0)", 2.0);
         assertEvaluate("abs(cast(-2 as bigint))", 2L);
         assertEvaluate("abs(cast(-2.0 as float))", 2.0f);
+        assertEvaluate("abs(cast(-12.23 as numeric(4,2)))", new BigDecimal("12.23"));
         assertEvaluateNull("abs(null)");
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/CeilFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/CeilFunctionTest.java
@@ -24,6 +24,8 @@ package io.crate.expression.scalar.arithmetic;
 import static io.crate.testing.Asserts.isFunction;
 import static io.crate.testing.Asserts.isLiteral;
 
+import java.math.BigDecimal;
+
 import org.junit.Test;
 
 import io.crate.expression.scalar.ScalarTestCase;
@@ -32,14 +34,23 @@ import io.crate.types.DataTypes;
 public class CeilFunctionTest extends ScalarTestCase {
 
     @Test
+    public void testEvaluateOnNumeric() {
+        assertNormalize("ceil(cast(123.456789 as numeric(9, 6)))", isLiteral(new BigDecimal(124)));
+        assertNormalize("ceil(cast(-123.456789 as numeric(9, 6)))", isLiteral(new BigDecimal(-123)));
+        assertNormalize("ceil(cast(null as numeric))", isLiteral(null, DataTypes.NUMERIC));
+    }
+
+    @Test
     public void testEvaluateOnDouble() throws Exception {
         assertNormalize("ceil(29.9)", isLiteral(30L));
+        assertNormalize("ceil(-29.9)", isLiteral(-29L));
         assertNormalize("ceil(null)", isLiteral(null));
     }
 
     @Test
     public void testEvaluateOnFloat() throws Exception {
         assertNormalize("ceil(cast(29.9 as float))", isLiteral(30));
+        assertNormalize("ceil(cast(-29.9 as float))", isLiteral(-29));
         assertNormalize("ceil(cast(null as float))", isLiteral(null, DataTypes.INTEGER));
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/ExpFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/ExpFunctionTest.java
@@ -23,6 +23,8 @@ package io.crate.expression.scalar.arithmetic;
 
 import static io.crate.testing.Asserts.isLiteral;
 
+import java.math.BigDecimal;
+
 import org.junit.Test;
 
 import io.crate.expression.scalar.ScalarTestCase;
@@ -35,5 +37,7 @@ public class ExpFunctionTest extends ScalarTestCase {
         assertNormalize("exp(1::bigint)", isLiteral(2.718281828459045, 1E-15d));
         assertNormalize("exp(1.0)", isLiteral(2.718281828459045, 1E-15d));
         assertNormalize("exp(1.0::real)", isLiteral(2.718281828459045, 1E-15d));
+        assertNormalize("exp(1.0::numeric)",
+            isLiteral(new BigDecimal("2.718281828459045235360287471352662"), new BigDecimal("1E-15")));
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/FloorFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/FloorFunctionTest.java
@@ -24,6 +24,8 @@ package io.crate.expression.scalar.arithmetic;
 import static io.crate.testing.Asserts.isFunction;
 import static io.crate.testing.Asserts.isLiteral;
 
+import java.math.BigDecimal;
+
 import org.junit.Test;
 
 import io.crate.expression.scalar.ScalarTestCase;
@@ -32,14 +34,23 @@ import io.crate.types.DataTypes;
 public class FloorFunctionTest extends ScalarTestCase {
 
     @Test
+    public void testEvaluateOnNumeric() {
+        assertNormalize("floor(cast(123.456789 as numeric(9, 6)))", isLiteral(new BigDecimal(123)));
+        assertNormalize("floor(cast(-123.456789 as numeric(9, 6)))", isLiteral(new BigDecimal(-124)));
+        assertNormalize("floor(cast(null as numeric))", isLiteral(null, DataTypes.NUMERIC));
+    }
+
+    @Test
     public void testEvaluateOnDouble() throws Exception {
         assertNormalize("floor(29.9)", isLiteral(29L));
+        assertNormalize("floor(-29.9)", isLiteral(-30L));
         assertNormalize("floor(cast(null as double))", isLiteral(null, DataTypes.LONG));
     }
 
     @Test
     public void testEvaluateOnFloat() throws Exception {
         assertNormalize("floor(cast(29.9 as float))", isLiteral(29));
+        assertNormalize("floor(cast(-29.9 as float))", isLiteral(-30));
         assertNormalize("floor(cast(null as float))", isLiteral(null, DataTypes.INTEGER));
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/RoundFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/RoundFunctionTest.java
@@ -39,7 +39,10 @@ public class RoundFunctionTest extends ScalarTestCase {
         assertEvaluate("round(42.2)", 42L);
         assertEvaluate("round(42)", 42);
         assertEvaluate("round(42::bigint)", 42L);
-        assertEvaluate("round(cast(42.2 as float))", 42);
+        assertEvaluate("round(cast(42.5 as float))", 43);
+        assertEvaluate("round(cast(-42.5 as float))", -42);
+        assertEvaluate("round(cast(12.545 as numeric(5, 2)))", new BigDecimal(13));
+        assertEvaluate("round(cast(-12.545 as numeric(5, 2)))", new BigDecimal(-13));
         assertEvaluateNull("round(null)");
 
         assertNormalize("round(id)", isFunction("round"));
@@ -69,6 +72,8 @@ public class RoundFunctionTest extends ScalarTestCase {
         assertEvaluate("round(2147483647, -1)", new BigDecimal("2147483650"));
         assertEvaluate("round(9223372036854775807, -1)", new BigDecimal("9223372036854775810"));
         assertEvaluate("round('92233720368547758070.123'::NUMERIC, 1)", new BigDecimal("92233720368547758070.1"));
+        assertEvaluate("round('12.345'::NUMERIC, 2)", new BigDecimal("12.35"));
+        assertEvaluate("round('-12.345'::NUMERIC, 2)", new BigDecimal("-12.35"));
 
         assertEvaluateNull("round(1,null)");
         assertEvaluateNull("round(null,null)");

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/SquareRootFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/SquareRootFunctionTest.java
@@ -24,6 +24,8 @@ package io.crate.expression.scalar.arithmetic;
 import static io.crate.testing.Asserts.isFunction;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.math.BigDecimal;
+
 import org.junit.Test;
 
 import io.crate.exceptions.ConversionException;
@@ -39,11 +41,15 @@ public class SquareRootFunctionTest extends ScalarTestCase {
         assertEvaluateNull("sqrt(null)");
         assertEvaluate("sqrt(cast(25 as integer))", 5.0);
         assertEvaluate("sqrt(cast(25.0 as float))", 5.0);
+        assertEvaluate("sqrt(cast(123.4 as numeric(6, 1)))",
+            new BigDecimal("11.10855526159905278255972911272118"));
     }
 
     @Test
     public void testSmallerThanZero() {
         assertThatThrownBy(() -> assertEvaluateNull("sqrt(-25.0)"))
+            .hasMessage("cannot take square root of a negative number");
+        assertThatThrownBy(() -> assertEvaluateNull("sqrt(-25.123::numeric(5,3))"))
             .hasMessage("cannot take square root of a negative number");
     }
 

--- a/server/src/testFixtures/java/io/crate/testing/Asserts.java
+++ b/server/src/testFixtures/java/io/crate/testing/Asserts.java
@@ -21,6 +21,7 @@
 
 package io.crate.testing;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -200,6 +201,16 @@ public class Asserts extends Assertions {
             assertThat(s).isExactlyInstanceOf(Literal.class);
             assertThat(s).hasDataType(DataTypes.DOUBLE);
             Double value = (Double) ((Input<?>) s).value();
+            assertThat(value).isCloseTo(expectedValue, Offset.offset(precisionError));
+        };
+    }
+
+    public static Consumer<Symbol> isLiteral(BigDecimal expectedValue, BigDecimal precisionError) {
+        return s -> {
+            assertThat(s).isNotNull();
+            assertThat(s).isExactlyInstanceOf(Literal.class);
+            assertThat(s).hasDataType(DataTypes.NUMERIC);
+            BigDecimal value = (BigDecimal) ((Input<?>) s).value();
             assertThat(value).isCloseTo(expectedValue, Offset.offset(precisionError));
         };
     }


### PR DESCRIPTION
- ABS
- CEIL
- FLOOR
- SQRT
- EXP
- ROUND (without precision)

Closes: #15632

