### PR TITLE
Bind explicit-joins before implicit joins

### DIFF
--- a/docs/appendices/release-notes/5.9.5.rst
+++ b/docs/appendices/release-notes/5.9.5.rst
@@ -47,8 +47,14 @@ See the :ref:`version_5.9.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that caused wrong results when implicit joins were combined
+  with outer-joins within the same query e.g.::
+
+      SELECT * FROM t1, t2 RIGHT JOIN t3 ON true
+
 - Fixed an issue leading to an error when running SELECT COUNT(*) on a Subquery
   with ``UNION ALL`` having a table on the one side and a renamed table or view
   on another. Example::
 
       SELECT count(*) FROM (SELECT id FROM users UNION ALL SELECT 1 as renamed) t;
+      

--- a/server/src/test/java/io/crate/planner/operators/JoinTest.java
+++ b/server/src/test/java/io/crate/planner/operators/JoinTest.java
@@ -1141,4 +1141,88 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
             "    └ Collect[doc.t1 | [a] | true]"
         );
     }
+
+    @Test
+    public void test_many_mized_implicit_and_explicit_joins() throws Exception {
+        var executor = SQLExecutor.builder(clusterService)
+            .build()
+            .addTable("CREATE TABLE doc.t1(a integer)")
+            .addTable("CREATE TABLE doc.t2(b integer)")
+            .addTable("CREATE TABLE doc.t3(c integer)")
+            .addTable("CREATE TABLE doc.t4(d integer)")
+            .addTable("CREATE TABLE doc.t5(e integer)")
+            .addTable("CREATE TABLE doc.t6(f integer)");
+
+
+        QueriedSelectRelation mss = e.analyze("SELECT * FROM doc.t1 right join doc.t2 on true, doc.t3, doc.t4, t5, t6");
+        var plannerCtx = executor.getPlannerContext();
+        var result = buildLogicalPlan(mss, plannerCtx);
+
+        assertThat(result).hasOperators(
+            "NestedLoopJoin[CROSS]",
+            "  ├ NestedLoopJoin[CROSS]",
+            "  │  ├ NestedLoopJoin[CROSS]",
+            "  │  │  ├ NestedLoopJoin[CROSS]",
+            "  │  │  │  ├ NestedLoopJoin[RIGHT | true]",
+            "  │  │  │  │  ├ Collect[doc.t1 | [a] | true]",
+            "  │  │  │  │  └ Collect[doc.t2 | [b] | true]",
+            "  │  │  │  └ Collect[doc.t3 | [c] | true]",
+            "  │  │  └ Collect[doc.t4 | [d] | true]",
+            "  │  └ Collect[doc.t5 | [e] | true]",
+            "  └ Collect[doc.t6 | [f] | true]"
+        );
+
+
+        mss = e.analyze("SELECT * FROM doc.t1, doc.t2, doc.t3 right join doc.t4 on true, doc.t5, doc.t6");
+        result = buildLogicalPlan(mss, plannerCtx);
+
+        assertThat(result).hasOperators(
+            "Eval[a, b, c, d, e, f]",
+            "  └ NestedLoopJoin[CROSS]",
+            "    ├ NestedLoopJoin[CROSS]",
+            "    │  ├ NestedLoopJoin[CROSS]",
+            "    │  │  ├ NestedLoopJoin[CROSS]",
+            "    │  │  │  ├ NestedLoopJoin[RIGHT | true]",
+            "    │  │  │  │  ├ Collect[doc.t3 | [c] | true]",
+            "    │  │  │  │  └ Collect[doc.t4 | [d] | true]",
+            "    │  │  │  └ Collect[doc.t1 | [a] | true]",
+            "    │  │  └ Collect[doc.t2 | [b] | true]",
+            "    │  └ Collect[doc.t5 | [e] | true]",
+            "    └ Collect[doc.t6 | [f] | true]"
+        );
+
+        mss = e.analyze("SELECT * FROM doc.t1, doc.t2 right join doc.t3 on true, doc.t4 left join doc.t5 on true, doc.t6");
+        result = buildLogicalPlan(mss, plannerCtx);
+
+        assertThat(result).hasOperators(
+            "Eval[a, b, c, d, e, f]",
+            "  └ NestedLoopJoin[CROSS]",
+            "    ├ NestedLoopJoin[LEFT | true]",
+            "    │  ├ NestedLoopJoin[CROSS]",
+            "    │  │  ├ NestedLoopJoin[CROSS]",
+            "    │  │  │  ├ NestedLoopJoin[RIGHT | true]",
+            "    │  │  │  │  ├ Collect[doc.t2 | [b] | true]",
+            "    │  │  │  │  └ Collect[doc.t3 | [c] | true]",
+            "    │  │  │  └ Collect[doc.t1 | [a] | true]",
+            "    │  │  └ Collect[doc.t4 | [d] | true]",
+            "    │  └ Collect[doc.t5 | [e] | true]",
+            "    └ Collect[doc.t6 | [f] | true]"
+        );
+
+        mss = e.analyze("SELECT * FROM doc.t1, doc.t2 right join doc.t3 on true left join doc.t5 on true, doc.t6");
+        result = buildLogicalPlan(mss, plannerCtx);
+
+        assertThat(result).hasOperators(
+            "Eval[a, b, c, e, f]",
+            "  └ NestedLoopJoin[CROSS]",
+            "    ├ NestedLoopJoin[LEFT | true]",
+            "    │  ├ NestedLoopJoin[CROSS]",
+            "    │  │  ├ NestedLoopJoin[RIGHT | true]",
+            "    │  │  │  ├ Collect[doc.t2 | [b] | true]",
+            "    │  │  │  └ Collect[doc.t3 | [c] | true]",
+            "    │  │  └ Collect[doc.t1 | [a] | true]",
+            "    │  └ Collect[doc.t5 | [e] | true]",
+            "    └ Collect[doc.t6 | [f] | true]"
+        );
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

When a query has mixed implicit and outer joins, the joins are wrongly bound. Currently, we bound implicit joins first to preserve the original join order, which leads to an incorrect join order and a wrong query plan e.g.:

```
SELECT * FROM t0, t1 RIGHT JOIN (SELECT 1 ) AS sub0 ON true WHERE (NOT ((t0.c1)>=(t0.c1))); 
```

results in:

```
+------------------------------------------------------------+
| QUERY PLAN                                                 |
+------------------------------------------------------------+
| NestedLoopJoin[RIGHT | true] (rows=unknown)                |
|   ├ NestedLoopJoin[CROSS] (rows=unknown)                   |
|   │  ├ Collect[doc.t0 | [c1] | (NOT (c1 >= c1))] (rows=0)  |
|   │  └ Collect[doc.t1 | [c0] | true] (rows=0)              |
|   └ Rename["1"] AS sub0 (rows=unknown)                     |
|     └ TableFunction[empty_row | [1] | true] (rows=unknown) |
+------------------------------------------------------------+
```

Explicit joins using `JOIN` bind stronger than implicit joins. This matters especially when outer-joins are involved because they can not be easily reordered since they have a preserved side. Therefore the query plan should have the following structure with the join order `(t1 right join sub0) cross join t0`:

```
+-----------------------------------------------------------------+
| QUERY PLAN                                                      |
+-----------------------------------------------------------------+
| Eval[c1, c0, "1"] (rows=unknown)                                |
|   └ NestedLoopJoin[CROSS] (rows=unknown)                        |
|     ├ NestedLoopJoin[RIGHT | true] (rows=unknown)               |
|     │  ├ Collect[doc.t1 | [c0] | true] (rows=unknown)           |
|     │  └ Rename["1"] AS sub0 (rows=unknown)                     |
|     │    └ TableFunction[empty_row | [1] | true] (rows=unknown) |
|     └ Collect[doc.t0 | [c1] | (NOT (c1 >= c1))] (rows=unknown)  |
+-----------------------------------------------------------------+
```

This binds the outer-joins first which leads to a correct query plan and result but does not necessarily preserve the original join order anymore of the inplicit joins. This is not a problem since inner/cross joins can be arbitrarily reordered.


See https://github.com/crate/crate/pull/16999 for original discussion.


Fixes https://github.com/crate/crate/issues/16951


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
