### PR TITLE
Infer analyzer from IndexReference in DocTableInfo

### DIFF
--- a/server/src/main/java/io/crate/fdw/ForeignTable.java
+++ b/server/src/main/java/io/crate/fdw/ForeignTable.java
@@ -115,7 +115,6 @@ public record ForeignTable(RelationName name,
                     case "references":
                         references = new HashMap<>();
                         Map<ColumnIdent, IndexReference.Builder> indexColumns = new HashMap<>();
-                        Map<ColumnIdent, String> analyzers = new HashMap<>();
 
                         Map<String, Object> properties = parser.map();
                         DocTableInfoFactory.parseColumns(
@@ -128,7 +127,6 @@ public record ForeignTable(RelationName name,
                             List.of(),
                             properties,
                             indexColumns,
-                            analyzers,
                             references
                         );
                         break;

--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfoFactory.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfoFactory.java
@@ -135,7 +135,6 @@ public class DocTableInfoFactory {
         Map<String, Object> properties = Maps.getOrDefault(mappingSource, "properties", Map.of());
         Map<ColumnIdent, Reference> references = new HashMap<>();
         Map<ColumnIdent, IndexReference.Builder> indexColumns = new HashMap<>();
-        Map<ColumnIdent, String> analyzers = new HashMap<>();
 
         parseColumns(
             expressionAnalyzer,
@@ -147,7 +146,6 @@ public class DocTableInfoFactory {
             partitionedBy,
             properties,
             indexColumns,
-            analyzers,
             references
         );
         var refExpressionAnalyzer = new ExpressionAnalyzer(
@@ -185,7 +183,6 @@ public class DocTableInfoFactory {
             references,
             indexColumns.entrySet().stream()
                 .collect(Collectors.toMap(Entry::getKey, e -> e.getValue().build(references))),
-            analyzers,
             Maps.get(metaMap, "pk_constraint_name"),
             primaryKeys,
             checkConstraints,
@@ -262,7 +259,6 @@ public class DocTableInfoFactory {
         Map<String, Object> properties = Maps.getOrDefault(mappingSource, "properties", Map.of());
         Map<ColumnIdent, Reference> references = new HashMap<>();
         Map<ColumnIdent, IndexReference.Builder> indexColumns = new HashMap<>();
-        Map<ColumnIdent, String> analyzers = new HashMap<>();
 
         parseColumns(
             expressionAnalyzer,
@@ -274,7 +270,6 @@ public class DocTableInfoFactory {
             partitionedBy,
             properties,
             indexColumns,
-            analyzers,
             references
         );
         var refExpressionAnalyzer = new ExpressionAnalyzer(
@@ -313,7 +308,6 @@ public class DocTableInfoFactory {
             references,
             indexColumns.entrySet().stream()
                 .collect(Collectors.toMap(Entry::getKey, e -> e.getValue().build(references))),
-            analyzers,
             Maps.get(metaMap, "pk_constraint_name"),
             primaryKeys,
             checkConstraints,
@@ -375,7 +369,6 @@ public class DocTableInfoFactory {
                                     List<ColumnIdent> partitionedBy,
                                     Map<String, Object> properties,
                                     Map<ColumnIdent, IndexReference.Builder> indexColumns,
-                                    Map<ColumnIdent, String> analyzers,
                                     Map<ColumnIdent, Reference> references) {
         CoordinatorTxnCtx txnCtx = CoordinatorTxnCtx.systemTransactionContext();
         for (Entry<String,Object> entry : properties.entrySet()) {
@@ -387,10 +380,6 @@ public class DocTableInfoFactory {
             columnProperties = innerProperties(columnProperties);
 
             String analyzer = (String) columnProperties.get("analyzer");
-            if (analyzer != null) {
-                analyzers.put(column, analyzer);
-            }
-
             String defaultExpressionString = Maps.get(columnProperties, "default_expr");
             Symbol defaultExpression = null;
             if (defaultExpressionString != null) {
@@ -473,7 +462,6 @@ public class DocTableInfoFactory {
                         partitionedBy,
                         nestedProperties,
                         indexColumns,
-                        analyzers,
                         references
                     );
                 }

--- a/server/src/test/java/io/crate/metadata/doc/DocSchemaInfoTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocSchemaInfoTest.java
@@ -179,7 +179,6 @@ public class DocSchemaInfoTest extends CrateDummyClusterServiceUnitTest {
             new RelationName(Schemas.DOC_SCHEMA_NAME, name),
             Map.of(),
             Map.of(),
-            Map.of(),
             null,
             List.of(),
             List.of(),

--- a/server/src/test/java/io/crate/metadata/doc/DocTableInfoTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocTableInfoTest.java
@@ -23,6 +23,7 @@ package io.crate.metadata.doc;
 
 import static io.crate.testing.Asserts.assertThat;
 import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
 
@@ -90,7 +91,6 @@ public class DocTableInfoTest extends CrateDummyClusterServiceUnitTest {
                 )
             ),
             Map.of(),
-            Map.of(),
             null,
             List.of(),
             List.of(),
@@ -155,7 +155,6 @@ public class DocTableInfoTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo info = new DocTableInfo(
             dummy,
             references,
-            Map.of(),
             Map.of(),
             null,
             List.of(),
@@ -287,7 +286,6 @@ public class DocTableInfoTest extends CrateDummyClusterServiceUnitTest {
                             null
                     )
                 ),
-                Map.of(),
                 Map.of(),
                 null,
                 List.of(),

--- a/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
+++ b/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
@@ -386,7 +386,6 @@ public abstract class AggregationTestCase extends ESTestCase {
             new RelationName("doc", shard.shardId().getIndexName()),
             targetColumns.stream().collect(Collectors.toMap(Reference::column, r -> r)),
             Map.of(),
-            Map.of(),
             null,
             List.of(),
             List.of(),

--- a/server/src/testFixtures/java/org/elasticsearch/index/engine/TranslogHandler.java
+++ b/server/src/testFixtures/java/org/elasticsearch/index/engine/TranslogHandler.java
@@ -73,7 +73,6 @@ public class TranslogHandler implements Engine.TranslogRecoveryRunner {
             relation,
             Map.of(ColumnIdent.of("value"), column),
             Map.of(),
-            Map.of(),
             null,
             List.of(),
             List.of(),


### PR DESCRIPTION
We maintained a separate `analyzers` map despite the information already
being present in the `references`.

Relates to:

- https://github.com/crate/crate/issues/11939
- https://github.com/crate/crate/pull/16964

There the cluster state will have references stored.
