### PR TITLE
Log warning when adding conrete col to OBJECT(IGNORED) if table isn't empty, handle data of different type on collect

### DIFF
--- a/docs/appendices/release-notes/5.9.3.rst
+++ b/docs/appendices/release-notes/5.9.3.rst
@@ -84,18 +84,6 @@ Fixes
   :ref:`INTEGER <type-integer>` to throw a ``ClassCastException`` or to return
   invalid results.
 
-- Fixed an issue which can cause the data of a table to not be queried anymore and the
-  :ref:`analyze` to fail, if a sub column is added to an object column with
-  column policy ``IGNORED`` when the table is not empty and the new column's
-  data type is different from the existing column's values.
-  This is not allowed anymore and results in an error. For example::
-
-    CREATE TABLE t (o OBJECT(IGNORED));
-    INSERT INTO t (o) VALUES ({x=1});
-    ALTER TABLE t ADD COLUMN o['x'] AS TEXT; <--- this is not allowed anymore
-    INSERT INTO t (o) VALUES ({x='foo'});
-    ANALYZE; <--- this will fail without the fix
-
 - Fixed an issue that lead to an error when selecting a table function inside a
   a scalar function and using a column inside a scalar but not having it
   neither in ``SELECT`` nor in the table function. For example::

--- a/docs/appendices/release-notes/5.9.3.rst
+++ b/docs/appendices/release-notes/5.9.3.rst
@@ -97,3 +97,10 @@ Fixes
         ELSE 'default'
       END
     FROM test;
+
+- Fixed an issue that caused the :ref:`analyze` statement to fail when executed
+  on a table that was created with an :ref:`OBJECT(IGNORED) <type-object>`
+  column and afterwards a sub-column with a concrete type was added to the
+  object column. In cases where data was already inserted into this sub-column
+  with a different type than defined later on, the :ref:`analyze` statement
+  failed with a cast error.

--- a/docs/general/ddl/alter-table.rst
+++ b/docs/general/ddl/alter-table.rst
@@ -171,6 +171,16 @@ And now a nested column named ``name`` is added to the ``obj_column``::
     +--------------------+-----------+
     SELECT 3 rows in set (... sec)
 
+.. NOTE::
+
+    Adding a sub-column to an object column which is declared with a
+    :ref:`IGNORED <type-object-columns-ignored>` policy on a table with
+    existing data **may shadow the existing data** of this column if the newly
+    defined data type doesn't match or an index or columnar store of the
+    new column is used by a query. Additionally, such an operation may fail if
+    the existing primary and replica shards are not in-sync to ensure data
+    consistency.
+
 .. _alter-table-rename-column:
 
 Renaming columns
@@ -204,7 +214,7 @@ To rename a sub-column of an object column, you can use subscript expressions::
     | renamed_obj_column['name']        | text      |
     +-----------------------------------+-----------+
     SELECT 3 rows in set (... sec)
-    
+
 Closing and opening tables
 ==========================
 

--- a/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
@@ -106,7 +106,8 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
         DocTableInfo table = nodeCtx.schemas().getTableInfo(relationName);
         this.referenceResolver = new LuceneReferenceResolver(
             indexShard.shardId().getIndexName(),
-            table.partitionedByColumns()
+            table.partitionedByColumns(),
+            table.isParentReferenceIgnored()
         );
         this.docInputFactory = new DocInputFactory(nodeCtx, referenceResolver);
         this.bigArrays = bigArrays;

