### PR TITLE
Fix ClassCastException when handling failures of the async response

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/broadcast/node/TransportBroadcastByNodeAction.java
@@ -418,18 +418,29 @@ public abstract class TransportBroadcastByNodeAction<Request extends BroadcastRe
         }
 
         private void onShardOperation(final NodeRequest request, final ShardRouting shardRouting, ActionListener<ShardOperationResult> listener) {
+            ActionListener<ShardOperationResult> wrappedListener = new ActionListener<>() {
+                @Override
+                public void onResponse(ShardOperationResult response) {
+                    listener.onResponse(response);
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    BroadcastShardOperationFailedException failure =
+                        new BroadcastShardOperationFailedException(shardRouting.shardId(), "operation " + actionName + " failed", e);
+                    listener.onFailure(failure);
+                }
+            };
             try {
                 if (logger.isTraceEnabled()) {
                     logger.trace("[{}]  executing operation for shard [{}]", actionName, shardRouting.shortSummary());
                 }
-                shardOperation(request.indicesLevelRequest, shardRouting, listener);
+                shardOperation(request.indicesLevelRequest, shardRouting, wrappedListener);
                 if (logger.isTraceEnabled()) {
                     logger.trace("[{}]  completed operation for shard [{}]", actionName, shardRouting.shortSummary());
                 }
             } catch (Exception e) {
-                BroadcastShardOperationFailedException failure =
-                    new BroadcastShardOperationFailedException(shardRouting.shardId(), "operation " + actionName + " failed", e);
-                listener.onFailure(failure);
+                wrappedListener.onFailure(e);
                 if (TransportActions.isShardNotAvailableException(e)) {
                     if (logger.isTraceEnabled()) {
                         logger.trace(new ParameterizedMessage(


### PR DESCRIPTION
Follow up to https://github.com/crate/crate/commit/c01e0fb346fb0e15257252bb2ed2c53cee26908b

We need to handle failures of the standalone "shardOperation" calls, so that listener failure handler doesn't fail with ClassCastExceptions.

I was not able to reproduce OptimizeTableIntegrationTest failures ([1](https://wacklig.pipifein.dev/github/crate/crate/case/io.crate.integrationtests.OptimizeTableIntegrationTest/testOptimize), [2](https://wacklig.pipifein.dev/github/crate/crate/day/2024-11-06)) locally but logs point out to the issue:

From https://wacklig.pipifein.dev/github/crate/crate/0ae06e35-3edf-4500-b194-9cfc292ea9de/8d918708-89c5-4879-b8a4-11b3d15220d0/stdout

```
failed to handle exception for action [indices:admin/seq_no/retention_lease_sync[p]], handler [org.elasticsearch.transport.TransportService$TimeoutResponseHandler/org.elasticsearch.transport.TransportService$5/[indices:admin/seq_no/retention_lease_sync[p]]:org.elasticsearch.index.seqno.RetentionLeaseSyncAction$1@32adef13]
java.lang.ClassCastException: class org.elasticsearch.transport.RemoteTransportException cannot be cast to class org.elasticsearch.action.support.broadcast.BroadcastShardOperationFailedException (org.elasticsearch.transport.RemoteTransportException and org.elasticsearch.action.support.broadcast.BroadcastShardOperationFailedException are in unnamed module of loader 'app')
	at org.elasticsearch.action.support.broadcast.node.TransportBroadcastByNodeAction$BroadcastByNodeTransportRequestHandler$1.onFailure(TransportBroadcastByNodeAction.java:395) ~[classes/:?]
	at org.elasticsearch.index.seqno.RetentionLeaseSyncAction$1.handleException(RetentionLeaseSyncAction.java:125) ~[classes/:?]
	at org.elasticsearch.transport.TransportService$5.handleException(TransportService.java:521) ~[classes/:?]
	at org.elasticsearch.transport.TransportService$TimeoutResponseHandler.handleException(TransportService.java:1021) ~[classes/:?]
	at org.elasticsearch.transport.TransportService$DirectResponseChannel.processException(TransportService.java:1123) ~[classes/:?]
	at org.elasticsearch.transport.TransportService$DirectResponseChannel.sendResponse(TransportService.java:1097) ~[classes/:?]
	at org.elasticsearch.action.support.ChannelActionListener.onFailure(ChannelActionListener.java:56) ~[classes/:?]
	at org.elasticsearch.action.support.replication.TransportReplicationAction$AsyncPrimaryAction.onFailure(TransportReplicationAction.java:442) ~[classes/:?]
	at org.elasticsearch.action.support.replication.TransportReplicationAction$AsyncPrimaryAction.lambda$doRun$1(TransportReplicationAction.java:349) ~[classes/:?]
	at org.elasticsearch.action.ActionListener$2.onFailure(ActionListener.java:106) ~[classes/:?]
	at org.elasticsearch.index.shard.IndexShard.lambda$wrapPrimaryOperationPermitListener$19(IndexShard.java:2646) ~[classes/:?]
	at org.elasticsearch.action.ActionListener$3.onResponse(ActionListener.java:126) ~[classes/:?]
	at org.elasticsearch.index.shard.IndexShardOperationPermits$2.doRun(IndexShardOperationPermits.java:268) ~[classes/:?]
	at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37) ~[classes/:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
```