### PR TITLE
Fix tiny typo in the partitioned tables docs

### DIFF
--- a/docs/general/ddl/partitioned-tables.rst
+++ b/docs/general/ddl/partitioned-tables.rst
@@ -127,7 +127,7 @@ It can be created using the :ref:`sql-create-table` statement using the
     CREATE OK, 1 row affected (... sec)
 
 This creates an empty partitioned table which is not yet backed by real
-partitions. Nonetheless does it behave like a *normal* table.
+partitions. Nonetheless it does behave like a *normal* table.
 
 When the value to partition by references one or more
 :ref:`sql-create-table-base-columns`, their values must be supplied upon


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes a tiny typo in the partitioned tables docs.

## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
