### PR TITLE
Remove undocumented shard.check_on_startup index setting

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -89,7 +89,6 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
         IndexSettings.MAX_NGRAM_DIFF_SETTING,
         IndexSettings.MAX_SHINGLE_DIFF_SETTING,
         IndexSettings.INDEX_TRANSLOG_SYNC_INTERVAL_SETTING,
-        IndexSettings.INDEX_CHECK_ON_STARTUP,
         IndexSettings.MAX_REFRESH_LISTENERS_PER_SHARD,
         ShardsLimitAllocationDecider.INDEX_TOTAL_SHARDS_PER_NODE_SETTING,
         IndexSettings.INDEX_GC_DELETES_SETTING,

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -65,18 +65,6 @@ public final class IndexSettings {
                       Property.IndexScope,
                       Property.ReplicatedIndexScope);
 
-    public static final Setting<String> INDEX_CHECK_ON_STARTUP = new Setting<>("index.shard.check_on_startup", "false", (s) -> {
-        switch (s) {
-            case "false":
-            case "true":
-            case "fix":
-            case "checksum":
-                return s;
-            default:
-                throw new IllegalArgumentException("unknown value for [index.shard.check_on_startup] must be one of [true, false, fix, checksum] but was: " + s);
-        }
-    }, DataTypes.STRING, Property.IndexScope);
-
     /**
      * Index setting describing for NGramTokenizer and NGramTokenFilter
      * the maximum difference between

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -23,10 +23,8 @@ import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.io.PrintStream;
 import java.io.UncheckedIOException;
 import java.nio.channels.ClosedByInterruptException;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -58,7 +56,6 @@ import java.util.stream.StreamSupport;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.index.CheckIndex;
 import org.apache.lucene.index.IndexCommit;
 import org.apache.lucene.index.SegmentInfos;
 import org.apache.lucene.index.Term;
@@ -86,9 +83,7 @@ import org.elasticsearch.cluster.routing.RecoverySource.SnapshotRecoverySource;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.CheckedConsumer;
 import org.elasticsearch.common.CheckedRunnable;
-import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.lease.Releasable;
-import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.metrics.CounterMetric;
 import org.elasticsearch.common.metrics.MeanMetric;
 import org.elasticsearch.common.settings.Settings;
@@ -130,8 +125,6 @@ import org.elasticsearch.index.seqno.SeqNoStats;
 import org.elasticsearch.index.seqno.SequenceNumbers;
 import org.elasticsearch.index.shard.PrimaryReplicaSyncer.ResyncTask;
 import org.elasticsearch.index.store.Store;
-import org.elasticsearch.index.store.Store.MetadataSnapshot;
-import org.elasticsearch.index.store.StoreFileMetadata;
 import org.elasticsearch.index.store.StoreStats;
 import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.index.translog.TranslogConfig;
@@ -152,7 +145,6 @@ import org.jetbrains.annotations.Nullable;
 
 import com.carrotsearch.hppc.ObjectLongMap;
 
-import io.crate.common.Booleans;
 import io.crate.common.collections.Tuple;
 import io.crate.common.exceptions.Exceptions;
 import io.crate.common.io.IOUtils;
@@ -173,7 +165,6 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     private final QueryCache queryCache;
     private final Store store;
     private final Object mutex = new Object();
-    private final String checkIndexOnStartup;
     private final CodecService codecService;
     private final TranslogConfig translogConfig;
     private final IndexEventListener indexEventListener;
@@ -288,7 +279,6 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         /* create engine config */
         logger.debug("state: [CREATED]");
 
-        this.checkIndexOnStartup = indexSettings.getValue(IndexSettings.INDEX_CHECK_ON_STARTUP);
         this.translogConfig = new TranslogConfig(shardId, shardPath().resolveTranslog(), indexSettings, bigArrays);
         final String aId = shardRouting.allocationId().getId();
         final long primaryTerm = indexSettings.getIndexMetadata().primaryTerm(shardId.id());
