### PR TITLE
Eval prunning must also check that there are no outputs to prune

### DIFF
--- a/docs/appendices/release-notes/5.9.5.rst
+++ b/docs/appendices/release-notes/5.9.5.rst
@@ -47,4 +47,8 @@ See the :ref:`version_5.9.0` release notes for a full list of changes in the
 Fixes
 =====
 
-None
+- Fixed an issue leading to an error when running SELECT COUNT(*) on a Subquery
+  with ``UNION ALL`` having a table on the one side and a renamed table or view
+  on another. Example::
+
+      SELECT count(*) FROM (SELECT id FROM users UNION ALL SELECT 1 as renamed) t;

--- a/server/src/main/java/io/crate/planner/operators/Eval.java
+++ b/server/src/main/java/io/crate/planner/operators/Eval.java
@@ -101,7 +101,7 @@ public final class Eval extends ForwardingLogicalPlan {
     @Override
     public LogicalPlan pruneOutputsExcept(SequencedCollection<Symbol> outputsToKeep) {
         LogicalPlan newSource = source.pruneOutputsExcept(outputsToKeep);
-        if (source == newSource) {
+        if (source == newSource && outputs.isEmpty()) {
             return this;
         }
         return new Eval(newSource, List.copyOf(outputsToKeep));

--- a/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -1539,12 +1539,11 @@ public class JoinIntegrationTest extends IntegTestCase {
         var stmt = "SELECT t3.e FROM t1 JOIN t3 ON t1.b = t3.f JOIN t2 ON t1.a = t2.c WHERE t2.d =t3.e";
         assertThat(execute("explain " + stmt)).hasLines(
             "Eval[e] (rows=0)",
-            "  └ Eval[b, a, e, f, c, d] (rows=0)",
-            "    └ HashJoin[INNER | ((a = c) AND (d = e))] (rows=0)",
-            "      ├ Collect[doc.t2 | [c, d] | true] (rows=2)",
-            "      └ HashJoin[INNER | (b = f)] (rows=1)",
-            "        ├ Collect[doc.t1 | [b, a] | true] (rows=1)",
-            "        └ Collect[doc.t3 | [e, f] | true] (rows=1)"
+            "  └ HashJoin[INNER | ((a = c) AND (d = e))] (rows=0)",
+            "    ├ Collect[doc.t2 | [c, d] | true] (rows=2)",
+            "    └ HashJoin[INNER | (b = f)] (rows=1)",
+            "      ├ Collect[doc.t1 | [b, a] | true] (rows=1)",
+            "      └ Collect[doc.t3 | [e, f] | true] (rows=1)"
         );
 
         execute(stmt);

--- a/server/src/test/java/io/crate/integrationtests/LookupJoinIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/LookupJoinIntegrationTest.java
@@ -145,7 +145,7 @@ public class LookupJoinIntegrationTest extends IntegTestCase {
             execute("explain (costs false)" + query, session);
             assertThat(response).hasLines(
                 "HashAggregate[count(name)]",
-                "  └ Eval[name, id, id]",
+                "  └ Eval[name]",
                 "    └ HashJoin[INNER | (id = id)]",
                 "      ├ MultiPhase",
                 "      │  └ Collect[doc.t1 | [id] | (id = ANY((x)))]",

--- a/server/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -682,7 +682,6 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(outerJoin.joinPhase().joinCondition()).isNull();
         assertThat(outerJoin.joinPhase().projections()).satisfiesExactly(
             p -> assertThat(p).isExactlyInstanceOf(EvalProjection.class),
-            p -> assertThat(p).isExactlyInstanceOf(EvalProjection.class),
             p -> assertThat(p).isExactlyInstanceOf(EvalProjection.class));
     }
 

--- a/server/src/test/java/io/crate/planner/UnionPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/UnionPlannerTest.java
@@ -24,7 +24,6 @@ package io.crate.planner;
 import static io.crate.analyze.TableDefinitions.TEST_DOC_LOCATIONS_TABLE_IDENT;
 import static io.crate.analyze.TableDefinitions.USER_TABLE_IDENT;
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -262,6 +261,21 @@ public class UnionPlannerTest extends CrateDummyClusterServiceUnitTest {
                     │      └ Collect[doc.users | [id] | true]
                     └ TableFunction[empty_row | [1, 1] | true]
                 """
+        );
+    }
+
+    @Test
+    public void test_union_works_when_both_sides_have_no_outputs_to_keep_on_prunning() {
+        LogicalPlan plan = e.logicalPlan(
+            "SELECT count(*) FROM (SELECT id FROM users UNION ALL SELECT 1 as renamed) t");
+
+        assertThat(plan).isEqualTo("""
+            HashAggregate[count(*)]
+              └ Rename[] AS t
+                └ Union[]
+                  ├ Collect[doc.users | [] | true]
+                  └ TableFunction[empty_row | [] | true]
+            """
         );
     }
 

--- a/server/src/test/java/io/crate/planner/ViewPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/ViewPlannerTest.java
@@ -49,14 +49,13 @@ public class ViewPlannerTest extends CrateDummyClusterServiceUnitTest {
         var logicalPlan = e.logicalPlan("SELECT id FROM v1");
         var expectedPlan =
             """
-            Eval[id]
-              └ Rename[id, o['i']] AS doc.v1
-                └ Eval[id, o['i']]
-                  └ HashJoin[LEFT | (o['i'] = o['i'])]
-                    ├ Rename[o['i']] AS g1
-                    │  └ Collect[doc.t1 | [o['i']] | true]
-                    └ Rename[id, o['i']] AS b
-                      └ Collect[doc.t1 | [id, o['i']] | true]
+            Rename[id] AS doc.v1
+              └ Eval[id]
+                └ HashJoin[LEFT | (o['i'] = o['i'])]
+                  ├ Rename[o['i']] AS g1
+                  │  └ Collect[doc.t1 | [o['i']] | true]
+                  └ Rename[id, o['i']] AS b
+                    └ Collect[doc.t1 | [id, o['i']] | true]
             """;
         assertThat(logicalPlan).isEqualTo(expectedPlan);
     }

--- a/server/src/test/java/io/crate/planner/operators/JoinTest.java
+++ b/server/src/test/java/io/crate/planner/operators/JoinTest.java
@@ -333,12 +333,11 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
         LogicalPlan plan = buildLogicalPlan(mss);
         assertThat(plan).isEqualTo("""
             Eval[name, id]
-              └ Eval[name, id, id]
-                └ HashJoin[INNER | (id = id)]
-                  ├ Collect[doc.locations | [id] | true]
-                  └ Collect[doc.users | [name, id] | true]""");
+              └ HashJoin[INNER | (id = id)]
+                ├ Collect[doc.locations | [id] | true]
+                └ Collect[doc.users | [name, id] | true]""");
 
-        LogicalPlan hashjoin = plan.sources().getFirst().sources().getFirst();
+        LogicalPlan hashjoin = plan.sources().getFirst();
         assertThat(hashjoin).isExactlyInstanceOf(HashJoin.class);
         assertThat(((HashJoin) hashjoin).lhs().relationNames())
             .as("Smaller table must be on the left-hand-side")


### PR DESCRIPTION
Following documented behavior:
> If there are no outputs to prune and if the source also didn't change, `this` must be returned

Fixes  https://github.com/crate/crate/issues/17051

Supersedes https://github.com/crate/crate/pull/17076/

