### PR TITLE
Throw an expected exception for `EXPLAIN ANALYZE INSERT`

### DIFF
--- a/docs/appendices/release-notes/5.9.6.rst
+++ b/docs/appendices/release-notes/5.9.6.rst
@@ -47,6 +47,9 @@ See the :ref:`version_5.9.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an ``EXPLAIN ANALYZE INSERT ...`` statement to throw an exception as it
+  is not supported.
+
 - Fixed a performance issue in transaction log replay, where the TranslogIndexer object was being
   recreated for each operation rather than being shared between all operations on a shard.
 

--- a/server/src/main/java/io/crate/planner/node/management/ExplainPlan.java
+++ b/server/src/main/java/io/crate/planner/node/management/ExplainPlan.java
@@ -207,8 +207,12 @@ public class ExplainPlan implements Plan {
         timer.start();
         BaseResultReceiver resultReceiver = new BaseResultReceiver();
         RowConsumer noopRowConsumer = new RowConsumerToResultReceiver(resultReceiver, 0, t -> {});
-        NodeOperationTree operationTree = LogicalPlanner.getNodeOperationTree(
-            plan, executor, plannerContext, params, subQueryResults);
+        NodeOperationTree operationTree = null;
+        try {
+            operationTree = LogicalPlanner.getNodeOperationTree(plan, executor, plannerContext, params, subQueryResults);
+        } catch (Throwable e) {
+            consumer.accept(null, e);
+        }
 
         resultReceiver.completionFuture()
             .whenComplete(createResultConsumer(executor, consumer, plannerContext.jobId(), timer, operationTree, subQueryExplainResults));

--- a/server/src/test/java/io/crate/analyze/ExplainAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/ExplainAnalyzerTest.java
@@ -119,4 +119,11 @@ public class ExplainAnalyzerTest extends CrateDummyClusterServiceUnitTest {
             .isExactlyInstanceOf(UnsupportedFeatureException.class)
             .hasMessageStartingWith("EXPLAIN VERBOSE is not supported for CopyFrom");
     }
+
+    @Test
+    public void test_explain_analyze_insert_unsupported() {
+        assertThatThrownBy(() -> e.analyze("explain analyze insert into users(id) values (1)"))
+            .isExactlyInstanceOf(UnsupportedFeatureException.class)
+            .hasMessageStartingWith("EXPLAIN ANALYZE is not supported for Insert");
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes https://github.com/crate/crate/issues/17159. Now the reported scenario behaves as expected:
```
cr> EXPLAIN analyze INSERT INTO t (id) VALUES (2);
UnsupportedFeatureException[EXPLAIN ANALYZE is not supported for Insert{table=Table{only=false, t, partitionProperties=[]}, duplicateKeyContext=DuplicateKeyContext{type=NONE, onDuplicateKeyAssignments=[], constraintColumns=[]}, columns=[id], insertSource=Query{with=Optional.emptyqueryBody=Values{rows=[ValuesList{values=[2]}]}, orderBy=[], limit=Optional.empty, offset=Optional.empty}, returning=[]}]
```

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
