### PR TITLE
Fix SQL printing of CastFunction target type

### DIFF
--- a/docs/appendices/release-notes/5.9.3.rst
+++ b/docs/appendices/release-notes/5.9.3.rst
@@ -118,3 +118,12 @@ Fixes
 
 - Fixed the error messages returned when a given parameter of type
   :ref:`type-object` fails on casting a object element to the expected type.
+
+- Fixed an issue that may cause the use of explicit casts inside a generated
+  column expression to fail with a SQL parsing error, depending on the target
+  type. For example::
+
+      CREATE TABLE t (
+        p GEO_POINT,
+        x ARRAY(DOUBLE) GENERATED ALWAYS AS p::ARRAY(DOUBLE)
+      );

--- a/docs/general/builtins/aggregation.rst
+++ b/docs/general/builtins/aggregation.rst
@@ -217,7 +217,7 @@ column to the ``numeric`` data type::
     cr> select avg(t.val :: numeric) from
     ... (select unnest([9223372036854775807, 9223372036854775807]) as val) t;
     +---------------------------+
-    | avg(cast(val AS numeric)) |
+    | avg(cast(val AS NUMERIC)) |
     +---------------------------+
     |       9223372036854775807 |
     +---------------------------+
@@ -786,7 +786,7 @@ the aggregation column to the ``numeric`` data type::
     cr> SELECT sum(count::numeric)
     ... FROM uservisits;
     +-----------------------------+
-    | sum(cast(count AS numeric)) |
+    | sum(cast(count AS NUMERIC)) |
     +-----------------------------+
     |         9223372036854775816 |
     +-----------------------------+

--- a/server/src/main/java/io/crate/expression/symbol/Function.java
+++ b/server/src/main/java/io/crate/expression/symbol/Function.java
@@ -65,6 +65,8 @@ import io.crate.expression.symbol.format.Style;
 import io.crate.metadata.FunctionName;
 import io.crate.metadata.Reference;
 import io.crate.metadata.functions.Signature;
+import io.crate.sql.SqlFormatter;
+import io.crate.sql.tree.ColumnPolicy;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -476,12 +478,13 @@ public class Function implements Symbol, Cloneable {
             builder.append(arguments().get(0).toString(style));
         } else {
             var targetType = arguments.get(1).valueType();
+            var columnType = targetType.toColumnType(ColumnPolicy.DYNAMIC, null);
             builder
                 .append(name)
                 .append("(")
                 .append(arguments().get(0).toString(style))
                 .append(" AS ")
-                .append(targetType.toString())
+                .append(SqlFormatter.formatSql(columnType))
                 .append(")");
         }
     }

--- a/server/src/test/java/io/crate/analyze/GroupByAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/GroupByAnalyzerTest.java
@@ -430,6 +430,6 @@ public class GroupByAnalyzerTest extends CrateDummyClusterServiceUnitTest {
             "group by name " +
             "having sum(power(power(id::double, id::double), id::double)) > 0");
         assertThat(relation.having())
-            .isSQL("(sum(power(power(cast(doc.users.id AS double precision), cast(doc.users.id AS double precision)), cast(doc.users.id AS double precision))) > 0.0)");
+            .isSQL("(sum(power(power(cast(doc.users.id AS DOUBLE PRECISION), cast(doc.users.id AS DOUBLE PRECISION)), cast(doc.users.id AS DOUBLE PRECISION))) > 0.0)");
     }
 }

--- a/server/src/test/java/io/crate/analyze/SymbolToColumnDefinitionConverterTest.java
+++ b/server/src/test/java/io/crate/analyze/SymbolToColumnDefinitionConverterTest.java
@@ -27,7 +27,6 @@ import static io.crate.testing.Asserts.isColumnDefinition;
 import static io.crate.testing.Asserts.isColumnType;
 import static io.crate.testing.Asserts.isEqualTo;
 import static io.crate.testing.Asserts.isObjectColumnType;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.List;
