### PR TITLE
Bind outer-joins before implicit joins

### DIFF
--- a/docs/appendices/release-notes/5.8.5.rst
+++ b/docs/appendices/release-notes/5.8.5.rst
@@ -40,6 +40,11 @@ See the :ref:`version_5.8.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that caused wrong results when implicit joins were combined
+  with outer-joins within the same query e.g.::
+
+      SELECT * FROM t1, t2 RIGHT JOIN t3 ON true
+
 - Fixed an issue which would allow to cast a number to a
   :ref:`NUMERIC<type-numeric>`, even if the ``NUMERIC``'s' precision and scale
   would not be sufficient to fit the number without loosing precision, instead

--- a/docs/appendices/release-notes/5.8.5.rst
+++ b/docs/appendices/release-notes/5.8.5.rst
@@ -40,11 +40,6 @@ See the :ref:`version_5.8.0` release notes for a full list of changes in the
 Fixes
 =====
 
-- Fixed an issue that caused wrong results when implicit joins were combined
-  with outer-joins within the same query e.g.::
-
-      SELECT * FROM t1, t2 RIGHT JOIN t3 ON true
-
 - Fixed an issue which would allow to cast a number to a
   :ref:`NUMERIC<type-numeric>`, even if the ``NUMERIC``'s' precision and scale
   would not be sufficient to fit the number without loosing precision, instead

--- a/docs/appendices/release-notes/5.9.5.rst
+++ b/docs/appendices/release-notes/5.9.5.rst
@@ -47,4 +47,7 @@ See the :ref:`version_5.9.0` release notes for a full list of changes in the
 Fixes
 =====
 
-None
+- Fixed an issue that caused wrong results when implicit joins were combined
+  with outer-joins within the same query e.g.::
+
+      SELECT * FROM t1, t2 RIGHT JOIN t3 ON true

--- a/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -1758,7 +1758,7 @@ public class JoinIntegrationTest extends IntegTestCase {
     @UseRandomizedSchema(random = false)
     @UseRandomizedOptimizerRules(0)
     @UseHashJoins(0)
-    public void test_explicit_joins_are_bind_before_implicit_join() throws Exception {
+    public void test_explicit_joins_are_bind_before_implicit_joins() throws Exception {
         execute("CREATE  TABLE  doc.t0(c1 VARCHAR(500))");
         execute("CREATE  TABLE  doc.t1(c0 VARCHAR(500))");
         execute("INSERT INTO doc.t0(c1) VALUES ('')");

--- a/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -1726,7 +1726,19 @@ public class JoinIntegrationTest extends IntegTestCase {
         execute("insert into t3 values (4), (5)");
         execute("refresh table t1, t2, t3");
 
-        execute("SELECT * FROM t1 LEFT JOIN (t2 LEFT JOIN t3 ON t2.id = t3.id) ON t2.id = t1.id;");
+        String query = "SELECT * FROM t1 LEFT JOIN (t2 LEFT JOIN t3 ON t2.id = t3.id) ON t1.id = t2.id";
+
+        execute("explain " + query);
+
+        assertThat(response).hasLines(
+            "HashJoin[LEFT | (id = id)] (rows=unknown)",
+            "  ├ Collect[doc.t1 | [id] | true] (rows=unknown)",
+            "  └ HashJoin[LEFT | (id = id)] (rows=unknown)",
+            "    ├ Collect[doc.t2 | [id] | true] (rows=unknown)",
+            "    └ Collect[doc.t3 | [id] | true] (rows=unknown)"
+        );
+
+        execute(query);
 
         assertThat(response).hasRowsInAnyOrder(
             "0| NULL| NULL",
@@ -1736,5 +1748,139 @@ public class JoinIntegrationTest extends IntegTestCase {
             "4| 4| 4",
             "5| 5| 5"
         );
+    }
+
+
+    /**
+     * https://github.com/crate/crate/issues/16951
+     */
+    @Test
+    @UseRandomizedSchema(random = false)
+    @UseRandomizedOptimizerRules(0)
+    @UseHashJoins(0)
+    public void test_explicit_joins_are_bind_before_implicit_join() throws Exception {
+        execute("CREATE  TABLE  doc.t0(c1 VARCHAR(500))");
+        execute("CREATE  TABLE  doc.t1(c0 VARCHAR(500))");
+        execute("INSERT INTO doc.t0(c1) VALUES ('')");
+        execute("REFRESH TABLE doc.t0, doc.t1");
+        String query = "SELECT * FROM doc.t0, doc.t1 RIGHT JOIN (SELECT 1) AS sub0 ON true WHERE (NOT ((doc.t0.c1)>=(doc.t0.c1)))";
+        execute("EXPLAIN " + query);
+
+        assertThat(response).hasLines(
+            "Eval[c1, c0, \"1\"] (rows=unknown)",
+            "  └ NestedLoopJoin[CROSS] (rows=unknown)",
+            "    ├ NestedLoopJoin[RIGHT | true] (rows=unknown)",
+            "    │  ├ Collect[doc.t1 | [c0] | true] (rows=unknown)",
+            "    │  └ Rename[\"1\"] AS sub0 (rows=unknown)",
+            "    │    └ TableFunction[empty_row | [1] | true] (rows=unknown)",
+            "    └ Collect[doc.t0 | [c1] | (NOT (c1 >= c1))] (rows=unknown)"
+        );
+
+        execute(query);
+        assertThat(response.rows()).isEmpty();
+    }
+
+
+    @Test
+    @UseRandomizedSchema(random = false)
+    @UseRandomizedOptimizerRules(0)
+    @UseHashJoins(0)
+    public void test_many_mized_implicit_and_explicit_joins() throws Exception {
+        execute("CREATE  TABLE  doc.t1(a integer)");
+        execute("CREATE  TABLE  doc.t2(b integer)");
+        execute("CREATE  TABLE  doc.t3(c integer)");
+        execute("CREATE  TABLE  doc.t4(d integer)");
+        execute("CREATE  TABLE  doc.t5(e integer)");
+        execute("CREATE  TABLE  doc.t6(f integer)");
+
+        execute("INSERT INTO doc.t1(a) VALUES (1)");
+        execute("INSERT INTO doc.t2(b) VALUES (2)");
+        execute("INSERT INTO doc.t3(c) VALUES (3)");
+        execute("INSERT INTO doc.t4(d) VALUES (4)");
+        execute("INSERT INTO doc.t5(e) VALUES (5)");
+        execute("INSERT INTO doc.t6(f) VALUES (6)");
+
+        execute("REFRESH TABLE doc.t1, doc.t2, doc.t3, doc.t4, doc.t5, doc.t6");
+
+        String query = "SELECT * FROM doc.t1 right join doc.t2 on true, doc.t3, doc.t4, t5, t6";
+        execute("explain " + query);
+
+        assertThat(response).hasLines(
+            "NestedLoopJoin[CROSS] (rows=unknown)",
+            "  ├ NestedLoopJoin[CROSS] (rows=unknown)",
+            "  │  ├ NestedLoopJoin[CROSS] (rows=unknown)",
+            "  │  │  ├ NestedLoopJoin[CROSS] (rows=unknown)",
+            "  │  │  │  ├ NestedLoopJoin[RIGHT | true] (rows=unknown)",
+            "  │  │  │  │  ├ Collect[doc.t1 | [a] | true] (rows=unknown)",
+            "  │  │  │  │  └ Collect[doc.t2 | [b] | true] (rows=unknown)",
+            "  │  │  │  └ Collect[doc.t3 | [c] | true] (rows=unknown)",
+            "  │  │  └ Collect[doc.t4 | [d] | true] (rows=unknown)",
+            "  │  └ Collect[doc.t5 | [e] | true] (rows=unknown)",
+            "  └ Collect[doc.t6 | [f] | true] (rows=unknown)"
+        );
+
+        execute(query);
+        assertThat(response).hasRows("1| 2| 3| 4| 5| 6");
+
+        query = "SELECT * FROM doc.t1, doc.t2, doc.t3 right join doc.t4 on true, doc.t5, doc.t6";
+        execute("explain " + query);
+
+        assertThat(response).hasLines(
+            "Eval[a, b, c, d, e, f] (rows=unknown)",
+            "  └ NestedLoopJoin[CROSS] (rows=unknown)",
+            "    ├ NestedLoopJoin[CROSS] (rows=unknown)",
+            "    │  ├ NestedLoopJoin[CROSS] (rows=unknown)",
+            "    │  │  ├ NestedLoopJoin[CROSS] (rows=unknown)",
+            "    │  │  │  ├ NestedLoopJoin[RIGHT | true] (rows=unknown)",
+            "    │  │  │  │  ├ Collect[doc.t3 | [c] | true] (rows=unknown)",
+            "    │  │  │  │  └ Collect[doc.t4 | [d] | true] (rows=unknown)",
+            "    │  │  │  └ Collect[doc.t1 | [a] | true] (rows=unknown)",
+            "    │  │  └ Collect[doc.t2 | [b] | true] (rows=unknown)",
+            "    │  └ Collect[doc.t5 | [e] | true] (rows=unknown)",
+            "    └ Collect[doc.t6 | [f] | true] (rows=unknown)"
+        );
+
+        execute(query);
+        assertThat(response).hasRows("1| 2| 3| 4| 5| 6");
+
+        query = "SELECT * FROM doc.t1, doc.t2 right join doc.t3 on true, doc.t4 left join doc.t5 on true, doc.t6";
+        execute("explain " + query);
+
+        assertThat(response).hasLines(
+            "Eval[a, b, c, d, e, f] (rows=unknown)",
+            "  └ NestedLoopJoin[CROSS] (rows=unknown)",
+            "    ├ NestedLoopJoin[LEFT | true] (rows=unknown)",
+            "    │  ├ NestedLoopJoin[CROSS] (rows=unknown)",
+            "    │  │  ├ NestedLoopJoin[CROSS] (rows=unknown)",
+            "    │  │  │  ├ NestedLoopJoin[RIGHT | true] (rows=unknown)",
+            "    │  │  │  │  ├ Collect[doc.t2 | [b] | true] (rows=unknown)",
+            "    │  │  │  │  └ Collect[doc.t3 | [c] | true] (rows=unknown)",
+            "    │  │  │  └ Collect[doc.t1 | [a] | true] (rows=unknown)",
+            "    │  │  └ Collect[doc.t4 | [d] | true] (rows=unknown)",
+            "    │  └ Collect[doc.t5 | [e] | true] (rows=unknown)",
+            "    └ Collect[doc.t6 | [f] | true] (rows=unknown)"
+        );
+
+        execute(query);
+        assertThat(response).hasRows("1| 2| 3| 4| 5| 6");
+
+        query = "SELECT * FROM doc.t1, doc.t2 right join doc.t3 on true left join doc.t5 on true, doc.t6";
+        execute("explain " + query);
+
+        assertThat(response).hasLines(
+            "Eval[a, b, c, e, f] (rows=unknown)",
+            "  └ NestedLoopJoin[CROSS] (rows=unknown)",
+            "    ├ NestedLoopJoin[LEFT | true] (rows=unknown)",
+            "    │  ├ NestedLoopJoin[CROSS] (rows=unknown)",
+            "    │  │  ├ NestedLoopJoin[RIGHT | true] (rows=unknown)",
+            "    │  │  │  ├ Collect[doc.t2 | [b] | true] (rows=unknown)",
+            "    │  │  │  └ Collect[doc.t3 | [c] | true] (rows=unknown)",
+            "    │  │  └ Collect[doc.t1 | [a] | true] (rows=unknown)",
+            "    │  └ Collect[doc.t5 | [e] | true] (rows=unknown)",
+            "    └ Collect[doc.t6 | [f] | true] (rows=unknown)"
+        );
+
+        execute(query);
+        assertThat(response).hasRows("1| 2| 3| 5| 6");
     }
 }

--- a/server/src/test/java/io/crate/planner/operators/JoinTest.java
+++ b/server/src/test/java/io/crate/planner/operators/JoinTest.java
@@ -63,6 +63,9 @@ import io.crate.statistics.TableStats;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.testing.T3;
+import io.crate.testing.UseHashJoins;
+import io.crate.testing.UseRandomizedOptimizerRules;
+import io.crate.testing.UseRandomizedSchema;
 
 public class JoinTest extends CrateDummyClusterServiceUnitTest {
 
@@ -1140,6 +1143,90 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
             "  └ HashJoin[LEFT | (a = b)]",
             "    ├ Collect[doc.t2 | [b] | true]",
             "    └ Collect[doc.t1 | [a] | true]"
+        );
+    }
+
+    @Test
+    public void test_many_mized_implicit_and_explicit_joins() throws Exception {
+        var executor = SQLExecutor.builder(clusterService)
+            .build()
+            .addTable("CREATE TABLE doc.t1(a integer)")
+            .addTable("CREATE TABLE doc.t2(b integer)")
+            .addTable("CREATE TABLE doc.t3(c integer)")
+            .addTable("CREATE TABLE doc.t4(d integer)")
+            .addTable("CREATE TABLE doc.t5(e integer)")
+            .addTable("CREATE TABLE doc.t6(f integer)");
+
+
+        QueriedSelectRelation mss = e.analyze("SELECT * FROM doc.t1 right join doc.t2 on true, doc.t3, doc.t4, t5, t6");
+        var plannerCtx = executor.getPlannerContext();
+        var result = buildLogicalPlan(mss, plannerCtx);
+
+        assertThat(result).hasOperators(
+            "NestedLoopJoin[CROSS]",
+            "  ├ NestedLoopJoin[CROSS]",
+            "  │  ├ NestedLoopJoin[CROSS]",
+            "  │  │  ├ NestedLoopJoin[CROSS]",
+            "  │  │  │  ├ NestedLoopJoin[RIGHT | true]",
+            "  │  │  │  │  ├ Collect[doc.t1 | [a] | true]",
+            "  │  │  │  │  └ Collect[doc.t2 | [b] | true]",
+            "  │  │  │  └ Collect[doc.t3 | [c] | true]",
+            "  │  │  └ Collect[doc.t4 | [d] | true]",
+            "  │  └ Collect[doc.t5 | [e] | true]",
+            "  └ Collect[doc.t6 | [f] | true]"
+        );
+
+
+        mss = e.analyze("SELECT * FROM doc.t1, doc.t2, doc.t3 right join doc.t4 on true, doc.t5, doc.t6");
+        result = buildLogicalPlan(mss, plannerCtx);
+
+        assertThat(result).hasOperators(
+            "Eval[a, b, c, d, e, f]",
+            "  └ NestedLoopJoin[CROSS]",
+            "    ├ NestedLoopJoin[CROSS]",
+            "    │  ├ NestedLoopJoin[CROSS]",
+            "    │  │  ├ NestedLoopJoin[CROSS]",
+            "    │  │  │  ├ NestedLoopJoin[RIGHT | true]",
+            "    │  │  │  │  ├ Collect[doc.t3 | [c] | true]",
+            "    │  │  │  │  └ Collect[doc.t4 | [d] | true]",
+            "    │  │  │  └ Collect[doc.t1 | [a] | true]",
+            "    │  │  └ Collect[doc.t2 | [b] | true]",
+            "    │  └ Collect[doc.t5 | [e] | true]",
+            "    └ Collect[doc.t6 | [f] | true]"
+        );
+
+        mss = e.analyze("SELECT * FROM doc.t1, doc.t2 right join doc.t3 on true, doc.t4 left join doc.t5 on true, doc.t6");
+        result = buildLogicalPlan(mss, plannerCtx);
+
+        assertThat(result).hasOperators(
+            "Eval[a, b, c, d, e, f]",
+            "  └ NestedLoopJoin[CROSS]",
+            "    ├ NestedLoopJoin[LEFT | true]",
+            "    │  ├ NestedLoopJoin[CROSS]",
+            "    │  │  ├ NestedLoopJoin[CROSS]",
+            "    │  │  │  ├ NestedLoopJoin[RIGHT | true]",
+            "    │  │  │  │  ├ Collect[doc.t2 | [b] | true]",
+            "    │  │  │  │  └ Collect[doc.t3 | [c] | true]",
+            "    │  │  │  └ Collect[doc.t1 | [a] | true]",
+            "    │  │  └ Collect[doc.t4 | [d] | true]",
+            "    │  └ Collect[doc.t5 | [e] | true]",
+            "    └ Collect[doc.t6 | [f] | true]"
+        );
+
+        mss = e.analyze("SELECT * FROM doc.t1, doc.t2 right join doc.t3 on true left join doc.t5 on true, doc.t6");
+        result = buildLogicalPlan(mss, plannerCtx);
+
+        assertThat(result).hasOperators(
+            "Eval[a, b, c, e, f]",
+            "  └ NestedLoopJoin[CROSS]",
+            "    ├ NestedLoopJoin[LEFT | true]",
+            "    │  ├ NestedLoopJoin[CROSS]",
+            "    │  │  ├ NestedLoopJoin[RIGHT | true]",
+            "    │  │  │  ├ Collect[doc.t2 | [b] | true]",
+            "    │  │  │  └ Collect[doc.t3 | [c] | true]",
+            "    │  │  └ Collect[doc.t1 | [a] | true]",
+            "    │  └ Collect[doc.t5 | [e] | true]",
+            "    └ Collect[doc.t6 | [f] | true]"
         );
     }
 }

--- a/server/src/test/java/io/crate/planner/operators/JoinTest.java
+++ b/server/src/test/java/io/crate/planner/operators/JoinTest.java
@@ -63,9 +63,6 @@ import io.crate.statistics.TableStats;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.testing.T3;
-import io.crate.testing.UseHashJoins;
-import io.crate.testing.UseRandomizedOptimizerRules;
-import io.crate.testing.UseRandomizedSchema;
 
 public class JoinTest extends CrateDummyClusterServiceUnitTest {
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

When a query has mixed implicit and outer joins, the joins are wrongly bound. Currently, we bound implicit joins first to preserve the original join order, which leads to an incorrect join order and a wrong query plan e.g.:

```
SELECT * FROM t0, t1 RIGHT JOIN (SELECT 1 ) AS sub0 ON true WHERE (NOT ((t0.c1)>=(t0.c1))); 
```

results in:

```
+------------------------------------------------------------+
| QUERY PLAN                                                 |
+------------------------------------------------------------+
| NestedLoopJoin[RIGHT | true] (rows=unknown)                |
|   ├ NestedLoopJoin[CROSS] (rows=unknown)                   |
|   │  ├ Collect[doc.t0 | [c1] | (NOT (c1 >= c1))] (rows=0)  |
|   │  └ Collect[doc.t1 | [c0] | true] (rows=0)              |
|   └ Rename["1"] AS sub0 (rows=unknown)                     |
|     └ TableFunction[empty_row | [1] | true] (rows=unknown) |
+------------------------------------------------------------+
```

Explicit joins using `JOIN` bind stronger than implicit joins. This matters especially when outer-joins are involved because they can not be easily reordered since they have a preserved side. Therefore the query plan should have the following structure with the join order `(t1 right join sub0) cross join t0`:

```
+-----------------------------------------------------------------+
| QUERY PLAN                                                      |
+-----------------------------------------------------------------+
| Eval[c1, c0, "1"] (rows=unknown)                                |
|   └ NestedLoopJoin[CROSS] (rows=unknown)                        |
|     ├ NestedLoopJoin[RIGHT | true] (rows=unknown)               |
|     │  ├ Collect[doc.t1 | [c0] | true] (rows=unknown)           |
|     │  └ Rename["1"] AS sub0 (rows=unknown)                     |
|     │    └ TableFunction[empty_row | [1] | true] (rows=unknown) |
|     └ Collect[doc.t0 | [c1] | (NOT (c1 >= c1))] (rows=unknown)  |
+-----------------------------------------------------------------+
```

This binds the outer-joins first which leads to a correct query plan and result but does not necessarily preserve the original join order anymore of the inplicit joins. This is not a problem since inner/cross joins can be arbitrarily reordered.





Fixes https://github.com/crate/crate/issues/16951


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
