### PR TITLE
Fix handling of SET .. TO DEFAULT for memory_limit and statement_timeout

### DIFF
--- a/docs/appendices/release-notes/5.9.4.rst
+++ b/docs/appendices/release-notes/5.9.4.rst
@@ -47,6 +47,9 @@ See the :ref:`version_5.9.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an ``ArrayIndexOutOfBoundsException`` that happened when using ``SET ...
+  TO DEFAULT`` with either ``statement_timeout`` or ``operation.memory_limit``.
+
 - Fixed an issue that caused incorrect result when comparing values of type
   ``geo_shape`` defined as object literals and one being a geometry collection
   and another ``MultiPolygon`` or ``MultiPoint``. Example of the query

--- a/server/src/test/java/io/crate/planner/statement/SetSessionPlanTest.java
+++ b/server/src/test/java/io/crate/planner/statement/SetSessionPlanTest.java
@@ -43,6 +43,7 @@ import io.crate.planner.PlannerContext;
 import io.crate.planner.operators.SubQueryResults;
 import io.crate.sql.tree.Assignment;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
 
 public class SetSessionPlanTest extends CrateDummyClusterServiceUnitTest {
 
@@ -70,5 +71,19 @@ public class SetSessionPlanTest extends CrateDummyClusterServiceUnitTest {
         assertThat(consumer.getBucket())
             .as("Must not raise an exception")
             .isEmpty();
+    }
+
+    @Test
+    public void test_can_reset_statement_timeout_and_memory_limit() throws Exception {
+        SQLExecutor e = SQLExecutor.of(clusterService);
+        List<String> statements = List.of(
+            "set \"statement_timeout\" to default",
+            "set \"operation.memory_limit\" to default"
+        );
+        for (String stmt : statements) {
+            SetSessionPlan plan = e.plan(stmt);
+            TestingRowConsumer result = e.execute(plan);
+            assertThat(result.getResult()).isEmpty();
+        }
     }
 }


### PR DESCRIPTION
The statements failed with an `ArrayIndexOutOfBoundsException`

```
cr> set statement_timeout to default;
ArrayIndexOutOfBoundsException[Index 0 out of bounds for length 0]
```

Noticed this while adding doc-tests for https://github.com/crate/crate/pull/17032

