### PR TITLE
Remove TranslogIndexer from DocTableInfo

### DIFF
--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
@@ -74,7 +74,6 @@ import io.crate.exceptions.ColumnUnknownException;
 import io.crate.exceptions.RelationUnknown;
 import io.crate.execution.ddl.tables.MappingUtil;
 import io.crate.execution.ddl.tables.MappingUtil.AllocPosition;
-import io.crate.execution.dml.TranslogIndexer;
 import io.crate.expression.symbol.DynamicReference;
 import io.crate.expression.symbol.RefReplacer;
 import io.crate.expression.symbol.Symbol;
@@ -201,7 +200,6 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
     private final Version versionUpgraded;
     private final boolean closed;
     private final ColumnPolicy columnPolicy;
-    private TranslogIndexer translogIndexer; // lazily initialised
     private ReferenceTree refTree;     // lazily initialised
     private final long tableVersion;
 
@@ -363,16 +361,6 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
     @Override
     public Set<Reference> droppedColumns() {
         return droppedColumns;
-    }
-
-    /**
-     * Get a TranslogIndexer based on this table
-     */
-    public TranslogIndexer getTranslogIndexer() {
-        if (this.translogIndexer == null) {
-            this.translogIndexer = new TranslogIndexer(this);
-        }
-        return this.translogIndexer;
     }
 
     public int maxPosition() {

--- a/server/src/test/java/io/crate/execution/dml/TranslogIndexerTest.java
+++ b/server/src/test/java/io/crate/execution/dml/TranslogIndexerTest.java
@@ -42,7 +42,7 @@ public class TranslogIndexerTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo table = executor.resolveTableInfo("tbl");
         assertThat(table).isNotNull();
 
-        TranslogIndexer ti = table.getTranslogIndexer();
+        TranslogIndexer ti = new TranslogIndexer(table);
         BytesReference source = new BytesArray("{\"1\":1,\"2\":2}");
         assertThatThrownBy(() -> ti.index("1", source))
             .isExactlyInstanceOf(TranslogMappingUpdateException.class)
@@ -54,7 +54,7 @@ public class TranslogIndexerTest extends CrateDummyClusterServiceUnitTest {
         SQLExecutor executor = SQLExecutor.of(clusterService)
             .addTable("create table tbl (id int, x int)");
         DocTableInfo table = executor.resolveTableInfo("tbl");
-        TranslogIndexer ti = table.getTranslogIndexer();
+        TranslogIndexer ti = new TranslogIndexer(table);
         BytesReference source = new BytesArray("{\"1\":1,\"2\":\"bar\"}");
         var doc = ti.index("1", source);
         // the value of field 2 is not indexed as it contains an invalid value (sanitize failed)


### PR DESCRIPTION
Became unused with https://github.com/crate/crate/pull/16322
