### PR TITLE
Documentation Theme: Update to `crate-docs-theme>=0.37.0.dev0`, introducing dark mode

### DIFF
--- a/blackbox/requirements.txt
+++ b/blackbox/requirements.txt
@@ -14,7 +14,7 @@ minio>=5.0.0
 dnslib
 
 # Documentation
-crate-docs-theme>=0.35.0
+crate-docs-theme>=0.37.0.dev0
 sphinx-csv-filter==0.4.0
 
 # Documentation: local development

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 # packages for RTD to pick up (not used for local dev)
-crate-docs-theme>=0.35.0
+crate-docs-theme>=0.37.0.dev0
 sphinx-csv-filter==0.4.0
 Pygments>=2.7.4,<3


### PR DESCRIPTION
## About
Use the new documentation theme that introduces dark mode. Thanks, @msbt.

## Preview
https://crate--17001.org.readthedocs.build/en/17001/

## References
- https://github.com/crate/crate-docs-theme/pull/546
- https://github.com/crate/cratedb-guide/pull/136