### PR TITLE
Tests: Flush response header immediately.

### DIFF
--- a/plugins/repository-gcs/src/test/java/io/crate/gcs/GCSBlobContainerRetriesTests.java
+++ b/plugins/repository-gcs/src/test/java/io/crate/gcs/GCSBlobContainerRetriesTests.java
@@ -611,9 +611,7 @@ public class GCSBlobContainerRetriesTests extends IntegTestCase {
         if (bytesToSend > 0) {
             exchange.getResponseBody().write(bytes, rangeStart, bytesToSend);
         }
-        if (randomBoolean()) {
-            exchange.getResponseBody().flush();
-        }
+        exchange.getResponseBody().flush(); // Required after JDK 23, see https://bugs.openjdk.org/browse/JDK-8331847
     }
 
     private String httpServerUrl() {


### PR DESCRIPTION
Related to JDK version bump to 23 and https://bugs.openjdk.org/browse/JDK-8331847

Fixes https://wacklig.pipifein.dev/github/crate/crate/case/io.crate.gcs.GCSBlobContainerRetriesTests/testReadBlobWithReadTimeouts 
and https://wacklig.pipifein.dev/github/crate/crate/case/io.crate.gcs.GCSBlobContainerRetriesTests/testReadBlobWithPrematureConnectionClose

