### PR TITLE
Fix flaky percentile test_custom_compression_setting_is_used

### DIFF
--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/PercentileAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/PercentileAggregationTest.java
@@ -23,6 +23,7 @@ package io.crate.execution.engine.aggregation.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.within;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
@@ -312,19 +313,25 @@ public class PercentileAggregationTest extends AggregationTestCase {
 
         Object resultDefault = executeAggregation(
             signature,
+            signature.getArgumentDataTypes(),
+            signature.getReturnType().createType(),
             rowsDefault.toArray(new Object[0][]),
+            false,
             List.of()
         );
         Object resultCustom = executeAggregation(
             signature,
+            signature.getArgumentDataTypes(),
+            signature.getReturnType().createType(),
             rowsDefault.stream()
                 .map(row -> new Object[]{row[0], row[1], customCompression})
                 .toArray(Object[][]::new),
+            false,
             List.of()
         );
 
         assertThat(resultCustom).isNotEqualTo(resultDefault);
         // Let's assert a concrete value to get failures if the implementation changes and reveals a different result
-        assertThat(resultCustom).isEqualTo(97.0);
+        assertThat((double) resultCustom).isEqualTo(113.066, within(0.01));
     }
 }


### PR DESCRIPTION
`executeAggregation` by default randomizes merge/reduce steps, which
caused the test to fail with:

    org.opentest4j.AssertionFailedError:

    expected: 97.0
     but was: 101.0
    	at __randomizedtesting.SeedInfo.seed([BEC47974092D5DDD:6CB81A4982710095]:0)
    	at io.crate.execution.engine.aggregation.impl.PercentileAggregationTest.test_custom_compression_setting_is_used(PercentileAggregationTest.java:328)

Given that the tdigest state is probabilistic, merges influence the
result.
