### PR TITLE
Use fastdoubleparser for string -> float/double parsing

### DIFF
--- a/libs/es-x-content/pom.xml
+++ b/libs/es-x-content/pom.xml
@@ -44,5 +44,10 @@
       <artifactId>jackson-dataformat-yaml</artifactId>
       <version>${versions.jackson}</version>
     </dependency>
+    <dependency>
+      <groupId>ch.randelshofer</groupId>
+      <artifactId>fastdoubleparser</artifactId>
+      <version>${versions.fastdoubleparser}</version>
+    </dependency>
   </dependencies>
 </project>

--- a/libs/es-x-content/src/main/java/org/elasticsearch/common/xcontent/support/AbstractXContentParser.java
+++ b/libs/es-x-content/src/main/java/org/elasticsearch/common/xcontent/support/AbstractXContentParser.java
@@ -34,6 +34,8 @@ import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentParseException;
 import org.elasticsearch.common.xcontent.XContentParser;
 
+import ch.randelshofer.fastdoubleparser.JavaDoubleParser;
+import ch.randelshofer.fastdoubleparser.JavaFloatParser;
 import io.crate.common.Booleans;
 import io.crate.common.CheckedFunction;
 
@@ -108,7 +110,7 @@ public abstract class AbstractXContentParser implements XContentParser {
         if (token == Token.VALUE_STRING) {
             checkCoerceString(coerce, Short.class);
 
-            double doubleValue = Double.parseDouble(text());
+            double doubleValue = JavaDoubleParser.parseDouble(text());
 
             if (doubleValue < Short.MIN_VALUE || doubleValue > Short.MAX_VALUE) {
                 throw new IllegalArgumentException("Value [" + text() + "] is out of range for a short");
@@ -133,7 +135,7 @@ public abstract class AbstractXContentParser implements XContentParser {
         Token token = currentToken();
         if (token == Token.VALUE_STRING) {
             checkCoerceString(coerce, Integer.class);
-            double doubleValue = Double.parseDouble(text());
+            double doubleValue = JavaDoubleParser.parseDouble(text());
 
             if (doubleValue < Integer.MIN_VALUE || doubleValue > Integer.MAX_VALUE) {
                 throw new IllegalArgumentException("Value [" + text() + "] is out of range for an integer");
@@ -205,7 +207,7 @@ public abstract class AbstractXContentParser implements XContentParser {
         Token token = currentToken();
         if (token == Token.VALUE_STRING) {
             checkCoerceString(coerce, Float.class);
-            return Float.parseFloat(text());
+            return JavaFloatParser.parseFloat(text());
         }
         return doFloatValue();
     }
@@ -223,7 +225,7 @@ public abstract class AbstractXContentParser implements XContentParser {
         Token token = currentToken();
         if (token == Token.VALUE_STRING) {
             checkCoerceString(coerce, Double.class);
-            return Double.parseDouble(text());
+            return JavaDoubleParser.parseDouble(text());
         }
         return doDoubleValue();
     }

--- a/pom.xml
+++ b/pom.xml
@@ -319,6 +319,7 @@
     <versions.junit>4.13.2</versions.junit>
     <versions.randomizedrunner>2.8.1</versions.randomizedrunner>
     <versions.jackson>2.18.1</versions.jackson>
+    <versions.fastdoubleparser>2.0.0</versions.fastdoubleparser>
     <versions.jopt_simple>6.0-alpha-3</versions.jopt_simple>
     <versions.antlr>4.13.2</versions.antlr>
     <versions.quickcheck>1.0</versions.quickcheck>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -303,6 +303,11 @@
       <version>${versions.jackson}</version>
     </dependency>
     <dependency>
+      <groupId>ch.randelshofer</groupId>
+      <artifactId>fastdoubleparser</artifactId>
+      <version>${versions.fastdoubleparser}</version>
+    </dependency>
+    <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
       <version>${versions.jdbc}</version>

--- a/server/src/main/java/io/crate/monitor/SysInfo.java
+++ b/server/src/main/java/io/crate/monitor/SysInfo.java
@@ -21,10 +21,6 @@
 
 package io.crate.monitor;
 
-import org.apache.logging.log4j.Logger;
-import org.apache.lucene.util.Constants;
-import org.apache.logging.log4j.LogManager;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -42,6 +38,12 @@ import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.util.Constants;
+
+import ch.randelshofer.fastdoubleparser.JavaFloatParser;
 
 /**
  * A class that provides system information as similarly as possible as it was returned by Sigar.
@@ -506,7 +508,7 @@ public class SysInfo {
                     if (!lines.isEmpty()) {
                         String[] parts = lines.get(0).split(" ");
                         if (parts.length == 2) {
-                            double uptimeMillis = Float.parseFloat(parts[1]) * 1000.0;
+                            double uptimeMillis = JavaFloatParser.parseFloat(parts[1]) * 1000.0;
                             return (long) uptimeMillis;
                         }
                     }

--- a/server/src/main/java/io/crate/protocols/postgres/types/DoubleType.java
+++ b/server/src/main/java/io/crate/protocols/postgres/types/DoubleType.java
@@ -22,10 +22,12 @@
 package io.crate.protocols.postgres.types;
 
 
-import io.netty.buffer.ByteBuf;
+import java.nio.charset.StandardCharsets;
 
 import org.jetbrains.annotations.NotNull;
-import java.nio.charset.StandardCharsets;
+
+import ch.randelshofer.fastdoubleparser.JavaDoubleParser;
+import io.netty.buffer.ByteBuf;
 
 class DoubleType extends PGType<Double> {
 
@@ -75,6 +77,6 @@ class DoubleType extends PGType<Double> {
 
     @Override
     Double decodeUTF8Text(byte[] bytes) {
-        return Double.parseDouble(new String(bytes, StandardCharsets.UTF_8));
+        return JavaDoubleParser.parseDouble(bytes);
     }
 }

--- a/server/src/main/java/io/crate/protocols/postgres/types/PointType.java
+++ b/server/src/main/java/io/crate/protocols/postgres/types/PointType.java
@@ -25,11 +25,11 @@ import java.nio.charset.StandardCharsets;
 import java.util.StringTokenizer;
 
 import org.jetbrains.annotations.NotNull;
-
 import org.locationtech.spatial4j.context.jts.JtsSpatialContext;
 import org.locationtech.spatial4j.shape.Point;
 import org.locationtech.spatial4j.shape.impl.PointImpl;
 
+import ch.randelshofer.fastdoubleparser.JavaDoubleParser;
 import io.crate.types.Regproc;
 import io.netty.buffer.ByteBuf;
 
@@ -97,12 +97,12 @@ public final class PointType extends PGType<Point> {
         double x;
         double y;
         if (tokenizer.hasMoreTokens()) {
-            x = Double.parseDouble(tokenizer.nextToken());
+            x = JavaDoubleParser.parseDouble(tokenizer.nextToken());
         } else {
             throw new IllegalArgumentException("Cannot parse input as point: " + value + " expected a point in format: (x, y)");
         }
         if (tokenizer.hasMoreTokens()) {
-            y = Double.parseDouble(tokenizer.nextToken());
+            y = JavaDoubleParser.parseDouble(tokenizer.nextToken());
         } else {
             throw new IllegalArgumentException("Cannot parse input as point: " + value + " expected a point in format: (x, y)");
         }

--- a/server/src/main/java/io/crate/protocols/postgres/types/RealType.java
+++ b/server/src/main/java/io/crate/protocols/postgres/types/RealType.java
@@ -22,10 +22,12 @@
 package io.crate.protocols.postgres.types;
 
 
-import io.netty.buffer.ByteBuf;
+import java.nio.charset.StandardCharsets;
 
 import org.jetbrains.annotations.NotNull;
-import java.nio.charset.StandardCharsets;
+
+import ch.randelshofer.fastdoubleparser.JavaFloatParser;
+import io.netty.buffer.ByteBuf;
 
 class RealType extends PGType<Float> {
 
@@ -75,6 +77,6 @@ class RealType extends PGType<Float> {
 
     @Override
     Float decodeUTF8Text(byte[] bytes) {
-        return Float.parseFloat(new String(bytes, StandardCharsets.UTF_8));
+        return JavaFloatParser.parseFloat(bytes);
     }
 }

--- a/server/src/main/java/io/crate/types/DoubleType.java
+++ b/server/src/main/java/io/crate/types/DoubleType.java
@@ -35,6 +35,7 @@ import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
+import ch.randelshofer.fastdoubleparser.JavaDoubleParser;
 import io.crate.Streamer;
 import io.crate.execution.dml.DoubleIndexer;
 import io.crate.execution.dml.ValueIndexer;
@@ -157,7 +158,7 @@ public class DoubleType extends DataType<Double> implements FixedWidthType, Stre
         } else if (value instanceof Double d) {
             return d;
         } else if (value instanceof String s) {
-            return Double.valueOf(s);
+            return JavaDoubleParser.parseDouble(s);
         } else if (value instanceof BigDecimal bigDecimalValue) {
             if (DOUBLE_MAX.compareTo(bigDecimalValue.toBigInteger()) <= 0
                 || DOUBLE_MIN.compareTo(bigDecimalValue.toBigInteger()) >= 0) {

--- a/server/src/main/java/io/crate/types/FloatType.java
+++ b/server/src/main/java/io/crate/types/FloatType.java
@@ -35,6 +35,7 @@ import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
+import ch.randelshofer.fastdoubleparser.JavaFloatParser;
 import io.crate.Streamer;
 import io.crate.execution.dml.FloatIndexer;
 import io.crate.execution.dml.ValueIndexer;
@@ -157,7 +158,7 @@ public class FloatType extends DataType<Float> implements Streamer<Float>, Fixed
         } else if (value instanceof Float f) {
             return f;
         } else if (value instanceof String s) {
-            return Float.parseFloat(s);
+            return JavaFloatParser.parseFloat(s);
         } else if (value instanceof BigDecimal bigDecimalValue) {
             if (MAX.compareTo(bigDecimalValue.toBigInteger()) <= 0
                 || MIN.compareTo(bigDecimalValue.toBigInteger()) >= 0) {

--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -60,6 +60,8 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.jetbrains.annotations.Nullable;
 
+import ch.randelshofer.fastdoubleparser.JavaDoubleParser;
+import ch.randelshofer.fastdoubleparser.JavaFloatParser;
 import io.crate.common.Booleans;
 import io.crate.common.StringUtils;
 import io.crate.common.collections.Tuple;
@@ -1118,7 +1120,7 @@ public class Setting<T> {
             key,
             (s) -> Float.toString(defaultValue),
             (s) -> {
-                float value = Float.parseFloat(s);
+                float value = JavaFloatParser.parseFloat(s);
                 if (value < minValue) {
                     throw new IllegalArgumentException("Failed to parse value [" + s + "] for setting [" + key + "] must be >= " + minValue);
                 }
@@ -1573,7 +1575,7 @@ public class Setting<T> {
 
     public static Setting<Double> doubleSetting(String key, double defaultValue, double minValue, double maxValue, Property... properties) {
         return new Setting<>(key, (s) -> Double.toString(defaultValue), (s) -> {
-            final double d = Double.parseDouble(s);
+            final double d = JavaDoubleParser.parseDouble(s);
             if (d < minValue) {
                 throw new IllegalArgumentException("Failed to parse value [" + s + "] for setting [" + key + "] must be >= " + minValue);
             }

--- a/server/src/main/java/org/elasticsearch/common/settings/Settings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Settings.java
@@ -67,6 +67,8 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.jetbrains.annotations.Nullable;
 
+import ch.randelshofer.fastdoubleparser.JavaDoubleParser;
+import ch.randelshofer.fastdoubleparser.JavaFloatParser;
 import io.crate.common.Booleans;
 import io.crate.common.io.IOUtils;
 import io.crate.common.unit.TimeValue;
@@ -249,7 +251,7 @@ public final class Settings {
             return defaultValue;
         }
         try {
-            return Float.parseFloat(sValue);
+            return JavaFloatParser.parseFloat(sValue);
         } catch (NumberFormatException e) {
             throw new SettingsException("Failed to parse float setting [" + setting + "] with value [" + sValue + "]", e);
         }
@@ -265,7 +267,7 @@ public final class Settings {
             return defaultValue;
         }
         try {
-            return Double.parseDouble(sValue);
+            return JavaDoubleParser.parseDouble(sValue);
         } catch (NumberFormatException e) {
             throw new SettingsException("Failed to parse double setting [" + setting + "] with value [" + sValue + "]", e);
         }

--- a/server/src/main/java/org/elasticsearch/common/unit/ByteSizeValue.java
+++ b/server/src/main/java/org/elasticsearch/common/unit/ByteSizeValue.java
@@ -25,6 +25,8 @@ import java.util.Objects;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.Strings;
 
+import ch.randelshofer.fastdoubleparser.JavaDoubleParser;
+
 public final class ByteSizeValue implements Comparable<ByteSizeValue> {
 
     public static final ByteSizeValue ZERO = new ByteSizeValue(0, ByteSizeUnit.BYTES);
@@ -170,7 +172,7 @@ public final class ByteSizeValue implements Comparable<ByteSizeValue> {
                 return new ByteSizeValue(Long.parseLong(s), unit);
             } catch (final NumberFormatException e) {
                 try {
-                    final double doubleValue = Double.parseDouble(s);
+                    final double doubleValue = JavaDoubleParser.parseDouble(s);
                     return new ByteSizeValue((long) (doubleValue * unit.toBytes(1)));
                 } catch (final NumberFormatException ignored) {
                     throw new ElasticsearchParseException("failed to parse setting [{}] with value [{}] as a size in bytes", e, settingName,

--- a/server/src/main/java/org/elasticsearch/common/unit/DistanceUnit.java
+++ b/server/src/main/java/org/elasticsearch/common/unit/DistanceUnit.java
@@ -21,6 +21,8 @@ package org.elasticsearch.common.unit;
 
 import org.elasticsearch.common.geo.GeoUtils;
 
+import ch.randelshofer.fastdoubleparser.JavaDoubleParser;
+
 /**
  * The DistanceUnit enumerates several units for measuring distances. These units
  * provide methods for converting strings and methods to convert units among each
@@ -201,11 +203,11 @@ public enum DistanceUnit {
             for (DistanceUnit unit : values()) {
                 for (String name : unit.names) {
                     if (distance.endsWith(name)) {
-                        return new Distance(Double.parseDouble(distance.substring(0, distance.length() - name.length())), unit);
+                        return new Distance(JavaDoubleParser.parseDouble(distance.substring(0, distance.length() - name.length())), unit);
                     }
                 }
             }
-            return new Distance(Double.parseDouble(distance), defaultUnit);
+            return new Distance(JavaDoubleParser.parseDouble(distance), defaultUnit);
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/unit/Fuzziness.java
+++ b/server/src/main/java/org/elasticsearch/common/unit/Fuzziness.java
@@ -19,12 +19,14 @@
 
 package org.elasticsearch.common.unit;
 
-import org.elasticsearch.ElasticsearchParseException;
-import org.elasticsearch.common.xcontent.XContentParser;
-
 import java.io.IOException;
 import java.util.Locale;
 import java.util.Objects;
+
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.xcontent.XContentParser;
+
+import ch.randelshofer.fastdoubleparser.JavaFloatParser;
 
 /**
  * A unit class that encapsulates all in-exact search
@@ -148,7 +150,7 @@ public final class Fuzziness {
         if (this.equals(AUTO) || isAutoWithCustomValues()) {
             return 1f;
         }
-        return Float.parseFloat(fuzziness.toString());
+        return JavaFloatParser.parseFloat(fuzziness.toString());
     }
 
     private int termLen(String text) {

--- a/server/src/main/java/org/elasticsearch/common/unit/MemorySizeValue.java
+++ b/server/src/main/java/org/elasticsearch/common/unit/MemorySizeValue.java
@@ -19,12 +19,14 @@
 
 package org.elasticsearch.common.unit;
 
-import org.elasticsearch.ElasticsearchParseException;
-import org.elasticsearch.monitor.jvm.JvmInfo;
+import static org.elasticsearch.common.unit.ByteSizeValue.parseBytesSizeValue;
 
 import java.util.Objects;
 
-import static org.elasticsearch.common.unit.ByteSizeValue.parseBytesSizeValue;
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.monitor.jvm.JvmInfo;
+
+import ch.randelshofer.fastdoubleparser.JavaDoubleParser;
 
 /** Utility methods to get memory sizes. */
 public enum MemorySizeValue {
@@ -38,7 +40,7 @@ public enum MemorySizeValue {
         if (sValue != null && sValue.endsWith("%")) {
             final String percentAsString = sValue.substring(0, sValue.length() - 1);
             try {
-                final double percent = Double.parseDouble(percentAsString);
+                final double percent = JavaDoubleParser.parseDouble(percentAsString);
                 if (percent < 0 || percent > 100) {
                     throw new ElasticsearchParseException("percentage should be in [0-100], got [{}]", percentAsString);
                 }

--- a/server/src/main/java/org/elasticsearch/common/unit/RatioValue.java
+++ b/server/src/main/java/org/elasticsearch/common/unit/RatioValue.java
@@ -21,6 +21,8 @@ package org.elasticsearch.common.unit;
 
 import org.elasticsearch.ElasticsearchParseException;
 
+import ch.randelshofer.fastdoubleparser.JavaDoubleParser;
+
 /**
  * Utility class to represent ratio and percentage values between 0 and 100
  */
@@ -53,7 +55,7 @@ public class RatioValue {
         if (sValue.endsWith("%")) {
             final String percentAsString = sValue.substring(0, sValue.length() - 1);
             try {
-                final double percent = Double.parseDouble(percentAsString);
+                final double percent = JavaDoubleParser.parseDouble(percentAsString);
                 if (percent < 0 || percent > 100) {
                     throw new ElasticsearchParseException("Percentage should be in [0-100], got [{}]", percentAsString);
                 }
@@ -63,7 +65,7 @@ public class RatioValue {
             }
         } else {
             try {
-                double ratio = Double.parseDouble(sValue);
+                double ratio = JavaDoubleParser.parseDouble(sValue);
                 if (ratio < 0 || ratio > 1.0) {
                     throw new ElasticsearchParseException("Ratio should be in [0-1.0], got [{}]", ratio);
                 }

--- a/server/src/main/java/org/elasticsearch/common/unit/SizeValue.java
+++ b/server/src/main/java/org/elasticsearch/common/unit/SizeValue.java
@@ -19,13 +19,15 @@
 
 package org.elasticsearch.common.unit;
 
+import java.io.IOException;
+
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 
-import java.io.IOException;
+import ch.randelshofer.fastdoubleparser.JavaDoubleParser;
 
 public class SizeValue implements Writeable, Comparable<SizeValue> {
 
@@ -178,15 +180,15 @@ public class SizeValue implements Writeable, Comparable<SizeValue> {
         long singles;
         try {
             if (sValue.endsWith("k") || sValue.endsWith("K")) {
-                singles = (long) (Double.parseDouble(sValue.substring(0, sValue.length() - 1)) * SizeUnit.C1);
+                singles = (long) (JavaDoubleParser.parseDouble(sValue.substring(0, sValue.length() - 1)) * SizeUnit.C1);
             } else if (sValue.endsWith("m") || sValue.endsWith("M")) {
-                singles = (long) (Double.parseDouble(sValue.substring(0, sValue.length() - 1)) * SizeUnit.C2);
+                singles = (long) (JavaDoubleParser.parseDouble(sValue.substring(0, sValue.length() - 1)) * SizeUnit.C2);
             } else if (sValue.endsWith("g") || sValue.endsWith("G")) {
-                singles = (long) (Double.parseDouble(sValue.substring(0, sValue.length() - 1)) * SizeUnit.C3);
+                singles = (long) (JavaDoubleParser.parseDouble(sValue.substring(0, sValue.length() - 1)) * SizeUnit.C3);
             } else if (sValue.endsWith("t") || sValue.endsWith("T")) {
-                singles = (long) (Double.parseDouble(sValue.substring(0, sValue.length() - 1)) * SizeUnit.C4);
+                singles = (long) (JavaDoubleParser.parseDouble(sValue.substring(0, sValue.length() - 1)) * SizeUnit.C4);
             } else if (sValue.endsWith("p") || sValue.endsWith("P")) {
-                singles = (long) (Double.parseDouble(sValue.substring(0, sValue.length() - 1)) * SizeUnit.C5);
+                singles = (long) (JavaDoubleParser.parseDouble(sValue.substring(0, sValue.length() - 1)) * SizeUnit.C5);
             } else {
                 singles = Long.parseLong(sValue);
             }

--- a/server/src/main/java/org/elasticsearch/index/MergePolicyConfig.java
+++ b/server/src/main/java/org/elasticsearch/index/MergePolicyConfig.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 
+import ch.randelshofer.fastdoubleparser.JavaDoubleParser;
 import io.crate.types.DataTypes;
 
 /**
@@ -243,7 +244,7 @@ public final class MergePolicyConfig {
             return 0.0;
         } else {
             try {
-                double value = Double.parseDouble(noCFSRatio);
+                double value = JavaDoubleParser.parseDouble(noCFSRatio);
                 if (value < 0.0 || value > 1.0) {
                     throw new IllegalArgumentException("NoCFSRatio must be in the interval [0..1] but was: [" + value + "]");
                 }

--- a/server/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
+++ b/server/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
@@ -44,6 +44,7 @@ import org.elasticsearch.monitor.Probes;
 import org.elasticsearch.monitor.os.OsStats.Cgroup;
 import org.elasticsearch.monitor.os.OsStats.Cgroup.CpuStat;
 
+import ch.randelshofer.fastdoubleparser.JavaDoubleParser;
 import io.crate.common.SuppressForbidden;
 
 
@@ -160,7 +161,11 @@ public class OsProbe {
                 final String procLoadAvg = readProcLoadavg();
                 assert procLoadAvg.matches("(\\d+\\.\\d+\\s+){3}\\d+/\\d+\\s+\\d+");
                 final String[] fields = procLoadAvg.split("\\s+");
-                return new double[]{Double.parseDouble(fields[0]), Double.parseDouble(fields[1]), Double.parseDouble(fields[2])};
+                return new double[]{
+                    JavaDoubleParser.parseDouble(fields[0]),
+                    JavaDoubleParser.parseDouble(fields[1]),
+                    JavaDoubleParser.parseDouble(fields[2])
+                };
             } catch (final IOException e) {
                 if (logger.isDebugEnabled()) {
                     logger.debug("error reading /proc/loadavg", e);


### PR DESCRIPTION
See https://github.com/wrandelshofer/FastDoubleParser

I noticed looking at the jackson 2.18.1 release notes that it's included
and thought why not use it if it's already there (the shaded version)

But after seeing https://github.com/FasterXML/jackson-core/issues/1264
it seems like using the shaded variant is discouraged, so this adds the
upstream dependency instead.
