### PR TITLE
Fix REST bulk row count receiver when run with a single bulk arg

### DIFF
--- a/server/src/main/java/io/crate/rest/action/RestBulkRowCountReceiver.java
+++ b/server/src/main/java/io/crate/rest/action/RestBulkRowCountReceiver.java
@@ -43,7 +43,10 @@ class RestBulkRowCountReceiver extends BaseResultReceiver {
     @Override
     public void setNextRow(Row row) {
         rowCount = (long) row.get(0);
-        failure = (Throwable) row.get(1);
+        // Can be an optimized bulk request with only 1 bulk arg/operation which carries only 1 column (row count).
+        if (results.length > 1) {
+            failure = (Throwable) row.get(1);
+        }
     }
 
     @Override

--- a/server/src/test/java/io/crate/rest/action/RestActionReceiversTest.java
+++ b/server/src/test/java/io/crate/rest/action/RestActionReceiversTest.java
@@ -132,4 +132,15 @@ public class RestActionReceiversTest extends ESTestCase {
             "{\"rowcount\":-2,\"error\":{\"code\":4091,\"message\":\"DuplicateKeyException[A document with the same primary key exists already]\"}}" +
             "]}").isEqualTo(s);
     }
+
+    @Test
+    public void test_rest_bulk_row_count_receiver_supports_single_column_row_on_single_bulk_arg() throws Exception {
+        var results = new RestBulkRowCountReceiver.Result[1];
+        var bulkRowCountReceiver = new RestBulkRowCountReceiver(results, 0);
+        // A row with a single column must not throw an exception on reading a possible second column
+        bulkRowCountReceiver.setNextRow(new Row1(1L));
+        bulkRowCountReceiver.allFinished();
+        assertThat(results[0].rowCount()).isEqualTo(1L);
+        assertThat(results[0].error()).isNull();
+    }
 }

--- a/server/src/testFixtures/java/io/crate/testing/SQLTransportExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLTransportExecutor.java
@@ -663,10 +663,9 @@ public class SQLTransportExecutor {
         public void setNextRow(Row row) {
             long rowCount = (long) row.get(0);
             Throwable failure = null;
-            try {
+            // Can be an optimized bulk request with only 1 bulk arg/operation which carries only 1 column (row count).
+            if (bulkResponse.size() > 1) {
                 failure = (Throwable) row.get(1);
-            } catch (IndexOutOfBoundsException e) {
-                // ignore, must be an optimized bulk request with only 1 bulk arg/operation
             }
             bulkResponse.update(resultIdx, rowCount, failure);
         }


### PR DESCRIPTION
If only a single bulk arg is provided, we run the operation as a single execution instead of a bulk one. As failures result in an exception on single execution the given row will only contain one row count column.

This fix will not try to resolve the 2nd column when only one bulk arg (one result payload) is detected.

Follow up of https://github.com/crate/crate/commit/c7fb24dd00e0f14c8a2ab6f9c99ef5c663e85e8b.
Fixes #16916.
