### PR TITLE
Fix: generated columns not dropped with no error

### DIFF
--- a/docs/appendices/release-notes/5.9.3.rst
+++ b/docs/appendices/release-notes/5.9.3.rst
@@ -47,6 +47,11 @@ See the :ref:`version_5.9.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that would prevent
+  :ref:`dropping <sql-alter-table-drop-column>` a
+  :ref:`generated column <ddl-generated-columns>` from a table, even though no
+  error was returned.
+
 - Fixed an issue that would cause an error to be thrown when attempting to
   ``ORDER BY`` on top of a complex query (e.g. a ``JOIN``), using an expression
   which contains a query parameter, e.g.::

--- a/server/src/main/java/io/crate/execution/ddl/tables/MappingUtil.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/MappingUtil.java
@@ -287,7 +287,7 @@ public final class MappingUtil {
 
         // Generated expressions
         List<GeneratedReference> newGenExpressions = references.stream()
-            .filter(ref -> ref instanceof GeneratedReference)
+            .filter(ref -> ref instanceof GeneratedReference && !ref.isDropped())
             .map(ref -> (GeneratedReference) ref)
             .toList();
         if (newGenExpressions.isEmpty() == false) {

--- a/server/src/main/java/io/crate/metadata/GeneratedReference.java
+++ b/server/src/main/java/io/crate/metadata/GeneratedReference.java
@@ -232,7 +232,7 @@ public final class GeneratedReference implements Reference {
 
     @Override
     public boolean isDropped() {
-        return false;
+        return ref.isDropped();
     }
 
     @Override

--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
@@ -244,7 +244,7 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
             return ref;
         });
         this.generatedColumns = this.references.values().stream()
-            .filter(r -> r instanceof GeneratedReference)
+            .filter(r -> r instanceof GeneratedReference && !r.isDropped())
             .map(r -> (GeneratedReference) r)
             .toList();
         this.indexColumns = indexColumns;


### PR DESCRIPTION
Fix an issue that would cause generated column to not be dropped with ALTER TABLE DROP COLUMN, because `isDropped()` was always returning `false` for `GeneratedReference`. Also adjust the places where DocTableInfo and metadata are built to skip those columns once dropped.

Fixes: #16972

