### PR TITLE
Expose partition_uuid in sys.shards

### DIFF
--- a/docs/admin/system-information.rst
+++ b/docs/admin/system-information.rst
@@ -955,6 +955,10 @@ Table schema
     * - ``partition_ident``
       - The partition ident of a partitioned table. Empty for non-partitioned tables.
       - ``TEXT``
+    * - ``partition_uuid``
+      - Internal id for the storage partition the shard is part of. Even tables
+        without ``PARTITIONED BY`` clause have an internal storage partition.
+      - ``TEXT``
     * - ``path``
       - Path to the shard directory on the filesystem. This directory contains state and index files.
       - ``TEXT``

--- a/server/src/main/java/io/crate/execution/engine/collect/sources/ShardCollectSource.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/sources/ShardCollectSource.java
@@ -468,13 +468,13 @@ public class ShardCollectSource implements CollectSource, IndexEventListener {
             IndexService indexService = indicesService.indexService(index);
             if (indexService == null) {
                 for (IntCursor shard : shards) {
-                    unassignedShards.add(toUnassignedShard(index.getName(), UnassignedShard.markAssigned(shard.value)));
+                    unassignedShards.add(toUnassignedShard(index, UnassignedShard.markAssigned(shard.value)));
                 }
                 continue;
             }
             for (IntCursor shard : shards) {
                 if (UnassignedShard.isUnassigned(shard.value)) {
-                    unassignedShards.add(toUnassignedShard(index.getName(), UnassignedShard.markAssigned(shard.value)));
+                    unassignedShards.add(toUnassignedShard(index, UnassignedShard.markAssigned(shard.value)));
                     continue;
                 }
                 ShardId shardId = new ShardId(index, shard.value);
@@ -482,7 +482,7 @@ public class ShardCollectSource implements CollectSource, IndexEventListener {
                     ShardCollectorProvider shardCollectorProvider = getCollectorProviderSafe(shardId);
                     shardRowContexts.add(shardCollectorProvider.shardRowContext());
                 } catch (ShardNotFoundException | IllegalIndexShardStateException e) {
-                    unassignedShards.add(toUnassignedShard(index.getName(), shard.value));
+                    unassignedShards.add(toUnassignedShard(index, shard.value));
                 }
             }
         }
@@ -505,7 +505,7 @@ public class ShardCollectSource implements CollectSource, IndexEventListener {
         return rows;
     }
 
-    private UnassignedShard toUnassignedShard(String indexName, int shardId) {
-        return new UnassignedShard(shardId, indexName, clusterService, false, ShardRoutingState.UNASSIGNED);
+    private UnassignedShard toUnassignedShard(Index index, int shardId) {
+        return new UnassignedShard(shardId, index, clusterService, false, ShardRoutingState.UNASSIGNED);
     }
 }

--- a/server/src/main/java/io/crate/expression/reference/sys/shard/ShardRowContext.java
+++ b/server/src/main/java/io/crate/expression/reference/sys/shard/ShardRowContext.java
@@ -124,6 +124,10 @@ public class ShardRowContext {
         return partitionIdent;
     }
 
+    public String partitionUUID() {
+        return indexShard.shardId().getIndex().getUUID();
+    }
+
     public int id() {
         return id;
     }

--- a/server/src/main/java/io/crate/metadata/shard/unassigned/UnassignedShard.java
+++ b/server/src/main/java/io/crate/metadata/shard/unassigned/UnassignedShard.java
@@ -23,6 +23,7 @@ package io.crate.metadata.shard.unassigned;
 
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.index.Index;
 
 import io.crate.metadata.IndexName;
 import io.crate.metadata.IndexParts;
