### PR TITLE
Only store explicitly set table properties as index settings

### DIFF
--- a/docs/admin/system-information.rst
+++ b/docs/admin/system-information.rst
@@ -1709,39 +1709,20 @@ How to reindex
 1. Use :ref:`ref-show-create-table` to get the schema required to create an
    empty copy of the table to recreate::
 
-    cr> SHOW CREATE TABLE rx.metrics;
-    +-----------------------------------------------------+
-    | SHOW CREATE TABLE rx.metrics                        |
-    +-----------------------------------------------------+
-    | CREATE TABLE IF NOT EXISTS "rx"."metrics" (         |
-    |    "id" TEXT NOT NULL,                                       |
-    |    "temperature" REAL,                              |
-    |    PRIMARY KEY ("id")                               |
-    | )                                                   |
-    | CLUSTERED BY ("id") INTO 4 SHARDS                   |
-    | WITH (                                              |
-    |    "allocation.max_retries" = 5,                    |
-    |    "blocks.metadata" = false,                       |
-    |    "blocks.read" = false,                           |
-    |    "blocks.read_only" = false,                      |
-    |    "blocks.read_only_allow_delete" = false,         |
-    |    "blocks.write" = false,                          |
-    |    codec = 'default',                               |
-    |    column_policy = 'strict',                        |
-    |    "mapping.total_fields.limit" = 1000,             |
-    |    max_ngram_diff = 1,                              |
-    |    max_shingle_diff = 3,                            |
-    |    number_of_replicas = '0-1',                      |
-    |    "routing.allocation.enable" = 'all',             |
-    |    "routing.allocation.total_shards_per_node" = -1, |
-    |    "store.type" = 'fs',                             |
-    |    "translog.durability" = 'REQUEST',               |
-    |    "translog.flush_threshold_size" = 536870912,     |
-    |    "translog.sync_interval" = 5000,                 |
-    |    "unassigned.node_left.delayed_timeout" = 60000,  |
-    |    "write.wait_for_active_shards" = '1'             |
-    | )                                                   |
-    +-----------------------------------------------------+
+    +---------------------------------------------+
+    | SHOW CREATE TABLE rx.metrics                |
+    +---------------------------------------------+
+    | CREATE TABLE IF NOT EXISTS "rx"."metrics" ( |
+    |    "id" TEXT NOT NULL,                      |
+    |    "temperature" REAL,                      |
+    |    PRIMARY KEY ("id")                       |
+    | )                                           |
+    | CLUSTERED BY ("id") INTO 4 SHARDS           |
+    | WITH (                                      |
+    |    column_policy = 'strict',                |
+    |    number_of_replicas = '0-1'               |
+    | )                                           |
+    +---------------------------------------------+
     SHOW 1 row in set (... sec)
 
 2. Create a new temporary table, using the schema returned from

--- a/docs/appendices/release-notes/5.10.0.rst
+++ b/docs/appendices/release-notes/5.10.0.rst
@@ -59,7 +59,13 @@ Changes
 SQL Statements
 --------------
 
-None
+- ``CREATE TABLE`` no longer persists default values for all available table
+  options but instead only stores the explicitly defined options. As a result,
+  ``SHOW CREATE TABLE`` will only show the explicitly defined options in the
+  ``WITH`` clause. An exception are the ``column_policy`` and
+  ``number_of_replicas`` options, which always show up. To get a complete view
+  of the effective options you can query the ``information_schema.tables``
+  table.
 
 SQL Standard and PostgreSQL Compatibility
 -----------------------------------------

--- a/docs/general/ddl/column-policy.rst
+++ b/docs/general/ddl/column-policy.rst
@@ -76,16 +76,21 @@ Now, you can do inserts that add columns::
 Which will update the table schema::
 
     cr> show create table my_table;
