### PR TITLE
Update gcs-repo dependency versions

### DIFF
--- a/plugins/repository-gcs/pom.xml
+++ b/plugins/repository-gcs/pom.xml
@@ -51,6 +51,13 @@
             <version>${versions.google.gax}</version>
         </dependency>
 
+        <!-- Use version that doesn't have https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-7254 -->
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>${versions.google.protobuf}</version>
+        </dependency>
+
         <dependency>
             <groupId>com.google.auth</groupId>
             <artifactId>google-auth-library-credentials</artifactId>

--- a/plugins/repository-gcs/pom.xml
+++ b/plugins/repository-gcs/pom.xml
@@ -83,10 +83,11 @@
             <version>${versions.google.oauth.client}</version>
         </dependency>
 
+        <!-- Explicitly use version without https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-25647 -->
         <dependency>
-            <groupId>com.google.cloud</groupId>
-            <artifactId>google-cloud-core-http</artifactId>
-            <version>${versions.google.cloud.core.http}</version>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>${versions.google.gson}</version>
         </dependency>
 
         <dependency>
@@ -112,7 +113,7 @@
         <dependency>
             <groupId>com.google.http-client</groupId>
             <artifactId>google-http-client-gson</artifactId>
-            <version>${versions.google.gson}</version>
+            <version>${versions.google.http.client.gson}</version>
         </dependency>
 
         <dependency>

--- a/plugins/repository-gcs/pom.xml
+++ b/plugins/repository-gcs/pom.xml
@@ -69,6 +69,13 @@
             <version>${versions.google.cloud.storage}</version>
         </dependency>
 
+        <!-- Explicitly use version without https://scout.docker.com/vulnerabilities/id/CVE-2021-22573 -->
+        <dependency>
+            <groupId>com.google.oauth-client</groupId>
+            <artifactId>google-oauth-client</artifactId>
+            <version>${versions.google.oauth.client}</version>
+        </dependency>
+
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-core-http</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -353,7 +353,8 @@
     <versions.google.cloud.core.http>2.23.0</versions.google.cloud.core.http>
 
     <versions.guava>32.0.1-jre</versions.guava>
-    <versions.google.gson>1.43.1</versions.google.gson>
+    <versions.google.http.client.gson>1.43.1</versions.google.http.client.gson>
+    <versions.google.gson>2.8.9</versions.google.gson>
     <versions.google.protobuf>3.25.5</versions.google.protobuf>
     <versions.google.errorprone>2.19.1</versions.google.errorprone>
     <versions.google.j2objc>2.8</versions.google.j2objc>

--- a/pom.xml
+++ b/pom.xml
@@ -348,6 +348,7 @@
     <versions.google.auth>1.23.0</versions.google.auth>
     <versions.google.oauth2>1.23.0</versions.google.oauth2>
     <versions.google.cloud.storage>1.113.1</versions.google.cloud.storage>
+    <versions.google.oauth.client>1.37.0</versions.google.oauth.client>
     <versions.google.cloud.core>2.30.0</versions.google.cloud.core>
     <versions.google.cloud.core.http>2.23.0</versions.google.cloud.core.http>
 

--- a/pom.xml
+++ b/pom.xml
@@ -354,6 +354,7 @@
 
     <versions.guava>32.0.1-jre</versions.guava>
     <versions.google.gson>1.43.1</versions.google.gson>
+    <versions.google.protobuf>3.25.5</versions.google.protobuf>
     <versions.google.errorprone>2.19.1</versions.google.errorprone>
     <versions.google.j2objc>2.8</versions.google.j2objc>
     <versions.checkerframework>3.48.2</versions.checkerframework>


### PR DESCRIPTION
https://hub.docker.com/layers/library/crate/latest/images/sha256-fa4ba58c68c2193b894086d6b814ac53bfe0f31a03bdbc26c5bace887ba3edaa

reports that google-oauth-client-1.31.0 has a vulnerability.

`./mvnw dependency:tree -Dincludes=com.google.oauth-client:google-oauth-client` output:

```
io.crate:crate-app:jar:5.10.0
[INFO] \- io.crate:repository-gcs:jar:5.10.0:runtime (optional)
[INFO]    \- com.google.cloud:google-cloud-storage:jar:1.113.1:runtime (optional)
[INFO]       \- com.google.oauth-client:google-oauth-client:jar:1.31.0:runtime (optional)
```

I tried to upgrade to 2.47.0 but got
401 Unauthorized
POST https://storage.googleapis.com/upload/storage/v1/b/bucket/o?projection=full&uploadType=multipart

which I couldn't reproduce locally


Using non-major version upgrade to be safe and don't introduce anything breaking

See https://mvnrepository.com/artifact/com.google.oauth-client/google-oauth-client


