### PR TITLE
Fix query used at JDBC FDW, alias symbols must be replaced by their source

### DIFF
--- a/docs/admin/fdw.rst
+++ b/docs/admin/fdw.rst
@@ -70,6 +70,8 @@ system::
    Only `DQL` (Data Query Language) statements are supported on foreign tables.
 
 
+.. _administration-fdw-jdbc:
+
 ``jdbc``
 ========
 

--- a/docs/appendices/release-notes/5.9.3.rst
+++ b/docs/appendices/release-notes/5.9.3.rst
@@ -108,3 +108,10 @@ Fixes
 - Fixed an issue that caused a :ref:`sql-create-table` statement to fail when a
   column defines a generated expression including a conditional
   :ref:`CASE <scalar-case-when-then-end>` function.
+
+- Fixed an issue that caused a SQL parsing error when running a query against
+  a ``FOREIGN TABLE`` of type :ref:`administration-fdw-jdbc` which contains an
+  aliased column name inside the ``WHERE`` clause. For example::
+
+      CREATE FOREIGN TABLE t (a INT) SERVER s;
+      SELECT * FROM (SELECT id as some_alias FROM t) tt WHERE tt.some_alias = 1;

--- a/server/src/main/java/io/crate/fdw/JdbcBatchIterator.java
+++ b/server/src/main/java/io/crate/fdw/JdbcBatchIterator.java
@@ -41,6 +41,8 @@ import java.util.concurrent.CompletionStage;
 import java.util.function.IntSupplier;
 import java.util.function.LongSupplier;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.Accountable;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.jetbrains.annotations.NotNull;
@@ -69,6 +71,8 @@ import io.crate.sql.tree.ColumnPolicy;
 import io.crate.types.DataType;
 
 public class JdbcBatchIterator implements BatchIterator<Row> {
+
+    private static final Logger LOGGER = LogManager.getLogger(JdbcBatchIterator.class);
 
     private final String url;
     private final Properties properties;
@@ -116,7 +120,7 @@ public class JdbcBatchIterator implements BatchIterator<Row> {
             .append(table.name())
             .append(qs);
 
-        return String.format(
+        var stmt = String.format(
             Locale.ENGLISH,
             "SELECT %s FROM %s WHERE %s",
             String.join(", ", Lists.mapLazy(
@@ -127,6 +131,8 @@ public class JdbcBatchIterator implements BatchIterator<Row> {
                 query,
                 ref -> new QuotedReference(ref, qs)).toString(Style.UNQUALIFIED)
         );
+        LOGGER.debug("Generated statement for foreign JDBC source: {}", stmt);
+        return stmt;
     }
 
     @Override

--- a/server/src/test/java/io/crate/fdw/ForeignDataWrapperPlannerTest.java
+++ b/server/src/test/java/io/crate/fdw/ForeignDataWrapperPlannerTest.java
@@ -22,7 +22,6 @@
 package io.crate.fdw;
 
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
@@ -32,9 +31,11 @@ import org.junit.Test;
 
 import io.crate.analyze.QueriedSelectRelation;
 import io.crate.exceptions.OperationOnInaccessibleRelationException;
+import io.crate.execution.dsl.phases.ForeignCollectPhase;
 import io.crate.planner.CreateForeignTablePlan;
 import io.crate.planner.CreateServerPlan;
 import io.crate.planner.CreateUserMappingPlan;
+import io.crate.planner.node.dql.Collect;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 
@@ -168,5 +169,22 @@ public class ForeignDataWrapperPlannerTest extends CrateDummyClusterServiceUnitT
         assertThat(relation.outputs()).satisfiesExactly(
             x -> assertThat(x).isFunction("subscript")
         );
+    }
+
+    @Test
+    public void test_foreign_collect_query_does_not_contain_aliased_symbol() throws Exception {
+        Settings options = Settings.builder()
+            .put("url", "jdbc:postgresql://localhost:5432/")
+            .build();
+        var e = SQLExecutor.of(clusterService)
+            .addTable("CREATE TABLE doc.t1 (id int)")
+            .addServer("pg", "jdbc", "crate", options)
+            .addForeignTable("CREATE FOREIGN TABLE IF NOT EXISTS \"doc\".\"t2\" (id int) SERVER pg OPTIONS (schema_name 'doc', table_name 't1')");
+
+        var stmt = "SELECT * FROM (SELECT id as some_alias FROM doc.t2) t WHERE t.some_alias = 1";
+        Collect collect = e.plan(stmt);
+        var query = ((ForeignCollectPhase) collect.collectPhase()).query();
+        // Without any logic (e.g. using the EvaluationNormalizer) to remove aliases, the query would be `(some_alias = 1)`
+        assertThat(query.toString()).isEqualTo("(id = 1)");
     }
 }


### PR DESCRIPTION
When the related optimizer is enabled, the query of a Filter is merged into the foreign collect phase. Such query must not contain any `AliasSymbol` as it's SQL representation (col as alias) isn't valid inside the WHERE clause and the source symbol must be used instead.