@@ -77,17 +78,18 @@ public final class UnassignedShard {
     private final String partitionIdent;
     private final String state;
     private final boolean orphanedPartition;
+    private final String partitionUUID;
 
     private static final String UNASSIGNED = "UNASSIGNED";
     private static final String INITIALIZING = "INITIALIZING";
 
 
     public UnassignedShard(int shardId,
-                           String indexName,
+                           Index index,
                            ClusterService clusterService,
                            Boolean primary,
                            ShardRoutingState state) {
-        IndexParts indexParts = IndexName.decode(indexName);
+        IndexParts indexParts = IndexName.decode(index.getName());
         this.schemaName = indexParts.schema();
         this.tableName = indexParts.table();
         this.partitionIdent = indexParts.partitionIdent();
@@ -96,6 +98,7 @@ public final class UnassignedShard {
         this.primary = primary;
         this.id = shardId;
         this.state = state == ShardRoutingState.UNASSIGNED ? UNASSIGNED : INITIALIZING;
+        this.partitionUUID = index.getUUID();
     }
 
     public String tableName() {
@@ -112,6 +115,10 @@ public final class UnassignedShard {
 
     public String partitionIdent() {
         return partitionIdent;
+    }
+
+    public String partitionUUID() {
+        return partitionUUID;
     }
 
     public Boolean primary() {

--- a/server/src/main/java/io/crate/metadata/sys/SysShardsTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/sys/SysShardsTableInfo.java
@@ -77,6 +77,7 @@ public class SysShardsTableInfo {
         static final ColumnIdent SCHEMA_NAME = ColumnIdent.of("schema_name");
         public static final ColumnIdent TABLE_NAME = ColumnIdent.of("table_name");
         public static final ColumnIdent PARTITION_IDENT = ColumnIdent.of("partition_ident");
+        public static final ColumnIdent PARTITION_UUID = ColumnIdent.of("partition_uuid");
         static final ColumnIdent NUM_DOCS = ColumnIdent.of("num_docs");
         public static final ColumnIdent PRIMARY = ColumnIdent.of("primary");
         static final ColumnIdent RELOCATING_NODE = ColumnIdent.of("relocating_node");
@@ -104,6 +105,7 @@ public class SysShardsTableInfo {
             entry(Columns.SCHEMA_NAME, () -> forFunction(UnassignedShard::schemaName)),
             entry(Columns.TABLE_NAME, () -> forFunction(UnassignedShard::tableName)),
             entry(Columns.PARTITION_IDENT, () -> forFunction(UnassignedShard::partitionIdent)),
+            entry(Columns.PARTITION_UUID, () -> forFunction(UnassignedShard::partitionUUID)),
             entry(Columns.ID, () -> forFunction(UnassignedShard::id)),
             entry(Columns.NUM_DOCS, () -> constant(0L)),
             entry(Columns.PRIMARY, () -> forFunction(UnassignedShard::primary)),
@@ -131,6 +133,7 @@ public class SysShardsTableInfo {
             .add("table_name", STRING, r -> r.indexParts().table())
             .add("id", INTEGER, ShardRowContext::id)
             .add("partition_ident", STRING, ShardRowContext::partitionIdent)
+            .add("partition_uuid", STRING, ShardRowContext::partitionUUID)
             .add("num_docs", LONG, ShardRowContext::numDocs)
             .add("primary", BOOLEAN, r -> r.indexShard().routingEntry().primary())
             .add("relocating_node", STRING, r -> r.indexShard().routingEntry().relocatingNodeId())

--- a/server/src/test/java/io/crate/execution/engine/collect/sources/SystemCollectSourceTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/sources/SystemCollectSourceTest.java
@@ -33,6 +33,8 @@ import java.util.stream.StreamSupport;
 
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.test.IntegTestCase;
 import org.junit.Test;
 
@@ -87,7 +89,7 @@ public class SystemCollectSourceTest extends IntegTestCase {
             false
         ).apply(Collections.singletonList(new UnassignedShard(
             1,
-            "foo",
+            new Index("foo", UUIDs.randomBase64UUID()),
             mock(ClusterService.class),
             true,
             ShardRoutingState.UNASSIGNED)));

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -24,6 +24,7 @@ package io.crate.integrationtests;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
 import java.util.List;
@@ -571,7 +572,7 @@ public class InformationSchemaTest extends IntegTestCase {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertThat(response.rowCount()).isEqualTo(1023);
+        assertThat(response.rowCount()).isEqualTo(1024);
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/SysShardsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysShardsTest.java
@@ -28,6 +28,7 @@ import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.resolveCanonicalString;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.nio.file.Path;
@@ -164,7 +165,6 @@ public class SysShardsTest extends IntegTestCase {
     public void testSelectStarAllTables() throws Exception {
         SQLResponse response = execute("select * from sys.shards");
         assertThat(response.rowCount()).isEqualTo(26L);
-        assertThat(response.cols().length).isEqualTo(21);
         assertThat(response.cols()).containsExactly(
             "blob_path",
             "closed",
@@ -175,6 +175,7 @@ public class SysShardsTest extends IntegTestCase {
             "num_docs",
             "orphan_partition",
             "partition_ident",
+            "partition_uuid",
             "path",
             "primary",
             "recovery",


### PR DESCRIPTION
Although kind of an implementation detail it can be useful in tests and
when diagnosing issues if the uuid is visible somewhere.

This will even be more the case after:

- https://github.com/crate/crate/issues/11939
- https://github.com/crate/crate/pull/16964
