### PR TITLE
Do not ignore uppercases in function names in a view's query body

### DIFF
--- a/docs/appendices/release-notes/5.9.7.rst
+++ b/docs/appendices/release-notes/5.9.7.rst
@@ -62,6 +62,11 @@ Fixes
   written to a partitioned table during a rolling upgrade and that table had
   setting ``warmer.enabled`` specified before the upgrade.
 
+- Fixed an issue that caused uppercase letters in quoted function names from
+  a ``CREATE VIEW`` statement to be converted to lowercases, leading to an
+  ``UnsupportedFeatureException`` or a false resolution to a different function
+  with the same name but in lowercases.
+
 - Fixed an issue that incorrectly updated ``VERSION`` settings from
   :ref:`information_schema.tables <information_schema_tables>` and
   :ref:`information_schema.table_partitions <is_table_partitions>` for

--- a/libs/sql-parser/src/main/java/io/crate/sql/ExpressionFormatter.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/ExpressionFormatter.java
@@ -27,7 +27,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
 import java.util.StringJoiner;
 import java.util.TreeMap;
 import java.util.stream.Collector;
@@ -98,9 +97,6 @@ public final class ExpressionFormatter {
     private static final Formatter DEFAULT_FORMATTER = new Formatter();
 
     private static final Collector<CharSequence, ?, String> COMMA_JOINER = Collectors.joining(", ");
-
-    private static final Set<String> FUNCTION_CALLS_WITHOUT_PARENTHESIS = Set.of(
-        "current_catalog", "current_schema", "current_user", "session_user", "user");
 
     private ExpressionFormatter() {
     }
@@ -358,8 +354,13 @@ public final class ExpressionFormatter {
                 );
             }
 
-            builder.append(node.getName());
-            if (!FUNCTION_CALLS_WITHOUT_PARENTHESIS.contains(node.getName().toString())) {
+            var name = node.getName().getParts();
+            for (int i = 0; i < name.size() - 1; i++) {
+                builder.append(Identifiers.quoteIfNeeded(name.get(i)));
+                builder.append(".");
+            }
+            builder.append(Identifiers.quoteFunctionIfNeeded(name.getLast()));
+            if (!Identifiers.PARENTHESIS_LESS_FUNCTIONS.contains(node.getName().toString())) {
                 builder.append('(').append(arguments).append(')');
             }
 

--- a/libs/sql-parser/src/main/java/io/crate/sql/Identifiers.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/Identifiers.java
@@ -62,10 +62,21 @@ public final class Identifiers {
 
     public static final Collection<Keyword> KEYWORDS = identifierCandidates();
 
-    static final Set<String> RESERVED_KEYWORDS = KEYWORDS.stream()
+    private static final Set<String> RESERVED_KEYWORDS = KEYWORDS.stream()
         .filter(Keyword::isReserved)
         .map(Keyword::getWord)
         .collect(Collectors.toSet());
+
+    public static final Set<String> PARENTHESIS_LESS_FUNCTIONS = Set.of(
+        "current_date",
+        "current_time",
+        "current_timestamp",
+        "current_schema",
+        "current_user",
+        "current_role",
+        "user",
+        "session_user"
+    );
 
     private Identifiers() {}
 
@@ -81,14 +92,25 @@ public final class Identifiers {
      * i.e. when it contain a double-quote, has upper case letters or is a SQL keyword
      */
     public static String quoteIfNeeded(String identifier) {
-        if (quotesRequired(identifier)) {
+        if (quotesRequired(false, identifier)) {
             return quote(identifier);
         }
         return identifier;
     }
 
-    private static boolean quotesRequired(String identifier) {
-        return isKeyWord(identifier) || !quotesNotRequired(identifier);
+    public static String quoteFunctionIfNeeded(String identifier) {
+        if (quotesRequired(true, identifier)) {
+            return quote(identifier);
+        }
+        return identifier;
+    }
+
+    private static boolean quotesRequired(boolean isFunction, String identifier) {
+        return (isKeyWord(identifier) && !isParenthesisLessFunction(isFunction, identifier)) || !quotesNotRequired(identifier);
+    }
+
+    private static boolean isParenthesisLessFunction(boolean isFunction, String identifier) {
+        return isFunction && PARENTHESIS_LESS_FUNCTIONS.contains(identifier);
     }
 
     public static boolean isKeyWord(String identifier) {

--- a/libs/sql-parser/src/test/java/io/crate/sql/IdentifiersTest.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/IdentifiersTest.java
@@ -71,5 +71,8 @@ public class IdentifiersTest {
         assertThat(Identifiers.quoteIfNeeded("_col")).isEqualTo("_col");
         assertThat(Identifiers.quoteIfNeeded("col_1")).isEqualTo("col_1");
         assertThat(Identifiers.quoteIfNeeded("col['a']")).isEqualTo("\"col['a']\"");
+        // current_schema can be a parenthesisless function, and it can also be a column
+        assertThat(Identifiers.quoteIfNeeded("current_schema")).isEqualTo("\"current_schema\"");
+        assertThat(Identifiers.quoteFunctionIfNeeded("current_schema")).isEqualTo("current_schema");
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

For example, `"Abs"` from `CREATE VIEW v AS (SELECT "Abs"(1))` must not be resolved to the builtin abs() function but a UDF named `"Abs"`.

`ExpressionFormatter` used for a view's query body generation did not preserve the quotes. The approach to fix is to utilize `Identifiers.quoteIfNeeded` method to add the missing quotes. But before that, the first commit is necessary to prevent test failures. (BTW, the first commit does not cause any behaviour changes.)

Fixes https://github.com/crate/crate/issues/17188.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
