### PR TITLE
Fix ColumnUnknownException from subscript expr with aliased subscriptexpr as the base

### DIFF
--- a/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -754,17 +754,19 @@ public class ExpressionAnalyzer {
                         context
                     );
                 }
-                DataType<?> currentType = baseType;
-                ColumnPolicy parentPolicy = baseType.columnPolicy();
-                for (String p : parts) {
-                    if (ArrayType.unnest(currentType) instanceof ObjectType objectType) {
-                        parentPolicy = objectType.columnPolicy();
-                        currentType = objectType.innerType(p);
+                if ((baseType == UndefinedType.INSTANCE) == false) {
+                    DataType<?> currentType = baseType;
+                    ColumnPolicy parentPolicy = baseType.columnPolicy();
+                    for (String p : parts) {
+                        if (ArrayType.unnest(currentType) instanceof ObjectType objectType) {
+                            parentPolicy = objectType.columnPolicy();
+                            currentType = objectType.innerType(p);
+                        }
                     }
-                }
-                if (parentPolicy == ColumnPolicy.STRICT ||
-                    (parentPolicy == ColumnPolicy.DYNAMIC && context.errorOnUnknownObjectKey())) {
-                    throw e;
+                    if (parentPolicy == ColumnPolicy.STRICT ||
+                        (parentPolicy == ColumnPolicy.DYNAMIC && context.errorOnUnknownObjectKey())) {
+                        throw e;
+                    }
                 }
                 return allocateFunction(
                     SubscriptFunction.NAME,


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes:
```
cr> create table t (obj_dynamic object);
CREATE OK, 1 row affected (1.605 sec)

cr> set error_on_unknown_object_key = 'false';
SET OK, 0 rows affected (0.009 sec)

cr> select alias['u'] from (select obj_dynamic['u'] as alias from t) tbl;
ColumnUnknownException[Column alias['u'] unknown]  <-- not expected since `alias['u']` is child of a dynamic object and the setting it set to false.
```

First attempt: https://github.com/crate/crate/pull/17109.

A regression(on master) caused by https://github.com/crate/crate/pull/17052.


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
