### PR TITLE
Deletes should release the index throttle

### DIFF
--- a/docs/appendices/release-notes/5.9.6.rst
+++ b/docs/appendices/release-notes/5.9.6.rst
@@ -49,3 +49,6 @@ Fixes
 
 - Fixed a performance issue in transaction log replay, where the TranslogIndexer object was being
   recreated for each operation rather than being shared between all operations on a shard.
+
+- Fixed a possible deadlock where concurrent delete requests could take a lock but then never
+  release it, leading to requests timing out and threads parked in infinite waits.

--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -6192,6 +6192,7 @@ public class InternalEngineTests extends EngineTestCase {
         }).when(delete).startTime();
         engine.activateThrottling();
         engine.delete(delete);
+        assertThat(engine.throttleLockIsHeldByCurrentThread()).isFalse();
         engine.deactivateThrottling();
     }
 


### PR DESCRIPTION
Deletes in InternalEngine acquire the throttle if they are not from a recovery, but do not currently release it.  The throttle uses a ReentrantLock, so if all indexing is going through a single thread this doesn't cause issues, but under indexing pressure we could end up with indexing threads waiting infinitely for a delete.

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