@@ -1288,7 +1278,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             return UNASSIGNED_SEQ_NO;
         }
         try {
-            maybeCheckIndex(); // check index here and won't do it again if ops-based recovery occurs
+            recoveryState.setStage(RecoveryState.Stage.VERIFY_INDEX);
             recoveryState.setStage(RecoveryState.Stage.TRANSLOG);
             if (safeCommit.isPresent() == false) {
                 assert globalCheckpoint == UNASSIGNED_SEQ_NO :
@@ -1479,7 +1469,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
      **/
     public void openEngineAndRecoverFromTranslog() throws IOException {
         recoveryState.validateCurrentStage(RecoveryState.Stage.INDEX);
-        maybeCheckIndex();
+        recoveryState.setStage(RecoveryState.Stage.VERIFY_INDEX);
         recoveryState.setStage(RecoveryState.Stage.TRANSLOG);
         final RecoveryState.Translog translogRecoveryStats = recoveryState.getTranslog();
         final Engine.TranslogRecoveryRunner translogRecoveryRunner = (engine, snapshot) -> {
@@ -2378,78 +2368,6 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     public boolean pendingInSync() {
         assert assertPrimaryMode();
         return replicationTracker.pendingInSync();
-    }
-
-    public void maybeCheckIndex() {
-        recoveryState.setStage(RecoveryState.Stage.VERIFY_INDEX);
-        if (Booleans.isTrue(checkIndexOnStartup) || "checksum".equals(checkIndexOnStartup)) {
-            try {
-                checkIndex();
-            } catch (IOException ex) {
-                throw new RecoveryFailedException(recoveryState, "check index failed", ex);
-            }
-        }
-    }
-
-    void checkIndex() throws IOException {
-        if (store.tryIncRef()) {
-            try {
-                doCheckIndex();
-            } catch (IOException e) {
-                store.markStoreCorrupted(e);
-                throw e;
-            } finally {
-                store.decRef();
-            }
-        }
-    }
-
-    private void doCheckIndex() throws IOException {
-        final long timeNS = System.nanoTime();
-        if (!Lucene.indexExists(store.directory())) {
-            return;
-        }
-        BytesStreamOutput os = new BytesStreamOutput();
-        PrintStream out = new PrintStream(os, false, StandardCharsets.UTF_8.name());
-
-        if ("checksum".equals(checkIndexOnStartup)) {
-            // physical verification only: verify all checksums for the latest commit
-            IOException corrupt = null;
-            MetadataSnapshot metadata = snapshotStoreMetadata();
-            for (Map.Entry<String, StoreFileMetadata> entry : metadata.asMap().entrySet()) {
-                try {
-                    Store.checkIntegrity(entry.getValue(), store.directory());
-                    out.println("checksum passed: " + entry.getKey());
-                } catch (IOException exc) {
-                    out.println("checksum failed: " + entry.getKey());
-                    exc.printStackTrace(out);
-                    corrupt = exc;
-                }
-            }
-            out.flush();
-            if (corrupt != null) {
-                logger.warn("check index [failure]\n{}", os.bytes().utf8ToString());
-                throw corrupt;
-            }
-        } else {
-            // full checkindex
-            final CheckIndex.Status status = store.checkIndex(out);
-            out.flush();
-            if (!status.clean) {
-                if (state == IndexShardState.CLOSED) {
-                    // ignore if closed....
-                    return;
-                }
-                logger.warn("check index [failure]\n{}", os.bytes().utf8ToString());
-                throw new IOException("index check failure");
-            }
-        }
-
-        if (logger.isDebugEnabled()) {
-            logger.debug("check index [success]\n{}", os.bytes().utf8ToString());
-        }
-
-        recoveryState.getVerifyIndex().checkIndexTime(Math.max(0, TimeValue.nsecToMSec(System.nanoTime() - timeNS)));
     }
 
     Engine getEngine() {

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
@@ -447,7 +447,7 @@ public class RecoveryTarget extends AbstractRefCounted implements RecoveryTarget
                 } else {
                     assert indexShard.assertRetentionLeasesPersisted();
                 }
-                indexShard.maybeCheckIndex();
+                state().setStage(RecoveryState.Stage.VERIFY_INDEX);
                 state().setStage(RecoveryState.Stage.TRANSLOG);
             } catch (CorruptIndexException | IndexFormatTooNewException | IndexFormatTooOldException ex) {
                 // this is a fatal exception at this stage.

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -141,7 +141,6 @@ import org.elasticsearch.repositories.IndexId;
 import org.elasticsearch.repositories.RepositoryData;
 import org.elasticsearch.snapshots.Snapshot;
 import org.elasticsearch.snapshots.SnapshotId;
-import org.elasticsearch.test.CorruptionUtils;
 import org.elasticsearch.test.DummyShardLock;
 import org.elasticsearch.test.VersionUtils;
 import org.elasticsearch.test.store.MockFSDirectoryFactory;
@@ -1165,74 +1164,6 @@ public class IndexShardTests extends IndexShardTestCase {
     }
 
     @Test
-    public void testIndexCheckOnStartup() throws Exception {
-        IndexShard indexShard = newStartedShard(true);
-
-        long numDocs = between(10, 100);
-        for (long i = 0; i < numDocs; i++) {
-            indexDoc(indexShard, Long.toString(i), "{}");
-        }
-        indexShard.flush(new FlushRequest());
-        closeShards(indexShard);
-
-        ShardPath shardPath = indexShard.shardPath();
-
-        Path indexPath = shardPath.getDataPath().resolve(ShardPath.INDEX_FOLDER_NAME);
-        CorruptionUtils.corruptIndex(random(), indexPath, false);
-
-        AtomicInteger corruptedMarkerCount = new AtomicInteger();
-         SimpleFileVisitor<Path> corruptedVisitor = new SimpleFileVisitor<>() {
-             @Override
-             public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-                 if (Files.isRegularFile(file) && file.getFileName().toString().startsWith(Store.CORRUPTED_MARKER_NAME_PREFIX)) {
-                     corruptedMarkerCount.incrementAndGet();
-                 }
-                 return FileVisitResult.CONTINUE;
-             }
-         };
-        Files.walkFileTree(indexPath, corruptedVisitor);
-
-        assertThat(corruptedMarkerCount.get()).as("corruption marker should not be there").isEqualTo(0);
-
-        ShardRouting shardRouting = ShardRoutingHelper.initWithSameId(
-            indexShard.routingEntry(),
-            RecoverySource.ExistingStoreRecoverySource.INSTANCE
-        );
-        // start shard and perform index check on startup. It enforce shard to fail due to corrupted index files
-        IndexMetadata indexMetadata = IndexMetadata.builder(
-            indexShard.indexSettings().getIndexMetadata()).settings(
-                Settings.builder()
-                    .put(indexShard.indexSettings.getSettings())
-                    .put(IndexSettings.INDEX_CHECK_ON_STARTUP.getKey(), randomFrom("true", "checksum")))
-            .build();
-
-        IndexShard corruptedShard = newShard(
-            shardRouting,
-            shardPath,
-            indexMetadata,
-            null,
-            indexShard.engineFactoryProviders(),
-            indexShard.getGlobalCheckpointSyncer(),
-            indexShard.getRetentionLeaseSyncer(),
-            EMPTY_EVENT_LISTENER
-        );
-
-        assertThatThrownBy(() -> newStartedShard(p -> corruptedShard, true))
-            .isExactlyInstanceOf(IndexShardRecoveryException.class)
-            .hasMessage("failed recovery");
-
-        // check that corrupt marker is there
-        Files.walkFileTree(indexPath, corruptedVisitor);
-        assertThat(corruptedMarkerCount.get()).as("store has to be marked as corrupted").isEqualTo(1);
-
-        try {
-            closeShards(corruptedShard);
-        } catch (RuntimeException e) {
-            // Ignored because corrupted shard can throw various exceptions on close
-        }
-    }
-
-    @Test
     public void testShardDoesNotStartIfCorruptedMarkerIsPresent() throws Exception {
         IndexShard indexShard = newStartedShard(true);
 
@@ -1311,96 +1242,6 @@ public class IndexShardTests extends IndexShardTestCase {
         corruptedMarkerCount.set(0);
         Files.walkFileTree(indexPath, corruptedVisitor);
         assertThat(corruptedMarkerCount.get()).as("store still has a single corrupt marker").isEqualTo(1);
-    }
-
-    /**
-     * Simulates a scenario that happens when we are async fetching snapshot metadata from GatewayService
-     * and checking index concurrently. This should always be possible without any exception.
-     */
-    @Test
-    public void testReadSnapshotAndCheckIndexConcurrently() throws Exception {
-        final boolean isPrimary = randomBoolean();
-        IndexShard indexShard = newStartedShard(isPrimary);
-        final long numDocs = between(10, 100);
-        for (long i = 0; i < numDocs; i++) {
-            indexDoc(indexShard, Long.toString(i), "{}");
-            if (randomBoolean()) {
-                indexShard.refresh("test");
-            }
-        }
-        indexShard.flush(new FlushRequest());
-        closeShards(indexShard);
-
-        ShardRouting shardRouting = ShardRoutingHelper.initWithSameId(
-            indexShard.routingEntry(),
-            isPrimary
-                ? RecoverySource.ExistingStoreRecoverySource.INSTANCE
-                : RecoverySource.PeerRecoverySource.INSTANCE
-        );
-        IndexMetadata indexMetadata = IndexMetadata
-            .builder(indexShard.indexSettings().getIndexMetadata())
-            .settings(
-                Settings.builder()
-                    .put(indexShard.indexSettings.getSettings())
-                    .put(IndexSettings.INDEX_CHECK_ON_STARTUP.getKey(), randomFrom("false", "true", "checksum")))
-            .build();
-        IndexShard newShard = newShard(
-            shardRouting,
-            indexShard.shardPath(),
-            indexMetadata,
-            null,
-            indexShard.engineFactoryProviders,
-            indexShard.getGlobalCheckpointSyncer(),
-            indexShard.getRetentionLeaseSyncer(),
-            EMPTY_EVENT_LISTENER
-        );
-
-        Store.MetadataSnapshot storeFileMetadatas = newShard.snapshotStoreMetadata();
-        assertThat(storeFileMetadatas.size())
-            .as("at least 2 files, commit and data: " + storeFileMetadatas.toString())
-            .isGreaterThan(1);
-        AtomicBoolean stop = new AtomicBoolean(false);
-        CountDownLatch latch = new CountDownLatch(1);
-        Thread snapshotter = new Thread(() -> {
-            latch.countDown();
-            while (stop.get() == false) {
-                try {
-                    Store.MetadataSnapshot readMeta = newShard.snapshotStoreMetadata();
-                    assertThat(readMeta.getNumDocs()).isEqualTo(numDocs);
-                    assertThat(storeFileMetadatas.recoveryDiff(readMeta).different).hasSize(0);
-                    assertThat(storeFileMetadatas.recoveryDiff(readMeta).missing).hasSize(0);
-                    assertThat(storeFileMetadatas.recoveryDiff(readMeta).identical.size())
-                        .isEqualTo(storeFileMetadatas.size());
-                } catch (IOException e) {
-                    throw new AssertionError(e);
-                }
-            }
-        });
-        snapshotter.start();
-
-        if (isPrimary) {
-            newShard.markAsRecovering(
-                "store",
-                new RecoveryState(
-                    newShard.routingEntry(),
-                    getFakeDiscoNode(newShard.routingEntry().currentNodeId()), null));
-        } else {
-            newShard.markAsRecovering(
-                "peer",
-                new RecoveryState(
-                    newShard.routingEntry(),
-                    getFakeDiscoNode(newShard.routingEntry().currentNodeId()),
-                    getFakeDiscoNode(newShard.routingEntry().currentNodeId()))
-            );
-        }
-        int iters = iterations(10, 100);
-        latch.await();
-        for (int i = 0; i < iters; i++) {
-            newShard.checkIndex();
-        }
-        assertThat(stop.compareAndSet(false, true)).isTrue();
-        snapshotter.join();
-        closeShards(newShard);
     }
 
     @Test

--- a/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
@@ -372,10 +372,6 @@ public abstract class IntegTestCase extends ESTestCase {
             builder.put(MergeSchedulerConfig.AUTO_THROTTLE_SETTING.getKey(), false);
         }
 
-        if (random.nextBoolean()) {
-            builder.put(IndexSettings.INDEX_CHECK_ON_STARTUP.getKey(), randomFrom("false", "checksum", "true"));
-        }
-
         if (randomBoolean()) {
             // keep this low so we don't stall tests
             builder.put(UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(),


### PR DESCRIPTION
It defaulted to false and so far we never felt the need to turn it on.