@@ -456,7 +455,7 @@ public class SymbolToColumnDefinitionConverterTest extends CrateDummyClusterServ
 
         assertThat(actual).satisfiesExactlyInAnyOrder(
             c -> assertThat(c).isColumnDefinition(
-                "cast(port['http'] AS boolean)",
+                "cast(port['http'] AS BOOLEAN)",
                 isColumnType(DataTypes.BOOLEAN.getName())),
             c -> assertThat(c).isColumnDefinition(
                 "active_threads",

--- a/server/src/test/java/io/crate/analyze/relations/QuerySplitterTest.java
+++ b/server/src/test/java/io/crate/analyze/relations/QuerySplitterTest.java
@@ -75,7 +75,7 @@ public class QuerySplitterTest extends CrateDummyClusterServiceUnitTest {
         Symbol symbol = asSymbol("t1.a = 10::text and t1.x = t2.y and (false)");
         Map<Set<RelationName>, Symbol> split = QuerySplitter.split(symbol);
         assertThat(split).hasSize(2);
-        assertThat(split.get(Set.of(tr1))).isSQL("(doc.t1.a = cast(10 AS text))");
+        assertThat(split.get(Set.of(tr1))).isSQL("(doc.t1.a = cast(10 AS TEXT))");
         assertThat(split.get(Set.of(tr1, tr2))).isSQL("((doc.t1.x = doc.t2.y) AND false)");
     }
 

--- a/server/src/test/java/io/crate/expression/scalar/arithmetic/IntervalFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/arithmetic/IntervalFunctionTest.java
@@ -148,7 +148,7 @@ public class IntervalFunctionTest extends ScalarTestCase {
         assertThatThrownBy(
             () -> assertEvaluate("null / interval '1 second'", null))
                 .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: (NULL / cast('1 second' AS interval)), " +
+            .hasMessageStartingWith("Unknown function: (NULL / cast('1 second' AS INTERVAL)), " +
                                     "no overload found for matching argument types: (undefined, interval).");
     }
 
@@ -176,6 +176,6 @@ public class IntervalFunctionTest extends ScalarTestCase {
         assertThatThrownBy(
             () -> assertEvaluate("interval '1 second' - '86401000'::timestamptz", 86400000L))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
-            .hasMessageStartingWith("Unknown function: (cast('1 second' AS interval) - cast('86401000' AS timestamp with time zone)), ");
+            .hasMessageStartingWith("Unknown function: (cast('1 second' AS INTERVAL) - cast('86401000' AS TIMESTAMP WITH TIME ZONE)), ");
     }
 }

--- a/server/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
+++ b/server/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
@@ -76,7 +76,8 @@ public class SymbolPrinterTest extends CrateDummyClusterServiceUnitTest {
             "  idx int," +
             "  s_arr array(text)," +
             "  a array(object as (b object as (c int)))," +
-            "  \"OBJ\" object as (intarray int[])" +
+            "  \"OBJ\" object as (intarray int[])," +
+            "  point geo_point" +
             ")";
         RelationName name = new RelationName(DocSchemaInfo.NAME, TABLE_NAME);
         DocTableInfo tableInfo = SQLExecutor.tableInfo(
@@ -327,9 +328,9 @@ public class SymbolPrinterTest extends CrateDummyClusterServiceUnitTest {
     public void testStyles() {
         Symbol nestedFn = sqlExpressions.asSymbol("abs(sqrt(ln(bar+cast(\"select\" as long)+1+1+1+1+1+1)))");
         assertThat(nestedFn.toString(Style.QUALIFIED)).isEqualTo(
-                   "abs(sqrt(ln((((((((doc.formatter.bar + cast(doc.formatter.\"select\" AS bigint)) + 1::bigint) + 1::bigint) + 1::bigint) + 1::bigint) + 1::bigint) + 1::bigint))))");
+                   "abs(sqrt(ln((((((((doc.formatter.bar + cast(doc.formatter.\"select\" AS BIGINT)) + 1::bigint) + 1::bigint) + 1::bigint) + 1::bigint) + 1::bigint) + 1::bigint))))");
         assertThat(nestedFn.toString(Style.UNQUALIFIED)).isEqualTo(
-                   "abs(sqrt(ln((((((((bar + cast(\"select\" AS bigint)) + 1::bigint) + 1::bigint) + 1::bigint) + 1::bigint) + 1::bigint) + 1::bigint))))");
+                   "abs(sqrt(ln((((((((bar + cast(\"select\" AS BIGINT)) + 1::bigint) + 1::bigint) + 1::bigint) + 1::bigint) + 1::bigint) + 1::bigint))))");
     }
 
     @Test
@@ -439,5 +440,10 @@ public class SymbolPrinterTest extends CrateDummyClusterServiceUnitTest {
                                 "CASE WHEN (doc.formatter.foo = 'bar') THEN 1 WHEN (doc.formatter.foo = 'foo') THEN 2 ELSE 3 END");
         assertPrintingRoundTrip("case foo when 'bar' then 1 when 'foo' then 2 else 3 end",
                                 "CASE WHEN (doc.formatter.foo = 'bar') THEN 1 WHEN (doc.formatter.foo = 'foo') THEN 2 ELSE 3 END");
+    }
+
+    @Test
+    public void test_cast_to_array() {
+        assertPrintingRoundTrip("point::ARRAY(DOUBLE)", "cast(doc.formatter.point AS ARRAY(DOUBLE PRECISION))");
     }
 }

