### PR TITLE
Support public key caching for jwk endpoints

### DIFF
--- a/docs/admin/auth/methods.rst
+++ b/docs/admin/auth/methods.rst
@@ -144,6 +144,10 @@ and the global configuration.
 
 See :ref:`create-user-jwt` and :ref:`jwt_defaults` for details.
 
+The `JWK endpoint`_ should provide ``Cache-Control`` headers to allow caching
+the keys to prevent CrateDB from re-requesting the keys each time a user logs
+in.
+
 It's recommended to have ``exp`` (`expiration date`_ as epoch seconds) in the
 header. If it's provided, the token's expiration date will be checked against
 the local system's time in UTC.

--- a/docs/appendices/release-notes/5.10.0.rst
+++ b/docs/appendices/release-notes/5.10.0.rst
@@ -110,6 +110,9 @@ Performance and Resilience Improvements
 Administration and Operations
 -----------------------------
 
+- Added caching for public keys retrieved from JWK endpoints for JWT
+  authentication. See :ref:`JWT authentication method <auth_jwt>` for more details.
+
 - Added node settings for the :ref:`jwt_defaults` allowing to provide global
   values for the :ref:`JWT properties <create-user-jwt>`.
 

--- a/server/src/main/java/io/crate/auth/CachingJwkProvider.java
+++ b/server/src/main/java/io/crate/auth/CachingJwkProvider.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.auth;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.elasticsearch.common.Strings;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
+
+import com.auth0.jwk.Jwk;
+import com.auth0.jwk.JwkException;
+import com.auth0.jwk.JwkProvider;
+import com.auth0.jwk.SigningKeyNotFoundException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+
+import io.netty.handler.codec.http.HttpHeaderNames;
+
+/**
+ * Custom @{@link JwkProvider} implementation based on
+ * <a href="https://github.com/auth0/jwks-rsa-java/blob/master/src/main/java/com/auth0/jwk/UrlJwkProvider.java">UrlJwkProvider.java</a>
+ * which caches results of public jwk keys for the duration of the "Cache-Control max-age"
+ * Http header value from the response of the jwt authentication endpoint or
+ * a provided default value.
+ */
+public class CachingJwkProvider implements JwkProvider {
+
+    private final URL url;
+    private final ObjectReader reader;
+    private final Clock clock;
+    private volatile JwkResult cache;
+
+    public CachingJwkProvider(String domain) {
+        this(domain, Clock.systemUTC());
+    }
+
+    CachingJwkProvider(String domain, Clock clock) {
+        this.url = urlForDomain(domain);
+        this.clock = clock;
+        this.reader = new ObjectMapper().readerFor(Map.class);
+    }
+
+    static URL urlForDomain(String domain) {
+        if (Strings.isNullOrEmpty(domain)) {
+            throw new IllegalArgumentException("A domain is required");
+        }
+        if (!domain.startsWith("http")) {
+            domain = "https://" + domain;
+        }
+        try {
+            final URI uri = new URI(domain).normalize();
+            return uri.toURL();
+        } catch (MalformedURLException | URISyntaxException e) {
+            throw new IllegalArgumentException("Invalid jwks uri", e);
+        }
+    }
+
+    @Override
+    public Jwk get(String keyId) throws JwkException {
+        var keys = cache;
+        Instant now = clock.instant();
+        if (keys == null || keys.expired(now)) {
+            keys = getKeys();
+            if (!keys.expired(now)) {
+                cache = keys;
+            }
+        }
+        Jwk jwk = keys.keys().get(keyId);
+        if (jwk == null) {
+            throw new SigningKeyNotFoundException(
+                "No key found in " + url.toString() + " with kid " + keyId,
+                null
+            );
+        }
+        return jwk;
+    }
+
+    @SuppressWarnings("unchecked")
+    private JwkResult getKeys() {
+        final List<Map<String, Object>> keys;
+        final Duration ttl;
+        try {
+            final URLConnection c = this.url.openConnection();
+            c.setRequestProperty("Accept", "application/json");
+            try (InputStream inputStream = c.getInputStream()) {
+                Map<String, Object> result = reader.readValue(inputStream);
+                keys = (List<Map<String, Object>>) result.get("keys");
+
+                String cacheControl = c.getHeaderField(HttpHeaderNames.CACHE_CONTROL.toString());
+                ttl = parseCacheControl(cacheControl);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Cannot obtain jwks from url " + url, e);
+        }
+
+        if (keys == null || keys.isEmpty()) {
+            throw new IllegalArgumentException("No keys found in " + url, null);
+        }
+        HashMap<String, Jwk> parsedKeys = HashMap.newHashMap(keys.size());
+        for (Map<String, Object> key : keys) {
+            Jwk jwk = Jwk.fromValues(key);
+            parsedKeys.put(jwk.getId(), jwk);
+        }
+        return new JwkResult(clock.instant().plus(ttl), parsedKeys);
+    }
+
+    private record JwkResult(Instant expirationTime, Map<String, Jwk> keys) {
+
+        public boolean expired(Instant now) {
+            return now.compareTo(expirationTime) >= 0;
+        }
+    }
+
+    @VisibleForTesting
+    static Duration parseCacheControl(@Nullable String cacheControl) {
+        if (cacheControl == null || !cacheControl.trim().startsWith("max-age=")) {
+            return Duration.ZERO;
+        }
+        String maxAgeValue = cacheControl.substring(cacheControl.indexOf("=") + 1);
+        try {
+            int seconds = Integer.parseInt(maxAgeValue);
+            return seconds > 0 ? Duration.ofSeconds(seconds) : Duration.ZERO;
+        } catch (NumberFormatException ignored) {
+            return Duration.ZERO;
+        }
+    }
+}

--- a/server/src/main/java/io/crate/auth/HostBasedAuthentication.java
+++ b/server/src/main/java/io/crate/auth/HostBasedAuthentication.java
@@ -118,19 +118,16 @@ public class HostBasedAuthentication implements Authentication {
     private SortedMap<String, HBAConf> hbaConf;
     private final Roles roles;
     private final DnsResolver dnsResolver;
-    private final Settings settings;
-
-    private final Supplier<String> clusterId;
+    private final JWTAuthenticationMethod jwtMethod;
 
     public HostBasedAuthentication(Settings settings,
                                    Roles roles,
                                    DnsResolver dnsResolver,
                                    Supplier<String> clusterId) {
         hbaConf = convertHbaSettingsToHbaConf(settings);
-        this.settings = settings;
         this.roles = roles;
         this.dnsResolver = dnsResolver;
-        this.clusterId = clusterId;
+        this.jwtMethod = new JWTAuthenticationMethod(roles, settings, clusterId);
     }
 
     @VisibleForTesting
@@ -149,13 +146,7 @@ public class HostBasedAuthentication implements Authentication {
             case (TrustAuthenticationMethod.NAME) -> new TrustAuthenticationMethod(roles);
             case (ClientCertAuth.NAME) -> new ClientCertAuth(roles);
             case (PasswordAuthenticationMethod.NAME) -> new PasswordAuthenticationMethod(roles);
-            case (JWTAuthenticationMethod.NAME) ->
-                new JWTAuthenticationMethod(
-                    roles,
-                    settings,
-                    JWTAuthenticationMethod::jwkProvider,
-                    clusterId
-                );
+            case (JWTAuthenticationMethod.NAME) -> jwtMethod;
             default -> null;
         };
     }

--- a/server/src/test/java/io/crate/auth/CachingJwkProviderTest.java
+++ b/server/src/test/java/io/crate/auth/CachingJwkProviderTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+
+import org.junit.Test;
+
+public class CachingJwkProviderTest {
+
+    @Test
+    public void test_get_cache_control_max_age_from_request() throws Exception {
+        var duration = CachingJwkProvider.parseCacheControl("max-age=1000");
+        assertThat(duration).isEqualTo(Duration.ofSeconds(1000));
+
+        duration = CachingJwkProvider.parseCacheControl("wrong");
+        assertThat(duration).isEqualTo(Duration.ZERO);
+
+        duration = CachingJwkProvider.parseCacheControl("max-age=-1");
+        assertThat(duration).isEqualTo(Duration.ZERO);
+
+        duration = CachingJwkProvider.parseCacheControl("max-age=1.1");
+        assertThat(duration).isEqualTo(Duration.ZERO);
+
+        duration = CachingJwkProvider.parseCacheControl("max-age=0");
+        assertThat(duration).isEqualTo(Duration.ZERO);
+    }
+}

--- a/server/src/test/java/io/crate/auth/UserAuthenticationMethodTest.java
+++ b/server/src/test/java/io/crate/auth/UserAuthenticationMethodTest.java
@@ -136,8 +136,8 @@ public class UserAuthenticationMethodTest extends ESTestCase {
         JWTAuthenticationMethod jwtAuth = new JWTAuthenticationMethod(
             roles,
             Settings.EMPTY,
-            jwkProviderFunction(null),
-            () -> "dummy"
+            () -> "dummy",
+            jwkProviderFunction(null)
         );
         assertThat(jwtAuth.name()).isEqualTo("jwt");
 
@@ -167,8 +167,8 @@ public class UserAuthenticationMethodTest extends ESTestCase {
         JWTAuthenticationMethod jwtAuth = new JWTAuthenticationMethod(
             roles,
             Settings.EMPTY,
-            jwkProviderFunction(null),
-            () -> clusterId
+            () -> clusterId,
+            jwkProviderFunction(null)
         );
 
         Credentials credentials = new Credentials(JWT_TOKEN);
@@ -195,8 +195,8 @@ public class UserAuthenticationMethodTest extends ESTestCase {
         JWTAuthenticationMethod jwtAuth = new JWTAuthenticationMethod(
             roles,
             Settings.EMPTY,
-            jwkProviderFunction(null),
-            () -> clusterId
+            () -> clusterId,
+            jwkProviderFunction(null)
         );
 
         Credentials credentials = new Credentials(JWT_TOKEN);
@@ -230,8 +230,8 @@ public class UserAuthenticationMethodTest extends ESTestCase {
         JWTAuthenticationMethod jwtAuth = new JWTAuthenticationMethod(
             roles,
             Settings.EMPTY,
-            jwkProviderFunction(null),
-            () -> "dummy"
+            () -> "dummy",
+            jwkProviderFunction(null)
         );
 
         Credentials credentials = new Credentials(jwt);
@@ -262,8 +262,8 @@ public class UserAuthenticationMethodTest extends ESTestCase {
         JWTAuthenticationMethod jwtAuth = new JWTAuthenticationMethod(
             roles,
             Settings.EMPTY,
-            jwkProviderFunction(null),
-            () -> "dummy"
+            () -> "dummy",
+            jwkProviderFunction(null)
         );
 
         Credentials credentials = new Credentials(jwt);
@@ -282,8 +282,8 @@ public class UserAuthenticationMethodTest extends ESTestCase {
         JWTAuthenticationMethod jwtAuth = new JWTAuthenticationMethod(
             roles,
             Settings.EMPTY,
-            jwkProviderFunction("RS384"),
-            () -> "dummy"
+            () -> "dummy",
+            jwkProviderFunction("RS384")
         );
 
         Credentials credentials = new Credentials(JWT_TOKEN);
@@ -320,8 +320,8 @@ public class UserAuthenticationMethodTest extends ESTestCase {
         JWTAuthenticationMethod jwtAuth = new JWTAuthenticationMethod(
             () -> List.of(JWT_USER),
             Settings.EMPTY,
-            jwkProviderFunction(null),
-            () -> null
+            () -> null,
+            jwkProviderFunction(null)
         );
 
         assertThatThrownBy(
@@ -338,7 +338,6 @@ public class UserAuthenticationMethodTest extends ESTestCase {
         JWTAuthenticationMethod jwtAuth = new JWTAuthenticationMethod(
             List::of,
             Settings.EMPTY,
-            null,
             () -> "dummy"
         );
 
@@ -367,8 +366,8 @@ public class UserAuthenticationMethodTest extends ESTestCase {
         JWTAuthenticationMethod jwtAuth = new JWTAuthenticationMethod(
             roles,
             Settings.EMPTY,
-            jwkProviderFunction(null),
-            () -> "dummy"
+            () -> "dummy",
+            jwkProviderFunction(null)
         );
 
         Credentials credentials = new Credentials(JWT_TOKEN);
@@ -400,8 +399,8 @@ public class UserAuthenticationMethodTest extends ESTestCase {
         JWTAuthenticationMethod jwtAuth = new JWTAuthenticationMethod(
             roles,
             settings,
-            jwkProviderFunction(null),
-            () -> null // ClusterId supplier is not used, aud is taken from defaults
+            () -> null, // ClusterId supplier is not used, aud is taken from defaults
+            jwkProviderFunction(null)
         );
 
         Credentials credentials = new Credentials(JWT_TOKEN);
@@ -424,6 +423,6 @@ public class UserAuthenticationMethodTest extends ESTestCase {
         when(mockJwkProvider.get(KID)).thenReturn(mockJwk);
         when(mockJwk.getPublicKey()).thenReturn(publicKey);
         when(mockJwk.getAlgorithm()).thenReturn(algorithm);
-        return ignored -> mockJwkProvider;
+        return _ -> mockJwkProvider;
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


JWT authentication requires retrieving public keys from JWK endpoints. These public keys can be cached by CrateDB by setting ``cache-control: max-age=`` in the header of the request. If it's provided, once the public key is requested for the first time, it will be cached for the given time.

Fixes https://github.com/crate/crate/issues/15786

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
