### PR TITLE
Stream partition columns as ColumnIdent in CreateTableRequest

### DIFF
--- a/server/src/main/java/io/crate/analyze/AnalyzedCreateTable.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedCreateTable.java
@@ -65,7 +65,7 @@ public record AnalyzedCreateTable(
          **/
         Map<String, AnalyzedCheck> checks,
         GenericProperties<Symbol> properties,
-        Optional<PartitionedBy<Symbol>> partitionedBy,
+        Optional<PartitionedBy<Reference>> partitionedBy,
         Optional<ClusteredBy<Symbol>> clusteredBy) implements DDLStatement {
 
     @Override
@@ -158,7 +158,7 @@ public record AnalyzedCreateTable(
         });
         ColumnIdent routingColumn = optClusteredBy.orElse(SysColumns.ID.COLUMN);
 
-        List<Symbol> partitionedByColumns = partitionedBy
+        List<Reference> partitionedByColumns = partitionedBy
             .map(PartitionedBy::columns)
             .orElse(List.of());
 

--- a/server/src/main/java/io/crate/analyze/BoundCreateTable.java
+++ b/server/src/main/java/io/crate/analyze/BoundCreateTable.java
@@ -30,13 +30,10 @@ import org.jetbrains.annotations.Nullable;
 
 import com.carrotsearch.hppc.IntArrayList;
 
