### PR TITLE
Fix return type of math functions with `NUMERIC` args

### DIFF
--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -2030,7 +2030,9 @@ clauses.
 ---------------
 
 Returns the absolute value of the given number in the datatype of the given
-number::
+number.
+
+Example::
 
     cr> select abs(214748.0998) AS a, abs(0) AS b, abs(-214748) AS c;
     +-------------+---+--------+
@@ -2078,9 +2080,12 @@ Returns the smallest integral value that is not less than the argument.
 Returns: ``numeric``, ``bigint`` or ``integer``
 
 Return value will be of type ``numeric`` if the input value is of ``numeric``
-type. It will be of ``integer`` if the input value is an ``integer``` or
-``float```.  If the input value is of type ``bigint`` or ``double precision``
-the return value will be of type ``bigint``::
+type, with the same precision and scale as the input type. It will be of
+``integer`` if the input value is an ``integer``` or ``float```.  If the input
+value is of type ``bigint`` or ``double precision`` the return value will be of
+type ``bigint``.
+
+Example::
 
     cr> select ceil(29.9) AS col;
     +-----+
@@ -2128,9 +2133,11 @@ Returns Euler's number ``e`` raised to the power of the given numeric value.
 
 Returns: ``numeric`` or ``double precision``
 
-Return value will be of type ``numeric`` if the input value is of ``numeric``
-type, and ``double precision`` for any other arithmetic type.
-::
+Return value will be of type ``numeric`` with unspecified precision and scale
+if the input value is of ``numeric`` type, and ``double precision`` for any
+other arithmetic type.
+
+Example::
 
     > select exp(1.0) AS exp;
     +-------------------+
@@ -2153,11 +2160,12 @@ Returns the largest integral value that is not less than the argument.
 Returns: ``numeric``, ``bigint`` or ``integer``
 
 Return value will be of type ``numeric`` if the input value is of ``numeric``
-type. It will be of type ``integer`` if the input value is an ``integer``` or
-``float```.  If the input value is of type ``bigint`` or ``double precision``
-the return value will be of type ``bigint``.
+type, with the same precision and scale as the input type. It will be of
+``integer`` if the input value is an ``integer``` or ``float```.  If the input
+value is of type ``bigint`` or ``double precision`` the return value will be of
+type ``bigint``.
 
-See below for an example::
+Example::
 
     cr> select floor(29.9) AS floor;
     +-------+
@@ -2177,11 +2185,11 @@ Returns the natural logarithm of given ``number``.
 
 Returns: ``numeric`` or ``double precision``
 
-Return value will be of type ``numeric`` if the input value is of ``numeric``
-type. It will be of type ``double precision`` if the input value is of any other
-arithmetic type.
+Return value will be of type ``numeric`` with unspecified precision and scale
+if the input value is of ``numeric`` type, and ``double precision`` for any
+other arithmetic type.
 
-See below for an example::
+Example::
 
     cr> SELECT ln(1) AS ln;
     +-----+
@@ -2209,12 +2217,12 @@ Returns: ``numeric`` or ``double precision``
 
 When the second argument (``b``) is provided it returns a value of type
 ``double precision``, even if ``x`` is of type ``numeric``, as it's implicitly
