### PR TITLE
Add missing PR rule to mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -15,6 +15,11 @@ queue_rules:
     merge_method: rebase
 
 pull_request_rules:
+  - name: default
+    conditions: []
+    actions:
+      queue:
+
   - name: backport 5.9
     actions:
       backport:


### PR DESCRIPTION
Follow up to https://github.com/crate/crate/pull/17019

Without this we'd have to manually add a PR to the queue (See https://docs.mergify.com/merge-queue/setup/#adding-a-pull-request-to-the-merge-queue)
