### PR TITLE
Fix link in create-repository.rst

### DIFF
--- a/docs/sql/statements/create-repository.rst
+++ b/docs/sql/statements/create-repository.rst
@@ -789,7 +789,7 @@ Parameters
 .. _AWS API endpoint: https://docs.aws.amazon.com/general/latest/gr/rande.html
 .. _AWS region: https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services/
 .. _Azure Blob storage: https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blobs-introduction
-.. _Azure service region: https://azure.microsoft.com/en-us/global-infrastructure/geographies/
+.. _Azure service region: https://azure.microsoft.com/en-us/explore/global-infrastructure/geographies/
 .. _Canned ACL: https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl
 .. _endpoint suffix: https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string#create-a-connection-string-with-an-endpoint-suffix
 .. _IAM roles: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
The link would redirect properly, so there was no user facing issue, just a failure in the link-check.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