-casted to ``double pricision`` (thus, possibly loosing precision). When it's not
-provided, then the return value will be of type ``numeric`` if the input value
-is of ``numeric`` type and of type ``double precision`` if the input value is of
-any other arithmetic type.
+casted to ``double precision`` (thus, possibly loosing precision). When it's not
+provided, then the return value will be of type ``numeric`` with unspecified
+precision and scale, if the input value is of ``numeric`` type and of
+`double precision`` for any other arithmetic type.
 
-See below for an example::
+Examples::
 
     cr> SELECT log(100, 10) AS log;
     +-----+
@@ -2353,14 +2361,20 @@ When ``precision`` is not specified, the ``round`` function rounds the input
 value to the closest integer for ``real`` and ``integer`` data types with ties
 rounding up, and to the closest ``bigint`` value for ``double precision`` and
 ``bigint`` data types with ties rounding up. When the data type of the argument
-is ``numeric``, then it returns the closest ``numeric`` value, with all decimal
-digits zeroed out, and with thies rounding up.
+is ``numeric``, then it returns the closest ``numeric`` value with the same
+precision and scale as the input type, with all decimal digits zeroed out, and
+with ties rounding up.
 
-When it is specified, the result's type is ``numeric``. Notice that
-``round(number)`` and ``round(number, 0)`` may return different result types.
+When it is specified, the result's type is ``numeric``. If ``number`` is of
+``numeric`` datatype, then the ``numeric`` type of the result has the same
+precision and scale with the input. If it's of any other arithmetic type, the
+``numeric`` datatype of the result has unspecified precision and scale.
+
+Notice that ``round(number)`` and ``round(number, 0)`` may return different
+result types.
 
 
-See below for examples::
+Examples::
 
     cr> select round(42.2) AS round;
     +-------+
@@ -2417,10 +2431,13 @@ See below for examples::
 
 Returns the square root of the argument.
 
-Returns: ``numeric`` for argument of type ``numeric`` and ``double precision``
-for any other arithmetic type.
+Returns: ``numeric`` or ``double precision``
 
-See below for an example::
+Return value will be of type ``numeric`` with unspecified precision and scale
+if the input value is of ``numeric`` type, and ``double precision`` for any
+other arithmetic type.
+
+Example::
 
     cr> select sqrt(25.0) AS sqrt;
     +------+
@@ -2438,10 +2455,13 @@ See below for an example::
 
 Returns the sine of the argument.
 
-Returns: ``numeric`` for argument of type ``numeric`` and ``double precision``
-for any other arithmetic type.
+Returns: ``numeric`` or ``double precision``
 
-See below for an example::
+Return value will be of type ``numeric`` with unspecified precision and scale
+if the input value is of ``numeric`` type, and ``double precision`` for any
+other arithmetic type.
+
+Example::
 
     cr> SELECT sin(1) AS sin;
     +--------------------+
@@ -2459,10 +2479,13 @@ See below for an example::
 
 Returns the arcsine of the argument.
 
-Returns: ``numeric`` for argument of type ``numeric`` and ``double precision``
-for any other arithmetic type.
+Returns: ``numeric`` or ``double precision``
 
-See below for an example::
+Return value will be of type ``numeric`` with unspecified precision and scale
+if the input value is of ``numeric`` type, and ``double precision`` for any
+other arithmetic type.
+
+Example::
 
     cr> SELECT asin(1) AS asin;
     +--------------------+
@@ -2480,10 +2503,13 @@ See below for an example::
 
 Returns the cosine of the argument.
 
-Returns: ``numeric`` for argument of type ``numeric`` and ``double precision``
-for any other arithmetic type.
+Returns: ``numeric`` or ``double precision``
 
-See below for an example::
+Return value will be of type ``numeric`` with unspecified precision and scale
+if the input value is of ``numeric`` type, and ``double precision`` for any
+other arithmetic type.
+
+Example::
 
     cr> SELECT cos(1) AS cos;
     +--------------------+
@@ -2501,10 +2527,13 @@ See below for an example::
 
 Returns the arccosine of the argument.
 
-Returns: ``numeric`` for argument of type ``numeric`` and ``double precision``
-for any other arithmetic type.
+Returns: ``numeric`` or ``double precision``
 
-See below for an example::
+Return value will be of type ``numeric`` with unspecified precision and scale
+if the input value is of ``numeric`` type, and ``double precision`` for any
+other arithmetic type.
+
+Example::
 
     cr> SELECT acos(-1) AS acos;
     +-------------------+
@@ -2522,10 +2551,13 @@ See below for an example::
 
 Returns the tangent of the argument.
 
-Returns: ``numeric`` for argument of type ``numeric`` and ``double precision``
-for any other arithmetic type.
+Returns: ``numeric`` or ``double precision``
 
-See below for an example::
+Return value will be of type ``numeric`` with unspecified precision and scale
+if the input value is of ``numeric`` type, and ``double precision`` for any
+other arithmetic type.
+
+Example::
 
     cr> SELECT tan(1) AS tan;
     +--------------------+
@@ -2545,10 +2577,13 @@ Returns the cotangent of the argument that represents the angle expressed in
 radians. The range of the argument is all real numbers. The cotangent of zero
 is undefined and returns ``Infinity``.
 
-Returns: ``numeric`` for argument of type ``numeric`` and ``double precision``
-for any other arithmetic type.
+Returns: ``numeric`` or ``double precision``
 
-See below for an example::
+Return value will be of type ``numeric`` with unspecified precision and scale
+if the input value is of ``numeric`` type, and ``double precision`` for any
+other arithmetic type.
+
+Example::
 
     cr> select cot(1) AS cot;
     +--------------------+
@@ -2566,10 +2601,13 @@ See below for an example::
 
 Returns the arctangent of the argument.
 
-Returns: ``numeric`` for argument of type ``numeric`` and ``double precision``
-for any other arithmetic type.
+Returns: ``numeric`` or ``double precision``
 
-See below for an example::
+Return value will be of type ``numeric`` with unspecified precision and scale
+if the input value is of ``numeric`` type, and ``double precision`` for any
+other arithmetic type.
+
+Example::
 
     cr> SELECT atan(1) AS atan;
     +--------------------+
@@ -2587,10 +2625,13 @@ See below for an example::
 
 Returns the arctangent of ``y/x``.
 
-Returns: ``numeric`` for argument of types ``numeric`` and ``double precision``
-for any other arithmetic type.
+Returns: ``numeric`` or ``double precision``
 
-::
+Return value will be of type ``numeric`` with unspecified precision and scale
+if the input value ``y`` or ``x`` is of ``numeric`` type, and
+``double precision`` for any other arithmetic type.
+
+Example::
 
     cr> SELECT atan2(2, 1) AS atan2;
     +--------------------+

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/ExpFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/ExpFunction.java
@@ -28,6 +28,7 @@ import io.crate.expression.scalar.UnaryScalar;
 import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
@@ -60,9 +61,9 @@ public class ExpFunction {
                 .returnType(DataTypes.NUMERIC.getTypeSignature())
                 .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
-            (declaredSignature, boundSignature) -> new UnaryScalar<>(
+            (declaredSignature, ignoredBoundSignature) -> new UnaryScalar<>(
                 declaredSignature,
-                boundSignature,
+                BoundSignature.sameAsUnbound(declaredSignature),
                 DataTypes.NUMERIC,
                 x -> BigDecimalMath.exp(x, MathContext.DECIMAL128))
         );

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/LogFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/LogFunction.java
@@ -147,9 +147,9 @@ public abstract class LogFunction extends Scalar<Number, Number> {
                     .returnType(DataTypes.NUMERIC.getTypeSignature())
                     .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
                     .build(),
-                (signature, boundSignature) -> new UnaryScalar<>(
+                (signature, ignoredBoundSignature) -> new UnaryScalar<>(
                     signature,
-                    boundSignature,
+                    BoundSignature.sameAsUnbound(signature),
                     DataTypes.NUMERIC,
                     x -> BigDecimalMath.log10(validateArgument(x, "log(x)"), MathContext.DECIMAL128)
                 )
@@ -194,9 +194,9 @@ public abstract class LogFunction extends Scalar<Number, Number> {
                     .returnType(DataTypes.NUMERIC.getTypeSignature())
                     .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
                     .build(),
-                (signature, boundSignature) -> new UnaryScalar<>(
+                (signature, ignoredBoundSignature) -> new UnaryScalar<>(
                     signature,
-                    boundSignature,
+                    BoundSignature.sameAsUnbound(signature),
                     DataTypes.NUMERIC,
                     x -> BigDecimalMath.log(validateArgument(x, "ln(x)"), MathContext.DECIMAL128)
                 )

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/SquareRootFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/SquareRootFunction.java
@@ -30,6 +30,7 @@ import io.crate.expression.scalar.UnaryScalar;
 import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 import io.crate.types.DataTypes;
 
@@ -58,9 +59,9 @@ public final class SquareRootFunction {
                 .returnType(DataTypes.NUMERIC.getTypeSignature())
                 .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
-            (signature, boundSignature) -> new UnaryScalar<>(
+            (signature, ignoredBoundSignature) -> new UnaryScalar<>(
                 signature,
-                boundSignature,
+                BoundSignature.sameAsUnbound(signature),
                 DataTypes.NUMERIC,
                 SquareRootFunction::sqrt
             )

--- a/server/src/main/java/io/crate/expression/scalar/arithmetic/TrigonometricFunctions.java
+++ b/server/src/main/java/io/crate/expression/scalar/arithmetic/TrigonometricFunctions.java
@@ -34,8 +34,8 @@ import io.crate.metadata.FunctionType;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
 import io.crate.metadata.Scalar.Feature;
+import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
-import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.DoubleType;
 
@@ -88,11 +88,11 @@ public final class TrigonometricFunctions {
                 .returnType(DataTypes.NUMERIC.getTypeSignature())
                 .features(Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
-            (signature, boundSignature) ->
+            (signature, ignoredBoundSignature) ->
                 new BinaryScalar<>(
                     (y, x) -> BigDecimalMath.atan2(y, x, MathContext.DECIMAL128),
                     signature,
-                    boundSignature,
+                    BoundSignature.sameAsUnbound(signature),
                     DataTypes.NUMERIC
             )
         );
@@ -117,15 +117,13 @@ public final class TrigonometricFunctions {
                 .returnType(DataTypes.NUMERIC.getTypeSignature())
                 .features(Scalar.Feature.DETERMINISTIC, Scalar.Feature.STRICTNULL)
                 .build(),
-            (signature, boundSignature) -> {
-                DataType<?> argType = boundSignature.argTypes().get(0);
-                return new UnaryScalar<>(
+            (signature, ignoredBoundSignature) ->
+                new UnaryScalar<>(
                     signature,
-                    boundSignature,
-                    argType,
-                    x -> argType.sanitizeValue(func.apply((BigDecimal) x))
-                );
-            }
+                    BoundSignature.sameAsUnbound(signature),
+                    DataTypes.NUMERIC,
+                    func
+                )
         );
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/AbsFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/AbsFunctionTest.java
@@ -26,11 +26,13 @@ import static io.crate.testing.Asserts.isLiteral;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 import org.junit.Test;
 
 import io.crate.exceptions.ConversionException;
 import io.crate.expression.scalar.ScalarTestCase;
+import io.crate.types.NumericType;
 
 
 public class AbsFunctionTest extends ScalarTestCase {
@@ -60,5 +62,10 @@ public class AbsFunctionTest extends ScalarTestCase {
     @Test
     public void testNormalizeNull() throws Exception {
         assertNormalize("abs(null)", isLiteral(null));
+    }
+
+    @Test
+    public void test_numeric_return_type() {
+        assertNormalize("abs(cast(null as numeric(10, 5)))", isLiteral(null, NumericType.of(List.of(10, 5))));
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/CeilFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/CeilFunctionTest.java
@@ -25,11 +25,13 @@ import static io.crate.testing.Asserts.isFunction;
 import static io.crate.testing.Asserts.isLiteral;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 import org.junit.Test;
 
 import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.types.DataTypes;
+import io.crate.types.NumericType;
 
 public class CeilFunctionTest extends ScalarTestCase {
 
@@ -38,6 +40,11 @@ public class CeilFunctionTest extends ScalarTestCase {
         assertNormalize("ceil(cast(123.456789 as numeric(9, 6)))", isLiteral(new BigDecimal(124)));
         assertNormalize("ceil(cast(-123.456789 as numeric(9, 6)))", isLiteral(new BigDecimal(-123)));
         assertNormalize("ceil(cast(null as numeric))", isLiteral(null, DataTypes.NUMERIC));
+    }
+
+    @Test
+    public void test_numeric_return_type() {
+        assertNormalize("ceil(cast(null as numeric(10, 5)))", isLiteral(null, NumericType.of(List.of(10, 5))));
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/ExpFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/ExpFunctionTest.java
@@ -28,6 +28,7 @@ import java.math.BigDecimal;
 import org.junit.Test;
 
 import io.crate.expression.scalar.ScalarTestCase;
+import io.crate.types.DataTypes;
 
 public class ExpFunctionTest extends ScalarTestCase {
 
@@ -39,5 +40,10 @@ public class ExpFunctionTest extends ScalarTestCase {
         assertNormalize("exp(1.0::real)", isLiteral(2.718281828459045, 1E-15d));
         assertNormalize("exp(1.0::numeric)",
             isLiteral(new BigDecimal("2.718281828459045235360287471352662"), new BigDecimal("1E-15")));
+    }
+
+    @Test
+    public void test_numeric_return_type() {
+        assertNormalize("exp(cast(null as numeric(10, 5)))", isLiteral(null, DataTypes.NUMERIC));
     }
 }

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/FloorFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/FloorFunctionTest.java
@@ -25,11 +25,13 @@ import static io.crate.testing.Asserts.isFunction;
 import static io.crate.testing.Asserts.isLiteral;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 import org.junit.Test;
 
 import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.types.DataTypes;
+import io.crate.types.NumericType;
 
 public class FloorFunctionTest extends ScalarTestCase {
 
@@ -38,6 +40,11 @@ public class FloorFunctionTest extends ScalarTestCase {
         assertNormalize("floor(cast(123.456789 as numeric(9, 6)))", isLiteral(new BigDecimal(123)));
         assertNormalize("floor(cast(-123.456789 as numeric(9, 6)))", isLiteral(new BigDecimal(-124)));
         assertNormalize("floor(cast(null as numeric))", isLiteral(null, DataTypes.NUMERIC));
+    }
+
+    @Test
+    public void test_numeric_return_type() {
+        assertNormalize("floor(cast(null as numeric(10, 5)))", isLiteral(null, NumericType.of(List.of(10, 5))));
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/LogFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/LogFunctionTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 import io.crate.exceptions.ConversionException;
 import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.expression.symbol.Literal;
+import io.crate.types.DataTypes;
 
 public class LogFunctionTest extends ScalarTestCase {
 
@@ -58,6 +59,12 @@ public class LogFunctionTest extends ScalarTestCase {
         assertNormalize("log(null, 10)", isLiteral(null));
         assertNormalize("log(10, null)", isLiteral(null));
         assertNormalize("log(null, null)", isLiteral(null));
+    }
+
+    @Test
+    public void test_numeric_return_type() {
+        assertNormalize("log(cast(null as numeric(10, 5)))", isLiteral(null, DataTypes.NUMERIC));
+        assertNormalize("ln(cast(null as numeric(10, 5)))", isLiteral(null, DataTypes.NUMERIC));
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/RoundFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/RoundFunctionTest.java
@@ -22,14 +22,18 @@
 package io.crate.expression.scalar.arithmetic;
 
 import static io.crate.testing.Asserts.isFunction;
+import static io.crate.testing.Asserts.isLiteral;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 import org.junit.Test;
 
 import io.crate.exceptions.ConversionException;
 import io.crate.expression.scalar.ScalarTestCase;
+import io.crate.types.DataTypes;
+import io.crate.types.NumericType;
 
 
 public class RoundFunctionTest extends ScalarTestCase {
@@ -46,6 +50,11 @@ public class RoundFunctionTest extends ScalarTestCase {
         assertEvaluateNull("round(null)");
 
         assertNormalize("round(id)", isFunction("round"));
+    }
+
+    @Test
+    public void test_numeric_return_type() {
+        assertNormalize("round(cast(null as numeric(10, 5)))", isLiteral(null, NumericType.of(List.of(10, 5))));
     }
 
     @Test
@@ -78,6 +87,12 @@ public class RoundFunctionTest extends ScalarTestCase {
         assertEvaluateNull("round(1,null)");
         assertEvaluateNull("round(null,null)");
         assertEvaluateNull("round(null,1)");
+    }
+
+    @Test
+    public void test_numeric_return_type_with_precision_param() {
+        assertNormalize("round(cast(null as numeric(10, 5)), 1)", isLiteral(null, NumericType.of(List.of(10, 5))));
+        assertNormalize("round(cast(null as double), 1)", isLiteral(null, DataTypes.NUMERIC));
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/SquareRootFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/SquareRootFunctionTest.java
@@ -22,6 +22,7 @@
 package io.crate.expression.scalar.arithmetic;
 
 import static io.crate.testing.Asserts.isFunction;
+import static io.crate.testing.Asserts.isLiteral;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.math.BigDecimal;
@@ -30,6 +31,7 @@ import org.junit.Test;
 
 import io.crate.exceptions.ConversionException;
 import io.crate.expression.scalar.ScalarTestCase;
+import io.crate.types.DataTypes;
 
 
 public class SquareRootFunctionTest extends ScalarTestCase {
@@ -43,6 +45,11 @@ public class SquareRootFunctionTest extends ScalarTestCase {
         assertEvaluate("sqrt(cast(25.0 as float))", 5.0);
         assertEvaluate("sqrt(cast(123.4 as numeric(6, 1)))",
             new BigDecimal("11.10855526159905278255972911272118"));
+    }
+
+    @Test
+    public void test_numeric_return_type() {
+        assertNormalize("sqrt(cast(null as numeric(10, 5)))", isLiteral(null, DataTypes.NUMERIC));
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/TrigonometricFunctionsTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/TrigonometricFunctionsTest.java
@@ -321,4 +321,16 @@ public class TrigonometricFunctionsTest extends ScalarTestCase {
         assertNormalize("atan2(age, age)", isFunction("atan2"));
         assertNormalize("cot(age)", isFunction("cot"));
     }
+
+    @Test
+    public void test_numeric_return_type() {
+        assertNormalize("sin(cast(null as numeric(10, 5)))", isLiteral(null, DataTypes.NUMERIC));
+        assertNormalize("asin(cast(null as numeric(10, 5)))", isLiteral(null, DataTypes.NUMERIC));
+        assertNormalize("cos(cast(null as numeric(10, 5)))", isLiteral(null, DataTypes.NUMERIC));
+        assertNormalize("acos(cast(null as numeric(10, 5)))", isLiteral(null, DataTypes.NUMERIC));
+        assertNormalize("tan(cast(null as numeric(10, 5)))", isLiteral(null, DataTypes.NUMERIC));
+        assertNormalize("atan(cast(null as numeric(10, 5)))", isLiteral(null, DataTypes.NUMERIC));
+        assertNormalize("atan2(cast(null as numeric(10, 5)), 1)", isLiteral(null, DataTypes.NUMERIC));
+        assertNormalize("cot(cast(null as numeric(10, 5)))", isLiteral(null, DataTypes.NUMERIC));
+    }
 }


### PR DESCRIPTION
For all math functions that support `NUMERIC` values as arg, don't use the boundSignature, but instead use the declared signature, to ensure that the return type is of generic `NUMERIC` with unspecified precision and scale.

Exceptions are, `abs()`, `floor()`, `ceil()` and `round()` where we actually want to return the same datatype as the one of the input.

Enhance doc by describing exactly this behavior for every function that supports `NUMERIC` args.

Follows: #16818
Follows: #16824
Follows: #16825

(this PR only affects master)

I chose to keep abs/floor/ceil/round return the input datatype, as to me it makes sense, there is no additional precision/scale needed, and already `round(<numeric>, <numDigits>)` was doing that.
Keep in mind that `round(<otherType>, <numDigits>)` returns a numeric of unspecified type, as we have for example a double, or float, so no precision/scale to maintain in this case.
