### PR TITLE
Move cross-join to inner-join logic into optimizer

### DIFF
--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -118,6 +118,7 @@ import io.crate.planner.optimizer.rule.RemoveOrderBeneathInsert;
 import io.crate.planner.optimizer.rule.RemoveRedundantEval;
 import io.crate.planner.optimizer.rule.ReorderHashJoin;
 import io.crate.planner.optimizer.rule.ReorderNestedLoopJoin;
+import io.crate.planner.optimizer.rule.RewriteFilterOnCrossJoinToInnerJoin;
 import io.crate.planner.optimizer.rule.RewriteFilterOnOuterJoinToInnerJoin;
 import io.crate.planner.optimizer.rule.RewriteGroupByKeysLimitToLimitDistinct;
 import io.crate.planner.optimizer.rule.RewriteJoinPlan;
@@ -161,6 +162,7 @@ public class LogicalPlanner {
         new MergeFilterAndCollect(),
         new MergeFilterAndForeignCollect(),
         new RewriteFilterOnOuterJoinToInnerJoin(),
+        new RewriteFilterOnCrossJoinToInnerJoin(),
         new MoveOrderBeneathUnion(),
         new MoveOrderBeneathNestedLoop(),
         new MoveOrderBeneathEval(),

--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnCrossJoinToInnerJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnCrossJoinToInnerJoin.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.rule;
+
+
+import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
+import static io.crate.planner.optimizer.matcher.Patterns.source;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import io.crate.analyze.relations.QuerySplitter;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.RelationName;
+import io.crate.planner.operators.EquiJoinDetector;
+import io.crate.planner.operators.Filter;
+import io.crate.planner.operators.JoinPlan;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.optimizer.Rule;
+import io.crate.planner.optimizer.matcher.Capture;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Pattern;
+import io.crate.sql.tree.JoinType;
+
+public final class RewriteFilterOnCrossJoinToInnerJoin implements Rule<Filter> {
+
+    private final Capture<JoinPlan> joinCapture;
+    private final Pattern<Filter> pattern;
+
+    public RewriteFilterOnCrossJoinToInnerJoin() {
+        this.joinCapture = new Capture<>();
+        this.pattern = typeOf(Filter.class)
+            .with(f -> EquiJoinDetector.isEquiJoin(f.query()))
+            .with(
+                source(),
+                typeOf(JoinPlan.class)
+                    .capturedAs(joinCapture)
+                    .with(j -> j.joinType() == JoinType.CROSS)
+            );
+    }
+
+    @Override
+    public Pattern<Filter> pattern() {
+        return pattern;
+    }
+
+    @Override
+    public LogicalPlan apply(Filter equiJoinConditionFilter, Captures captures, Context context) {
+        JoinPlan crossJoin = captures.get(joinCapture);
+        Symbol query = equiJoinConditionFilter.query();
+        Map<Set<RelationName>, Symbol> filterRelations = QuerySplitter.split(query);
+
+        List<RelationName> lhs = crossJoin.lhs().relationNames();
+        List<RelationName> rhs = crossJoin.rhs().relationNames();
+        // TODO this could be extended to also support nested-joins with more than 2 relations
+        if (lhs.size() == 1 && rhs.size() == 1) {
+            HashSet<RelationName> sources = HashSet.newHashSet(2);
+            sources.addAll(lhs);
+            sources.addAll(rhs);
+            if (filterRelations.containsKey(sources)) {
+                return new JoinPlan(
+                    crossJoin.lhs(),
+                    crossJoin.rhs(),
+                    JoinType.INNER,
+                    query
+                );
+            }
+        }
+        return null;
+    }
+}

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -260,6 +260,7 @@ public class PgCatalogITest extends IntegTestCase {
             "optimizer_remove_redundant_eval| true| Indicates if the optimizer rule RemoveRedundantEval is activated.| NULL| NULL",
             "optimizer_reorder_hash_join| true| Indicates if the optimizer rule ReorderHashJoin is activated.| NULL| NULL",
             "optimizer_reorder_nested_loop_join| true| Indicates if the optimizer rule ReorderNestedLoopJoin is activated.| NULL| NULL",
+            "optimizer_rewrite_filter_on_cross_join_to_inner_join| true| Indicates if the optimizer rule RewriteFilterOnCrossJoinToInnerJoin is activated.| NULL| NULL",
             "optimizer_rewrite_filter_on_outer_join_to_inner_join| true| Indicates if the optimizer rule RewriteFilterOnOuterJoinToInnerJoin is activated.| NULL| NULL",
             "optimizer_rewrite_group_by_keys_limit_to_limit_distinct| true| Indicates if the optimizer rule RewriteGroupByKeysLimitToLimitDistinct is activated.| NULL| NULL",
             "optimizer_rewrite_left_outer_join_to_hash_join| true| Indicates if the optimizer rule RewriteLeftOuterJoinToHashJoin is activated.| NULL| NULL",

--- a/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
@@ -434,6 +434,7 @@ public class ShowIntegrationTest extends IntegTestCase {
             "optimizer_remove_redundant_eval| true| Indicates if the optimizer rule RemoveRedundantEval is activated.",
             "optimizer_reorder_hash_join| true| Indicates if the optimizer rule ReorderHashJoin is activated.",
             "optimizer_reorder_nested_loop_join| true| Indicates if the optimizer rule ReorderNestedLoopJoin is activated.",
+            "optimizer_rewrite_filter_on_cross_join_to_inner_join| true| Indicates if the optimizer rule RewriteFilterOnCrossJoinToInnerJoin is activated.",
             "optimizer_rewrite_filter_on_outer_join_to_inner_join| true| Indicates if the optimizer rule RewriteFilterOnOuterJoinToInnerJoin is activated.",
             "optimizer_rewrite_group_by_keys_limit_to_limit_distinct| true| Indicates if the optimizer rule RewriteGroupByKeysLimitToLimitDistinct is activated.",
             "optimizer_rewrite_left_outer_join_to_hash_join| true| Indicates if the optimizer rule RewriteLeftOuterJoinToHashJoin is activated.",

--- a/server/src/test/java/io/crate/planner/operators/JoinPlanBuilderTest.java
+++ b/server/src/test/java/io/crate/planner/operators/JoinPlanBuilderTest.java
@@ -22,7 +22,6 @@
 package io.crate.planner.operators;
 
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -82,38 +81,6 @@ public class JoinPlanBuilderTest extends CrateDummyClusterServiceUnitTest {
         assertThat(joinPair.condition()).isSQL("(doc.t1.a = doc.t2.b)");
         assertThat(joinPair.joinType()).isEqualTo(JoinType.INNER);
         assertThat(remainingQueries).hasSize(1);
-    }
-
-    @Test
-    public void testImplicitToExplicit_InnerJoinPairWithConditionAlreadyExists() {
-        List<JoinPair> joinPairs = new ArrayList<>();
-        joinPairs.add(JoinPair.of(T3.T1, T3.T2, JoinType.INNER, asSymbol("t1.a = t2.b")));
-        Map<Set<RelationName>, Symbol> remainingQueries = new HashMap<>();
-        remainingQueries.put(Set.of(T3.T1, T3.T2), asSymbol("t1.x = t2.y"));
-        List<JoinPair> newJoinPairs =
-            JoinPlanBuilder.convertImplicitJoinConditionsToJoinPairs(joinPairs, remainingQueries);
-
-        assertThat(newJoinPairs).hasSize(1);
-        JoinPair joinPair = newJoinPairs.get(0);
-        assertThat(joinPair.condition()).isSQL("((doc.t1.a = doc.t2.b) AND (doc.t1.x = doc.t2.y))");
-        assertThat(joinPair.joinType()).isEqualTo(JoinType.INNER);
-        assertThat(remainingQueries).isEmpty();
-    }
-
-    @Test
-    public void testImplicitToExplicit_CrossJoinPairAlreadyExists() {
-        List<JoinPair> joinPairs = new ArrayList<>();
-        joinPairs.add(JoinPair.of(T3.T1, T3.T2, JoinType.CROSS, null));
-        Map<Set<RelationName>, Symbol> remainingQueries = new HashMap<>();
-        remainingQueries.put(Set.of(T3.T1, T3.T2), asSymbol("t1.x = t2.y"));
-        List<JoinPair> newJoinPairs =
-            JoinPlanBuilder.convertImplicitJoinConditionsToJoinPairs(joinPairs, remainingQueries);
-
-        assertThat(newJoinPairs).hasSize(1);
-        JoinPair joinPair = newJoinPairs.get(0);
-        assertThat(joinPair.condition()).isSQL("(doc.t1.x = doc.t2.y)");
-        assertThat(joinPair.joinType()).isEqualTo(JoinType.INNER);
-        assertThat(remainingQueries).isEmpty();
     }
 
     @Test

--- a/server/src/test/java/io/crate/planner/optimizer/rule/RewriteFilterOnCrossJoinToInnerJoinTest.java
+++ b/server/src/test/java/io/crate/planner/optimizer/rule/RewriteFilterOnCrossJoinToInnerJoinTest.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.optimizer.rule;
+
+import static io.crate.testing.Asserts.assertThat;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.crate.planner.operators.Filter;
+import io.crate.planner.operators.JoinPlan;
+import io.crate.planner.operators.LogicalPlan;
+import io.crate.planner.optimizer.matcher.Captures;
+import io.crate.planner.optimizer.matcher.Match;
+import io.crate.sql.tree.JoinType;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+
+public class RewriteFilterOnCrossJoinToInnerJoinTest extends CrateDummyClusterServiceUnitTest {
+
+    private LogicalPlan t1;
+    private LogicalPlan t2;
+    private SQLExecutor e;
+
+    @Before
+    public void prepare() throws Exception {
+        e = SQLExecutor.of(clusterService)
+            .addTable("create table t1 (a int)")
+            .addTable("create table t2 (b int)");
+
+        t1 = e.logicalPlan("SELECT a FROM t1");
+        t2 = e.logicalPlan("SELECT b FROM t2");
+    }
+
+    @Test
+    public void test_rewrite_equ_join_filter_on_top_of_cross_join_to_inner_join() {
+        var join1 = new JoinPlan(t1, t2, JoinType.CROSS, null);
+        var filter = new Filter(join1, e.asSymbol("doc.t1.a = doc.t2.b"));
+
+        assertThat(filter).hasOperators(
+            "Filter[(a = b)]",
+            "  └ Join[CROSS]",
+            "    ├ Collect[doc.t1 | [a] | true]",
+            "    └ Collect[doc.t2 | [b] | true]"
+        );
+
+        var rule = new RewriteFilterOnCrossJoinToInnerJoin();
+        Match<Filter> match = rule.pattern().accept(filter, Captures.empty());
+
+        Assertions.assertThat(match.isPresent()).isTrue();
+        assertThat(match.value()).isEqualTo(filter);
+
+        var result = rule.apply(match.value(),
+            match.captures(),
+            e.ruleContext());
+
+        assertThat(result).hasOperators(
+            "Join[INNER | (a = b)]",
+            "  ├ Collect[doc.t1 | [a] | true]",
+            "  └ Collect[doc.t2 | [b] | true]"
+        );
+    }
+
+    @Test
+    public void test_rewrite_equ_join_filter_on_top_of_cross_join_to_inner_join_on_split_query() {
+        var join1 = new JoinPlan(t1, t2, JoinType.CROSS, null);
+        var filter = new Filter(join1, e.asSymbol("doc.t1.a = doc.t2.b and doc.t1.a = 10"));
+
+        assertThat(filter).hasOperators(
+            "Filter[((a = b) AND (a = 10))]",
+            "  └ Join[CROSS]",
+            "    ├ Collect[doc.t1 | [a] | true]",
+            "    └ Collect[doc.t2 | [b] | true]"
+        );
+
+        var rule = new RewriteFilterOnCrossJoinToInnerJoin();
+        Match<Filter> match = rule.pattern().accept(filter, Captures.empty());
+
+        Assertions.assertThat(match.isPresent()).isTrue();
+        assertThat(match.value()).isEqualTo(filter);
+
+        var result = rule.apply(match.value(),
+            match.captures(),
+            e.ruleContext());
+
+        assertThat(result).hasOperators(
+            "Join[INNER | ((a = b) AND (a = 10))]",
+            "  ├ Collect[doc.t1 | [a] | true]",
+            "  └ Collect[doc.t2 | [b] | true]"
+        );
+    }
+
+    @Test
+    public void test_do_not_rewrite_non_equi_join_filter_on_top_of_cross_join_when_filter_does_not_match() {
+        var join1 = new JoinPlan(t1, t2, JoinType.CROSS, null);
+        var filter = new Filter(join1, e.asSymbol("doc.t1.a = 1"));
+
+        assertThat(filter).hasOperators(
+            "Filter[(a = 1)]",
+            "  └ Join[CROSS]",
+            "    ├ Collect[doc.t1 | [a] | true]",
+            "    └ Collect[doc.t2 | [b] | true]"
+        );
+
+        var rule = new RewriteFilterOnCrossJoinToInnerJoin();
+        Match<Filter> match = rule.pattern().accept(filter, Captures.empty());
+
+        Assertions.assertThat(match.isPresent()).isFalse();
+    }
+}


### PR DESCRIPTION
This moves the logic to convert a filter with an equi-join condition on top of a cross-join to an inner-join, into an optimizer rule for the following reasons:

- The transformation is tracked by the optimizer and transparent to the user
- The rule can be applied within the optimization process multiple times while the query plan changes

Follow-up https://github.com/crate/crate/pull/17088

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
