### PR TITLE
Small cleanups in TransportShardAction

### DIFF
--- a/server/src/main/java/io/crate/execution/dml/delete/TransportShardDeleteAction.java
+++ b/server/src/main/java/io/crate/execution/dml/delete/TransportShardDeleteAction.java
@@ -140,7 +140,7 @@ public class TransportShardDeleteAction extends TransportShardAction<ShardDelete
     }
 
     @Override
-    protected WriteReplicaResult<ShardDeleteRequest> processRequestItemsOnReplica(IndexShard indexShard, ShardDeleteRequest request) throws IOException {
+    protected WriteReplicaResult processRequestItemsOnReplica(IndexShard indexShard, ShardDeleteRequest request) throws IOException {
         Translog.Location translogLocation = null;
         for (ShardDeleteRequest.Item item : request.items()) {
             int location = item.location();
@@ -166,7 +166,7 @@ public class TransportShardDeleteAction extends TransportShardAction<ShardDelete
                 }
             }
         }
-        return new WriteReplicaResult<>(translogLocation, null, indexShard);
+        return new WriteReplicaResult(translogLocation, null, indexShard);
     }
 
     private Engine.DeleteResult shardDeleteOperationOnPrimary(ShardDeleteRequest.Item item, IndexShard indexShard) throws IOException {

--- a/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
@@ -275,7 +275,7 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
     }
 
     @Override
-    protected WriteReplicaResult<ShardUpsertRequest> processRequestItemsOnReplica(IndexShard indexShard, ShardUpsertRequest request) throws IOException {
+    protected WriteReplicaResult processRequestItemsOnReplica(IndexShard indexShard, ShardUpsertRequest request) throws IOException {
         Reference[] insertColumns = request.insertColumns();
         if (insertColumns == null) {
             // On the primary, update columns get converted to insert columns, so
@@ -283,7 +283,7 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
             // this should mean that there are either no items to index, or that
             // all items on the primary errored out and so should be ignored.
             assert noItemsToIndexOnReplica(request);
-            return new WriteReplicaResult<>(null, null, indexShard);
+            return new WriteReplicaResult(null, null, indexShard);
         }
 
         Translog.Location location = null;
@@ -384,7 +384,7 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
                 : "If parsedDoc.newColumns is empty there must be no mapping update requirement";
             location = result.getTranslogLocation();
         }
-        return new WriteReplicaResult<>(location, null, indexShard);
+        return new WriteReplicaResult(location, null, indexShard);
     }
 
     /**

--- a/server/src/main/java/io/crate/replication/logical/action/ReplayChangesAction.java
+++ b/server/src/main/java/io/crate/replication/logical/action/ReplayChangesAction.java
@@ -217,9 +217,9 @@ public class ReplayChangesAction extends ActionType<ReplicationResponse> {
         }
 
         @Override
-        protected WriteReplicaResult<Request> shardOperationOnReplica(Request request, IndexShard replica) throws Exception {
+        protected WriteReplicaResult shardOperationOnReplica(Request request, IndexShard replica) throws Exception {
             Translog.Location location = performOnReplica(request, replica);
-            return new WriteReplicaResult<>(location, null, replica);
+            return new WriteReplicaResult(location, null, replica);
         }
 
         private Translog.Location performOnReplica(Request request, IndexShard replica) throws Exception {

--- a/server/src/main/java/org/elasticsearch/action/resync/TransportResyncReplicationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/resync/TransportResyncReplicationAction.java
@@ -103,10 +103,10 @@ public class TransportResyncReplicationAction extends TransportWriteAction<Resyn
     }
 
     @Override
-    protected WriteReplicaResult<ResyncReplicationRequest> shardOperationOnReplica(ResyncReplicationRequest request,
-                                                                                   IndexShard replica) throws Exception {
+    protected WriteReplicaResult shardOperationOnReplica(ResyncReplicationRequest request,
+                                                         IndexShard replica) throws Exception {
         Translog.Location location = performOnReplica(request, replica);
-        return new WriteReplicaResult<>(location, null, replica);
+        return new WriteReplicaResult(location, null, replica);
     }
 
     public static Translog.Location performOnReplica(ResyncReplicationRequest request, IndexShard replica) throws Exception {

--- a/server/src/main/java/org/elasticsearch/action/support/replication/TransportWriteAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/TransportWriteAction.java
@@ -113,31 +113,9 @@ public abstract class TransportWriteAction<
     }
 
     /**
-     * Called on the primary with a reference to the primary {@linkplain IndexShard} to modify.
-     *
-     * @param listener listener for the result of the operation on primary, including current translog location and operation response
-     * and failure async refresh is performed on the <code>primary</code> shard according to the <code>Request</code> refresh policy
-     */
-    @Override
-    protected abstract void shardOperationOnPrimary(
-            Request request, IndexShard primary, ActionListener<PrimaryResult<ReplicaRequest, Response>> listener);
-
-    /**
-     * Called once per replica with a reference to the replica {@linkplain IndexShard} to modify.
-     *
-     * @return the result of the operation on replica, including current translog location and operation response and failure
-     * async refresh is performed on the <code>replica</code> shard according to the <code>ReplicaRequest</code> refresh policy
-     */
-    @Override
-    protected abstract WriteReplicaResult<ReplicaRequest> shardOperationOnReplica(
-            ReplicaRequest request, IndexShard replica) throws Exception;
-
-    /**
      * Result of taking the action on the primary.
-     *
-     * NOTE: public for testing
      */
