### PR TITLE
Support nested subscript access on unknown sub-column of virtual table

### DIFF
--- a/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -2998,5 +2998,8 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         var analyzed = executor.analyze("select obj_dynamic['u']['u2'] from (select obj_dynamic['u'] from t) t2");
         Assertions.assertThat(analyzed.outputs()).hasSize(1);
         assertThat(analyzed.outputs().getFirst()).isFunction("subscript");
+        analyzed = executor.analyze("select obj_dynamic['u']['u2']['u3'] from (select obj_dynamic['u'] from t) t2");
+        Assertions.assertThat(analyzed.outputs()).hasSize(1);
+        assertThat(analyzed.outputs().getFirst()).isFunction("subscript");
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Relates to https://github.com/crate/crate/issues/14828 and adds support for


```
create table t (obj_dynamic object);
SET error_on_unknown_object_key = 'false';
select obj_dynamic['u']['u2'] from (select obj_dynamic['u'] from t) t2;

```

Which previously failed with `ColumnUnknownException[Column obj_dynamic['u']['u2'] unknown]`

Follows https://github.com/crate/crate/pull/17133.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
