### PR TITLE
Upgrade template on new partitions creation

### DIFF
--- a/docs/appendices/release-notes/5.9.7.rst
+++ b/docs/appendices/release-notes/5.9.7.rst
@@ -50,3 +50,7 @@ Fixes
 - Fixed an issue leading to an error when exporting big tables via ``COPY TO``
   to the :ref:`Azure Blob Storage <sql-copy-to-az>`.
   This also has a positive effect on performance.
+
+- Fixed an issue that could prevent the creation of new partitions if data was
+  written to a partitioned table during a rolling upgrade and that table had
+  setting ``warmer.enabled`` specified before the upgrade.

--- a/server/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
+++ b/server/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
@@ -259,7 +259,7 @@ public class GatewayMetaState implements Closeable {
         return changed ? upgradedMetadata.build() : metadata;
     }
 
-    private static <Data> boolean applyPluginUpgraders(ImmutableOpenMap<String, Data> existingData,
+    public static <Data> boolean applyPluginUpgraders(ImmutableOpenMap<String, Data> existingData,
                                                        UnaryOperator<Map<String, Data>> upgrader,
                                                        Consumer<String> removeData,
                                                        BiConsumer<String, Data> putData) {

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitionsActionTest.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitionsActionTest.java
@@ -22,14 +22,21 @@
 package org.elasticsearch.action.admin.indices.create;
 
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.IntegTestCase;
 import org.junit.Before;
 import org.junit.Test;
@@ -38,6 +45,7 @@ import com.carrotsearch.hppc.cursors.ObjectCursor;
 
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
+import io.crate.testing.UseNewCluster;
 import io.crate.testing.UseRandomizedSchema;
 
 @UseRandomizedSchema(random = false)
@@ -138,5 +146,57 @@ public class TransportCreatePartitionsActionTest extends IntegTestCase {
     public void testEmpty() throws Exception {
         assertThatThrownBy(() -> CreatePartitionsRequest.of(List.of()))
             .hasMessage("Must create at least one partition");
+    }
+
+    @Test
+    @UseNewCluster
+    // Upgrade once logic can be affected by other tests as they all share the same action instance,
+    // use new cluster to aovid flakiness
+    public void test_creation_of_a_new_partition_upgrades_template_and_does_it_once() throws Exception {
+        execute("create table tbl (a int) " +
+            "partitioned by (a) " +
+            "clustered into 1 shards " +
+            "with (number_of_replicas=0)");
+
+        ensureYellow();
+
+        ClusterState clusterState = cluster().clusterService().state();
+        Metadata.Builder metadataBuilder = Metadata.builder(clusterState.metadata());
+
+        String tableTemplateName = PartitionName.templateName("doc", "tbl");
+        IndexTemplateMetadata indexTemplateMetadata = clusterState.metadata().templates().get(tableTemplateName);
+        assertThat(indexTemplateMetadata).isNotNull();
+
+
+        // Remove template and re-add with artificially injected setting that was removed in 5.8
+        metadataBuilder.removeTemplate(tableTemplateName);
+        IndexTemplateMetadata.Builder templateBuilder = IndexTemplateMetadata.builder(tableTemplateName)
+            .version(1)
+            .patterns(indexTemplateMetadata.patterns())
+            .putMapping(indexTemplateMetadata.mapping())
+            .settings(Settings.builder()
+                .put(indexTemplateMetadata.settings())
+                .put(IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(), Version.V_5_7_5)
+                .put("index.warmer.enabled", "true")
+            );
+        metadataBuilder.put(templateBuilder);
+        ClusterState artificialState = new ClusterState.Builder(clusterState).metadata(metadataBuilder).build();
+
+        // Imitation of "insert into tbl (a) values (1)".
+        CreatePartitionsRequest request = new CreatePartitionsRequest(RelationName.fromIndexName(tableTemplateName), List.of(List.of("1")));
+
+        TransportCreatePartitionsAction actionSpy = spy(action);
+        ClusterState newState = actionSpy.executeCreateIndices(artificialState, request);
+        indexTemplateMetadata = newState.metadata().templates().get(tableTemplateName);
+        // Value of the removed setting used to be "true"
+        assertThat(indexTemplateMetadata.settings().get("index.warmer.enabled", null)).isNull();
+        verify(actionSpy, times(1)).upgradeTemplates(any(), any());
+
+        // Each node upgrades templates only once when it's a master and creates partitions for the first time.
+        // We need a new request to avoid "partition already exists" short-cut logic.
+        request = new CreatePartitionsRequest(RelationName.fromIndexName(tableTemplateName), List.of(List.of("2")));
+        actionSpy.executeCreateIndices(newState, request);
+        // Without do-once logic would have been 2
+        verify(actionSpy, times(1)).upgradeTemplates(any(), any());
     }
 }


### PR DESCRIPTION
Fixes https://github.com/crate/crate/issues/17150


After https://github.com/crate/crate/commit/c8edfff8fe7713b071841b9db1aea26e3f500245, we upgrade templates only on node startup in `GatewayMetaState` or on logical replication or on a snapshot restore. That is not enough to prevent old templates being applied on new nodes.

Say, we are running a rolling upgrade.
One node has been upgraded to VERSION.CURRENT and a master node, which is on old version < CURRENT creates partitions/new indices with old metadata/removed settings. All upgraded nodes will get incoming old template via `IndicesClusterStateService` and keep it forever as they are already accomplished upgrade-on-startup.

We upgrade on the fly as a trade-off to the pre-5.6.0 state where we used to upgrade template on each cluster change and submit synchronous  request via PutTemplate API to the master node to apply it.

Each upgraded node either never becomes a master and doesn't really need upgrade or eventually upgrades (on demand) when performs some operations as a master node.
