### PR TITLE
Added Support for Group By All 

### DIFF
--- a/docs/appendices/release-notes/5.10.0.rst
+++ b/docs/appendices/release-notes/5.10.0.rst
@@ -68,18 +68,17 @@ SQL Statements
   table.
 
 - Added support for ``GROUP BY ALL`` clause which allows grouping by all output
- columns that are not aggregate functions without explicitly listing them, e.g.::
+  columns that are not aggregate functions without explicitly listing them, e.g.::
 
+    SELECT department, title, AVG(salary) as avg_salary
+    FROM employees
+    GROUP BY ALL;
 
-   SELECT department, title, AVG(salary) as avg_salary
-   FROM employees
-   GROUP BY ALL;
+  This is equivalent to::
 
- This is equivalent to::
-
-   SELECT department, title, AVG(salary) as avg_salary
-   FROM employees
-   GROUP BY department, title;
+    SELECT department, title, AVG(salary) as avg_salary
+    FROM employees
+    GROUP BY department, title;
 
 SQL Standard and PostgreSQL Compatibility
 -----------------------------------------

--- a/docs/appendices/release-notes/5.10.0.rst
+++ b/docs/appendices/release-notes/5.10.0.rst
@@ -67,6 +67,20 @@ SQL Statements
   of the effective options you can query the ``information_schema.tables``
   table.
 
+- Added support for ``GROUP BY ALL`` clause which allows grouping by all output
+ columns that are not aggregate functions without explicitly listing them, e.g.::
+
+
+   SELECT department, title, AVG(salary) as avg_salary
+   FROM employees
+   GROUP BY ALL;
+
+ This is equivalent to::
+
+   SELECT department, title, AVG(salary) as avg_salary
+   FROM employees
+   GROUP BY department, title;
+
 SQL Standard and PostgreSQL Compatibility
 -----------------------------------------
 

--- a/docs/sql/statements/select.rst
+++ b/docs/sql/statements/select.rst
@@ -309,8 +309,9 @@ each group.
 ``GROUP BY ALL``
 ''''''''''''''''
 
-``GROUP BY ALL`` is a convenient shorthand syntax that automatically groups by all non-aggregate
-columns in the SELECT list. This eliminates the need to explicitly list all grouping columns.
+``GROUP BY ALL`` is a shorthand syntax that groups all non-aggregate columns in
+the SELECT list. This eliminates the need to explicitly list all grouping
+columns.
 
 ::
 

--- a/docs/sql/statements/select.rst
+++ b/docs/sql/statements/select.rst
@@ -304,6 +304,43 @@ each group.
   column from the queried relation rather than an output column name.
 
 
+.. _sql-select-group-by-all:
+
+``GROUP BY ALL``
+''''''''''''''''
+
+``GROUP BY ALL`` is a convenient shorthand syntax that automatically groups by all non-aggregate
+columns in the SELECT list. This eliminates the need to explicitly list all grouping columns.
+
+::
+
+   GROUP BY ALL [HAVING condition]
+
+When using ``GROUP BY ALL``, the following rules apply:
+- All output columns that are not aggregate functions are used as grouping columns
+- Aggregate functions (like COUNT, SUM, AVG etc.) are excluded from the automatic grouping
+- The order of columns in the grouping matches their order in the SELECT list
+
+    For example::
+
+        SELECT department, title, AVG(salary) as avg_salary
+        FROM employees
+        GROUP BY ALL;
+
+    Is equivalent to explicitly listing all non-aggregate columns::
+
+        SELECT department, title, AVG(salary) as avg_salary
+        FROM employees
+        GROUP BY department, title;
+
+.. NOTE::
+
+  The same limitations that apply to regular GROUP BY also apply to GROUP BY ALL:
+  - Grouping can only be applied on indexed fields
+  - Non-aggregate columns in the SELECT list must appear in the grouping
+  - The HAVING clause can be used with GROUP BY ALL for filtering groups
+
+
 .. _sql-select-having:
 
 ``HAVING``

--- a/docs/sql/statements/select.rst
+++ b/docs/sql/statements/select.rst
@@ -334,14 +334,6 @@ When using ``GROUP BY ALL``, the following rules apply:
         FROM employees
         GROUP BY department, title;
 
-.. NOTE::
-
-  The same limitations that apply to regular GROUP BY also apply to GROUP BY ALL:
-  - Grouping can only be applied on indexed fields
-  - Non-aggregate columns in the SELECT list must appear in the grouping
-  - The HAVING clause can be used with GROUP BY ALL for filtering groups
-
-
 .. _sql-select-having:
 
 ``HAVING``

