### PR TITLE
Use partition created version to determine storage formats

### DIFF
--- a/benchmarks/src/main/java/io/crate/execution/dml/IndexerBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/execution/dml/IndexerBenchmark.java
@@ -98,6 +98,7 @@ public class IndexerBenchmark {
         indexer = new Indexer(
             table.concreteIndices(Metadata.EMPTY_METADATA)[0],
             table,
+            table.versionCreated(),
             new CoordinatorTxnCtx(session.sessionSettings()),
             injector.getInstance(NodeContext.class),
             List.of(

--- a/extensions/functions/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregation.java
+++ b/extensions/functions/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregation.java
@@ -166,11 +166,14 @@ public class HyperLogLogDistinctAggregation extends AggregationFunction<HyperLog
         return null;
     }
 
+
+
     @Nullable
     @Override
     public DocValueAggregator<?> getDocValueAggregator(LuceneReferenceResolver referenceResolver,
                                                        List<Reference> aggregationReferences,
                                                        DocTableInfo table,
+                                                       Version shardCreatedVersion,
                                                        List<Literal<?>> optionalParams) {
         if (aggregationReferences.stream().anyMatch(x -> x != null && !x.hasDocValues())) {
             return null;

--- a/server/src/main/java/io/crate/execution/dml/Indexer.java
+++ b/server/src/main/java/io/crate/execution/dml/Indexer.java
@@ -391,6 +391,7 @@ public class Indexer {
     @SuppressWarnings("unchecked")
     public Indexer(String indexName,
                    DocTableInfo table,
+                   Version shardVersionCreated,
                    TransactionContext txnCtx,
                    NodeContext nodeCtx,
                    List<Reference> targetColumns,
@@ -530,7 +531,7 @@ public class Indexer {
             }
         }
         this.expressions = ctxForRefs.expressions();
-        this.tableVersionCreated = table.versionCreated();
+        this.tableVersionCreated = shardVersionCreated;
     }
 
     /**

--- a/server/src/main/java/io/crate/execution/dml/RawIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/RawIndexer.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.jetbrains.annotations.NotNull;
@@ -51,6 +52,7 @@ public class RawIndexer {
     private final TransactionContext txnCtx;
     private final NodeContext nodeCtx;
     private final Symbol[] returnValues;
+    private final Version shardVersionCreated;
 
     private final Map<Set<String>, Indexer> indexers = new HashMap<>();
     private final List<Reference> nonDeterministicSynthetics;
@@ -61,6 +63,7 @@ public class RawIndexer {
 
     public RawIndexer(String indexName,
                       DocTableInfo table,
+                      Version shardVersionCreated,
                       TransactionContext txnCtx,
                       NodeContext nodeCtx,
                       Symbol[] returnValues,
@@ -71,6 +74,7 @@ public class RawIndexer {
         this.nodeCtx = nodeCtx;
         this.returnValues = returnValues;
         this.nonDeterministicSynthetics = nonDeterministicSynthetics;
+        this.shardVersionCreated = shardVersionCreated;
     }
 
     /**
@@ -98,6 +102,7 @@ public class RawIndexer {
             return new Indexer(
                 indexName,
                 table,
+                shardVersionCreated,
                 txnCtx,
                 nodeCtx,
                 targetRefs,

--- a/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
@@ -150,6 +150,7 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
         Indexer indexer = new Indexer(
             indexName,
             tableInfo,
+            indexShard.getVersionCreated(),
             txnCtx,
             nodeCtx,
             insertColumns,
@@ -161,6 +162,7 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
             updatingIndexer = new Indexer(
                 request.index(),
                 tableInfo,
+                indexShard.getVersionCreated(),
                 txnCtx,
                 nodeCtx,
                 updateToInsert.columns(),
@@ -192,6 +194,7 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
             rawIndexer = new RawIndexer(
                 indexName,
                 tableInfo,
+                indexShard.getVersionCreated(),
                 txnCtx,
                 nodeCtx,
                 request.returnValues(),
@@ -311,6 +314,7 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
             rawIndexer = new RawIndexer(
                 indexName,
                 tableInfo,
+                indexShard.getVersionCreated(),
                 txnCtx,
                 nodeCtx,
                 null,
@@ -321,6 +325,7 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
             indexer = new Indexer(
                 indexName,
                 tableInfo,
+                indexShard.getVersionCreated(),
                 txnCtx,
                 nodeCtx,
                 targetColumns,

--- a/server/src/main/java/io/crate/execution/engine/aggregation/AggregationFunction.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/AggregationFunction.java
@@ -132,6 +132,7 @@ public abstract class AggregationFunction<TPartial, TFinal> implements FunctionI
     public DocValueAggregator<?> getDocValueAggregator(LuceneReferenceResolver referenceResolver,
                                                        List<Reference> aggregationReferences,
                                                        DocTableInfo table,
+                                                       Version shardCreatedVersion,
                                                        List<Literal<?>> optionalParams) {
         return null;
     }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregation.java
@@ -159,6 +159,7 @@ public class ArbitraryAggregation extends AggregationFunction<Object, Object> {
     public DocValueAggregator<?> getDocValueAggregator(LuceneReferenceResolver referenceResolver,
                                                        List<Reference> aggregationReferences,
                                                        DocTableInfo table,
+                                                       Version shardCreatedVersion,
                                                        List<Literal<?>> optionalParams) {
         Reference arg = aggregationReferences.get(0);
         if (arg == null) {

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/CmpByAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/CmpByAggregation.java
@@ -155,6 +155,7 @@ public final class CmpByAggregation extends AggregationFunction<CmpByAggregation
     public DocValueAggregator<?> getDocValueAggregator(LuceneReferenceResolver referenceResolver,
                                                        List<Reference> aggregationReferences,
                                                        DocTableInfo table,
+                                                       Version shardCreatedVersion,
                                                        List<Literal<?>> optionalParams) {
         Reference returnField = aggregationReferences.getFirst();
         Reference searchField = aggregationReferences.getLast();
@@ -182,14 +183,14 @@ public final class CmpByAggregation extends AggregationFunction<CmpByAggregation
                         searchField.storageIdent(),
                         searchType,
                         resultExpression,
-                        new CollectorContext(() -> StoredRowLookup.create(table, referenceResolver.getIndexName()))
+                        new CollectorContext(() -> StoredRowLookup.create(shardCreatedVersion, table, referenceResolver.getIndexName()))
                     );
                 } else {
                     return new MaxByLong(
                         searchField.storageIdent(),
                         searchType,
                         resultExpression,
-                        new CollectorContext(() -> StoredRowLookup.create(table, referenceResolver.getIndexName()))
+                        new CollectorContext(() -> StoredRowLookup.create(shardCreatedVersion, table, referenceResolver.getIndexName()))
                     );
                 }
             default:

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/CountAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/CountAggregation.java
@@ -299,6 +299,7 @@ public class CountAggregation extends AggregationFunction<MutableLong, Long> {
     public DocValueAggregator<?> getDocValueAggregator(LuceneReferenceResolver referenceResolver,
                                                        List<Reference> aggregationReferences,
                                                        DocTableInfo table,
+                                                       Version shardCreatedVersion,
                                                        List<Literal<?>> optionalParams) {
         if (aggregationReferences.size() != 1) {
             return null;

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregation.java
@@ -306,6 +306,7 @@ public class GeometricMeanAggregation extends AggregationFunction<GeometricMeanA
     public DocValueAggregator<?> getDocValueAggregator(LuceneReferenceResolver referenceResolver,
                                                        List<Reference> aggregationReferences,
                                                        DocTableInfo table,
+                                                       Version shardCreatedVersion,
                                                        List<Literal<?>> optionalParams) {
         Reference reference = aggregationReferences.get(0);
         if (reference == null) {

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/MaximumAggregation.java
@@ -220,6 +220,7 @@ public abstract class MaximumAggregation extends AggregationFunction<Object, Obj
         public DocValueAggregator<?> getDocValueAggregator(LuceneReferenceResolver referenceResolver,
                                                            List<Reference> aggregationReferences,
                                                            DocTableInfo table,
+                                                           Version shardCreatedVersion,
                                                            List<Literal<?>> optionalParams) {
             Reference reference = aggregationReferences.get(0);
 

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/MinimumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/MinimumAggregation.java
@@ -254,6 +254,7 @@ public abstract class MinimumAggregation extends AggregationFunction<Object, Obj
         public DocValueAggregator<?> getDocValueAggregator(LuceneReferenceResolver referenceResolver,
                                                            List<Reference> aggregationReferences,
                                                            DocTableInfo table,
+                                                           Version shardCreatedVersion,
                                                            List<Literal<?>> optionalParams) {
             Reference reference = aggregationReferences.get(0);
             if (reference == null) {

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/NumericSumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/NumericSumAggregation.java
@@ -181,6 +181,7 @@ public class NumericSumAggregation extends AggregationFunction<BigDecimal, BigDe
     public DocValueAggregator<?> getDocValueAggregator(LuceneReferenceResolver referenceResolver,
                                                        List<Reference> aggregationReferences,
                                                        DocTableInfo table,
+                                                       Version shardCreatedVersion,
                                                        List<Literal<?>> optionalParams) {
         Reference reference = aggregationReferences.get(0);
         if (reference == null) {

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationAggregation.java
@@ -228,6 +228,7 @@ public class StandardDeviationAggregation extends AggregationFunction<StandardDe
     public DocValueAggregator<?> getDocValueAggregator(LuceneReferenceResolver referenceResolver,
                                                        List<Reference> aggregationReferences,
                                                        DocTableInfo table,
+                                                       Version shardCreatedVersion,
                                                        List<Literal<?>> optionalParams) {
         Reference reference = aggregationReferences.get(0);
         if (reference == null) {

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/SumAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/SumAggregation.java
@@ -194,6 +194,7 @@ public class SumAggregation<T extends Number> extends AggregationFunction<T, T> 
     public DocValueAggregator<?> getDocValueAggregator(LuceneReferenceResolver referenceResolver,
                                                        List<Reference> aggregationReferences,
                                                        DocTableInfo table,
+                                                       Version shardCreatedVersion,
                                                        List<Literal<?>> optionalParams) {
         Reference reference = aggregationReferences.get(0);
 

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/TopKAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/TopKAggregation.java
@@ -220,6 +220,7 @@ public class TopKAggregation extends AggregationFunction<TopKAggregation.State, 
     public DocValueAggregator<?> getDocValueAggregator(LuceneReferenceResolver referenceResolver,
                                                        List<Reference> aggregationReferences,
                                                        DocTableInfo table,
+                                                       Version shardCreatedVersion,
                                                        List<Literal<?>> optionalParams) {
         if (aggregationReferences.isEmpty()) {
             return null;

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
@@ -228,6 +228,7 @@ public class VarianceAggregation extends AggregationFunction<Variance, Double> {
     public DocValueAggregator<?> getDocValueAggregator(LuceneReferenceResolver referenceResolver,
                                                        List<Reference> aggregationReferences,
                                                        DocTableInfo table,
+                                                       Version shardCreatedVersion,
                                                        List<Literal<?>> optionalParams) {
         Reference reference = aggregationReferences.get(0);
         if (reference == null) {

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/AverageAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/AverageAggregation.java
@@ -310,6 +310,7 @@ public class AverageAggregation extends AggregationFunction<AverageAggregation.A
     public DocValueAggregator<?> getDocValueAggregator(LuceneReferenceResolver referenceResolver,
                                                        List<Reference> aggregationReferences,
                                                        DocTableInfo table,
+                                                       Version shardCreatedVersion,
                                                        List<Literal<?>> optionalParams) {
         Reference reference = aggregationReferences.get(0);
         if (reference == null) {

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/numeric/NumericAverageAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/average/numeric/NumericAverageAggregation.java
@@ -196,6 +196,7 @@ public class NumericAverageAggregation extends AggregationFunction<NumericAverag
     public DocValueAggregator<?> getDocValueAggregator(LuceneReferenceResolver referenceResolver,
                                                        List<Reference> aggregationReferences,
                                                        DocTableInfo table,
+                                                       Version shardCreatedVersion,
                                                        List<Literal<?>> optionalParams) {
         Reference reference = aggregationReferences.get(0);
         if (reference == null) {

--- a/server/src/main/java/io/crate/execution/engine/collect/DocValuesAggregates.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/DocValuesAggregates.java
@@ -93,7 +93,8 @@ public final class DocValuesAggregates {
             referenceResolver,
             aggregateProjection.aggregations(),
             phase.toCollect(),
-            table
+            table,
+            indexShard.getVersionCreated()
         );
         if (aggregators == null) {
             return null;
@@ -109,6 +110,7 @@ public final class DocValuesAggregates {
             indexShard.shardId().getIndexName(),
             indexService.indexAnalyzers(),
             table,
+            indexShard.getVersionCreated(),
             indexService.cache()
         );
 
@@ -141,7 +143,8 @@ public final class DocValuesAggregates {
                                                              LuceneReferenceResolver referenceResolver,
                                                              List<Aggregation> aggregations,
                                                              List<Symbol> toCollect,
-                                                             DocTableInfo table) {
+                                                             DocTableInfo table,
+                                                             Version shardVersionCreated) {
         ArrayList<DocValueAggregator> aggregator = new ArrayList<>(aggregations.size());
         for (int i = 0; i < aggregations.size(); i++) {
             Aggregation aggregation = aggregations.get(i);
@@ -180,6 +183,7 @@ public final class DocValuesAggregates {
                 referenceResolver,
                 aggregationReferences,
                 table,
+                shardVersionCreated,
                 literals
             );
             if (docValueAggregator == null) {

--- a/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIterator.java
@@ -118,12 +118,15 @@ final class DocValuesGroupByOptimizedIterator {
             }
         }
 
+        Version shardCreatedVersion = indexShard.getVersionCreated();
+
         List<DocValueAggregator> aggregators = DocValuesAggregates.createAggregators(
             functions,
             referenceResolver,
             groupProjection.values(),
             collectPhase.toCollect(),
-            table
+            table,
+            shardCreatedVersion
         );
         if (aggregators == null) {
             return null;
@@ -148,6 +151,7 @@ final class DocValuesGroupByOptimizedIterator {
             indexName,
             indexService.indexAnalyzers(),
             table,
+            shardCreatedVersion,
             indexService.cache()
         );
 
@@ -161,7 +165,7 @@ final class DocValuesGroupByOptimizedIterator {
                 collectTask.memoryManager(),
                 collectTask.minNodeVersion(),
                 queryContext.query(),
-                new CollectorContext(sharedShardContext.readerId(), () -> StoredRowLookup.create(table, indexName))
+                new CollectorContext(sharedShardContext.readerId(), () -> StoredRowLookup.create(shardCreatedVersion, table, indexName))
             );
         } else {
             return GroupByIterator.forManyKeys(
@@ -173,7 +177,7 @@ final class DocValuesGroupByOptimizedIterator {
                 collectTask.memoryManager(),
                 collectTask.minNodeVersion(),
                 queryContext.query(),
-                new CollectorContext(sharedShardContext.readerId(), () -> StoredRowLookup.create(table, indexName))
+                new CollectorContext(sharedShardContext.readerId(), () -> StoredRowLookup.create(shardCreatedVersion, table, indexName))
             );
         }
     }

--- a/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
@@ -163,8 +163,9 @@ final class GroupByOptimizedIterator {
         RamAccounting ramAccounting = collectTask.getRamAccounting();
 
         String indexName = indexShard.shardId().getIndexName();
+        Version shardCreatedVersion = indexShard.getVersionCreated();
         CollectorContext collectorContext
-            = new CollectorContext(sharedShardContext.readerId(), () -> StoredRowLookup.create(table, indexName));
+            = new CollectorContext(sharedShardContext.readerId(), () -> StoredRowLookup.create(shardCreatedVersion, table, indexName));
         InputRow inputRow = new InputRow(docCtx.topLevelInputs());
 
         LuceneQueryBuilder.Context queryContext = luceneQueryBuilder.convert(
@@ -173,6 +174,7 @@ final class GroupByOptimizedIterator {
             indexName,
             indexService.indexAnalyzers(),
             table,
+            shardCreatedVersion,
             indexService.cache()
         );
 

--- a/server/src/main/java/io/crate/execution/engine/collect/PKLookupOperation.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/PKLookupOperation.java
@@ -99,7 +99,7 @@ public final class PKLookupOperation {
             if (docIdAndVersion == null) {
                 return null;
             }
-            StoredRowLookup storedRowLookup = StoredRowLookup.create(table, shard.shardId().getIndexName(), columns, getResult.fromTranslog());
+            StoredRowLookup storedRowLookup = StoredRowLookup.create(shard.getVersionCreated(), table, shard.shardId().getIndexName(), columns, getResult.fromTranslog());
             try {
                 StoredRow storedRow
                     = storedRowLookup.getStoredRow(new ReaderContext(docIdAndVersion.reader.getContext()), docIdAndVersion.docId);

--- a/server/src/main/java/io/crate/execution/engine/collect/count/CountOperation.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/count/CountOperation.java
@@ -156,6 +156,7 @@ public class CountOperation {
                 indexName,
                 indexService.indexAnalyzers(),
                 table,
+                indexShard.getVersionCreated(),
                 indexService.cache()
             );
             if (Thread.interrupted()) {

--- a/server/src/main/java/io/crate/execution/engine/fetch/FetchCollector.java
+++ b/server/src/main/java/io/crate/execution/engine/fetch/FetchCollector.java
@@ -28,6 +28,7 @@ import java.util.List;
 import org.apache.lucene.codecs.StoredFieldsReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.ReaderUtil;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.lucene.index.SequentialStoredFieldsLeafReader;
 
 import com.carrotsearch.hppc.IntArrayList;
@@ -63,7 +64,8 @@ class FetchCollector {
         this.ramAccounting = ramAccounting;
         this.readerId = readerId;
         var table = fetchTask.table(readerId);
-        CollectorContext collectorContext = new CollectorContext(readerId, () -> StoredRowLookup.create(table, indexName));
+        Version shardCreatedVersion = fetchTask.indexShard(readerId).getVersionCreated();
+        CollectorContext collectorContext = new CollectorContext(readerId, () -> StoredRowLookup.create(shardCreatedVersion, table, indexName));
         for (LuceneCollectorExpression<?> collectorExpression : this.collectorExpressions) {
             collectorExpression.startCollect(collectorContext);
         }

--- a/server/src/main/java/io/crate/execution/engine/fetch/FetchTask.java
+++ b/server/src/main/java/io/crate/execution/engine/fetch/FetchTask.java
@@ -41,6 +41,7 @@ import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.shard.IllegalIndexShardStateException;
+import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
 import org.jetbrains.annotations.NotNull;
 
@@ -181,6 +182,14 @@ public class FetchTask implements Task {
             throw new IllegalArgumentException(String.format(Locale.ENGLISH, "Reader with id %d not found", readerId));
         }
         return sharedShardContext.indexService();
+    }
+
+    public IndexShard indexShard(int readerId) {
+        SharedShardContext sharedShardContext = shardContexts.get(readerId);
+        if (sharedShardContext == null) {
+            throw new IllegalArgumentException(String.format(Locale.ENGLISH, "Reader with id %d not found", readerId));
+        }
+        return sharedShardContext.indexShard();
     }
 
     @Override

--- a/server/src/main/java/io/crate/execution/jobs/SharedShardContext.java
+++ b/server/src/main/java/io/crate/execution/jobs/SharedShardContext.java
@@ -38,6 +38,7 @@ import io.crate.common.collections.RefCountedItem;
 public class SharedShardContext {
 
     private final IndexService indexService;
+    private final IndexShard indexShard;
     private final int readerId;
     private final RefCountedItem<Engine.Searcher> searcher;
 
@@ -46,9 +47,9 @@ public class SharedShardContext {
                        int readerId,
                        BiFunction<ShardId, Engine.Searcher, Engine.Searcher> wrapSearcher) {
         this.indexService = indexService;
-        IndexShard indexShard = indexService.getShard(shardId.id());
+        this.indexShard = indexService.getShard(shardId.id());
         this.readerId = readerId;
-        this.searcher = new RefCountedItem<Engine.Searcher>(
+        this.searcher = new RefCountedItem<>(
             source -> wrapSearcher.apply(shardId, indexShard.acquireSearcher(source)),
             Engine.Searcher::close
         );
@@ -61,6 +62,10 @@ public class SharedShardContext {
 
     public IndexService indexService() {
         return indexService;
+    }
+
+    public IndexShard indexShard() {
+        return indexShard;
     }
 
     public int readerId() {

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/StoredRowLookup.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/StoredRowLookup.java
@@ -67,12 +67,12 @@ public abstract class StoredRowLookup implements StoredRow {
     protected boolean docVisited = false;
     protected Map<String, Object> parsedSource = null;
 
-    public static StoredRowLookup create(DocTableInfo table, String indexName) {
-        return create(table, indexName, List.of(), false);
+    public static StoredRowLookup create(Version shardCreatedVersion, DocTableInfo table, String indexName) {
+        return create(shardCreatedVersion, table, indexName, List.of(), false);
     }
 
-    public static StoredRowLookup create(DocTableInfo table, String indexName, List<Symbol> columns, boolean fromTranslog) {
-        if (table.versionCreated().before(PARTIAL_STORED_SOURCE_VERSION) || fromTranslog) {
+    public static StoredRowLookup create(Version shardCreatedVersion, DocTableInfo table, String indexName, List<Symbol> columns, boolean fromTranslog) {
+        if (shardCreatedVersion.before(PARTIAL_STORED_SOURCE_VERSION) || fromTranslog) {
             return new FullStoredRowLookup(table, indexName, columns);
         }
         return new ColumnAndStoredRowLookup(table, indexName, columns);

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -336,6 +336,10 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         return this.store;
     }
 
+    public Version getVersionCreated() {
+        return this.store.indexSettings().getIndexVersionCreated();
+    }
+
     public boolean isClosed() {
         return this.queryCache == null;
     }

--- a/server/src/test/java/io/crate/execution/dml/IndexerTest.java
+++ b/server/src/test/java/io/crate/execution/dml/IndexerTest.java
@@ -108,6 +108,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         return new Indexer(
             table.ident().indexNameOrAlias(),
             table,
+            table.versionCreated(),
             new CoordinatorTxnCtx(e.getSessionSettings()),
             e.nodeCtx,
             Stream.of(columns)
@@ -151,6 +152,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         Indexer indexer = new Indexer(
             table.ident().indexNameOrAlias(),
             table,
+            Version.CURRENT,
             new CoordinatorTxnCtx(executor.getSessionSettings()),
             executor.nodeCtx,
             List.of(o),
@@ -190,6 +192,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         Indexer indexer = new Indexer(
             table.ident().indexNameOrAlias(),
             table,
+            Version.CURRENT,
             new CoordinatorTxnCtx(executor.getSessionSettings()),
             executor.nodeCtx,
             List.of(o),
@@ -253,6 +256,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         Indexer indexer = new Indexer(
             table.ident().indexNameOrAlias(),
             table,
+            Version.CURRENT,
             new CoordinatorTxnCtx(executor.getSessionSettings()),
             executor.nodeCtx,
             List.of(o),
@@ -295,6 +299,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         var indexer = new Indexer(
             table.ident().indexNameOrAlias(),
             table,
+            Version.CURRENT,
             txnCtx,
             executor.nodeCtx,
             List.of(y),
@@ -310,6 +315,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         indexer = new Indexer(
             table.ident().indexNameOrAlias(),
             table,
+            Version.CURRENT,
             txnCtx,
             executor.nodeCtx,
             List.of(x),
@@ -332,6 +338,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         Indexer indexer = new Indexer(
             table.ident().indexNameOrAlias(),
             table,
+            Version.CURRENT,
             new CoordinatorTxnCtx(executor.getSessionSettings()),
             executor.nodeCtx,
             List.of(x),
@@ -356,6 +363,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         Indexer indexer = new Indexer(
             partition,
             table,
+            Version.CURRENT,
             new CoordinatorTxnCtx(executor.getSessionSettings()),
             executor.nodeCtx,
             List.of(x),
@@ -376,6 +384,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         Indexer indexer = new Indexer(
             table.ident().indexNameOrAlias(),
             table,
+            Version.CURRENT,
             new CoordinatorTxnCtx(executor.getSessionSettings()),
             executor.nodeCtx,
             List.of(o),
@@ -406,6 +415,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         Indexer indexer = new Indexer(
             table.ident().indexNameOrAlias(),
             table,
+            Version.CURRENT,
             new CoordinatorTxnCtx(executor.getSessionSettings()),
             executor.nodeCtx,
             List.of(x),
@@ -433,6 +443,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         Indexer indexer1 = new Indexer(
             table.ident().indexNameOrAlias(),
             table,
+            Version.CURRENT,
             new CoordinatorTxnCtx(executor.getSessionSettings()),
             executor.nodeCtx,
             List.of(x, y),
@@ -444,6 +455,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         Indexer indexer2 = new Indexer(
             table.ident().indexNameOrAlias(),
             table,
+            Version.CURRENT,
             new CoordinatorTxnCtx(executor.getSessionSettings()),
             executor.nodeCtx,
             List.of(x, o),
@@ -461,6 +473,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         Indexer indexer = new Indexer(
             table.ident().indexNameOrAlias(),
             table,
+            Version.CURRENT,
             new CoordinatorTxnCtx(executor.getSessionSettings()),
             executor.nodeCtx,
             List.of(
@@ -491,6 +504,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         Indexer indexer = new Indexer(
             table.ident().indexNameOrAlias(),
             table,
+            Version.CURRENT,
             new CoordinatorTxnCtx(executor.getSessionSettings()),
             executor.nodeCtx,
             List.of(
@@ -522,6 +536,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         Indexer indexer = new Indexer(
             table.ident().indexNameOrAlias(),
             table,
+            Version.CURRENT,
             new CoordinatorTxnCtx(executor.getSessionSettings()),
             executor.nodeCtx,
             List.of(
@@ -547,6 +562,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         Indexer indexer = new Indexer(
             table.ident().indexNameOrAlias(),
             table,
+            Version.CURRENT,
             new CoordinatorTxnCtx(executor.getSessionSettings()),
             executor.nodeCtx,
             List.of(
@@ -571,6 +587,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         Indexer indexer = new Indexer(
             table.ident().indexNameOrAlias(),
             table,
+            Version.CURRENT,
             new CoordinatorTxnCtx(e.getSessionSettings()),
             e.nodeCtx,
             List.of(
@@ -596,6 +613,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         Indexer indexer = new Indexer(
             table.ident().indexNameOrAlias(),
             table,
+            Version.CURRENT,
             new CoordinatorTxnCtx(e.getSessionSettings()),
             e.nodeCtx,
             List.of(
@@ -704,6 +722,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
             Indexer indexer = new Indexer(
                 table.ident().indexNameOrAlias(),
                 table,
+                Version.CURRENT,
                 new CoordinatorTxnCtx(e.getSessionSettings()),
                 e.nodeCtx,
                 Lists.map(columns, c -> table.getReference(c)),
@@ -733,6 +752,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         Indexer indexer = new Indexer(
             table.ident().indexNameOrAlias(),
             table,
+            Version.CURRENT,
             new CoordinatorTxnCtx(e.getSessionSettings()),
             e.nodeCtx,
             List.of(
@@ -776,6 +796,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
             new Indexer(
                 table.ident().indexNameOrAlias(),
                 table,
+                Version.CURRENT,
                 new CoordinatorTxnCtx(e.getSessionSettings()),
                 e.nodeCtx,
                 List.<Reference>of(
@@ -1051,6 +1072,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         indexer = new Indexer(
             newTable.ident().indexNameOrAlias(),
             newTable,
+            Version.CURRENT,
             new CoordinatorTxnCtx(e.getSessionSettings()),
             e.nodeCtx,
             List.of("x", "o", "y").stream()
@@ -1144,6 +1166,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         Indexer indexer = new Indexer(
             table.ident().indexNameOrAlias(),
             table,
+            Version.CURRENT,
             new CoordinatorTxnCtx(executor.getSessionSettings()),
             executor.nodeCtx,
             List.of(x, y),
@@ -1179,6 +1202,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         Indexer indexer = new Indexer(
             partition,
             table,
+            Version.CURRENT,
             new CoordinatorTxnCtx(executor.getSessionSettings()),
             executor.nodeCtx,
             List.of(
@@ -1211,6 +1235,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         Indexer indexer = new Indexer(
             table.ident().indexNameOrAlias(),
             table,
+            Version.CURRENT,
             new CoordinatorTxnCtx(executor.getSessionSettings()),
             executor.nodeCtx,
             List.of(x),

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/CountAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/CountAggregationTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 import java.util.Map;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.junit.Test;
@@ -84,6 +85,7 @@ public class CountAggregationTest extends AggregationTestCase {
             mock(LuceneReferenceResolver.class),
             aggregationReferences,
             sourceTable,
+            Version.CURRENT,
             List.of()
         );
         if (expectedAggregatorClass == null) {

--- a/server/src/test/java/io/crate/execution/engine/collect/DocValuesAggregatesTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/DocValuesAggregatesTest.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import org.elasticsearch.Version;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -86,7 +87,8 @@ public class DocValuesAggregatesTest extends CrateDummyClusterServiceUnitTest {
             mock(LuceneReferenceResolver.class),
             List.of(longSumAggregation()),
             List.of(e.asSymbol("tbl.x")),
-            table
+            table,
+            Version.CURRENT
         );
         assertThat(aggregators)
             .satisfiesExactly(a -> assertThat(a).isExactlyInstanceOf((SumAggregation.SumLong.class)));
@@ -99,7 +101,8 @@ public class DocValuesAggregatesTest extends CrateDummyClusterServiceUnitTest {
             mock(LuceneReferenceResolver.class),
             List.of(longSumAggregation()),
             List.of(e.asSymbol("tbl.x::real")),
-            table
+            table,
+            Version.CURRENT
         );
         assertThat(aggregators).isNull();
 
@@ -108,7 +111,8 @@ public class DocValuesAggregatesTest extends CrateDummyClusterServiceUnitTest {
             mock(LuceneReferenceResolver.class),
             List.of(longSumAggregation()),
             List.of(e.asSymbol("tbl.x::numeric")),
-            table
+            table,
+            Version.CURRENT
         );
         assertThat(aggregators)
             .satisfiesExactly(a -> assertThat(a).isExactlyInstanceOf((SumAggregation.SumLong.class)));
@@ -129,7 +133,8 @@ public class DocValuesAggregatesTest extends CrateDummyClusterServiceUnitTest {
                     List.of(Literal.of(1L)))
             ),
             Collections.emptyList(),
-            table
+            table,
+            Version.CURRENT
         );
         assertThat(aggregators).isNull();
     }
@@ -141,7 +146,8 @@ public class DocValuesAggregatesTest extends CrateDummyClusterServiceUnitTest {
             mock(LuceneReferenceResolver.class),
             List.of(longSumAggregation()),
             List.of(Literal.of(1)),
-            table
+            table,
+            Version.CURRENT
         );
         assertThat(aggregators).isNull();
     }
@@ -154,7 +160,8 @@ public class DocValuesAggregatesTest extends CrateDummyClusterServiceUnitTest {
             mock(LuceneReferenceResolver.class),
             List.of(longSumAggregation()),
             List.of(xRef),
-            table
+            table,
+            Version.CURRENT
         );
         assertThat(aggregators).isNotNull();
 
@@ -175,7 +182,8 @@ public class DocValuesAggregatesTest extends CrateDummyClusterServiceUnitTest {
                 xRef.isDropped(),
                 xRef.defaultExpression())
             ),
-            table
+            table,
+            Version.CURRENT
         );
         assertThat(aggregators).isNull();
     }
@@ -190,7 +198,8 @@ public class DocValuesAggregatesTest extends CrateDummyClusterServiceUnitTest {
                     longSumAggregation(2)
             ),
             List.of(e.asSymbol("tbl.Payload_subInt"), e.asSymbol("tbl.payload_subInt"),e.asSymbol("tbl.x")),
-            table
+            table,
+            Version.CURRENT
         );
         //select count(tbl.Payload_subInt), count(tbl.payload_subInt), sum(tbl.x) from tbl;
         assertThat(actualAggregators)

--- a/server/src/test/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIteratorTest.java
@@ -139,6 +139,7 @@ public class DocValuesGroupByOptimizedIteratorTest extends CrateDummyClusterServ
                 null)
             ),
             mock(DocTableInfo.class),
+            Version.CURRENT,
             List.of()
         );
         var keyExpressions = List.of(new LongColumnReference("y"));
@@ -201,6 +202,7 @@ public class DocValuesGroupByOptimizedIteratorTest extends CrateDummyClusterServ
                 null)
             ),
             mock(DocTableInfo.class),
+            Version.CURRENT,
             List.of()
         );
         var keyExpressions = List.of(new StringColumnReference("x"), new LongColumnReference("y"));

--- a/server/src/test/java/io/crate/expression/predicate/IsNullPredicateTest.java
+++ b/server/src/test/java/io/crate/expression/predicate/IsNullPredicateTest.java
@@ -67,6 +67,7 @@ public class IsNullPredicateTest extends ScalarTestCase {
                 indexEnv.indexService().index().getName(),
                 indexEnv.indexService().indexAnalyzers(),
                 table,
+                Version.CURRENT,
                 indexEnv.queryCache()
             );
             SimpleReference ref = new SimpleReference(
@@ -97,6 +98,7 @@ public class IsNullPredicateTest extends ScalarTestCase {
                 indexEnv.indexService().index().getName(),
                 indexEnv.indexService().indexAnalyzers(),
                 table,
+                Version.CURRENT,
                 indexEnv.queryCache()
             ).query();
             assertThat(query).isExactlyInstanceOf(GenericFunctionQuery.class);

--- a/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
+++ b/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
@@ -253,6 +253,7 @@ public abstract class AggregationTestCase extends ESTestCase {
                     refResolver,
                     targetColumns,
                     mock(DocTableInfo.class),
+                    Version.CURRENT,
                     List.of()
                 );
                 if (docValueAggregator != null) {
@@ -404,6 +405,7 @@ public abstract class AggregationTestCase extends ESTestCase {
         Indexer indexer = new Indexer(
             shard.shardId().getIndexName(),
             table,
+            Version.CURRENT,
             CoordinatorTxnCtx.systemTransactionContext(),
             nodeCtx,
             targetColumns,
@@ -608,6 +610,7 @@ public abstract class AggregationTestCase extends ESTestCase {
             mock(LuceneReferenceResolver.class),
             toReference(argumentTypes),
             mock(DocTableInfo.class),
+            Version.CURRENT,
             List.of()
         );
         assertThat(docValueAggregator)

--- a/server/src/testFixtures/java/io/crate/testing/QueryTester.java
+++ b/server/src/testFixtures/java/io/crate/testing/QueryTester.java
@@ -135,6 +135,7 @@ public final class QueryTester implements AutoCloseable {
             Indexer indexer = new Indexer(
                 table.concreteIndices(plannerContext.clusterState().metadata())[0],
                 table,
+                Version.CURRENT,
                 plannerContext.transactionContext(),
                 plannerContext.nodeContext(),
                 List.of(table.getReference(ColumnIdent.fromPath(column))),
@@ -150,6 +151,7 @@ public final class QueryTester implements AutoCloseable {
             Indexer indexer = new Indexer(
                 table.concreteIndices(plannerContext.clusterState().metadata())[0],
                 table,
+                Version.CURRENT,
                 plannerContext.transactionContext(),
                 plannerContext.nodeContext(),
                 Lists.map(columns, c -> table.getReference(ColumnIdent.fromPath(c))),
@@ -178,7 +180,7 @@ public final class QueryTester implements AutoCloseable {
                 query,
                 null,
                 false,
-                new CollectorContext(() -> StoredRowLookup.create(table, indexEnv.luceneReferenceResolver().getIndexName())),
+                new CollectorContext(() -> StoredRowLookup.create(Version.CURRENT, table, indexEnv.luceneReferenceResolver().getIndexName())),
                 Collections.singletonList(input),
                 ctx.expressions()
             );
@@ -209,6 +211,7 @@ public final class QueryTester implements AutoCloseable {
                     indexEnv.indexService().index().getName(),
                     indexEnv.indexService().indexAnalyzers(),
                     table,
+                    Version.CURRENT,
                     indexEnv.queryCache()
                 ).query(),
                 indexEnv

--- a/server/src/testFixtures/java/io/crate/types/DataTypeTestCase.java
+++ b/server/src/testFixtures/java/io/crate/types/DataTypeTestCase.java
@@ -160,7 +160,7 @@ public abstract class DataTypeTestCase<T> extends CrateDummyClusterServiceUnitTe
             );
 
             Scorer scorer = weight.scorer(leafReader);
-            CollectorContext collectorContext = new CollectorContext(1, () -> StoredRowLookup.create(table, "index"));
+            CollectorContext collectorContext = new CollectorContext(1, () -> StoredRowLookup.create(Version.CURRENT, table, "index"));
             ReaderContext readerContext = new ReaderContext(leafReader);
             DocIdSetIterator iterator = scorer.iterator();
             int nextDoc = iterator.nextDoc();


### PR DESCRIPTION
Rather than switching on the table created version, this will allow large partitioned tables originally created by previous versions of Crate to switch to the new smaller disk-footprint storage format after an upgrade as soon as a new partition is opened.