### PR TITLE
The SubQueryAndParamBinder must not ignore conversion exceptions

### DIFF
--- a/docs/appendices/release-notes/5.9.3.rst
+++ b/docs/appendices/release-notes/5.9.3.rst
@@ -115,3 +115,6 @@ Fixes
 
       CREATE FOREIGN TABLE t (a INT) SERVER s;
       SELECT * FROM (SELECT id as some_alias FROM t) tt WHERE tt.some_alias = 1;
+
+- Fixed the error messages returned when a given parameter of type
+  :ref:`type-object` fails on casting a object element to the expected type.

--- a/server/src/main/java/io/crate/planner/operators/SubQueryAndParamBinder.java
+++ b/server/src/main/java/io/crate/planner/operators/SubQueryAndParamBinder.java
@@ -92,6 +92,8 @@ public class SubQueryAndParamBinder extends FunctionCopyVisitor<Void> implements
         }
         try {
             return Literal.ofUnchecked(type, type.implicitCast(value));
+        } catch (ConversionException e) {
+            throw e;
         } catch (ClassCastException | IllegalArgumentException e) {
             throw new ConversionException(value, type);
         }

--- a/server/src/test/java/io/crate/planner/operators/SubQueryAndParamBinderTest.java
+++ b/server/src/test/java/io/crate/planner/operators/SubQueryAndParamBinderTest.java
@@ -29,8 +29,12 @@ import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
 
 import io.crate.data.Row;
+import io.crate.data.Row1;
+import io.crate.expression.symbol.ParameterSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.testing.SqlExpressions;
+import io.crate.types.DataTypes;
+import io.crate.types.ObjectType;
 
 public class SubQueryAndParamBinderTest extends ESTestCase {
 
@@ -39,10 +43,16 @@ public class SubQueryAndParamBinderTest extends ESTestCase {
         SubQueryAndParamBinder paramBinder = new SubQueryAndParamBinder(Row.EMPTY, SubQueryResults.EMPTY);
         Symbol symbol = new SqlExpressions(Map.of()).asSymbol("$1 > 10");
 
-        assertThatThrownBy(() -> {
-            paramBinder.apply(symbol);
+        assertThatThrownBy(() -> paramBinder.apply(symbol))
+            .hasMessage("The query contains a parameter placeholder $1, but there are only 0 parameter values");
+    }
 
-        })
-                .hasMessage("The query contains a parameter placeholder $1, but there are only 0 parameter values");
+    @Test
+    public void test_nested_conversion_exception_are_not_ignored() {
+        var paramSymbol = new ParameterSymbol(0, ObjectType.builder().setInnerType("x", DataTypes.INTEGER).build());
+        SubQueryAndParamBinder paramBinder = new SubQueryAndParamBinder(new Row1(Map.of("x", "foo")), SubQueryResults.EMPTY);
+
+        assertThatThrownBy(() -> paramBinder.apply(paramSymbol))
+            .hasMessage("Cannot cast object element `x` with value `foo` to type `integer`");
     }
 }


### PR DESCRIPTION
A conversion exception happening by an implicit cast must be thrown as-is and not be turned into a new one. Otherwise the information on which nesting level the error occurred is gone.

Fixes #16947.
