### PR TITLE
Use Symbol.hashCode() to differentiate ScopeSymbol symbols

### DIFF
--- a/docs/appendices/release-notes/5.9.6.rst
+++ b/docs/appendices/release-notes/5.9.6.rst
@@ -61,3 +61,14 @@ Fixes
   accuracy of the result can be now controlled and adjusted to the user's needs.
   Be aware that higher ``compression`` values will lead to slightly higher memory
   consumption.
+
+- Fixed a regression introduced with :ref:`version_5.8.5` which caused queries
+  containing a symbol pointing to an ignored column or dynamic system column of
+  an aliased relation to fail with an planner error. This happens only if the
+  related symbol was used multiple times, e.g. as a select item and inside the
+  where clause. Example::
+
+    SELECT values['ts_month']
+    FROM information_schema.table_partitions alias
+    WHERE values['ts_month'] = '2022-08-01'
+

--- a/server/src/main/java/io/crate/expression/symbol/ScopedSymbol.java
+++ b/server/src/main/java/io/crate/expression/symbol/ScopedSymbol.java
@@ -82,6 +82,14 @@ public final class ScopedSymbol implements Symbol {
     }
 
     /**
+     * Creates a ScopedSymbol describing the output from a relation, pointing to a single specific symbol of a child
+     * relation.
+     * <p>
+     * It uses the hashCode of the symbol to disambiguate columns with the same name but different source relations.
+     * Using the identity of the symbol is not possible because dynamic or void references are not cached and are
+     * created on the fly on every look up. This would lead to different identities for the same symbol.
+     * </p>
+     *
      * @param relation owner of this symbol
      * @param column name of the symbol
      * @param symbol the symbol this ScopedSymbol is pointing towards
@@ -90,7 +98,7 @@ public final class ScopedSymbol implements Symbol {
         this.relation = relation;
         this.column = column;
         this.dataType = symbol.valueType();
-        this.identity = System.identityHashCode(symbol);
+        this.identity = symbol.hashCode();
     }
 
     public RelationName relation() {

--- a/server/src/test/java/io/crate/planner/AliasPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/AliasPlannerTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner;
+
+import static io.crate.testing.Asserts.assertThat;
+
+import org.junit.Test;
+
+import io.crate.planner.node.dql.Collect;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+
+public class AliasPlannerTest extends CrateDummyClusterServiceUnitTest {
+
+    /**
+     * Tests a regression introduced by <a href="https://github.com/crate/crate/commit/1433bbaff379e1d20d4f4c54446d4c35b86cb63e">1433bba</a>
+     * causing to throw an exception.
+     * Relates to <a href="https://github.com/crate/crate/issues/17153">#17153</a>.
+     */
+    @Test
+    public void test_scoped_symbol_pointing_to_dynamic_system_sub_column_used_multiple_times() throws Exception {
+        var e = SQLExecutor.builder(clusterService)
+            .build();
+        Collect plan = e.plan("""
+            SELECT values['ts_month']
+            FROM information_schema.table_partitions alias
+            WHERE values['ts_month'] = '2022-08-01'
+            """);
+        assertThat(plan.collectPhase().toCollect().getFirst()).isDynamicReference();
+    }
+
+    /**
+     * Tests a regression introduced by <a href="https://github.com/crate/crate/commit/1433bbaff379e1d20d4f4c54446d4c35b86cb63e">1433bba</a>
+     * causing to throw an exception.
+     * Relates to <a href="https://github.com/crate/crate/issues/17153">#17153</a>.
+     */
+    @Test
+    public void test_scoped_symbol_pointing_to_ignored_sub_column_used_multiple_times() throws Exception {
+        var e = SQLExecutor.builder(clusterService).build()
+            .addTable("CREATE TABLE t (values OBJECT(IGNORED))");
+        Collect plan = e.plan("""
+            SELECT values['ts_month']
+            FROM t AS alias
+            WHERE values['ts_month'] = '2022-08-01'
+            """);
+        assertThat(plan.collectPhase().toCollect().getFirst()).isDynamicReference();
+    }
+}


### PR DESCRIPTION
The relation resolver return new instances on each field resolving for the same unknown dynamic or ignored references. To match same instances, use the symbols `hashCode` implementation.

Relates to https://github.com/crate/crate/commit/1433bba.
Fixes #17153.
