### PR TITLE
Add PG Wire protection against invalid or huge startup messages

### DIFF
--- a/docs/appendices/release-notes/5.9.4.rst
+++ b/docs/appendices/release-notes/5.9.4.rst
@@ -69,3 +69,7 @@ Fixes
          type='GeometryCollection',
          geometries=[{type='Point', coordinates=[10, 40]}, {type='Point', coordinates=[40, 30]}]
        }::GEO_SHAPE;
+
+- Fixed an issue on the :ref:`PostgreSQL wire protocol <interface-postgresql>`
+  that may cause the node to crash with OutOfMemory exceptions when a client
+  sends a invalid (or huge) startup message.

--- a/server/src/main/java/io/crate/protocols/postgres/PGError.java
+++ b/server/src/main/java/io/crate/protocols/postgres/PGError.java
@@ -40,8 +40,20 @@ import io.crate.exceptions.UserDefinedFunctionUnknownException;
 
 public class PGError {
 
-    public static final byte[] SEVERITY_FATAL = "FATAL".getBytes(StandardCharsets.UTF_8);
-    public static final byte[] SEVERITY_ERROR = "ERROR".getBytes(StandardCharsets.UTF_8);
+    public enum Severity {
+        ERROR,
+        FATAL;
+
+        private final byte[] bytes;
+
+        Severity() {
+            bytes = name().getBytes(StandardCharsets.UTF_8);
+        }
+
+        public byte[] bytes() {
+            return bytes;
+        }
+    }
 
     private final PGErrorStatus status;
     private final String message;

--- a/server/src/main/java/io/crate/protocols/postgres/PgDecoder.java
+++ b/server/src/main/java/io/crate/protocols/postgres/PgDecoder.java
@@ -24,6 +24,9 @@ package io.crate.protocols.postgres;
 import java.util.List;
 import java.util.function.Supplier;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
@@ -32,11 +35,23 @@ import io.netty.handler.ssl.SslContext;
 
 public class PgDecoder extends ByteToMessageDecoder {
 
-    static final int CANCEL_CODE = 80877102;
+    private static final Logger LOGGER = LogManager.getLogger(PgDecoder.class);
+
+    static final int CANCEL_REQUEST_CODE = 80877102;
     static final int SSL_REQUEST_CODE = 80877103;
+    // Version 3.0  ((3 << 16) | 0)
+    static final int PROTOCOL_VERSION_REQUEST_CODE = 196608;
 
     static final int MIN_STARTUP_LENGTH = 8;
     static final int MIN_MSG_LENGTH = 5;
+
+    /*
+     * In protocol 3.0 and later, the startup packet length is not fixed, but
+     * we set an arbitrary limit on it anyway.  This is just to prevent simple
+     * denial-of-service attacks via sending enough data to run the server
+     * out of memory.
+     */
+    static final int MAX_STARTUP_LENGTH = 10000;
 
     public enum State {
 
@@ -96,36 +111,68 @@ public class PgDecoder extends ByteToMessageDecoder {
         }
     }
 
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        super.channelRead(ctx, msg);
+    }
+
     private ByteBuf decode(ChannelHandlerContext ctx, ByteBuf in) {
         switch (state) {
             case STARTUP: {
-                if (in.readableBytes() < MIN_STARTUP_LENGTH) {
+                LOGGER.trace("Readable bytes: {}", in.readableBytes());
+                if (in.readableBytes() == 0) {
+                    // No data at all, don't bother with any complaints logged as such cases often occur for legitimate
+                    // reasons. E.g. some monitoring solutions may open and close the connections without sending any data.
+                    Channel channel = ctx.channel();
+                    ByteBuf out = ctx.alloc().buffer(1);
+                    channel.writeAndFlush(out.writeByte('0'));
                     return null;
                 }
 
                 in.markReaderIndex();
-                payloadLength = in.readInt() - 8;
+                payloadLength = in.readInt();
+
+                if (payloadLength < MIN_STARTUP_LENGTH || payloadLength > MAX_STARTUP_LENGTH) {
+                    in.skipBytes(in.readableBytes());
+                    throw new IllegalStateException("invalid length of startup packet");
+                }
+                payloadLength -= 8; // length includes itself and the request code
+
                 int requestCode = in.readInt();
 
-                if (requestCode == SSL_REQUEST_CODE) {
-                    SslContext sslContext = getSslContext.get();
-                    Channel channel = ctx.channel();
-                    ByteBuf out = ctx.alloc().buffer(1);
-                    if (sslContext == null) {
-                        channel.writeAndFlush(out.writeByte('N'));
-                    } else {
-                        channel.writeAndFlush(out.writeByte('S'));
-                        ctx.pipeline().addFirst(sslContext.newHandler(ctx.alloc()));
-                    }
-                    in.markReaderIndex();
-                    return decode(ctx, in);
-                } else {
-                    if (in.readableBytes() < payloadLength) {
-                        in.resetReaderIndex();
-                        return null;
-                    }
-                    state = requestCode == CANCEL_CODE ? State.CANCEL : State.STARTUP_PARAMETERS;
-                    return in.readBytes(payloadLength);
+                LOGGER.trace("Received startup message code={}, length={}", requestCode, payloadLength);
+
+                switch (requestCode) {
+                    case SSL_REQUEST_CODE:
+                        SslContext sslContext = getSslContext.get();
+                        Channel channel = ctx.channel();
+                        ByteBuf out = ctx.alloc().buffer(1);
+                        if (sslContext == null) {
+                            channel.writeAndFlush(out.writeByte('N'));
+                        } else {
+                            channel.writeAndFlush(out.writeByte('S'));
+                            ctx.pipeline().addFirst(sslContext.newHandler(ctx.alloc()));
+                        }
+                        if (in.readableBytes() < MIN_STARTUP_LENGTH) {
+                            // more data needed before we can decode the next message
+                            return null;
+                        }
+                        return decode(ctx, in);
+                    case PROTOCOL_VERSION_REQUEST_CODE,
+                         CANCEL_REQUEST_CODE:
+                        if (in.readableBytes() < payloadLength) {
+                            LOGGER.trace("Readable bytes: {} < payloadLength: {}. Reset buffer", in.readableBytes(), payloadLength);
+                            in.resetReaderIndex();
+                            return null;
+                        }
+                        state = requestCode == CANCEL_REQUEST_CODE ? State.CANCEL : State.STARTUP_PARAMETERS;
+                        return in.readBytes(payloadLength);
+                    default:
+                        // bad message, skip any remaining data
+                        in.skipBytes(in.readableBytes());
+                        int major = requestCode >> 16;
+                        int minor = requestCode & 0xFFFF;
+                        throw new IllegalStateException("Unsupported frontend protocol " + major + "." + minor + ": server supports 3.0 to 3.0");
                 }
             }
 
@@ -150,6 +197,8 @@ public class PgDecoder extends ByteToMessageDecoder {
                 return in.readBytes(payloadLength);
             }
             default:
+                // bad message, skip any remaining data
+                in.skipBytes(in.readableBytes());
                 throw new IllegalStateException("Invalid state " + state);
         }
     }


### PR DESCRIPTION
The maximum payload of a startup message is limited to 10000 bytes, same as PG does. This should be enough for any startup parameters but protects against any DoS by sending huge payloads which may even cause OOM's.

See https://github.com/postgres/postgres/blob/master/src/backend/tcop/backend_startup.c#L468 on how PG handles startup messages.