### PR TITLE
Use kr.motd.maven as plugin instead of extension

### DIFF
--- a/plugins/crate-copy-azure/pom.xml
+++ b/plugins/crate-copy-azure/pom.xml
@@ -100,12 +100,20 @@
     </dependencies>
 
     <build>
-        <extensions>
-            <extension>
+        <plugins>
+            <plugin>
                 <groupId>kr.motd.maven</groupId>
                 <artifactId>os-maven-plugin</artifactId>
                 <version>${versions.plugin.os}</version>
-            </extension>
-        </extensions>
+                <executions>
+                    <execution>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>detect</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 </project>


### PR DESCRIPTION
Had issues on my M1 Mac (aarch64) and following this: https://github.com/trustin/os-maven-plugin?tab=readme-ov-file#issues-with-eclipse-m2e-or-other-ides it seems to solve the issue.
