### PR TITLE
Update junit5 from 5.10.3 to 5.11.3

### DIFF
--- a/libs/dex/pom.xml
+++ b/libs/dex/pom.xml
@@ -70,7 +70,7 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
+      <artifactId>junit-jupiter</artifactId>
       <version>${versions.junit5}</version>
       <scope>test</scope>
     </dependency>

--- a/libs/pgwire/pom.xml
+++ b/libs/pgwire/pom.xml
@@ -50,7 +50,7 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
+      <artifactId>junit-jupiter</artifactId>
       <version>${versions.junit5}</version>
       <scope>test</scope>
     </dependency>

--- a/libs/shared/pom.xml
+++ b/libs/shared/pom.xml
@@ -68,7 +68,7 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
+      <artifactId>junit-jupiter</artifactId>
       <version>${versions.junit5}</version>
       <scope>test</scope>
     </dependency>

--- a/libs/sql-parser/pom.xml
+++ b/libs/sql-parser/pom.xml
@@ -65,8 +65,14 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
+      <artifactId>junit-jupiter</artifactId>
       <version>${versions.junit5}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-commons</artifactId>
+      <version>${versions.junit-platform-commons}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -314,7 +314,8 @@
     <versions.annotations>26.0.1</versions.annotations>
     <versions.log4j>2.24.1</versions.log4j>
     <versions.assertj>3.26.3</versions.assertj>
-    <versions.junit5>5.10.3</versions.junit5>
+    <versions.junit5>5.11.3</versions.junit5>
+    <versions.junit-platform-commons>1.11.3</versions.junit-platform-commons>
     <versions.junit>4.13.2</versions.junit>
     <versions.randomizedrunner>2.8.1</versions.randomizedrunner>
     <versions.jackson>2.18.1</versions.jackson>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -321,6 +321,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-commons</artifactId>
+      <version>${versions.junit-platform-commons}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
       <version>${versions.junit5}</version>


### PR DESCRIPTION
Use the jnuit-jupiter artifact instead of the api, and also use the junit-platform-commons dependency where necessary (`sql-parser` and `server` modules).

