### PR TITLE
Add another profile for x86_64

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -447,6 +447,18 @@
       </properties>
     </profile>
     <profile>
+      <id>x86_64</id>
+      <activation>
+        <property>
+          <name>os.arch</name>
+          <value>x86_64</value>
+        </property>
+      </activation>
+      <properties>
+        <os.arch.classifier>x86_64</os.arch.classifier>
+      </properties>
+    </profile>
+    <profile>
       <id>aarch64</id>
       <activation>
         <property>


### PR DESCRIPTION
On x86_64 MacOS
 `./mvnw -version` shows arch: "x86_64", existing "amd64" doesn't fit.

 Follow up to https://github.com/crate/crate/commit/8121f192202b3aa8ccdff63232cb968bf7d6a0c3
 
 Without this change  `./mvnw package` fails with 
```
  Could not resolve dependencies for project io.crate:crate-copy-azure:jar:5.10.0
[ERROR] dependency: org.apache.opendal:opendal-java:jar:osx-${os.arch.classifier}:0.46.3 (compile)
```