--- a/libs/sql-parser/src/main/antlr/io/crate/sql/parser/antlr/SqlBaseParser.g4
+++ b/libs/sql-parser/src/main/antlr/io/crate/sql/parser/antlr/SqlBaseParser.g4
@@ -190,7 +190,7 @@ querySpec
     : SELECT setQuant? selectItem (COMMA selectItem)*
       (FROM relation (COMMA relation)*)?
       where?
-      (GROUP BY expr (COMMA expr)*)?
+      (GROUP BY ( ALL | expr (COMMA expr)*))?
       (HAVING having=booleanExpression)?
       (WINDOW windows+=namedWindow (COMMA windows+=namedWindow)*)?                   #defaultQuerySpec
     | VALUES values (COMMA values)*                                                  #valuesRelation

--- a/libs/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
@@ -96,6 +96,7 @@ import io.crate.sql.tree.GCDanglingArtifacts;
 import io.crate.sql.tree.GeneratedExpressionConstraint;
 import io.crate.sql.tree.GenericProperties;
 import io.crate.sql.tree.GrantPrivilege;
+import io.crate.sql.tree.GroupBy;
 import io.crate.sql.tree.IndexColumnConstraint;
 import io.crate.sql.tree.IndexDefinition;
 import io.crate.sql.tree.Insert;
@@ -498,12 +499,18 @@ public final class SqlFormatter {
                     .append('\n');
             }
 
