### PR TITLE
Fix `alter` from falsely updating table version created setting to latest

### DIFF
--- a/docs/appendices/release-notes/5.9.7.rst
+++ b/docs/appendices/release-notes/5.9.7.rst
@@ -54,3 +54,9 @@ Fixes
 - Fixed an issue that could prevent the creation of new partitions if data was
   written to a partitioned table during a rolling upgrade and that table had
   setting ``warmer.enabled`` specified before the upgrade.
+
+- Fixed an issue that incorrectly updated ``VERSION`` settings from
+  :ref:`information_schema.tables <information_schema_tables>` and
+  :ref:`information_schema.table_partitions <is_table_partitions>` for
+  partitioned tables and their new partitions to the latest version following a
+  node upgrade.

--- a/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -148,7 +148,6 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
         switch (key) {
             case IndexMetadata.SETTING_CREATION_DATE:
             case IndexMetadata.SETTING_INDEX_UUID:
-            case IndexMetadata.SETTING_VERSION_CREATED:
             case IndexMetadata.SETTING_HISTORY_UUID:
             case IndexMetadata.SETTING_VERSION_UPGRADED:
             case MergePolicyConfig.INDEX_MERGE_ENABLED:

--- a/server/src/test/java/io/crate/metadata/cluster/AlterTableClusterStateExecutorTest.java
+++ b/server/src/test/java/io/crate/metadata/cluster/AlterTableClusterStateExecutorTest.java
@@ -24,7 +24,9 @@ package io.crate.metadata.cluster;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_ROUTING_EXCLUDE_GROUP_PREFIX;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_CREATION_DATE;
+import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_INDEX_VERSION_CREATED;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
+import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_VERSION_CREATED;
 import static org.elasticsearch.common.settings.AbstractScopedSettings.ARCHIVED_SETTINGS_PREFIX;
 
 import java.io.IOException;
@@ -32,7 +34,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.settings.IndexScopedSettings;
@@ -103,5 +107,40 @@ public class AlterTableClusterStateExecutorTest {
         Settings filteredSettings = AlterTableClusterStateExecutor.filterSettings(settingToFilter, supportedSettings);
         assertThat(filteredSettings.isEmpty()).isFalse();
         assertThat(filteredSettings.get(fullName)).isEqualTo("node1");
+    }
+
+    @Test
+    public void test_altering_settings_do_not_modify_version_created() throws IOException {
+        IndexScopedSettings indexScopedSettings = IndexScopedSettings.DEFAULT_SCOPED_SETTINGS;
+
+        RelationName relationName = new RelationName(Schemas.DOC_SCHEMA_NAME, "t1");
+        String templateName = PartitionName.templateName(relationName.schema(), relationName.name());
+
+        final Version v = Version.V_5_4_0;
+
+        Settings settings = Settings.builder()
+            .put(IndexMetadata.SETTING_VERSION_CREATED, v)
+            .build();
+        IndexTemplateMetadata indexTemplateMetadata = IndexTemplateMetadata.builder(templateName)
+            .patterns(Collections.singletonList("*"))
+            .settings(settings)
+            .putMapping("{\"default\": {}}")
+            .build();
+
+        ClusterState initialState = ClusterState.builder(ClusterState.EMPTY_STATE)
+            .metadata(Metadata.builder().put(indexTemplateMetadata))
+            .build();
+
+        ClusterState result =
+            AlterTableClusterStateExecutor.updateTemplate(initialState,
+                relationName,
+                settings,
+                Map.of(),
+                (_, _) -> { },
+                indexScopedSettings);
+
+        IndexTemplateMetadata template = result.metadata().templates().get(templateName);
+        assertThat(template.settings().keySet()).containsExactly(SETTING_VERSION_CREATED);
+        assertThat(SETTING_INDEX_VERSION_CREATED.get(template.settings())).isEqualTo(v);
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes:
```
-- on 5.7.5:
cr> create table tbl (id int, o object(strict) as (a array(int))) partitioned by (id);
cr> insert into tbl values (1, {a=[1]});
cr> insert into tbl values (2, {a=[1, 2]});

-- upgraded to latest:
cr> ALTER TABLE tbl SET (number_of_replicas = 1); -- can be any alter stmts that modified the settings
cr> select version from information_schema.tables where table_name = 'tbl';
+-----------------------------------------+
| version                                 |
+-----------------------------------------+
| {"created": "5.10.0", "upgraded": null} |  -- should be 5.7.5
+-----------------------------------------+

cr> insert into tbl values (4, {a=[1,2,3]});
cr> select version from information_schema.table_partitions where table_name = 'tbl';
+--------------------------------------------+
| version                                    |
+--------------------------------------------+
| {"created": "5.10.0"}                      |  -- this should be 5.7.5
| {"created": "5.7.5", "upgraded": "5.10.0"} |
| {"created": "5.7.5", "upgraded": "5.10.0"} |
+--------------------------------------------+
```

`alter` stmt that alters settings removed `version.created` and then it was set to the latest version along the way.

Non-partitioned tables are not affected.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
