### PR TITLE
Fix filtering by unbounded numeric literal, `= <numeric>::numeric`

### DIFF
--- a/server/src/test/java/io/crate/lucene/NumericEqQueryTest.java
+++ b/server/src/test/java/io/crate/lucene/NumericEqQueryTest.java
@@ -23,6 +23,7 @@ package io.crate.lucene;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.PointRangeQuery;
 import org.apache.lucene.search.Query;
 import org.junit.Test;
@@ -113,6 +114,20 @@ public class NumericEqQueryTest extends LuceneQueryBuilderTest {
         assertThat(convert(col + " <= -1.105")).isEqualTo(convert(col + " < -1.10"));
         assertThat(convert(col + " <= -1.1")).isEqualTo(convert(col + " < -1.09"));
         assertThat(convert(col + " <= -1")).isEqualTo(convert(col + " < -0.99"));
+    }
+
+    @Test
+    public void test_equals_unbounded_numeric_with_larger_scale() {
+        assertThat(convert("x = 1.111::numeric")).isExactlyInstanceOf(MatchNoDocsQuery.class);
+        assertThat(convert("y = 1.111::numeric")).isExactlyInstanceOf(MatchNoDocsQuery.class);
+    }
+
+    @Test
+    public void test_same_significant_digits_produce_distinct_lucene_queries() {
+        String col = randomBoolean() ? "x" : "y";
+        assertThat(convert(col + " = 1.11::numeric").toString()).isEqualTo(col + ":[111 TO 111]");
+        assertThat(convert(col + " = 11.1::numeric").toString()).isEqualTo(col + ":[1110 TO 1110]");
+        assertThat(convert(col + " = 111::numeric").toString()).isEqualTo(col + ":[11100 TO 11100]");
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Initial attempt https://github.com/crate/crate/pull/16829 with narrowed scope.

Fixes:
```
cr> create table t (a numeric(4,2));
CREATE OK, 1 row affected (1.642 sec)
cr> insert into t values (1.11);
INSERT OK, 1 row affected (2.536 sec)
cr> insert into t values (11.11);
INSERT OK, 1 row affected (1.567 sec)
cr> select * from t where a = 1.111::numeric;  -- 1.111 has scale = 3 so it can be turned into a MatchNoDocsQuery
+-------+
|     a |
+-------+
| 11.11 |
+-------+
SELECT 1 row in set (1.843 sec)
cr> select * from t where a =111::numeric;  -- the unscaled value of 111 was 111 which was identical to the unscaled value of 1.11.
+------+
|    a |
+------+
| 1.11 |
+------+
SELECT 1 row in set (0.004 sec)
```
Please see the test cases added for more.

https://github.com/crate/crate/blob/a1f77cfb706fb3fb470a58e5d0dad58eb679ade6/docs/appendices/release-notes/5.9.1.rst?plain=1#L118-L120 is enough that we do not need an extra release entry.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
