### PR TITLE
Fix filtering by `= <numeric>`

### DIFF
--- a/server/src/main/java/io/crate/planner/optimizer/symbol/rule/SwapCastsInComparisonOperators.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/rule/SwapCastsInComparisonOperators.java
@@ -37,7 +37,9 @@ import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
 import io.crate.planner.optimizer.symbol.FunctionLookup;
 import io.crate.planner.optimizer.symbol.Rule;
+import io.crate.types.ArrayType;
 import io.crate.types.DataType;
+import io.crate.types.DataTypes;
 
 
 public class SwapCastsInComparisonOperators implements Rule<Function> {
@@ -72,6 +74,10 @@ public class SwapCastsInComparisonOperators implements Rule<Function> {
         var castFunction = captures.get(castCapture);
         var reference = castFunction.arguments().get(0);
         DataType<?> targetType = reference.valueType();
+        // TODO to be removed, see https://github.com/crate/crate/pull/16829#discussion_r1809553120
+        if (ArrayType.unnest(targetType).id() == DataTypes.NUMERIC.id()) {
+            targetType = castFunction.valueType();
+        }
         CastMode castMode = castFunction.castMode();
         assert castMode != null : "Pattern matched, function must be a cast";
         Symbol castedLiteral = literalOrParam.cast(targetType, castMode);


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes:
```
cr> create table t (a numeric(3,2));
CREATE OK, 1 row affected (1.768 sec)
cr> insert into t values (1.11);
INSERT OK, 1 row affected (3.031 sec)
cr> select * from t where a = 11.1::numeric;
+------+
|    a |
+------+
| 1.11 |
+------+
SELECT 1 row in set (0.021 sec)
```

https://github.com/crate/crate/blob/a1f77cfb706fb3fb470a58e5d0dad58eb679ade6/docs/appendices/release-notes/5.9.1.rst?plain=1#L118-L120 is enough that we do not need an extra release entry.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
