### PR TITLE
Rewrite right-outer-join to left-outer-hash-join

### DIFF
--- a/docs/appendices/release-notes/5.10.0.rst
+++ b/docs/appendices/release-notes/5.10.0.rst
@@ -88,17 +88,18 @@ None
 Performance and Resilience Improvements
 ---------------------------------------
 
-- Added hash-join execution for left-outer-equi-joins. This improves performance
-  for left-outer-join with an equi-join condition significantly with the cost of
-  higher memory consumption e.g.::
+- Added hash-join execution for left/right-outer-equi-joins. This improves
+  performance for left/right-outer-join with an equi-join condition significantly
+  with the cost of higher memory consumption e.g.::
 
     SELECT * FROM t1 LEFT JOIN t2 OM t1.id = t2.id;
 
-  This optimization can be disabled, with the session setting::
+  This optimization can be disabled, with the session settings::
 
     SET rewrite_left_outer_join_to_hash_join = false
+    SET rewrite_right_outer_join_to_hash_join = false
 
-  Note that this setting is experimental, and may change in the future.
+  Note that these settings are experimental, and may change in the future.
 
 Administration and Operations
 -----------------------------

--- a/docs/general/dql/joins.rst
+++ b/docs/general/dql/joins.rst
@@ -261,7 +261,7 @@ once. The whole operation will be repeated with the next block of the first
 relation once scanning the second relation has finished.
 
 This optimisation can be applied if the join is an ``INNER`` or ``LEFT OUTER``
-join and the join condition satisfies the following rules:
+or ``RIGHT OUTER`` join and the join condition satisfies the following rules:
 
 - Contains at least one ``EQUAL`` :ref:`operator <gloss-operator>`
 

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -122,6 +122,7 @@ import io.crate.planner.optimizer.rule.RewriteFilterOnOuterJoinToInnerJoin;
 import io.crate.planner.optimizer.rule.RewriteGroupByKeysLimitToLimitDistinct;
 import io.crate.planner.optimizer.rule.RewriteJoinPlan;
 import io.crate.planner.optimizer.rule.RewriteLeftOuterJoinToHashJoin;
+import io.crate.planner.optimizer.rule.RewriteRightOuterJoinToHashJoin;
 import io.crate.planner.optimizer.rule.RewriteToQueryThenFetch;
 import io.crate.planner.optimizer.tracer.OptimizerTracer;
 import io.crate.role.Role;
