### PR TITLE
Include inner types to object literal's data type

### DIFF
--- a/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -1051,14 +1051,17 @@ public class ExpressionAnalyzer {
                 return Literal.EMPTY_OBJECT;
             }
             List<Symbol> arguments = new ArrayList<>(values.size() * 2);
+            var typeBuilder = ObjectType.of(ColumnPolicy.DYNAMIC);
             for (Map.Entry<String, Expression> entry : values.entrySet()) {
                 arguments.add(Literal.of(entry.getKey()));
                 arguments.add(entry.getValue().accept(this, context));
+                typeBuilder.setInnerType(entry.getKey(), entry.getValue().accept(this, context).valueType());
             }
-            return allocateFunction(
-                MapFunction.NAME,
+            return new Function(
+                MapFunction.SIGNATURE,
                 arguments,
-                context);
+                typeBuilder.build()
+            );
         }
 
         private static final Map<IntervalLiteral.IntervalField, IntervalParser.Precision> INTERVAL_FIELDS =


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Part of https://github.com/crate/crate/issues/14828 specifically regarding missing inner types of object literals causing ColumnUnknownExceptions.

## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
