### PR TITLE
Clean up usage of lucene deprecated search method

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/lucene/search/UnscoredLeafCollector.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/search/UnscoredLeafCollector.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package org.elasticsearch.common.lucene.search;
+
+import org.apache.lucene.search.LeafCollector;
+import org.apache.lucene.search.Scorable;
+
+/**
+ * A LeafCollector that does not use a Scorer, and so can be implemented as a
+ * FunctionalInterface
+ */
+public interface UnscoredLeafCollector extends LeafCollector {
+
+    @Override
+    default void setScorer(Scorable scorer) {}
+}


### PR DESCRIPTION
The IndexSearcher.search(Query, Collector) method has been deprecated in favour of IndexSearcher.search(Query, CollectorManager)
* Switch to this new method in ReservoirSampler, also refactoring the ReservoirCollector and introducing an UnscoredLeafCollector interface to make implementation neater.
* Switch to using IndexSearcher.count(Query) in InternalEngineTests
* Remove an inadvertently committed Seed annotation on InternalEngineTests, and fix a test bug in a randomized branch that was never exercised due to the fixed seed.