### PR TITLE
Documentation: Use crate-docs-theme==0.35.1.dev0 to fix the build

### DIFF
--- a/blackbox/requirements.txt
+++ b/blackbox/requirements.txt
@@ -14,7 +14,7 @@ minio>=5.0.0
 dnslib
 
 # Documentation
-crate-docs-theme>=0.35.0
+crate-docs-theme==0.35.1.dev0
 sphinx-csv-filter==0.4.0
 
 # Documentation: local development

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 # packages for RTD to pick up (not used for local dev)
-crate-docs-theme>=0.35.0
+crate-docs-theme==0.35.1.dev0
 sphinx-csv-filter==0.4.0
 Pygments>=2.7.4,<3


### PR DESCRIPTION
## Problem
@BaurzhanSakhariev reported that blackbox/docs builds started failing?

## Probing
- https://github.com/crate/crate-docs-theme/pull/539
