### PR TITLE
compare flakiness with different JDK versions

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/disruption/seqno/ConcurrentSeqNoVersioningIT.java
+++ b/server/src/test/java/io/crate/integrationtests/disruption/seqno/ConcurrentSeqNoVersioningIT.java
@@ -64,6 +64,9 @@ import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.Test;
 
+import com.carrotsearch.randomizedtesting.annotations.Repeat;
+import com.carrotsearch.randomizedtesting.annotations.Seed;
+
 import io.crate.common.SuppressForbidden;
 import io.crate.common.exceptions.Exceptions;
 import io.crate.common.unit.TimeValue;
@@ -124,6 +127,7 @@ import io.crate.testing.SQLResponse;
  * </ul>
  */
 @IntegTestCase.ClusterScope(scope = IntegTestCase.Scope.TEST, minNumDataNodes = 4, maxNumDataNodes = 6)
+@Seed("709F6BE21D75FBB")
 public class ConcurrentSeqNoVersioningIT extends AbstractDisruptionTestCase {
 
     @Override
@@ -138,6 +142,7 @@ public class ConcurrentSeqNoVersioningIT extends AbstractDisruptionTestCase {
     // Wait up to 1 minute (+10s in thread to ensure it does not time out) for threads to complete previous round before initiating next
     // round.
     @Test
+    @Repeat(iterations = 100)
     public void testSeqNoCASLinearizability() {
         final int disruptTimeSeconds = scaledRandomIntBetween(1, 8);
 


### PR DESCRIPTION
Relates to https://github.com/crate/crate/issues/10364

Quick test:

Current suspect is JDK 23 update (first failure was on [24.10](https://wacklig.pipifein.dev/github/crate/crate/97247184-86e8-4bd6-b97a-641d32610c0f/76a3e7a4-1ac9-4883-9756-12157ae69a4f))

Will try with JDK 23.0.2 and 22 to rule out or confirm the suspect