### PR TITLE
sanitizeMap must not compose a geometry collection of a single but non-composable type

### DIFF
--- a/server/src/main/java/io/crate/geo/GeoJSONUtils.java
+++ b/server/src/main/java/io/crate/geo/GeoJSONUtils.java
@@ -290,17 +290,15 @@ public class GeoJSONUtils {
                 }
             });
             Map<String, Object> transformed = new HashMap<>();
-            if (sameType[0] == true) {
-                String targetType = COMPOSABLE_TYPES.get(typeInCollection[0]);
-                if (targetType != null) {
-                    transformed.put(TYPE_FIELD, targetType);
-                    final List<Object> coords = new ArrayList<>();
-                    forEach(geometries, input -> {
-                        Map<String, Object> validatedShape = (Map<String, Object>) input;
-                        coords.add(validatedShape.get(COORDINATES_FIELD));
-                    });
-                    transformed.put(COORDINATES_FIELD, coords);
-                }
+            String targetType = COMPOSABLE_TYPES.get(typeInCollection[0]);
+            if (sameType[0] == true && targetType != null) {
+                transformed.put(TYPE_FIELD, targetType);
+                final List<Object> coords = new ArrayList<>();
+                forEach(geometries, input -> {
+                    Map<String, Object> validatedShape = (Map<String, Object>) input;
+                    coords.add(validatedShape.get(COORDINATES_FIELD));
+                });
+                transformed.put(COORDINATES_FIELD, coords);
             } else {
                 transformed.put(TYPE_FIELD, GEOMETRY_COLLECTION);
                 transformed.put(GEOMETRIES_FIELD, sanitizedGeometries);

--- a/server/src/test/java/io/crate/geo/GeoJSONUtilsTest.java
+++ b/server/src/test/java/io/crate/geo/GeoJSONUtilsTest.java
@@ -329,4 +329,23 @@ public class GeoJSONUtilsTest {
         assertThat(geometries.get(1)).containsEntry(GeoJSONUtils.TYPE_FIELD, "Point");
         assertThat(geometries.get(2)).containsEntry(GeoJSONUtils.TYPE_FIELD, "Point");
     }
+
+    @Test
+    public void test_geometry_collection_of_a_single_part_of_not_compasable_type_not_transformed() throws Exception {
+        String wkt = "MULTILINESTRING ((10.05 10.28, 20.95 20.89), (20.95 20.89, 31.92 21.45))";
+        Map<String, Object> multiLineString = GeoJSONUtils.wkt2Map(wkt);
+
+        Map<String, Object> collection = Map.of(
+            GeoJSONUtils.TYPE_FIELD,
+            GeoJSONUtils.GEOMETRY_COLLECTION,
+            GeoJSONUtils.GEOMETRIES_FIELD,
+            List.of(multiLineString, multiLineString)
+        );
+        Map<String, Object> sanitizedMap = GeoJSONUtils.sanitizeMap(collection);
+        assertThat(sanitizedMap.get(GeoJSONUtils.TYPE_FIELD)).isEqualTo(GeoJSONUtils.GEOMETRY_COLLECTION);
+        List<Map<String, Object>> geometries = Maps.get(sanitizedMap, GeoJSONUtils.GEOMETRIES_FIELD);
+        assertThat(geometries).hasSize(2);
+        assertThat(geometries.get(0)).containsEntry(GeoJSONUtils.TYPE_FIELD, "MultiLineString");
+        assertThat(geometries.get(1)).containsEntry(GeoJSONUtils.TYPE_FIELD, "MultiLineString");
+    }
 }


### PR DESCRIPTION
Fixes regression introduced in https://github.com/crate/crate/commit/92127e65a62fcbf2aad67520712f477fa46e63a0

