### PR TITLE
Ensure that all columns inside scalar are added to outputs

### DIFF
--- a/docs/appendices/release-notes/5.9.3.rst
+++ b/docs/appendices/release-notes/5.9.3.rst
@@ -95,3 +95,17 @@ Fixes
     ALTER TABLE t ADD COLUMN o['x'] AS TEXT; <--- this is not allowed anymore
     INSERT INTO t (o) VALUES ({x='foo'});
     ANALYZE; <--- this will fail without the fix
+
+- Fixed an issue that lead to an error when selecting a table function inside a
+  a scalar function and using a column inside a scalar but not having it
+  neither in ``SELECT`` nor in the table function. For example::
+
+    SELECT
+      CASE
+        WHEN regexp_matches(col1, '^a') != []
+            THEN 'found'
+        WHEN col2 LIKE '%xyz%'  <--- col2 is not in SELECT targets and not used in the table function
+            THEN 'special case'
+        ELSE 'default'
+      END
+    FROM test;


### PR DESCRIPTION
If scalar has a table function call and uses a column, not used neither in the table function, nor in the SELECT list, that column must be collected to ensure that EvalProjection has all required Symbols.

Fixes https://github.com/crate/crate/issues/16868