### PR TITLE
Mark primary key reference as not null in TableElementsAnalyzer

### DIFF
--- a/server/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
@@ -790,6 +790,7 @@ public class TableElementsAnalyzer implements FieldProvider<Reference> {
         }
         column.pkConstraintName = pkConstraintName;
         column.primaryKey = true;
+        column.nullable = false;
         ColumnIdent columnName = column.name;
         DataType<?> type = column.type;
         if (type instanceof ArrayType) {

--- a/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -215,8 +215,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
 
         Map<String, List<String>> constraints = (Map<String, List<String>>) metaMapping.get("constraints");
         List<String> notNullColumns = constraints != null ? constraints.get("not_null") : List.of();
-        assertThat(notNullColumns).hasSize(1);
-        assertThat(notNullColumns.get(0)).isEqualTo("name");
+        assertThat(notNullColumns).containsExactly("name");
     }
 
     @Test


### PR DESCRIPTION
Primary keys are implicitly not nullable.
Currently the table elements analyzer created `Reference` instances
where `nullable()` was true for primary keys and this was later fixed
due to the mapping write/parse logic.

With https://github.com/crate/crate/pull/16964 references will be stored
as-is, so they must be correct in the first place.