-    +-----------------------------------------------------+
-    | SHOW CREATE TABLE doc.my_table                      |
-    +-----------------------------------------------------+
-    | CREATE TABLE IF NOT EXISTS "doc"."my_table" (       |
-    |    "title" TEXT,                                    |
-    |    "author" TEXT,                                   |
-    |    "new_col" BIGINT                                 |
-    | )                                                   |
-    | CLUSTERED INTO 4 SHARDS                             |
-    ...
+    +-----------------------------------------------+
+    | SHOW CREATE TABLE doc.my_table                |
+    +-----------------------------------------------+
+    | CREATE TABLE IF NOT EXISTS "doc"."my_table" ( |
+    |    "title" TEXT,                              |
+    |    "author" TEXT,                             |
+    |    "new_col" BIGINT                           |
+    | )                                             |
+    | CLUSTERED INTO 4 SHARDS                       |
+    | WITH (                                        |
+    |    column_policy = 'dynamic',                 |
+    |    number_of_replicas = '0-1'                 |
+    | )                                             |
+    +-----------------------------------------------+
+    SHOW 1 row in set (... sec)
 
 New columns added to dynamic tables are identical to regular columns. You can
 retrieve them, sort by them and use them in where clauses.

--- a/docs/general/ddl/show-create-table.rst
+++ b/docs/general/ddl/show-create-table.rst
@@ -18,52 +18,30 @@ The ``SHOW CREATE TABLE`` statement prints the ``CREATE TABLE`` statement of an
 existing user-created doc table in the cluster::
 
     cr> show create table my_table;
-    +-----------------------------------------------------+
-    | SHOW CREATE TABLE doc.my_table                      |
-    +-----------------------------------------------------+
-    | CREATE TABLE IF NOT EXISTS "doc"."my_table" (       |
-    |    "first_column" INTEGER NOT NULL,                          |
-    |    "second_column" TEXT,                            |
-    |    "third_column" TIMESTAMP WITH TIME ZONE,         |
-    |    "fourth_column" OBJECT(STRICT) AS (              |
-    |       "key" TEXT,                                   |
-    |       "value" TEXT                                  |
-    |    ),                                               |
-    |    PRIMARY KEY ("first_column")                     |
-    | )                                                   |
-    | CLUSTERED BY ("first_column") INTO 5 SHARDS         |
-    | WITH (                                              |
-    |    "allocation.max_retries" = 5,                    |
-    |    "blocks.metadata" = false,                       |
-    |    "blocks.read" = false,                           |
-    |    "blocks.read_only" = false,                      |
-    |    "blocks.read_only_allow_delete" = false,         |
-    |    "blocks.write" = false,                          |
-    |    codec = 'default',                               |
-    |    column_policy = 'strict',                        |
-    |    "mapping.total_fields.limit" = 1000,             |
-    |    max_ngram_diff = 1,                              |
-    |    max_shingle_diff = 3,                            |
-    |    "merge.scheduler.max_thread_count" = 1,          |
-    |    number_of_replicas = '0-1',                      |
-    |    "routing.allocation.enable" = 'all',             |
-    |    "routing.allocation.total_shards_per_node" = -1, |
-    |    "store.type" = 'fs',                             |
-    |    "translog.durability" = 'REQUEST',               |
-    |    "translog.flush_threshold_size" = 536870912,     |
-    |    "translog.sync_interval" = 5000,                 |
-    |    "unassigned.node_left.delayed_timeout" = 60000,  |
-    |    "write.wait_for_active_shards" = '1'             |
-    | )                                                   |
-    +-----------------------------------------------------+
+    +-----------------------------------------------+
+    | SHOW CREATE TABLE doc.my_table                |
+    +-----------------------------------------------+
+    | CREATE TABLE IF NOT EXISTS "doc"."my_table" ( |
+    |    "first_column" INTEGER NOT NULL,           |
+    |    "second_column" TEXT,                      |
+    |    "third_column" TIMESTAMP WITH TIME ZONE,   |
+    |    "fourth_column" OBJECT(STRICT) AS (        |
+    |       "key" TEXT,                             |
+    |       "value" TEXT                            |
+    |    ),                                         |
+    |    PRIMARY KEY ("first_column")               |
+    | )                                             |
+    | CLUSTERED BY ("first_column") INTO 5 SHARDS   |
+    | WITH (                                        |
+    |    column_policy = 'strict',                  |
+    |    "merge.scheduler.max_thread_count" = 1,    |
+    |    number_of_replicas = '0-1'                 |
+    | )                                             |
+    +-----------------------------------------------+
     SHOW 1 row in set (... sec)
 
