### PR TITLE
Set new partitions' version created setting to the smallest non-client node version

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitionsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitionsAction.java
@@ -366,14 +366,15 @@ public class TransportCreatePartitionsAction extends TransportMasterNodeAction<C
     }
 
     private Settings createCommonIndexSettings(ClusterState currentState, @Nullable IndexTemplateMetadata template) {
-        Version minVersion = currentState.nodes().getSmallestNonClientNodeVersion();
-        Settings.Builder indexSettingsBuilder = Settings.builder()
-            .put(IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(), minVersion);
+        Settings.Builder indexSettingsBuilder = Settings.builder();
 
         // apply template
         if (template != null) {
             indexSettingsBuilder.put(template.settings());
         }
+
+        Version minVersion = currentState.nodes().getSmallestNonClientNodeVersion();
+        indexSettingsBuilder.put(IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(), minVersion);
 
         validateSoftDeletesSetting(indexSettingsBuilder.build());
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes unexpected behaviour change from a refactoring task,  https://github.com/crate/crate/pull/17111/commits/8014ef9a2f9acd352ca67f5629952f9a3b847b78. It was not released.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
