### PR TITLE
WIP: Recognize lowercase patterns in to_char

### DIFF
--- a/docs/appendices/release-notes/5.9.6.rst
+++ b/docs/appendices/release-notes/5.9.6.rst
@@ -49,3 +49,8 @@ Fixes
 
 - Fixed a performance issue in transaction log replay, where the TranslogIndexer object was being
   recreated for each operation rather than being shared between all operations on a shard.
+
+- Fixed an issue causing :ref:`to_char <scalar-to_char>` function to return an
+  incorrect result for a pattern string with lowercase symbols. Example::
+
+      SELECT to_char('2024-12-13'::timestamp, 'yyyy-mm-dd');

--- a/server/src/main/java/io/crate/expression/scalar/formatting/DateTimeFormatter.java
+++ b/server/src/main/java/io/crate/expression/scalar/formatting/DateTimeFormatter.java
@@ -70,7 +70,6 @@ public class DateTimeFormatter {
         P_M_LOWER("p.m."),
         YEAR_WITH_COMMA("Y,YYY"),
         YEAR_YYYY("YYYY"),
-        YEAR_LOWER_YYYY("yyyy"),
         YEAR_YYY("YYY"),
         YEAR_YY("YY"),
         YEAR_Y("Y"),
@@ -211,6 +210,18 @@ public class DateTimeFormatter {
                 nextTokenNode = null;
             } else {
                 nextTokenNode = currentTokenNode.children.get(pattern_to_consume.charAt(idx));
+
+                if (nextTokenNode == null) {
+                    /*
+                    Both queries below are valid in Postgres:
+                     - SELECT to_char('2024-12-13'::timestamp, 'yyyy-mm-dd');
+                     - SELECT to_char('2024-12-13'::timestamp, 'YYYY-MM-DD');
+                    We register patterns only in uppercase
+                    unless it's a special ones that control output by the case (like Mon, MON, mon).
+                    If matching "as is" didn't work, try upper case.
+                    */
+                    nextTokenNode = currentTokenNode.children.get(Character.toUpperCase(pattern_to_consume.charAt(idx)));
+                }
             }
 
             if (nextTokenNode == null && idx > 0) {
@@ -301,7 +312,7 @@ public class DateTimeFormatter {
                 String s = String.valueOf(datetime.getYear());
                 yield s.substring(0, 1) + "," + s.substring(1);
             }
-            case YEAR_YYYY, YEAR_LOWER_YYYY -> padStart(String.valueOf(datetime.getYear()), 4, '0');
+            case YEAR_YYYY -> padStart(String.valueOf(datetime.getYear()), 4, '0');
             case YEAR_YYY -> {
                 String s = padStart(String.valueOf(datetime.getYear()), 4, '0');
                 yield s.substring(s.length() - 3);

--- a/server/src/test/java/io/crate/expression/scalar/formatting/ToCharFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/formatting/ToCharFunctionTest.java
@@ -39,6 +39,14 @@ public class ToCharFunctionTest extends ScalarTestCase {
         );
     }
 
+
+    @Test
+    public void test_lower_case_patterns() throws Exception {
+        assertEvaluate("to_char('2024-12-13'::timestamp, 'yyyy-mm-dd')", "2024-12-13");
+    }
+
+
+
     @Test
     public void test_lower_case_yyyy_supported() throws Exception {
         assertEvaluate("to_char(timestamp '1970-01-01', 'yyyy')", "1970");


### PR DESCRIPTION
Pre-requisite for https://github.com/crate/crate/issues/9663.

`to_date` and `to_timestamp` will use the same formatter as `to_char` and if we want to be PG compatible, we must accept lowercase symbols.


```
SELECT to_char('2024-12-13'::timestamp, 'yyyy-mm-dd');   // CrateDB returns 2024-mm-dd  
SELECT to_char('2024-12-13'::timestamp, 'YYYY-MM-DD'); 


SELECT to_char('2024-12-13'::timestamp, 'd');  -- CrateDB returns 'd'
SELECT to_char('2024-12-13'::timestamp, 'D'); 
```

https://www.db-fiddle.com/f/hnPyxRCS2ZjKFJBkBM3Rfj/0

We already mitigate some common scenarios like `yyyy` by explicitly registering them in lowercase (https://github.com/crate/crate/pull/15462) but that's not a generic approach - we missed to do it for some other entries as shown in the example.

Solution: when traversing "allowed-patterns-trie", try to transit to the state with uppercase if original state didn't work.

This way we can also remove almost all lowercase entries. 

Some entries like Mon, MON, mon still needs to be registered in a mixed case because case there stands for 
"get data from the input and transform" instead of "get number from the input"

