### PR TITLE
Change the default behaviour of `SymbolVisitor.visitAlias` to visit the inner symbol

### DIFF
--- a/server/src/main/java/io/crate/analyze/validator/GroupBySymbolValidator.java
+++ b/server/src/main/java/io/crate/analyze/validator/GroupBySymbolValidator.java
@@ -23,7 +23,6 @@ package io.crate.analyze.validator;
 
 import java.util.Locale;
 
-import io.crate.expression.symbol.AliasSymbol;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.MatchPredicate;
 import io.crate.expression.symbol.Symbol;
@@ -76,11 +75,6 @@ public class GroupBySymbolValidator {
         @Override
         protected Void visitSymbol(Symbol symbol, Boolean insideScalar) {
             return null;
-        }
-
-        @Override
-        public Void visitAlias(AliasSymbol aliasSymbol, Boolean insideScalar) {
-            return aliasSymbol.symbol().accept(this, insideScalar);
         }
     }
 }

--- a/server/src/main/java/io/crate/execution/engine/sort/LuceneSort.java
+++ b/server/src/main/java/io/crate/execution/engine/sort/LuceneSort.java
@@ -43,7 +43,6 @@ import io.crate.expression.InputFactory;
 import io.crate.expression.reference.doc.lucene.CollectorContext;
 import io.crate.expression.reference.doc.lucene.LuceneCollectorExpression;
 import io.crate.expression.reference.doc.lucene.NullSentinelValues;
-import io.crate.expression.symbol.AliasSymbol;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitor;
@@ -237,11 +236,6 @@ public class LuceneSort extends SymbolVisitor<LuceneSort.SortSymbolContext, Sort
     @Override
     public SortField visitFunction(final Function function, final SortSymbolContext context) {
         return customSortField(function.toString(), function, context);
-    }
-
-    @Override
-    public SortField visitAlias(AliasSymbol aliasSymbol, SortSymbolContext context) {
-        return aliasSymbol.symbol().accept(this, context);
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/BaseImplementationSymbolVisitor.java
+++ b/server/src/main/java/io/crate/expression/BaseImplementationSymbolVisitor.java
@@ -27,7 +27,6 @@ import java.util.Locale;
 import io.crate.common.collections.Lists;
 import io.crate.data.Input;
 import io.crate.exceptions.UnsupportedFeatureException;
-import io.crate.expression.symbol.AliasSymbol;
 import io.crate.expression.symbol.DynamicReference;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
@@ -85,11 +84,6 @@ public class BaseImplementationSymbolVisitor<C> extends SymbolVisitor<C, Input<?
     @Override
     public Input<?> visitDynamicReference(DynamicReference symbol, C context) {
         return visitReference(symbol, context);
-    }
-
-    @Override
-    public Input<?> visitAlias(AliasSymbol aliasSymbol, C context) {
-        return aliasSymbol.symbol().accept(this, context);
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/eval/EvaluatingNormalizer.java
+++ b/server/src/main/java/io/crate/expression/eval/EvaluatingNormalizer.java
@@ -250,11 +250,6 @@ public class EvaluatingNormalizer {
                 function.ignoreNulls()
             );
         }
-
-        @Override
-        public Symbol visitAlias(AliasSymbol aliasSymbol, TransactionContext context) {
-            return aliasSymbol.symbol().accept(this, context);
-        }
     }
 
     public Symbol normalize(@Nullable Symbol symbol, @NotNull TransactionContext txnCtx) {

--- a/server/src/main/java/io/crate/expression/symbol/DefaultTraversalSymbolVisitor.java
+++ b/server/src/main/java/io/crate/expression/symbol/DefaultTraversalSymbolVisitor.java
@@ -97,10 +97,4 @@ public abstract class DefaultTraversalSymbolVisitor<C, R> extends SymbolVisitor<
         matchPredicate.options().accept(this, context);
         return null;
     }
-
-    @Override
-    public R visitAlias(AliasSymbol aliasSymbol, C context) {
-        aliasSymbol.symbol().accept(this, context);
-        return null;
-    }
 }

--- a/server/src/main/java/io/crate/expression/symbol/GroupAndAggregateSemantics.java
+++ b/server/src/main/java/io/crate/expression/symbol/GroupAndAggregateSemantics.java
@@ -99,11 +99,6 @@ public final class GroupAndAggregateSemantics {
             return null;
         }
 
-        @Override
-        public Void visitAlias(AliasSymbol aliasSymbol, Void context) {
-            return aliasSymbol.symbol().accept(this, context);
-        }
-
         private static void raiseException(Symbol symbol) {
             throw new IllegalArgumentException(
                 "Cannot group or aggregate on '" + symbol.toString() + "' with an undefined type." +

--- a/server/src/main/java/io/crate/expression/symbol/SymbolVisitor.java
+++ b/server/src/main/java/io/crate/expression/symbol/SymbolVisitor.java
@@ -83,7 +83,7 @@ public class SymbolVisitor<C, R> {
     }
 
     public R visitAlias(AliasSymbol aliasSymbol, C context) {
-        return visitSymbol(aliasSymbol, context);
+        return aliasSymbol.symbol().accept(this, context);
     }
 
     public R visitFetchMarker(FetchMarker fetchMarker, C context) {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

SymbolVisitors like `SemanticSortValidator` neglected to override `aliasSymbol` and end up skipping validations(see https://github.com/crate/crate/pull/16950#discussion_r1838308355). The main concern was not catching MatchPredicates within aliasSymbols but we still get similar exceptions thrown elsewhere:
```
cr> SELECT match(txt, 'abc') AS alias
    FROM t1
    ORDER BY 1 DESC;
UnsupportedFeatureException[Function FunctionName{schema='null', name='match'}(object, text, text, object) is not a scalar function.]
=> not thrown from `SemanticSortValidator`
```

In an attempt to fix above, I thought maybe we could change the the default behaviour of `SymbolVisitor.visitAlias` to visit the inner symbol and simplify SymbolVisitor implementations.

## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