-The table settings returned within the ``WITH`` clause of the result are all
-available table settings showing their respective values at the time of the
-execution of the ``SHOW`` statement.
+The ``WITH`` clause always shows ``column_policy`` and ``number_of_replicas``
+plus any explicitly set settings.
 
-Different versions of CrateDB may have different default table settings. This
-means that if you re-create the table using the resulting ``CREATE TABLE``
-statement the settings of the 'old' table may differ from the settings of the
-'new' table. This is because the table settings are set explicitly on creation
-time.
+To see all currently effective settings you can query the ``settings`` column of
+:ref:`information_schema_tables`.

--- a/server/src/main/java/io/crate/analyze/AnalyzedCreateTable.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedCreateTable.java
@@ -46,6 +46,7 @@ import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.SysColumns;
+import io.crate.metadata.settings.NumberOfReplicas;
 import io.crate.planner.operators.SubQueryAndParamBinder;
 import io.crate.planner.operators.SubQueryResults;
 import io.crate.sql.tree.ClusteredBy;
@@ -104,8 +105,9 @@ public record AnalyzedCreateTable(
             .map(numberOfShards::fromNumberOfShards)
             .orElseGet(numberOfShards::defaultNumberOfShards);
 
-        Settings.Builder builder = Settings.builder();
-        builder.put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, numShards);
+        Settings.Builder builder = Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, numShards)
+            .put(NumberOfReplicas.SETTING.getDefault(Settings.EMPTY));
 
         Map<ColumnIdent, Reference> references = new LinkedHashMap<>();
         LinkedHashSet<Reference> primaryKeys = new LinkedHashSet<>();
@@ -143,7 +145,7 @@ public record AnalyzedCreateTable(
         }
 
         TableProperties.analyze(
-            builder, TableParameters.TABLE_CREATE_PARAMETER_INFO, properties.map(toValue), true);
+            builder, TableParameters.TABLE_CREATE_PARAMETER_INFO, properties.map(toValue));
 
         Optional<ColumnIdent> optClusteredBy = clusteredBy
             .flatMap(ClusteredBy::column)

--- a/server/src/main/java/io/crate/analyze/TableParameters.java
+++ b/server/src/main/java/io/crate/analyze/TableParameters.java
@@ -26,7 +26,6 @@ import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_READ_ONLY
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -136,24 +135,6 @@ public class TableParameters {
             // this setting is needed for tests and is not documented. see IndexRecoveryIT for usages.
             Store.INDEX_STORE_STATS_REFRESH_INTERVAL_SETTING
         );
-
-    /**
-     * Settings which are not included in table default settings
-     */
-    static final Set<Setting<?>> SETTINGS_NOT_INCLUDED_IN_DEFAULT = Set.of(
-        IndexMetadata.INDEX_NUMBER_OF_ROUTING_SHARDS_SETTING,
-        IndexService.GLOBAL_CHECKPOINT_SYNC_INTERVAL_SETTING,
-        MergeSchedulerConfig.MAX_THREAD_COUNT_SETTING,
-        IndexSettings.INDEX_SOFT_DELETES_SETTING,
-        IndexSettings.INDEX_SOFT_DELETES_RETENTION_LEASE_PERIOD_SETTING,
-        IndexService.RETENTION_LEASE_SYNC_INTERVAL_SETTING,
-
-        // We want IndexSettings#isExplicitRefresh and it's usages to work
-        IndexSettings.INDEX_REFRESH_INTERVAL_SETTING,
-
-        IndexSettings.FILE_BASED_RECOVERY_THRESHOLD_SETTING,
-        Store.INDEX_STORE_STATS_REFRESH_INTERVAL_SETTING
-    );
 
     private static final Map<String, Setting<?>> SUPPORTED_SETTINGS_DEFAULT
         = Lists.concat(PARTITION_SETTINGS, TABLE_ONLY_SETTINGS)

