### PR TITLE
Make routingColumn nullable on boundCreateTable

### DIFF
--- a/server/src/main/java/io/crate/analyze/AnalyzedCreateTable.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedCreateTable.java
@@ -45,7 +45,6 @@ import io.crate.metadata.NodeContext;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.TransactionContext;
-import io.crate.metadata.doc.SysColumns;
 import io.crate.metadata.settings.NumberOfReplicas;
 import io.crate.planner.operators.SubQueryAndParamBinder;
 import io.crate.planner.operators.SubQueryResults;
@@ -156,7 +155,7 @@ public record AnalyzedCreateTable(
                     "Clustered by column `" + c + "` must be part of primary keys: " + Lists.map(primaryKeys, Reference::column));
             }
         });
-        ColumnIdent routingColumn = optClusteredBy.orElse(SysColumns.ID.COLUMN);
+        ColumnIdent routingColumn = optClusteredBy.orElse(null);
 
         List<Reference> partitionedByColumns = partitionedBy
             .map(PartitionedBy::columns)

--- a/server/src/main/java/io/crate/execution/ddl/tables/CreateTableClient.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/CreateTableClient.java
@@ -43,7 +43,6 @@ import io.crate.exceptions.RelationAlreadyExists;
 import io.crate.exceptions.SQLExceptions;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
-import io.crate.metadata.doc.SysColumns;
 import io.crate.sql.tree.ColumnPolicy;
 
 public class CreateTableClient {
@@ -65,7 +64,6 @@ public class CreateTableClient {
         Settings.Builder settingsBuilder = Settings.builder()
             .put(createTable.settings());
         settingsBuilder.remove(TableParameters.COLUMN_POLICY.getKey());
-        ColumnIdent routingColumn = createTable.routingColumn().equals(SysColumns.ID.COLUMN) ? null : createTable.routingColumn();
         if (minNodeVersion.onOrAfter(Version.V_5_4_0)) {
             createTableRequest = new CreateTableRequest(
                 relationName,
@@ -74,7 +72,7 @@ public class CreateTableClient {
                 pKeysIndices,
                 createTable.getCheckConstraints(),
                 settingsBuilder.build(),
-                routingColumn,
+                createTable.routingColumn(),
                 tableColumnPolicy,
                 Lists.map(createTable.partitionedBy(), Reference::column)
             );

--- a/server/src/testFixtures/java/io/crate/testing/TestingHelpers.java
+++ b/server/src/testFixtures/java/io/crate/testing/TestingHelpers.java
@@ -70,7 +70,6 @@ import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.SimpleReference;
-import io.crate.metadata.doc.SysColumns;
 import io.crate.metadata.settings.session.SessionSettingRegistry;
 import io.crate.planner.optimizer.LoadedRules;
 import io.crate.role.Role;
@@ -376,10 +375,7 @@ public class TestingHelpers {
             boundCreateTable.getCheckConstraints(),
             Lists.map(boundCreateTable.partitionedBy(), Reference::column),
             tableColumnPolicy,
-            boundCreateTable.routingColumn().equals(SysColumns.ID.COLUMN)
-                ? null
-                : boundCreateTable.routingColumn()
+            boundCreateTable.routingColumn()
         );
-
     }
 }


### PR DESCRIPTION
It was set to `_id` as fallback only to be changed back to `null` in
other places.
