### PR TITLE
Remove release notes; not backported to 5.8

### DIFF
--- a/docs/appendices/release-notes/5.8.5.rst
+++ b/docs/appendices/release-notes/5.8.5.rst
@@ -119,7 +119,3 @@ Fixes
   generated ``geo_shape`` column with type ``Polygon``, ``MultiPolygon``,
   ``LineString`` or ``MultiLineString`` and a user provides a correct value for
   this generated column.
-
-- Fixed an issue that caused ``>``, ``<``, ``>=`` or ``<=`` on
-  :ref:`NUMERIC <type-numeric>` types with unmatched precisions and scales or
-  negative values to return invalid results.


### PR DESCRIPTION
https://github.com/crate/crate/pull/16837 is not backported to 5.8.