### PR TITLE
Consolidate DataTypeTestCase.getDataDef() and getType()

### DIFF
--- a/server/src/test/java/io/crate/types/ArrayTypeTest.java
+++ b/server/src/test/java/io/crate/types/ArrayTypeTest.java
@@ -38,21 +38,11 @@ public class ArrayTypeTest extends DataTypeTestCase<List<Object>> {
 
     @Override
     @SuppressWarnings("unchecked")
-    public DataType<List<Object>> getType() {
-        // we don't support arrays of float vectors
-        // TODO: maybe make this a property of the DataType itself rather than a check in DataTypeAnalyzer?
-        DataType<Object> randomType = (DataType<Object>) DataTypeTesting.randomTypeExcluding(
-            Set.of(FloatVectorType.INSTANCE_ONE)
-        );
-        return new ArrayType<>(randomType);
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
     protected DataDef<List<Object>> getDataDef() {
         // Exclude float vectors and objects - we don't support arrays of float vector,
         // and arrays of objects aren't currently handled by data generation code; these
         // are tested in ObjectTypeTest instead.
+        // TODO: maybe make this a property of the DataType itself rather than a check in DataTypeAnalyzer?
         DataType<Object> randomType = (DataType<Object>) DataTypeTesting.randomTypeExcluding(
             Set.of(FloatVectorType.INSTANCE_ONE, ObjectType.UNTYPED)
         );

--- a/server/src/test/java/io/crate/types/BitStringTypeTest.java
+++ b/server/src/test/java/io/crate/types/BitStringTypeTest.java
@@ -39,8 +39,8 @@ import io.crate.testing.DataTypeTesting;
 public class BitStringTypeTest extends DataTypeTestCase<BitString> {
 
     @Override
-    public DataType<BitString> getType() {
-        return BitStringType.INSTANCE_ONE;
+    protected DataDef<BitString> getDataDef() {
+        return DataDef.fromType(BitStringType.INSTANCE_ONE);
     }
 
     private static final SessionSettings SESSION_SETTINGS = CoordinatorTxnCtx.systemTransactionContext().sessionSettings();

--- a/server/src/test/java/io/crate/types/BooleanTypeTest.java
+++ b/server/src/test/java/io/crate/types/BooleanTypeTest.java
@@ -33,8 +33,8 @@ import org.junit.Test;
 public class BooleanTypeTest extends DataTypeTestCase<Boolean> {
 
     @Override
-    public DataType<Boolean> getType() {
-        return BooleanType.INSTANCE;
+    protected DataDef<Boolean> getDataDef() {
+        return DataDef.fromType(BooleanType.INSTANCE);
     }
 
     @Test

--- a/server/src/test/java/io/crate/types/ByteTypeTest.java
+++ b/server/src/test/java/io/crate/types/ByteTypeTest.java
@@ -32,8 +32,8 @@ import org.junit.Test;
 public class ByteTypeTest extends DataTypeTestCase<Byte> {
 
     @Override
-    public DataType<Byte> getType() {
-        return ByteType.INSTANCE;
+    protected DataDef<Byte> getDataDef() {
+        return DataDef.fromType(ByteType.INSTANCE);
     }
 
     @Test

--- a/server/src/test/java/io/crate/types/CharacterTypeTest.java
+++ b/server/src/test/java/io/crate/types/CharacterTypeTest.java
@@ -34,8 +34,8 @@ import io.crate.testing.SqlExpressions;
 public class CharacterTypeTest extends DataTypeTestCase<String> {
 
     @Override
-    public DataType<String> getType() {
-        return CharacterType.INSTANCE;
+    protected DataDef<String> getDataDef() {
+        return DataDef.fromType(CharacterType.INSTANCE);
     }
 
     private static final SessionSettings SESSION_SETTINGS = CoordinatorTxnCtx.systemTransactionContext().sessionSettings();

--- a/server/src/test/java/io/crate/types/DoubleTypeTest.java
+++ b/server/src/test/java/io/crate/types/DoubleTypeTest.java
@@ -33,8 +33,8 @@ import org.junit.Test;
 public class DoubleTypeTest extends DataTypeTestCase<Double> {
 
     @Override
-    public DataType<Double> getType() {
-        return DoubleType.INSTANCE;
+    protected DataDef<Double> getDataDef() {
+        return DataDef.fromType(DoubleType.INSTANCE);
     }
 
     @Test

--- a/server/src/test/java/io/crate/types/FloatTypeTest.java
+++ b/server/src/test/java/io/crate/types/FloatTypeTest.java
@@ -33,8 +33,8 @@ import org.junit.Test;
 public class FloatTypeTest extends DataTypeTestCase<Float> {
 
     @Override
-    public DataType<Float> getType() {
-        return FloatType.INSTANCE;
+    protected DataDef<Float> getDataDef() {
+        return DataDef.fromType(FloatType.INSTANCE);
     }
 
     @Test

--- a/server/src/test/java/io/crate/types/FloatVectorTypeTest.java
+++ b/server/src/test/java/io/crate/types/FloatVectorTypeTest.java
@@ -28,10 +28,10 @@ import java.util.ArrayList;
 import org.junit.Test;
 
 public class FloatVectorTypeTest extends DataTypeTestCase<float[]> {
-
+    
     @Override
-    public DataType<float[]> getType() {
-        return new FloatVectorType(4);
+    protected DataDef<float[]> getDataDef() {
+        return DataDef.fromType(new FloatVectorType(4));
     }
 
     @Override

--- a/server/src/test/java/io/crate/types/GeoPointTypeTest.java
+++ b/server/src/test/java/io/crate/types/GeoPointTypeTest.java
@@ -38,8 +38,8 @@ import org.locationtech.spatial4j.shape.impl.PointImpl;
 public class GeoPointTypeTest extends DataTypeTestCase<Point> {
 
     @Override
-    public DataType<Point> getType() {
-        return GeoPointType.INSTANCE;
+    protected DataDef<Point> getDataDef() {
+        return DataDef.fromType(GeoPointType.INSTANCE);
     }
 
     @Override

--- a/server/src/test/java/io/crate/types/GeoShapeTypeTest.java
+++ b/server/src/test/java/io/crate/types/GeoShapeTypeTest.java
@@ -55,11 +55,11 @@ public class GeoShapeTypeTest extends DataTypeTestCase<Map<String, Object>> {
         "multipoint (10 10, 20 20)"
     );
 
-    private GeoShapeType type = GeoShapeType.INSTANCE;
+    private final GeoShapeType type = GeoShapeType.INSTANCE;
 
     @Override
-    public DataType<Map<String, Object>> getType() {
-        return type;
+    protected DataDef<Map<String, Object>> getDataDef() {
+        return DataDef.fromType(type);
     }
 
     private static Map<String, Object> parse(String json) {

--- a/server/src/test/java/io/crate/types/IntegerTypeTest.java
+++ b/server/src/test/java/io/crate/types/IntegerTypeTest.java
@@ -32,8 +32,8 @@ import org.junit.Test;
 public class IntegerTypeTest extends DataTypeTestCase<Integer> {
 
     @Override
-    public DataType<Integer> getType() {
-        return IntegerType.INSTANCE;
+    protected DataDef<Integer> getDataDef() {
+        return DataDef.fromType(IntegerType.INSTANCE);
     }
 
     @Test

--- a/server/src/test/java/io/crate/types/IntervalTypeTest.java
+++ b/server/src/test/java/io/crate/types/IntervalTypeTest.java
@@ -30,8 +30,8 @@ import org.junit.Test;
 public class IntervalTypeTest extends DataTypeTestCase<Period> {
 
     @Override
-    public DataType<Period> getType() {
-        return IntervalType.INSTANCE;
+    protected DataDef<Period> getDataDef() {
+        return DataDef.fromType(IntervalType.INSTANCE);
     }
 
     @Test

--- a/server/src/test/java/io/crate/types/IpTypeTest.java
+++ b/server/src/test/java/io/crate/types/IpTypeTest.java
@@ -30,8 +30,8 @@ import org.junit.Test;
 public class IpTypeTest extends DataTypeTestCase<String> {
 
     @Override
-    public DataType<String> getType() {
-        return IpType.INSTANCE;
+    protected DataDef<String> getDataDef() {
+        return DataDef.fromType(IpType.INSTANCE);
     }
 
     @Test

--- a/server/src/test/java/io/crate/types/LongTypeTest.java
+++ b/server/src/test/java/io/crate/types/LongTypeTest.java
@@ -32,8 +32,8 @@ import org.junit.Test;
 public class LongTypeTest extends DataTypeTestCase<Long> {
 
     @Override
-    public DataType<Long> getType() {
-        return LongType.INSTANCE;
+    protected DataDef<Long> getDataDef() {
+        return DataDef.fromType(LongType.INSTANCE);
     }
 
     @Test

--- a/server/src/test/java/io/crate/types/NestedArrayTypeTest.java
+++ b/server/src/test/java/io/crate/types/NestedArrayTypeTest.java
@@ -62,7 +62,7 @@ public class NestedArrayTypeTest extends DataTypeTestCase<List<List<Object>>> {
     @SuppressWarnings("unchecked")
     public DataType<List<List<Object>>> getType() {
         DataType<Object> randomType = (DataType<Object>) DataTypeTesting.randomTypeExcluding(
-            Set.of(FloatVectorType.INSTANCE_ONE)
+            Set.of(FloatVectorType.INSTANCE_ONE, ObjectType.UNTYPED)
         );
         return new ArrayType<>(new ArrayType<>(randomType));
     }

--- a/server/src/test/java/io/crate/types/NestedArrayTypeTest.java
+++ b/server/src/test/java/io/crate/types/NestedArrayTypeTest.java
@@ -60,15 +60,6 @@ public class NestedArrayTypeTest extends DataTypeTestCase<List<List<Object>>> {
 
     @Override
     @SuppressWarnings("unchecked")
-    public DataType<List<List<Object>>> getType() {
-        DataType<Object> randomType = (DataType<Object>) DataTypeTesting.randomTypeExcluding(
-            Set.of(FloatVectorType.INSTANCE_ONE, ObjectType.UNTYPED)
-        );
-        return new ArrayType<>(new ArrayType<>(randomType));
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
     public void test_reference_resolver_docvalues_off() throws Exception {
         DataType<Object> randomType = (DataType<Object>) DataTypeTesting.randomTypeExcluding(
             Set.of(FloatVectorType.INSTANCE_ONE, ObjectType.UNTYPED, BitStringType.INSTANCE_ONE, IpType.INSTANCE, BooleanType.INSTANCE,

--- a/server/src/test/java/io/crate/types/NumericTypeTest.java
+++ b/server/src/test/java/io/crate/types/NumericTypeTest.java
@@ -231,11 +231,11 @@ public class NumericTypeTest extends DataTypeTestCase<BigDecimal> {
     }
 
     @Override
-    public DataType<BigDecimal> getType() {
+    protected DataDef<BigDecimal> getDataDef() {
         var random = random();
         int precision = random.nextInt(2, 39);
         int scale = random.nextInt(0, precision - 1);
-        return new NumericType(precision, scale);
+        return DataDef.fromType(new NumericType(precision, scale));
     }
 
     @Test

--- a/server/src/test/java/io/crate/types/ObjectTypeTest.java
+++ b/server/src/test/java/io/crate/types/ObjectTypeTest.java
@@ -43,11 +43,6 @@ import io.crate.testing.DataTypeTesting;
 public class ObjectTypeTest extends DataTypeTestCase<Map<String, Object>> {
 
     @Override
-    public DataType<Map<String, Object>> getType() {
-        return new ObjectType.Builder().setInnerType("x", DataTypeTesting.randomTypeExcluding(Set.of(ObjectType.UNTYPED))).build();
-    }
-
-    @Override
     protected DataDef<Map<String, Object>> getDataDef() {
         // float vectors will not compare properly so we exclude them here
         DataType<?> innerType

--- a/server/src/test/java/io/crate/types/RegclassTypeTest.java
+++ b/server/src/test/java/io/crate/types/RegclassTypeTest.java
@@ -34,8 +34,8 @@ import io.crate.metadata.settings.SessionSettings;
 public class RegclassTypeTest extends DataTypeTestCase<Regclass> {
 
     @Override
-    public DataType<Regclass> getType() {
-        return RegclassType.INSTANCE;
+    protected DataDef<Regclass> getDataDef() {
+        return DataDef.fromType(RegclassType.INSTANCE);
     }
 
     private static final SessionSettings SESSION_SETTINGS = CoordinatorTxnCtx.systemTransactionContext().sessionSettings();

--- a/server/src/test/java/io/crate/types/ShortTypeTest.java
+++ b/server/src/test/java/io/crate/types/ShortTypeTest.java
@@ -33,8 +33,8 @@ import org.junit.Test;
 public class ShortTypeTest extends DataTypeTestCase<Short> {
 
     @Override
-    public DataType<Short> getType() {
-        return ShortType.INSTANCE;
+    protected DataDef<Short> getDataDef() {
+        return DataDef.fromType(ShortType.INSTANCE);
     }
 
     @Test

--- a/server/src/test/java/io/crate/types/StringTypeTest.java
+++ b/server/src/test/java/io/crate/types/StringTypeTest.java
@@ -39,8 +39,8 @@ public class StringTypeTest extends DataTypeTestCase<String> {
     private static final SessionSettings SESSION_SETTINGS = CoordinatorTxnCtx.systemTransactionContext().sessionSettings();
 
     @Override
-    public DataType<String> getType() {
-        return StringType.of(randomIntBetween(1, 40));
+    protected DataDef<String> getDataDef() {
+        return DataDef.fromType(StringType.of(randomIntBetween(1, 40)));
     }
 
     @Test


### PR DESCRIPTION
These two methods essentially do the same thing, but they can get out of sync with each other and result in occasional flaky tests.

This also fixes a random failure in NestedArrayTypeTest, where getType() would rarely return an undefined object as its grandchild type which would trigger faulty assumptions in the translog roundtrip tests (a similar to fix to #16897)