### PR TITLE
Add support for the `ALTER SERVER` statement

### DIFF
--- a/docs/admin/fdw.rst
+++ b/docs/admin/fdw.rst
@@ -160,5 +160,6 @@ Example::
 .. seealso::
 
    - :ref:`ref-create-server`
+   - :ref:`ref-alter-server`
    - :ref:`ref-create-foreign-table`
    - :ref:`ref-create-user-mapping`

--- a/docs/appendices/release-notes/5.10.0.rst
+++ b/docs/appendices/release-notes/5.10.0.rst
@@ -80,6 +80,9 @@ SQL Statements
     FROM employees
     GROUP BY department, title;
 
+- Added support for the :ref:`ref-alter-server` statement to change
+  the options of an existing :ref:`foreign server <administration-fdw>`.
+
 SQL Standard and PostgreSQL Compatibility
 -----------------------------------------
 

--- a/docs/sql/statements/alter-server.rst
+++ b/docs/sql/statements/alter-server.rst
@@ -1,0 +1,60 @@
+.. highlight:: psql
+.. _ref-alter-server:
+
+=================
+``ALTER SERVER``
+=================
+
+Alter an existing foreign server
+
+.. rubric:: Table of contents
+
+.. contents::
+   :local:
+
+
+Synopsis
+========
+
+.. code-block:: psql
+
+  ALTER SERVER server_name
+  OPTIONS ( [ ADD | SET | DROP ] option ['value'] [, ... ] )
+
+Description
+===========
+
+``ALTER SERVER`` is a DDL statement that changes the options of an existing
+foreign server.
+
+The servers options added, changed or dropped via the ``ALTER SERVER`` are
+visible in
+:ref:`information_schema.foreign_server_options <foreign_server_options>`.
+
+Altering a server requires ``AL`` permission on cluster level.
+
+Parameters
+==========
+
+:server_name:
+  A unique name for the server.
+
+
+Clauses
+=======
+
+``OPTIONS``
+-----------
+
+:[ ADD | SET | DROP ] option ['value']:
+  Change options for the server. ``ADD``, ``SET``, and ``DROP`` specify the
+  action to be performed. If no operation is explicitly specified, default to
+  ``ADD``. Option names must be unique, duplicate names will result in an error.
+
+
+See :ref:`administration-fdw` for the foreign data wrapper specific options.
+
+.. seealso::
+
+   - :ref:`ref-create-server`
+   - :ref:`ref-drop-server`

--- a/docs/sql/statements/create-server.rst
+++ b/docs/sql/statements/create-server.rst
@@ -28,7 +28,7 @@ Description
 
 Servers created via ``CREATE SERVER`` are visible in
 :ref:`information_schema.foreign_servers <foreign_servers>` and their options in
-:ref:`information_schema.foreign_table_options <foreign_server_options>`.
+:ref:`information_schema.foreign_server_options <foreign_server_options>`.
 
 Creating a server requires ``AL`` permission on cluster level.
 

--- a/docs/sql/statements/index.rst
+++ b/docs/sql/statements/index.rst
@@ -11,8 +11,9 @@ SQL Statements
 
     alter-cluster
     alter-publication
-    alter-table
     alter-role
+    alter-server
+    alter-table
     alter-user
     analyze
     begin

--- a/libs/sql-parser/src/main/antlr/io/crate/sql/parser/antlr/SqlBaseParser.g4
+++ b/libs/sql-parser/src/main/antlr/io/crate/sql/parser/antlr/SqlBaseParser.g4
@@ -143,6 +143,7 @@ alterStmt
     | ALTER PUBLICATION name=ident
         ((ADD | SET | DROP) TABLE qname ASTERISK?  (COMMA qname ASTERISK? )*)        #alterPublication
     | ALTER SUBSCRIPTION name=ident alterSubscriptionMode                            #alterSubscription
