### PR TITLE
Change RolesManager to not inherit Roles as it isn't needed

### DIFF
--- a/server/src/main/java/io/crate/planner/Planner.java
+++ b/server/src/main/java/io/crate/planner/Planner.java
@@ -521,7 +521,7 @@ public class Planner extends AnalyzedStatementVisitor<PlannerContext, Plan> {
                 "CrateDB has no transactions, so any `SET LOCAL` change would be dropped in the next statement.");
             return NoopPlan.INSTANCE;
         } else {
-            return new SetSessionAuthorizationPlan(analysis, roleManager);
+            return new SetSessionAuthorizationPlan(analysis, nodeCtx.roles());
         }
     }
 

--- a/server/src/main/java/io/crate/role/RoleManager.java
+++ b/server/src/main/java/io/crate/role/RoleManager.java
@@ -30,7 +30,7 @@ import org.jetbrains.annotations.Nullable;
 /**
  * responsible for creating and deleting roles (and users)
  */
-public interface RoleManager extends Roles {
+public interface RoleManager {
 
     /**
      * Create a role.

--- a/server/src/main/java/io/crate/role/RoleManagerService.java
+++ b/server/src/main/java/io/crate/role/RoleManagerService.java
@@ -30,12 +30,9 @@ import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.inject.Singleton;
 import org.jetbrains.annotations.Nullable;
 
-import io.crate.auth.AccessControl;
-import io.crate.auth.AccessControlImpl;
 import io.crate.exceptions.RoleAlreadyExistsException;
 import io.crate.exceptions.RoleUnknownException;
 import io.crate.metadata.cluster.DDLClusterStateService;
-import io.crate.metadata.settings.CoordinatorSessionSettings;
 
 @Singleton
 public class RoleManagerService implements RoleManager {
@@ -132,15 +129,5 @@ public class RoleManagerService implements RoleManager {
             }
             return r.affectedRows();
         });
-    }
-
-
-    @Override
-    public AccessControl getAccessControl(CoordinatorSessionSettings sessionSettings) {
-        return new AccessControlImpl(roles, sessionSettings);
-    }
-
-    public Collection<Role> roles() {
-        return roles.roles();
     }
 }

--- a/server/src/test/java/io/crate/auth/HttpAuthUpstreamHandlerTest.java
+++ b/server/src/test/java/io/crate/auth/HttpAuthUpstreamHandlerTest.java
@@ -48,7 +48,6 @@ import org.junit.Test;
 import io.crate.protocols.postgres.ConnectionProperties;
 import io.crate.role.Role;
 import io.crate.role.Roles;
-import io.crate.role.StubRoleManager;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
@@ -76,7 +75,7 @@ public class HttpAuthUpstreamHandlerTest extends ESTestCase {
         DnsResolver.SYSTEM,
         () -> "dummy"
     );
-    private final HttpAuthUpstreamHandler handlerWithHBA = new HttpAuthUpstreamHandler(Settings.EMPTY, authService, new StubRoleManager());
+    private final HttpAuthUpstreamHandler handlerWithHBA = new HttpAuthUpstreamHandler(Settings.EMPTY, authService, () -> List.of(Role.CRATE_USER));
 
     private static void assertUnauthorized(DefaultFullHttpResponse resp, String expectedBody) {
         assertThat(resp.status()).isEqualTo(HttpResponseStatus.UNAUTHORIZED);
@@ -137,7 +136,7 @@ public class HttpAuthUpstreamHandlerTest extends ESTestCase {
     @Test
     public void testAuthorized() throws Exception {
         HttpAuthUpstreamHandler handler = new HttpAuthUpstreamHandler(
-            Settings.EMPTY, new AlwaysOKAuthentication(() -> List.of(Role.CRATE_USER)), new StubRoleManager());
+            Settings.EMPTY, new AlwaysOKAuthentication(() -> List.of(Role.CRATE_USER)), () -> List.of(Role.CRATE_USER));
         EmbeddedChannel ch = new EmbeddedChannel(handler);
 
         DefaultHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/_sql");
@@ -190,7 +189,7 @@ public class HttpAuthUpstreamHandlerTest extends ESTestCase {
         var settings = Settings.builder()
             .put(AuthSettings.AUTH_TRUST_HTTP_SUPPORT_X_REAL_IP.getKey(), true)
             .build();
-        HttpAuthUpstreamHandler handler = new HttpAuthUpstreamHandler(settings, authService, new StubRoleManager());
+        HttpAuthUpstreamHandler handler = new HttpAuthUpstreamHandler(settings, authService, () -> List.of(Role.CRATE_USER));
         EmbeddedChannel ch = new EmbeddedChannel(handler);
 
         DefaultHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/_sql");
@@ -212,7 +211,7 @@ public class HttpAuthUpstreamHandlerTest extends ESTestCase {
         var settings = Settings.builder()
             .put(AuthSettings.AUTH_TRUST_HTTP_SUPPORT_X_REAL_IP.getKey(), true)
             .build();
-        HttpAuthUpstreamHandler handler = new HttpAuthUpstreamHandler(settings, authService, new StubRoleManager());
+        HttpAuthUpstreamHandler handler = new HttpAuthUpstreamHandler(settings, authService, () -> List.of(Role.CRATE_USER));
         EmbeddedChannel ch = new EmbeddedChannel(handler);
 
         DefaultHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/_sql");
@@ -258,7 +257,7 @@ public class HttpAuthUpstreamHandlerTest extends ESTestCase {
     public void testUserAuthenticationWithDisabledHBA() throws Exception {
         Authentication authServiceNoHBA = new AlwaysOKAuthentication(() -> List.of(Role.CRATE_USER));
 
-        HttpAuthUpstreamHandler handler = new HttpAuthUpstreamHandler(Settings.EMPTY, authServiceNoHBA, new StubRoleManager());
+        HttpAuthUpstreamHandler handler = new HttpAuthUpstreamHandler(Settings.EMPTY, authServiceNoHBA, () -> List.of(Role.CRATE_USER));
         EmbeddedChannel ch = new EmbeddedChannel(handler);
 
         HttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/_sql");
@@ -272,7 +271,7 @@ public class HttpAuthUpstreamHandlerTest extends ESTestCase {
     @Test
     public void testUnauthorizedUserWithDisabledHBA() throws Exception {
         Authentication authServiceNoHBA = new AlwaysOKAuthentication(List::of);
-        HttpAuthUpstreamHandler handler = new HttpAuthUpstreamHandler(Settings.EMPTY, authServiceNoHBA, new StubRoleManager());
+        HttpAuthUpstreamHandler handler = new HttpAuthUpstreamHandler(Settings.EMPTY, authServiceNoHBA, () -> List.of(Role.CRATE_USER));
         EmbeddedChannel ch = new EmbeddedChannel(handler);
 
         HttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/_sql");

--- a/server/src/test/java/io/crate/planner/statement/SetSessionAuthorizationPlanTest.java
+++ b/server/src/test/java/io/crate/planner/statement/SetSessionAuthorizationPlanTest.java
@@ -51,6 +51,7 @@ public class SetSessionAuthorizationPlanTest extends CrateDummyClusterServiceUni
         var user = RolesHelper.userOf("test");
         var e = SQLExecutor.builder(clusterService)
             .setRoleManager(new StubRoleManager(List.of(user, Role.CRATE_USER), false))
+            .setRoles(() -> List.of(user, Role.CRATE_USER))
             .build();
         var sessionSettings = e.getSessionSettings();
         sessionSettings.setSessionUser(Role.CRATE_USER);
@@ -62,10 +63,13 @@ public class SetSessionAuthorizationPlanTest extends CrateDummyClusterServiceUni
 
     @Test
     public void test_set_session_auth_to_default_sets_session_user_to_authenticated_user() throws Exception {
-        var e = SQLExecutor.builder(clusterService).build();
+        var testUser = RolesHelper.userOf("test");
+        var e = SQLExecutor.builder(clusterService)
+            .setRoles(() -> List.of(testUser, Role.CRATE_USER))
+            .build();
 
         var sessionSettings = e.getSessionSettings();
-        sessionSettings.setSessionUser(RolesHelper.userOf("test"));
+        sessionSettings.setSessionUser(testUser);
         assertThat(sessionSettings.sessionUser()).isNotEqualTo(sessionSettings.authenticatedUser());
 
         e.execute("SET SESSION AUTHORIZATION DEFAULT");

--- a/server/src/test/java/io/crate/protocols/postgres/PgClientTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/PgClientTest.java
@@ -49,8 +49,6 @@ import org.junit.Test;
 
 import com.carrotsearch.randomizedtesting.annotations.Repeat;
 
-import io.crate.session.Session;
-import io.crate.session.Sessions;
 import io.crate.auth.AlwaysOKAuthentication;
 import io.crate.auth.Authentication;
 import io.crate.metadata.settings.session.SessionSettingRegistry;
@@ -58,7 +56,8 @@ import io.crate.netty.NettyBootstrap;
 import io.crate.protocols.ssl.SslContextProvider;
 import io.crate.replication.logical.metadata.ConnectionInfo;
 import io.crate.role.Role;
-import io.crate.role.StubRoleManager;
+import io.crate.session.Session;
+import io.crate.session.Sessions;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 
 public class PgClientTest extends CrateDummyClusterServiceUnitTest {
@@ -131,7 +130,7 @@ public class PgClientTest extends CrateDummyClusterServiceUnitTest {
             serverNodeSettings,
             new SessionSettingRegistry(Set.of()),
             sqlOperations,
-            new StubRoleManager(),
+            () -> List.of(Role.CRATE_USER),
             networkService,
             authentication,
             nettyBootstrap,

--- a/server/src/test/java/io/crate/protocols/postgres/PostgresNettyPublishPortTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/PostgresNettyPublishPortTest.java
@@ -46,13 +46,13 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import io.crate.session.Sessions;
 import io.crate.auth.AlwaysOKAuthentication;
 import io.crate.metadata.settings.session.SessionSettingRegistry;
 import io.crate.netty.NettyBootstrap;
 import io.crate.protocols.ssl.SslContextProvider;
 import io.crate.role.Role;
-import io.crate.role.StubRoleManager;
+import io.crate.role.Roles;
+import io.crate.session.Sessions;
 
 public class PostgresNettyPublishPortTest extends ESTestCase {
 
@@ -103,14 +103,14 @@ public class PostgresNettyPublishPortTest extends ESTestCase {
     public void testBindAndPublishAddressDefault() {
         // First check if binding to a local works
         NetworkService networkService = new NetworkService(Collections.emptyList());
-        StubRoleManager userManager = new StubRoleManager();
+        Roles roles = () -> List.of(Role.CRATE_USER);
         PostgresNetty psql = new PostgresNetty(
             Settings.EMPTY,
             new SessionSettingRegistry(Set.of()),
             mock(Sessions.class),
-            userManager,
+            roles,
             networkService,
-            new AlwaysOKAuthentication(userManager),
+            new AlwaysOKAuthentication(roles),
             nettyBootstrap,
             mock(Netty4Transport.class),
             PageCacheRecycler.NON_RECYCLING_INSTANCE,
@@ -128,14 +128,14 @@ public class PostgresNettyPublishPortTest extends ESTestCase {
         // Check override for network.host
         Settings settingsWithCustomHost = Settings.builder().put("network.host", "cantbindtothis").build();
         NetworkService networkService = new NetworkService(Collections.emptyList());
-        StubRoleManager userManager = new StubRoleManager();
+        Roles roles = () -> List.of(Role.CRATE_USER);
         PostgresNetty psql = new PostgresNetty(
             settingsWithCustomHost,
             new SessionSettingRegistry(Set.of()),
             mock(Sessions.class),
-            userManager,
+            roles,
             networkService,
-            new AlwaysOKAuthentication(userManager),
+            new AlwaysOKAuthentication(roles),
             nettyBootstrap,
             mock(Netty4Transport.class),
             PageCacheRecycler.NON_RECYCLING_INSTANCE,
@@ -157,14 +157,14 @@ public class PostgresNettyPublishPortTest extends ESTestCase {
         // Check override for network.bind_host
         Settings settingsWithCustomBind = Settings.builder().put("network.bind_host", "cantbindtothis").build();
         NetworkService networkService = new NetworkService(Collections.emptyList());
-        StubRoleManager userManager = new StubRoleManager();
+        Roles roles = () -> List.of(Role.CRATE_USER);
         PostgresNetty psql = new PostgresNetty(
             settingsWithCustomBind,
             new SessionSettingRegistry(Set.of()),
             mock(Sessions.class),
-            userManager,
+            roles,
             networkService,
-            new AlwaysOKAuthentication(userManager),
+            new AlwaysOKAuthentication(roles),
             nettyBootstrap,
             mock(Netty4Transport.class),
             PageCacheRecycler.NON_RECYCLING_INSTANCE,
@@ -186,14 +186,14 @@ public class PostgresNettyPublishPortTest extends ESTestCase {
         // Check override for network.publish_host
         Settings settingsWithCustomPublish = Settings.builder().put("network.publish_host", "cantbindtothis").build();
         NetworkService networkService = new NetworkService(Collections.emptyList());
-        StubRoleManager userManager = new StubRoleManager();
+        Roles roles = () -> List.of(Role.CRATE_USER);
         PostgresNetty psql = new PostgresNetty(
             settingsWithCustomPublish,
             new SessionSettingRegistry(Set.of()),
             mock(Sessions.class),
-            userManager,
+            roles,
             networkService,
-            new AlwaysOKAuthentication(() -> List.of(Role.CRATE_USER)),
+            new AlwaysOKAuthentication(roles),
             nettyBootstrap,
             mock(Netty4Transport.class),
             PageCacheRecycler.NON_RECYCLING_INSTANCE,

--- a/server/src/test/java/io/crate/replication/logical/action/TransportCreateSubscriptionActionTest.java
+++ b/server/src/test/java/io/crate/replication/logical/action/TransportCreateSubscriptionActionTest.java
@@ -54,14 +54,14 @@ import io.crate.metadata.Schemas;
 import io.crate.replication.logical.LogicalReplicationService;
 import io.crate.replication.logical.metadata.ConnectionInfo;
 import io.crate.replication.logical.metadata.RelationMetadata;
+import io.crate.role.Role;
 import io.crate.role.Roles;
-import io.crate.role.StubRoleManager;
 import io.crate.sql.tree.QualifiedName;
 
 public class TransportCreateSubscriptionActionTest {
 
     private final LogicalReplicationService logicalReplicationService = mock(LogicalReplicationService.class);
-    private final Roles roles = new StubRoleManager();
+    private final Roles roles = () -> List.of(Role.CRATE_USER);
     private final ClusterService clusterService = mock(ClusterService.class);
     private TransportCreateSubscriptionAction transportCreateSubscriptionAction;
 


### PR DESCRIPTION
The only non-test related `RoleManger` implementation gets a `Role` instance, letting it implement `Roles` by itself isn't needed and increases complexity.