### PR TITLE
Use iss from token only for payload verification.

### DIFF
--- a/server/src/main/java/io/crate/auth/JWTAuthenticationMethod.java
+++ b/server/src/main/java/io/crate/auth/JWTAuthenticationMethod.java
@@ -102,7 +102,7 @@ public class JWTAuthenticationMethod implements AuthenticationMethod {
                 audience = jwtProperties.aud() != null ? jwtProperties.aud() : audience;
             }
 
-            JwkProvider jwkProvider = urlToJwkProvider.apply(decodedJWT.getIssuer());
+            JwkProvider jwkProvider = urlToJwkProvider.apply(issuer);
             // Expiration date is checked by default(if provided in token)
             Algorithm algorithm = resolveAlgorithm(jwkProvider, decodedJWT);
             Verification verification = JWT.require(algorithm)


### PR DESCRIPTION
CrateDB must not fire any requests against token's iss as it can be some malicious endpoint.

Instead, we should use it only for the payload verification (pre signature check)

Not a bug because token claims verification fails without this change (we have a failure before we fire a request) but can be an issue with caching in place as we may cache by wrong(malicious) endpoint.

Relates to https://github.com/crate/crate/pull/16937#discussion_r1836245300