### PR TITLE
Docs: Add `null_or_empty(array)`

### DIFF
--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -3504,6 +3504,31 @@ skipped and ``NULL`` leaf elements within arrays are preserved.
     :ref:`UNNEST table function <unnest>`
 
 
+.. _scalar-null-or-empty-array:
+
+``null_or_empty(array)``
+-------------------------
+
+The ``null_or_empty(array)`` function returns a Boolean indicating if an array
+is ``NULL`` or empty (``[]``).
+
+This can serve as a faster alternative to ``IS NULL`` if matching on empty
+array is acceptable. It makes better use of indices.
+
+::
+
+    cr> SELECT null_or_empty([]) w,
+    ...        null_or_empty([[]]) x,
+    ...        null_or_empty(NULL) y,
+    ...        null_or_empty([1]) z;
+    +------+-------+------+-------+
+    | w    | x     | y    | z     |
+    +------+-------+------+-------+
+    | TRUE | FALSE | TRUE | FALSE |
+    +------+-------+------+-------+
+    SELECT 1 row in set (... sec)
+
+
 .. _scalar-objects:
 
 Object functions
@@ -3582,13 +3607,13 @@ objects::
         SELECT 1 row in set (... sec)
 
 
-.. _scalar-null-or-empty:
+.. _scalar-null-or-empty-object:
 
 
 ``null_or_empty(object)``
 -------------------------
 
-The ``null_or_empty(object)`` function returns a boolean indicating if an object
+The ``null_or_empty(object)`` function returns a Boolean indicating if an object
 is ``NULL`` or empty (``{}``).
 
 This can serve as a faster alternative to ``IS NULL`` if matching on empty


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Currently, only `null_or_empty(object)` is documented. We recently learned in a support case that `null_or_empty(array)` is supported also.


## Checklist

 - [X] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [X] Updated documentation & `sql_features` table for user facing changes
 - [X] Touched code is covered by tests
 - [X] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
