### PR TITLE
Enable cast from array of text to array of object

### DIFF
--- a/docs/appendices/release-notes/5.9.3.rst
+++ b/docs/appendices/release-notes/5.9.3.rst
@@ -47,4 +47,6 @@ See the :ref:`version_5.9.0` release notes for a full list of changes in the
 Fixes
 =====
 
-None
+- Fixed an issue that prevented to cast an array of :ref:`TEXT <type-text>`
+  containing JSON text representation values to an array of
+  :ref:`OBJECT <type-object>`.

--- a/server/src/main/java/io/crate/expression/symbol/Symbol.java
+++ b/server/src/main/java/io/crate/expression/symbol/Symbol.java
@@ -197,14 +197,20 @@ public interface Symbol extends Writeable, Accountable {
             return this;
         } else if (targetType.equals(valueType())) {
             return this;
-        } else if (ArrayType.unnest(targetType).equals(DataTypes.UNTYPED_OBJECT)
-                   && valueType().id() == targetType.id()) {
-            return this;
-        } else if (ArrayType.unnest(targetType).equals(DataTypes.NUMERIC)
-                   && valueType().id() == DataTypes.NUMERIC.id()) {
-            // Do not cast numerics to unscaled numerics because we do not want to loose precision + scale
-            return this;
+        } else {
+            DataType<?> innerTargetType = ArrayType.unnest(targetType);
+            DataType<?> innerValueType = ArrayType.unnest(valueType());
+            if (innerTargetType.equals(DataTypes.UNTYPED_OBJECT) &&
+                innerTargetType.id() == innerValueType.id() &&
+                valueType().id() == targetType.id()) {
+                return this;
+            } else if (innerTargetType.equals(DataTypes.NUMERIC) &&
+                valueType().id() == DataTypes.NUMERIC.id()) {
+                // Do not cast numerics to unscaled numerics because we do not want to loose precision + scale
+                return this;
+            }
         }
+
         return generateCastFunction(this, targetType, modes);
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/cast/CastFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/cast/CastFunctionTest.java
@@ -330,4 +330,16 @@ public class CastFunctionTest extends ScalarTestCase {
             .isExactlyInstanceOf(ConversionException.class)
             .hasMessage("Cannot cast value `i-am-not-json` to type `object`");
     }
+
+    @Test
+    public void test_cast_text_array_to_object_array() {
+        assertEvaluate("tags::ARRAY(OBJECT)",
+            List.of(Map.of("x", "foo", "y", 2), Map.of("y", 2, "z", "bar")),
+            Literal.of(List.of("{\"x\":\"foo\",\"y\":2}", "{\"y\":2,\"z\":\"bar\"}"), new ArrayType<>(DataTypes.STRING)));
+
+        assertEvaluate("tags::ARRAY(JSON)::ARRAY(OBJECT)",
+            List.of(Map.of("x", "foo", "y", 2), Map.of("y", 2, "z", "bar")),
+            Literal.of(List.of("{\"x\":\"foo\",\"y\":2}", "{\"y\":2,\"z\":\"bar\"}"), new ArrayType<>(DataTypes.STRING)));
+    }
+
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes https://github.com/crate/crate/issues/16887


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
