### PR TITLE
Forbid adding a sub-column to an object(ignored) if table isn't empty

### DIFF
--- a/docs/appendices/release-notes/5.9.3.rst
+++ b/docs/appendices/release-notes/5.9.3.rst
@@ -71,3 +71,14 @@ Fixes
       |       1.0 |
       +-----------+
 
+- Fixed an issue which can cause the data of a table to not be queried anymore and the
+  :ref:`analyze` to fail, if a sub column is added to an object column with
+  column policy ``IGNORED`` when the table is not empty and the new column's
+  data type is different from the existing column's values.
+  This is not allowed anymore and results in an error. For example::
+
+    CREATE TABLE t (o OBJECT(IGNORED));
+    INSERT INTO t (o) VALUES ({x=1});
+    ALTER TABLE t ADD COLUMN o['x'] AS TEXT; <--- this is not allowed anymore
+    INSERT INTO t (o) VALUES ({x='foo'});
+    ANALYZE; <--- this will fail without the fix

--- a/server/src/main/java/io/crate/execution/ddl/tables/AlterTableClient.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/AlterTableClient.java
@@ -61,12 +61,14 @@ import io.crate.execution.support.ChainableAction;
 import io.crate.execution.support.ChainableActions;
 import io.crate.metadata.GeneratedReference;
 import io.crate.metadata.PartitionName;
+import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.table.TableInfo;
 import io.crate.replication.logical.LogicalReplicationService;
 import io.crate.replication.logical.metadata.Publication;
 import io.crate.session.CollectingResultReceiver;
 import io.crate.session.Sessions;
+import io.crate.sql.tree.ColumnPolicy;
 
 @Singleton
 public class AlterTableClient {
@@ -121,11 +123,20 @@ public class AlterTableClient {
     }
 
     public CompletableFuture<Long> addColumn(AddColumnRequest addColumnRequest) {
+        var newReferences = addColumnRequest.references();
         String subject = null;
         if (addColumnRequest.pKeyIndices().isEmpty() == false) {
             subject = "primary key";
         } else if (addColumnRequest.references().stream().anyMatch(ref -> ref instanceof GeneratedReference)) {
             subject = "generated";
+        } else {
+            for (Reference newRef : newReferences) {
+                if (newReferences.stream().anyMatch(r -> r.column().isChildOf(newRef.column()))
+                    && newRef.columnPolicy().equals(ColumnPolicy.IGNORED)) {
+                    subject = "sub column to an OBJECT(IGNORED) parent";
+                    break;
+                }
+            }
         }
         if (subject != null) {
             String finalSubject = subject;


### PR DESCRIPTION
If the table is not empty it may already contain data for the explicit added new column. The data may be of a different type, which then breaks collecting and streaming the data. Thus this may break querying the data or running `ANALYZE`.

As we do not know which data the table already has without processing each row, we simply throw an exception if we detect that the table isn't empty.