### PR TITLE
Fix flaky rest bulk error test

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/RestSQLActionIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/RestSQLActionIntegrationTest.java
@@ -171,7 +171,10 @@ public class RestSQLActionIntegrationTest extends SQLHttpIntegrationTest {
                 "{\"rowcount\":-2,\"error\":{\"code\":4000,\"message\":\"SQLParseException[Column `val['a']` already exists with type `bigint`. Cannot add same column with type `text`]\"}}",
             "{\"rowcount\":-2,\"error\":{\"code\":4000,\"message\":\"SQLParseException[Column `val['a']` already exists with type `text`. Cannot add same column with type `bigint`]\"}}," +
                 "{\"rowcount\":-2,\"error\":{\"code\":4000,\"message\":\"SQLParseException[Column `val['a']` already exists with type `text`. Cannot add same column with type `bigint`]\"}}," +
-                "{\"rowcount\":1}"
+                "{\"rowcount\":1}",
+            "{\"rowcount\":-2,\"error\":{\"code\":4000,\"message\":\"SQLParseException[Cannot cast object element `a` with value `2` to type `text`]\"}}," +
+                "{\"rowcount\":-2,\"error\":{\"code\":4000,\"message\":\"SQLParseException[Cannot cast object element `a` with value `22` to type `text`]\"}}," +
+                "{\"rowcount\":1}]}"
         );
     }
 


### PR DESCRIPTION
`test_insert_with_failing_bulk_args_response_error_messages` became flaky as the object element cast exception changed by https://github.com/crate/crate/commit/4638323.

Follow up of https://github.com/crate/crate/commit/4638323.
