### PR TITLE
Fix jacoco coverage report generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
           <!-- by default is false but is set to true by `serverTest` profile to avoid running tests
                for modules on which `server` module depends on, when running `mvn -Pserver test` -->
           <skip>${skipRunTests}</skip>
-          <argLine>-XX:+UseSerialGC -XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=512M</argLine>
+          <argLine>@{argLine} -XX:+UseSerialGC -XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=512M</argLine>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Adds jacoco properties to surefire plugin by late property binding, see https://www.eclemma.org/jacoco/trunk/doc/prepare-agent-mojo.html

This enables codecov uploads again which were failing for some time as the uploader could not find any reports.