-            if (!node.getGroupBy().isEmpty()) {
-                append(indent,
-                    "GROUP BY " + node.getGroupBy().stream()
-                        .map(e -> formatStandaloneExpression(e, parameters))
-                        .collect(COMMA_JOINER))
-                    .append('\n');
+            if (node.getGroupBy().isPresent()) {
+                GroupBy groupBy = node.getGroupBy().get();
+                if (groupBy.isAll()) {
+                    append(indent, "GROUP BY ALL\n");
+                } else if (!groupBy.getExpressions().isEmpty()) {
+                    append(indent, "GROUP BY ");
+                    append(indent,
+                        groupBy.getExpressions().stream()
+                            .map(e -> formatStandaloneExpression(e, parameters))
+                            .collect(COMMA_JOINER));
+                    builder.append('\n');
+                }
             }
 
             if (node.getHaving().isPresent()) {

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
@@ -228,6 +228,10 @@ public abstract class AstVisitor<R, C> {
         return visitQueryBody(node, context);
     }
 
+    protected R visitGroupBy(GroupBy node, C context) {
+        return visitNode(node, context);
+    }
+
     protected R visitAliasedRelation(AliasedRelation node, C context) {
         return visitRelation(node, context);
     }

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/DefaultTraversalVisitor.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/DefaultTraversalVisitor.java
@@ -222,8 +222,11 @@ public abstract class DefaultTraversalVisitor<R, C> extends AstVisitor<R, C> {
         if (node.getWhere().isPresent()) {
             node.getWhere().get().accept(this, context);
         }
-        for (Expression expression : node.getGroupBy()) {
-            expression.accept(this, context);
+        if (node.getGroupBy().isPresent()) {
+            GroupBy groupBy = node.getGroupBy().get();
+            for (Expression expression : groupBy.getExpressions()) {
+                expression.accept(this, context);
+            }
         }
         if (node.getHaving().isPresent()) {
             node.getHaving().get().accept(this, context);

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/GroupBy.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/GroupBy.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.sql.tree;
+
+import java.util.List;
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+public class GroupBy extends Node {
+
+    private final boolean isAll;
+    private final List<Expression> expressions;
+
+    private GroupBy(boolean isAll, List<Expression> expressions) {
+        this.isAll = isAll;
+        this.expressions = requireNonNull(expressions, "expressions is null");
+    }
+
+    public static GroupBy all() {
+        return new GroupBy(true, List.of());
+    }
+
+    public static GroupBy of(List<Expression> expressions) {
+        return new GroupBy(false, expressions);
+    }
+
+    public boolean isAll() {
+        return isAll;
+    }
+
+    public List<Expression> getExpressions() {
+        return expressions;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitGroupBy(this, context);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        GroupBy groupBy = (GroupBy) o;
+        return isAll == groupBy.isAll &&
+            Objects.equals(expressions, groupBy.expressions);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(Boolean.valueOf(isAll), expressions);
+    }
+
+    @Override
+    public String toString() {
+        return "GroupBy{" +
+            "isAll=" + isAll +
+            ", expressions=" + expressions +
+            '}';
+    }
+}

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/QuerySpecification.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/QuerySpecification.java
@@ -33,7 +33,7 @@ public class QuerySpecification extends QueryBody {
     private final Select select;
     private final List<Relation> from;
     private final Optional<Expression> where;
-    private final List<Expression> groupBy;
+    private final Optional<GroupBy> groupBy;
     private final Optional<Expression> having;
     private final List<SortItem> orderBy;
     private final Optional<Expression> limit;
@@ -43,7 +43,7 @@ public class QuerySpecification extends QueryBody {
     public QuerySpecification(Select select,
                               List<Relation> from,
                               Optional<Expression> where,
-                              List<Expression> groupBy,
+                              Optional<GroupBy> groupBy,
                               Optional<Expression> having,
                               Map<String, Window> windows,
                               List<SortItem> orderBy,
@@ -72,7 +72,7 @@ public class QuerySpecification extends QueryBody {
         return where;
     }
 
-    public List<Expression> getGroupBy() {
+    public Optional<GroupBy> getGroupBy() {
         return groupBy;
     }
 
@@ -111,14 +111,14 @@ public class QuerySpecification extends QueryBody {
         }
         QuerySpecification that = (QuerySpecification) o;
         return Objects.equals(select, that.select) &&
-               Objects.equals(from, that.from) &&
-               Objects.equals(where, that.where) &&
-               Objects.equals(groupBy, that.groupBy) &&
-               Objects.equals(having, that.having) &&
-               Objects.equals(orderBy, that.orderBy) &&
-               Objects.equals(limit, that.limit) &&
-               Objects.equals(offset, that.offset) &&
-               Objects.equals(windows, that.windows);
+            Objects.equals(from, that.from) &&
+            Objects.equals(where, that.where) &&
+            Objects.equals(groupBy, that.groupBy) &&
+            Objects.equals(having, that.having) &&
+            Objects.equals(orderBy, that.orderBy) &&
+            Objects.equals(limit, that.limit) &&
+            Objects.equals(offset, that.offset) &&
+            Objects.equals(windows, that.windows);
     }
 
     @Override
@@ -129,15 +129,15 @@ public class QuerySpecification extends QueryBody {
     @Override
     public String toString() {
         return "QuerySpecification{" +
-               "select=" + select +
-               ", from=" + from +
-               ", where=" + where +
-               ", groupBy=" + groupBy +
-               ", having=" + having +
-               ", orderBy=" + orderBy +
-               ", limit=" + limit +
-               ", offset=" + offset +
-               ", windows=" + windows +
-               '}';
+            "select=" + select +
+            ", from=" + from +
+            ", where=" + where +
+            ", groupBy=" + groupBy +
+            ", having=" + having +
+            ", orderBy=" + orderBy +
+            ", limit=" + limit +
+            ", offset=" + offset +
+            ", windows=" + windows +
+            '}';
     }
 }

--- a/libs/sql-parser/src/test/java/io/crate/sql/parser/TestSqlParser.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/parser/TestSqlParser.java
@@ -74,55 +74,55 @@ public class TestSqlParser {
             SqlParser.createStatement("-- this is a line comment\nSelect \n-- this is a line comment\n1"))
             .isExactlyInstanceOf(Query.class);
         assertThat(SqlParser.createStatement(
-                  """
-                  /* this
-                         is a multiline
-                         comment
-                      */
-                  Select 1;"""))
+            """
+            /* this
+                   is a multiline
+                   comment
+                */
+            Select 1;"""))
             .isExactlyInstanceOf(Query.class);
         assertThat(SqlParser.createStatement(
-                  """
-                  Select 1;    /* this
-                         is a multiline
-                         comment
-                      */"""))
+            """
+            Select 1;    /* this
+                   is a multiline
+                   comment
+                */"""))
             .isExactlyInstanceOf(Query.class);
         assertThat(SqlParser.createStatement(
-                  """
-                  Select    /* this
-                         is a multiline
-                         comment
-                      */1"""))
+            """
+            Select    /* this
+                   is a multiline
+                   comment
+                */1"""))
             .isExactlyInstanceOf(Query.class);
         assertThat(SqlParser.createStatement(
-                  """
-                  Select    /* this
-                         is a multiline
-                         comment
-                      */
-                  -- line comment
-                  1"""))
+            """
+            Select    /* this
+                   is a multiline
+                   comment
+                */
+            -- line comment
+            1"""))
             .isExactlyInstanceOf(Query.class);
         assertThat(SqlParser.createStatement(
-                """
-                  CREATE TABLE IF NOT EXISTS "doc"."data" (
-                     "week__generated" TIMESTAMP GENERATED ALWAYS AS date_trunc('week', "ts"),
-                     "mid" STRING, -- measurement id, mainly used for triggers, starts for continuuous measurment with random uuid
-                     "res" INTEGER, -- resolution in ms
-                     "ts" TIMESTAMP,
-                     "val_avg" FLOAT,
-                     "val_max" FLOAT,
-                     "val_min" FLOAT,
-                     "val_stddev" FLOAT,
-                     "vid" STRING, -- variable id, unique uuid
-                     PRIMARY KEY ("ts", "mid", "vid", "res", "week__generated")
-                  )
-                  CLUSTERED INTO 3 SHARDS
-                  PARTITIONED BY ("res", "week__generated")
-                  WITH (
-                     number_of_replicas = '1'
-                  );"""))
+            """
+              CREATE TABLE IF NOT EXISTS "doc"."data" (
+                 "week__generated" TIMESTAMP GENERATED ALWAYS AS date_trunc('week', "ts"),
+                 "mid" STRING, -- measurement id, mainly used for triggers, starts for continuuous measurment with random uuid
+                 "res" INTEGER, -- resolution in ms
+                 "ts" TIMESTAMP,
+                 "val_avg" FLOAT,
+                 "val_max" FLOAT,
+                 "val_min" FLOAT,
+                 "val_stddev" FLOAT,
+                 "vid" STRING, -- variable id, unique uuid
+                 PRIMARY KEY ("ts", "mid", "vid", "res", "week__generated")
+              )
+              CLUSTERED INTO 3 SHARDS
+              PARTITIONED BY ("res", "week__generated")
+              WITH (
+                 number_of_replicas = '1'
+              );"""))
             .isExactlyInstanceOf(CreateTable.class);
     }
 
