### PR TITLE
Fix ColumnUnknownException when querying for a sub-col of dynamic system column

### DIFF
--- a/docs/appendices/release-notes/5.9.6.rst
+++ b/docs/appendices/release-notes/5.9.6.rst
@@ -72,3 +72,11 @@ Fixes
     FROM information_schema.table_partitions alias
     WHERE values['ts_month'] = '2022-08-01'
 
+
+- Fixed a ``ColumnUnknownException`` thrown when querying a user-defined table
+  setting. For example ::
+
+      CREATE TABLE t (a INT) WITH ("routing.allocation.exclude.foo" = 'bar')
+      SELECT settings['routing']['allocation']['exclude']['foo'] FROM information_schema.tables WHERE table_name = 't';
+      ColumnUnknownException[Column settings['routing']['allocation']['exclude']['foo'] unknown]
+

--- a/server/src/main/java/io/crate/metadata/SystemTable.java
+++ b/server/src/main/java/io/crate/metadata/SystemTable.java
@@ -32,6 +32,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -360,7 +361,7 @@ public final class SystemTable<T> implements TableInfo {
         }
 
         public ObjectBuilder<T, P> addDynamicObject(String column, DataType<?> leafType, Function<T, Map<String, Object>> getObject) {
-            return add(new DynamicColumn<>(baseColumn.getChild(column), leafType, getObject));
+            return add(new DynamicColumn<>(baseColumn.getChild(column), leafType, t -> Objects.requireNonNullElse(getObject.apply(t), Map.of())));
         }
 
         @Override
@@ -391,13 +392,9 @@ public final class SystemTable<T> implements TableInfo {
             ObjectType objectType = typeBuilder.build();
             parent.add(new Column<>(baseColumn, objectType, new ObjectExpression<>(directChildren, objectIsNull)));
             for (Column<T, ?> column : columns) {
-                addColumnToParent(column);
+                parent.add(column);
             }
             return parent;
-        }
-
-        private <U> void addColumnToParent(Column<T, U> column) {
-            parent.add(new Column<>(column.column, column.type, column.getProperty));
         }
     }
 

--- a/server/src/test/java/io/crate/integrationtests/TableSettingsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TableSettingsTest.java
@@ -22,10 +22,8 @@
 package io.crate.integrationtests;
 
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
-import static io.crate.protocols.postgres.PGErrorStatus.UNDEFINED_COLUMN;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
-import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Locale;
@@ -178,12 +176,9 @@ public class TableSettingsTest extends IntegTestCase {
 
     @Test
     public void testSelectConcreteDynamicSetting() {
-        Asserts.assertSQLError(() -> execute("select settings['routing']['allocation']['exclude']['foo'] from information_schema.tables " +
-            "where table_name = 'settings_table'")
-        )
-            .hasPGError(UNDEFINED_COLUMN)
-            .hasHTTPError(NOT_FOUND, 4043)
-            .hasMessageContaining("Column settings['routing']['allocation']['exclude']['foo'] unknown");
+        execute("select settings['routing']['allocation']['exclude']['foo'] from information_schema.tables " +
+            "where table_name = 'settings_table'");
+        assertThat(printedTable(response.rows())).isEqualTo("bar\n");
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes:
```
cr> create table t (a int) with ("routing.allocation.exclude.foo" = 'bar');
CREATE OK, 1 row affected (1.603 sec)
cr> select settings['routing']['allocation']['exclude'] from information_schema.tables where table_name = 't';
+----------------------------------------------+
| settings['routing']['allocation']['exclude'] |
+----------------------------------------------+
| {"foo": "bar"}                               |
+----------------------------------------------+
SELECT 1 row in set (0.145 sec)
-- since above works, below must return `bar`
cr> select settings['routing']['allocation']['exclude']['foo'] from information_schema.tables where table_name = 't';
ColumnUnknownException[Column settings['routing']['allocation']['exclude']['foo'] unknown]
```

Relates: https://github.com/crate/crate/pull/17103.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
