### PR TITLE
Readd crate-node script to tarball distribution

### DIFF
--- a/app/src/assembly/src.xml
+++ b/app/src/assembly/src.xml
@@ -40,6 +40,7 @@
       <includes>
         <include>crate</include>
         <include>crate.bat</include>
+        <include>crate-node</include>
       </includes>
     </fileSet>
     <fileSet>

--- a/app/src/main/dist/bin/crate-node
+++ b/app/src/main/dist/bin/crate-node
@@ -1,0 +1,181 @@
+#!/bin/sh
+
+#
+# Copyright © 2015-2021 the original authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+##############################################################################
+#
+#   crate-node start up script for POSIX
+#   This is derived from the gradle generated script.
+#
+#   Important for running:
+#
+#   (1) You need a POSIX-compliant shell to run this script. If your /bin/sh is
+#       noncompliant, but you have some other compliant shell such as ksh or
+#       bash, then to run this script, type that shell name before the whole
+#       command line, like:
+#
+#           ksh crate-node
+#
+#       Busybox and similar reduced shells will NOT work, because this script
+#       requires all of these POSIX shell features:
+#         * functions;
+#         * expansions «$var», «${var}», «${var:-default}», «${var+SET}»,
+#           «${var#prefix}», «${var%suffix}», and «$( cmd )»;
+#         * compound commands having a testable exit status, especially «case»;
+#         * various built-in commands including «command», «set», and «ulimit».
+#
+#   Important for patching:
+#
+#   (2) This script targets any POSIX shell, so it avoids extensions provided
+#       by Bash, Ksh, etc; in particular arrays are avoided.
+#
+#       The "traditional" practice of packing multiple parameters into a
+#       space-separated string is a well documented source of bugs and security
+#       problems, so this is (mostly) avoided, by progressively accumulating
+#       options in "$@", and eventually passing that to Java.
+#
+#       Where the inherited environment variables (DEFAULT_JVM_OPTS, JAVA_OPTS,
+#       and CRATE_NODE_OPTS) rely on word-splitting, this is performed explicitly;
+#       see the in-line comments for details.
+#
+#       There are tweaks for specific operating systems such as AIX, CygWin,
+#       Darwin, MinGW, and NonStop.
+#
+#   (3) This script is generated from the Groovy template
+#       https://github.com/gradle/gradle/blob/master/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+#       within the Gradle project.
+#
+#       You can find Gradle at https://github.com/gradle/gradle/.
+#
+##############################################################################
+
+# Attempt to set APP_HOME
+
+# Resolve links: $0 may be a link
+app_path=$0
+
+# Need this for daisy-chained symlinks.
+while
+    APP_HOME=${app_path%"${app_path##*/}"}  # leaves a trailing /; empty if no leading path
+    [ -h "$app_path" ]
+do
+    ls=$( ls -ld "$app_path" )
+    link=${ls#*' -> '}
+    case $link in             #(
+      /*)   app_path=$link ;; #(
+      *)    app_path=$APP_HOME$link ;;
+    esac
+done
+
+APP_HOME=$( cd "${APP_HOME:-./}.." && pwd -P ) || exit
+
+# Add default JVM options here. You can also use JAVA_OPTS and CRATE_NODE_OPTS to pass JVM options to this script.
+DEFAULT_JVM_OPTS=""
+
+
+CLASSPATH=""
+for libname in "$APP_HOME"/lib/*.jar; do
+    if [ "x$CLASSPATH" != "x" ]; then
+        CLASSPATH="$CLASSPATH:$libname"
+    else
+        CLASSPATH="$libname"
+    fi
+done
+
+
+darwin=false
+case "$( uname )" in                #(
+  Darwin* )         darwin=true  ;; #(
+esac
+if ${darwin}; then
+    JAVACMD="${APP_HOME}/jdk/Contents/Home/bin/java"
+else
+    JAVACMD="${APP_HOME}/jdk/bin/java"
+fi
+
+
+# Collect all arguments for the java command, stacking in reverse order:
+#   * args from the command line
+#   * the main class name
+#   * -classpath
+#   * -D...appname settings
+#   * --module-path (only if needed)
+#   * DEFAULT_JVM_OPTS, JAVA_OPTS, and CRATE_NODE_OPTS environment variables.
+
+
+# Collect all arguments for the java command;
+#   * $DEFAULT_JVM_OPTS, $JAVA_OPTS, and $CRATE_NODE_OPTS can contain fragments of
+#     shell script including quotes and variable substitutions, so put them in
+#     double quotes to make sure that they get re-expanded; and
+#   * put everything else in single quotes, so that it's not re-expanded.
+
+set -- \
+        -classpath "$CLASSPATH" \
+        org.elasticsearch.cluster.coordination.NodeToolCli \
+        "$@"
+
+# Use "xargs" to parse quoted args.
+#
+# With -n1 it outputs one arg per line, with the quotes and backslashes removed.
+#
+# In Bash we could simply go:
+#
+#   readarray ARGS < <( xargs -n1 <<<"$var" ) &&
+#   set -- "${ARGS[@]}" "$@"
+#
+# but POSIX shell has neither arrays nor command substitution, so instead we
+# post-process each arg (as a line of input to sed) to backslash-escape any
+# character that might be a shell metacharacter, then use eval to reverse
+# that process (while maintaining the separation between arguments), and wrap
+# the whole thing up as a single "set" statement.
+#
+# This will of course break if any of these variables contains a newline or
+# an unmatched quote.
+#
+
+eval "set -- $(
+        printf '%s\n' "$DEFAULT_JVM_OPTS $JAVA_OPTS $CRATE_NODE_OPTS" |
+        xargs -n1 |
+        sed ' s~[^-[:alnum:]+,./:=@_]~\\&~g; ' |
+        tr '\n' ' '
+    )" '"$@"'
+
+test_substring() {
+    case $1 in
+        *$2*)
+    return 1
+    ;;
+    *)
+    return 0
+    ;;
+    esac
+}
+
+CMDARGS=$*
+if test -z ${4}; then
+    :
+else
+    CMDARGS_NOSPACES=$(echo ${CMDARGS} | tr -d ' ')
+    if test_substring ${CMDARGS_NOSPACES} "-Cpath.home="; then
+        CMDARGS="${CMDARGS} -Cpath.home=${APP_HOME}"
+    fi
+    if test_substring ${CMDARGS_NOSPACES} "-Cpath.conf="; then
+        CMDARGS="${CMDARGS} -Cpath.conf=${APP_HOME}/config"
+    fi
+fi
+
+exec ${JAVACMD} ${CMDARGS}

--- a/docs/appendices/release-notes/5.9.3.rst
+++ b/docs/appendices/release-notes/5.9.3.rst
@@ -47,6 +47,8 @@ See the :ref:`version_5.9.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Re-added the missing ``crate-node`` script to the tarball distribution.
+
 - Fixed an issue that caused error to be thrown when attempting to access a
   nested field of an :ref:`OBJECT <type-object>`, which contains also arrays of
   :ref:`OBJECT <type-object>`, e.g.::


### PR DESCRIPTION
First tried out the maven appassembler plugin but couldn't get it
working within this setup and we'd like some customization anyway (like
using the bundled jlink jdk)

So this uses the variant we had included in earlier CrateDB versions via
the gradle generation and adapts it slightly (E.g. CLASSPATH is dynamic,
like in the bin/crate script)

Doesn't include a .bat variant because Windows is not supported for
production anyhow. (and if people must, they could always use `java -cp ... org.elasticsearch.cluster.coordination.NodeToolCli directly`
