### PR TITLE
Swap casts without losing precisions

### DIFF
--- a/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -563,4 +563,9 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         symbol = executor.asSymbol("t1.a not ilike all(['a', 'b', 'c'])");
         assertThat(symbol).isSQL("(doc.t1.a NOT ILIKE ALL(['a', 'b', 'c']))");
     }
+
+    @Test
+    public void test_float_ref_to_double_literal_comparison() {
+
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
From https://github.com/crate/crate/pull/16829#discussion_r1809606022:
```
cr> create table t (a float);
CREATE OK, 1 row affected (1.738 sec)
cr> insert into t values (0.123456789);
INSERT OK, 1 row affected (0.155 sec)
cr> select * from t where a = 0.123456789;
+------------+
|          a |
+------------+
| 0.12345679 |  -- this should not be returned
+------------+
SELECT 1 row in set (0.033 sec)
```

## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
