### PR TITLE
Fix exceptions thrown when querying nested object arrays' sub-columns

### DIFF
--- a/docs/appendices/release-notes/5.9.3.rst
+++ b/docs/appendices/release-notes/5.9.3.rst
@@ -60,6 +60,9 @@ Fixes
   :ref:`generated column <ddl-generated-columns>` from a table, even though no
   error was returned.
 
+- Fixed an issue that caused exceptions when querying sub-columns of nested
+  object arrays.
+
 - Fixed an issue that would cause an error to be thrown when attempting to
   ``ORDER BY`` on top of a complex query (e.g. a ``JOIN``), using an expression
   which contains a query parameter, e.g.::

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/StoredRow.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/StoredRow.java
@@ -55,18 +55,7 @@ public interface StoredRow {
             if (tmp instanceof Map) {
                 m = (Map<?, ?>) tmp;
             } else if (tmp instanceof List<?> list) {
-                if (i + 1 == path.size()) {
-                    return list;
-                }
-                ArrayList<Object> newList = new ArrayList<>(list.size());
-                for (Object o : list) {
-                    if (o instanceof Map) {
-                        newList.add(extractValue((Map<?, ?>) o, path, i + 1));
-                    } else {
-                        newList.add(o);
-                    }
-                }
-                return newList;
+                return extractValueHelper(list, path, i);
             } else {
                 if (i + 1 != path.size()) {
                     return null;
@@ -75,5 +64,22 @@ public interface StoredRow {
             }
         }
         return tmp;
+    }
+
+    private static Object extractValueHelper(final List<?> list, List<String> path, int pathStartIndex) {
+        if (pathStartIndex + 1 == path.size()) {
+            return list;
+        }
+        ArrayList<Object> newList = new ArrayList<>(list.size());
+        for (Object o : list) {
+            if (o instanceof Map<?,?> m) {
+                newList.add(extractValue(m, path, pathStartIndex + 1));
+            } else if (o instanceof List<?> l) {
+                newList.add(extractValueHelper(l, path, pathStartIndex));
+            } else {
+                newList.add(o);
+            }
+        }
+        return newList;
     }
 }

--- a/server/src/main/java/io/crate/metadata/table/TableInfo.java
+++ b/server/src/main/java/io/crate/metadata/table/TableInfo.java
@@ -47,7 +47,7 @@ import io.crate.types.ObjectType;
 public interface TableInfo extends RelationInfo {
 
     Predicate<DataType<?>> IS_OBJECT_ARRAY =
-        type -> type instanceof ArrayType && ((ArrayType<?>) type).innerType().id() == ObjectType.ID;
+        type -> type instanceof ArrayType && ArrayType.unnest(type).id() == ObjectType.ID;
 
     /**
      * returns information about a column with the given ident.
@@ -144,7 +144,7 @@ public interface TableInfo extends RelationInfo {
         int arrayDimensions = 0;
         for (var parent : getParents(column)) {
             if (IS_OBJECT_ARRAY.test(parent.valueType())) {
-                arrayDimensions++;
+                arrayDimensions += ArrayType.dimensions(parent.valueType());
             }
         }
         return makeArray(ref.valueType(), arrayDimensions);

--- a/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -31,6 +31,7 @@ import static io.crate.testing.Asserts.isFunction;
 import static io.crate.testing.Asserts.isLiteral;
 import static io.crate.testing.Asserts.isReference;
 import static io.crate.testing.Asserts.toCondition;
+import static io.crate.types.ArrayType.makeArray;
 import static org.assertj.core.api.Assertions.anyOf;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -2868,6 +2869,16 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         assertThat(relation.outputs()).satisfiesExactly(
             x -> assertThat(x).isScopedSymbol("x")
                 .hasDataType(DataTypes.INTEGER)
+        );
+    }
+
+    @Test
+    public void test_sub_columns_of_nested_object_arrays() throws IOException {
+        var executor = SQLExecutor.of(clusterService)
+            .addTable("create table t (o object as (a int)[][])");
+        QueriedSelectRelation relation = executor.analyze("select o['a'] from t");
+        assertThat(relation.outputs()).satisfiesExactly(
+            output -> assertThat(output.valueType()).isEqualTo(makeArray(DataTypes.INTEGER, 2))
         );
     }
 }

--- a/server/src/test/java/io/crate/expression/reference/doc/lucene/StoredRowLookupTest.java
+++ b/server/src/test/java/io/crate/expression/reference/doc/lucene/StoredRowLookupTest.java
@@ -65,4 +65,21 @@ public class StoredRowLookupTest {
         Map<String, Map<String, Integer>> m = singletonMap("x", singletonMap("a", 1)); // such that x['a'] = 1
         assertThat(StoredRow.extractValue(m, Arrays.asList("x", "a", "a"), 0)).isNull(); // x['a']['a'] should return null
     }
+
+    @Test
+    public void test_extract_sub_columns_of_nested_object_arrays() {
+        Map<String, List<List<Map<String, Integer>>>> m = singletonMap(
+            "o",
+            Arrays.asList(
+                List.of(singletonMap("a", 1)),
+                List.of(singletonMap("a", 2), singletonMap("a", 3)),
+                null)
+        );
+        assertThat(StoredRow.extractValue(m, Arrays.asList("o", "a"), 0)).isEqualTo(
+            Arrays.asList(
+                List.of(1),
+                List.of(2, 3),
+                null)
+        );
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes:
```
cr> create table t (o object as (a int)[][]);
CREATE OK, 1 row affected (0.320 sec)
cr> insert into t values ([ [{a=1}], [{a=1},{a=1}], null ]);
INSERT OK, 1 row affected (0.096 sec)

cr> select o['a'] from t;
ArrayViaDocValuesUnsupportedException[Column "2" has a value that is an array. Loading arrays via doc-values is not supported.]

cr> select * from t where array_length(o['a'], 1) >= 1;
UnsupportedFunctionException[Unknown function: array_length(doc.t.o['a'], 1), no overload found for matching argument types: (integer, integer). Possible candidates: array_length(array(E), integer):integer]
```

This PR fixes two issues
- identify `o['a']` as `array_array_int` (if `o` is 1D object array, CrateDB identifies `o['a']` as `array_int` as expected)
- to be able to parse the data returned from Lucene as nested object arrays

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
