### PR TITLE
Fix for incorrectly updated version created settings for partitioned tables

### DIFF
--- a/server/src/main/java/io/crate/metadata/upgrade/IndexTemplateCreatedVersionFixer.java
+++ b/server/src/main/java/io/crate/metadata/upgrade/IndexTemplateCreatedVersionFixer.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.metadata.upgrade;
+
+import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_VERSION_CREATED;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.UnaryOperator;
+import java.util.stream.StreamSupport;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.common.settings.Settings;
+
+public class IndexTemplateCreatedVersionFixer implements UnaryOperator<Metadata> {
+
+    @Override
+    public Metadata apply(Metadata metadata) {
+        var templates = metadata.templates();
+        var metadataBuilder = new Metadata.Builder(metadata);
+        for (Iterator<String> it = templates.keysIt(); it.hasNext(); ) {
+            String templateName = it.next();
+            List<Version> partitionVersionsCreated = StreamSupport.stream(metadata.indices().spliterator(), false)
+                .filter(e -> e.key.startsWith(templateName))
+                .map(e -> e.value)
+                .map(IndexMetadata::getCreationVersion).sorted().distinct().toList();
+            if (partitionVersionsCreated.size() <= 1) {
+                continue;
+            }
+            final Version lowestPartionVersion = partitionVersionsCreated.getFirst();
+            IndexTemplateMetadata indexTemplateMetadata = templates.get(templateName);
+            if (!lowestPartionVersion.equals(indexTemplateMetadata.settings().getAsVersion(SETTING_VERSION_CREATED, Version.CURRENT))) {
+                Settings upgradedSettings = Settings.builder()
+                    .put(indexTemplateMetadata.settings())
+                    .put(SETTING_VERSION_CREATED, lowestPartionVersion)
+                    .build();
+                IndexTemplateMetadata upgradedIndexTemplateMetadata = new IndexTemplateMetadata.Builder(indexTemplateMetadata)
+                    .settings(upgradedSettings)
+                    .build();
+                metadataBuilder.put(upgradedIndexTemplateMetadata);
+                metadata = metadataBuilder.build();
+            }
+        }
+        return metadata;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
+++ b/server/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
@@ -220,6 +220,8 @@ public class GatewayMetaState implements Closeable {
     public static Metadata upgradeMetadata(Metadata metadata,
                                     MetadataIndexUpgradeService metadataIndexUpgradeService,
                                     MetadataUpgrader metadataUpgrader) {
+        metadata = metadataUpgrader.indexTemplateVersionCreatedFixer.apply(metadata);
+
         boolean changed = false;
         final Metadata.Builder upgradedMetadata = Metadata.builder(metadata);
 

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -207,6 +207,7 @@ import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
 import io.crate.metadata.settings.session.SessionSettingRegistry;
 import io.crate.metadata.sys.MetadataSysModule;
 import io.crate.metadata.sys.SysSchemaInfo;
+import io.crate.metadata.upgrade.IndexTemplateCreatedVersionFixer;
 import io.crate.metadata.upgrade.IndexTemplateUpgrader;
 import io.crate.metadata.upgrade.MetadataIndexUpgrader;
 import io.crate.module.CrateCommonModule;
@@ -587,7 +588,8 @@ public class Node implements Closeable {
 
             final MetadataUpgrader metadataUpgrader = new MetadataUpgrader(
                 customMetadataUpgraders,
-                indexTemplateMetadataUpgraders);
+                indexTemplateMetadataUpgraders,
+                new IndexTemplateCreatedVersionFixer());
             final MetadataIndexUpgradeService metadataIndexUpgradeService = new MetadataIndexUpgradeService(
                 nodeContext,
                 indexScopedSettings,

--- a/server/src/main/java/org/elasticsearch/plugins/MetadataUpgrader.java
+++ b/server/src/main/java/org/elasticsearch/plugins/MetadataUpgrader.java
@@ -32,11 +32,12 @@ import java.util.function.UnaryOperator;
  */
 public class MetadataUpgrader {
     public final UnaryOperator<Map<String, Metadata.Custom>> customMetadataUpgraders;
-
     public final UnaryOperator<Map<String, IndexTemplateMetadata>> indexTemplateMetadataUpgraders;
+    public final UnaryOperator<Metadata> indexTemplateVersionCreatedFixer;
 
     public MetadataUpgrader(Collection<UnaryOperator<Map<String, Metadata.Custom>>> customMetadataUpgraders,
-                            Collection<UnaryOperator<Map<String, IndexTemplateMetadata>>> indexTemplateMetadataUpgraders) {
+                            Collection<UnaryOperator<Map<String, IndexTemplateMetadata>>> indexTemplateMetadataUpgraders,
+                            UnaryOperator<Metadata> indexTemplateVersionCreatedFixer) {
         this.customMetadataUpgraders = customs -> {
             Map<String, Metadata.Custom> upgradedCustoms = new HashMap<>(customs);
             for (UnaryOperator<Map<String, Metadata.Custom>> customMetadataUpgrader : customMetadataUpgraders) {
@@ -52,5 +53,7 @@ public class MetadataUpgrader {
             }
             return upgradedTemplates;
         };
+
+        this.indexTemplateVersionCreatedFixer = indexTemplateVersionCreatedFixer;
     }
 }

--- a/server/src/test/java/io/crate/license/LicenseCustomMetadataUpgraderTest.java
+++ b/server/src/test/java/io/crate/license/LicenseCustomMetadataUpgraderTest.java
@@ -26,6 +26,7 @@ import static org.elasticsearch.gateway.GatewayMetaStateTests.randomMetadata;
 
 import java.util.EnumSet;
 import java.util.List;
+import java.util.function.UnaryOperator;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.Metadata;
@@ -53,7 +54,8 @@ public class LicenseCustomMetadataUpgraderTest {
         var customMetadataUpgraderLoader = new CustomMetadataUpgraderLoader(Settings.EMPTY);
         var metadataUpgrader = new MetadataUpgrader(
             List.of(customs -> customMetadataUpgraderLoader.apply(customs)),
-            List.of()
+            List.of(),
+            UnaryOperator.identity()
         );
         var upgrade = GatewayMetaState.upgradeMetadata(metadata, new GatewayMetaStateTests.MockMetadataIndexUpgradeService(false), metadataUpgrader);
         assertThat(upgrade != metadata).isTrue();

--- a/server/src/test/java/io/crate/metadata/upgrade/IndexTemplateCreatedVersionFixerTest.java
+++ b/server/src/test/java/io/crate/metadata/upgrade/IndexTemplateCreatedVersionFixerTest.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.metadata.upgrade;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
+import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.common.settings.Settings;
+import org.junit.Test;
+
+public class IndexTemplateCreatedVersionFixerTest {
+
+    @Test
+    public void test_does_not_affect_empty_partitioned_table() throws IOException {
+        var metadataWithEmptyPartitionedTable = new Metadata.Builder().put(
+            IndexTemplateMetadata.builder("empty_table")
+                .patterns(List.of("*"))
+                .putMapping("{\"default\": {}}")
+                .build()
+        ).build();
+
+        assertThat(new IndexTemplateCreatedVersionFixer().apply(metadataWithEmptyPartitionedTable))
+            .isSameAs(metadataWithEmptyPartitionedTable);
+    }
+
+    @Test
+    public void test_does_not_affect_partitioned_table_with_single_created_version() throws IOException {
+        Settings settings = Settings.builder()
+            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.V_5_4_0)
+            .put(SETTING_NUMBER_OF_SHARDS, 1)
+            .put(SETTING_NUMBER_OF_REPLICAS, 1)
+            .build();
+
+        // create indexMetadata and templateMetadata as V_5_4_0
+        IndexMetadata indexMetadata1 = IndexMetadata.builder("t.idx1").settings(settings).build();
+        IndexMetadata indexMetadata2 = IndexMetadata.builder("t.idx2").settings(settings).build();
+        IndexTemplateMetadata indexTemplateMetadata = IndexTemplateMetadata.builder("t")
+            .settings(settings)
+            .patterns(List.of("*"))
+            .putMapping("{\"default\": {}}")
+            .build();
+        Metadata metadata = Metadata.builder()
+            .put(indexTemplateMetadata)
+            .put(indexMetadata1, true)
+            .put(indexMetadata2, true)
+            .build();
+        assertThat(new IndexTemplateCreatedVersionFixer().apply(metadata)).isSameAs(metadata);
+    }
+
+    @Test
+    public void test_does_not_affect_partitioned_table_with_valid_multiple_created_versions() throws IOException {
+        Settings v540 = Settings.builder()
+            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.V_5_4_0)
+            .put(SETTING_NUMBER_OF_SHARDS, 1)
+            .put(SETTING_NUMBER_OF_REPLICAS, 1)
+            .build();
+        Settings v470 = Settings.builder()
+            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.V_4_7_0)
+            .put(SETTING_NUMBER_OF_SHARDS, 1)
+            .put(SETTING_NUMBER_OF_REPLICAS, 1)
+            .build();
+
+        // create indexMetadata as V_5_4_0, V_4_7_0
+        // create templateMetadata as V_4_7_0(valid)
+        IndexMetadata indexMetadata1 = IndexMetadata.builder("t.idx1").settings(v540).build();
+        IndexMetadata indexMetadata2 = IndexMetadata.builder("t.idx2").settings(v470).build();
+        IndexTemplateMetadata indexTemplateMetadata = IndexTemplateMetadata.builder("t")
+            .settings(v470)
+            .patterns(List.of("*"))
+            .putMapping("{\"default\": {}}")
+            .build();
+        Metadata metadata = Metadata.builder()
+            .put(indexTemplateMetadata)
+            .put(indexMetadata1, true)
+            .put(indexMetadata2, true)
+            .build();
+        assertThat(new IndexTemplateCreatedVersionFixer().apply(metadata)).isSameAs(metadata);
+    }
+
+    @Test
+    public void test_does_not_affect_partitioned_table_with_invalid_multiple_created_versions() throws IOException {
+        Settings v540 = Settings.builder()
+            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.V_5_4_0)
+            .put(SETTING_NUMBER_OF_SHARDS, 1)
+            .put(SETTING_NUMBER_OF_REPLICAS, 1)
+            .build();
+        Settings v470 = Settings.builder()
+            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.V_4_7_0)
+            .put(SETTING_NUMBER_OF_SHARDS, 1)
+            .put(SETTING_NUMBER_OF_REPLICAS, 1)
+            .build();
+
+        // create indexMetadata as V_5_4_0, V_4_7_0
+        // create templateMetadata as V_5_4_0(invalid). An index with V_4_7_0 suggests that the created version
+        // for the template must be on or before V_4_7_0
+        IndexMetadata indexMetadata1 = IndexMetadata.builder("t.idx1").settings(v540).build();
+        IndexMetadata indexMetadata2 = IndexMetadata.builder("t.idx2").settings(v470).build();
+        IndexTemplateMetadata indexTemplateMetadata = IndexTemplateMetadata.builder("t")
+            .settings(v540)
+            .patterns(List.of("*"))
+            .putMapping("{\"default\": {}}")
+            .build();
+        Metadata metadata = Metadata.builder()
+            .put(indexTemplateMetadata)
+            .put(indexMetadata1, true)
+            .put(indexMetadata2, true)
+            .build();
+        Metadata fixed = new IndexTemplateCreatedVersionFixer().apply(metadata);
+        assertThat(fixed.templates().size()).isEqualTo(1);
+        IndexTemplateMetadata fixedTemplateMd = fixed.templates().get("t");
+        assertThat(fixedTemplateMd.settings().getAsVersion(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT))
+            .isEqualTo(Version.V_4_7_0);
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes https://github.com/crate/support/issues/509, the wrong version created caused wrong query generations.

Follows https://github.com/crate/crate/pull/17178, https://github.com/crate/crate/pull/17178#issuecomment-2569250101. 

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
