### PR TITLE
Add support for `NUMERIC` arg to `log()` and `ln()`

### DIFF
--- a/docs/appendices/release-notes/5.10.0.rst
+++ b/docs/appendices/release-notes/5.10.0.rst
@@ -71,8 +71,10 @@ Data Types
 
 - Added support for :ref:`NUMERIC type<type-numeric>` to the following
   arithmetic scalar functions: :ref:`ABS<scalar-abs>`, :ref:`CEIL<scalar-ceil>`,
-  :ref:`FLOOR<scalar-floor>`, :ref:`EXP<scalar-exp>`, :ref:`SQRT<scalar-sqrt>`
-  and :ref:`ROUND<scalar-round>` (for the variation of only one argument).
+  :ref:`FLOOR<scalar-floor>`, :ref:`ROUND<scalar-round>` (for the variation of
+  only one argument), :ref:`EXP<scalar-exp>`, :ref:`SQRT<scalar-sqrt>`,
+  :ref:`LN<scalar-ln>` and :ref:`LOG<scalar-log>` (for the variation of only one
+  argument).
 
 Scalar and Aggregation Functions
 --------------------------------

--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -2175,7 +2175,11 @@ See below for an example::
 
 Returns the natural logarithm of given ``number``.
 
-Returns: ``double precision``
+Returns: ``numeric`` or ``double precision``
+
+Return value will be of type ``numeric`` if the input value is of ``numeric``
+type. It will be of type ``double precision`` if the input value is of any other
+arithmetic type.
 
 See below for an example::
 
@@ -2196,14 +2200,21 @@ See below for an example::
 
 .. _scalar-log:
 
-``log(x : number, b : number)``
--------------------------------
+``log(x : number[, b : number])``
+---------------------------------
 
 Returns the logarithm of given ``x`` to base ``b``.
 
-Returns: ``double precision``
+Returns: ``numeric`` or ``double precision``
 
-See below for an example, which essentially is the same as above::
+When the second argument (``b``) is provided it returns a value of type
+``double precision``, even if ``x`` is of type ``numeric``, as it's implicitly
+casted to ``double pricision`` (thus, possibly loosing precision). When it's not
+provided, then the return value will be of type ``numeric`` if the input value
+is of ``numeric`` type and of type ``double precision`` if the input value is of
+any other arithmetic type.
+
+See below for an example::
 
     cr> SELECT log(100, 10) AS log;
     +-----+


### PR DESCRIPTION
Add support to `ln()` and `log()` but only for the one arg version,
so the log base 10 version, as the `BigDecimalMath` library doesn't
support log with an arbitrary base.

Since `BigDecimalMaths`'s `log10` and `ln` throw a different error
messages, already during their calculations, change `validateResult`
to `validateArgument` to do a consistent pre-validation for doubles
and BigDecimals.

Follows: #16818
Relates: #15632