### PR TITLE
Fix possible NPE when using invalid Azure repository endpoints

### DIFF
--- a/docs/appendices/release-notes/5.9.5.rst
+++ b/docs/appendices/release-notes/5.9.5.rst
@@ -57,4 +57,8 @@ Fixes
   on another. Example::
 
       SELECT count(*) FROM (SELECT id FROM users UNION ALL SELECT 1 as renamed) t;
-      
+
+- Return a proper error message when using an invalid
+  :ref:`sql-create-repo-azure-endpoint` or
+  :ref:`sql-create-repo-azure-secondary_endpoint` URI for defining an
+  :ref:`azure repository <sql-create-repo-azure>`.

--- a/plugins/es-repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureRepository.java
+++ b/plugins/es-repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureRepository.java
@@ -23,6 +23,7 @@ import static org.elasticsearch.repositories.azure.AzureStorageService.MAX_CHUNK
 import static org.elasticsearch.repositories.azure.AzureStorageService.MIN_CHUNK_SIZE;
 
 import java.net.Proxy;
+import java.net.URI;
 import java.util.List;
 import java.util.Locale;
 import java.util.function.Function;
@@ -30,6 +31,7 @@ import java.util.function.Function;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.cluster.metadata.RepositoryMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
@@ -112,10 +114,16 @@ public class AzureRepository extends BlobStoreRepository {
             Setting.Property.NodeScope);
 
         static final Setting<String> ENDPOINT_SETTING =
-            Setting.simpleString("endpoint", Property.NodeScope);
+            Setting.simpleString(
+                "endpoint",
+                val -> validateEndpoint(val, "endpoint"),
+                Property.NodeScope);
 
         static final Setting<String> SECONDARY_ENDPOINT_SETTING =
-            Setting.simpleString("secondary_endpoint", Property.NodeScope);
+            Setting.simpleString(
+                "secondary_endpoint",
+                val -> validateEndpoint(val, "secondary_endpoint"),
+                Property.NodeScope);
 
         /**
          * Azure endpoint suffix. Default to core.windows.net (CloudStorageAccount.DEFAULT_DNS).
@@ -147,6 +155,24 @@ public class AzureRepository extends BlobStoreRepository {
          */
         static final Setting<Integer> PROXY_PORT_SETTING =
             Setting.intSetting("proxy_port", 0, 0, 65535, Setting.Property.NodeScope);
+
+        /**
+         * Verify that the endpoint is a valid URI with a nonnull scheme and host.
+         * Otherwise, the Azure SDK will throw an NPE exception if host is null.
+         */
+        private static void validateEndpoint(String endpoint, String settingName) {
+            if (Strings.isNullOrEmpty(endpoint)) {
+                return;
+            }
+            try {
+                var uri = new URI(endpoint);
+                if (uri.getScheme() == null || uri.getHost() == null) {
+                    throw new ElasticsearchParseException("Invalid " + settingName + " URI: " + endpoint);
+                }
+            } catch (Exception e) {
+                throw new ElasticsearchParseException("Invalid " + settingName + " URI: " + endpoint, e);
+            }
+        }
     }
 
     public static List<Setting<?>> optionalSettings() {

--- a/plugins/es-repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureStorageSettings.java
+++ b/plugins/es-repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureStorageSettings.java
@@ -29,11 +29,11 @@ import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsException;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import com.microsoft.azure.storage.LocationMode;
 
-import org.jetbrains.annotations.Nullable;
-import org.jetbrains.annotations.VisibleForTesting;
 import io.crate.common.unit.TimeValue;
 
 public final class AzureStorageSettings {

--- a/plugins/es-repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureStorageServiceTests.java
+++ b/plugins/es-repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureStorageServiceTests.java
@@ -49,7 +49,7 @@ public class AzureStorageServiceTests extends ESTestCase {
     @Test
     public void test_cannot_set_endpoint_and_endpoint_suffix() {
         final Settings settings = Settings.builder().put(buildClientCredSettings())
-            .put("endpoint", "my_endpoint")
+            .put("endpoint", "http://my-endpoint")
             .put("endpoint_suffix", "my_endpoint_suffix").build();
         assertThatThrownBy(() -> storageServiceWithSettings(settings))
             .isExactlyInstanceOf(SettingsException.class)
@@ -59,7 +59,7 @@ public class AzureStorageServiceTests extends ESTestCase {
     @Test
     public void test_cannot_set_secondary_endpoint_without_endpoint() {
         final Settings settings = Settings.builder().put(buildClientCredSettings())
-            .put("secondary_endpoint", "my_secondary_endpoint").build();
+            .put("secondary_endpoint", "http://my-secondary-endpoint").build();
         assertThatThrownBy(() -> storageServiceWithSettings(settings))
             .isExactlyInstanceOf(SettingsException.class)
             .hasMessage("Cannot specify secondary_endpoint without specifying endpoint");

--- a/plugins/es-repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureStorageSettingsTest.java
+++ b/plugins/es-repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureStorageSettingsTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package org.elasticsearch.repositories.azure;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.settings.SettingsException;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Test;
+
+public class AzureStorageSettingsTest extends ESTestCase {
+
+    @Test
+    public void test_raise_exception_on_endpoint_uri_without_valid_host() {
+        {
+            var settings = Settings.builder()
+                .put("endpoint", "http://invalid.127.0.0.1")
+                .build();
+            assertThatThrownBy(() -> AzureStorageSettings.getClientSettings(settings))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Invalid endpoint URI: http://invalid.127.0.0.1");
+        }
+        {
+            var settings = Settings.builder()
+                .put("endpoint", "http://127.0.0.1")
+                .put("secondary_endpoint", "http://invalid.127.0.0.1")
+                .build();
+            assertThatThrownBy(() -> AzureStorageSettings.getClientSettings(settings))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Invalid secondary_endpoint URI: http://invalid.127.0.0.1");
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -1190,7 +1190,8 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                     metadata.name(),
                     errorInfo.getClass().getSimpleName(),
                     errorInfo.getMessage()
-                )
+                ),
+                errorInfo
             );
         }
     }


### PR DESCRIPTION
Add endpoint URI validation otherwise the Azure SDK will produce an NPE if the endpoint URI returns NULL for the `host` part.

This issue popped up while running the [AzureSnapshotIntegrationTest.create_azure_snapshot_and_restore_with_secondary_endpoint](https://github.com/crate/crate/blob/master/plugins/es-repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureSnapshotIntegrationTest.java#L111) on Windows, as Windows does not resolve `127.0.0.1` to a hostname, resulting in an invalid URI of `http://invalid.127.0.0.1` at [invalidHttpServerUrl()](https://github.com/crate/crate/blob/master/plugins/es-repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureSnapshotIntegrationTest.java#L209). This causes an NPE inside the Azure SDK and the error message was not helpful.

The mentioned test which is failing on Windows will be fixed in a separate PR.