### PR TITLE
Add examples for `memory_limit` and `statement_timeout` to docs

### DIFF
--- a/blackbox/test_docs.py
+++ b/blackbox/test_docs.py
@@ -498,6 +498,8 @@ def load_tests(loader, suite, ignore):
         tests.append(docsuite(fn, setUp=setUpLocationsAndQuotes))
 
     for fn in doctest_files(
+            'config/cluster.rst',
+            'config/session.rst',
             'general/occ.rst',
             'sql/statements/refresh.rst',
             'sql/statements/create-table.rst',

--- a/docs/config/cluster.rst
+++ b/docs/config/cluster.rst
@@ -1075,6 +1075,14 @@ Default value for the :ref:`memory.operation_limit
 session setting <conf-session-memory-operation-limit>`. Changing the cluster
 setting will only affect new sessions, not existing sessions.
 
+Example statement to update the default value to 1 GB, i.e. 1073741824 bytes::
+
+    cr> SET GLOBAL "memory.operation_limit" = 1073741824;
+
+Operations that hit this memory limit will trigger a ``CircuitBreakingException``
+that can be handled in the application to inform the user about too much memory
+consumption for the particular query.
+
 Query circuit breaker
 ---------------------
 

--- a/docs/config/cluster.rst
+++ b/docs/config/cluster.rst
@@ -106,6 +106,7 @@ Collecting stats
   execute::
 
     cr> SET GLOBAL "stats.jobs_log_filter" = $$ended - started > '5 minutes'::interval$$;
+    SET OK, 1 row affected (... sec)
 
 .. _stats.jobs_log_persistent_filter:
 
@@ -1078,6 +1079,7 @@ setting will only affect new sessions, not existing sessions.
 Example statement to update the default value to 1 GB, i.e. 1073741824 bytes::
 
     cr> SET GLOBAL "memory.operation_limit" = 1073741824;
+    SET OK, 1 row affected (... sec)
 
 Operations that hit this memory limit will trigger a ``CircuitBreakingException``
 that can be handled in the application to inform the user about too much memory
@@ -1483,6 +1485,14 @@ Chunk size to transfer files during the initial recovery of a replicating table.
 
 Controls the number of file chunk requests that can be sent in parallel between
 clusters during the recovery.
+
+.. hide:
+
+   cr> RESET GLOBAL "stats.jobs_log_filter"
+   RESET OK, 1 row affected (... sec)
+
+   cr> RESET GLOBAL "memory.operation_limit"
+   RESET OK, 1 row affected (... sec)
 
 .. _bootstrap checks: https://crate.io/docs/crate/howtos/en/latest/admin/bootstrap-checks.html
 .. _multi-zone setup how-to guide: https://crate.io/docs/crate/howtos/en/latest/clustering/multi-zone-setup.html

--- a/docs/config/session.rst
+++ b/docs/config/session.rst
@@ -40,6 +40,10 @@ Besides using ``SHOW``, it is also possible to use the :ref:`current_setting
     All the active settings for a session can also be retrieved from the
     :ref:`sys.sessions <sys-sessions>` table.
 
+.. NOTE::
+    Default values for session settings can set per role using :ref:`ALTER ROLE
+    <ref-alter-role>`.
+
 Supported session settings
 ==========================
 
@@ -88,12 +92,21 @@ Supported session settings
   | *Default:* ``'0'``
   | *Modifiable:* ``yes``
 
-  The maximum duration of any statement before it gets cancelled. If ``0`` (the
-  default), queries are allowed to run infinitely and don't get cancelled
-  automatically.
+  The maximum duration of any statement in milliseconds before it gets
+  cancelled. If ``0`` (the default), queries are allowed to run infinitely and
+  don't get cancelled automatically.
 
   The value is an ``INTERVAL`` with a maximum of ``2147483647`` milliseconds.
   That's roughly 24 days.
+
+  Example statement to update the default value to 50 seconds, i.e. 50,000ms:
+
+  .. code-block:: sql
+
+    SET GLOBAL PERSISTENT statement_timeout = '50000ms';
+
+  After executing the statement, every **new** database session will apply the
+  limit.
 
 .. _conf-session-memory-operation-limit:
 
@@ -113,6 +126,16 @@ operation. You can use the :ref:`sys.operations <sys-operations>` view to get
 some insights, but keep in mind that both, operations which are used to execute
 a query, and their name could change with any release, including hotfix
 releases.
+
+Example statement to update the default value to 1GB, i.e. 1073741824 bytes:
+
+.. code-block:: sql
+
+  SET GLOBAL PERSISTENT 'memory.operation_limit' = '1073741824';
+
+Operations that hit this memory limit will trigger a CircuitBreakerException
+that can be handled in the application to inform the user about too much memory
+consumption for the particular query.
 
 .. _conf-session-enable-hashjoin:
 

--- a/docs/config/session.rst
+++ b/docs/config/session.rst
@@ -20,7 +20,8 @@ example:
 
 .. code-block:: sql
 
-  SET search_path TO myschema, doc;
+  cr> SET search_path TO myschema, doc;
+  SET OK, 0 rows affected (... sec)
 
 Alternatively, session settings can be modified permanently from their default
 values for a user, with the use of :ref:`ALTER ROLE <ref-alter-role>`.
@@ -103,7 +104,8 @@ Supported session settings
 
   .. code-block:: sql
 
-    SET GLOBAL PERSISTENT statement_timeout = '50000ms';
+    cr> SET LOCAL statement_timeout = '50000ms';
+    SET OK, 0 rows affected (... sec)
 
   After executing the statement, every **new** database session will apply the
   limit.
@@ -131,7 +133,8 @@ Example statement to update the default value to 1GB, i.e. 1073741824 bytes:
 
 .. code-block:: sql
 
-  SET GLOBAL PERSISTENT 'memory.operation_limit' = '1073741824';
+  cr> SET LOCAL "memory.operation_limit" = '1073741824';
+  SET OK, 0 rows affected (... sec)
 
 Operations that hit this memory limit will trigger a CircuitBreakerException
 that can be handled in the application to inform the user about too much memory
@@ -263,5 +266,16 @@ consumption for the particular query.
   Experimental session settings might be removed in the future even in minor
   feature releases.
 
+
+.. hide:
+
+  cr> SET "memory.operation_limit" TO DEFAULT;
+  SET OK, 0 rows affected (... sec)
+
+  cr> SET "statement_timeout" TO DEFAULT;
+  SET OK, 0 rows affected (... sec)
+
+  cr> SET search_path TO DEFAULT;
+  SET OK, 0 rows affected (... sec)
 
 .. _search_path: https://www.postgresql.org/docs/10/static/ddl-schemas.html#DDL-SCHEMAS-PATH


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

- Examples for easier setting of the parameters with default values.

## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
