### PR TITLE
Remove type specific logic from DataTypes.merge

### DIFF
--- a/server/src/main/java/io/crate/types/ArrayType.java
+++ b/server/src/main/java/io/crate/types/ArrayType.java
@@ -389,6 +389,15 @@ public class ArrayType<T> extends DataType<List<T>> {
     }
 
     @Override
+    DataType<?> merge(DataType<?> other) {
+        if (other instanceof ArrayType<?> o) {
+            return new ArrayType<>(DataTypes.merge(this.innerType, o.innerType));
+        } else {
+            return super.merge(other);
+        }
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;

--- a/server/src/main/java/io/crate/types/DataType.java
+++ b/server/src/main/java/io/crate/types/DataType.java
@@ -218,6 +218,14 @@ public abstract class DataType<T> implements Comparable<DataType<?>>, Writeable,
         return possibleConversions.contains(other.id());
     }
 
+    DataType<?> merge(DataType<?> other) {
+        assert this.id() == other.id() || this.precedes(other) : "'this' precedes 'other' or they must be the same type";
+        if (other.isConvertableTo(this, false)) {
+            return this;
+        }
+        throw new IllegalArgumentException("'" + other + "' is not convertible to '" + this + "'");
+    }
+
     @Override
     public int hashCode() {
         return id();

--- a/server/src/main/java/io/crate/types/DataTypes.java
+++ b/server/src/main/java/io/crate/types/DataTypes.java
@@ -640,26 +640,16 @@ public final class DataTypes {
     }
 
     public static DataType<?> merge(DataType<?> leftType, DataType<?> rightType) {
-        if (leftType.id() == ObjectType.ID && rightType.id() == ObjectType.ID) {
-            return ObjectType.merge((ObjectType) leftType, (ObjectType) rightType);
-        }
-        if (leftType.id() == ArrayType.ID && rightType.id() == ArrayType.ID) {
-            return new ArrayType<>(merge(((ArrayType<?>) leftType).innerType(), ((ArrayType<?>) rightType).innerType()));
-        }
-        if (leftType.id() == NumericType.ID && rightType.id() == NumericType.ID) {
-            return NumericType.INSTANCE;
-        }
+        final DataType<?> higher;
+        final DataType<?> lower;
         if (leftType.precedes(rightType)) {
-            if (rightType.isConvertableTo(leftType, false)) {
-                return leftType;
-            }
-            throw new IllegalArgumentException("'" + rightType + "' is not convertible to '" + leftType + "'");
+            higher = leftType;
+            lower = rightType;
         } else {
-            if (leftType.isConvertableTo(rightType, false)) {
-                return rightType;
-            }
-            throw new IllegalArgumentException("'" + leftType + "' is not convertible to '" + rightType + "'");
+            higher = rightType;
+            lower = leftType;
         }
+        return higher.merge(lower);
     }
 
     public static DataType<?> fromId(Integer id) {

--- a/server/src/main/java/io/crate/types/NumericType.java
+++ b/server/src/main/java/io/crate/types/NumericType.java
@@ -167,6 +167,15 @@ public class NumericType extends DataType<BigDecimal> implements Streamer<BigDec
     }
 
     @Override
+    DataType<?> merge(DataType<?> other) {
+        if (other instanceof NumericType o) {
+            return NumericType.INSTANCE;
+        } else {
+            return super.merge(other);
+        }
+    }
+
+    @Override
     public BigDecimal valueForInsert(BigDecimal value) {
         return value;
     }

--- a/server/src/main/java/io/crate/types/ObjectType.java
+++ b/server/src/main/java/io/crate/types/ObjectType.java
@@ -276,7 +276,16 @@ public class ObjectType extends DataType<Map<String, Object>> implements Streame
         return true;
     }
 
-    public static ObjectType merge(ObjectType left, ObjectType right) {
+    @Override
+    DataType<?> merge(DataType<?> other) {
+        if (other instanceof ObjectType o) {
+            return merge(this, o);
+        } else {
+            return super.merge(other);
+        }
+    }
+
+    private static ObjectType merge(ObjectType left, ObjectType right) {
         ObjectType.Builder mergedObjectBuilder = ObjectType.builder();
         for (var e : left.innerTypes().entrySet()) {
             mergedObjectBuilder.setInnerType(e.getKey(), e.getValue());


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Follows: https://github.com/crate/crate/pull/16731#issuecomment-2416346389

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
