### PR TITLE
Fix issue with subscript on nested object arrays

### DIFF
--- a/docs/appendices/release-notes/5.9.3.rst
+++ b/docs/appendices/release-notes/5.9.3.rst
@@ -47,6 +47,12 @@ See the :ref:`version_5.9.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that caused error to be thrown when attempting to access a
+  nested field of an :ref:`OBJECT <type-object>`, which contains also arrays of
+  :ref:`OBJECT <type-object>`, e.g.::
+
+      SELECT {"o"=[{"oo"={"x"= 10}}, {"oo"={"x"= 20}}]}['o']['oo']['x']
+
 - Fixed an issue that prevented to cast an array of :ref:`TEXT <type-text>`
   containing JSON text representation values to an array of
   :ref:`OBJECT <type-object>`.

--- a/server/src/main/java/io/crate/expression/scalar/SubscriptFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/SubscriptFunction.java
@@ -210,9 +210,15 @@ public class SubscriptFunction extends Scalar<Object, Object> {
 
     static Object lookupByName(List<DataType<?>> argTypes, Object base, Object name, boolean errorOnUnknownObjectKey) {
         if (!(base instanceof Map<?, ?> map)) {
+            if (base instanceof List<?> list) {
+                List<Object> result = new ArrayList<>(list.size());
+                for (Object item : list) {
+                    result.add(lookupByName(argTypes, item, name, errorOnUnknownObjectKey));
+                }
+                return result;
+            }
             throw new IllegalArgumentException("Base argument to subscript must be an object, not " + base);
-        }
-        if (errorOnUnknownObjectKey && !map.containsKey(name)) {
+        } else if (errorOnUnknownObjectKey && !map.containsKey(name)) {
             DataType<?> objectArgType = argTypes.get(0);
             // Type could also be "undefined"
             if (objectArgType instanceof ObjectType objType) {
@@ -221,8 +227,9 @@ public class SubscriptFunction extends Scalar<Object, Object> {
                 }
             }
             throw ColumnUnknownException.ofUnknownRelation("The object `" + base + "` does not contain the key `" + name + "`");
+        } else {
+            return map.get(name);
         }
-        return map.get(name);
     }
 
     private interface PreFilterQueryBuilder {

--- a/server/src/test/java/io/crate/expression/scalar/SubscriptObjectFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/SubscriptObjectFunctionTest.java
@@ -22,8 +22,10 @@
 package io.crate.expression.scalar;
 
 import static io.crate.testing.Asserts.isLiteral;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.List;
 import java.util.Map;
 
 import org.assertj.core.api.Assertions;
@@ -83,6 +85,14 @@ public class SubscriptObjectFunctionTest extends ScalarTestCase {
         assertEvaluateNull("subscript_obj({x=null}, 'x', 'y')");
     }
 
+    @SuppressWarnings("unchecked")
+    @Test
+    public void test_subscript_obj_with_nested_array_obj() throws Exception {
+        assertEvaluate("subscript_obj({\"o\"= [{\"oo\"= {\"x\"= 10}}, {\"oo\"= {\"x\"= 20}}]}, 'o', 'oo', 'x')",
+            o -> assertThat((List<Integer>) o).containsExactly(10, 20));
+    }
+
+    @SuppressWarnings("unchecked")
     @Test
     public void testEvaluateNestedObjectWithUnknownObjectkeysWithSessionSetting() throws Exception {
         // missing key in the very front
@@ -99,5 +109,13 @@ public class SubscriptObjectFunctionTest extends ScalarTestCase {
             .hasMessageContaining("The object `{y={z=test}}` does not contain the key `x`");
         sqlExpressions.setErrorOnUnknownObjectKey(false);
         assertEvaluateNull("{\"x\" = {\"y\" = {\"z\" = 'test'}}}['x']['x']['z']");
+        // object array, where one item (object) contains key and the other doesn't
+        sqlExpressions.setErrorOnUnknownObjectKey(true);
+        Assertions.assertThatThrownBy(() -> assertEvaluate("{\"o\"= [{\"oo\"= {\"x\"= 10}}, {\"oo\"= {\"y\"= 20}}]}['o']['oo']['x']", null))
+            .isExactlyInstanceOf(ColumnUnknownException.class)
+            .hasMessageContaining("The object `{y=20}` does not contain the key `x`");
+        sqlExpressions.setErrorOnUnknownObjectKey(false);
+        assertEvaluate("{\"o\"= [{\"oo\"= {\"x\"= 10}}, {\"oo\"= {\"y\"= 20}}]}['o']['oo']['x']",
+            o -> assertThat((List<Integer>) o).containsExactly(10, null));
     }
 }


### PR DESCRIPTION
Previously, `SubscriptFunction#lookupByName()` didn't support nested object arrays, it expected only objects of primitive fields, therefore expression like:

```
SELECT {"o"= [{"oo"= {"x"= 10}}, {"oo"= {"x"= 20}}]}['o']['oo']['x']
```
would fail.

Fixes: #16892