--- a/server/src/main/java/io/crate/planner/node/ddl/AlterTablePlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/AlterTablePlan.java
@@ -155,7 +155,7 @@ public class AlterTablePlan implements Plan {
     public static Settings.Builder getTableParameter(AlterTable<Object> node, TableParameters tableParameters) {
         Settings.Builder settingsBuilder = Settings.builder();
         if (!node.genericProperties().isEmpty()) {
-            TableProperties.analyze(settingsBuilder, tableParameters, node.genericProperties(), false);
+            TableProperties.analyze(settingsBuilder, tableParameters, node.genericProperties());
         } else if (!node.resetProperties().isEmpty()) {
             TableProperties.analyzeResetProperties(settingsBuilder, tableParameters, node.resetProperties());
         }

--- a/server/src/main/java/io/crate/planner/node/ddl/CreateBlobTablePlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/CreateBlobTablePlan.java
@@ -46,6 +46,7 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.RelationName;
+import io.crate.metadata.settings.NumberOfReplicas;
 import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Plan;
 import io.crate.planner.PlannerContext;
@@ -108,14 +109,12 @@ public class CreateBlobTablePlan implements Plan {
         CreateBlobTable<Object> blobTable = createBlobTable.map(eval);
         GenericProperties<Object> properties = blobTable.genericProperties();
 
-        // apply default in case it is not specified in the properties,
-        // if it is it will get overwritten afterwards.
         Settings.Builder builder = Settings.builder();
+        builder.put(NumberOfReplicas.SETTING.getDefault(Settings.EMPTY));
         TableProperties.analyze(
             builder,
             TableParameters.CREATE_BLOB_TABLE_PARAMETERS,
-            properties,
-            true
+            properties
         );
         builder.put(SETTING_INDEX_BLOBS_ENABLED.getKey(), true);
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -464,7 +464,7 @@ public class MetadataCreateIndexService {
             for (final String key : settings.keySet()) {
                 final Setting<?> setting = indexScopedSettings.get(key);
                 if (setting == null) {
-                    assert indexScopedSettings.isPrivateSetting(key);
+                    assert indexScopedSettings.isPrivateSetting(key) : key + " must be a private setting if it is missing";
                 } else if (setting.isPrivateIndex()) {
                     validationErrors.add("private index setting [" + key + "] can not be set explicitly");
                 }

--- a/server/src/test/java/io/crate/analyze/TableInfoToASTTest.java
+++ b/server/src/test/java/io/crate/analyze/TableInfoToASTTest.java
@@ -102,27 +102,9 @@ public class TableInfoToASTTest extends CrateDummyClusterServiceUnitTest {
             )
             CLUSTERED INTO 5 SHARDS
             WITH (
-               "allocation.max_retries" = 5,
-               "blocks.metadata" = false,
-               "blocks.read" = false,
-               "blocks.read_only" = false,
-               "blocks.read_only_allow_delete" = false,
-               "blocks.write" = false,
-               codec = 'default',
                column_policy = 'strict',
-               "mapping.total_fields.limit" = 1000,
-               max_ngram_diff = 1,
-               max_shingle_diff = 3,
                "merge.scheduler.max_thread_count" = 1,
-               number_of_replicas = '0-all',
-               "routing.allocation.enable" = 'all',
-               "routing.allocation.total_shards_per_node" = -1,
-               "store.type" = 'fs',
-               "translog.durability" = 'REQUEST',
-               "translog.flush_threshold_size" = 536870912,
-               "translog.sync_interval" = 5000,
-               "unassigned.node_left.delayed_timeout" = 60000,
-               "write.wait_for_active_shards" = '1'
+               number_of_replicas = '0-all'
             )""");
     }
 
@@ -152,27 +134,9 @@ public class TableInfoToASTTest extends CrateDummyClusterServiceUnitTest {
             )
             CLUSTERED INTO 5 SHARDS
             WITH (
-               "allocation.max_retries" = 5,
-               "blocks.metadata" = false,
-               "blocks.read" = false,
-               "blocks.read_only" = false,
-               "blocks.read_only_allow_delete" = false,
-               "blocks.write" = false,
-               codec = 'default',
                column_policy = 'strict',
-               "mapping.total_fields.limit" = 1000,
-               max_ngram_diff = 1,
-               max_shingle_diff = 3,
                "merge.scheduler.max_thread_count" = 1,
-               number_of_replicas = '0-all',
-               "routing.allocation.enable" = 'all',
-               "routing.allocation.total_shards_per_node" = -1,
-               "store.type" = 'fs',
-               "translog.durability" = 'REQUEST',
-               "translog.flush_threshold_size" = 536870912,
-               "translog.sync_interval" = 5000,
-               "unassigned.node_left.delayed_timeout" = 60000,
-               "write.wait_for_active_shards" = '1'
+               number_of_replicas = '0-all'
             )""");
     }
 
@@ -204,27 +168,9 @@ public class TableInfoToASTTest extends CrateDummyClusterServiceUnitTest {
             )
             CLUSTERED BY ("col_a") INTO 5 SHARDS
             WITH (
-               "allocation.max_retries" = 5,
-               "blocks.metadata" = false,
-               "blocks.read" = false,
-               "blocks.read_only" = false,
-               "blocks.read_only_allow_delete" = false,
-               "blocks.write" = false,
-               codec = 'default',
                column_policy = 'strict',
-               "mapping.total_fields.limit" = 1000,
-               max_ngram_diff = 1,
-               max_shingle_diff = 3,
                "merge.scheduler.max_thread_count" = 1,
-               number_of_replicas = '0-all',
-               "routing.allocation.enable" = 'all',
-               "routing.allocation.total_shards_per_node" = -1,
-               "store.type" = 'fs',
-               "translog.durability" = 'REQUEST',
-               "translog.flush_threshold_size" = 536870912,
-               "translog.sync_interval" = 5000,
-               "unassigned.node_left.delayed_timeout" = 60000,
-               "write.wait_for_active_shards" = '1'
+               number_of_replicas = '0-all'
             )""");
     }
 
@@ -253,26 +199,8 @@ public class TableInfoToASTTest extends CrateDummyClusterServiceUnitTest {
             )
             CLUSTERED INTO 5 SHARDS
             WITH (
-               "allocation.max_retries" = 5,
-               "blocks.metadata" = false,
-               "blocks.read" = false,
-               "blocks.read_only" = false,
-               "blocks.read_only_allow_delete" = false,
-               "blocks.write" = false,
-               codec = 'default',
                column_policy = 'strict',
-               "mapping.total_fields.limit" = 1000,
-               max_ngram_diff = 1,
-               max_shingle_diff = 3,
-               number_of_replicas = '0-all',
-               "routing.allocation.enable" = 'all',
-               "routing.allocation.total_shards_per_node" = -1,
-               "store.type" = 'fs',
-               "translog.durability" = 'REQUEST',
-               "translog.flush_threshold_size" = 536870912,
-               "translog.sync_interval" = 5000,
-               "unassigned.node_left.delayed_timeout" = 60000,
-               "write.wait_for_active_shards" = '1'
+               number_of_replicas = '0-all'
             )""");
     }
 
@@ -298,27 +226,9 @@ public class TableInfoToASTTest extends CrateDummyClusterServiceUnitTest {
             CLUSTERED BY ("cluster_column") INTO 5 SHARDS
             PARTITIONED BY ("partition_column")
             WITH (
-               "allocation.max_retries" = 5,
-               "blocks.metadata" = false,
-               "blocks.read" = false,
-               "blocks.read_only" = false,
-               "blocks.read_only_allow_delete" = false,
-               "blocks.write" = false,
-               codec = 'default',
                column_policy = 'strict',
-               "mapping.total_fields.limit" = 1000,
-               max_ngram_diff = 1,
-               max_shingle_diff = 3,
                "merge.scheduler.max_thread_count" = 1,
-               number_of_replicas = '0-all',
-               "routing.allocation.enable" = 'all',
-               "routing.allocation.total_shards_per_node" = -1,
-               "store.type" = 'fs',
-               "translog.durability" = 'REQUEST',
-               "translog.flush_threshold_size" = 536870912,
-               "translog.sync_interval" = 5000,
-               "unassigned.node_left.delayed_timeout" = 60000,
-               "write.wait_for_active_shards" = '1'
+               number_of_replicas = '0-all'
             )""");
     }
 
@@ -372,27 +282,9 @@ public class TableInfoToASTTest extends CrateDummyClusterServiceUnitTest {
             )
             CLUSTERED INTO 5 SHARDS
             WITH (
-               "allocation.max_retries" = 5,
-               "blocks.metadata" = false,
-               "blocks.read" = false,
-               "blocks.read_only" = false,
-               "blocks.read_only_allow_delete" = false,
-               "blocks.write" = false,
-               codec = 'default',
                column_policy = 'strict',
-               "mapping.total_fields.limit" = 1000,
-               max_ngram_diff = 1,
-               max_shingle_diff = 3,
                "merge.scheduler.max_thread_count" = 1,
-               number_of_replicas = '0-all',
-               "routing.allocation.enable" = 'all',
-               "routing.allocation.total_shards_per_node" = -1,
-               "store.type" = 'fs',
-               "translog.durability" = 'REQUEST',
-               "translog.flush_threshold_size" = 536870912,
-               "translog.sync_interval" = 5000,
-               "unassigned.node_left.delayed_timeout" = 60000,
-               "write.wait_for_active_shards" = '1'
+               number_of_replicas = '0-all'
             )""");
     }
 
