### PR TITLE
Guess inner types for objects and unify list/union cast semantics

### DIFF
--- a/server/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
@@ -485,6 +485,28 @@ public class TableElementsAnalyzer implements FieldProvider<Reference> {
         });
     }
 
+    private void addColumn(ColumnIdent columnName, DataType<?> dataType) {
+        RefBuilder builder = new RefBuilder(columnName, dataType);
+        RefBuilder exists = columns.put(columnName, builder);
+        if (exists != null) {
+            throw new IllegalArgumentException("column \"" + columnName.sqlFqn() + "\" specified more than once");
+        }
+        if (table != null) {
+            builder.builtReference = table.getReference(columnName);
+        }
+        while (dataType instanceof ArrayType<?> arrayType) {
+            dataType = arrayType.innerType();
+        }
+        if (dataType instanceof ObjectType objectType) {
+            for (var entry : objectType.innerTypes().entrySet()) {
+                String childName = entry.getKey();
+                ColumnIdent childColumn = ColumnIdent.getChildSafe(columnName, childName);
+                DataType<?> childType = entry.getValue();
+                addColumn(childColumn, childType);
+            }
+        }
+    }
+
     class PeekColumns extends DefaultTraversalVisitor<Void, Void> {
 
         @Override
@@ -539,27 +561,6 @@ public class TableElementsAnalyzer implements FieldProvider<Reference> {
             return null;
         }
 
-        private void addColumn(ColumnIdent columnName, DataType<?> dataType) {
-            RefBuilder builder = new RefBuilder(columnName, dataType);
-            RefBuilder exists = columns.put(columnName, builder);
-            if (exists != null) {
-                throw new IllegalArgumentException("column \"" + columnName.sqlFqn() + "\" specified more than once");
-            }
-            if (table != null) {
-                builder.builtReference = table.getReference(columnName);
-            }
-            while (dataType instanceof ArrayType<?> arrayType) {
-                dataType = arrayType.innerType();
-            }
-            if (dataType instanceof ObjectType objectType) {
-                for (var entry : objectType.innerTypes().entrySet()) {
-                    String childName = entry.getKey();
-                    ColumnIdent childColumn = ColumnIdent.getChildSafe(columnName, childName);
-                    DataType<?> childType = entry.getValue();
-                    addColumn(childColumn, childType);
-                }
-            }
-        }
     }
 
     class ColumnAnalyzer extends DefaultTraversalVisitor<Void, ColumnIdent> {
@@ -663,8 +664,15 @@ public class TableElementsAnalyzer implements FieldProvider<Reference> {
                 if (generatedExpression != null) {
                     builder.generated = expressionAnalyzer.convert(generatedExpression, expressionContext);
                     EnsureNoMatchPredicate.ensureNoMatchPredicate(builder.generated, "Cannot use MATCH in CREATE TABLE statements");
-                    if (builder.type == DataTypes.UNDEFINED) {
+                    if (builder.type == DataTypes.UNDEFINED || builder.type.equals(ObjectType.UNTYPED)) {
                         builder.type = builder.generated.valueType();
+                        // Add concrete sub-columns defined by the generated expression
+                        if (builder.type instanceof ObjectType objectType) {
+                            for (Map.Entry<String, DataType<?>> entry : objectType.innerTypes().entrySet()) {
+                                ColumnIdent childColumn = ColumnIdent.getChildSafe(columnName, entry.getKey());
+                                addColumn(childColumn, entry.getValue());
+                            }
+                        }
                     } else {
                         builder.generated = builder.generated.cast(builder.type, CastMode.IMPLICIT);
                     }

--- a/server/src/main/java/io/crate/execution/dml/ArrayIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/ArrayIndexer.java
@@ -187,7 +187,7 @@ public class ArrayIndexer<T> implements ValueIndexer<List<T>> {
     private void handleNullArrayUpcast(List<?> values,
                                        Consumer<? super Reference> onDynamicColumn,
                                        Synthetics synthetics) throws IOException {
-        DataType<?> type = DataTypes.valueFromList(values, true);
+        DataType<?> type = DataTypes.typeFromList(values, true);
         if (DataTypes.isArrayOfNulls(type)) {
             return;
         }
@@ -200,8 +200,11 @@ public class ArrayIndexer<T> implements ValueIndexer<List<T>> {
         onDynamicColumn.accept(ref);
         StorageSupport<?> storageSupport = type.storageSupport();
         assert storageSupport != null;  // null storage will have thrown an exception in buildReference
+
+        // The reference resolver passed in to the new type must return `NULL` as the (child) columns are not present
+        // yet. They will be added later in the schema update process.
         ValueIndexer<Object> indexer
-            = (ValueIndexer<Object>) storageSupport.valueIndexer(ref.ident().tableIdent(), ref, _ -> ref);
+            = (ValueIndexer<Object>) storageSupport.valueIndexer(ref.ident().tableIdent(), ref, _ -> null);
         indexer.collectSchemaUpdates(values, onDynamicColumn, synthetics);
     }
 

--- a/server/src/main/java/io/crate/execution/dml/ObjectIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/ObjectIndexer.java
@@ -186,6 +186,8 @@ public class ObjectIndexer implements ValueIndexer<Map<String, Object>> {
                 var type = child.reference.valueType();
                 try {
                     innerValue = type.sanitizeValue(innerValue);
+                } catch (ConversionException e) {
+                    throw e;
                 } catch (ClassCastException | IllegalArgumentException e) {
                     throw new ConversionException(innerValue, type);
                 }

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/rule/SwapCastsInComparisonOperators.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/rule/SwapCastsInComparisonOperators.java
@@ -23,7 +23,6 @@ package io.crate.planner.optimizer.symbol.rule;
 
 import static io.crate.expression.operator.Operators.COMPARISON_OPERATORS;
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
-import static io.crate.types.DataTypes.isSafeConversion;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -62,9 +61,6 @@ public class SwapCastsInComparisonOperators implements Rule<Function> {
             DataType<?> refInnerType = ArrayType.unnest(ref.valueType());
             DataType<?> literalInnerType = ArrayType.unnest(literal.valueType());
             if (!DataTypes.isNumeric(literalInnerType) || !DataTypes.isNumeric(refInnerType)) {
-                return true;
-            }
-            if (isSafeConversion(literalInnerType, refInnerType)) {
                 return true;
             }
             return isNarrowingConversionPossible(literal.value(), ref.valueType());

--- a/server/src/main/java/io/crate/types/DataTypes.java
+++ b/server/src/main/java/io/crate/types/DataTypes.java
@@ -50,6 +50,7 @@ import org.locationtech.spatial4j.shape.jts.JtsPoint;
 
 import io.crate.Streamer;
 import io.crate.sql.tree.BitString;
+import io.crate.sql.tree.ColumnPolicy;
 
 public final class DataTypes {
 
@@ -249,17 +250,6 @@ public final class DataTypes {
         entry(JsonType.ID, Set.of(ObjectType.ID))
     );
 
-    /**
-     * Contains number conversions which are "safe" (= a conversion would not reduce the number of bytes
-     * used to store the value)
-     */
-    private static final Map<Integer, Set<DataType<?>>> SAFE_CONVERSIONS = Map.of(
-        BYTE.id(), Set.of(SHORT, INTEGER, LONG, TIMESTAMPZ, TIMESTAMP, DATE, FLOAT, DOUBLE),
-        SHORT.id(), Set.of(INTEGER, LONG, TIMESTAMPZ, TIMESTAMP, DATE, FLOAT, DOUBLE),
-        INTEGER.id(), Set.of(LONG, TIMESTAMPZ, TIMESTAMP, DATE, FLOAT, DOUBLE),
-        LONG.id(), Set.of(TIMESTAMPZ, TIMESTAMP, DATE, DOUBLE),
-        FLOAT.id(), Set.of(DOUBLE));
-
     public static boolean isArray(DataType<?> type) {
         return type.id() == ArrayType.ID;
     }
@@ -311,9 +301,17 @@ public final class DataTypes {
     public static DataType<?> guessType(Object value) {
         return switch (value) {
             case null -> UNDEFINED;
-            case Map<?, ?> map -> UNTYPED_OBJECT;
-            case List<?> list -> valueFromList(list, false);
-            case Object[] array -> valueFromList(Arrays.asList(array), false);
+            case Map<?, ?> map -> {
+                ObjectType.Builder builder = ObjectType.of(ColumnPolicy.DYNAMIC);
+                for (var entry : map.entrySet()) {
+                    Object key = entry.getKey();
+                    Object val = entry.getValue();
+                    builder.setInnerType(key.toString(), guessType(val));
+                }
+                yield builder.build();
+            }
+            case List<?> list -> typeFromList(list, false);
+            case Object[] array -> typeFromList(Arrays.asList(array), false);
             case float[] values -> new FloatVectorType(values.length);
             case BigDecimal bigDecimal -> new NumericType(bigDecimal.precision(), bigDecimal.scale());
             default -> {
@@ -365,48 +363,19 @@ public final class DataTypes {
      * @param upcast    if true, then use the widest possible compatible numeric type
      *                  e.g. a list of integers produces array(long)
      */
-    public static DataType<?> valueFromList(List<?> value, boolean upcast) {
+    public static DataType<?> typeFromList(List<?> value, boolean upcast) {
         DataType<?> highest = DataTypes.UNDEFINED;
         for (Object o : value) {
             if (o == null) {
                 continue;
             }
             DataType<?> current = guessType(o);
-            // JSON libraries tend to optimize things like [ 0.0, 1.2 ] to [ 0, 1.2 ]; so we allow mixed types
-            // in such cases.
-            if (!current.equals(highest) && !safeConversionPossible(current, highest)) {
-                throw new IllegalArgumentException(
-                    "Mixed dataTypes inside a list are not supported. Found " + highest + " and " + current);
-            }
-            if (current.precedes(highest)) {
-                highest = current;
-            }
+            highest = DataTypes.merge(highest, current);
         }
         if (upcast) {
             highest = upcast(highest);
         }
         return new ArrayType<>(highest);
-    }
-
-    public static boolean isSafeConversion(DataType<?> source, DataType<?> target) {
-        return SAFE_CONVERSIONS.getOrDefault(source.id(), Set.of()).contains(target);
-    }
-
-    private static boolean safeConversionPossible(DataType<?> type1, DataType<?> type2) {
-        final DataType<?> source;
-        final DataType<?> target;
-        if (type1.precedes(type2)) {
-            source = type2;
-            target = type1;
-        } else {
-            source = type1;
-            target = type2;
-        }
-        if (source.id() == DataTypes.UNDEFINED.id()) {
-            return true;
-        }
-        Set<DataType<?>> conversions = SAFE_CONVERSIONS.get(source.id());
-        return conversions != null && conversions.contains(target);
     }
 
     public static final Map<String, DataType<?>> TYPES_BY_NAME_OR_ALIAS = Map.ofEntries(

--- a/server/src/main/java/io/crate/types/ObjectType.java
+++ b/server/src/main/java/io/crate/types/ObjectType.java
@@ -274,22 +274,19 @@ public class ObjectType extends DataType<Map<String, Object>> implements Streame
             return true;
         }
 
-        if (o.id() != id() || o.id() == UNDEFINED.id()) {
-            return false;
-        }
-        ObjectType that = (ObjectType) o;
-        if (innerTypes.isEmpty() || that.innerTypes().isEmpty()) {
+        if (ArrayType.unnest(o) == UNDEFINED) {
+            // We allow to override an empty array type (inner type is undefined) with an object type.
+            // See {@link SqlMappingTest#test_dynamic_null_array_get_by_pk}
             return true;
-        } else {
-            for (var thisInnerField : this.innerTypes.entrySet()) {
-                var thisInnerType = thisInnerField.getValue();
-                var thatInnerType = that.innerTypes().get(thisInnerField.getKey());
-                if (thatInnerType != null && !thisInnerType.isConvertableTo(thatInnerType, explicitCast)) {
-                    return false;
-                }
-            }
         }
-        return true;
+
+        // Do not check the inner types here as this will result in a generic object type cast error if inner types
+        // aren't convertible.
+        // Let's fall through, so the {@link #cast(Object, boolean)} method will be called. It checks the inner types
+        // and provide a more specific error message including the original value (which isn't available here).
+        // See {@link SqlMappingTest#testInsertObjectIntoString}
+
+        return o.id() == id();
     }
 
     @Override

--- a/server/src/test/java/io/crate/DataTypeTest.java
+++ b/server/src/test/java/io/crate/DataTypeTest.java
@@ -89,7 +89,17 @@ public class DataTypeTest extends ESTestCase {
 
         List<Object> objects = List.of(objA, objB);
         DataType<?> dataType = DataTypes.guessType(objects);
-        assertThat(dataType).isEqualTo(new ArrayType<>(DataTypes.UNTYPED_OBJECT));
+        var expectedObjectType = ObjectType.of(ColumnPolicy.DYNAMIC)
+            .setInnerType("a", DataTypes.INTEGER)
+            .setInnerType(
+                "b",
+                ObjectType.of(ColumnPolicy.DYNAMIC)
+                    .setInnerType("bn1", DataTypes.INTEGER)
+                    .setInnerType("bn2", DataTypes.INTEGER)
+                    .build()
+            )
+            .build();
+        assertThat(dataType).isEqualTo(new ArrayType<>(expectedObjectType));
     }
 
     @Test
@@ -109,7 +119,7 @@ public class DataTypeTest extends ESTestCase {
 
     @Test
     public void testForValueMixedDataTypeInList() {
-        List<Object> objects = Arrays.<Object>asList("foo", 1);
+        List<Object> objects = Arrays.<Object>asList("foo", List.of(1));
         assertThatThrownBy(() -> DataTypes.guessType(objects))
             .isExactlyInstanceOf(IllegalArgumentException.class);
     }

--- a/server/src/test/java/io/crate/expression/scalar/geo/WithinFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/geo/WithinFunctionTest.java
@@ -110,7 +110,7 @@ public class WithinFunctionTest extends ScalarTestCase {
     @Test
     public void testEvaluateObjectWithinShape() {
         assertEvaluate("within(geopoint, geoshape)", true,
-            Literal.of(Map.of("type", "Point", "coordinates", new double[]{10.0, 10.0})),
+            Literal.of(Map.of("type", "Point", "coordinates", new Double[]{10.0, 10.0})),
             Literal.of(
                 DataTypes.GEO_SHAPE,
                 DataTypes.GEO_SHAPE.implicitCast("POLYGON ((5 5, 20 5, 30 30, 5 30, 5 5))")

--- a/server/src/test/java/io/crate/integrationtests/GeoShapeIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/GeoShapeIntegrationTest.java
@@ -40,18 +40,18 @@ import io.crate.types.JsonType;
 
 public class GeoShapeIntegrationTest extends IntegTestCase {
 
-    private static final Map<String, Object> GEO_SHAPE1 = Map.of(
-        "coordinates", new double[][]{
-            {0, 0},
-            {1, 1}
-        },
+    private final Map<String, Object> geoShape1 = Map.of(
+        "coordinates", List.of(
+            List.of(0.0, 0.0),
+            List.of(1.0, 1.0)
+        ),
         "type", "LineString"
     );
-    private static final Map<String, Object> GEO_SHAPE2 = Map.of(
-        "coordinates", new double[][]{
-            {2, 2},
-            {3, 3}
-        },
+    private final Map<String, Object> geoShape2 = Map.of(
+        "coordinates", List.of(
+            List.of(2.0, 2.0),
+            List.of(3.0, 3.0)
+        ),
         "type", "LineString"
     );
 
@@ -68,11 +68,11 @@ public class GeoShapeIntegrationTest extends IntegTestCase {
         execute("INSERT INTO shaped (id, shape, bkd_shape) VALUES (?, ?, ?)",
             $$(
                 $(1L, "POINT (13.0 52.4)", "POINT (13.0 52.4)"),
-                $(2L, GEO_SHAPE1, GEO_SHAPE1)
+                $(2L, geoShape1, geoShape1)
             )
         );
         execute("INSERT INTO shaped (id, shapes, bkd_shapes) VALUES (?, ?, ?)",
-            $(3, new Object[]{GEO_SHAPE1, GEO_SHAPE2}, new Object[]{GEO_SHAPE1, GEO_SHAPE2})
+            $(3, new Object[]{geoShape1, geoShape2}, new Object[]{geoShape1, geoShape2})
         );
         execute("REFRESH TABLE shaped");
     }

--- a/server/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
@@ -501,6 +501,15 @@ public class SQLTypeMappingTest extends IntegTestCase {
         execute("insert into t (a, x) values (1, [])");
         execute("insert into t (a, x) values (2, [{y=1},{y=2}])");
         execute("refresh table t");
+
+        // Ensure correct type is stored into the table's metadata
+        execute("SELECT column_name, data_type FROM information_schema.columns WHERE table_name = 't' ORDER BY ordinal_position");
+        assertThat(response).hasRows(
+            "a| integer",
+            "x| object_array",
+            "x['y']| bigint"
+        );
+
         assertBusy(() -> {
             execute("select * from t order by a");
             assertThat(response).hasRows("1| []", "2| [{y=1}, {y=2}]");

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -1294,15 +1294,13 @@ public class TransportSQLActionTest extends IntegTestCase {
         assertThat(response).hasRowCount(1L);
         execute("select * from t where within(p, ?)", $(Map.of(
             "type", "Polygon",
-            "coordinates", new double[][][]{
-                {
-                    {5.0, 5.0},
-                    {30.0, 5.0},
-                    {30.0, 30.0},
-                    {5.0, 30.0},
-                    {5.0, 5.0}
-                }
-            }
+            "coordinates", List.of(List.of(
+                    List.of(5.0, 5.0),
+                    List.of(30.0, 5.0),
+                    List.of(30.0, 30.0),
+                    List.of(5.0, 30.0),
+                    List.of(5.0, 5.0)
+                ))
         )));
         assertThat(response).hasRowCount(1L);
 

--- a/server/src/test/java/io/crate/integrationtests/ViewsITest.java
+++ b/server/src/test/java/io/crate/integrationtests/ViewsITest.java
@@ -290,4 +290,17 @@ public class ViewsITest extends IntegTestCase {
                 "Cannot rename view %s.v1 to %s.tbl_parted, table %s.tbl_parted already exists",
                 schema, schema, schema));
     }
+
+    @Test
+    public void test_object_column_of_view_contain_inner_types() throws Exception {
+        execute("CREATE TABLE data (value_1 BOOLEAN, value_2 INTEGER)");
+        execute("CREATE VIEW data_view AS " +
+            "SELECT { value_1 = value_1, value_2 = value_2 } AS o FROM data");
+        execute("SELECT column_name, data_type FROM information_schema.columns WHERE table_name = 'data_view' ORDER BY ordinal_position");
+        assertThat(response).hasRows(
+            "o| object",
+            "o['value_1']| boolean",
+            "o['value_2']| integer"
+        );
+    }
 }

--- a/server/src/test/java/io/crate/types/TypeConversionTest.java
+++ b/server/src/test/java/io/crate/types/TypeConversionTest.java
@@ -124,16 +124,6 @@ public class TypeConversionTest extends ESTestCase {
     }
 
     @Test
-    public void testToNullConversions() throws Exception {
-        for (DataType<?> type : Lists.concat(
-            DataTypes.PRIMITIVE_TYPES,
-            Arrays.asList(DataTypes.GEO_POINT, DataTypes.GEO_SHAPE, DataTypes.UNTYPED_OBJECT))) {
-            assertThat(type.isConvertableTo(DataTypes.UNDEFINED, false)).isFalse();
-        }
-        assertThat(DataTypes.UNDEFINED.isConvertableTo(DataTypes.UNDEFINED, false)).isTrue();
-    }
-
-    @Test
     public void testGeoPointConversion() throws Exception {
         assertThat(DataTypes.GEO_POINT.isConvertableTo(new ArrayType<>(DataTypes.DOUBLE), false)).isTrue();
         assertThat(DataTypes.STRING.isConvertableTo(DataTypes.GEO_POINT, false)).isTrue();
@@ -188,7 +178,8 @@ public class TypeConversionTest extends ESTestCase {
         var thisObj = ObjectType.of(ColumnPolicy.DYNAMIC).setInnerType("field", DataTypes.GEO_POINT).build();
         var thatObj = ObjectType.of(ColumnPolicy.DYNAMIC).setInnerType("field", DataTypes.INTEGER).build();
 
-        assertThat(thisObj.isConvertableTo(thatObj, false)).isFalse();
+        // We don't check inner types for convertibility to let the conversion fail at runtime with a proper error message
+        assertThat(thisObj.isConvertableTo(thatObj, false)).isTrue();
     }
 
     @Test


### PR DESCRIPTION
*Description taken from the [original PR](#16589)*

This adds inner type information for object literals to support cases
like `{x=10}['x']`.

Adding the type information caused issues with list of objects because
type detection for lists had special cast semantics not used elsewhere
in the system and it didn't merge type information from objects.

This changes the list type inference to use the same logic we also use
for union - which makes it a bit more lenient.


Might relate to: https://github.com/crate/crate/issues/15493 

The 2nd commit will be squashed once approved (in order to see the changed compared to the original commit).

Supersede #16589.