-    public static class WritePrimaryResult<ReplicaRequest extends ReplicationRequest<ReplicaRequest>,
+    protected static class WritePrimaryResult<ReplicaRequest extends ReplicationRequest<ReplicaRequest>,
             Response extends ReplicationResponse> extends PrimaryResult<ReplicaRequest, Response> {
         public final Location location;
         public final IndexShard primary;
@@ -183,9 +161,9 @@ public abstract class TransportWriteAction<
     /**
      * Result of taking the action on the replica.
      */
-    public static class WriteReplicaResult<ReplicaRequest extends ReplicationRequest<ReplicaRequest>>
-            extends ReplicaResult implements RespondingWriteResult {
-        public final Location location;
+    protected static class WriteReplicaResult
+        extends ReplicaResult implements RespondingWriteResult {
+        private final Location location;
         private final IndexShard replica;
 
         public WriteReplicaResult(@Nullable Location location,

--- a/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseSyncAction.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseSyncAction.java
@@ -141,12 +141,12 @@ public class RetentionLeaseSyncAction extends
     }
 
     @Override
-    protected WriteReplicaResult<Request> shardOperationOnReplica(final Request request, final IndexShard replica) throws WriteStateException {
+    protected WriteReplicaResult shardOperationOnReplica(final Request request, final IndexShard replica) throws WriteStateException {
         Objects.requireNonNull(request);
         Objects.requireNonNull(replica);
         replica.updateRetentionLeasesOnReplica(request.getRetentionLeases());
         replica.persistRetentionLeases();
-        return new WriteReplicaResult<>(null, null, replica);
+        return new WriteReplicaResult(null, null, replica);
     }
 
     @Override

--- a/server/src/test/java/io/crate/execution/dml/delete/TransportShardDeleteActionTest.java
+++ b/server/src/test/java/io/crate/execution/dml/delete/TransportShardDeleteActionTest.java
@@ -33,7 +33,7 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.elasticsearch.Version;
-import org.elasticsearch.action.support.replication.TransportWriteAction;
+import org.elasticsearch.action.support.replication.TransportReplicationAction;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.Settings;
@@ -100,7 +100,7 @@ public class TransportShardDeleteActionTest extends CrateDummyClusterServiceUnit
         final ShardDeleteRequest request = new ShardDeleteRequest(shardId, UUID.randomUUID());
         request.add(1, new ShardDeleteRequest.Item("1"));
 
-        TransportWriteAction.WritePrimaryResult<ShardDeleteRequest, ShardResponse> result =
+        TransportReplicationAction.PrimaryResult<ShardDeleteRequest, ShardResponse> result =
             transportShardDeleteAction.processRequestItems(indexShard, request, new AtomicBoolean(true));
 
         assertThat(result.finalResponseIfSuccessful.failure()).isExactlyInstanceOf(InterruptedException.class);

--- a/server/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
+++ b/server/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
@@ -37,7 +37,7 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.elasticsearch.Version;
-import org.elasticsearch.action.support.replication.TransportWriteAction;
+import org.elasticsearch.action.support.replication.TransportReplicationAction;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.UUIDs;
@@ -217,7 +217,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
         ).newRequest(shardId);
         request.add(1, ShardUpsertRequest.Item.forInsert("1", List.of(), Translog.UNSET_AUTO_GENERATED_TIMESTAMP, missingAssignmentsColumns, new Object[]{1}, null));
 
-        TransportWriteAction.WritePrimaryResult<ShardUpsertRequest, ShardResponse> result =
+        TransportReplicationAction.PrimaryResult<ShardUpsertRequest, ShardResponse> result =
             transportShardUpsertAction.processRequestItems(indexShard, request, new AtomicBoolean(false));
 
         assertThat(result.finalResponseIfSuccessful.failure()).isExactlyInstanceOf(VersionConflictEngineException.class);
@@ -239,7 +239,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
         ).newRequest(shardId);
         request.add(1, ShardUpsertRequest.Item.forInsert("1", List.of(), Translog.UNSET_AUTO_GENERATED_TIMESTAMP, missingAssignmentsColumns, new Object[]{1}, null));
 
-        TransportWriteAction.WritePrimaryResult<ShardUpsertRequest, ShardResponse> result =
+        TransportReplicationAction.PrimaryResult<ShardUpsertRequest, ShardResponse> result =
             transportShardUpsertAction.processRequestItems(indexShard, request, new AtomicBoolean(false));
 
         ShardResponse response = result.finalResponseIfSuccessful;
@@ -264,7 +264,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
         ).newRequest(shardId);
         request.add(1, ShardUpsertRequest.Item.forInsert("1", List.of(), Translog.UNSET_AUTO_GENERATED_TIMESTAMP, missingAssignmentsColumns, new Object[]{1}, null));
 
-        TransportWriteAction.WritePrimaryResult<ShardUpsertRequest, ShardResponse> result =
+        TransportReplicationAction.PrimaryResult<ShardUpsertRequest, ShardResponse> result =
             transportShardUpsertAction.processRequestItems(indexShard, request, new AtomicBoolean(true));
 
         assertThat(result.finalResponseIfSuccessful.failure()).isExactlyInstanceOf(InterruptedException.class);

--- a/server/src/test/java/org/elasticsearch/index/seqno/RetentionLeaseSyncActionTests.java
+++ b/server/src/test/java/org/elasticsearch/index/seqno/RetentionLeaseSyncActionTests.java
@@ -29,8 +29,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.replication.ReplicationResponse;
+import org.elasticsearch.action.support.replication.TransportReplicationAction;
 import org.elasticsearch.action.support.replication.TransportReplicationAction.PrimaryResult;
-import org.elasticsearch.action.support.replication.TransportWriteAction;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
@@ -148,8 +148,8 @@ public class RetentionLeaseSyncActionTests extends ESTestCase {
         final RetentionLeases retentionLeases = mock(RetentionLeases.class);
         final RetentionLeaseSyncAction.Request request = new RetentionLeaseSyncAction.Request(indexShard.shardId(), retentionLeases);
 
-        final TransportWriteAction.WriteReplicaResult<RetentionLeaseSyncAction.Request> result =
-                action.shardOperationOnReplica(request, indexShard);
+        final TransportReplicationAction.ReplicaResult result =
+            action.shardOperationOnReplica(request, indexShard);
         // the retention leases on the shard should be updated
         verify(indexShard).updateRetentionLeasesOnReplica(retentionLeases);
         // the retention leases on the shard should be persisted


### PR DESCRIPTION
- remove redundant abstract method defns in TransportShardAction
- remove unused generics from WriteReplicaResult
- adjust visibility of internal classes