@@ -420,27 +312,9 @@ public class TableInfoToASTTest extends CrateDummyClusterServiceUnitTest {
             )
             CLUSTERED INTO 5 SHARDS
             WITH (
-               "allocation.max_retries" = 5,
-               "blocks.metadata" = false,
-               "blocks.read" = false,
-               "blocks.read_only" = false,
-               "blocks.read_only_allow_delete" = false,
-               "blocks.write" = false,
-               codec = 'default',
                column_policy = 'strict',
-               "mapping.total_fields.limit" = 1000,
-               max_ngram_diff = 1,
-               max_shingle_diff = 3,
                "merge.scheduler.max_thread_count" = 1,
-               number_of_replicas = '0-all',
-               "routing.allocation.enable" = 'all',
-               "routing.allocation.total_shards_per_node" = -1,
-               "store.type" = 'fs',
-               "translog.durability" = 'REQUEST',
-               "translog.flush_threshold_size" = 536870912,
-               "translog.sync_interval" = 5000,
-               "unassigned.node_left.delayed_timeout" = 60000,
-               "write.wait_for_active_shards" = '1'
+               number_of_replicas = '0-all'
             )""");
     }
 
@@ -466,27 +340,9 @@ public class TableInfoToASTTest extends CrateDummyClusterServiceUnitTest {
             )
             CLUSTERED INTO 4 SHARDS
             WITH (
-               "allocation.max_retries" = 5,
-               "blocks.metadata" = false,
-               "blocks.read" = false,
-               "blocks.read_only" = false,
-               "blocks.read_only_allow_delete" = false,
-               "blocks.write" = false,
-               codec = 'default',
                column_policy = 'strict',
-               "mapping.total_fields.limit" = 1000,
-               max_ngram_diff = 1,
-               max_shingle_diff = 3,
                "merge.scheduler.max_thread_count" = 1,
-               number_of_replicas = '0-1',
-               "routing.allocation.enable" = 'all',
-               "routing.allocation.total_shards_per_node" = -1,
-               "store.type" = 'fs',
-               "translog.durability" = 'REQUEST',
-               "translog.flush_threshold_size" = 536870912,
-               "translog.sync_interval" = 5000,
-               "unassigned.node_left.delayed_timeout" = 60000,
-               "write.wait_for_active_shards" = '1'
+               number_of_replicas = '0-1'
             )""");
     }
 


### PR DESCRIPTION
Relates to https://github.com/crate/crate/issues/11939

And it has the advantage that it is easier to see what settings users configured explicitly on a glance.
In case we change defaults for settings were we think changing the value also for tables created in older versions would be problematic we can in the future then still use old defaults for old versions given that we'll be able to distinguish between explicit/implicit values.