--- a/server/src/test/java/io/crate/lucene/ThreeValuedLogicQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/ThreeValuedLogicQueryBuilderTest.java
@@ -139,6 +139,6 @@ public class ThreeValuedLogicQueryBuilderTest extends LuceneQueryBuilderTest {
     @Test
     public void test_negated_cast_on_object() {
         assertThat(convert("NOT (cast(obj as string))")).hasToString(
-            "+(+*:* -cast(obj AS text)) #(NOT cast(obj AS text))");
+            "+(+*:* -cast(obj AS TEXT)) #(NOT cast(obj AS TEXT))");
     }
 }

--- a/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -241,7 +241,7 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
             "  └ Limit[2::bigint;0::bigint]",
             "    └ MultiPhase",
             "      └ Eval[1]",
-            "        └ Collect[doc.t1 | [1] | (x > cast((SELECT count(*) FROM (doc.t2)) AS integer))]",
+            "        └ Collect[doc.t1 | [1] | (x > cast((SELECT count(*) FROM (doc.t2)) AS INTEGER))]",
             "      └ Limit[2::bigint;0::bigint]",
             "        └ Limit[1::bigint;0]",
             "          └ Count[doc.t2 | true]"
@@ -262,7 +262,7 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(plan).isEqualTo(
             """
             Eval[i, cnt]
-              └ HashJoin[INNER | (cnt = cast(i AS bigint))]
+              └ HashJoin[INNER | (cnt = cast(i AS BIGINT))]
                 ├ Rename[cnt] AS t1
                 │  └ Eval[count(*) AS cnt]
                 │    └ Count[doc.t1 | true]
@@ -577,19 +577,19 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
             SELECT a::int ai, avg(x), i::long FROM t1 WHERE a='3' GROUP BY 1,3
             """);
         assertThat(plan).hasOperators(
-            "GroupHashAggregate[ai, \"avg(x)\", \"cast(i AS bigint)\"]",
-            "  └ Union[ai, \"avg(x)\", \"cast(i AS bigint)\"]",
-            "    ├ GroupHashAggregate[ai, \"avg(x)\", \"cast(i AS bigint)\"]",
-            "    │  └ Union[ai, \"avg(x)\", \"cast(i AS bigint)\"]",
-            "    │    ├ Eval[cast(a AS integer) AS ai, avg(x), cast(i AS bigint)]",
-            "    │    │  └ GroupHashAggregate[cast(a AS integer) AS ai, cast(i AS bigint) | avg(x)]",
-            "    │    │    └ Collect[doc.t1 | [cast(a AS integer) AS ai, cast(i AS bigint), x] | (a = '1')]",
-            "    │    └ Eval[cast(a AS integer) AS ai, avg(x), cast(i AS bigint)]",
-            "    │      └ GroupHashAggregate[cast(a AS integer) AS ai, cast(i AS bigint) | avg(x)]",
-            "    │        └ Collect[doc.t1 | [cast(a AS integer) AS ai, cast(i AS bigint), x] | (a = '2')]",
-            "    └ Eval[cast(a AS integer) AS ai, avg(x), cast(i AS bigint)]",
-            "      └ GroupHashAggregate[cast(a AS integer) AS ai, cast(i AS bigint) | avg(x)]",
-            "        └ Collect[doc.t1 | [cast(a AS integer) AS ai, cast(i AS bigint), x] | (a = '3')]"
+            "GroupHashAggregate[ai, \"avg(x)\", \"cast(i AS BIGINT)\"]",
+            "  └ Union[ai, \"avg(x)\", \"cast(i AS BIGINT)\"]",
+            "    ├ GroupHashAggregate[ai, \"avg(x)\", \"cast(i AS BIGINT)\"]",
+            "    │  └ Union[ai, \"avg(x)\", \"cast(i AS BIGINT)\"]",
+            "    │    ├ Eval[cast(a AS INTEGER) AS ai, avg(x), cast(i AS BIGINT)]",
+            "    │    │  └ GroupHashAggregate[cast(a AS INTEGER) AS ai, cast(i AS BIGINT) | avg(x)]",
+            "    │    │    └ Collect[doc.t1 | [cast(a AS INTEGER) AS ai, cast(i AS BIGINT), x] | (a = '1')]",
+            "    │    └ Eval[cast(a AS INTEGER) AS ai, avg(x), cast(i AS BIGINT)]",
+            "    │      └ GroupHashAggregate[cast(a AS INTEGER) AS ai, cast(i AS BIGINT) | avg(x)]",
+            "    │        └ Collect[doc.t1 | [cast(a AS INTEGER) AS ai, cast(i AS BIGINT), x] | (a = '2')]",
+            "    └ Eval[cast(a AS INTEGER) AS ai, avg(x), cast(i AS BIGINT)]",
+            "      └ GroupHashAggregate[cast(a AS INTEGER) AS ai, cast(i AS BIGINT) | avg(x)]",
+            "        └ Collect[doc.t1 | [cast(a AS INTEGER) AS ai, cast(i AS BIGINT), x] | (a = '3')]"
         );
     }
 
