### PR TITLE
Add RelationMetadata.Table

### DIFF
--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportCreateTableAction.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportCreateTableAction.java
@@ -24,7 +24,9 @@ package io.crate.execution.ddl.tables;
 import static org.elasticsearch.cluster.metadata.MetadataCreateIndexService.validateSoftDeletesSetting;
 
 import java.io.IOException;
+import java.util.List;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.ActiveShardCount;
@@ -35,6 +37,8 @@ import org.elasticsearch.cluster.ack.ClusterStateUpdateResponse;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.IndexMetadata.State;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.MetadataCreateIndexService;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Priority;
@@ -47,9 +51,15 @@ import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
+import io.crate.common.collections.Lists;
 import io.crate.exceptions.RelationAlreadyExists;
 import io.crate.execution.ddl.Templates;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.NodeContext;
+import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
+import io.crate.metadata.doc.DocTableInfo;
+import io.crate.metadata.doc.DocTableInfoFactory;
 
 /**
  * Action to perform creation of tables on the master but avoid race conditions with creating views.
@@ -79,10 +89,12 @@ public class TransportCreateTableAction extends TransportMasterNodeAction<Create
     private final MetadataCreateIndexService createIndexService;
     private final IndicesService indicesService;
     private final IndexScopedSettings indexScopedSettings;
+    private final DocTableInfoFactory docTableInfoFactory;
 
     @Inject
     public TransportCreateTableAction(TransportService transportService,
                                       ClusterService clusterService,
+                                      NodeContext nodeContext,
                                       ThreadPool threadPool,
                                       IndicesService indicesService,
                                       IndexScopedSettings indexScopedSettings,
@@ -96,6 +108,7 @@ public class TransportCreateTableAction extends TransportMasterNodeAction<Create
         this.createIndexService = createIndexService;
         this.indicesService = indicesService;
         this.indexScopedSettings = indexScopedSettings;
+        this.docTableInfoFactory = new DocTableInfoFactory(nodeContext);
     }
 
     @Override
@@ -168,16 +181,52 @@ public class TransportCreateTableAction extends TransportMasterNodeAction<Create
 
             @Override
             public ClusterState execute(ClusterState currentState) throws Exception {
+                ClusterState newState;
                 if (isPartitioned) {
-                    return Templates.add(
+                    newState = Templates.add(
                         indicesService,
                         createIndexService,
                         currentState,
                         request,
                         normalizedSettings
                     );
+                } else {
+                    newState = createIndexService.add(currentState, request, normalizedSettings);
                 }
-                return createIndexService.add(currentState, request, normalizedSettings);
+
+                if (currentState.nodes().getSmallestNonClientNodeVersion().onOrAfter(Version.V_6_0_0)) {
+                    List<String> indexUUIDs = newState.metadata().getIndices(
+                        relationName,
+                        List.of(),
+                        false,
+                        imd -> imd.getIndexUUID()
+                    );
+
+                    // To avoid assigning new oids this needs to use references from the already updated metadata
+                    DocTableInfo docTable = docTableInfoFactory.create(relationName, newState.metadata());
+                    List<Reference> columns = Lists.map(request.references(), ref -> {
+                        ColumnIdent column = ref.column();
+                        Reference reference = docTable.getReference(column);
+                        return reference != null ? reference : docTable.indexColumn(column);
+                    });
+                    Metadata.Builder newMetadata = Metadata.builder(newState.metadata())
+                        .setTable(
+                            relationName,
+                            columns,
+                            normalizedSettings,
+                            request.routingColumn(),
+                            request.tableColumnPolicy(),
+                            request.pkConstraintName(),
+                            request.checkConstraints(),
+                            request.primaryKeys(),
+                            request.partitionedBy(),
+                            State.OPEN,
+                            indexUUIDs
+                        );
+                    return ClusterState.builder(newState).metadata(newMetadata).build();
+                }
+
+                return newState;
             }
         };
         clusterService.submitStateUpdateTask("create-table", createTableTask);

--- a/server/src/main/java/io/crate/fdw/ForeignTable.java
+++ b/server/src/main/java/io/crate/fdw/ForeignTable.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -115,6 +116,7 @@ public record ForeignTable(RelationName name,
                     case "references":
                         references = new HashMap<>();
                         Map<ColumnIdent, IndexReference.Builder> indexColumns = new HashMap<>();
+                        Set<Reference> droppedColumns = new HashSet<>();
 
                         Map<String, Object> properties = parser.map();
                         DocTableInfoFactory.parseColumns(
@@ -127,7 +129,8 @@ public record ForeignTable(RelationName name,
                             List.of(),
                             properties,
                             indexColumns,
-                            references
+                            references,
+                            droppedColumns
                         );
                         break;
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/RelationMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/RelationMetadata.java
@@ -23,15 +23,25 @@
 package org.elasticsearch.cluster.metadata;
 
 import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
+import org.elasticsearch.cluster.metadata.IndexMetadata.State;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.settings.Settings;
+import org.jetbrains.annotations.Nullable;
 
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
+import io.crate.sql.tree.ColumnPolicy;
 
 public sealed interface RelationMetadata extends Writeable permits
-    RelationMetadata.BlobTable {
+    RelationMetadata.BlobTable,
+    RelationMetadata.Table {
 
     short ord();
 
@@ -41,10 +51,10 @@ public sealed interface RelationMetadata extends Writeable permits
         short ord = in.readShort();
         return switch (ord) {
             case BlobTable.ORD -> RelationMetadata.BlobTable.of(in);
+            case Table.ORD -> RelationMetadata.Table.of(in);
             default -> throw new IllegalArgumentException("Invalid RelationMetadata ord: " + ord);
         };
     }
-
 
     public static void toStream(StreamOutput out, RelationMetadata v) throws IOException {
         out.writeShort(v.ord());
@@ -70,6 +80,70 @@ public sealed interface RelationMetadata extends Writeable permits
         @Override
         public short ord() {
             return ORD;
+        }
+    }
+
+    public static final record Table(
+            RelationName name,
+            List<Reference> columns,
+            Settings settings,
+            @Nullable ColumnIdent routingColumn,
+            ColumnPolicy columnPolicy,
+            @Nullable String pkConstraintName,
+            Map<String, String> checkConstraints,
+            List<ColumnIdent> primaryKeys,
+            List<ColumnIdent> partitionedBy,
+            IndexMetadata.State state,
+            List<String> indexUUIDs) implements RelationMetadata {
+
+        private static final short ORD = 1;
+
+        @Override
+        public short ord() {
+            return ORD;
+        }
+
+        public static Table of(StreamInput in) throws IOException {
+            RelationName name = new RelationName(in);
+            List<Reference> columns = in.readList(Reference::fromStream);
+            Settings settings = Settings.readSettingsFromStream(in);
+            ColumnIdent routingColumn = in.readOptionalWriteable(ColumnIdent::of);
+            ColumnPolicy columnPolicy = ColumnPolicy.VALUES.get(in.readVInt());
+            String pkConstraintName = in.readOptionalString();
+            Map<String, String> checkConstraints = in.readMap(
+                LinkedHashMap::new, StreamInput::readString, StreamInput::readString);
+            List<ColumnIdent> primaryKeys = in.readList(ColumnIdent::of);
+            List<ColumnIdent> partitionedBy = in.readList(ColumnIdent::of);
+            State state = in.readEnum(State.class);
+            List<String> indexUUIDs = in.readStringList();
+            return new Table(
+                name,
+                columns,
+                settings,
+                routingColumn,
+                columnPolicy,
+                pkConstraintName,
+                checkConstraints,
+                primaryKeys,
+                partitionedBy,
+                state,
+                indexUUIDs
+            );
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            name.writeTo(out);
+            out.writeCollection(columns, Reference::toStream);
+            Settings.writeSettingsToStream(out, settings);
+            out.writeOptionalWriteable(routingColumn);
+            out.writeVInt(columnPolicy.ordinal());
+            out.writeOptionalString(pkConstraintName);
+            out.writeMap(checkConstraints, StreamOutput::writeString, StreamOutput::writeString);
+            out.writeList(primaryKeys);
+            out.writeList(partitionedBy);
+            out.writeEnum(state);
+            out.writeStringCollection(indexUUIDs);
         }
     }
 }

--- a/server/src/test/java/io/crate/execution/ddl/tables/DropColumnTaskTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/tables/DropColumnTaskTest.java
@@ -23,6 +23,7 @@ package io.crate.execution.ddl.tables;
 
 import static io.crate.testing.Asserts.assertThat;
 import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
@@ -77,7 +78,8 @@ public class DropColumnTaskTest extends CrateDummyClusterServiceUnitTest {
         assertThat(newTable.columns()).hasSize(2);
         assertThat(newTable.droppedColumns()).satisfiesExactly(
             x -> assertThat(x)
-                .hasName("_dropped_2")
+                .hasName("y")
+                .hasFieldOrPropertyWithValue("dropped", true)
                 .hasPosition(2)
         );
     }
@@ -111,7 +113,8 @@ public class DropColumnTaskTest extends CrateDummyClusterServiceUnitTest {
         assertThat(newTable.columns()).hasSize(2);
         assertThat(newTable.droppedColumns()).satisfiesExactly(
             x -> assertThat(x)
-                .hasName("_dropped_2")
+                .hasName("y")
+                .hasFieldOrPropertyWithValue("dropped", true)
                 .hasPosition(2)
         );
     }

--- a/server/src/test/java/io/crate/integrationtests/CreateTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CreateTableIntegrationTest.java
@@ -27,6 +27,7 @@ import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -48,6 +49,7 @@ import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.test.IntegTestCase;
 import org.junit.Test;
 
+import io.crate.metadata.RelationName;
 import io.crate.testing.Asserts;
 
 public class CreateTableIntegrationTest extends IntegTestCase {
@@ -94,6 +96,7 @@ public class CreateTableIntegrationTest extends IntegTestCase {
                 return ClusterState.builder(currentState)
                     .metadata(
                         Metadata.builder(metadata)
+                            .dropRelation(new RelationName("doc", "tbl"))
                             .put(
                                 IndexMetadata.builder(indexMetadata)
                                     .putMapping(new MappingMetadata(new CompressedXContent(newMapping)))

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -28,6 +28,7 @@ import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 

--- a/server/src/test/java/io/crate/metadata/doc/DocSchemaInfoTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocSchemaInfoTest.java
@@ -28,6 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -179,6 +180,7 @@ public class DocSchemaInfoTest extends CrateDummyClusterServiceUnitTest {
             new RelationName(Schemas.DOC_SCHEMA_NAME, name),
             Map.of(),
             Map.of(),
+            Set.of(),
             null,
             List.of(),
             List.of(),

--- a/server/src/test/java/io/crate/metadata/doc/DocTableInfoTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocTableInfoTest.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.assertj.core.api.Assertions;
@@ -91,6 +92,7 @@ public class DocTableInfoTest extends CrateDummyClusterServiceUnitTest {
                 )
             ),
             Map.of(),
+            Set.of(),
             null,
             List.of(),
             List.of(),
@@ -155,6 +157,7 @@ public class DocTableInfoTest extends CrateDummyClusterServiceUnitTest {
             dummy,
             references,
             Map.of(),
+            Set.of(),
             null,
             List.of(),
             List.of(),
@@ -253,51 +256,49 @@ public class DocTableInfoTest extends CrateDummyClusterServiceUnitTest {
 
         ColumnIdent a = ColumnIdent.of("a", List.of());
         ColumnIdent b = ColumnIdent.of("b", List.of());
+        SimpleReference refa = new SimpleReference(
+            new ReferenceIdent(relationName, a),
+            RowGranularity.DOC,
+            DataTypes.INTEGER,
+            IndexType.PLAIN,
+            true,
+            false,
+            1,
+            1,
+            false,
+            null
+        );
+        SimpleReference refb = new SimpleReference(
+            new ReferenceIdent(relationName, b),
+            RowGranularity.DOC,
+            DataTypes.INTEGER,
+            IndexType.PLAIN,
+            true,
+            false,
+            2,
+            2,
+            true,
+            null
+        );
         DocTableInfo info = new DocTableInfo(
-                relationName,
-                Map.of(
-                    a,
-                    new SimpleReference(
-                            new ReferenceIdent(relationName, a),
-                            RowGranularity.DOC,
-                            DataTypes.INTEGER,
-                            IndexType.PLAIN,
-                            true,
-                            false,
-                            1,
-                            1,
-                            false,
-                            null
-                    ),
-                    b,
-                    new SimpleReference(
-                            new ReferenceIdent(relationName, b),
-                            RowGranularity.DOC,
-                            DataTypes.INTEGER,
-                            IndexType.PLAIN,
-                            true,
-                            false,
-                            2,
-                            2,
-                            true,
-                            null
-                    )
-                ),
-                Map.of(),
-                null,
-                List.of(),
-                List.of(),
-                null,
-                Settings.builder()
-                    .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 5)
-                    .build(),
-                List.of(),
-                ColumnPolicy.DYNAMIC,
-                Version.CURRENT,
-                null,
-                false,
-                Operation.ALL,
-                0
+            relationName,
+            Map.of(a, refa, b, refb),
+            Map.of(),
+            Set.of(refb),
+            null,
+            List.of(),
+            List.of(),
+            null,
+            Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 5)
+                .build(),
+            List.of(),
+            ColumnPolicy.DYNAMIC,
+            Version.CURRENT,
+            null,
+            false,
+            Operation.ALL,
+            0
         );
 
         assertThat(info.droppedColumns()).satisfiesExactly(

--- a/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
+++ b/server/src/testFixtures/java/io/crate/operation/aggregation/AggregationTestCase.java
@@ -386,6 +386,7 @@ public abstract class AggregationTestCase extends ESTestCase {
             new RelationName("doc", shard.shardId().getIndexName()),
             targetColumns.stream().collect(Collectors.toMap(Reference::column, r -> r)),
             Map.of(),
+            Set.of(),
             null,
             List.of(),
             List.of(),

--- a/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
@@ -946,7 +946,7 @@ public class SQLExecutor {
         ).build();
 
         Metadata.Builder mdBuilder = Metadata.builder(prevState.metadata())
-            .addBlobTable(relationName, indexMetadata.getIndexUUID())
+            .setBlobTable(relationName, indexMetadata.getIndexUUID())
             .put(indexMetadata, true);
         ClusterState state = ClusterState.builder(prevState)
             .metadata(mdBuilder)

--- a/server/src/testFixtures/java/org/elasticsearch/index/engine/TranslogHandler.java
+++ b/server/src/testFixtures/java/org/elasticsearch/index/engine/TranslogHandler.java
@@ -72,6 +72,7 @@ public class TranslogHandler implements Engine.TranslogRecoveryRunner {
             relation,
             Map.of(ColumnIdent.of("value"), column),
             Map.of(),
+            Set.of(),
             null,
             List.of(),
             List.of(),


### PR DESCRIPTION
This currently includes https://github.com/crate/crate/pull/17424 to make some tests pass
Second commit is the actual change

---

Follow up to https://github.com/crate/crate/pull/17114
Relates to https://github.com/crate/crate/issues/11939

This adds the relation metadata for tables.
This will eventually replace the mapping on index level, and templates
for partitioned tables.

For BWC and to keep the scope of this smaller, this currently doesn't
remove templates or the mapping but only adds RelationMetadata.Table as
additional structures.

Similarly - routing (`metdata.getIndices`) doesn't yet use the
`indexUUIDs` because there are still places left that use the name based
`IndexNameExpressionResolver`