### PR TITLE
CorreatedJoin prunning must not add SelectSymbol to the input plan outputs

### DIFF
--- a/docs/appendices/release-notes/5.9.4.rst
+++ b/docs/appendices/release-notes/5.9.4.rst
@@ -47,6 +47,10 @@ See the :ref:`version_5.9.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue leading to an error when running ``ANALYZE`` followed by a
+  correlated subquery with the Subquery being an ``INNER JOIN`` and a table on
+  the right side having more records than a table on the left side.
+
 - Fixed an ``ArrayIndexOutOfBoundsException`` that happened when using ``SET ...
   TO DEFAULT`` with either ``statement_timeout`` or ``operation.memory_limit``.
 

--- a/server/src/main/java/io/crate/planner/operators/CorrelatedJoin.java
+++ b/server/src/main/java/io/crate/planner/operators/CorrelatedJoin.java
@@ -152,6 +152,7 @@ public class CorrelatedJoin implements LogicalPlan {
         selectSymbol.relation().visitSymbols(tree ->
             tree.visit(OuterColumn.class, outerColumn -> toCollect.add(outerColumn.symbol()))
         );
+        toCollect.remove(selectSymbol);
         LogicalPlan newInputPlan = inputPlan.pruneOutputsExcept(toCollect);
 
         if (inputPlan == newInputPlan) {


### PR DESCRIPTION
Fixes https://github.com/crate/crate/issues/17016