### PR TITLE
Fix filtering by comparisions of different data types

### DIFF
--- a/docs/appendices/release-notes/5.9.3.rst
+++ b/docs/appendices/release-notes/5.9.3.rst
@@ -50,3 +50,18 @@ Fixes
 - Fixed an issue that prevented to cast an array of :ref:`TEXT <type-text>`
   containing JSON text representation values to an array of
   :ref:`OBJECT <type-object>`.
+
+- Fixed an issue that caused ``ClassCastExceptions`` or invalid results when
+  the ``WHERE`` clause contained comparisons of different data types. For
+  example::
+
+      SELECT * FROM t WHERE a < 128;
+      SQLParseException[Cannot cast `128` of type `integer` to type `byte`]
+
+      SELECT * FROM t WHERE float_col = 0.99999999;
+      +-----------+
+      | float_col |
+      +-----------+
+      |       1.0 |
+      +-----------+
+

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/Optimizer.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/Optimizer.java
@@ -41,6 +41,7 @@ import io.crate.planner.optimizer.symbol.rule.MoveArrayLengthOnReferenceCastToLi
 import io.crate.planner.optimizer.symbol.rule.MoveReferenceCastToLiteralCastOnArrayOperatorsWhenLeftIsReference;
 import io.crate.planner.optimizer.symbol.rule.MoveReferenceCastToLiteralCastOnArrayOperatorsWhenRightIsReference;
 import io.crate.planner.optimizer.symbol.rule.MoveSubscriptOnReferenceCastToLiteralCastInsideOperators;
+import io.crate.planner.optimizer.symbol.rule.RemoveRedundantImplicitCastOverReferences;
 import io.crate.planner.optimizer.symbol.rule.SimplifyEqualsOperationOnIdenticalReferences;
 import io.crate.planner.optimizer.symbol.rule.SwapCastsInComparisonOperators;
 import io.crate.planner.optimizer.symbol.rule.SwapCastsInLikeOperators;
