### PR TITLE
Fix flaky test_pk_extraction_interrupted_when_exceeds_timeout

### DIFF
--- a/server/src/main/java/io/crate/session/Session.java
+++ b/server/src/main/java/io/crate/session/Session.java
@@ -983,7 +983,7 @@ public class Session implements AutoCloseable {
      */
     public static class TimeoutToken {
 
-        private TimeValue statementTimeout;
+        protected TimeValue statementTimeout;
         private long startNanos;
         private boolean enabled = true;
 


### PR DESCRIPTION
Don't rely on execution time in tests, use a test session to timeout after X iterations