@@ -170,7 +170,7 @@ public class TestSqlParser {
                     selectList(new DoubleLiteral(123.456E7)),
                     table(QualifiedName.of("dual")),
                     Optional.empty(),
-                    List.of(),
+                    Optional.empty(),
                     Optional.empty(),
                     Map.of(),
                     List.of(),
@@ -605,9 +605,9 @@ public class TestSqlParser {
     private static void assertParsed(String input, Node expected, Node parsed) {
         if (!parsed.equals(expected)) {
             fail(format("expected%n%n%s%n%nto parse as%n%n%s%n%nbut was%n%n%s%n",
-                        indent(input),
-                        indent(formatSql(expected)),
-                        indent(formatSql(parsed))));
+                indent(input),
+                indent(formatSql(expected)),
+                indent(formatSql(parsed))));
         }
     }
 

--- a/server/src/test/java/io/crate/analyze/relations/GroupByScalarAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/relations/GroupByScalarAnalyzerTest.java
@@ -26,11 +26,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
+import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
 
+import io.crate.analyze.QueriedSelectRelation;
 import io.crate.analyze.TableDefinitions;
+import io.crate.expression.symbol.Symbol;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 
@@ -70,4 +73,14 @@ public class GroupByScalarAnalyzerTest extends CrateDummyClusterServiceUnitTest 
         AnalyzedRelation relation = executor.analyze("select abs(id * 2) from users group by id");
         assertThat(relation.outputs().get(0).toColumn().sqlFqn()).isEqualTo("abs((id * 2::bigint))");
     }
+
+    @Test
+    public void testValidGroupByAllClause() throws Exception {
+        AnalyzedRelation relation = executor.analyze("select id, id + 10, sum(no_index) as sum_index, name from users group by All");
+        List<Symbol> groupBySymbols = ((QueriedSelectRelation) relation).groupBy();
+        assertThat(groupBySymbols).hasSize(3);
+        assertThat(groupBySymbols.get(0).equals("id"));
+        assertThat(groupBySymbols.get(1).equals("name"));
+    }
+
 }


### PR DESCRIPTION
Summary of the changes / Why this improves CrateDB
Added support for GROUP BY ALL syntax, which provides a convenient shorthand for grouping by all non-aggregate columns in the SELECT list.
	•	Reduces verbosity in queries with many grouping columns
	•	Eliminates need to explicitly list all grouping columns
	•	Makes queries more maintainable by automatically including non-aggregate columns in grouping
Example:
SELECT department, title, AVG(salary) 
FROM employees 
GROUP BY ALL;

Is equivalent to:

SELECT department, title, AVG(salary) 
FROM employees 
GROUP BY department, title; 

Checklist
Added documentation in docs/appendices/release-notes/5.10.0.rst: 
Updated SQL documentation Added test coverage 
No breaking changes: Additive feature only