@@ -605,19 +605,19 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
             LIMIT 10
             """);
         assertThat(plan).hasOperators(
-            "LimitDistinct[10::bigint;0 | [ai, \"avg(x)\", \"cast(i AS bigint)\"]]",
-            "  └ Union[ai, \"avg(x)\", \"cast(i AS bigint)\"]",
-            "    ├ GroupHashAggregate[ai, \"avg(x)\", \"cast(i AS bigint)\"]",
-            "    │  └ Union[ai, \"avg(x)\", \"cast(i AS bigint)\"]",
-            "    │    ├ Eval[cast(a AS integer) AS ai, avg(x), cast(i AS bigint)]",
-            "    │    │  └ GroupHashAggregate[cast(a AS integer) AS ai, cast(i AS bigint) | avg(x)]",
-            "    │    │    └ Collect[doc.t1 | [cast(a AS integer) AS ai, cast(i AS bigint), x] | (a = '1')]",
-            "    │    └ Eval[cast(a AS integer) AS ai, avg(x), cast(i AS bigint)]",
-            "    │      └ GroupHashAggregate[cast(a AS integer) AS ai, cast(i AS bigint) | avg(x)]",
-            "    │        └ Collect[doc.t1 | [cast(a AS integer) AS ai, cast(i AS bigint), x] | (a = '2')]",
-            "    └ Eval[cast(a AS integer) AS ai, avg(x), cast(i AS bigint)]",
-            "      └ GroupHashAggregate[cast(a AS integer) AS ai, cast(i AS bigint) | avg(x)]",
-            "        └ Collect[doc.t1 | [cast(a AS integer) AS ai, cast(i AS bigint), x] | (a = '3')]"
+            "LimitDistinct[10::bigint;0 | [ai, \"avg(x)\", \"cast(i AS BIGINT)\"]]",
+            "  └ Union[ai, \"avg(x)\", \"cast(i AS BIGINT)\"]",
+            "    ├ GroupHashAggregate[ai, \"avg(x)\", \"cast(i AS BIGINT)\"]",
+            "    │  └ Union[ai, \"avg(x)\", \"cast(i AS BIGINT)\"]",
+            "    │    ├ Eval[cast(a AS INTEGER) AS ai, avg(x), cast(i AS BIGINT)]",
+            "    │    │  └ GroupHashAggregate[cast(a AS INTEGER) AS ai, cast(i AS BIGINT) | avg(x)]",
+            "    │    │    └ Collect[doc.t1 | [cast(a AS INTEGER) AS ai, cast(i AS BIGINT), x] | (a = '1')]",
+            "    │    └ Eval[cast(a AS INTEGER) AS ai, avg(x), cast(i AS BIGINT)]",
+            "    │      └ GroupHashAggregate[cast(a AS INTEGER) AS ai, cast(i AS BIGINT) | avg(x)]",
+            "    │        └ Collect[doc.t1 | [cast(a AS INTEGER) AS ai, cast(i AS BIGINT), x] | (a = '2')]",
+            "    └ Eval[cast(a AS INTEGER) AS ai, avg(x), cast(i AS BIGINT)]",
+            "      └ GroupHashAggregate[cast(a AS INTEGER) AS ai, cast(i AS BIGINT) | avg(x)]",
+            "        └ Collect[doc.t1 | [cast(a AS INTEGER) AS ai, cast(i AS BIGINT), x] | (a = '3')]"
         );
     }
 
@@ -676,10 +676,10 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
             """);
         assertThat(plan)
             .hasOperators(
-                "Eval[try_cast(x AS bigint) AS val]",
-                "  └ Rename[try_cast(x AS bigint) AS val, try_cast(x AS bigint)] AS t",
-                "    └ OrderBy[try_cast(x AS bigint) ASC]",
-                "      └ Collect[doc.t1 | [try_cast(x AS bigint) AS val, try_cast(x AS bigint)] | (x < 123)]"
+                "Eval[try_cast(x AS BIGINT) AS val]",
+                "  └ Rename[try_cast(x AS BIGINT) AS val, try_cast(x AS BIGINT)] AS t",
+                "    └ OrderBy[try_cast(x AS BIGINT) ASC]",
+                "      └ Collect[doc.t1 | [try_cast(x AS BIGINT) AS val, try_cast(x AS BIGINT)] | (x < 123)]"
             );
     }
 

--- a/server/src/test/java/io/crate/planner/optimizer/symbol/CollectQueryCastRulesTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/symbol/CollectQueryCastRulesTest.java
@@ -174,10 +174,10 @@ public class CollectQueryCastRulesTest extends CrateDummyClusterServiceUnitTest 
     @Test
     public void test_any_operator_does_not_move_explicit_reference_cast_to_literal_cast() {
         var query = toQuery("1 = ANY(d_array::int[])");
-        assertThat(query.toString()).isEqualTo("(1 = ANY(cast(d_array AS integer_array)))");
+        assertThat(query.toString()).isEqualTo("(1 = ANY(cast(d_array AS ARRAY(INTEGER))))");
 
         query = toQuery("f::int = ANY([1.1])");
-        assertThat(query.toString()).isEqualTo("(cast(f AS integer) = ANY([1.1]))");
+        assertThat(query.toString()).isEqualTo("(cast(f AS INTEGER) = ANY([1.1]))");
     }
 
     @Test


### PR DESCRIPTION
To print a data type as valid SQL including all optional type parameters, the `DataType.toColumnType()` + SQLFormatter must be used.

Fixes #16973.