### PR TITLE
Eliminate cross-join also when join-order is the same

### DIFF
--- a/server/src/main/java/io/crate/planner/optimizer/rule/EliminateCrossJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/EliminateCrossJoin.java
@@ -68,15 +68,12 @@ public class EliminateCrossJoin implements Rule<JoinPlan> {
             if (joinGraph.hasCrossJoin()) {
                 var newOrder = eliminateCrossJoin(joinGraph);
                 if (newOrder != null) {
-                    var originalOrder = joinGraph.nodes();
-                    if (originalOrder.equals(newOrder) == false) {
-                        var newJoinPlan = reorder(joinGraph, newOrder);
-                        if (newJoinPlan != null) {
-                            return Eval.create(
-                                newJoinPlan,
-                                join.outputs()
-                            );
-                        }
+                    var newJoinPlan = reorder(joinGraph, newOrder);
+                    if (newJoinPlan != null) {
+                        return Eval.create(
+                            newJoinPlan,
+                            join.outputs()
+                        );
                     }
                 }
             }


### PR DESCRIPTION
Cross-join elimination can also happen when the join-order did not change. Therefore, also emit a new plan when the order did not change. I discovered this while working on https://github.com/crate/crate/pull/17087. See test case for more details.

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
