### PR TITLE
Support subscript access on unknown sub-column of virtual table

### DIFF
--- a/server/src/main/java/io/crate/analyze/relations/AliasedAnalyzedRelation.java
+++ b/server/src/main/java/io/crate/analyze/relations/AliasedAnalyzedRelation.java
@@ -33,9 +33,7 @@ import io.crate.exceptions.AmbiguousColumnException;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.expression.symbol.ScopedSymbol;
 import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.VoidReference;
 import io.crate.metadata.ColumnIdent;
-import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.table.Operation;
 
@@ -115,11 +113,6 @@ public class AliasedAnalyzedRelation implements AnalyzedRelation, FieldResolver 
         Symbol field = relation.getField(childColumnName, operation, errorOnUnknownObjectKey);
         if (field == null) {
             return null;
-        }
-        if (field instanceof VoidReference voidReference) {
-            return new VoidReference(
-                new ReferenceIdent(alias, voidReference.column()),
-                voidReference.position());
         }
         ScopedSymbol scopedSymbol = new ScopedSymbol(alias, column, field);
 

--- a/server/src/main/java/io/crate/analyze/relations/AnalyzedView.java
+++ b/server/src/main/java/io/crate/analyze/relations/AnalyzedView.java
@@ -32,7 +32,6 @@ import io.crate.exceptions.AmbiguousColumnException;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.expression.symbol.ScopedSymbol;
 import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.VoidReference;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.table.Operation;
@@ -91,8 +90,8 @@ public final class AnalyzedView implements AnalyzedRelation, FieldResolver {
     @Override
     public Symbol getField(ColumnIdent column, Operation operation, boolean errorOnUnknownObjectKey) throws AmbiguousColumnException, ColumnUnknownException, UnsupportedOperationException {
         Symbol field = relation.getField(column, operation, errorOnUnknownObjectKey);
-        if (field == null || field instanceof VoidReference) {
-            return field;
+        if (field == null) {
+            return null;
         }
         ScopedSymbol scopedSymbol = new ScopedSymbol(name, column, field);
         int i = outputSymbols.indexOf(scopedSymbol);

--- a/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -85,7 +85,6 @@ import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolType;
 import io.crate.expression.symbol.Symbols;
-import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.FunctionType;
 import io.crate.metadata.PartitionName;
@@ -2730,8 +2729,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         var analyzed = executor.analyze("select obj_dy['missing_key'] from (select obj_dy from e1) alias");
         assertThat(analyzed.outputs()).hasSize(1);
         assertThat(analyzed.outputs().getFirst())
-            .isVoidReference()
-            .hasName("obj_dy['missing_key']");
+            .isField("obj_dy['missing_key']");
 
         assertThatThrownBy(() -> executor.analyze("select obj_st['missing_key'] from (select obj_st from e1) alias"))
             .isExactlyInstanceOf(ColumnUnknownException.class)
@@ -2816,9 +2814,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         var analyzed = executor.analyze("select alias.o['unknown_key'] from (select * from t) alias");
         assertThat(analyzed.outputs()).hasSize(1);
         assertThat(analyzed.outputs().getFirst())
-            .isVoidReference()
-            .hasColumnIdent(ColumnIdent.of("o", "unknown_key"))
-            .hasTableIdent(new RelationName(null, "alias"));
+            .isField("o['unknown_key']", new RelationName(null, "alias"));
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Relates to https://github.com/crate/crate/issues/14828 and adds support for:

```
create table t (obj_dynamic object);
SET error_on_unknown_object_key = 'false';
select obj_dynamic['u'] from (select obj_dynamic['u'] from t) t2;
```

Which failed before with a `UnsupportedFeatureException[Can't handle Symbol [VoidReference: obj_dynamic['u']]]`

The approach to fix is to refer to the behaviour of a similar query that works, `select obj_dynamic['u'] from (select obj_dynamic from t) t2`. See the comments for more details.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
