### PR TITLE
Rename TableCreator & AlterTableOperation

### DIFF
--- a/server/src/main/java/io/crate/execution/ddl/tables/AlterTableClient.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/AlterTableClient.java
@@ -69,7 +69,7 @@ import io.crate.session.CollectingResultReceiver;
 import io.crate.session.Sessions;
 
 @Singleton
-public class AlterTableOperation {
+public class AlterTableClient {
 
     public static final String RESIZE_PREFIX = ".resized.";
 
@@ -89,20 +89,20 @@ public class AlterTableOperation {
     private final LogicalReplicationService logicalReplicationService;
 
     @Inject
-    public AlterTableOperation(ClusterService clusterService,
-                               TransportRenameTableAction transportRenameTableAction,
-                               TransportOpenCloseTableOrPartitionAction transportOpenCloseTableOrPartitionAction,
-                               TransportCloseTable transportCloseTable,
-                               TransportResizeAction transportResizeAction,
-                               TransportDeleteIndexAction transportDeleteIndexAction,
-                               TransportSwapAndDropIndexNameAction transportSwapAndDropIndexNameAction,
-                               TransportAlterTableAction transportAlterTableAction,
-                               TransportDropConstraintAction transportDropConstraintAction,
-                               TransportAddColumnAction transportAddColumnAction,
-                               TransportDropColumnAction transportDropColumnAction,
-                               Sessions sessions,
-                               IndexScopedSettings indexScopedSettings,
-                               LogicalReplicationService logicalReplicationService) {
+    public AlterTableClient(ClusterService clusterService,
+                            TransportRenameTableAction transportRenameTableAction,
+                            TransportOpenCloseTableOrPartitionAction transportOpenCloseTableOrPartitionAction,
+                            TransportCloseTable transportCloseTable,
+                            TransportResizeAction transportResizeAction,
+                            TransportDeleteIndexAction transportDeleteIndexAction,
+                            TransportSwapAndDropIndexNameAction transportSwapAndDropIndexNameAction,
+                            TransportAlterTableAction transportAlterTableAction,
+                            TransportDropConstraintAction transportDropConstraintAction,
+                            TransportAddColumnAction transportAddColumnAction,
+                            TransportDropColumnAction transportDropColumnAction,
+                            Sessions sessions,
+                            IndexScopedSettings indexScopedSettings,
+                            LogicalReplicationService logicalReplicationService) {
 
         this.clusterService = clusterService;
         this.transportRenameTableAction = transportRenameTableAction;

--- a/server/src/main/java/io/crate/execution/ddl/tables/CreateTableClient.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/CreateTableClient.java
@@ -45,12 +45,12 @@ import io.crate.metadata.Reference;
 import io.crate.metadata.doc.SysColumns;
 import io.crate.sql.tree.ColumnPolicy;
 
-public class TableCreator {
+public class CreateTableClient {
 
-    protected static final Logger LOGGER = LogManager.getLogger(TableCreator.class);
+    protected static final Logger LOGGER = LogManager.getLogger(CreateTableClient.class);
     private final NodeClient client;
 
-    public TableCreator(NodeClient client) {
+    public CreateTableClient(NodeClient client) {
         this.client = client;
     }
 

--- a/server/src/main/java/io/crate/metadata/IndexParts.java
+++ b/server/src/main/java/io/crate/metadata/IndexParts.java
@@ -25,7 +25,7 @@ import java.util.List;
 
 import org.jetbrains.annotations.Nullable;
 
-import io.crate.execution.ddl.tables.AlterTableOperation;
+import io.crate.execution.ddl.tables.AlterTableClient;
 
 /**
  * Parts of an encoded index: Schema, table and partitionIdent.
@@ -34,7 +34,7 @@ import io.crate.execution.ddl.tables.AlterTableOperation;
 public record IndexParts(String schema, String table, @Nullable String partitionIdent) {
 
     public static final List<String> DANGLING_INDICES_PREFIX_PATTERNS = List.of(
-        AlterTableOperation.RESIZE_PREFIX + "*"
+        AlterTableClient.RESIZE_PREFIX + "*"
     );
 
     public String partitionIdent() {

--- a/server/src/main/java/io/crate/planner/DependencyCarrier.java
+++ b/server/src/main/java/io/crate/planner/DependencyCarrier.java
@@ -34,11 +34,10 @@ import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.threadpool.ThreadPool;
 
-import io.crate.session.DCLStatementDispatcher;
 import io.crate.analyze.repositories.RepositoryParamValidator;
 import io.crate.execution.ddl.RepositoryService;
 import io.crate.execution.ddl.TransportSwapRelationsAction;
-import io.crate.execution.ddl.tables.AlterTableOperation;
+import io.crate.execution.ddl.tables.AlterTableClient;
 import io.crate.execution.ddl.tables.TransportDropTableAction;
 import io.crate.execution.ddl.views.TransportCreateViewAction;
 import io.crate.execution.ddl.views.TransportDropViewAction;
@@ -55,6 +54,7 @@ import io.crate.replication.logical.action.TransportAlterPublicationAction;
 import io.crate.replication.logical.action.TransportCreatePublicationAction;
 import io.crate.replication.logical.action.TransportCreateSubscriptionAction;
 import io.crate.replication.logical.action.TransportDropPublicationAction;
+import io.crate.session.DCLStatementDispatcher;
 import io.crate.statistics.TransportAnalyzeAction;
 
 /**
@@ -78,7 +78,7 @@ public class DependencyCarrier {
     private final TransportCreateUserDefinedFunctionAction createFunctionAction;
     private final TransportDropUserDefinedFunctionAction dropFunctionAction;
     private final Provider<TransportAnalyzeAction> analyzeAction;
-    private final AlterTableOperation alterTableOperation;
+    private final AlterTableClient alterTableClient;
     private final FulltextAnalyzerResolver fulltextAnalyzerResolver;
     private final RepositoryService repositoryService;
     private final RepositoryParamValidator repositoryParamValidator;
@@ -108,7 +108,7 @@ public class DependencyCarrier {
                              TransportCreateUserDefinedFunctionAction createFunctionAction,
                              TransportDropUserDefinedFunctionAction dropFunctionAction,
                              Provider<TransportAnalyzeAction> analyzeAction,
-                             AlterTableOperation alterTableOperation,
+                             AlterTableClient alterTableOperation,
                              FulltextAnalyzerResolver fulltextAnalyzerResolver,
                              RepositoryService repositoryService,
                              RepositoryParamValidator repositoryParamValidator,
@@ -135,7 +135,7 @@ public class DependencyCarrier {
         this.createFunctionAction = createFunctionAction;
         this.dropFunctionAction = dropFunctionAction;
         this.analyzeAction = analyzeAction;
-        this.alterTableOperation = alterTableOperation;
+        this.alterTableClient = alterTableOperation;
         this.fulltextAnalyzerResolver = fulltextAnalyzerResolver;
         this.repositoryService = repositoryService;
         this.repositoryParamValidator = repositoryParamValidator;
@@ -214,8 +214,8 @@ public class DependencyCarrier {
         return fulltextAnalyzerResolver;
     }
 
-    public AlterTableOperation alterTableOperation() {
-        return alterTableOperation;
+    public AlterTableClient alterTableClient() {
+        return alterTableClient;
     }
 
     public RepositoryParamValidator repositoryParamValidator() {

--- a/server/src/main/java/io/crate/planner/Planner.java
+++ b/server/src/main/java/io/crate/planner/Planner.java
@@ -35,7 +35,6 @@ import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.common.settings.Settings;
 import org.jetbrains.annotations.Nullable;
 
-import io.crate.session.Cursors;
 import io.crate.analyze.AnalyzedAlterRole;
 import io.crate.analyze.AnalyzedAlterTable;
 import io.crate.analyze.AnalyzedAlterTableAddColumn;
@@ -103,7 +102,7 @@ import io.crate.analyze.ExplainAnalyzedStatement;
 import io.crate.analyze.NumberOfShards;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.data.Row;
-import io.crate.execution.ddl.tables.TableCreator;
+import io.crate.execution.ddl.tables.CreateTableClient;
 import io.crate.fdw.ForeignDataWrappers;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.NodeContext;
@@ -165,6 +164,7 @@ import io.crate.replication.logical.plan.CreateSubscriptionPlan;
 import io.crate.replication.logical.plan.DropPublicationPlan;
 import io.crate.replication.logical.plan.DropSubscriptionPlan;
 import io.crate.role.RoleManager;
+import io.crate.session.Cursors;
 import io.crate.sql.tree.SetSessionAuthorizationStatement;
 import io.crate.statistics.TableStats;
 
@@ -177,7 +177,7 @@ public class Planner extends AnalyzedStatementVisitor<PlannerContext, Plan> {
     private final TableStats tableStats;
     private final LogicalPlanner logicalPlanner;
     private final NumberOfShards numberOfShards;
-    private final TableCreator tableCreator;
+    private final CreateTableClient tableCreator;
     private final RoleManager roleManager;
     private final ForeignDataWrappers foreignDataWrappers;
     private final SessionSettingRegistry sessionSettingRegistry;
@@ -191,7 +191,7 @@ public class Planner extends AnalyzedStatementVisitor<PlannerContext, Plan> {
                    NodeContext nodeCtx,
                    TableStats tableStats,
                    NumberOfShards numberOfShards,
-                   TableCreator tableCreator,
+                   CreateTableClient tableCreator,
                    RoleManager roleManager,
                    ForeignDataWrappers foreignDataWrappers,
                    SessionSettingRegistry sessionSettingRegistry) {

--- a/server/src/main/java/io/crate/planner/node/ddl/AlterTableAddColumnPlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/AlterTableAddColumnPlan.java
@@ -57,7 +57,7 @@ public class AlterTableAddColumnPlan implements Plan {
             params,
             subQueryResults
         );
-        dependencies.alterTableOperation().addColumn(request)
+        dependencies.alterTableClient().addColumn(request)
             .whenComplete(new OneRowActionListener<>(consumer, rCount -> new Row1(rCount == null ? -1 : rCount)));
     }
 }

--- a/server/src/main/java/io/crate/planner/node/ddl/AlterTableDropCheckConstraintPlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/AlterTableDropCheckConstraintPlan.java
@@ -56,7 +56,7 @@ public class AlterTableDropCheckConstraintPlan implements Plan {
             dropCheckConstraint.name()
         );
 
-        dependencies.alterTableOperation()
+        dependencies.alterTableClient()
             .dropConstraint(request)
             .whenComplete(new OneRowActionListener<>(consumer, rCount -> new Row1(rCount == null ? -1 : rCount)));
     }

--- a/server/src/main/java/io/crate/planner/node/ddl/AlterTableDropColumnPlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/AlterTableDropColumnPlan.java
@@ -52,7 +52,7 @@ public class AlterTableDropColumnPlan implements Plan {
                               Row params,
                               SubQueryResults subQueryResults) throws Exception {
         var dropColumnRequest = new DropColumnRequest(alterTable.table().ident(), alterTable.columns());
-        dependencies.alterTableOperation().dropColumn(dropColumnRequest)
+        dependencies.alterTableClient().dropColumn(dropColumnRequest)
             .whenComplete(new OneRowActionListener<>(consumer, rCount -> new Row1(rCount == null ? -1 : rCount)));
     }
 }

--- a/server/src/main/java/io/crate/planner/node/ddl/AlterTableOpenClosePlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/AlterTableOpenClosePlan.java
@@ -71,7 +71,7 @@ public class AlterTableOpenClosePlan implements Plan {
             ? null
             : PartitionName.ofAssignments(tableInfo, table.partitionProperties(), plannerContext.clusterState().metadata());
 
-        dependencies.alterTableOperation()
+        dependencies.alterTableClient()
             .closeOrOpen(tableInfo.ident(), analyzedAlterTable.isOpenTable(), partitionName)
             .whenComplete(new OneRowActionListener<>(consumer, rCount -> new Row1(rCount == null ? -1 : rCount)));
     }

--- a/server/src/main/java/io/crate/planner/node/ddl/AlterTablePlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/AlterTablePlan.java
@@ -84,7 +84,7 @@ public class AlterTablePlan implements Plan {
         );
 
 
-        dependencies.alterTableOperation().setSettingsOrResize(stmt)
+        dependencies.alterTableClient().setSettingsOrResize(stmt)
             .whenComplete(new OneRowActionListener<>(consumer, rCount -> new Row1(rCount == null ? -1 : rCount)));
     }
 

--- a/server/src/main/java/io/crate/planner/node/ddl/AlterTableRenameTablePlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/AlterTableRenameTablePlan.java
@@ -49,7 +49,7 @@ public class AlterTableRenameTablePlan implements Plan {
                               PlannerContext plannerContext,
                               RowConsumer consumer,
                               Row params, SubQueryResults subQueryResults) throws Exception {
-        dependencies.alterTableOperation().rename(analyzedAlterTableRenameTable)
+        dependencies.alterTableClient().rename(analyzedAlterTableRenameTable)
             .whenComplete(new OneRowActionListener<>(consumer, rCount -> new Row1(rCount == null ? -1 : rCount)));
     }
 }

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -181,7 +181,7 @@ import io.crate.common.io.IOUtils;
 import io.crate.common.unit.TimeValue;
 import io.crate.execution.TransportExecutorModule;
 import io.crate.execution.ddl.RepositoryService;
-import io.crate.execution.ddl.tables.TableCreator;
+import io.crate.execution.ddl.tables.CreateTableClient;
 import io.crate.execution.engine.collect.CollectOperationModule;
 import io.crate.execution.engine.collect.files.CopyModule;
 import io.crate.execution.engine.collect.stats.JobsLogService;
@@ -748,7 +748,7 @@ public class Node implements Closeable {
                 nodeContext,
                 tableStats,
                 new NumberOfShards(clusterService),
-                new TableCreator(client),
+                new CreateTableClient(client),
                 rolesManager,
                 new ForeignDataWrappers(settings, clusterService, nodeContext),
                 sessionSettingRegistry

--- a/server/src/test/java/io/crate/execution/ddl/tables/AlterTableOperationTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/tables/AlterTableOperationTest.java
@@ -61,7 +61,7 @@ public class AlterTableOperationTest extends ESTestCase {
             .build();
 
 
-        assertThatThrownBy(() -> AlterTableOperation.validateReadOnlyIndexForResize(indexMetadata))
+        assertThatThrownBy(() -> AlterTableClient.validateReadOnlyIndexForResize(indexMetadata))
             .isExactlyInstanceOf(IllegalStateException.class)
             .hasMessageStartingWith("Table/Partition needs to be at a read-only state");
     }
@@ -75,14 +75,14 @@ public class AlterTableOperationTest extends ESTestCase {
         RelationName t1 = new RelationName("doc", "t1");
         var oneTablePublished = Map.of("pub1", new Publication("owner", false, List.of(t1)));
 
-        assertThatThrownBy(() -> AlterTableOperation.validateSettingsForPublishedTables(t1, settings, oneTablePublished, DEFAULT_SCOPED_SETTINGS))
+        assertThatThrownBy(() -> AlterTableClient.validateSettingsForPublishedTables(t1, settings, oneTablePublished, DEFAULT_SCOPED_SETTINGS))
             .isExactlyInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining(
                     "Setting [index.number_of_shards] cannot be applied to table 'doc.t1' because it is included in a logical replication publication 'pub1'");
 
         var allTablesPublished = Map.of("pub1", new Publication("owner", true, List.of()));
 
-        assertThatThrownBy(() -> AlterTableOperation.validateSettingsForPublishedTables(t1, settings, allTablesPublished, DEFAULT_SCOPED_SETTINGS))
+        assertThatThrownBy(() -> AlterTableClient.validateSettingsForPublishedTables(t1, settings, allTablesPublished, DEFAULT_SCOPED_SETTINGS))
             .isExactlyInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining(
                     "Setting [index.number_of_shards] cannot be applied to table 'doc.t1' because it is included in a logical replication publication 'pub1'");
@@ -94,7 +94,7 @@ public class AlterTableOperationTest extends ESTestCase {
             .settings(baseIndexSettings())
             .build();
 
-        assertThatThrownBy(() -> AlterTableOperation.validateNumberOfShardsForResize(indexMetadata, 5))
+        assertThatThrownBy(() -> AlterTableClient.validateNumberOfShardsForResize(indexMetadata, 5))
             .isExactlyInstanceOf(IllegalArgumentException.class)
             .hasMessage("Table/partition is already allocated <5> shards");
     }
@@ -104,7 +104,7 @@ public class AlterTableOperationTest extends ESTestCase {
         IndexMetadata indexMetadata = IndexMetadata.builder("t1")
             .settings(baseIndexSettings())
             .build();
-        AlterTableOperation.validateNumberOfShardsForResize(indexMetadata, 10);
+        AlterTableClient.validateNumberOfShardsForResize(indexMetadata, 10);
     }
 
     @Test
@@ -113,14 +113,14 @@ public class AlterTableOperationTest extends ESTestCase {
             .settings(baseIndexSettings())
             .build();
 
-        assertThatThrownBy(() -> AlterTableOperation.validateNumberOfShardsForResize(indexMetadata, 3))
+        assertThatThrownBy(() -> AlterTableClient.validateNumberOfShardsForResize(indexMetadata, 3))
             .isExactlyInstanceOf(IllegalArgumentException.class)
             .hasMessage("Requested number of shards: <3> needs to be a factor of the current one: <5>");
     }
 
     @Test
     public void testNullNumberOfShardsRequestedIsNotPermitted() {
-        assertThatThrownBy(() -> AlterTableOperation.getNumberOfShards(Settings.EMPTY))
+        assertThatThrownBy(() -> AlterTableClient.getNumberOfShards(Settings.EMPTY))
             .isExactlyInstanceOf(NullPointerException.class)
             .hasMessage("Setting 'number_of_shards' is missing");
     }

--- a/server/src/test/java/io/crate/integrationtests/DanglingIndicesIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/DanglingIndicesIntegrationTest.java
@@ -29,7 +29,7 @@ import org.elasticsearch.test.IntegTestCase;
 import org.junit.After;
 import org.junit.Test;
 
-import io.crate.execution.ddl.tables.AlterTableOperation;
+import io.crate.execution.ddl.tables.AlterTableClient;
 
 @IntegTestCase.ClusterScope(numDataNodes = 1)
 public class DanglingIndicesIntegrationTest extends IntegTestCase {
@@ -48,8 +48,8 @@ public class DanglingIndicesIntegrationTest extends IntegTestCase {
         execute("refresh table doc.t2");
         execute("create blob table blobs clustered into 3 shards with (number_of_replicas=0)");
 
-        final String dangling1 = AlterTableOperation.RESIZE_PREFIX + "t1";
-        final String dangling2 = AlterTableOperation.RESIZE_PREFIX + ".partitioned.t2.ident";
+        final String dangling1 = AlterTableClient.RESIZE_PREFIX + "t1";
+        final String dangling2 = AlterTableClient.RESIZE_PREFIX + ".partitioned.t2.ident";
 
         createIndex(dangling1, dangling2);
 


### PR DESCRIPTION
Problem:

"Operation" is usually used in the context of components that run the
actual operation - e.g. on collect side (CountOperation, MapOperation)

AlterTableOperation didn't fit that - it's just the client to send
requests for the operation on another node.

Solution:

Use name that indices it's a client. Adapt `TableCreator` to match that
pattern.
