### PR TITLE
Experiment: getCommonType sounds equivalent to merge

### DIFF
--- a/server/src/main/java/io/crate/types/TypeCompatibility.java
+++ b/server/src/main/java/io/crate/types/TypeCompatibility.java
@@ -36,38 +36,10 @@ public final class TypeCompatibility {
         if (type2.equals(UndefinedType.INSTANCE)) {
             return type1;
         }
-        String type1Base = type1.getTypeSignature().getBaseTypeName();
-        String type2Base = type2.getTypeSignature().getBaseTypeName();
-        if (type1Base.equals(type2Base)) {
-            // If given types share the same base, e.g. arrays, parameter types must be compatible.
-            if (type1.getTypeParameters().isEmpty() == false || type2.getTypeParameters().isEmpty() == false) {
-                try {
-                    return DataTypes.merge(type1, type2);
-                } catch (IllegalArgumentException ex) {
-                    return null;
-                }
-            }
-            return type1;
+        try {
+            return DataTypes.merge(type1, type2);
+        } catch (IllegalArgumentException ex) {
+            return null;
         }
-        return convertTypeByPrecedence(type1, type2);
-    }
-
-    @Nullable
-    private static DataType<?> convertTypeByPrecedence(DataType<?> type1, DataType<?> type2) {
-        final DataType<?> higherPrecedenceArg;
-        final DataType<?> lowerPrecedenceArg;
-        if (type1.precedes(type2)) {
-            higherPrecedenceArg = type1;
-            lowerPrecedenceArg = type2;
-        } else {
-            higherPrecedenceArg = type2;
-            lowerPrecedenceArg = type1;
-        }
-        if (lowerPrecedenceArg.isConvertableTo(higherPrecedenceArg, false)) {
-            return higherPrecedenceArg;
-        } else if (higherPrecedenceArg.isConvertableTo(lowerPrecedenceArg, false)) {
-            return lowerPrecedenceArg;
-        }
-        return null;
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes https://github.com/crate/crate/issues/16838:
```
cr> create table t (a numeric(4,2));
inseCREATE OK, 1 row affected (2.305 sec)
cr> insert into t values (1.11);
INSERT OK, 1 row affected (0.159 sec)
cr> select * from t where a = 1.111;
+------+
|    a |
+------+
| 1.11 |  -- 1.111 seems to be implicitly casted to 1.11 and falsely matches
+------+
SELECT 1 row in set (1.171 sec)
```
where `a(numeric(4,2)) = 1.111(double)` is resolved to `op_=(numeric(4,2), numeric(4,2))` causing `1.111` to be cast to `numeric(4,2)`. My intention is to resolve this comparison to be resolved to `op_=(numeric(null,null), numeric(null,null))`.

## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
