### PR TITLE
Fix cla-check.yml

### DIFF
--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -4,7 +4,7 @@ on:
     types: [opened, synchronize, unlabeled]
 jobs:
   check-author-signed-cla:
-    uses: crate/cla-check/.github/workflows/cla-check-workflow.yml@main
+    uses: crate/actions/.github/workflows/cla-check-workflow.yml@main
     # with: 
       # simulate_no_cla: true
     secrets: inherit

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,7 +2,7 @@
 queue_rules:
   - name: default
     queue_conditions:
-      - status-success=^check-author-signed-cla
+      - status-success~=^check-author-signed-cla
       - status-success=ci/jenkins/pr_tests
       - status-success~=^Test CrateDB SQL on ubuntu
       - status-success=docs/readthedocs.org:crate


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
A reusable workflow can't be located in a private repo if it's called from a public repo.

The test for this was made from a private repo, so this limitation was unfortunately not caught.