-import io.crate.common.collections.Lists;
-import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
-import io.crate.types.DataTypes;
 
 public record BoundCreateTable(
         RelationName tableName,
@@ -54,7 +51,7 @@ public record BoundCreateTable(
          **/
         Map<String, AnalyzedCheck> checks,
         ColumnIdent routingColumn,
-        List<Symbol> partitionedByColumns) {
+        List<Reference> partitionedByColumns) {
 
     public boolean isPartitioned() {
         return !partitionedByColumns.isEmpty();
@@ -69,14 +66,8 @@ public record BoundCreateTable(
         return partitionedByColumns.isEmpty() ? null : PartitionName.templatePrefix(tableName.schema(), tableName.name());
     }
 
-    public List<List<String>> partitionedBy() {
-        return Lists.map(partitionedByColumns, BoundCreateTable::toPartitionMapping);
-    }
-
-    public static List<String> toPartitionMapping(Symbol symbol) {
-        String fqn = symbol.toColumn().fqn();
-        String typeMappingName = DataTypes.esMappingNameFrom(symbol.valueType().id());
-        return List.of(fqn, typeMappingName);
+    public List<Reference> partitionedBy() {
+        return partitionedByColumns;
     }
 
     public Map<String, String> getCheckConstraints() {

--- a/server/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
@@ -386,8 +386,14 @@ public class TableElementsAnalyzer implements FieldProvider<Reference> {
         }
         GenericProperties<Symbol> properties = createTable.properties().map(toSymbol);
         Optional<ClusteredBy<Symbol>> clusteredBy = createTable.clusteredBy().map(x -> x.map(toSymbol));
-
-        Optional<PartitionedBy<Symbol>> partitionedBy = createTable.partitionedBy().map(x -> x.map(toSymbol));
+        Function<Expression, Reference> toRef = x -> {
+            Symbol symbol = toSymbol.apply(x);
+            if (symbol instanceof Reference ref) {
+                return ref;
+            }
+            throw new IllegalArgumentException("Expression must be a column: " + x);
+        };
+        Optional<PartitionedBy<Reference>> partitionedBy = createTable.partitionedBy().map(x -> x.map(toRef));
         partitionedBy.ifPresent(p -> p.columns().forEach(partitionColumn -> {
             ColumnIdent partitionColumnIdent = partitionColumn.toColumn();
             RefBuilder column = columns.get(partitionColumnIdent);

--- a/server/src/main/java/io/crate/execution/ddl/tables/CreateTableClient.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/CreateTableClient.java
@@ -37,6 +37,7 @@ import com.carrotsearch.hppc.IntArrayList;
 
 import io.crate.analyze.BoundCreateTable;
 import io.crate.analyze.TableParameters;
+import io.crate.common.collections.Lists;
 import io.crate.common.exceptions.Exceptions;
 import io.crate.exceptions.RelationAlreadyExists;
 import io.crate.exceptions.SQLExceptions;
@@ -75,7 +76,7 @@ public class CreateTableClient {
                 settingsBuilder.build(),
                 routingColumn,
                 tableColumnPolicy,
-                createTable.partitionedBy()
+                Lists.map(createTable.partitionedBy(), Reference::column)
             );
         } else {
             throw new UnsupportedOperationException("All nodes in the cluster must at least have version 5.4.0");

--- a/server/src/main/java/io/crate/execution/ddl/tables/CreateTableRequest.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/CreateTableRequest.java
@@ -26,6 +26,7 @@ import static org.elasticsearch.common.settings.Settings.readSettingsFromStream;
 import static org.elasticsearch.common.settings.Settings.writeSettingsToStream;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -46,6 +47,7 @@ import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 import io.crate.sql.tree.ColumnPolicy;
+import io.crate.types.DataTypes;
 
 /**
  * Creates a table represented by an ES index or an ES template (partitioned table).
@@ -55,7 +57,7 @@ public class CreateTableRequest extends MasterNodeRequest<CreateTableRequest> im
 
     // Fields required to add column(s), aligned with AddColumnRequest
     private final RelationName relationName;
-    private final List<Reference> colsToAdd;
+    private final List<Reference> columns;
     @Nullable
     private final String pkConstraintName;
     private final IntArrayList pKeyIndices;
@@ -66,20 +68,20 @@ public class CreateTableRequest extends MasterNodeRequest<CreateTableRequest> im
     @Nullable
     private final ColumnIdent routingColumn;
     private final ColumnPolicy tableColumnPolicy; // The only setting which is set as a "mapping" change (see TableParameter.mappings()), 'strict' by default.
-    private final List<List<String>> partitionedBy;
+    private final List<ColumnIdent> partitionedBy;
 
     public CreateTableRequest(RelationName relationName,
                               @Nullable String pkConstraintName,
-                              List<Reference> colsToAdd,
+                              List<Reference> columns,
                               IntArrayList pKeyIndices,
                               Map<String, String> checkConstraints,
                               Settings settings,
                               @Nullable ColumnIdent routingColumn,
                               ColumnPolicy tableColumnPolicy,
-                              List<List<String>> partitionedBy) {
+                              List<ColumnIdent> partitionedBy) {
         this.relationName = relationName;
         this.pkConstraintName = pkConstraintName;
-        this.colsToAdd = colsToAdd;
+        this.columns = columns;
         this.pKeyIndices = pKeyIndices;
         this.checkConstraints = checkConstraints;
         this.settings = settings;
@@ -113,7 +115,7 @@ public class CreateTableRequest extends MasterNodeRequest<CreateTableRequest> im
         this.relationName = new RelationName(in);
         this.checkConstraints = in.readMap(
             LinkedHashMap::new, StreamInput::readString, StreamInput::readString);
-        this.colsToAdd = in.readList(Reference::fromStream);
+        this.columns = in.readList(Reference::fromStream);
         int numPKIndices = in.readVInt();
         this.pKeyIndices = new IntArrayList(numPKIndices);
         for (int i = 0; i < numPKIndices; i++) {
@@ -121,13 +123,23 @@ public class CreateTableRequest extends MasterNodeRequest<CreateTableRequest> im
         }
 
         this.settings = readSettingsFromStream(in);
-        if (in.getVersion().onOrAfter(Version.V_5_10_0)) {
+        boolean after510 = in.getVersion().onOrAfter(Version.V_5_10_0);
+        if (after510) {
             this.routingColumn = in.readOptionalWriteable(ColumnIdent::of);
         } else {
             this.routingColumn = ColumnIdent.fromPath(in.readOptionalString());
         }
         this.tableColumnPolicy = ColumnPolicy.VALUES.get(in.readVInt());
-        this.partitionedBy = in.readList(StreamInput::readStringList);
+        if (after510) {
+            this.partitionedBy = in.readList(ColumnIdent::of);
+        } else {
+            // List of [fqn, typeMappingName]
+            List<List<String>> partitionedBy = in.readList(StreamInput::readStringList);
+            this.partitionedBy = new ArrayList<>(partitionedBy.size());
+            for (List<String> column : partitionedBy) {
+                this.partitionedBy.add(ColumnIdent.fromPath(column.get(0)));
+            }
+        }
     }
 
     @Override
@@ -138,19 +150,31 @@ public class CreateTableRequest extends MasterNodeRequest<CreateTableRequest> im
         }
         relationName.writeTo(out);
         out.writeMap(checkConstraints, StreamOutput::writeString, StreamOutput::writeString);
-        out.writeCollection(colsToAdd, Reference::toStream);
+        out.writeCollection(columns, Reference::toStream);
         out.writeVInt(pKeyIndices.size());
         for (int i = 0; i < pKeyIndices.size(); i++) {
             out.writeVInt(pKeyIndices.get(i));
         }
         writeSettingsToStream(out, settings);
-        if (out.getVersion().onOrAfter(Version.V_5_10_0)) {
+        boolean after510 = out.getVersion().onOrAfter(Version.V_5_10_0);
+        if (after510) {
             out.writeOptionalWriteable(routingColumn);
         } else {
             out.writeOptionalString(routingColumn == null ? null : routingColumn.fqn());
         }
         out.writeVInt(tableColumnPolicy.ordinal());
-        out.writeCollection(partitionedBy, StreamOutput::writeStringCollection);
+        if (after510) {
+            out.writeList(partitionedBy);
+        } else {
+            out.writeVInt(partitionedBy.size());
+            for (ColumnIdent column : partitionedBy) {
+                int refIdx = Reference.indexOf(columns, column);
+                Reference reference = columns.get(refIdx);
+                out.writeVInt(2);
+                out.writeString(column.fqn());
+                out.writeString(DataTypes.esMappingNameFrom(reference.valueType().id()));
+            }
+        }
     }
 
     @NotNull
@@ -169,7 +193,7 @@ public class CreateTableRequest extends MasterNodeRequest<CreateTableRequest> im
     }
 
     @NotNull
-    public List<List<String>> partitionedBy() {
+    public List<ColumnIdent> partitionedBy() {
         return partitionedBy;
     }
 
@@ -180,7 +204,7 @@ public class CreateTableRequest extends MasterNodeRequest<CreateTableRequest> im
 
     @NotNull
     public List<Reference> references() {
-        return this.colsToAdd;
+        return this.columns;
     }
 
     @NotNull

--- a/server/src/main/java/io/crate/metadata/Reference.java
+++ b/server/src/main/java/io/crate/metadata/Reference.java
@@ -51,7 +51,7 @@ public interface Reference extends Symbol {
         .comparing(Reference::position)
         .thenComparing(r -> r.column().fqn());
 
-    static int indexOf(Iterable<? extends Reference> refs, ColumnIdent column) {
+    public static int indexOf(Iterable<? extends Reference> refs, ColumnIdent column) {
         int i = 0;
         for (Reference ref : refs) {
             if (ref.column().equals(column)) {

--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
@@ -63,7 +63,6 @@ import org.jetbrains.annotations.Nullable;
 
 import com.carrotsearch.hppc.IntArrayList;
 
-import io.crate.analyze.BoundCreateTable;
 import io.crate.analyze.DropColumn;
 import io.crate.analyze.ParamTypeHints;
 import io.crate.analyze.WhereClause;
@@ -1067,7 +1066,7 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
             allColumns,
             pKeyIndices,
             checkConstraintMap,
-            Lists.map(partitionedByColumns, BoundCreateTable::toPartitionMapping),
+            Lists.map(partitionedByColumns, Reference::column),
             columnPolicy,
             clusteredBy == SysColumns.ID.COLUMN ? null : clusteredBy
         ));

--- a/server/src/test/java/io/crate/analyze/CreateAlterPartitionedTableAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateAlterPartitionedTableAnalyzerTest.java
@@ -22,6 +22,7 @@
 package io.crate.analyze;
 
 import static io.crate.metadata.FulltextAnalyzerResolver.CustomType.ANALYZER;
+import static io.crate.testing.Asserts.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -57,6 +58,7 @@ import io.crate.sql.parser.ParsingException;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.testing.TestingHelpers;
+import io.crate.types.DataTypes;
 
 public class CreateAlterPartitionedTableAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
@@ -142,7 +144,9 @@ public class CreateAlterPartitionedTableAnalyzerTest extends CrateDummyClusterSe
                                             "  name string," +
                                             "  date timestamp with time zone" +
                                             ") partitioned by (name)");
-        assertThat(analysis.partitionedBy()).containsExactly(List.of("name", "keyword"));
+        assertThat(analysis.partitionedBy()).satisfiesExactly(
+            x -> assertThat(x).hasName("name")
+        );
 
         Map<String, Object> mapping = TestingHelpers.toMapping(analysis);
         Map<String, Object> mappingProperties = (Map<String, Object>) mapping.get("properties");
@@ -188,8 +192,8 @@ public class CreateAlterPartitionedTableAnalyzerTest extends CrateDummyClusterSe
                     )
                 )
         );
-        assertThat(analysis.partitionedBy().get(0)).containsExactly("name", "keyword");
-        assertThat(analysis.partitionedBy().get(1)).containsExactly("date", "date");
+        assertThat(analysis.partitionedBy().get(0)).hasName("name").hasType(DataTypes.STRING);
+        assertThat(analysis.partitionedBy().get(1)).hasName("date").hasType(DataTypes.TIMESTAMPZ);
     }
 
     @Test
@@ -220,8 +224,8 @@ public class CreateAlterPartitionedTableAnalyzerTest extends CrateDummyClusterSe
             ),
             "type", "object"
         ));
-        assertThat(analysis.partitionedBy().get(0)).containsExactly("date", "date");
-        assertThat(analysis.partitionedBy().get(1)).containsExactly("o.name", "keyword");
+        assertThat(analysis.partitionedBy().get(0)).hasName("date").hasType(DataTypes.TIMESTAMPZ);
+        assertThat(analysis.partitionedBy().get(1)).hasName("o['name']").hasType(DataTypes.STRING);
     }
 
     @Test
@@ -303,7 +307,9 @@ public class CreateAlterPartitionedTableAnalyzerTest extends CrateDummyClusterSe
                                             "  date timestamp with time zone," +
                                             "  primary key (id1, id2)" +
                                             ") partitioned by (id1)");
-        assertThat(analysis.partitionedBy()).containsExactly(List.of("id1", "integer"));
+        assertThat(analysis.partitionedBy()).satisfiesExactly(
+            x -> assertThat(x).hasName("id1")
+        );
 
         Map<String, Object> mapping = TestingHelpers.toMapping(analysis);
         Map<String, Object> mappingProperties = (Map<String, Object>) mapping.get("properties");

--- a/server/src/testFixtures/java/io/crate/testing/TestingHelpers.java
+++ b/server/src/testFixtures/java/io/crate/testing/TestingHelpers.java
@@ -57,6 +57,7 @@ import com.carrotsearch.randomizedtesting.RandomizedTest;
 
 import io.crate.analyze.BoundCreateTable;
 import io.crate.analyze.TableParameters;
+import io.crate.common.collections.Lists;
 import io.crate.data.Row;
 import io.crate.execution.ddl.tables.MappingUtil;
 import io.crate.metadata.ColumnIdent;
@@ -373,7 +374,7 @@ public class TestingHelpers {
             references,
             pKeysIndices,
             boundCreateTable.getCheckConstraints(),
-            boundCreateTable.partitionedBy(),
+            Lists.map(boundCreateTable.partitionedBy(), Reference::column),
             tableColumnPolicy,
             boundCreateTable.routingColumn().equals(SysColumns.ID.COLUMN)
                 ? null


### PR DESCRIPTION
Partitioned by columns are currently represented as a nested list with
`[<fqn>, <mappingType>]` entries in the `_meta` mapping.

The `<mappingType>` is redundant. The information is available in the
actual column definition.
`<fqn>` is problematic (See https://github.com/crate/crate/issues/16063) and
the `List<List<String>>` list typing is clunky given that the inner list has
two known entries.

This changes the request in preparation for
https://github.com/crate/crate/issues/11939 where we can store them as
`ColumnIdent` directly.