@@ -55,7 +56,8 @@ public class Optimizer {
         new MoveReferenceCastToLiteralCastOnArrayOperatorsWhenLeftIsReference(),
         new MoveSubscriptOnReferenceCastToLiteralCastInsideOperators(),
         new MoveArrayLengthOnReferenceCastToLiteralCastInsideOperators(),
-        new SimplifyEqualsOperationOnIdenticalReferences()
+        new SimplifyEqualsOperationOnIdenticalReferences(),
+        new RemoveRedundantImplicitCastOverReferences()
     );
 
     public static Symbol optimizeCasts(Symbol query, PlannerContext plannerCtx) {

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/rule/RemoveRedundantImplicitCastOverReferences.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/rule/RemoveRedundantImplicitCastOverReferences.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.symbol.rule;
+
+import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
+
+import org.jetbrains.annotations.Nullable;
+
+import io.crate.expression.scalar.cast.ImplicitCastFunction;
+import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.SymbolType;
+import io.crate.metadata.NodeContext;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Pattern;
+import io.crate.planner.optimizer.symbol.FunctionLookup;
+import io.crate.planner.optimizer.symbol.Rule;
+import io.crate.types.ArrayType;
+
+/**
+ * Sometimes redundant casts are introduced, i.e.:: for numeric_array column whose type is `NUMERIC(p,s)`, queries like
+ * `numeric_array = [1.11, 1.12]::numeric[]` resolve to `op_=(NUMERIC(null, null), NUMERIC(null,null))` such that
+ * numeric_array is cast to NUMERIC(null, null) by {@link io.crate.analyze.expressions.ExpressionAnalyzer#cast}. However,
+ * it is an implicit cast(to the same type) that the values are not intended to be modified in any way, the cast is
+ * redundant and can be removed.
+ */
+public class RemoveRedundantImplicitCastOverReferences implements Rule<Function> {
+
+    private final Pattern<Function> pattern;
+
+    public RemoveRedundantImplicitCastOverReferences() {
+        this.pattern = typeOf(Function.class)
+            .with(cast -> cast.name().equals(ImplicitCastFunction.NAME))
+            .with(cast -> cast.arguments().getFirst().symbolType() == SymbolType.REFERENCE)
+            .with(cast -> (ArrayType.unnest(cast.valueType()).id() == ArrayType.unnest(cast.arguments().getFirst().valueType()).id()) &&
+                ArrayType.dimensions(cast.valueType()) == ArrayType.dimensions(cast.arguments().getFirst().valueType()));
+    }
+
+    @Override
+    public Pattern<Function> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public Symbol apply(Function cast,
+                        Captures captures,
+                        NodeContext nodeCtx,
+                        FunctionLookup functionLookup,
+                        @Nullable Symbol parentNode) {
+        return cast.arguments().getFirst();
+    }
+}

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/rule/SwapCastsInComparisonOperators.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/rule/SwapCastsInComparisonOperators.java
@@ -23,15 +23,19 @@ package io.crate.planner.optimizer.symbol.rule;
 
 import static io.crate.expression.operator.Operators.COMPARISON_OPERATORS;
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
+import static io.crate.types.DataTypes.isSafeConversion;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 import io.crate.expression.scalar.cast.CastMode;
 import io.crate.expression.scalar.cast.ImplicitCastFunction;
 import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolType;
 import io.crate.metadata.NodeContext;
+import io.crate.metadata.Reference;
 import io.crate.planner.optimizer.matcher.Capture;
 import io.crate.planner.optimizer.matcher.Captures;
 import io.crate.planner.optimizer.matcher.Pattern;
@@ -41,11 +45,50 @@ import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 
-
 public class SwapCastsInComparisonOperators implements Rule<Function> {
 
     private final Capture<Function> castCapture;
     private final Pattern<Function> pattern;
+
+    /**
+     * A cast is 'swappable' if the cast does not cause loss of precision. This method executes the casts in uncertain
+     * situations. i.e.:: casting 126 type of int to a byte, which is a narrowing conversion, is convertable since 126
+     * does fit in a byte.
+     */
+    private static boolean isSwappable(Function cmpOp) {
+        if (cmpOp.arguments().get(1) instanceof Literal<?> literal) {
+            Function cast = (Function) cmpOp.arguments().getFirst();
+            Reference ref = (Reference) cast.arguments().getFirst();
+            DataType<?> refInnerType = ArrayType.unnest(ref.valueType());
+            DataType<?> literalInnerType = ArrayType.unnest(literal.valueType());
+            if (!DataTypes.isNumeric(literalInnerType) || !DataTypes.isNumeric(refInnerType)) {
+                return true;
+            }
+            if (isSafeConversion(literalInnerType, refInnerType)) {
+                return true;
+            }
+            return isNarrowingConversionPossible(literal.value(), ref.valueType());
+        }
+        return true;
+    }
+
+    /**
+     * Executes a narrowing conversion to verify that it is possible.
+     */
+    private static boolean isNarrowingConversionPossible(Object value, DataType<?> targetType) {
+        if (DataTypes.isArray(targetType)) {
+            return ((List<?>) value).stream().allMatch(e -> isNarrowingConversionPossible(e, ((ArrayType<?>) targetType).innerType()));
+        } else {
+            try {
+                Number n = (Number) value;
+                var literalStr = String.valueOf(n);
+                var castedStr = String.valueOf(targetType.implicitCast(n));
+                return new BigDecimal(literalStr).compareTo(new BigDecimal(castedStr)) == 0;
+            } catch (IllegalArgumentException | ClassCastException e) {
+                return false;
+            }
+        }
+    }
 
     public SwapCastsInComparisonOperators() {
         this.castCapture = new Capture<>();
@@ -56,7 +99,7 @@ public class SwapCastsInComparisonOperators implements Rule<Function> {
                 // We have to respect explicit casts, see https://github.com/crate/crate/issues/12135
                 .with(f -> f.name().equals(ImplicitCastFunction.NAME))
                 .with(f -> f.arguments().get(0).symbolType() == SymbolType.REFERENCE)
-            );
+            ).with(SwapCastsInComparisonOperators::isSwappable);
     }
 
     @Override
@@ -74,14 +117,6 @@ public class SwapCastsInComparisonOperators implements Rule<Function> {
         var castFunction = captures.get(castCapture);
         var reference = castFunction.arguments().get(0);
         DataType<?> targetType = reference.valueType();
-
-        // For `WHERE <numeric_array_ref> = <numeric_array_literal>`, where the ref is type of NUMERIC(x,y) and casted
-        // to NUMERIC(null,null), the cast to be moved must be NUMERIC(null, null) not NUMERIC(x,y). Because NUMERIC(x,y)
-        // may cause the numeric array literal to be rounded.
-        if (ArrayType.unnest(targetType).id() == DataTypes.NUMERIC.id()) {
-            targetType = castFunction.valueType();
-        }
-
         CastMode castMode = castFunction.castMode();
         assert castMode != null : "Pattern matched, function must be a cast";
         Symbol castedLiteral = literalOrParam.cast(targetType, castMode);

--- a/server/src/main/java/io/crate/types/DataTypes.java
+++ b/server/src/main/java/io/crate/types/DataTypes.java
@@ -387,6 +387,10 @@ public final class DataTypes {
         return new ArrayType<>(highest);
     }
 
+    public static boolean isSafeConversion(DataType<?> source, DataType<?> target) {
+        return SAFE_CONVERSIONS.getOrDefault(source.id(), Set.of()).contains(target);
+    }
+
     private static boolean safeConversionPossible(DataType<?> type1, DataType<?> type2) {
         final DataType<?> source;
         final DataType<?> target;
@@ -558,6 +562,10 @@ public final class DataTypes {
      */
     public static boolean isNumericPrimitive(DataType<?> type) {
         return NUMERIC_PRIMITIVE_TYPE_IDS.contains(type.id());
+    }
+
+    public static boolean isNumeric(DataType<?> type) {
+        return NUMERIC_PRIMITIVE_TYPE_IDS.contains(type.id()) || NUMERIC.id() == type.id();
     }
 
     /**

--- a/server/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
@@ -186,16 +186,6 @@ public class SQLTypeMappingTest extends IntegTestCase {
     }
 
     @Test
-    public void testInvalidWhereClause() throws Exception {
-        setUpSimple();
-
-        Asserts.assertSQLError(() -> execute("delete from t1 where byte_field=129"))
-            .hasPGError(INTERNAL_ERROR)
-            .hasHTTPError(BAD_REQUEST, 4000)
-            .hasMessageContaining("Cannot cast `129` of type `integer` to type `byte`");
-    }
-
-    @Test
     public void testInvalidWhereInWhereClause() throws Exception {
         setUpSimple();
 

--- a/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -820,4 +820,15 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
         query = convert("(['hello', 'world'] in (string_array))");
         assertThat(query).hasToString("(['hello', 'world'] = ANY([string_array]))");
     }
+
+    @Test
+    public void test_comparisons_between_different_types_do_not_cause_precision_loss() {
+        Query query = convert("byte_col < 128"); // byte to int comparison
+        assertThat(query).isExactlyInstanceOf(GenericFunctionQuery.class);
+        assertThat(query).hasToString("(byte_col < 128)");
+
+        query = convert("f = 0.99999999"); // float to double conparison
+        assertThat(query).isExactlyInstanceOf(GenericFunctionQuery.class);
+        assertThat(query).hasToString("(f = 0.99999999)");
+    }
 }

--- a/server/src/test/java/io/crate/lucene/NumericEqQueryTest.java
+++ b/server/src/test/java/io/crate/lucene/NumericEqQueryTest.java
@@ -135,9 +135,9 @@ public class NumericEqQueryTest extends LuceneQueryBuilderTest {
     @Test
     public void test_terms_query_with_same_significant_digits() {
         assertThat(convert("xarr = [1.11, 11.1, 111]::numeric[]").toString())
-            .isEqualTo("+xarr:{111 1110 11100} +(xarr = [1.11, 11.1, 111.0])");
+            .isEqualTo("+xarr:{111 1110 11100} +(xarr = [1.11, 11.10, 111.00])");
         assertThat(convert("yarr = [1.11, 11.1, 111]::numeric[]").toString())
-            .isEqualTo("+yarr:{111 1110 11100} +(yarr = [1.11, 11.1, 111.0])");
+            .isEqualTo("+yarr:{111 1110 11100} +(yarr = [1.11, 11.10, 111.00])");
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes

```
cr> create table t (a byte, b float);
CREATE OK, 1 row affected (1.702 sec)
cr> insert into t(b) values (0.12345679);
INSERT OK, 1 row affected (0.108 sec)

cr> select * from t where a < 128;
SQLParseException[Cannot cast `128` of type `integer` to type `byte`]

cr> select * from t where b = 0.123456789;
+------+------------+
| a    |          b |
+------+------------+
| NULL | 0.12345679 | -- 0.123456789 is rounded to 0.12345679 and falsely matches
+------+------------+
SELECT 1 row in set (0.010 sec)
```

What happened was that `SwapCastsInComparisonOperators` swapped casts that led to precision loss or exceptions. The approach to fix is to prevent such casts to be swapped.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