+    | ALTER SERVER  name=ident alterServerOptions                                    #alterServer
     ;
 
 
@@ -636,6 +637,17 @@ kvOptions
 kvOption
     : ident parameterOrLiteral
     ;
+
+alterServerOptions
+    : OPTIONS OPEN_ROUND_BRACKET kvOptionWithOperation (COMMA kvOptionWithOperation)* CLOSE_ROUND_BRACKET
+    ;
+
+kvOptionWithOperation
+    : operation=(ADD | SET)? ident parameterOrLiteral
+    | ident parameterOrLiteral
+    | operation=DROP ident
+    ;
+
 
 
 functionArgument

--- a/libs/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
@@ -45,6 +45,7 @@ import io.crate.sql.tree.AllColumns;
 import io.crate.sql.tree.AlterPublication;
 import io.crate.sql.tree.AlterRoleReset;
 import io.crate.sql.tree.AlterRoleSet;
+import io.crate.sql.tree.AlterServer;
 import io.crate.sql.tree.AlterSubscription;
 import io.crate.sql.tree.Assignment;
 import io.crate.sql.tree.AstVisitor;
@@ -208,7 +209,41 @@ public final class SqlFormatter {
                     String optionName = entry.getKey();
                     Expression optionValue = entry.getValue();
                     append(indent, optionName);
+                    append(indent, " ");
                     optionValue.accept(this, indent);
+                    if (it.hasNext()) {
+                        append(indent, ", ");
+                    }
+                }
+                append(indent, ")");
+            }
+            return null;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public Void visitAlterServer(AlterServer<?> alterServerGen, Integer indent) {
+            AlterServer<Expression> alterServer = (AlterServer<Expression>) alterServerGen;
+            append(indent, "ALTER SERVER ");
+            append(indent, alterServer.name());
+            List<AlterServer.Option<Expression>> options = alterServer.options();
+            if (!options.isEmpty()) {
+                append(indent, " OPTIONS (");
+                Iterator<AlterServer.Option<Expression>> it = options.iterator();
+                while (it.hasNext()) {
+                    var entry = it.next();
+                    AlterServer.Operation operation = entry.operation();
+                    String optionName = entry.key();
+                    Expression optionValue = entry.value();
+                    if (operation != null) {
+                        append(indent, operation.name());
+                        append(indent, " ");
+                    }
+                    append(indent, optionName);
+                    append(indent, " ");
+                    if (optionValue != null) {
+                        optionValue.accept(this, indent);
+                    }
                     if (it.hasNext()) {
                         append(indent, ", ");
                     }

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/AlterServer.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/AlterServer.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.sql.tree;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.jetbrains.annotations.Nullable;
+
+public class AlterServer<T> extends Statement {
+
+    public enum Operation {
+        ADD,
+        SET,
+        DROP
+    }
+
+    public record Option<T>(Operation operation, String key, @Nullable T value) {}
+
+
+    private final String name;
+    private final List<Option<T>> options;
+
+    public AlterServer(String name,
+                       List<Option<T>> options) {
+        this.name = name;
+        this.options = options;
+    }
+
+    public String name() {
+        return name;
+    }
+
+
+    public List<Option<T>> options() {
+        return options;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, options);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        AlterServer<?> other = (AlterServer<?>) obj;
+        return Objects.equals(name, other.name)
+                && Objects.equals(options, other.options);
+    }
+
+    @Override
+    public String toString() {
+        return "AlterServer{name=" + name + "}";
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitAlterServer(this, context);
+    }
+}

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
@@ -724,6 +724,10 @@ public abstract class AstVisitor<R, C> {
         return visitStatement(createServer, context);
     }
 
+    public R visitAlterServer(AlterServer<?> alterServer, C context) {
+        return visitStatement(alterServer, context);
+    }
+
     public R visitCreateForeignTable(CreateForeignTable createForeignTable, C context) {
         return visitStatement(createForeignTable, context);
     }

--- a/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -39,6 +39,7 @@ import io.crate.sql.SqlFormatter;
 import io.crate.sql.tree.AlterPublication;
 import io.crate.sql.tree.AlterRoleReset;
 import io.crate.sql.tree.AlterRoleSet;
+import io.crate.sql.tree.AlterServer;
 import io.crate.sql.tree.AlterSubscription;
 import io.crate.sql.tree.ArrayComparisonExpression;
 import io.crate.sql.tree.ArrayLikePredicate;
@@ -2157,6 +2158,22 @@ public class TestStatementBuilder {
     }
 
     @Test
+    void test_alter_server() {
+        printStatement("ALTER SERVER jarvis OPTIONS (ADD host 'foo', SET dbname 'cratedb', DROP port)");
+        printStatement("ALTER SERVER jarvis OPTIONS (ADD host 'foo')");
+        printStatement("ALTER SERVER jarvis OPTIONS (SET dbname 'cratedb')");
+        printStatement("ALTER SERVER jarvis OPTIONS (DROP port)");
+        printStatement("ALTER SERVER jarvis OPTIONS (host 'foo')");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void test_alter_server_default_option_operation_is_add() {
+        AlterServer<Expression> alterServer = (AlterServer<Expression>) SqlParser.createStatement("ALTER SERVER jarvis OPTIONS (host 'foo')");
+        assertThat(alterServer.options()).contains(new AlterServer.Option<>(AlterServer.Operation.ADD, "host", new StringLiteral("foo")));
+    }
+
+    @Test
     public void test_drop_server() throws Exception {
         printStatement("drop server jarvis");
         printStatement("drop server pg1, pg2");
@@ -2251,6 +2268,7 @@ public class TestStatementBuilder {
             statement instanceof Fetch ||
             statement instanceof Close ||
             statement instanceof CreateServer ||
+            statement instanceof AlterServer ||
             statement instanceof CreateUserMapping ||
             statement instanceof DropServer ||
             statement instanceof DropForeignTable ||

--- a/server/src/main/java/io/crate/analyze/AnalyzedAlterServer.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedAlterServer.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.analyze;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import io.crate.expression.symbol.Symbol;
+import io.crate.sql.tree.AlterServer;
+
+public record AnalyzedAlterServer(String name,
+                                  List<AlterServer.Option<Symbol>> options)
+        implements AnalyzedStatement {
+
+    @Override
+    public <C, R> R accept(AnalyzedStatementVisitor<C, R> visitor, C context) {
+        return visitor.visitAlterServer(this, context);
+    }
+
+    @Override
+    public boolean isWriteOperation() {
+        return true;
+    }
+
+    @Override
+    public void visitSymbols(Consumer<? super Symbol> consumer) {
+        options.stream()
+            .filter(o -> o.value() != null)
+            .forEach(o -> consumer.accept(o.value()));
+    }
+}

--- a/server/src/main/java/io/crate/analyze/AnalyzedStatementVisitor.java
+++ b/server/src/main/java/io/crate/analyze/AnalyzedStatementVisitor.java
@@ -304,6 +304,10 @@ public class AnalyzedStatementVisitor<C, R> {
         return visitAnalyzedStatement(analyzedCreateServer, context);
     }
 
+    public R visitAlterServer(AnalyzedAlterServer analyzedAlterServer, C context) {
+        return visitAnalyzedStatement(analyzedAlterServer, context);
+    }
+
     public R visitCreateForeignTable(AnalyzedCreateForeignTable analyzedCreateForeignTable, C context) {
         return visitAnalyzedStatement(analyzedCreateForeignTable, context);
     }

--- a/server/src/main/java/io/crate/auth/AccessControlImpl.java
+++ b/server/src/main/java/io/crate/auth/AccessControlImpl.java
@@ -26,6 +26,7 @@ import static io.crate.role.Permission.READ_WRITE_DEFINE;
 import java.util.Locale;
 
 import io.crate.analyze.AnalyzedAlterRole;
+import io.crate.analyze.AnalyzedAlterServer;
 import io.crate.analyze.AnalyzedAlterTable;
 import io.crate.analyze.AnalyzedAlterTableAddColumn;
 import io.crate.analyze.AnalyzedAlterTableDropCheckConstraint;
@@ -925,6 +926,18 @@ public final class AccessControlImpl implements AccessControl {
 
         @Override
         public Void visitCreateServer(AnalyzedCreateServer createServer, Role user) {
+            Privileges.ensureUserHasPrivilege(
+                relationVisitor.roles,
+                user,
+                Permission.AL,
+                Securable.CLUSTER,
+                null
+            );
+            return null;
+        }
+
+        @Override
+        public Void visitAlterServer(AnalyzedAlterServer analyzedAlterServer, Role user) {
             Privileges.ensureUserHasPrivilege(
                 relationVisitor.roles,
                 user,

--- a/server/src/main/java/io/crate/fdw/AlterServerRequest.java
+++ b/server/src/main/java/io/crate/fdw/AlterServerRequest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.fdw;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.settings.Settings;
+
+public class AlterServerRequest extends AcknowledgedRequest<AlterServerRequest> {
+
+    private final String name;
+    private final Settings optionsAdded;
+    private final Settings optionsUpdated;
+    private final List<String> optionsRemoved;
+
+    public AlterServerRequest(String name,
+                              Settings optionsAdded,
+                              Settings optionsUpdated,
+                              List<String> optionsRemoved) {
+        this.name = name;
+        this.optionsAdded = optionsAdded;
+        this.optionsUpdated = optionsUpdated;
+        this.optionsRemoved = optionsRemoved;
+    }
+
+    public AlterServerRequest(StreamInput in) throws IOException {
+        this.name = in.readString();
+        this.optionsAdded = Settings.readSettingsFromStream(in);
+        this.optionsUpdated = Settings.readSettingsFromStream(in);
+        this.optionsRemoved = in.readList(StreamInput::readString);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(name);
+        Settings.writeSettingsToStream(out, optionsAdded);
+        Settings.writeSettingsToStream(out, optionsUpdated);
+        out.writeCollection(optionsRemoved, StreamOutput::writeString);
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public Settings optionsAdded() {
+        return optionsAdded;
+    }
+
+    public Settings optionsUpdated() {
+        return optionsUpdated;
+    }
+
+    public List<String> optionsRemoved() {
+        return optionsRemoved;
+    }
+}

--- a/server/src/main/java/io/crate/fdw/AlterServerTask.java
+++ b/server/src/main/java/io/crate/fdw/AlterServerTask.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.fdw;
+
+import java.util.Locale;
+
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.settings.Settings;
+import org.jetbrains.annotations.VisibleForTesting;
+
+public final class AlterServerTask extends AckedClusterStateUpdateTask<AcknowledgedResponse> {
+
+    private final AlterServerRequest request;
+
+    public AlterServerTask(AlterServerRequest request) {
+        super(Priority.NORMAL, request);
+        this.request = request;
+    }
+
+    @Override
+    protected AcknowledgedResponse newResponse(boolean acknowledged) {
+        return new AcknowledgedResponse(acknowledged);
+    }
+
+    @Override
+    public ClusterState execute(ClusterState currentState) throws Exception {
+        ServersMetadata serversMetadata = currentState.metadata().custom(
+            ServersMetadata.TYPE,
+            ServersMetadata.EMPTY
+        );
+        var serverName = request.name();
+        ServersMetadata.Server oldServer = serversMetadata.get(serverName);
+        var optionsBuilder = Settings.builder().put(oldServer.options());
+
+        processOptions(request, optionsBuilder);
+
+        ServersMetadata.Server newServer = serversMetadata.get(serverName)
+            .withOptions(optionsBuilder.build());
+
+        var newServersMetadata = serversMetadata.put(serverName, newServer);
+        return ClusterState.builder(currentState)
+            .metadata(
+                Metadata.builder(currentState.metadata())
+                    .putCustom(ServersMetadata.TYPE, newServersMetadata)
+            )
+            .build();
+    }
+
+    @VisibleForTesting
+    static void processOptions(AlterServerRequest request, Settings.Builder optionsBuilder) {
+        var serverName = request.name();
+        for (var entry : request.optionsAdded().getAsStructuredMap().entrySet()) {
+            if (optionsBuilder.get(entry.getKey()) != null) {
+                throw new IllegalArgumentException(String.format(
+                    Locale.ENGLISH,
+                    "Option `%s` already exists for server `%s`, use SET to change it",
+                    entry.getKey(),
+                    serverName
+                ));
+            }
+            optionsBuilder.put(entry.getKey(), entry.getValue());
+        }
+        for (var entry : request.optionsUpdated().getAsStructuredMap().entrySet()) {
+            if (optionsBuilder.get(entry.getKey()) == null) {
+                throw new IllegalArgumentException(String.format(
+                    Locale.ENGLISH,
+                    "Option `%s` does not exist for server `%s`, use ADD to add it",
+                    entry.getKey(),
+                    serverName
+                ));
+            }
+            optionsBuilder.put(entry.getKey(), entry.getValue());
+        }
+        for (var option : request.optionsRemoved()) {
+            if (optionsBuilder.get(option) == null) {
+                throw new IllegalArgumentException(String.format(
+                    Locale.ENGLISH,
+                    "Option `%s` does not exist for server `%s`",
+                    option,
+                    serverName
+                ));
+            }
+            optionsBuilder.remove(option);
+        }
+    }
+}

--- a/server/src/main/java/io/crate/fdw/ServersMetadata.java
+++ b/server/src/main/java/io/crate/fdw/ServersMetadata.java
@@ -151,6 +151,10 @@ public final class ServersMetadata extends AbstractNamedDiffable<Metadata.Custom
             return options.getAsStructuredMap().entrySet().stream()
                 .map(x -> new Option(name, owner, x.getKey(), DataTypes.STRING.implicitCast(x.getValue())));
         }
+
+        public Server withOptions(Settings options) {
+            return new Server(name, fdw, owner, users, options);
+        }
     }
 
     private final Map<String, Server> servers;
@@ -198,8 +202,13 @@ public final class ServersMetadata extends AbstractNamedDiffable<Metadata.Custom
                                String fdw,
                                String owner,
                                Settings options) {
-        HashMap<String, Server> servers = new HashMap<>(this.servers);
         Server server = new Server(name, fdw, owner, Map.of(), options);
+        return put(name, server);
+    }
+
+    public ServersMetadata put(String name,
+                               Server server) {
+        HashMap<String, Server> servers = new HashMap<>(this.servers);
         servers.put(name, server);
         return new ServersMetadata(servers);
     }
@@ -331,7 +340,7 @@ public final class ServersMetadata extends AbstractNamedDiffable<Metadata.Custom
                     .flatMap(e -> e.getValue().getAsStructuredMap().entrySet().stream()
                         .map(setting -> new UserMappingOptionsTableInfo.UserMappingOptions(
                             e.getKey(), server.name(), setting.getKey(), setting.getValue().toString())
-                ))).iterator();
+                        ))).iterator();
     }
 
     public Iterable<Option> getOptions() {

--- a/server/src/main/java/io/crate/fdw/TransportAlterServerAction.java
+++ b/server/src/main/java/io/crate/fdw/TransportAlterServerAction.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.fdw;
+
+import java.io.IOException;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+@Singleton
+public class TransportAlterServerAction extends TransportMasterNodeAction<AlterServerRequest, AcknowledgedResponse> {
+
+    public static final Action ACTION = new Action();
+
+
+    public static class Action extends ActionType<AcknowledgedResponse> {
+        public static final String NAME = "internal:crate:sql/fdw/server/alter";
+
+        private Action() {
+            super(NAME);
+        }
+    }
+
+
+    @Inject
+    public TransportAlterServerAction(TransportService transportService,
+                                      ClusterService clusterService,
+                                      ThreadPool threadPool) {
+        super(
+            ACTION.name(),
+            transportService,
+            clusterService,
+            threadPool,
+            AlterServerRequest::new
+        );
+    }
+
+    @Override
+    protected String executor() {
+        return ThreadPool.Names.SAME;
+    }
+
+    @Override
+    protected AcknowledgedResponse read(StreamInput in) throws IOException {
+        return new AcknowledgedResponse(in);
+    }
+
+    @Override
+    protected void masterOperation(AlterServerRequest request,
+                                   ClusterState state,
+                                   ActionListener<AcknowledgedResponse> listener) throws Exception {
+        if (state.nodes().getMinNodeVersion().before(Version.V_5_7_0)) {
+            throw new IllegalStateException(
+                "Cannot execute ALTER SERVER while there are <5.7.0 nodes in the cluster");
+        }
+        AlterServerTask updateTask = new AlterServerTask(request);
+        updateTask.completionFuture().whenComplete(listener);
+        clusterService.submitStateUpdateTask("alter_server", updateTask);
+    }
+
+    @Override
+    protected ClusterBlockException checkBlock(AlterServerRequest request, ClusterState state) {
+        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+    }
+}

--- a/server/src/main/java/io/crate/planner/AlterServerPlan.java
+++ b/server/src/main/java/io/crate/planner/AlterServerPlan.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.elasticsearch.ResourceNotFoundException;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+
+import io.crate.analyze.AnalyzedAlterServer;
+import io.crate.analyze.SymbolEvaluator;
+import io.crate.data.Row;
+import io.crate.data.RowConsumer;
+import io.crate.execution.support.OneRowActionListener;
+import io.crate.expression.symbol.Symbol;
+import io.crate.fdw.AlterServerRequest;
+import io.crate.fdw.ForeignDataWrapper;
+import io.crate.fdw.ForeignDataWrappers;
+import io.crate.fdw.ServersMetadata;
+import io.crate.fdw.TransportAlterServerAction;
+import io.crate.metadata.CoordinatorTxnCtx;
+import io.crate.planner.operators.SubQueryResults;
+
+public class AlterServerPlan implements Plan {
+
+    private final ForeignDataWrappers foreignDataWrappers;
+    private final AnalyzedAlterServer alterServer;
+
+    public AlterServerPlan(ForeignDataWrappers foreignDataWrappers,
+                           AnalyzedAlterServer alterServer) {
+        this.foreignDataWrappers = foreignDataWrappers;
+        this.alterServer = alterServer;
+    }
+
+    @Override
+    public StatementType type() {
+        return StatementType.DDL;
+    }
+
+    @Override
+    public void executeOrFail(DependencyCarrier dependencies,
+                              PlannerContext plannerContext,
+                              RowConsumer consumer,
+                              Row params,
+                              SubQueryResults subQueryResults) throws Exception {
+
+        CoordinatorTxnCtx transactionContext = plannerContext.transactionContext();
+        Function<Symbol, Object> convert = new SymbolEvaluator(
+            transactionContext,
+            plannerContext.nodeContext(),
+            subQueryResults
+        ).bind(params);
+
+        Metadata metadata = plannerContext.clusterState().metadata();
+        ServersMetadata servers = metadata.custom(ServersMetadata.TYPE);
+        if (servers == null) {
+            throw new ResourceNotFoundException(
+                String.format(Locale.ENGLISH, "Server `%s` not found", alterServer.name()));
+        }
+        ServersMetadata.Server server = servers.get(alterServer.name());
+
+        ForeignDataWrapper fdw = foreignDataWrappers.get(server.fdw());
+
+        HashSet<String> optionNames = new HashSet<>();
+        Settings.Builder optionsAdded = Settings.builder();
+        Settings.Builder optionsUpdated = Settings.builder();
+        List<String> optionsRemoved = new ArrayList<>();
+
+        Map<String, Setting<?>> mandatoryOptions = fdw.mandatoryServerOptions().stream()
+            .collect(Collectors.toMap(Setting::getKey, Function.identity()));
+
+        for (var option : alterServer.options()) {
+            if (mandatoryOptions.get(option.key()) == null) {
+                throw new IllegalArgumentException(String.format(
+                    Locale.ENGLISH,
+                    "Unsupported server options for foreign data wrapper `%s`: %s. Valid options are: %s",
+                    server.fdw(),
+                    option.key(),
+                    fdw.mandatoryServerOptions().stream()
+                        .map(Setting::getKey)
+                        .collect(Collectors.joining(", "))
+                ));
+            }
+            if (optionNames.add(option.key()) == false) {
+                throw new IllegalArgumentException(String.format(
+                    Locale.ENGLISH,
+                    "Option `%s` is specified multiple times for server `%s`",
+                    option.key(),
+                    alterServer.name()
+                ));
+            }
+            switch (option.operation()) {
+                case ADD:
+                    assert option.value() != null : "value must not be null for ADD operation";
+                    optionsAdded.put(option.key(), convert.apply(option.value()));
+                    break;
+                case DROP:
+                    if (mandatoryOptions.get(option.key()) != null) {
+                        throw new IllegalArgumentException(String.format(
+                            Locale.ENGLISH,
+                            "Cannot remove mandatory server option `%s` for server `%s`",
+                            option.key(),
+                            alterServer.name()
+                        ));
+                    }
+                    optionsRemoved.add(option.key());
+                    break;
+                case SET:
+                    assert option.value() != null : "value must not be null for SET operation";
+                    optionsUpdated.put(option.key(), convert.apply(option.value()));
+                    break;
+                default:
+                    throw new AssertionError("Unsupported operation: " + option.operation());
+            }
+        }
+
+        var request = new AlterServerRequest(
+            alterServer.name(),
+            optionsAdded.build(),
+            optionsUpdated.build(),
+            optionsRemoved
+        );
+        dependencies.client()
+            .execute(TransportAlterServerAction.ACTION, request)
+            .whenComplete(OneRowActionListener.oneIfAcknowledged(consumer));
+    }
+}

--- a/server/src/main/java/io/crate/planner/Planner.java
+++ b/server/src/main/java/io/crate/planner/Planner.java
@@ -36,6 +36,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.jetbrains.annotations.Nullable;
 
 import io.crate.analyze.AnalyzedAlterRole;
+import io.crate.analyze.AnalyzedAlterServer;
 import io.crate.analyze.AnalyzedAlterTable;
 import io.crate.analyze.AnalyzedAlterTableAddColumn;
 import io.crate.analyze.AnalyzedAlterTableDropCheckConstraint;
@@ -670,6 +671,11 @@ public class Planner extends AnalyzedStatementVisitor<PlannerContext, Plan> {
     @Override
     public Plan visitCreateServer(AnalyzedCreateServer createServer, PlannerContext context) {
         return new CreateServerPlan(foreignDataWrappers, createServer);
+    }
+
+    @Override
+    public Plan visitAlterServer(AnalyzedAlterServer alterServer, PlannerContext context) {
+        return new AlterServerPlan(foreignDataWrappers, alterServer);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -121,6 +121,7 @@ import io.crate.execution.jobs.kill.TransportKillAllNodeAction;
 import io.crate.execution.jobs.kill.TransportKillJobsNodeAction;
 import io.crate.execution.jobs.transport.JobAction;
 import io.crate.execution.jobs.transport.TransportJobAction;
+import io.crate.fdw.TransportAlterServerAction;
 import io.crate.fdw.TransportCreateForeignTableAction;
 import io.crate.fdw.TransportCreateServerAction;
 import io.crate.fdw.TransportCreateUserMappingAction;
@@ -240,6 +241,7 @@ public class ActionModule extends AbstractModule {
         actions.register(DropSubscriptionAction.INSTANCE, DropSubscriptionAction.TransportAction.class);
 
         actions.register(TransportCreateServerAction.ACTION, TransportCreateServerAction.class);
+        actions.register(TransportAlterServerAction.ACTION, TransportAlterServerAction.class);
         actions.register(TransportCreateForeignTableAction.ACTION, TransportCreateForeignTableAction.class);
         actions.register(TransportCreateUserMappingAction.ACTION, TransportCreateUserMappingAction.class);
         actions.register(TransportDropServerAction.ACTION, TransportDropServerAction.class);

--- a/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
+++ b/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
@@ -800,6 +800,12 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
     }
 
     @Test
+    public void test_alter_server_requires_al() throws Exception {
+        analyze("ALTER SERVER pg OPTIONS (SET url 'foo')", normalUser);
+        assertAskedForCluster(Permission.AL);
+    }
+
+    @Test
     public void test_drop_server_requires_al() throws Exception {
         analyze("drop server pg", normalUser);
         assertAskedForCluster(Permission.AL);

--- a/server/src/test/java/io/crate/fdw/AlterServerTaskTest.java
+++ b/server/src/test/java/io/crate/fdw/AlterServerTaskTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.fdw;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+
+import org.elasticsearch.ResourceNotFoundException;
+import org.elasticsearch.common.settings.Settings;
+import org.junit.Test;
+
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+
+public class AlterServerTaskTest extends CrateDummyClusterServiceUnitTest {
+
+    @Test
+    public void test_cannot_alter_unknown_server() {
+        AlterServerRequest request = new AlterServerRequest(
+            "server1",
+            Settings.EMPTY,
+            Settings.EMPTY,
+            List.of("key1")
+        );
+        AlterServerTask task = new AlterServerTask(request);
+
+        assertThatThrownBy(() -> task.execute(clusterService.state()))
+            .isExactlyInstanceOf(ResourceNotFoundException.class)
+            .hasMessage("Server `server1` not found");
+    }
+
+    @Test
+    public void test_cannot_add_existing_option() {
+        AlterServerRequest request = new AlterServerRequest(
+            "server1",
+            Settings.builder().put("key1", "value1").build(),
+            Settings.EMPTY,
+            List.of()
+        );
+
+        assertThatThrownBy(() -> AlterServerTask.processOptions(request, Settings.builder().put("key1", "value1")))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Option `key1` already exists for server `server1`, use SET to change it");
+    }
+
+    @Test
+    public void test_cannot_set_non_existing_option() {
+        AlterServerRequest request = new AlterServerRequest(
+            "server1",
+            Settings.EMPTY,
+            Settings.builder().put("key1", "value1").build(),
+            List.of()
+        );
+
+        assertThatThrownBy(() -> AlterServerTask.processOptions(request, Settings.builder()))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Option `key1` does not exist for server `server1`, use ADD to add it");
+    }
+
+    @Test
+    public void test_cannot_drop_non_existing_option() {
+        AlterServerRequest request = new AlterServerRequest(
+            "server1",
+            Settings.EMPTY,
+            Settings.EMPTY,
+            List.of("key1")
+        );
+
+        assertThatThrownBy(() -> AlterServerTask.processOptions(request, Settings.builder()))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Option `key1` does not exist for server `server1`");
+    }
+}


### PR DESCRIPTION
Implementation conforms to `ISO/IEC 9075-9 (SQL/MED)`, but only supports the `OPTIONS` clause, thus this is mandatory.

Closes #16164.