### PR TITLE
Remove unrelated release notes entry

### DIFF
--- a/docs/appendices/release-notes/5.10.0.rst
+++ b/docs/appendices/release-notes/5.10.0.rst
@@ -135,8 +135,3 @@ Client interfaces
 - Added an ::ref:`error <http-bulk-errors>` payload to failed bulk responses
   issued over the :ref`interface-http` containing details of the error that
   caused the bulk operation to fail.
-
-User Interface
---------------
-
-- Updated to Admin UI 1.24.9 to fix an issue with rendering the UI.


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

As requested in https://github.com/crate/crate/pull/17021

## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
