### PR TITLE
Use alt way to set classifier for opendal dep

### DIFF
--- a/plugins/crate-copy-azure/pom.xml
+++ b/plugins/crate-copy-azure/pom.xml
@@ -33,7 +33,7 @@
             <groupId>org.apache.opendal</groupId>
             <artifactId>opendal-java</artifactId>
             <version>${versions.opendal}</version>
-            <classifier>${os.detected.classifier}</classifier>
+            <classifier>${os.classifier}</classifier>
         </dependency>
 
         <dependency>
@@ -98,14 +98,4 @@
             <classifier>tests</classifier>
         </dependency>
     </dependencies>
-
-    <build>
-        <extensions>
-            <extension>
-                <groupId>kr.motd.maven</groupId>
-                <artifactId>os-maven-plugin</artifactId>
-                <version>${versions.plugin.os}</version>
-            </extension>
-        </extensions>
-    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -432,5 +432,57 @@
         <module>server</module>
       </modules>
     </profile>
+
+    <!-- os.classifier -->
+    <profile>
+      <id>amd64</id>
+      <activation>
+        <property>
+          <name>os.arch</name>
+          <value>amd64</value>
+        </property>
+      </activation>
+      <properties>
+        <os.arch.classifier>x86_64</os.arch.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>aarch64</id>
+      <activation>
+        <property>
+          <name>os.arch</name>
+          <value>aarch64</value>
+        </property>
+      </activation>
+      <properties>
+        <os.arch.classifier>aarch_64</os.arch.classifier>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>linux</id>
+      <activation>
+        <property>
+          <name>os.name</name>
+          <value>Linux</value>
+        </property>
+      </activation>
+      <properties>
+        <os.classifier>linux-${os.arch.classifier}</os.classifier>
+      </properties>
+    </profile>
+    <profile>
+      <id>osx</id>
+      <activation>
+        <property>
+          <name>os.name</name>
+          <value>Mac OS X</value>
+        </property>
+      </activation>
+      <properties>
+        <os.classifier>osx-${os.arch.classifier}</os.classifier>
+      </properties>
+    </profile>
+
   </profiles>
 </project>


### PR DESCRIPTION
IDEs have issues with `kr.motd.maven` plugin which was setting the variable to be used as `classifier` for opendal. So instead use auto-activated maven profiles based on `os.name/arch` to set correctly a `os.classifier` property and use it for opendal.
