### PR TITLE
Fix DocTableInfo.isParentRefIgnored for nested objects involving dynamic policy

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
@@ -107,7 +107,7 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
         this.referenceResolver = new LuceneReferenceResolver(
             indexShard.shardId().getIndexName(),
             table.partitionedByColumns(),
-            table.isParentReferenceIgnored()
+            table.isIgnoredReference()
         );
         this.docInputFactory = new DocInputFactory(nodeCtx, referenceResolver);
         this.bigArrays = bigArrays;

--- a/server/src/main/java/io/crate/execution/engine/fetch/NodeFetchOperation.java
+++ b/server/src/main/java/io/crate/execution/engine/fetch/NodeFetchOperation.java
@@ -83,7 +83,7 @@ public class NodeFetchOperation {
             LuceneReferenceResolver resolver = new LuceneReferenceResolver(
                 indexName,
                 table.partitionedByColumns(),
-                table.isParentReferenceIgnored()
+                table.isIgnoredReference()
             );
             ArrayList<LuceneCollectorExpression<?>> exprs = new ArrayList<>(refs.size());
             for (Reference reference : refs) {

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/DocCollectorExpression.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/DocCollectorExpression.java
@@ -59,7 +59,7 @@ public abstract class DocCollectorExpression<T> extends LuceneCollectorExpressio
     }
 
     public static LuceneCollectorExpression<?> create(final Reference reference,
-                                                      Predicate<Reference> isParentReferenceIgnored) {
+                                                      Predicate<Reference> isIgnoredReference) {
         assert reference.column().name().equals(SysColumns.DOC.name()) :
             "column name must be " + SysColumns.DOC.name();
         if (reference.column().isRoot()) {
@@ -67,7 +67,7 @@ public abstract class DocCollectorExpression<T> extends LuceneCollectorExpressio
         }
 
         Function<Object, Object> valueConverter;
-        if (isParentReferenceIgnored.test(reference)) {
+        if (isIgnoredReference.test(reference)) {
             // If the parent reference is ignored, the child column may have been ignored as well before and may contain
             // a value that does not fit the current defined child column data type.
             valueConverter = val -> reference.valueType().sanitizeValueLenient(val);

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/StoredRowLookup.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/StoredRowLookup.java
@@ -230,7 +230,7 @@ public abstract class StoredRowLookup implements StoredRow {
             } else {
                 LuceneCollectorExpression<?> expr = LuceneReferenceResolver.typeSpecializedExpression(
                     ref,
-                    table.isParentReferenceIgnored()
+                    table.isIgnoredReference()
                 );
                 assert expr instanceof DocCollectorExpression<?> == false;
                 var column = ref.toColumn();

--- a/server/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
+++ b/server/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
@@ -105,7 +105,7 @@ public class LuceneQueryBuilder {
         var refResolver = new LuceneReferenceResolver(
             indexName,
             table.partitionedByColumns(),
-            table.isParentReferenceIgnored()
+            table.isIgnoredReference()
         );
         var normalizer = new EvaluatingNormalizer(nodeCtx, RowGranularity.PARTITION, refResolver, null);
         Context ctx = new Context(
@@ -160,7 +160,7 @@ public class LuceneQueryBuilder {
                 new LuceneReferenceResolver(
                     indexName,
                     partitionColumns,
-                    table.isParentReferenceIgnored()
+                    table.isIgnoredReference()
                 )
             );
             this.queryCache = queryCache;

--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
@@ -339,8 +339,21 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
         return referenceTree().findFirstParentMatching(child, test);
     }
 
-    public Predicate<Reference> isParentReferenceIgnored() {
-        return ref -> findParentReferenceMatching(ref, r -> r.columnPolicy() == ColumnPolicy.IGNORED) != null;
+    /**
+     * A reference is ignored if it is an ignored object or an immediate child of an ignored object.
+     */
+    public Predicate<Reference> isIgnoredReference() {
+        return ref -> {
+            if (ref.valueType() instanceof ObjectType) {
+                return ref.columnPolicy() == ColumnPolicy.IGNORED;
+            }
+            for (Reference parent : getParents(ref.column())) {
+                if (parent.valueType() instanceof ObjectType) {
+                    return parent.columnPolicy() == ColumnPolicy.IGNORED;
+                }
+            }
+            return false;
+        };
     }
 
     private ReferenceTree referenceTree() {

--- a/server/src/main/java/io/crate/statistics/ReservoirSampler.java
+++ b/server/src/main/java/io/crate/statistics/ReservoirSampler.java
@@ -254,7 +254,7 @@ public final class ReservoirSampler {
         LuceneReferenceResolver referenceResolver = new LuceneReferenceResolver(
             indexName,
             docTable.partitionedByColumns(),
-            docTable.isParentReferenceIgnored()
+            docTable.isIgnoredReference()
         );
         List<? extends LuceneCollectorExpression<?>> expressions = Lists.map(
             columns,

--- a/server/src/test/java/io/crate/expression/reference/doc/lucene/LuceneReferenceResolverTest.java
+++ b/server/src/test/java/io/crate/expression/reference/doc/lucene/LuceneReferenceResolverTest.java
@@ -117,7 +117,7 @@ public class LuceneReferenceResolverTest extends CrateDummyClusterServiceUnitTes
         LuceneReferenceResolver refResolver = new LuceneReferenceResolver(
             partitionName.asIndexName(),
             table.partitionedByColumns(),
-            table.isParentReferenceIgnored()
+            table.isIgnoredReference()
         );
         Reference year = table.getReference(ColumnIdent.of("year"));
         LuceneCollectorExpression<?> impl1 = refResolver.getImplementation(year);

--- a/server/src/testFixtures/java/io/crate/testing/IndexEnv.java
+++ b/server/src/testFixtures/java/io/crate/testing/IndexEnv.java
@@ -91,7 +91,7 @@ public final class IndexEnv implements AutoCloseable {
         luceneReferenceResolver = new LuceneReferenceResolver(
             indexName,
             table.partitionedByColumns(),
-            table.isParentReferenceIgnored()
+            table.isIgnoredReference()
         );
         indexService = indexModule.newIndexService(
             nodeContext,


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
`DocTableInfo.isParentReferenceIgnored` was added by https://github.com/crate/crate/pull/16930. Came across this method and I think it did not handle nested object cases,
```
    public void test_ignored_object_or_immediate_child_of_ignored_object_are_ignored_references() throws IOException {
        SQLExecutor e = SQLExecutor.of(clusterService)
            .addTable("""
                create table tbl (
                    o object(ignored) as (b int, o2 object(dynamic) as (a int))
                )
                """);

        DocTableInfo table = e.resolveTableInfo("tbl");
        Reference o = table.getReference(ColumnIdent.of("o"));
        Reference o2 = table.getReference(ColumnIdent.of("o", List.of("o2")));
        Reference a = table.getReference(ColumnIdent.of("o", List.of("o2", "a")));
        Reference b = table.getReference(ColumnIdent.of("o", List.of("b")));

        assertThat(table.isIgnoredReference().test(o)).isTrue();
        assertThat(table.isIgnoredReference().test(o2)).isFalse();  -- on master, table.isParentReferenceIgnored().test(o2) returns true
        assertThat(table.isIgnoredReference().test(a)).isFalse();  -- on master, table.isParentReferenceIgnored().test(a) returns true
        assertThat(table.isIgnoredReference().test(b)).isTrue();
    }
```

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
