### PR TITLE
Don't used nested objects in ObjectTypeTest

### DIFF
--- a/server/src/test/java/io/crate/types/ObjectTypeTest.java
+++ b/server/src/test/java/io/crate/types/ObjectTypeTest.java
@@ -44,7 +44,7 @@ public class ObjectTypeTest extends DataTypeTestCase<Map<String, Object>> {
 
     @Override
     public DataType<Map<String, Object>> getType() {
-        return new ObjectType.Builder().setInnerType("x", DataTypeTesting.randomType()).build();
+        return new ObjectType.Builder().setInnerType("x", DataTypeTesting.randomTypeExcluding(Set.of(ObjectType.UNTYPED))).build();
     }
 
     @Override


### PR DESCRIPTION
DataTypeTesting.randomType() can return an ObjectType with no inner types, and when this is passed to DataTypeTesting.getDataGenerator(), the returned map will have a random dynamically-generated inner value. In test_translog_streaming_roundtrip this will create dynamic updates which are not accounted for by the test, resulting in failures when comparing the output from the indexer and the translog.

See https://wacklig.pipifein.dev/github/crate/crate/98fc0011-a89b-4f16-8049-68f674080b80/4f319d79-58ce-421d-8360-de8eaf274e53