### PR TITLE
Prune id field if it can be retrieved from elsewhere

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
@@ -108,6 +108,7 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
         this.referenceResolver = new LuceneReferenceResolver(
             indexShard.shardId().getIndexName(),
             table.partitionedByColumns(),
+            table.primaryKeyReference(),
             table.isParentReferenceIgnored()
         );
         this.docInputFactory = new DocInputFactory(nodeCtx, referenceResolver);

--- a/server/src/main/java/io/crate/execution/engine/fetch/NodeFetchOperation.java
+++ b/server/src/main/java/io/crate/execution/engine/fetch/NodeFetchOperation.java
@@ -83,6 +83,7 @@ public class NodeFetchOperation {
             LuceneReferenceResolver resolver = new LuceneReferenceResolver(
                 indexName,
                 table.partitionedByColumns(),
+                table.primaryKeyReference(),
                 table.isParentReferenceIgnored()
             );
             ArrayList<LuceneCollectorExpression<?>> exprs = new ArrayList<>(refs.size());

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/VirtualIdCollectorExpression.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/VirtualIdCollectorExpression.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.reference.doc.lucene;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import org.apache.lucene.search.Scorable;
+
+import io.crate.execution.engine.fetch.ReaderContext;
+
+public class VirtualIdCollectorExpression extends LuceneCollectorExpression<String> {
+
+    private final LuceneCollectorExpression<?> delegate;
+
+    public VirtualIdCollectorExpression(LuceneCollectorExpression<?> delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public String value() {
+        return Objects.toString(delegate.value());
+    }
+
+    @Override
+    public void startCollect(CollectorContext context) {
+        delegate.startCollect(context);
+    }
+
+    @Override
+    public void setNextDocId(int doc) {
+        delegate.setNextDocId(doc);
+    }
+
+    @Override
+    public void setNextReader(ReaderContext context) throws IOException {
+        delegate.setNextReader(context);
+    }
+
+    @Override
+    public void setScorer(Scorable scorer) {
+        delegate.setScorer(scorer);
+    }
+}

--- a/server/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
+++ b/server/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
@@ -106,6 +106,7 @@ public class LuceneQueryBuilder {
         var refResolver = new LuceneReferenceResolver(
             indexName,
             table.partitionedByColumns(),
+            table.primaryKeyReference(),
             table.isParentReferenceIgnored()
         );
         var normalizer = new EvaluatingNormalizer(nodeCtx, RowGranularity.PARTITION, refResolver, null);
@@ -117,7 +118,6 @@ public class LuceneQueryBuilder {
             queryCache,
             indexAnalyzers,
             indexName,
-            table.partitionedByColumns(),
             query
         );
         ctx.query = eliminateNullsIfPossible(
@@ -153,7 +153,6 @@ public class LuceneQueryBuilder {
                 QueryCache queryCache,
                 IndexAnalyzers indexAnalyzers,
                 String indexName,
-                List<Reference> partitionColumns,
                 Symbol parentQuery) {
             this.table = table;
             this.shardCreatedVersion = shardCreatedVersion;
@@ -164,7 +163,8 @@ public class LuceneQueryBuilder {
                 nodeCtx,
                 new LuceneReferenceResolver(
                     indexName,
-                    partitionColumns,
+                    table.partitionedByColumns(),
+                    table.primaryKeyReference(),
                     table.isParentReferenceIgnored()
                 )
             );

--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfoFactory.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfoFactory.java
@@ -113,6 +113,18 @@ public class DocTableInfoFactory {
         );
     }
 
+    public static boolean hasVirtualPrimaryKey(IndexMetadata indexMetadata) {
+        MappingMetadata mapping = indexMetadata.mapping();
+        Map<String, Object> mappingSource = mapping == null ? Map.of() : mapping.sourceAsMap();
+        final Map<String, Object> metaMap = Maps.getOrDefault(mappingSource, "_meta", Map.of());
+        List<ColumnIdent> primaryKeys = getPrimaryKeys(metaMap);
+        if (primaryKeys.size() != 1) {
+            return false;
+        }
+        var col = primaryKeys.getFirst();
+        return Objects.equals(SysColumns.Names.ID, col.fqn()) == false && Objects.equals(SysColumns.Names.UID, col.fqn()) == false;
+    }
+
     public void validateSchema(IndexMetadata indexMetadata) {
         String indexName = indexMetadata.getIndex().getName();
         if (IndexName.isDangling(indexName)) {

--- a/server/src/main/java/io/crate/metadata/table/TableInfo.java
+++ b/server/src/main/java/io/crate/metadata/table/TableInfo.java
@@ -26,6 +26,7 @@ import static io.crate.types.ArrayType.makeArray;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.function.Predicate;
 
 import org.elasticsearch.cluster.ClusterState;
@@ -38,6 +39,7 @@ import io.crate.metadata.RelationInfo;
 import io.crate.metadata.Routing;
 import io.crate.metadata.RoutingProvider;
 import io.crate.metadata.SimpleReference;
+import io.crate.metadata.doc.SysColumns;
 import io.crate.metadata.settings.CoordinatorSessionSettings;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
@@ -55,6 +57,22 @@ public interface TableInfo extends RelationInfo {
      */
     @Nullable
     Reference getReference(ColumnIdent columnIdent);
+
+    /**
+     * returns a Reference that can be used to get the primary key,
+     *         or {@code null} if such a Reference is not available
+     */
+    @Nullable
+    default Reference primaryKeyReference() {
+        if (primaryKey().size() != 1) {
+            return null;
+        }
+        var col = primaryKey().getFirst();
+        if (Objects.equals(col.fqn(), SysColumns.Names.ID) || Objects.equals(col.fqn(), SysColumns.Names.UID)) {
+            return null;
+        }
+        return getReference(col);
+    }
 
     /**
      * This is like {@link #getReference(ColumnIdent)},

--- a/server/src/main/java/io/crate/statistics/ReservoirSampler.java
+++ b/server/src/main/java/io/crate/statistics/ReservoirSampler.java
@@ -253,6 +253,7 @@ public final class ReservoirSampler {
         LuceneReferenceResolver referenceResolver = new LuceneReferenceResolver(
             indexName,
             docTable.partitionedByColumns(),
+            docTable.primaryKeyReference(),
             docTable.isParentReferenceIgnored()
         );
 

--- a/server/src/main/java/org/elasticsearch/index/IndexModule.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexModule.java
@@ -276,7 +276,8 @@ public final class IndexModule {
             BigArrays bigArrays,
             ThreadPool threadPool,
             QueryCache indicesQueryCache,
-            Supplier<TableInfo> getTable) throws IOException {
+            Supplier<TableInfo> getTable,
+            boolean hasVirtualPrimaryKey) throws IOException {
 
         final IndexEventListener eventListener = freeze();
         eventListener.beforeIndexCreated(indexSettings.getIndex(), indexSettings.getSettings());
@@ -302,6 +303,7 @@ public final class IndexModule {
             directoryFactory,
             eventListener,
             getTable,
+            hasVirtualPrimaryKey,
             indexOperationListeners
         );
     }

--- a/server/src/main/java/org/elasticsearch/index/engine/EngineConfig.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/EngineConfig.java
@@ -19,20 +19,21 @@
 
 package org.elasticsearch.index.engine;
 
+import java.util.List;
+import java.util.Objects;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
+
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.index.MergePolicy;
 import org.apache.lucene.search.QueryCache;
 import org.apache.lucene.search.QueryCachingPolicy;
 import org.apache.lucene.search.ReferenceManager;
-import org.jetbrains.annotations.Nullable;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.MemorySizeValue;
-import io.crate.common.unit.TimeValue;
-import io.crate.types.DataTypes;
-
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.codec.CodecService;
 import org.elasticsearch.index.mapper.ParsedDocument;
@@ -43,11 +44,10 @@ import org.elasticsearch.index.translog.TranslogConfig;
 import org.elasticsearch.indices.IndexingMemoryController;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.jetbrains.annotations.Nullable;
 
-import java.util.List;
-import java.util.Objects;
-import java.util.function.LongSupplier;
-import java.util.function.Supplier;
+import io.crate.common.unit.TimeValue;
+import io.crate.types.DataTypes;
 
 /*
  * Holds all the configuration that is used to create an {@link Engine}.
@@ -77,6 +77,7 @@ public final class EngineConfig {
     private final CircuitBreakerService circuitBreakerService;
     private final LongSupplier globalCheckpointSupplier;
     private final Supplier<RetentionLeases> retentionLeasesSupplier;
+    private final boolean virtualIdField;
 
     /**
      * A supplier of the outstanding retention leases. This is used during merged operations to determine which operations that have been
@@ -135,7 +136,8 @@ public final class EngineConfig {
                         LongSupplier globalCheckpointSupplier,
                         Supplier<RetentionLeases> retentionLeasesSupplier,
                         LongSupplier primaryTermSupplier,
-                        TombstoneDocSupplier tombstoneDocSupplier) {
+                        TombstoneDocSupplier tombstoneDocSupplier,
+                        boolean virtualIdField) {
         this.shardId = shardId;
         this.indexSettings = indexSettings;
         this.threadPool = threadPool;
@@ -170,6 +172,7 @@ public final class EngineConfig {
         this.retentionLeasesSupplier = Objects.requireNonNull(retentionLeasesSupplier);
         this.primaryTermSupplier = primaryTermSupplier;
         this.tombstoneDocSupplier = tombstoneDocSupplier;
+        this.virtualIdField = virtualIdField;
     }
 
     /**
@@ -240,6 +243,10 @@ public final class EngineConfig {
      */
     public LongSupplier getGlobalCheckpointSupplier() {
         return globalCheckpointSupplier;
+    }
+
+    public boolean isIdFieldVirtual() {
+        return virtualIdField;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -2293,7 +2293,8 @@ public class InternalEngine extends Engine {
                     Lucene.SOFT_DELETES_FIELD,
                     softDeletesPolicy::getRetentionQuery,
                     new PrunePostingsMergePolicy(mergePolicy, SysColumns.Names.ID)
-                )
+                ),
+                engineConfig.isIdFieldVirtual()
             );
         }
         boolean shuffleForcedMerge = Booleans.parseBoolean(System.getProperty("es.shuffle_forced_merge", Boolean.TRUE.toString()));

--- a/server/src/main/java/org/elasticsearch/index/engine/LuceneChangesSnapshot.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/LuceneChangesSnapshot.java
@@ -246,8 +246,8 @@ final class LuceneChangesSnapshot implements Translog.Snapshot {
             assert assertDocSoftDeleted(leaf.reader(), segmentDocID) : "Noop but soft_deletes field is not set [" + op + "]";
         } else {
             final String id = fields.id();
-            final Term uid = new Term(SysColumns.Names.ID, Uid.encodeId(id));
             if (isTombstone) {
+                final Term uid = new Term(SysColumns.Names.ID, Uid.encodeId(id));
                 op = new Translog.Delete(id, uid, seqNo, primaryTerm, version);
                 assert assertDocSoftDeleted(leaf.reader(), segmentDocID) : "Delete op but soft_deletes field is not set [" + op + "]";
             } else {

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -239,6 +239,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     private final Analyzer indexAnalyzer;
 
     private final DocTableInfoFactory tableFactory;
+    private final boolean hasVirtualPrimaryKey;
 
     public IndexShard(
             NodeContext nodeContext,
@@ -255,7 +256,9 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             BigArrays bigArrays,
             List<IndexingOperationListener> listeners,
             Runnable globalCheckpointSyncer,
-            RetentionLeaseSyncer retentionLeaseSyncer, CircuitBreakerService circuitBreakerService) throws IOException {
+            RetentionLeaseSyncer retentionLeaseSyncer,
+            CircuitBreakerService circuitBreakerService,
+            boolean hasVirtualPrimaryKey) throws IOException {
         super(shardRouting.shardId(), indexSettings);
         assert shardRouting.initializing();
         this.shardRouting = shardRouting;
@@ -276,6 +279,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         this.path = path;
         this.circuitBreakerService = circuitBreakerService;
         this.tableFactory = new DocTableInfoFactory(nodeContext);
+        this.hasVirtualPrimaryKey = hasVirtualPrimaryKey;
         /* create engine config */
         logger.debug("state: [CREATED]");
 
@@ -2596,7 +2600,8 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             globalCheckpointSupplier,
             replicationTracker::getRetentionLeases,
             this::getOperationPrimaryTerm,
-            tombstoneDocSupplier()
+            tombstoneDocSupplier(),
+            hasVirtualPrimaryKey
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -452,7 +452,7 @@ public class IndicesService extends AbstractLifecycleComponent
             idxSettings.getNumberOfReplicas(),
             indexCreationContext);
 
-        final IndexModule indexModule = new IndexModule(idxSettings, analysisRegistry,engineFactoryProviders, directoryFactories);
+        final IndexModule indexModule = new IndexModule(idxSettings, analysisRegistry, engineFactoryProviders, directoryFactories);
         for (IndexingOperationListener operationListener : indexingOperationListeners) {
             indexModule.addIndexOperationListener(operationListener);
         }
@@ -471,7 +471,8 @@ public class IndicesService extends AbstractLifecycleComponent
             bigArrays,
             threadPool,
             indicesQueryCache,
-            () -> schemas.getTableInfo(RelationName.fromIndexName(indexName))
+            () -> schemas.getTableInfo(RelationName.fromIndexName(indexName)),
+            DocTableInfoFactory.hasVirtualPrimaryKey(indexMetadata)
         );
     }
 

--- a/server/src/test/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/DocValuesGroupByOptimizedIteratorTest.java
@@ -275,7 +275,7 @@ public class DocValuesGroupByOptimizedIteratorTest extends CrateDummyClusterServ
         var collectPhase = createCollectPhase(List.of(reference), List.of(groupProjection));
         var collectTask = createCollectTask(shard, collectPhase, Version.CURRENT);
         var nodeCtx = createNodeContext();
-        var referenceResolver = new LuceneReferenceResolver(shard.shardId().getIndexName(), List.of(), _ -> false);
+        var referenceResolver = new LuceneReferenceResolver(shard.shardId().getIndexName(), List.of(), null, _ -> false);
 
         var it = DocValuesGroupByOptimizedIterator.tryOptimize(
             functions,

--- a/server/src/test/java/io/crate/execution/engine/collect/GroupByOptimizedIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/GroupByOptimizedIteratorTest.java
@@ -242,7 +242,7 @@ public class GroupByOptimizedIteratorTest extends CrateDummyClusterServiceUnitTe
             new InputFactory(nodeCtx),
             new DocInputFactory(
                 nodeCtx,
-                new LuceneReferenceResolver(shard.shardId().getIndexName(), List.of(), (_) -> false)
+                new LuceneReferenceResolver(shard.shardId().getIndexName(), List.of(), null, (_) -> false)
             ),
             collectPhase,
             collectTask

--- a/server/src/test/java/io/crate/expression/reference/doc/lucene/LuceneReferenceResolverTest.java
+++ b/server/src/test/java/io/crate/expression/reference/doc/lucene/LuceneReferenceResolverTest.java
@@ -49,6 +49,7 @@ public class LuceneReferenceResolverTest extends CrateDummyClusterServiceUnitTes
     private static final LuceneReferenceResolver LUCENE_REFERENCE_RESOLVER = new LuceneReferenceResolver(
         RELATION_NAME.indexNameOrAlias(),
         List.of(),
+        null,
         (_) -> false
     );
 
@@ -116,6 +117,7 @@ public class LuceneReferenceResolverTest extends CrateDummyClusterServiceUnitTes
         LuceneReferenceResolver refResolver = new LuceneReferenceResolver(
             partitionName.asIndexName(),
             table.partitionedByColumns(),
+            null,
             table.isParentReferenceIgnored()
         );
         Reference year = table.getReference(ColumnIdent.of("year"));

--- a/server/src/test/java/io/crate/integrationtests/DanglingIndicesIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/DanglingIndicesIntegrationTest.java
@@ -22,7 +22,6 @@
 package io.crate.integrationtests;
 
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.test.IntegTestCase;

--- a/server/src/test/java/io/crate/integrationtests/PruneRecoverySourceIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PruneRecoverySourceIntegrationTest.java
@@ -24,11 +24,13 @@ package io.crate.integrationtests;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import java.io.IOException;
+import java.util.function.IntFunction;
 
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.StoredFieldVisitor;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.engine.Engine;
+import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.test.IntegTestCase;
 import org.junit.Test;
@@ -36,43 +38,95 @@ import org.junit.Test;
 @IntegTestCase.ClusterScope(minNumDataNodes = 3)
 public class PruneRecoverySourceIntegrationTest extends IntegTestCase {
 
-    @Test
-    public void testPruneRecoverySource() throws IOException {
-        execute("create table tbl (x int) with (number_of_replicas=2)");
-        for (int i = 0; i < 500; i++) {
-            execute("insert into tbl (x) values (" + i + ")");
+    private void indexWith(String statement, int docCount, IntFunction<Object[]> supplier) {
+        for (int i = 0; i < docCount; i++) {
+            execute(statement, supplier.apply(i));
         }
+    }
+
+    @Test
+    public void testPruneRecoverySource() throws Exception {
+
+        int docCount = 500;
+
+        execute("create table tbl (x int) with (number_of_replicas=2)");
+        indexWith("insert into tbl (x) values (?)", docCount, i -> new Object[]{ i });
+        execute("refresh table tbl");
+        execute("select count(*) from tbl");
+        assertThat(response.rows()[0][0]).isEqualTo((long) docCount);
+
         execute("optimize table tbl with (max_num_segments = 1)");
         execute("refresh table tbl");
+        assertThat(storedFieldCount("_recovery_source")).isLessThan(docCount);
+        // generated ids don't get pruned
+        assertThat(storedFieldCount("_id")).isEqualTo(docCount);
+    }
 
-        int docCount = 0;
-        int[] recoverySourceCount = new int[1];
+    @Test
+    public void testPruneId() throws Exception {
 
+        int docCount = 500;
+
+        execute("create table tbl (x int primary key) with (number_of_replicas=2)");
+        indexWith("insert into tbl (x) values (?)", docCount, i -> new Object[]{ i });
+        execute("refresh table tbl");
+        execute("select count(*) from tbl");
+        assertThat(response.rows()[0][0]).isEqualTo((long) docCount);
+
+        execute("optimize table tbl with (max_num_segments = 1)");
+        execute("refresh table tbl");
+        assertThat(storedFieldCount("_recovery_source")).isLessThan(docCount);
+        // ids that map to a single field stored elsewhere can be pruned
+        assertThat(storedFieldCount("_id")).isLessThan(docCount);
+    }
+
+    @Test
+    public void testMultiplePrimaryKeys() throws Exception {
+
+        int docCount = 500;
+
+        execute("create table tbl (x int primary key, y int primary key) with (number_of_replicas=2)");
+        indexWith("insert into tbl (x, y) values (?, ?)", docCount, i -> new Object[]{ i, i + 1 });
+        execute("refresh table tbl");
+        execute("select count(*) from tbl");
+        assertThat(response.rows()[0][0]).isEqualTo((long) docCount);
+
+        execute("optimize table tbl with (max_num_segments = 1)");
+        execute("refresh table tbl");
+        assertThat(storedFieldCount("_recovery_source")).isLessThan(docCount);
+        // We don't prune IDs if they don't directly map to a single other source
+        assertThat(storedFieldCount("_id")).isEqualTo(docCount);
+
+    }
+
+    private int storedFieldCount(String field) throws IOException {
+        ensureGreen();
+        int[] fieldCount = new int[1];
         var indexesService = cluster().getDataNodeInstance(IndicesService.class);
         for (IndexService service : indexesService) {
-            try (Engine.Searcher searcher = service.getShard(0).acquireSearcher("test")) {
-                var reader = searcher.getIndexReader();
-                var storedFields = reader.storedFields();
-                for (int doc = 0; doc < reader.maxDoc(); doc++) {
-                    docCount++;
-                    storedFields.document(doc, new StoredFieldVisitor() {
-                        @Override
-                        public Status needsField(FieldInfo fieldInfo) throws IOException {
-                            return Status.YES;
-                        }
-
-                        @Override
-                        public void binaryField(FieldInfo fieldInfo, byte[] value) throws IOException {
-                            if (fieldInfo.name.equals("_recovery_source")) {
-                                recoverySourceCount[0]++;
+            for (IndexShard shard : service) {
+                try (Engine.Searcher searcher = shard.acquireSearcher("test")) {
+                    var reader = searcher.getIndexReader();
+                    var storedFields = reader.storedFields();
+                    for (int doc = 0; doc < reader.maxDoc(); doc++) {
+                        storedFields.document(doc, new StoredFieldVisitor() {
+                            @Override
+                            public Status needsField(FieldInfo fieldInfo) {
+                                return Status.YES;
                             }
-                        }
-                    });
+
+                            @Override
+                            public void binaryField(FieldInfo fieldInfo, byte[] value) {
+                                if (fieldInfo.name.equals(field)) {
+                                    fieldCount[0]++;
+                                }
+                            }
+                        });
+                    }
                 }
             }
         }
-
-        assertThat(docCount).isGreaterThan(recoverySourceCount[0]);
+        return fieldCount[0];
     }
 
 }

--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -3220,7 +3220,8 @@ public class InternalEngineTests extends EngineTestCase {
             () -> UNASSIGNED_SEQ_NO,
             () -> RetentionLeases.EMPTY,
             primaryTerm::get,
-            tombstoneDocSupplier()
+            tombstoneDocSupplier(),
+            false
         );
         assertThatThrownBy(() -> new InternalEngine(brokenConfig))
             .isExactlyInstanceOf(EngineCreationFailureException.class);

--- a/server/src/test/java/org/elasticsearch/index/engine/RecoverySourcePruneMergePolicyTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/RecoverySourcePruneMergePolicyTests.java
@@ -62,7 +62,8 @@ public class RecoverySourcePruneMergePolicyTests extends ESTestCase {
             RecoverySourcePruneMergePolicy mp = new RecoverySourcePruneMergePolicy(
                 "extra_source",
                 MatchNoDocsQuery::new,
-                newLogMergePolicy()
+                newLogMergePolicy(),
+                false
             );
             iwc.setMergePolicy(new ShuffleForcedMergePolicy(mp));
             try (IndexWriter writer = new IndexWriter(dir, iwc)) {
@@ -131,7 +132,7 @@ public class RecoverySourcePruneMergePolicyTests extends ESTestCase {
             IndexWriterConfig iwc = newIndexWriterConfig();
             iwc.setMergePolicy(new RecoverySourcePruneMergePolicy("extra_source",
                                                                   () -> new TermQuery(new Term("even", "true")),
-                                                                  iwc.getMergePolicy()));
+                                                                  iwc.getMergePolicy(), false));
             try (IndexWriter writer = new IndexWriter(dir, iwc)) {
                 for (int i = 0; i < 20; i++) {
                     if (i > 0 && randomBoolean()) {
@@ -173,7 +174,7 @@ public class RecoverySourcePruneMergePolicyTests extends ESTestCase {
         try (Directory dir = newDirectory()) {
             IndexWriterConfig iwc = newIndexWriterConfig();
             iwc.setMergePolicy(new RecoverySourcePruneMergePolicy("extra_source",
-                                                                  () -> new MatchAllDocsQuery(), iwc.getMergePolicy()));
+                                                                  () -> new MatchAllDocsQuery(), iwc.getMergePolicy(), false));
             try (IndexWriter writer = new IndexWriter(dir, iwc)) {
                 for (int i = 0; i < 20; i++) {
                     if (i > 0 && randomBoolean()) {

--- a/server/src/test/java/org/elasticsearch/indices/IndexingMemoryControllerIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndexingMemoryControllerIT.java
@@ -71,7 +71,7 @@ public class IndexingMemoryControllerIT extends IntegTestCase {
                                     config.getQueryCachingPolicy(), config.getTranslogConfig(), config.getFlushMergesAfter(),
                                     config.getExternalRefreshListener(), config.getInternalRefreshListener(),
                                     config.getCircuitBreakerService(), config.getGlobalCheckpointSupplier(), config.retentionLeasesSupplier(),
-                                    config.getPrimaryTermSupplier(), config.getTombstoneDocSupplier());
+                                    config.getPrimaryTermSupplier(), config.getTombstoneDocSupplier(), config.isIdFieldVirtual());
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/indices/IndexingMemoryControllerTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndexingMemoryControllerTests.java
@@ -393,7 +393,7 @@ public class IndexingMemoryControllerTests extends IndexShardTestCase {
                                 config.getQueryCachingPolicy(), config.getTranslogConfig(), config.getFlushMergesAfter(),
                                 config.getExternalRefreshListener(), internalRefreshListener,
                                 config.getCircuitBreakerService(), config.getGlobalCheckpointSupplier(), config.retentionLeasesSupplier(),
-                                config.getPrimaryTermSupplier(), config.getTombstoneDocSupplier());
+                                config.getPrimaryTermSupplier(), config.getTombstoneDocSupplier(), config.isIdFieldVirtual());
     }
 
     ThreadPoolStats.Stats getRefreshThreadPoolStats() {

--- a/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
+++ b/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
@@ -221,6 +221,7 @@ public abstract class AggregationTestCase extends ESTestCase {
         var refResolver = new LuceneReferenceResolver(
             shard.shardId().getIndexName(),
             List.of(),
+            null,
             (_) -> false
         );
 
@@ -563,7 +564,9 @@ public abstract class AggregationTestCase extends ESTestCase {
                 BigArrays.NON_RECYCLING_INSTANCE,
                 List.of(),
                 () -> { },
-                RetentionLeaseSyncer.EMPTY, new NoneCircuitBreakerService()
+                RetentionLeaseSyncer.EMPTY,
+                new NoneCircuitBreakerService(),
+                false
             );
         } catch (IOException e) {
             IOUtils.close(store);

--- a/server/src/testFixtures/java/io/crate/testing/IndexEnv.java
+++ b/server/src/testFixtures/java/io/crate/testing/IndexEnv.java
@@ -91,6 +91,7 @@ public final class IndexEnv implements AutoCloseable {
         luceneReferenceResolver = new LuceneReferenceResolver(
             indexName,
             table.partitionedByColumns(),
+            table.primaryKeyReference(),
             table.isParentReferenceIgnored()
         );
         indexService = indexModule.newIndexService(
@@ -112,7 +113,8 @@ public final class IndexEnv implements AutoCloseable {
             BigArrays.NON_RECYCLING_INSTANCE,
             threadPool,
             IndicesQueryCache.createCache(Settings.EMPTY),
-            () -> table
+            () -> table,
+            false
         );
         IndexWriterConfig conf = new IndexWriterConfig(new StandardAnalyzer());
         writer = new IndexWriter(new ByteBuffersDirectory(), conf);

--- a/server/src/testFixtures/java/org/elasticsearch/index/engine/EngineTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/index/engine/EngineTestCase.java
@@ -217,7 +217,8 @@ public abstract class EngineTestCase extends ESTestCase {
             globalCheckpointSupplier,
             config.retentionLeasesSupplier(),
             config.getPrimaryTermSupplier(),
-            tombstoneDocSupplier()
+            tombstoneDocSupplier(),
+            config.isIdFieldVirtual()
         );
     }
 
@@ -241,7 +242,8 @@ public abstract class EngineTestCase extends ESTestCase {
             config.getGlobalCheckpointSupplier(),
             config.retentionLeasesSupplier(),
             config.getPrimaryTermSupplier(),
-            config.getTombstoneDocSupplier());
+            config.getTombstoneDocSupplier(),
+            config.isIdFieldVirtual());
     }
 
     public EngineConfig copy(EngineConfig config, MergePolicy mergePolicy) {
@@ -264,7 +266,8 @@ public abstract class EngineTestCase extends ESTestCase {
             config.getGlobalCheckpointSupplier(),
             config.retentionLeasesSupplier(),
             config.getPrimaryTermSupplier(),
-            config.getTombstoneDocSupplier()
+            config.getTombstoneDocSupplier(),
+            config.isIdFieldVirtual()
         );
     }
 
@@ -701,7 +704,8 @@ public abstract class EngineTestCase extends ESTestCase {
             globalCheckpointSupplier,
             retentionLeasesSupplier,
             primaryTerm,
-            tombstoneDocSupplier());
+            tombstoneDocSupplier(),
+            false);
     }
 
     protected EngineConfig config(EngineConfig config,
@@ -736,7 +740,8 @@ public abstract class EngineTestCase extends ESTestCase {
             config.getGlobalCheckpointSupplier(),
             config.retentionLeasesSupplier(),
             config.getPrimaryTermSupplier(),
-            tombstoneDocSupplier);
+            tombstoneDocSupplier,
+            config.isIdFieldVirtual());
     }
 
     protected EngineConfig noOpConfig(IndexSettings indexSettings, Store store, Path translogPath) {

--- a/server/src/testFixtures/java/org/elasticsearch/index/shard/IndexShardTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/index/shard/IndexShardTestCase.java
@@ -532,7 +532,8 @@ public abstract class IndexShardTestCase extends ESTestCase {
                 BigArrays.NON_RECYCLING_INSTANCE,
                 Arrays.asList(listeners),
                 globalCheckpointSyncer,
-                retentionLeaseSyncer, breakerService
+                retentionLeaseSyncer, breakerService,
+                false
             );
             indexShard.addShardFailureCallback(DEFAULT_SHARD_FAILURE_HANDLER);
             success = true;


### PR DESCRIPTION
If the primary key on a table is a single column with doc-values enabled, then 
it can be retrieved from this column instead of being separately stored.

Separate storage is still required for replication, so rather than bypassing storage
entirely, the recovery source pruning mechanism is extended to also remove the
id field if it is no longer needed.

Resolves #12475 