### PR TITLE
Fix reference tree recursion when children have the same name as parent

### DIFF
--- a/server/src/main/java/io/crate/metadata/ReferenceTree.java
+++ b/server/src/main/java/io/crate/metadata/ReferenceTree.java
@@ -166,15 +166,11 @@ public class ReferenceTree {
     private static Node findRef(Node root, ColumnIdent columnIdent) {
         switch (root) {
             case Composite c -> {
-                if (columnIdent.isRoot() && Objects.equals(c.name, columnIdent.name())) {
-                    return c;
+                var child = c.children.get(columnIdent.name());
+                if (child == null) {
+                    return null;
                 }
-                if (c.children.containsKey(columnIdent.name())) {
-                    return columnIdent.isRoot()
-                        ? c.children.get(columnIdent.name())
-                        : findRef(c.children.get(columnIdent.name()), columnIdent.shiftRight());
-                }
-                return null;
+                return columnIdent.isRoot() ? child : findRef(child, columnIdent.shiftRight());
             }
             case Leaf l -> {
                 return l;
@@ -182,4 +178,8 @@ public class ReferenceTree {
         }
     }
 
+    @Override
+    public String toString() {
+        return root.toString();
+    }
 }

--- a/server/src/test/java/io/crate/metadata/doc/DocTableInfoTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocTableInfoTest.java
@@ -23,7 +23,6 @@ package io.crate.metadata.doc;
 
 import static io.crate.testing.Asserts.assertThat;
 import static java.util.Collections.singletonList;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
 
@@ -627,7 +626,8 @@ public class DocTableInfoTest extends CrateDummyClusterServiceUnitTest {
                     c2 text,
                     c3 array(int),
                     c4 object as (d1 int, d2 object as (e1 int, e2 int)),
-                    c5 array(object as (d1 int, d2 object as (e1 int, e2 int, e3 int)))
+                    c5 array(object as (d1 int, d2 object as (e1 int, e2 int, e3 int))),
+                    x object as (x object as (x int))
                 )
                 """);
 
@@ -650,5 +650,11 @@ public class DocTableInfoTest extends CrateDummyClusterServiceUnitTest {
 
         assertThat(table.getLeafReferences(table.getReference("c1")))
             .hasSize(1);
+
+        var x = table.getReference("x");
+        var x_children = table.getChildReferences(x);
+        var x_x = table.getReference("x.x");
+        var x_x_children = table.getChildReferences(x_x);
+        assertThat(x_children).isNotEqualTo(x_x_children);
     }
 }


### PR DESCRIPTION
Calling findChildren on x['x'] would return the children of 'x' instead.