### PR TITLE
Change CreatePartitionsRequest to use PartitionName instead of index names

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/indexing/BulkShardCreationLimiter.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/BulkShardCreationLimiter.java
@@ -21,10 +21,10 @@
 
 package io.crate.execution.engine.indexing;
 
+import java.util.function.Predicate;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
-import java.util.function.Predicate;
 
 public class BulkShardCreationLimiter implements Predicate<ShardedRequests<?, ?>> {
 
@@ -45,8 +45,8 @@ public class BulkShardCreationLimiter implements Predicate<ShardedRequests<?, ?>
 
     @Override
     public boolean test(ShardedRequests<?, ?> requests) {
-        if (requests.itemsByMissingIndex.isEmpty() == false) {
-            int numberOfShardForAllIndices = numberOfAllShards * requests.itemsByMissingIndex.size();
+        if (requests.itemsByMissingPartition.isEmpty() == false) {
+            int numberOfShardForAllIndices = numberOfAllShards * requests.itemsByMissingPartition.size();
             int numberOfShardsPerNode = numberOfShardForAllIndices / numDataNodes;
             if (numberOfShardsPerNode >= MAX_NEW_SHARDS_PER_NODE) {
                 if (LOGGER.isDebugEnabled()) {

--- a/server/src/main/java/io/crate/execution/engine/indexing/ShardingUpsertExecutor.java
+++ b/server/src/main/java/io/crate/execution/engine/indexing/ShardingUpsertExecutor.java
@@ -161,13 +161,13 @@ public class ShardingUpsertExecutor
         collectFailingSourceUris(requests, upsertResults);
         collectFailingItems(requests, upsertResults);
 
-        if (requests.itemsByMissingIndex.isEmpty()) {
+        if (requests.itemsByMissingPartition.isEmpty()) {
             return execRequests(requests, upsertResults);
         }
         createPartitionsRequestOngoing = true;
         return elasticsearchClient.execute(
             CreatePartitionsAction.INSTANCE,
-            new CreatePartitionsRequest(requests.itemsByMissingIndex.keySet()))
+            CreatePartitionsRequest.of(requests.itemsByMissingPartition.keySet()))
             .thenCompose(resp -> {
                 grouper.reResolveShardLocations(requests);
                 createPartitionsRequestOngoing = false;

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreatePartitionsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreatePartitionsRequest.java
@@ -21,62 +21,121 @@
 
 package org.elasticsearch.action.admin.indices.create;
 
-import org.elasticsearch.Version;
-import org.elasticsearch.action.support.master.AcknowledgedRequest;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import org.elasticsearch.Version;
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import io.crate.common.collections.Lists;
+import io.crate.metadata.PartitionName;
+import io.crate.metadata.RelationName;
+
 public class CreatePartitionsRequest extends AcknowledgedRequest<CreatePartitionsRequest> {
 
-    private final Collection<String> indices;
+    private final RelationName relationName;
+    private final List<List<String>> partitionValuesList;
 
     /**
-     * Constructs a new request to create indices with the specified names.
-     */
-    public CreatePartitionsRequest(Collection<String> indices) {
-        this.indices = indices;
+     * @param partitions partitions to create. Limited to one unique relation
+     **/
+    public static CreatePartitionsRequest of(Collection<PartitionName> partitions) {
+        List<RelationName> relations = partitions.stream()
+            .map(PartitionName::relationName)
+            .distinct()
+            .toList();
+        return switch (relations.size()) {
+            case 0 -> throw new IllegalArgumentException("Must create at least one partition");
+            case 1 -> new CreatePartitionsRequest(relations.get(0), Lists.map(partitions, PartitionName::values));
+            default -> throw new IllegalArgumentException("Cannot create partitions for more than one table in the same request");
+        };
     }
 
-    public Collection<String> indices() {
-        return indices;
+    public CreatePartitionsRequest(RelationName relationName, List<List<String>> partitionValuesList) {
+        this.relationName = relationName;
+        this.partitionValuesList = partitionValuesList;
+    }
+
+    public RelationName relationName() {
+        return relationName;
+    }
+
+    public List<List<String>> partitionValuesList() {
+        return partitionValuesList;
+    }
+
+    /**
+     * @return index names created from {@link #relationName()} and {@link #partitionValuesList()}
+     **/
+    public List<String> indexNames() {
+        return Lists.map(partitionValuesList, values -> new PartitionName(relationName, values).asIndexName());
     }
 
     public CreatePartitionsRequest(StreamInput in) throws IOException {
         super(in);
-        if (in.getVersion().before(Version.V_5_3_0)) {
-            // The only usage of jobId was removed in https://github.com/crate/crate/commit/31e0f7f447eaa006e756c20bd32346b2680ebee6
-            // Nodes < 5.3.0 still send UUID which is written as 2 longs, we consume them but don't create an UUID out of them.
-            in.readLong();
-            in.readLong();
+        if (in.getVersion().onOrAfter(Version.V_5_10_0)) {
+            this.relationName = new RelationName(in);
+            int numPartitions = in.readVInt();
+            this.partitionValuesList = new ArrayList<>(numPartitions);
+            for (int i = 0; i < numPartitions; i++) {
+                int numValues = in.readVInt();
+                List<String> partitionValues = new ArrayList<>(numValues);
+                for (int j = 0; j < numValues; j++) {
+                    partitionValues.add(in.readOptionalString());
+                }
+                this.partitionValuesList.add(partitionValues);
+            }
+        } else {
+            if (in.getVersion().before(Version.V_5_3_0)) {
+                // The only usage of jobId was removed in https://github.com/crate/crate/commit/31e0f7f447eaa006e756c20bd32346b2680ebee6
+                // Nodes < 5.3.0 still send UUID which is written as 2 longs, we consume them but don't create an UUID out of them.
+                in.readLong();
+                in.readLong();
+            }
+            int numIndices = in.readVInt();
+            this.partitionValuesList = new ArrayList<>(numIndices);
+            RelationName relation = null;
+            for (int i = 0; i < numIndices; i++) {
+                PartitionName partitionName = PartitionName.fromIndexOrTemplate(in.readString());
+                if (relation == null) {
+                    relation = partitionName.relationName();
+                }
+                partitionValuesList.add(partitionName.values());
+            }
+            this.relationName = relation;
         }
-        int numIndices = in.readVInt();
-        List<String> indicesList = new ArrayList<>(numIndices);
-        for (int i = 0; i < numIndices; i++) {
-            indicesList.add(in.readString());
-        }
-        this.indices = indicesList;
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        if (out.getVersion().before(Version.V_5_3_0)) {
-            // Nodes < 5.3.0 still expect 2 longs.
-            // They are used to construct an UUID but last time they were actually used in CrateDB 0.55.0.
-            // Hence, sending dummy values.
-            out.writeLong(0L);
-            out.writeLong(0L);
-        }
+        if (out.getVersion().onOrAfter(Version.V_5_10_0)) {
+            relationName.writeTo(out);
+            out.writeVInt(partitionValuesList.size());
+            for (List<String> partitionValues : partitionValuesList) {
+                out.writeVInt(partitionValues.size());
+                for (String value : partitionValues) {
+                    out.writeOptionalString(value);
+                }
+            }
+        } else {
+            if (out.getVersion().before(Version.V_5_3_0)) {
+                // Nodes < 5.3.0 still expect 2 longs.
+                // They are used to construct an UUID but last time they were actually used in CrateDB 0.55.0.
+                // Hence, sending dummy values.
+                out.writeLong(0L);
+                out.writeLong(0L);
+            }
 
-        out.writeVInt(indices.size());
-        for (String index : indices) {
-            out.writeString(index);
+            out.writeVInt(partitionValuesList.size());
+            for (List<String> partitionValues : partitionValuesList) {
+                String indexName = new PartitionName(relationName, partitionValues).asIndexName();
+                out.writeString(indexName);
+            }
         }
     }
-
 }

--- a/server/src/test/java/io/crate/execution/engine/indexing/BulkShardCreationLimiterTest.java
+++ b/server/src/test/java/io/crate/execution/engine/indexing/BulkShardCreationLimiterTest.java
@@ -23,6 +23,7 @@ package io.crate.execution.engine.indexing;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.elasticsearch.test.ESTestCase;
@@ -31,6 +32,8 @@ import org.junit.Test;
 
 import io.crate.data.breaker.RamAccounting;
 import io.crate.execution.dml.delete.ShardDeleteRequest;
+import io.crate.metadata.PartitionName;
+import io.crate.metadata.RelationName;
 
 public class BulkShardCreationLimiterTest extends ESTestCase {
 
@@ -38,12 +41,18 @@ public class BulkShardCreationLimiterTest extends ESTestCase {
 
     @Before
     public void setup() {
+        RelationName relationName = new RelationName("doc", "tbl");
         UUID jobId = UUID.randomUUID();
         shardedRequests = new ShardedRequests<>(
             shardId -> new ShardDeleteRequest(shardId, jobId),
             RamAccounting.NO_ACCOUNTING
         );
-        shardedRequests.add(new ShardDeleteRequest.Item("id1"), "dummy", null, RowSourceInfo.EMPTY_INSTANCE);
+        shardedRequests.add(
+            new ShardDeleteRequest.Item("id1"),
+            new PartitionName(relationName, List.of("1")).asIndexName(),
+            null,
+            RowSourceInfo.EMPTY_INSTANCE
+        );
     }
 
     @Test

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/create/CreatePartitionsRequestTest.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/create/CreatePartitionsRequestTest.java
@@ -23,29 +23,25 @@ package org.elasticsearch.action.admin.indices.create;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Arrays;
+import java.util.List;
 
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.junit.Test;
+
+import io.crate.metadata.RelationName;
 
 
 public class CreatePartitionsRequestTest {
 
     @Test
     public void testSerialization() throws Exception {
-        CreatePartitionsRequest request = new CreatePartitionsRequest(Arrays.asList("a", "b", "c"));
+        RelationName tbl = new RelationName("doc", "tbl");
+        CreatePartitionsRequest request = new CreatePartitionsRequest(tbl, List.of(List.of("1"), List.of("2")));
         BytesStreamOutput out = new BytesStreamOutput();
         request.writeTo(out);
         CreatePartitionsRequest requestDeserialized = new CreatePartitionsRequest(out.bytes().streamInput());
 
-        assertThat(requestDeserialized.indices()).containsExactly("a", "b", "c");
-
-        request = new CreatePartitionsRequest(Arrays.asList("a", "b", "c"));
-        out = new BytesStreamOutput();
-        request.writeTo(out);
-        requestDeserialized = new CreatePartitionsRequest(out.bytes().streamInput());
-
-        assertThat(requestDeserialized.indices()).containsExactly("a", "b", "c");
+        assertThat(requestDeserialized.partitionValuesList()).containsExactly(List.of("1"), List.of("2"));
+        assertThat(requestDeserialized.relationName()).isEqualTo(tbl);
     }
-
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitionsActionTest.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitionsActionTest.java
@@ -22,24 +22,20 @@
 package org.elasticsearch.action.admin.indices.create;
 
 import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
-import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.Metadata;
-import org.elasticsearch.common.Strings;
-import org.elasticsearch.indices.InvalidIndexNameException;
 import org.elasticsearch.test.IntegTestCase;
 import org.junit.Before;
 import org.junit.Test;
 
 import com.carrotsearch.hppc.cursors.ObjectCursor;
 
-import io.crate.exceptions.SQLExceptions;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
 import io.crate.testing.UseRandomizedSchema;
@@ -140,26 +136,7 @@ public class TransportCreatePartitionsActionTest extends IntegTestCase {
 
     @Test
     public void testEmpty() throws Exception {
-        AcknowledgedResponse response = action.execute(
-            new CreatePartitionsRequest(List.of())).get();
-        assertThat(response.isAcknowledged()).isTrue();
-    }
-
-    @Test
-    public void testCreateInvalidName() {
-        CreatePartitionsRequest createPartitionsRequest = new CreatePartitionsRequest(Arrays.asList("valid", "invalid/#haha"));
-        assertThatThrownBy(
-            () -> {
-                try {
-                    action.execute(createPartitionsRequest).get();
-                } catch (Exception e) {
-                    throw SQLExceptions.unwrap(e);
-                }
-            })
-            .isExactlyInstanceOf(InvalidIndexNameException.class)
-            .hasMessage("Invalid index name [invalid/#haha], must not contain the following characters " + Strings.INVALID_FILENAME_CHARS);
-
-        // if one name is invalid no index is created
-        assertThat(cluster().clusterService().state().metadata().hasIndex("valid")).isFalse();
+        assertThatThrownBy(() -> CreatePartitionsRequest.of(List.of()))
+            .hasMessage("Must create at least one partition");
     }
 }


### PR DESCRIPTION
As part of https://github.com/crate/crate/issues/11939 we might make the
following changes:

- Indices no longer have a name, but UUID only. To allow for rename and
  swap operations that don't change `IndexMetadata` and don't require
  closing and re-opening of indices.
- Indices are linked to relations via a `indexUUIDs` property on
  `RelationMetadata`. Template, aliases and complex indexNameExpression
  resolve logic would be gone.

But that would imply that we can no longer encode partition values into
index names. Instead we'd have partition values as concrete properties
on `IndexMetdata` (or elsewhere, still TDB)

To prepare for moving into that direction, this changes the
`CreatePartitionsRequest` to use a list of `PartitionName` instead of a
list of index names.
