### PR TITLE
Fix an issue with ORDER BY with query params

### DIFF
--- a/docs/appendices/release-notes/5.9.3.rst
+++ b/docs/appendices/release-notes/5.9.3.rst
@@ -47,6 +47,12 @@ See the :ref:`version_5.9.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that would cause an error to be thrown when attempting to
+  ``ORDER BY`` on top of a complex query (e.g. a ``JOIN``), using an expression
+  which contains a query parameter, e.g.::
+
+      SELECT * FROM t1 JOIN t2 ON t1.a = t2.b ORDER BY abs(t2.i + ?) DESC
+
 - Re-added the missing ``crate-node`` script to the tarball distribution.
 
 - Fixed an issue that caused error to be thrown when attempting to access a

--- a/server/src/test/java/io/crate/integrationtests/SelectOrderByIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SelectOrderByIntegrationTest.java
@@ -186,4 +186,21 @@ public class SelectOrderByIntegrationTest extends IntegTestCase {
             "1| 1",
             "1| 2");
     }
+
+    @Test
+    public void test_order_by_on_join_with_parameter() {
+        execute("create table t1(a string, x int, i int)");
+        execute("insert into t1(a, x, i) values ('foo', 1, 1)");
+        execute("insert into t1(a, x, i) values ('bar', 2, 2)");
+        execute("create table t2(b string, y int, i int)");
+        execute("insert into t2(b, y, i) values ('crate', 1, 1)");
+        execute("insert into t2(b, y, i) values ('db', 2, 2)");
+        execute("refresh table t1, t2");
+        execute("SELECT t1.a, t2.b, abs(t2.i + ?), t1.x, t2.y FROM t1 JOIN t2 ON t1.i = t2.i ORDER BY 3 DESC",
+            new Object[]{-5});
+        assertThat(response).hasRows(
+            "foo| crate| 4| 1| 1",
+            "bar| db| 3| 2| 2"
+        );
+    }
 }


### PR DESCRIPTION
When the ORDER BY is applied on top of another operation (e.g. a JOIN) and not directly on a `Collect`, then a
`OrderedLimitAndOffsetProjection` is added to the plan, which previously didn't use the `SubQueryAndParamBinder` to substitude the query params with the bound values.

Fixes: #16912

