### PR TITLE
Fix issue with PK lookup with lots of values

### DIFF
--- a/docs/appendices/release-notes/5.9.3.rst
+++ b/docs/appendices/release-notes/5.9.3.rst
@@ -47,6 +47,14 @@ See the :ref:`version_5.9.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that would lead to wrong results when querying a table with a
+  ``WHERE`` clause which filters on multiple columns, which are part of
+  :ref:`PRIMARY KEY<constraints-primary-key>`, and there at least one of them is
+  tested against lots of values, e.g.::
+
+      SELECT * FROM t
+        WHERE pk1 IN (<long_list_of_values>) AND pk2 = 3 AND pk3 = 'foo'
+
 - Fixed an issue that would prevent
   :ref:`dropping <sql-alter-table-drop-column>` a
   :ref:`generated column <ddl-generated-columns>` from a table, even though no

--- a/docs/general/occ.rst
+++ b/docs/general/occ.rst
@@ -121,6 +121,10 @@ Known limitations
       together in the WHERE clause with equals comparisons and if there are also equals
       comparisons on primary key columns]
 
+- There is an exception to this behaviour, when the ``WHERE`` clause contains
+  complex filtering and/or lots of Primary Key values. You can find more details
+  :ref:`here <sql-refresh-description_collect_exception>`.
+
 .. NOTE::
 
    Both ``DELETE`` and ``UPDATE`` commands will return a row count of ``0``, if

--- a/docs/sql/statements/refresh.rst
+++ b/docs/sql/statements/refresh.rst
@@ -105,6 +105,30 @@ key lookups, as they see the data even if the table hasn't been refreshed yet.
 See also :ref:`concept-consistency`.
 
 
+.. _sql-refresh-description_collect_exception:
+
+.. NOTE::
+
+    Due to internal constraints, when the ``WHERE`` clause filters on multiple
+    columns of a ``PRIMARY KEY``, but one or more of those columns is tested
+    against lots of values, the query might be executed using a ``Collect``
+    operator instead of a ``Get``, thus records might be unavailable until a
+    ``REFRESH`` is run. The same situation could occur when the ``WHERE`` clause
+    contains long complex expressions, e.g.::
+
+        SELECT * FROM t
+        WHERE pk1 IN (<long_list_of_values>) AND pk2 = 3 AND pk3 = 'foo'
+
+        SELECT * FROM t
+        WHERE pk1 = ?
+            AND pk2 = ?
+            AND pk3 = ?
+            OR pk1 = ?
+            AND pk2 = ?
+            AND pk3 = ?
+            OR pk1 = ?
+            ...
+
 .. _sql-refresh-parameters:
 
 Parameters

--- a/server/src/main/java/io/crate/analyze/where/EqualityExtractor.java
+++ b/server/src/main/java/io/crate/analyze/where/EqualityExtractor.java
@@ -151,7 +151,8 @@ public class EqualityExtractor {
         for (List<EqProxy> proxies : cp) {
             // Protect against large queries, where the number of combinations to check grows large
             if (++iterations >= maxIterations()) {
-                break;
+                // Fallback to lucene query (collect)
+                return EqMatches.NONE;
             }
             boolean anyNull = false;
             for (EqProxy proxy : proxies) {

--- a/server/src/test/java/io/crate/analyze/where/EqualityExtractorTest.java
+++ b/server/src/test/java/io/crate/analyze/where/EqualityExtractorTest.java
@@ -396,7 +396,7 @@ public class EqualityExtractorTest extends EqualityExtractorBaseTest {
         EqualityExtractor extractor = new EqualityExtractor(normalizer) {
             @Override
             protected int maxIterations() {
-                return 1;
+                return 100; // with 20 `x=? AND i=?` joined with OR, 100 iterations are not enough
             }
         };
 
@@ -407,7 +407,7 @@ public class EqualityExtractorTest extends EqualityExtractorBaseTest {
         extractor = new EqualityExtractor(normalizer) {
             @Override
             protected int maxIterations() {
-                return 100;
+                return 1000; // make sure iterations are enough to extract pk matches
             }
         };
         matches = extractor.extractMatches(


### PR DESCRIPTION
When querying on a table using multiple columns which comprise the PRIMARY KEY, we use `EqualityExtractor` to extract the PK matches and build a `Get` plan instead of `Collect`. This operation can take lots of time when complex expressions or lots of values are tested against at least one of the PK columns. With: #16098 we introduced a MAX_ITERATIONS threshold to stop the process of extracting the pk matches, to avoid spending lots of time in this optimisation. But when the iteration threshold was reached we just exited the loop, and returned what was found so far, instead of returning `null` pk matches, and therefore falling back to a simple `Collect` operation.

Fixes: #16942
Relates: #16066
