### PR TITLE
Do not index array lengths for object arrays within object arrays

### DIFF
--- a/server/src/main/java/io/crate/expression/predicate/IsNullPredicate.java
+++ b/server/src/main/java/io/crate/expression/predicate/IsNullPredicate.java
@@ -21,6 +21,7 @@
 
 package io.crate.expression.predicate;
 
+import static io.crate.execution.dml.ArrayIndexer.ARRAY_LENGTH_FIELD_SUPPORTED_VERSION;
 import static io.crate.lucene.LuceneQueryBuilder.genericFunctionFilter;
 import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
 
@@ -35,7 +36,6 @@ import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
-import org.elasticsearch.Version;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.jetbrains.annotations.Nullable;
 
@@ -124,7 +124,7 @@ public class IsNullPredicate<T> extends Scalar<Boolean, T> {
         DataType<?> valueType = ref.valueType();
         boolean canUseFieldsExist = ref.hasDocValues() || ref.indexType() == IndexType.FULLTEXT;
         if (valueType instanceof ArrayType<?>) {
-            if (context.tableInfo().versionCreated().onOrAfter(Version.V_5_9_0)) {
+            if (context.tableInfo().versionCreated().onOrAfter(ARRAY_LENGTH_FIELD_SUPPORTED_VERSION)) {
                 // Array columns in tables on and after 5.9 indexes _array_length_ fields. For null rows, nothing is indexed
                 // such that FieldExistsQuery can be used.
                 return ArrayIndexer.arrayLengthExistsQuery(ref, context.tableInfo()::getReference);

--- a/server/src/main/java/io/crate/expression/scalar/ArrayUpperFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayUpperFunction.java
@@ -21,6 +21,7 @@
 
 package io.crate.expression.scalar;
 
+import static io.crate.execution.dml.ArrayIndexer.ARRAY_LENGTH_FIELD_SUPPORTED_VERSION;
 import static io.crate.expression.scalar.array.ArrayArgumentValidators.ensureInnerTypeIsNotUndefined;
 import static io.crate.lucene.LuceneQueryBuilder.genericFunctionFilter;
 import static io.crate.metadata.functions.TypeVariableConstraint.typeVariable;
@@ -32,7 +33,6 @@ import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
-import org.elasticsearch.Version;
 import org.jetbrains.annotations.Nullable;
 
 import io.crate.data.Input;
@@ -179,7 +179,7 @@ public class ArrayUpperFunction extends Scalar<Integer, Object> {
         int cmpVal = cmpNumber.intValue();
         // If the array col is from a table created on or after 5.9, we can utilize '_array_length_' indexes,
         // see ArrayIndexer for details
-        if (context.tableInfo().versionCreated().onOrAfter(Version.V_5_9_0)) {
+        if (context.tableInfo().versionCreated().onOrAfter(ARRAY_LENGTH_FIELD_SUPPORTED_VERSION)) {
             return toQueryUsingArrayLengthIndex(parentName, arrayRef, cmpVal, context.tableInfo()::getReference);
         }
 

--- a/server/src/test/java/io/crate/lucene/NestedArrayLuceneQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/NestedArrayLuceneQueryBuilderTest.java
@@ -179,4 +179,67 @@ public class NestedArrayLuceneQueryBuilderTest extends LuceneQueryBuilderTest {
             assertThat(tester.runQuery("o", "array_length(o['a'], 2) = 4")).isEmpty();
         }
     }
+
+    @Test
+    public void test_length_of_arrays_within_object_arrays() throws Exception {
+        QueryTester.Builder builder = new QueryTester.Builder(
+            THREAD_POOL,
+            clusterService,
+            Version.CURRENT,
+            "create table tbl (o_array array(object as (xs int[], o_array_2 array(object as (xs2 int[])))))"
+        );
+        var o_array = List.of(
+            Map.of(
+                "xs", // length = 2
+                List.of(1, 2),
+                "o_array_2", // length = 4
+                List.of(
+                    Map.of(
+                        "xs2", // length = 5
+                        List.of(1, 2, 3, 4, 5)),
+                    Map.of("xs2", List.of(1, 2, 3, 4, 5)),
+                    Map.of("xs2", List.of(1, 2, 3, 4, 5)),
+                    Map.of("xs2", List.of(1, 2, 3, 4, 5))
+                )
+            )
+        );
+        builder.indexValue("o_array", o_array);
+        try (QueryTester tester = builder.build()) {
+            assertThat(tester.runQuery("o_array", "array_length(o_array, 1) = 1")).containsExactly(o_array);
+            assertThat(tester.runQuery("o_array", "array_length(o_array, 1) != 1")).isEmpty();
+
+            assertThat(tester.runQuery("o_array", "array_length(o_array['xs'], 1) = 1")).containsExactly(o_array);
+            assertThat(tester.runQuery("o_array", "array_length(o_array['xs'], 1) != 1")).isEmpty();
+
+            assertThat(tester.runQuery("o_array", "array_length(o_array['xs'][1], 1) = 2")).containsExactly(o_array);
+            assertThat(tester.runQuery("o_array", "array_length(o_array['xs'][1], 1) != 2")).isEmpty();
+
+            assertThat(tester.runQuery("o_array", "array_length(o_array['o_array_2'], 1) = 1")).containsExactly(o_array);
+            assertThat(tester.runQuery("o_array", "array_length(o_array['o_array_2'], 1) != 1")).isEmpty();
+
+            assertThat(tester.runQuery("o_array", "array_length(o_array['o_array_2'][1], 1) = 4")).containsExactly(o_array);
+            assertThat(tester.runQuery("o_array", "array_length(o_array['o_array_2'][1], 1) != 4")).isEmpty();
+
+            assertThat(tester.runQuery("o_array", "array_length(o_array['o_array_2']['xs2'], 1) = 1")).containsExactly(o_array);
+            assertThat(tester.runQuery("o_array", "array_length(o_array['o_array_2']['xs2'], 1) != 1")).isEmpty();
+
+            assertThat(tester.runQuery("o_array", "array_length(o_array['o_array_2']['xs2'][1], 1) = 4")).containsExactly(o_array);
+            assertThat(tester.runQuery("o_array", "array_length(o_array['o_array_2']['xs2'][1], 1) != 4")).isEmpty();
+
+            assertThat(tester.runQuery("o_array", "array_length(o_array['o_array_2']['xs2'][1][1], 1) = 5")).containsExactly(o_array);
+            assertThat(tester.runQuery("o_array", "array_length(o_array['o_array_2']['xs2'][1][1], 1) != 5")).isEmpty();
+
+            // array lengths of the children of the root level array are equal to the array length of the root level array
+            assertThat(tester.toQuery("array_length(o_array, 1) = 1").toString()).isEqualTo("_array_length_o_array:[1 TO 1]");
+            assertThat(tester.toQuery("array_length(o_array['xs'], 1) = 1").toString()).isEqualTo("_array_length_o_array:[1 TO 1]");
+            assertThat(tester.toQuery("array_length(o_array['o_array_2'], 1) = 1").toString()).isEqualTo("_array_length_o_array:[1 TO 1]");
+            assertThat(tester.toQuery("array_length(o_array['o_array_2']['xs2'], 1) = 1").toString()).isEqualTo("_array_length_o_array:[1 TO 1]");
+
+            // array length fields are not indexed for arrays within arrays, utilize generic function queries
+            assertThat(tester.toQuery("array_length(o_array['xs'][1], 1) = 2").toString()).isEqualTo("(array_length(o_array[1]['xs'], 1) = 2)");
+            assertThat(tester.toQuery("array_length(o_array['o_array_2'][1], 1) = 4").toString()).isEqualTo("(array_length(o_array[1]['o_array_2'], 1) = 4)");
+            assertThat(tester.toQuery("array_length(o_array['o_array_2']['xs2'][1], 1) = 4").toString()).isEqualTo("(array_length(o_array[1]['o_array_2']['xs2'], 1) = 4)");
+            assertThat(tester.toQuery("array_length(o_array['o_array_2']['xs2'][1][1], 1) = 5").toString()).isEqualTo("(array_length(o_array[1]['o_array_2']['xs2'][1], 1) = 5)");
+        }
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The array length fields of an array that is also a child of another array are not necessary since CrateDB currently do not utilize them. This PR is to remove the unused fields; it does not fix any functional issues.

Follows https://github.com/crate/crate/pull/16688

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
