### PR TITLE
Fix broken HLL publication paper link

### DIFF
--- a/docs/general/builtins/aggregation.rst
+++ b/docs/general/builtins/aggregation.rst
@@ -973,7 +973,7 @@ Limitations
 
 .. _Aggregate function: https://en.wikipedia.org/wiki/Aggregate_function
 .. _Geometric Mean: https://en.wikipedia.org/wiki/Geometric_mean
-.. _HyperLogLog++: https://research.google.com/pubs/archive/40671.pdf
+.. _HyperLogLog++: http://static.googleusercontent.com/media/research.google.com/en//pubs/archive/40671.pdf
 .. _Percentile: https://en.wikipedia.org/wiki/Percentile
 .. _Standard Deviation: https://en.wikipedia.org/wiki/Standard_deviation
 .. _TDigest: https://github.com/tdunning/t-digest/blob/master/docs/t-digest-paper/histo.pdf


### PR DESCRIPTION
The existing link isn't valid anymore:
```
 /home/runner/work/crate/crate/docs/general/builtins/aggregation.rst:397: WARNING: broken link: https://research.google.com/pubs/pub40671.html (404 Client Error: Not Found for url: https://ai.google/research/pubs/pub40671/)
```

Google move it to a protected area at https://research.google/pubs/hyperloglog-in-practice-algorithmic-engineering-of-a-state-of-the-art-cardinality-estimation-algorithm/ but I found the static link which still works.
