### PR TITLE
Normalize geometry collection geo shapes provided as object literals

### DIFF
--- a/docs/appendices/release-notes/5.9.4.rst
+++ b/docs/appendices/release-notes/5.9.4.rst
@@ -47,4 +47,18 @@ See the :ref:`version_5.9.0` release notes for a full list of changes in the
 Fixes
 =====
 
-None
+- Fixed an issue that caused incorrect result when comparing values of type
+  ``geo_shape`` defined as object literals and one being a geometry collection
+  and another ``MultiPolygon`` or ``MultiPoint``. Example of the query
+  that used to return ``false`` instead of ``true``::
+
+      SELECT
+       {
+         type='MultiPoint',
+         coordinates=[[10, 40], [40, 30]]
+       }::GEO_SHAPE
+        =
+       {
+         type='GeometryCollection',
+         geometries=[{type='Point', coordinates=[10, 40]}, {type='Point', coordinates=[40, 30]}]
+       }::GEO_SHAPE;

--- a/docs/general/builtins/comparison-operators.rst
+++ b/docs/general/builtins/comparison-operators.rst
@@ -80,6 +80,18 @@ This means that the order of vertices may be different in topologically equal ge
     +------+
     SELECT 1 row in set (... sec)
 
+Geometry collections, containing only linestrings, points or polygons are
+normalized to MultiLineString, MultiPoint and MultiPolygon. Hence, geometry
+collection of points is equal to a MultiPoint with the same points set::
+
+    cr> select 'MULTIPOINT ((10 40), (40 30), (20 20))'::GEO_SHAPE = 'GEOMETRYCOLLECTION (POINT (10 40), POINT(40 30), POINT(20 20))'::GEO_SHAPE;
+    +------+
+    | true |
+    +------+
+    | TRUE |
+    +------+
+    SELECT 1 row in set (... sec)
+
 .. TIP::
 
     Comparison operators are commonly used to filter rows (e.g., in the

--- a/server/src/main/java/io/crate/types/GeoShapeType.java
+++ b/server/src/main/java/io/crate/types/GeoShapeType.java
@@ -114,7 +114,6 @@ public class GeoShapeType extends DataType<Map<String, Object>> implements Strea
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public Map<String, Object> implicitCast(Object value) throws IllegalArgumentException, ClassCastException {
         if (value == null) {
             return null;
@@ -125,8 +124,7 @@ public class GeoShapeType extends DataType<Map<String, Object>> implements Strea
         } else if (value instanceof Shape shape) {
             return GeoJSONUtils.shape2Map(shape);
         } else if (value instanceof Map<?, ?> map) {
-            GeoJSONUtils.validateGeoJson(map);
-            return (Map<String, Object>) value;
+            return GeoJSONUtils.sanitizeMap(map);
         } else {
             throw new ClassCastException("Can't cast '" + value + "' to " + getName());
         }
@@ -138,8 +136,7 @@ public class GeoShapeType extends DataType<Map<String, Object>> implements Strea
         if (value == null) {
             return null;
         } else if (value instanceof Map<?, ?> map) {
-            GeoJSONUtils.validateGeoJson(map);
-            return (Map<String, Object>) value;
+            return GeoJSONUtils.sanitizeMap(map);
         } else {
             return GeoJSONUtils.shape2Map((Shape) value);
         }

--- a/server/src/test/java/io/crate/types/GeoShapeTypeTest.java
+++ b/server/src/test/java/io/crate/types/GeoShapeTypeTest.java
@@ -171,7 +171,7 @@ public class GeoShapeTypeTest extends DataTypeTestCase<Map<String, Object>> {
     public void test_sanitize_value_geo_shape_objects() {
         for (Shape shape : GeoJSONUtilsTest.SHAPES) {
             Map<String, Object> map = type.sanitizeValue(shape);
-            GeoJSONUtils.validateGeoJson(map);
+            GeoJSONUtils.sanitizeMap(map);
         }
     }
 
@@ -331,6 +331,36 @@ public class GeoShapeTypeTest extends DataTypeTestCase<Map<String, Object>> {
             """);
         assertThat(type.compare(shape1, shape2)).isEqualTo(1);
         assertThat(type.compare(shape2, shape1)).isEqualTo(1);
+    }
+
+    @Test
+    public void test_geometry_collection_equal_to_corresponding_multi_part() throws Exception {
+        Map<String, Object> collection = parse(
+            """
+            {
+                "type": "GeometryCollection",
+                "geometries": [
+                    {
+                        "type": "Point",
+                        "coordinates": [1.0, 1.0]
+                    },
+                    {
+                        "type": "Point",
+                        "coordinates": [2.0, 2.0]
+                    }
+                ]
+            }
+            """
+        );
+        Map<String, Object> multiPoint = parse("""
+            {
+                "type": "MultiPoint",
+                "coordinates": [[1.0, 1.0], [2.0, 2.0]]
+            }
+            """
+        );
+        assertThat(type.implicitCast(collection)).isEqualTo(type.implicitCast(multiPoint));
+        assertThat(type.sanitizeValue(collection)).isEqualTo(type.sanitizeValue(multiPoint));
     }
 }
 


### PR DESCRIPTION
Transform geometry collection to `MultiPoint` or `MultiPoligon` if possible. This aligns it with WKT string behavior

Relates to https://github.com/crate/crate/pull/16761#discussion_r1806034489