### PR TITLE
Unify and clarify circuit breaker exception message

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/breaker/CircuitBreakingException.java
+++ b/server/src/main/java/org/elasticsearch/common/breaker/CircuitBreakingException.java
@@ -20,10 +20,12 @@
 package org.elasticsearch.common.breaker;
 
 import java.io.IOException;
+import java.util.Locale;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.rest.RestStatus;
 
 /**
@@ -46,10 +48,20 @@ public class CircuitBreakingException extends ElasticsearchException {
         bytesWanted = in.readLong();
     }
 
-    public CircuitBreakingException(String message, long bytesWanted, long byteLimit) {
-        super(message);
-        this.bytesWanted = bytesWanted;
-        this.byteLimit = byteLimit;
+    public CircuitBreakingException(long bytesAdded,
+                                    long bytesUsed,
+                                    long bytesLimit,
+                                    String component) {
+        super(String.format(
+            Locale.ENGLISH,
+            "Allocating %s for '%s' failed, breaker would use %s in total. Limit is %s. Either increase memory and limit, change the query or reduce concurrent query load",
+            new ByteSizeValue(bytesAdded),
+            component,
+            new ByteSizeValue(bytesUsed),
+            new ByteSizeValue(bytesLimit)
+        ));
+        this.bytesWanted = bytesUsed;
+        this.byteLimit = bytesLimit;
     }
 
     @Override

--- a/server/src/test/java/io/crate/execution/engine/distribution/merge/RamAccountingPageIteratorTest.java
+++ b/server/src/test/java/io/crate/execution/engine/distribution/merge/RamAccountingPageIteratorTest.java
@@ -40,8 +40,8 @@ import org.junit.Test;
 
 import io.crate.analyze.OrderBy;
 import io.crate.breaker.ConcurrentRamAccounting;
-import io.crate.breaker.TypedRowAccounting;
 import io.crate.breaker.RowAccountingWithEstimatorsTest;
+import io.crate.breaker.TypedRowAccounting;
 import io.crate.data.Row;
 import io.crate.data.RowN;
 import io.crate.data.breaker.RamAccounting;
@@ -156,6 +156,6 @@ public class RamAccountingPageIteratorTest extends ESTestCase {
                 new KeyIterable<>(0, Collections.singletonList(TEST_ROWS[0])),
                 new KeyIterable<>(1, Collections.singletonList(TEST_ROWS[1])))))
             .isExactlyInstanceOf(CircuitBreakingException.class)
-            .hasMessage("[query] Data too large, data for field [test] would be [288/288b], which is larger than the limit of [197/197b]");
+            .hasMessage("Allocating 144b for 'query' failed, breaker would use 288b in total. Limit is 197b. Either increase memory and limit, change the query or reduce concurrent query load");
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/CircuitBreakerIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CircuitBreakerIntegrationTest.java
@@ -70,10 +70,7 @@ public class CircuitBreakerIntegrationTest extends IntegTestCase {
         execute("set global \"indices.breaker.query.limit\"='100b'");
 
         Asserts.assertSQLError(() -> execute("select text from t1 group by text"))
-            .hasMessageContainingAll(
-                "[query] Data too large, data for [collect: 0] would be ",
-                "which is larger than the limit of [100/100b]"
-            )
+            .hasMessageContaining("Allocating 120b for 'collect: 0' failed, breaker would use 120b in total. Limit is 100b. Either increase memory and limit, change the query or reduce concurrent query load")
             .hasPGError(INTERNAL_ERROR)
             .hasHTTPError(INTERNAL_SERVER_ERROR, 5000);
     }

--- a/server/src/test/java/io/crate/integrationtests/GroupByAggregateBreakerTest.java
+++ b/server/src/test/java/io/crate/integrationtests/GroupByAggregateBreakerTest.java
@@ -46,7 +46,6 @@ public class GroupByAggregateBreakerTest extends IntegTestCase {
         Asserts.assertSQLError(() -> execute("select region, count(*) from sys.summits group by 1"))
             .hasPGError(INTERNAL_ERROR)
             .hasHTTPError(INTERNAL_SERVER_ERROR, 5000)
-            .hasMessageContaining("[query] Data too large, data for [collect: 0] would be [280/280b], " +
-                                         "which is larger than the limit of [256/256b]");
+            .hasMessageContaining("Allocating 112b for 'collect: 0' failed, breaker would use 280b in total. Limit is 256b. Either increase memory and limit, change the query or reduce concurrent query load");
     }
 }

--- a/server/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorIT.java
+++ b/server/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorIT.java
@@ -357,7 +357,7 @@ public class ReplicaShardAllocatorIT extends IntegTestCase {
                     } catch (InterruptedException e) {
                         throw new AssertionError(e);
                     }
-                    throw new CircuitBreakingException("not enough memory for indexing", 100, 50);
+                    throw new CircuitBreakingException(100, 150, 120, "dummy");
                 }
             }
             connection.sendRequest(requestId, action, request, options);


### PR DESCRIPTION
Showing the values twice, once in bytes without unit and a second time
in a human readable number with units was a bit confusing.

Before:

    [query] Data too large, data for [collect: 0] would be [280/280b] which is larger than the limit of [256/256b]

After:

    Allocating 112b for 'collect: 0' failed, breaker would use 280b in total. Limit is 256b. Either increase memory and limit, change the query or reduce concurrent query load.

Closes https://github.com/crate/crate/issues/17029
