### PR TITLE
Fix error handling for unknown object keys from aliasSymbols

### DIFF
--- a/server/src/main/java/io/crate/analyze/QueriedSelectRelation.java
+++ b/server/src/main/java/io/crate/analyze/QueriedSelectRelation.java
@@ -149,6 +149,9 @@ public class QueriedSelectRelation implements AnalyzedRelation {
             }
             childPath.addFirst(parentIdent.leafName());
         }
+        if (match != null) {
+            outputs.add(match);
+        }
         return match;
     }
 

--- a/server/src/main/java/io/crate/analyze/relations/AliasedAnalyzedRelation.java
+++ b/server/src/main/java/io/crate/analyze/relations/AliasedAnalyzedRelation.java
@@ -33,9 +33,7 @@ import io.crate.exceptions.AmbiguousColumnException;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.expression.symbol.ScopedSymbol;
 import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.VoidReference;
 import io.crate.metadata.ColumnIdent;
-import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.table.Operation;
 
@@ -116,11 +114,14 @@ public class AliasedAnalyzedRelation implements AnalyzedRelation, FieldResolver 
         if (field == null) {
             return null;
         }
+        /*
         if (field instanceof VoidReference voidReference) {
             return new VoidReference(
                 new ReferenceIdent(alias, voidReference.column()),
                 voidReference.position());
         }
+
+         */
         ScopedSymbol scopedSymbol = new ScopedSymbol(alias, column, field);
 
         // If the scopedSymbol exists already, return that instance.
@@ -131,6 +132,7 @@ public class AliasedAnalyzedRelation implements AnalyzedRelation, FieldResolver 
             return scopedSymbols.get(i);
         }
         scopedSymbols.add(scopedSymbol);
+        outputs.add(scopedSymbol);
         return scopedSymbol;
     }
 

--- a/server/src/main/java/io/crate/analyze/relations/AnalyzedView.java
+++ b/server/src/main/java/io/crate/analyze/relations/AnalyzedView.java
@@ -62,7 +62,7 @@ public final class AnalyzedView implements AnalyzedRelation, FieldResolver {
             var column = output.toColumn();
             outputs.add(new ScopedSymbol(name, column, output));
         }
-        this.outputSymbols = List.copyOf(outputs);
+        this.outputSymbols = outputs;
     }
 
     @NotNull
@@ -98,6 +98,8 @@ public final class AnalyzedView implements AnalyzedRelation, FieldResolver {
         int i = outputSymbols.indexOf(scopedSymbol);
         if (i >= 0) {
             return outputSymbols.get(i);
+        } else {
+            outputSymbols.add(scopedSymbol);
         }
         return scopedSymbol;
     }

--- a/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -30,6 +30,7 @@ import static io.crate.testing.Asserts.isField;
 import static io.crate.testing.Asserts.isFunction;
 import static io.crate.testing.Asserts.isLiteral;
 import static io.crate.testing.Asserts.isReference;
+import static io.crate.testing.Asserts.isScopedSymbol;
 import static io.crate.testing.Asserts.toCondition;
 import static io.crate.types.ArrayType.makeArray;
 import static org.assertj.core.api.Assertions.anyOf;
@@ -2295,8 +2296,9 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
                 "(select u1.friends as f1, u2.friends as f2 from doc.users u1, doc.users u2) joined");
         assertThat(relation.outputs())
             .satisfiesExactly(
-                isFunction(SubscriptFunction.NAME, isField("f1"), isLiteral("id")),
-                isFunction(SubscriptFunction.NAME, isField("f2"), isLiteral("id")));
+                isScopedSymbol("f1['id']"),
+                isScopedSymbol("f2['id']")
+            );
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes:
```
cr> create table t (obj_dynamic object);
CREATE OK, 1 row affected (1.605 sec)

cr> set error_on_unknown_object_key = 'false';
SET OK, 0 rows affected (0.009 sec)

cr> select alias['u'] from (select obj_dynamic['u'] as alias from t) tbl;
ColumnUnknownException[Column alias['u'] unknown]  <-- not expected since `alias['u']` is child of a dynamic object and the setting it set to false.
```

There is a fall back logic to use subscript function with appropriate column policy, but the column policy is not available.

The approach to address this issue is to allow resolving a sub-column from the source query whose outputs contain only the parent column. The sub-column is then added to the source's outputs as well.

i.e.:
Resolve `alias['u']` from
```
select alias['u'] from (select obj_dynamic['u'] as alias from t) tbl;
```
as `obj_dynamic['u']['u']`(a reference) as if the `analyzedRelation` for
```
(select obj_dynamic['u'] as alias from t)
```
includes `(obj_dynamic['u']['u'] AS alias['u'])` in its outputs. Then actually adds `obj_dynamic['u']['u']` to the outputs.


A regression caused by https://github.com/crate/crate/pull/17052.

## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
