### PR TITLE
Fix UnsupportedFeatureException from complex ORDER BY expression validation

### DIFF
--- a/docs/appendices/release-notes/5.9.3.rst
+++ b/docs/appendices/release-notes/5.9.3.rst
@@ -132,3 +132,8 @@ Fixes
         p GEO_POINT,
         x ARRAY(DOUBLE) GENERATED ALWAYS AS p::ARRAY(DOUBLE)
       );
+
+- Fixed an issue that caused an ``UnsupportedFeatureException`` when
+  ``ORDER BY`` expression contained a nested function. For example::
+
+    SELECT * FROM t ORDER BY LEFT(txt_col, 1) = ANY(['a']);

--- a/server/src/main/java/io/crate/analyze/validator/SemanticSortValidator.java
+++ b/server/src/main/java/io/crate/analyze/validator/SemanticSortValidator.java
@@ -88,19 +88,15 @@ public class SemanticSortValidator {
             if (!context.inFunction && !SUPPORTED_TYPES.contains(symbol.valueType().id())) {
                 throw new UnsupportedOperationException(
                     String.format(Locale.ENGLISH,
-                                  "Cannot %s '%s': invalid return type '%s'.",
-                                  context.operation,
-                                  symbol,
-                                  symbol.valueType())
+                        "Cannot %s '%s': invalid return type '%s'.",
+                        context.operation,
+                        symbol,
+                        symbol.valueType())
                 );
             }
-            try {
-                context.inFunction = true;
-                for (Symbol arg : symbol.arguments()) {
-                    arg.accept(this, context);
-                }
-            } finally {
-                context.inFunction = false;
+            context.inFunction = true;
+            for (Symbol arg : symbol.arguments()) {
+                arg.accept(this, context);
             }
             return null;
         }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`SemanticSortValidator.InnerValidator.visitFunction` did not save/restore `context.inFunction` correctly that when popped from the inner function of a nested function, `context.inFunction` was set to `false` while still within the outer function.

Most of the time the validation falsely passed due to the logic that checks for order by expressions consist of a primitive column only.

Fixes https://github.com/crate/crate/issues/16946


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
