### PR TITLE
Fix printing of a `CASE` expression.

### DIFF
--- a/docs/appendices/release-notes/5.9.3.rst
+++ b/docs/appendices/release-notes/5.9.3.rst
@@ -104,3 +104,7 @@ Fixes
   object column. In cases where data was already inserted into this sub-column
   with a different type than defined later on, the :ref:`analyze` statement
   failed with a cast error.
+
+- Fixed an issue that caused a :ref:`sql-create-table` statement to fail when a
+  column defines a generated expression including a conditional
+  :ref:`CASE <scalar-case-when-then-end>` function.

--- a/server/src/main/java/io/crate/expression/symbol/Function.java
+++ b/server/src/main/java/io/crate/expression/symbol/Function.java
@@ -55,6 +55,7 @@ import io.crate.expression.scalar.cast.CastMode;
 import io.crate.expression.scalar.cast.ExplicitCastFunction;
 import io.crate.expression.scalar.cast.ImplicitCastFunction;
 import io.crate.expression.scalar.cast.TryCastFunction;
+import io.crate.expression.scalar.conditional.CaseFunction;
 import io.crate.expression.scalar.systeminformation.CurrentSchemaFunction;
 import io.crate.expression.scalar.systeminformation.CurrentSchemasFunction;
 import io.crate.expression.scalar.timestamp.CurrentTimeFunction;
@@ -373,6 +374,19 @@ public class Function implements Symbol, Cloneable {
 
             case ArrayFunction.NAME:
                 printArray(builder, style);
+                break;
+
+            case CaseFunction.NAME:
+                builder.append("CASE");
+                for (int i = 2; i < arguments.size(); i += 2) {
+                    builder.append(" WHEN ");
+                    builder.append(arguments.get(i).toString(style));
+                    builder.append(" THEN ");
+                    builder.append(arguments.get(i + 1).toString(style));
+                }
+                builder.append(" ELSE ");
+                builder.append(arguments.get(1).toString(style));
+                builder.append(" END");
                 break;
 
             default:

--- a/server/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
+++ b/server/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
@@ -432,4 +432,12 @@ public class SymbolPrinterTest extends CrateDummyClusterServiceUnitTest {
         assertPrintingRoundTrip("foo NOT LIKE ALL (['a', 'b', 'c'])", "(doc.formatter.foo NOT LIKE ALL(['a', 'b', 'c']))");
         assertPrintingRoundTrip("foo ILIKE ALL (['a', 'b', 'c'])", "(doc.formatter.foo ILIKE ALL(['a', 'b', 'c']))");
     }
+
+    @Test
+    public void test_case_expression() {
+        assertPrintingRoundTrip("case when foo = 'bar' then 1 when foo = 'foo' then 2 else 3 end",
+                                "CASE WHEN (doc.formatter.foo = 'bar') THEN 1 WHEN (doc.formatter.foo = 'foo') THEN 2 ELSE 3 END");
+        assertPrintingRoundTrip("case foo when 'bar' then 1 when 'foo' then 2 else 3 end",
+                                "CASE WHEN (doc.formatter.foo = 'bar') THEN 1 WHEN (doc.formatter.foo = 'foo') THEN 2 ELSE 3 END");
+    }
 }

--- a/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -701,7 +701,7 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
         // which lead to failure of constructing an execution plan
         assertThat(plan).isEqualTo(
             """
-                Eval[case(true, 'default', (NOT (regexp_matches(name, '^a') = [])), 'found', (text LIKE '%xyz%'), 'special case')]
+                Eval[CASE WHEN (NOT (regexp_matches(name, '^a') = [])) THEN 'found' WHEN (text LIKE '%xyz%') THEN 'special case' ELSE 'default' END]
                   └ ProjectSet[regexp_matches(name, '^a'), name, text]
                     └ Collect[doc.users | [name, text] | true]
                 """


### PR DESCRIPTION
The internal `CaseFunction` must be print as SQL as a conditional case expression, otherwise the output isn't valid SQL and cannot be parsed again.

Fixes #16953.