### PR TITLE
Test: fix test_can_select_node_attributes_sub_fields

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/SysNodesITest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysNodesITest.java
@@ -89,7 +89,7 @@ public class SysNodesITest extends IntegTestCase {
 
     @Test
     public void test_can_select_node_attributes_sub_fields() {
-        execute("SELECT attributes['color'] FROM sys.nodes order by 1");
+        execute("SELECT attributes['color'] FROM sys.nodes order by name");
         int numDataNodes = cluster().numDataNodes();
         String[] expectedRows = new String[numDataNodes];
         for (int i = 0; i < numDataNodes; i++) {


### PR DESCRIPTION
`test_can_select_node_attributes_sub_fields` added from https://github.com/crate/crate/pull/17103 has a typo.

Please see `test_node_attributes`, which was used to write the test.