### PR TITLE
Documentation: Fix link to HyperLogLog++ paper

### DIFF
--- a/docs/general/builtins/aggregation.rst
+++ b/docs/general/builtins/aggregation.rst
@@ -973,7 +973,7 @@ Limitations
 
 .. _Aggregate function: https://en.wikipedia.org/wiki/Aggregate_function
 .. _Geometric Mean: https://en.wikipedia.org/wiki/Geometric_mean
-.. _HyperLogLog++: https://research.google.com/pubs/pub40671.html
+.. _HyperLogLog++: https://research.google.com/pubs/archive/40671.pdf
 .. _Percentile: https://en.wikipedia.org/wiki/Percentile
 .. _Standard Deviation: https://en.wikipedia.org/wiki/Standard_deviation
 .. _TDigest: https://github.com/tdunning/t-digest/blob/master/docs/t-digest-paper/histo.pdf

--- a/extensions/functions/src/main/java/io/crate/execution/engine/aggregation/impl/HyperLogLogPlusPlus.java
+++ b/extensions/functions/src/main/java/io/crate/execution/engine/aggregation/impl/HyperLogLogPlusPlus.java
@@ -35,7 +35,7 @@ import java.util.function.IntFunction;
 
 /**
  * Hyperloglog++ counter, implemented based on pseudo code from
- * http://static.googleusercontent.com/media/research.google.com/fr//pubs/archive/40671.pdf
+ * https://research.google.com/pubs/archive/40671.pdf
  * and its appendix
  * https://docs.google.com/document/d/1gyjfMHy43U9OWBXxfaeG-3MjGzejW1dlpyMwEYAAWEI/view?fullscreen
  *


### PR DESCRIPTION
## About
Fix broken link.

## Problem
> /home/runner/work/crate/crate/docs/general/builtins/aggregation.rst:397:
> WARNING: broken link: https://research.google.com/pubs/pub40671.html
> (404 Client Error: Not Found for url: https://ai.google/research/pubs/pub40671/)
