### PR TITLE
Update OpenDAL to 0.47.6 and use a bigger buffer size to avoid BlockCountExceedsLimit error

### DIFF
--- a/docs/appendices/release-notes/5.9.7.rst
+++ b/docs/appendices/release-notes/5.9.7.rst
@@ -47,4 +47,6 @@ See the :ref:`version_5.9.0` release notes for a full list of changes in the
 Fixes
 =====
 
-None
+- Fixed an issue leading to an error when exporting big tables via ``COPY TO``
+  to the :ref:`Azure Blob Storage <sql-copy-to-az>`.
+  This also has a positive effect on performance.

--- a/plugins/crate-copy-azure/pom.xml
+++ b/plugins/crate-copy-azure/pom.xml
@@ -26,12 +26,12 @@
         </dependency>
         <dependency>
             <groupId>org.apache.opendal</groupId>
-            <artifactId>opendal-java</artifactId>
+            <artifactId>opendal</artifactId>
             <version>${versions.opendal}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.opendal</groupId>
-            <artifactId>opendal-java</artifactId>
+            <artifactId>opendal</artifactId>
             <version>${versions.opendal}</version>
             <classifier>${os.classifier}</classifier>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -335,7 +335,7 @@
     <versions.caffeine>3.1.8</versions.caffeine>
     <versions.jodatime>2.12.7</versions.jodatime>
     <versions.aws>1.12.353</versions.aws>
-    <versions.opendal>0.46.3</versions.opendal>
+    <versions.opendal>0.47.6</versions.opendal>
     <versions.commonsmath>3.6.1</versions.commonsmath>
     <versions.commonscodec>1.17.1</versions.commonscodec>
     <versions.bigmath>2.3.2</versions.bigmath>


### PR DESCRIPTION
Renamed artifacts to reflect https://github.com/apache/opendal/commit/fac74d488ba82181330510f52be97f1338408878

Fixes https://github.com/crate/crate/issues/17136
