### PR TITLE
Lower default overload_protection max_concurrency and queue_size

### DIFF
--- a/docs/appendices/release-notes/5.10.0.rst
+++ b/docs/appendices/release-notes/5.10.0.rst
@@ -139,6 +139,10 @@ Performance and Resilience Improvements
   or it can be removed explicitly by an ``OPTIMIZE`` operation after indexing
   to a table or partition has completed.
 
+- Lowered the default ``max_concurrency`` and ``queue_size``
+  :ref:`overload_protection` values, this should help cluster stability without
+  slowing down operations.
+
 Administration and Operations
 -----------------------------
 

--- a/docs/config/cluster.rst
+++ b/docs/config/cluster.rst
@@ -1319,7 +1319,7 @@ The minimum number of concurrent operations allowed per target node.
 .. _overload_protection.dml.max_concurrency:
 
 **overload_protection.dml.max_concurrency**
-  | *Default:* ``2000``
+  | *Default:* ``100``
   | *Runtime:* ``yes``
 
 The maximum number of concurrent operations allowed per target node.
@@ -1327,7 +1327,7 @@ The maximum number of concurrent operations allowed per target node.
 .. _overload_protection.dml.queue_size:
 
 **overload_protection.dml.queue_size**
-  | *Default:* ``200``
+  | *Default:* ``25``
   | *Runtime:* ``yes``
 
 How many operations are allowed to queue up.

--- a/server/src/main/java/io/crate/execution/jobs/NodeLimits.java
+++ b/server/src/main/java/io/crate/execution/jobs/NodeLimits.java
@@ -24,15 +24,14 @@ package io.crate.execution.jobs;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.jetbrains.annotations.Nullable;
-
-import io.crate.common.concurrent.ConcurrencyLimit;
-
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
+import org.jetbrains.annotations.Nullable;
+
+import io.crate.common.concurrent.ConcurrencyLimit;
 
 /**
  * Tracks concurrency limits per node
@@ -49,9 +48,9 @@ public class NodeLimits {
     public static final Setting<Integer> MIN_CONCURRENCY =
         Setting.intSetting("overload_protection.dml.min_concurrency", 1, Property.NodeScope, Property.Dynamic, Property.Exposed);
     public static final Setting<Integer> MAX_CONCURRENCY =
-        Setting.intSetting("overload_protection.dml.max_concurrency", 2000, Property.NodeScope, Property.Dynamic, Property.Exposed);
+        Setting.intSetting("overload_protection.dml.max_concurrency", 100, Property.NodeScope, Property.Dynamic, Property.Exposed);
     public static final Setting<Integer> QUEUE_SIZE =
-        Setting.intSetting("overload_protection.dml.queue_size", 200, Property.NodeScope, Property.Dynamic, Property.Exposed);
+        Setting.intSetting("overload_protection.dml.queue_size", 25, Property.NodeScope, Property.Dynamic, Property.Exposed);
 
     private static final double SMOOTHING = 0.2;
     private static final int LONG_WINDOW = 600;


### PR DESCRIPTION
A lower queue_size should reduce memory consumption and based on some
testing it doesn't seem to affect throughput negatively.

Similar with the concurrency: Given that the limit is _per_ target node,
and each client node maintains its own concurrency the total concurrent
requests a node can receive could've been unreasonably high.

For example, in a cluster with 5 nodes, each node could've sent up to
2000 concurrent requests to a single node receiving 10000 requests. Even
on beefy 128+ cores machines they can't reasonable process that much in
parallel and the amount of requests leads to memory pressure.

The adaptive concurrency logic starting out at 5 concurrent requests
helped to counter that to some degree but given that testing showed no
real benefit of the high maximum this lowers it.

(targets 5.10 despite feature freeze because this is gray area around hotfix/feature as it aims to improve stability)