@@ -171,6 +172,7 @@ public class LogicalPlanner {
         new EliminateCrossJoin(),
         new EquiJoinToLookupJoin(),
         new RewriteLeftOuterJoinToHashJoin(),
+        new RewriteRightOuterJoinToHashJoin(),
         new RewriteJoinPlan()
     );
 

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteRightOuterJoinToHashJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteRightOuterJoinToHashJoin.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.rule;
+
+import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
+
+import io.crate.planner.operators.EquiJoinDetector;
+import io.crate.planner.operators.Eval;
+import io.crate.planner.operators.HashJoin;
+import io.crate.planner.operators.JoinPlan;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Pattern;
+import io.crate.sql.tree.JoinType;
+
+public class RewriteRightOuterJoinToHashJoin implements Rule<JoinPlan> {
+
+    private final Pattern<JoinPlan> pattern =
+        typeOf(JoinPlan.class)
+            .with(j -> j.joinType() == JoinType.RIGHT &&
+                EquiJoinDetector.isEquiJoin(j.joinCondition()));
+
+    @Override
+    public Pattern<JoinPlan> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public LogicalPlan apply(JoinPlan join,
+                             Captures captures,
+                             Rule.Context context) {
+        if (context.txnCtx().sessionSettings().hashJoinsEnabled()) {
+            return Eval.create(
+                new HashJoin(
+                    join.rhs(),
+                    join.lhs(),
+                    join.joinCondition(),
+                    JoinType.LEFT,
+                    join.lookUpJoin()
+                ),
+                join.outputs()
+            );
+        }
+        return null;
+    }
+}

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -263,6 +263,7 @@ public class PgCatalogITest extends IntegTestCase {
             "optimizer_rewrite_filter_on_outer_join_to_inner_join| true| Indicates if the optimizer rule RewriteFilterOnOuterJoinToInnerJoin is activated.| NULL| NULL",
             "optimizer_rewrite_group_by_keys_limit_to_limit_distinct| true| Indicates if the optimizer rule RewriteGroupByKeysLimitToLimitDistinct is activated.| NULL| NULL",
             "optimizer_rewrite_left_outer_join_to_hash_join| true| Indicates if the optimizer rule RewriteLeftOuterJoinToHashJoin is activated.| NULL| NULL",
+            "optimizer_rewrite_right_outer_join_to_hash_join| true| Indicates if the optimizer rule RewriteRightOuterJoinToHashJoin is activated.| NULL| NULL",
             "optimizer_rewrite_to_query_then_fetch| true| Indicates if the optimizer rule RewriteToQueryThenFetch is activated.| NULL| NULL",
             "search_path| doc| Sets the schema search order.| NULL| NULL",
             "server_version| 14.0| Reports the emulated PostgreSQL version number| NULL| NULL",

--- a/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
@@ -24,7 +24,6 @@ package io.crate.integrationtests;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Locale;
 
@@ -438,6 +437,7 @@ public class ShowIntegrationTest extends IntegTestCase {
             "optimizer_rewrite_filter_on_outer_join_to_inner_join| true| Indicates if the optimizer rule RewriteFilterOnOuterJoinToInnerJoin is activated.",
             "optimizer_rewrite_group_by_keys_limit_to_limit_distinct| true| Indicates if the optimizer rule RewriteGroupByKeysLimitToLimitDistinct is activated.",
             "optimizer_rewrite_left_outer_join_to_hash_join| true| Indicates if the optimizer rule RewriteLeftOuterJoinToHashJoin is activated.",
+            "optimizer_rewrite_right_outer_join_to_hash_join| true| Indicates if the optimizer rule RewriteRightOuterJoinToHashJoin is activated.",
             "optimizer_rewrite_to_query_then_fetch| true| Indicates if the optimizer rule RewriteToQueryThenFetch is activated.",
             "search_path| doc| Sets the schema search order.",
             "server_version| 14.0| Reports the emulated PostgreSQL version number",

--- a/server/src/test/java/io/crate/planner/operators/OuterJoinRewriteTest.java
+++ b/server/src/test/java/io/crate/planner/operators/OuterJoinRewriteTest.java
@@ -95,14 +95,13 @@ public class OuterJoinRewriteTest extends CrateDummyClusterServiceUnitTest {
             "SELECT * FROM t1 RIGHT JOIN t2 ON t1.x = t2.x " +
             "WHERE coalesce(t1.x, 10) = 10 AND t2.x > 5"
         );
-        var expectedPlan =
-            """
-            Filter[(coalesce(x, 10) = 10)]
-              └ NestedLoopJoin[RIGHT | (x = x)]
-                ├ Collect[doc.t1 | [x] | true]
-                └ Collect[doc.t2 | [x] | (x > 5)]
-            """;
-        assertThat(plan).isEqualTo(expectedPlan);
+        assertThat(plan).hasOperators(
+            "Eval[x, x]",
+            "  └ Filter[(coalesce(x, 10) = 10)]",
+            "    └ HashJoin[LEFT | (x = x)]",
+            "      ├ Collect[doc.t2 | [x] | (x > 5)]",
+            "      └ Collect[doc.t1 | [x] | true]"
+        );
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Follow-up https://github.com/crate/crate/pull/16780

Right-outer-joins can be rewritten to left-outer-hash-joins by swapping the lhs/rhs and keeping the original output order. 


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
