### PR TITLE
Raise an error if FILTER is used with non-aggregate window function

### DIFF
--- a/docs/appendices/release-notes/5.9.7.rst
+++ b/docs/appendices/release-notes/5.9.7.rst
@@ -47,6 +47,9 @@ See the :ref:`version_5.9.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that caused ``FILTER`` clauses on non-aggregate window
+  functions to be ignored instead of raising an unsupported error.
+
 - Fixed an issue leading to an error when exporting big tables via ``COPY TO``
   to the :ref:`Azure Blob Storage <sql-copy-to-az>`.
   This also has a positive effect on performance.

--- a/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -1279,6 +1279,9 @@ public class ExpressionAnalyzer {
                             functionName));
                     }
                 }
+            } else if (filter != null) {
+                throw new UnsupportedOperationException(
+                    "FILTER is not implemented for non-aggregate window functions (" + functionName + ")");
             }
             newFunction = new WindowFunction(
                 signature,


### PR DESCRIPTION
Fixes https://github.com/crate/crate/issues/17168
