### PR TITLE
Improve error messages for aliased match predicates in select stmts

### DIFF
--- a/server/src/main/java/io/crate/analyze/validator/SelectSymbolValidator.java
+++ b/server/src/main/java/io/crate/analyze/validator/SelectSymbolValidator.java
@@ -24,6 +24,7 @@ package io.crate.analyze.validator;
 import java.util.Collection;
 import java.util.Locale;
 
+import io.crate.expression.symbol.AliasSymbol;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.MatchPredicate;
 import io.crate.expression.symbol.Symbol;
@@ -66,6 +67,11 @@ public class SelectSymbolValidator {
         @Override
         public Void visitSymbol(Symbol symbol, Void context) {
             return null;
+        }
+
+        @Override
+        public Void visitAlias(AliasSymbol aliasSymbol, Void context) {
+            return aliasSymbol.symbol().accept(this, context);
         }
     }
 }

--- a/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -597,4 +597,11 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
             x -> assertThat(x).isLiteral(List.of("hello"))
         );
     }
+
+    @Test
+    public void test_aliased_match_predicate_in_select_throws() {
+        assertThatThrownBy(() -> executor.analyze("select match(a, 'foo') as alias from t1"))
+            .isExactlyInstanceOf(UnsupportedOperationException.class)
+            .hasMessageStartingWith("match predicate cannot be selected");
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
`SelectSymbolValidator` could not catch `MatchPredicate` that is aliased and did not throw expected exceptions. However, this is not a bug since exceptions were thrown elsewhere.

```
-- before fix
cr> select match(txt, 'abc') as alias from t1;
UnsupportedFeatureException[Function FunctionName{schema='null', name='match'}(object, text, text, object) is not a scalar function.]
-- after fix
cr> select match(txt, 'abc') as alias from t1;
UnsupportedFeatureException[match predicate cannot be selected]
```

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