--- a/server/src/main/java/io/crate/execution/engine/fetch/NodeFetchOperation.java
+++ b/server/src/main/java/io/crate/execution/engine/fetch/NodeFetchOperation.java
@@ -79,9 +79,11 @@ public class NodeFetchOperation {
         FetchCollector createCollector(int readerId, RamAccounting ramAccounting) {
             IndexService indexService = fetchTask.indexService(readerId);
             String indexName = indexService.index().getName();
+            var table = fetchTask.table(readerId);
             LuceneReferenceResolver resolver = new LuceneReferenceResolver(
                 indexName,
-                fetchTask.table(readerId).partitionedByColumns()
+                table.partitionedByColumns(),
+                table.isParentReferenceIgnored()
             );
             ArrayList<LuceneCollectorExpression<?>> exprs = new ArrayList<>(refs.size());
             for (Reference reference : refs) {

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/ColumnFieldVisitor.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/ColumnFieldVisitor.java
@@ -58,7 +58,7 @@ public class ColumnFieldVisitor extends StoredFieldVisitor {
     public ColumnFieldVisitor(DocTableInfo table) {
         this.droppedColumns
             = table.droppedColumns().stream().map(Reference::column).collect(Collectors.toUnmodifiableSet());
-        this.storedSourceParser = new SourceParser(table);
+        this.storedSourceParser = new SourceParser(table.droppedColumns(), table.lookupNameBySourceKey(), true);
         this.tableVersion = table.versionCreated();
     }
 

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/DocCollectorExpression.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/DocCollectorExpression.java
@@ -68,13 +68,9 @@ public abstract class DocCollectorExpression<T> extends LuceneCollectorExpressio
 
         Function<Object, Object> valueConverter;
         if (isParentReferenceIgnored.test(reference)) {
-            valueConverter = val -> {
-                try {
-                    return reference.valueType().sanitizeValue(val);
-                } catch (ClassCastException | IllegalArgumentException e) {
-                    return null;
-                }
-            };
+            // If the parent reference is ignored, the child column may have been ignored as well before and may contain
+            // a value that does not fit the current defined child column data type.
+            valueConverter = val -> reference.valueType().sanitizeValueLenient(val);
         } else {
             valueConverter = val -> val;
         }

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/DocCollectorExpression.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/DocCollectorExpression.java
@@ -23,6 +23,8 @@ package io.crate.expression.reference.doc.lucene;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 import io.crate.execution.engine.fetch.ReaderContext;
 import io.crate.metadata.Reference;
@@ -56,13 +58,28 @@ public abstract class DocCollectorExpression<T> extends LuceneCollectorExpressio
         this.context = context;
     }
 
-    public static LuceneCollectorExpression<?> create(final Reference reference) {
+    public static LuceneCollectorExpression<?> create(final Reference reference,
+                                                      Predicate<Reference> isParentReferenceIgnored) {
         assert reference.column().name().equals(SysColumns.DOC.name()) :
             "column name must be " + SysColumns.DOC.name();
         if (reference.column().isRoot()) {
             return new RootDocCollectorExpression(reference);
         }
-        return new ChildDocCollectorExpression(reference);
+
+        Function<Object, Object> valueConverter;
+        if (isParentReferenceIgnored.test(reference)) {
+            valueConverter = val -> {
+                try {
+                    return reference.valueType().sanitizeValue(val);
+                } catch (ClassCastException | IllegalArgumentException e) {
+                    return null;
+                }
+            };
+        } else {
+            valueConverter = val -> val;
+        }
+
+        return new ChildDocCollectorExpression(reference, valueConverter);
     }
 
     static final class RootDocCollectorExpression extends DocCollectorExpression<Map<String, Object>> {
@@ -79,14 +96,16 @@ public abstract class DocCollectorExpression<T> extends LuceneCollectorExpressio
 
     static final class ChildDocCollectorExpression extends DocCollectorExpression<Object> {
 
-        private ChildDocCollectorExpression(Reference ref) {
+        private final Function<Object, Object> valueConverter;
+
+        private ChildDocCollectorExpression(Reference ref, Function<Object, Object> valueConverter) {
             super(ref);
+            this.valueConverter = valueConverter;
         }
 
         @Override
         public Object value() {
-            // correct type detection is ensured by the source parser
-            return source.get(ref.column().path());
+            return valueConverter.apply(source.get(ref.column().path()));
         }
     }
 }

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/LuceneReferenceResolver.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/LuceneReferenceResolver.java
@@ -22,6 +22,7 @@
 package io.crate.expression.reference.doc.lucene;
 
 import java.util.List;
+import java.util.function.Predicate;
 
 import io.crate.exceptions.UnhandledServerException;
 import io.crate.exceptions.UnsupportedFeatureException;
@@ -57,11 +58,14 @@ public class LuceneReferenceResolver implements ReferenceResolver<LuceneCollecto
 
     private final List<Reference> partitionColumns;
     private final String indexName;
+    private final Predicate<Reference> isParentRefIgnored;
 
     public LuceneReferenceResolver(final String indexName,
-                                   final List<Reference> partitionColumns) {
+                                   final List<Reference> partitionColumns,
+                                   Predicate<Reference> isParentRefIgnored) {
         this.indexName = indexName;
         this.partitionColumns = partitionColumns;
+        this.isParentRefIgnored = isParentRefIgnored;
     }
 
     public String getIndexName() {
@@ -101,7 +105,7 @@ public class LuceneReferenceResolver implements ReferenceResolver<LuceneCollecto
                 return new PrimaryTermCollectorExpression();
 
             case SysColumns.Names.DOC: {
-                return DocCollectorExpression.create(ref);
+                return DocCollectorExpression.create(ref, isParentRefIgnored);
             }
 
             default: {
@@ -111,12 +115,13 @@ public class LuceneReferenceResolver implements ReferenceResolver<LuceneCollecto
                         ref.valueType().implicitCast(PartitionName.fromIndexOrTemplate(indexName).values().get(partitionPos))
                     );
                 }
-                return typeSpecializedExpression(ref);
+                return typeSpecializedExpression(ref, isParentRefIgnored);
             }
         }
     }
 
-    public static LuceneCollectorExpression<?> typeSpecializedExpression(final Reference ref) {
+    public static LuceneCollectorExpression<?> typeSpecializedExpression(final Reference ref,
+                                                                         Predicate<Reference> isParentRefIgnored) {
         final String fqn = ref.storageIdent();
         // non-ignored dynamic references should have been resolved to void references by this point
         if (ref instanceof VoidReference) {
@@ -124,7 +129,7 @@ public class LuceneReferenceResolver implements ReferenceResolver<LuceneCollecto
         }
         assert ref instanceof DynamicReference == false || ref.columnPolicy() == ColumnPolicy.IGNORED;
         if (ref.hasDocValues() == false) {
-            return DocCollectorExpression.create(DocReferences.toDocLookup(ref));
+            return DocCollectorExpression.create(DocReferences.toDocLookup(ref), isParentRefIgnored);
         }
         DataType<?> valueType = ref.valueType();
         return switch (valueType.id()) {
@@ -139,7 +144,7 @@ public class LuceneReferenceResolver implements ReferenceResolver<LuceneCollecto
             case LongType.ID, TimestampType.ID_WITH_TZ, TimestampType.ID_WITHOUT_TZ -> new LongColumnReference(fqn);
             case IntegerType.ID -> new IntegerColumnReference(fqn);
             case GeoPointType.ID -> new GeoPointColumnReference(fqn);
-            case ArrayType.ID -> DocCollectorExpression.create(DocReferences.toDocLookup(ref));
+            case ArrayType.ID -> DocCollectorExpression.create(DocReferences.toDocLookup(ref), isParentRefIgnored);
             case FloatVectorType.ID -> new FloatVectorColumnReference(fqn);
             case NumericType.ID -> NumericStorage.getCollectorExpression(fqn, (NumericType) valueType);
             default -> throw new UnhandledServerException("Unsupported type: " + valueType.getName());

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/StoredRowLookup.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/StoredRowLookup.java
@@ -138,7 +138,7 @@ public abstract class StoredRowLookup implements StoredRow {
 
         public FullStoredRowLookup(DocTableInfo table, String indexName, List<Symbol> columns) {
             super(table, indexName);
-            this.sourceParser = new SourceParser(table.droppedColumns(), table.lookupNameBySourceKey());
+            this.sourceParser = new SourceParser(table.droppedColumns(), table.lookupNameBySourceKey(), true);
             register(columns);
         }
 

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/StoredRowLookup.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/StoredRowLookup.java
@@ -227,7 +227,10 @@ public abstract class StoredRowLookup implements StoredRow {
             } else if (ref.valueType().storageSupportSafe().retrieveFromStoredFields() || ref.hasDocValues() == false) {
                 this.fieldsVisitor.registerRef(ref);
             } else {
-                LuceneCollectorExpression<?> expr = LuceneReferenceResolver.typeSpecializedExpression(ref);
+                LuceneCollectorExpression<?> expr = LuceneReferenceResolver.typeSpecializedExpression(
+                    ref,
+                    table.isParentReferenceIgnored()
+                );
                 assert expr instanceof DocCollectorExpression<?> == false;
                 var column = ref.toColumn();
                 if (column.isRoot() == false && column.name().equals(SysColumns.Names.DOC)) {

--- a/server/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
+++ b/server/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
@@ -104,7 +104,8 @@ public class LuceneQueryBuilder {
                            QueryCache queryCache) throws UnsupportedFeatureException {
         var refResolver = new LuceneReferenceResolver(
             indexName,
-            table.partitionedByColumns()
+            table.partitionedByColumns(),
+            table.isParentReferenceIgnored()
         );
         var normalizer = new EvaluatingNormalizer(nodeCtx, RowGranularity.PARTITION, refResolver, null);
         Context ctx = new Context(
@@ -158,7 +159,8 @@ public class LuceneQueryBuilder {
                 nodeCtx,
                 new LuceneReferenceResolver(
                     indexName,
-                    partitionColumns
+                    partitionColumns,
+                    table.isParentReferenceIgnored()
                 )
             );
             this.queryCache = queryCache;

--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
@@ -345,6 +345,10 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
         return referenceTree().findFirstParentMatching(child, test);
     }
 
+    public Predicate<Reference> isParentReferenceIgnored() {
+        return ref -> findParentReferenceMatching(ref, r -> r.columnPolicy() == ColumnPolicy.IGNORED) != null;
+    }
+
     private ReferenceTree referenceTree() {
         if (refTree == null) {
             refTree = ReferenceTree.of(references.values());

--- a/server/src/main/java/io/crate/statistics/ReservoirSampler.java
+++ b/server/src/main/java/io/crate/statistics/ReservoirSampler.java
@@ -253,7 +253,8 @@ public final class ReservoirSampler {
         String indexName = indexService.index().getName();
         LuceneReferenceResolver referenceResolver = new LuceneReferenceResolver(
             indexName,
-            docTable.partitionedByColumns()
+            docTable.partitionedByColumns(),
+            docTable.isParentReferenceIgnored()
         );
         List<? extends LuceneCollectorExpression<?>> expressions = Lists.map(
             columns,

--- a/server/src/main/java/io/crate/types/DataType.java
+++ b/server/src/main/java/io/crate/types/DataType.java
@@ -159,6 +159,27 @@ public abstract class DataType<T> implements Comparable<DataType<?>>, Writeable,
      */
     public abstract T sanitizeValue(Object value);
 
+    /**
+     * Sanitizes the value lenient, handle any exception thrown by {@link DataType#sanitizeValue(Object)}
+     * and return NULL instead.
+     * <p>
+     * On some mapping changes, e.g. adding a new column with a concrete child type to an ignored object, the
+     * replica translog or existing shards may contain entries with values that cannot be sanitized to the current
+     * mapping. In this case, document processing should not fail due to a single corrupt value.
+     *
+     * @param value The value to sanitize to the target {@link DataType}.
+     * @return The value of {@link DataType} or NULL in case of a sanitization error.
+     * @see DataType#sanitizeValue(Object)
+     */
+    @Nullable
+    public T sanitizeValueLenient(Object value) {
+        try {
+            return sanitizeValue(value);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
     public TypeSignature getTypeSignature() {
         return new TypeSignature(getName());
     }

--- a/server/src/main/java/io/crate/types/ObjectType.java
+++ b/server/src/main/java/io/crate/types/ObjectType.java
@@ -184,6 +184,15 @@ public class ObjectType extends DataType<Map<String, Object>> implements Streame
         return convert(value, DataType::sanitizeValue);
     }
 
+    @Override
+    public Map<String, Object> sanitizeValueLenient(Object value) {
+        try {
+            return convert(value, DataType::sanitizeValueLenient);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
     @SuppressWarnings("unchecked")
     private Map<String, Object> convert(Object value,
                                         BiFunction<DataType<?>, Object, Object> innerType) {

--- a/server/src/test/java/io/crate/execution/dml/IndexerTest.java
+++ b/server/src/test/java/io/crate/execution/dml/IndexerTest.java
@@ -129,7 +129,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     static Map<String, Object> sourceMap(ParsedDocument parsedDocument, DocTableInfo tableInfo) throws Exception {
-        var sourceParser = new SourceParser(tableInfo.droppedColumns(), tableInfo.lookupNameBySourceKey());
+        var sourceParser = new SourceParser(tableInfo.droppedColumns(), tableInfo.lookupNameBySourceKey(), true);
         return sourceParser.parse(parsedDocument.source());
     }
 

--- a/server/src/test/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIteratorTest.java
@@ -280,7 +280,7 @@ public class DocValuesGroupByOptimizedIteratorTest extends CrateDummyClusterServ
         var collectPhase = createCollectPhase(List.of(reference), List.of(groupProjection));
         var collectTask = createCollectTask(shard, collectPhase, Version.CURRENT);
         var nodeCtx = createNodeContext();
-        var referenceResolver = new LuceneReferenceResolver(shard.shardId().getIndexName(), List.of());
+        var referenceResolver = new LuceneReferenceResolver(shard.shardId().getIndexName(), List.of(), _ -> false);
 
         var it = DocValuesGroupByOptimizedIterator.tryOptimize(
             functions,

--- a/server/src/test/java/io/crate/execution/engine/collect/GroupByOptimizedIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/GroupByOptimizedIteratorTest.java
@@ -244,7 +244,7 @@ public class GroupByOptimizedIteratorTest extends CrateDummyClusterServiceUnitTe
             new InputFactory(nodeCtx),
             new DocInputFactory(
                 nodeCtx,
-                new LuceneReferenceResolver(shard.shardId().getIndexName(), List.of())
+                new LuceneReferenceResolver(shard.shardId().getIndexName(), List.of(), (_) -> false)
             ),
             collectPhase,
             collectTask

--- a/server/src/test/java/io/crate/expression/reference/doc/lucene/LuceneReferenceResolverTest.java
+++ b/server/src/test/java/io/crate/expression/reference/doc/lucene/LuceneReferenceResolverTest.java
@@ -49,7 +49,8 @@ public class LuceneReferenceResolverTest extends CrateDummyClusterServiceUnitTes
     private static final RelationName RELATION_NAME = new RelationName("s", "t");
     private static final LuceneReferenceResolver LUCENE_REFERENCE_RESOLVER = new LuceneReferenceResolver(
         RELATION_NAME.indexNameOrAlias(),
-        List.of()
+        List.of(),
+        (_) -> false
     );
 
     @Test
@@ -115,7 +116,8 @@ public class LuceneReferenceResolverTest extends CrateDummyClusterServiceUnitTes
         PartitionName partitionName = new PartitionName(new RelationName("doc", "tbl"), List.of("2023"));
         LuceneReferenceResolver refResolver = new LuceneReferenceResolver(
             partitionName.asIndexName(),
-            table.partitionedByColumns()
+            table.partitionedByColumns(),
+            table.isParentReferenceIgnored()
         );
         Reference year = table.getReference(ColumnIdent.of("year"));
         LuceneCollectorExpression<?> impl1 = refResolver.getImplementation(year);

--- a/server/src/test/java/io/crate/expression/reference/doc/lucene/SourceParserTest.java
+++ b/server/src/test/java/io/crate/expression/reference/doc/lucene/SourceParserTest.java
@@ -49,7 +49,7 @@ public class SourceParserTest extends ESTestCase {
 
     @Test
     public void test_extract_single_value_from_json_with_multiple_columns() throws Exception {
-        SourceParser sourceParser = new SourceParser(Set.of(), UnaryOperator.identity());
+        SourceParser sourceParser = new SourceParser(Set.of(), UnaryOperator.identity(), true);
         var column = ColumnIdent.of("_doc", List.of("x"));
         sourceParser.register(column, DataTypes.INTEGER);
         Map<String, Object> result = sourceParser.parse(new BytesArray(
@@ -63,7 +63,7 @@ public class SourceParserTest extends ESTestCase {
 
     @Test
     public void test_unnecessary_leafs_of_object_columns_are_not_collected() throws Exception {
-        SourceParser sourceParser = new SourceParser(Set.of(), UnaryOperator.identity());
+        SourceParser sourceParser = new SourceParser(Set.of(), UnaryOperator.identity(), true);
         var x = ColumnIdent.of("_doc", List.of("obj", "x"));
         var z = ColumnIdent.of("_doc", List.of("obj", "z"));
         sourceParser.register(x, DataTypes.INTEGER);
@@ -80,7 +80,7 @@ public class SourceParserTest extends ESTestCase {
 
     @Test
     public void test_full_object_is_collected_if_full_object_requested() throws Exception {
-        SourceParser sourceParser = new SourceParser(Set.of(), UnaryOperator.identity());
+        SourceParser sourceParser = new SourceParser(Set.of(), UnaryOperator.identity(), true);
         var obj = ColumnIdent.of("_doc", List.of("obj"));
         var x = ColumnIdent.of("_doc", List.of("obj", "x"));
         // the order in which the columns are registered must not matter
@@ -103,7 +103,7 @@ public class SourceParserTest extends ESTestCase {
 
     @Test
     public void test_string_encoded_numbers_will_be_parsed_by_data_type() {
-        SourceParser sourceParser = new SourceParser(Set.of(), UnaryOperator.identity());
+        SourceParser sourceParser = new SourceParser(Set.of(), UnaryOperator.identity(), true);
         sourceParser.register(ColumnIdent.of("_doc", List.of("i")), DataTypes.INTEGER);
         sourceParser.register(ColumnIdent.of("_doc", List.of("l")), DataTypes.LONG);
         sourceParser.register(ColumnIdent.of("_doc", List.of("f")), DataTypes.FLOAT);
@@ -129,7 +129,7 @@ public class SourceParserTest extends ESTestCase {
 
     @Test
     public void test_string_encoded_boolean_will_be_parsed_by_data_type() {
-        SourceParser sourceParser = new SourceParser(Set.of(), UnaryOperator.identity());
+        SourceParser sourceParser = new SourceParser(Set.of(), UnaryOperator.identity(), true);
         sourceParser.register(ColumnIdent.of("_doc", List.of("b")), DataTypes.BOOLEAN);
         Map<String, Object> result = sourceParser.parse(new BytesArray(
             """
@@ -141,7 +141,7 @@ public class SourceParserTest extends ESTestCase {
 
     @Test
     public void test_uses_inner_type_info_to_parse_objects() throws Exception {
-        SourceParser sourceParser = new SourceParser(Set.of(), UnaryOperator.identity());
+        SourceParser sourceParser = new SourceParser(Set.of(), UnaryOperator.identity(), true);
         BitStringType bitStringType = new BitStringType(4);
         ObjectType objectType = ObjectType.builder()
             .setInnerType("bs", bitStringType)
@@ -164,7 +164,7 @@ public class SourceParserTest extends ESTestCase {
 
     @Test
     public void test_null_object_sibling_subcolumn_has_same_name() {
-        SourceParser sourceParser = new SourceParser(Set.of(), UnaryOperator.identity());
+        SourceParser sourceParser = new SourceParser(Set.of(), UnaryOperator.identity(), true);
         ObjectType innerObjectType = ObjectType.builder()
             .setInnerType("target", DataTypes.FLOAT)
             .build();
@@ -196,7 +196,7 @@ public class SourceParserTest extends ESTestCase {
 
     @Test
     public void test_null_object_next_not_sibling_column_has_same_name() {
-        SourceParser sourceParser = new SourceParser(Set.of(), UnaryOperator.identity());
+        SourceParser sourceParser = new SourceParser(Set.of(), UnaryOperator.identity(), true);
         ObjectType objectType = ObjectType.builder()
             .setInnerType("target", DataTypes.FLOAT)
             .build();
@@ -222,7 +222,7 @@ public class SourceParserTest extends ESTestCase {
     // tracks a bug: https://github.com/crate/crate/issues/13504
     @Test
     public void test_nested_array_access() {
-        SourceParser sourceParser = new SourceParser(Set.of(), UnaryOperator.identity());
+        SourceParser sourceParser = new SourceParser(Set.of(), UnaryOperator.identity(), true);
         // ex:
         //   CREATE TABLE test (
         //   "a" array(object as (
@@ -262,7 +262,7 @@ public class SourceParserTest extends ESTestCase {
 
     @Test
     public void test_nested_array_of_geotype() {
-        SourceParser sourceParser = new SourceParser(Set.of(), UnaryOperator.identity());
+        SourceParser sourceParser = new SourceParser(Set.of(), UnaryOperator.identity(), true);
         ArrayType<?> type = new ArrayType<>(new ArrayType<>(GeoPointType.INSTANCE));
         sourceParser.register(ColumnIdent.of("_doc", List.of("a")), type);
         var result = sourceParser.parse(new BytesArray("""
@@ -277,7 +277,7 @@ public class SourceParserTest extends ESTestCase {
     // https://github.com/crate/crate/issues/13990
     @Test
     public void test_convert_empty_or_null_arrays_added_dynamically_to_nulls() {
-        SourceParser sourceParser = new SourceParser(Set.of(), UnaryOperator.identity());
+        SourceParser sourceParser = new SourceParser(Set.of(), UnaryOperator.identity(), true);
         var type = ObjectType.UNTYPED;
         sourceParser.register(ColumnIdent.of("_doc", List.of("x")), type);
         var result = sourceParser.parse(
@@ -296,7 +296,7 @@ public class SourceParserTest extends ESTestCase {
     // https://github.com/crate/crate/issues/14451
     @Test
     public void test_nested_arrays_from_ignored_objects() {
-        SourceParser sourceParser = new SourceParser(Set.of(), UnaryOperator.identity());
+        SourceParser sourceParser = new SourceParser(Set.of(), UnaryOperator.identity(), true);
         sourceParser.register(ColumnIdent.of("_doc", List.of("obj", "x")), UndefinedType.INSTANCE);
         var result = sourceParser.parse(
             new BytesArray(
@@ -318,7 +318,8 @@ public class SourceParserTest extends ESTestCase {
                 createReference(ColumnIdent.of("o", List.of("oo", "b")), DataTypes.INTEGER),
                 createReference(ColumnIdent.of("o", List.of("oo", "s")), DataTypes.INTEGER)
             ),
-            UnaryOperator.identity()
+            UnaryOperator.identity(),
+            true
         );
         var ooType = new ObjectType.Builder()
             .setInnerType("a", DataTypes.INTEGER)
@@ -363,8 +364,9 @@ public class SourceParserTest extends ESTestCase {
             .build();
 
         SourceParser sourceParser = new SourceParser(
-                Set.of(createReference(ColumnIdent.of("o", List.of("oo")), ooType)),
-                UnaryOperator.identity()
+            Set.of(createReference(ColumnIdent.of("o", List.of("oo")), ooType)),
+            UnaryOperator.identity(),
+            true
         );
         // Register parent column in order to collect ony this one, ignoring any other column
         sourceParser.register(ColumnIdent.of("_doc", List.of("o")), oType);
@@ -382,8 +384,9 @@ public class SourceParserTest extends ESTestCase {
     @Test
     public void test_drop_sub_column_with_children_collect_all() {
         SourceParser sourceParser = new SourceParser(
-                Set.of(createReference(ColumnIdent.of("o", List.of("oo")), DataTypes.UNTYPED_OBJECT)),
-                UnaryOperator.identity()
+            Set.of(createReference(ColumnIdent.of("o", List.of("oo")), DataTypes.UNTYPED_OBJECT)),
+            UnaryOperator.identity(),
+            true
         );
 
         // We don't register any column to the SourceParser in order to parse the complete document
@@ -405,7 +408,8 @@ public class SourceParserTest extends ESTestCase {
                 createReference(ColumnIdent.of("o", List.of("oo", "b")), DataTypes.INTEGER),
                 createReference(ColumnIdent.of("o", List.of("oo", "t")), DataTypes.INTEGER)
             ),
-            UnaryOperator.identity()
+            UnaryOperator.identity(),
+            true
         );
         var ooType = new ObjectType.Builder()
             .setInnerType("a", DataTypes.INTEGER)
@@ -467,8 +471,9 @@ public class SourceParserTest extends ESTestCase {
                 .build();
 
         SourceParser sourceParser = new SourceParser(
-                Set.of(createReference(ColumnIdent.of("o", List.of("oo")), ooType)),
-                UnaryOperator.identity()
+            Set.of(createReference(ColumnIdent.of("o", List.of("oo")), ooType)),
+            UnaryOperator.identity(),
+            true
         );
 
         sourceParser.register(ColumnIdent.of("_doc", List.of("o")), oType);
@@ -486,10 +491,7 @@ public class SourceParserTest extends ESTestCase {
     @Test
     @SuppressWarnings("unchecked")
     public void test_parse_long_from_object_array() throws Exception {
-        SourceParser sourceParser = new SourceParser(
-            Set.of(),
-            UnaryOperator.identity()
-        );
+        SourceParser sourceParser = new SourceParser(Set.of(), UnaryOperator.identity(), true);
 
         var objType = new ObjectType.Builder()
             .setInnerType("x", DataTypes.LONG)
@@ -510,5 +512,18 @@ public class SourceParserTest extends ESTestCase {
             Map.of("x", 10L),
             Map.of("x", 20L)
         );
+    }
+
+    @Test
+    public void test_parser_uses_null_values_instead_throwing_exceptions_on_value_parsing_errors() {
+        SourceParser sourceParser = new SourceParser(Set.of(), UnaryOperator.identity(), false);
+        var column = ColumnIdent.of("_doc", List.of("x"));
+        sourceParser.register(column, DataTypes.INTEGER);
+        Map<String, Object> result = sourceParser.parse(new BytesArray(
+            """
+               {"x": "foo"}
+            """));
+
+        assertThat(result.get("x")).isNull();
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/AlterTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/AlterTableIntegrationTest.java
@@ -376,7 +376,8 @@ public class AlterTableIntegrationTest extends IntegTestCase {
 
     @Test
     public void test_can_add_sub_column_to_ignored_parent_if_table_is_not_empty_and_can_query_data_of_different_type() {
-        execute("CREATE TABLE t1 (obj object(ignored))");
+        // Setting translog to async to increase chances that the first record is processed after the column is added.
+        execute("CREATE TABLE t1 (obj object(ignored)) WITH (\"translog.durability\" = 'async')");
         execute("INSERT INTO t1 (obj) VALUES ({a={b=21, c=22}})");
         execute("REFRESH TABLE t1");
         boolean enableColumnarStore = randomBoolean();

--- a/server/src/test/java/io/crate/integrationtests/AnalyzeITest.java
+++ b/server/src/test/java/io/crate/integrationtests/AnalyzeITest.java
@@ -84,4 +84,18 @@ public class AnalyzeITest extends IntegTestCase {
         assertThat(row[1]).isEqualTo(List.of("[1]", "[2]"));
         assertThat(row[2]).isEqualTo(List.of());
     }
+
+    @Test
+    public void test_analyze_works_on_data_with_different_type_than_defined() {
+        execute("CREATE TABLE t1 (obj object(ignored))");
+        execute("INSERT INTO t1 (obj) VALUES ({a={b=21, c=22}})");
+        execute("REFRESH TABLE t1");
+        boolean enableColumnarStore = randomBoolean();
+        execute("ALTER TABLE t1 ADD COLUMN obj['a'] text STORAGE WITH (COLUMNSTORE=" + enableColumnarStore + ")");
+        execute("INSERT INTO t1 (obj) VALUES ({a='bar'})");
+        execute("REFRESH TABLE t1");
+
+        // analyze should not fail
+        execute("ANALYZE");
+    }
 }

--- a/server/src/test/java/io/crate/integrationtests/CopyFromFailFastITest.java
+++ b/server/src/test/java/io/crate/integrationtests/CopyFromFailFastITest.java
@@ -23,6 +23,7 @@ package io.crate.integrationtests;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.newTempDir;
 import static io.crate.integrationtests.CopyIntegrationTest.tmpFileWithLines;
+import static io.crate.testing.Asserts.assertExpectedLogMessages;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
@@ -34,12 +35,9 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.assertj.core.api.Assertions;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.routing.OperationRouting;
-import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.test.IntegTestCase;
 import org.elasticsearch.test.MockLogAppender;
 import org.elasticsearch.test.junit.annotations.TestLogging;
@@ -48,8 +46,8 @@ import org.junit.Test;
 
 import com.carrotsearch.randomizedtesting.LifecycleScope;
 
-import io.crate.session.Sessions;
 import io.crate.exceptions.JobKilledException;
+import io.crate.session.Sessions;
 import io.crate.testing.SQLTransportExecutor;
 import io.crate.testing.UseJdbc;
 import io.crate.testing.UseRandomizedOptimizerRules;
@@ -155,6 +153,7 @@ public class CopyFromFailFastITest extends IntegTestCase {
                     .isExactlyInstanceOf(JobKilledException.class)
                     .hasMessageContaining("Cannot cast value `fail here` to type `integer`");
             },
+            "io.crate.execution.dml.upsert",
             new MockLogAppender.PatternSeenEventExcpectation(
                 "assert failure on node=" + nodeNameOfShard1,
                 "io.crate.execution.dml.upsert.TransportShardUpsertAction",
@@ -231,6 +230,7 @@ public class CopyFromFailFastITest extends IntegTestCase {
                     .isExactlyInstanceOf(JobKilledException.class)
                     .hasMessageContaining("Cannot cast value `fail here` to type `integer`");
             },
+            "io.crate.execution.dml.upsert",
             new MockLogAppender.PatternSeenEventExcpectation(
                 "assert failure on node=" + nodeNameOfShard0,
                 "io.crate.execution.dml.upsert.TransportShardUpsertAction",
@@ -261,20 +261,4 @@ public class CopyFromFailFastITest extends IntegTestCase {
         execute("select * from t");
         assertThat(response.rowCount()).isEqualTo(cluster().numDataNodes());
     }
-
-    private void assertExpectedLogMessages(Runnable command,
-                                           MockLogAppender.LoggingExpectation ... expectations) throws IllegalAccessException {
-        Logger testLogger = LogManager.getLogger("io.crate.execution.dml.upsert");
-        MockLogAppender appender = new MockLogAppender();
-        Loggers.addAppender(testLogger, appender);
-        try {
-            appender.start();
-            Arrays.stream(expectations).forEach(appender::addExpectation);
-            command.run();
-            appender.assertAllExpectationsMatched();
-        } finally {
-            Loggers.removeAppender(testLogger, appender);
-        }
-    }
-
 }

--- a/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
+++ b/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
@@ -220,7 +220,8 @@ public abstract class AggregationTestCase extends ESTestCase {
         var shard = newStartedPrimaryShard(nodeCtx, targetColumns, threadPool);
         var refResolver = new LuceneReferenceResolver(
             shard.shardId().getIndexName(),
-            List.of()
+            List.of(),
+            (_) -> false
         );
 
         try {

--- a/server/src/testFixtures/java/io/crate/testing/Asserts.java
+++ b/server/src/testFixtures/java/io/crate/testing/Asserts.java
@@ -21,19 +21,26 @@
 
 package io.crate.testing;
 
+import static org.elasticsearch.test.ESTestCase.assertBusy;
+
 import java.math.BigDecimal;
+import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.Condition;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.assertj.core.data.Offset;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.translog.Translog;
+import org.elasticsearch.test.MockLogAppender;
 
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.relations.AnalyzedRelation;
@@ -313,4 +320,21 @@ public class Asserts extends Assertions {
     public static Function<Scalar, Consumer<Scalar>> isNotSameInstance() {
         return scalar -> s -> assertThat(s).isNotSameAs(scalar);
     }
+
+    public static void assertExpectedLogMessages(Runnable command,
+                                                 String loggerName,
+                                                 MockLogAppender.LoggingExpectation ... expectations) throws Exception {
+        Logger testLogger = LogManager.getLogger(loggerName);
+        MockLogAppender appender = new MockLogAppender();
+        Loggers.addAppender(testLogger, appender);
+        try {
+            appender.start();
+            Arrays.stream(expectations).forEach(appender::addExpectation);
+            command.run();
+            assertBusy(appender::assertAllExpectationsMatched);
+        } finally {
+            Loggers.removeAppender(testLogger, appender);
+        }
+    }
+
 }

--- a/server/src/testFixtures/java/io/crate/testing/IndexEnv.java
+++ b/server/src/testFixtures/java/io/crate/testing/IndexEnv.java
@@ -90,7 +90,8 @@ public final class IndexEnv implements AutoCloseable {
         nodeEnvironment = new NodeEnvironment(Settings.EMPTY, env);
         luceneReferenceResolver = new LuceneReferenceResolver(
             indexName,
-            table.partitionedByColumns()
+            table.partitionedByColumns(),
+            table.isParentReferenceIgnored()
         );
         indexService = indexModule.newIndexService(
             nodeContext,


### PR DESCRIPTION
- Log warning instead of throwing exception when adding col to ignored object
   Instead of throwing an exception when adding a conrete column to an OBJECT(IGNORED) when the table isn't empty, a warning is logged. By this, no breaking change is introduced to still support such use-cases.
   Follow up of https://github.com/crate/crate/commit/d150a2e57f8a6da80bacf146f934d8e0cd87466b.

- Handle stored source data of different type on collect
   If a column was initially of type IGNORED and later added with a concrete type, the already stored data may be of a different type. Just returning the different type data leads to cast exceptions, thus the data will be sanitised, leading to NULL values if not fitting.

   Returning NULL values in such cases will align to the scenario where the columnar store (docvalues) is enabled for this new column and used to fetch it's data as the old data won't exists in the new columnar store.

- Adds note to the `ADD COLUMN` documentation to explain possible issues when adding a sub-column to an ignored object. Closes #11790. 