### PR TITLE
Add policy to column_details in info_schema.columns

### DIFF
--- a/docs/appendices/release-notes/5.10.0.rst
+++ b/docs/appendices/release-notes/5.10.0.rst
@@ -163,6 +163,9 @@ Administration and Operations
 - Updated :ref:`statement_timeout setting <conf-session-statement-timeout>` to
   also account for parsing, analysis and planning phases.
 
+- Added a ``policy`` sub-column to ``column_details`` in the
+  ``information_schema.columns`` table.
+
 Client interfaces
 -----------------
 

--- a/docs/general/information-schema.rst
+++ b/docs/general/information-schema.rst
@@ -358,36 +358,37 @@ infinite recursion of your mind, beware!)::
     | column_details           | object     |               12 |
     | column_details['name']   | text       |               13 |
     | column_details['path']   | text_array |               14 |
-    | column_name              | text       |               15 |
-    | data_type                | text       |               16 |
-    | datetime_precision       | integer    |               17 |
-    | domain_catalog           | text       |               18 |
-    | domain_name              | text       |               19 |
-    | domain_schema            | text       |               20 |
-    | generation_expression    | text       |               21 |
-    | identity_cycle           | boolean    |               22 |
-    | identity_generation      | text       |               23 |
-    | identity_increment       | text       |               24 |
-    | identity_maximum         | text       |               25 |
-    | identity_minimum         | text       |               26 |
-    | identity_start           | text       |               27 |
-    | interval_precision       | integer    |               28 |
-    | interval_type            | text       |               29 |
-    | is_generated             | text       |               30 |
-    | is_identity              | boolean    |               31 |
-    | is_nullable              | boolean    |               32 |
-    | numeric_precision        | integer    |               33 |
-    | numeric_precision_radix  | integer    |               34 |
-    | numeric_scale            | integer    |               35 |
-    | ordinal_position         | integer    |               36 |
-    | table_catalog            | text       |               37 |
-    | table_name               | text       |               38 |
-    | table_schema             | text       |               39 |
-    | udt_catalog              | text       |               40 |
-    | udt_name                 | text       |               41 |
-    | udt_schema               | text       |               42 |
+    | column_details['policy'] | text       |               15 |
+    | column_name              | text       |               16 |
+    | data_type                | text       |               17 |
+    | datetime_precision       | integer    |               18 |
+    | domain_catalog           | text       |               19 |
+    | domain_name              | text       |               20 |
+    | domain_schema            | text       |               21 |
+    | generation_expression    | text       |               22 |
+    | identity_cycle           | boolean    |               23 |
+    | identity_generation      | text       |               24 |
+    | identity_increment       | text       |               25 |
+    | identity_maximum         | text       |               26 |
+    | identity_minimum         | text       |               27 |
+    | identity_start           | text       |               28 |
+    | interval_precision       | integer    |               29 |
+    | interval_type            | text       |               30 |
+    | is_generated             | text       |               31 |
+    | is_identity              | boolean    |               32 |
+    | is_nullable              | boolean    |               33 |
+    | numeric_precision        | integer    |               34 |
+    | numeric_precision_radix  | integer    |               35 |
+    | numeric_scale            | integer    |               36 |
+    | ordinal_position         | integer    |               37 |
+    | table_catalog            | text       |               38 |
+    | table_name               | text       |               39 |
+    | table_schema             | text       |               40 |
+    | udt_catalog              | text       |               41 |
+    | udt_name                 | text       |               42 |
+    | udt_schema               | text       |               43 |
     +--------------------------+------------+------------------+
-    SELECT 42 rows in set (... sec)
+    SELECT 43 rows in set (... sec)
 
 
 .. rubric:: Schema

--- a/server/src/main/java/io/crate/metadata/information/InformationColumnsTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/information/InformationColumnsTableInfo.java
@@ -118,6 +118,7 @@ public class InformationColumnsTableInfo {
         .startObject("column_details")
             .add("name", STRING , r -> r.ref().column().name())
             .add("path", STRING_ARRAY, r -> r.ref().column().path())
+            .add("policy", STRING, r -> r.ref().valueType().columnPolicy().lowerCaseName())
         .endObject()
         .setPrimaryKeys(
             ColumnIdent.of("table_catalog"),

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -572,13 +572,12 @@ public class InformationSchemaTest extends IntegTestCase {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertThat(response.rowCount()).isEqualTo(1024);
+        assertThat(response.rowCount()).isEqualTo(1025);
     }
 
     @Test
     public void testColumnsColumns() {
         execute("select column_name, data_type from information_schema.columns where table_schema='information_schema' and table_name='columns' order by column_name asc");
-        assertThat(response.rowCount()).isEqualTo(42L);
         assertThat(response).hasRows(
             "character_maximum_length| integer",
             "character_octet_length| integer",
@@ -594,6 +593,7 @@ public class InformationSchemaTest extends IntegTestCase {
             "column_details| object",
             "column_details['name']| text",
             "column_details['path']| text_array",
+            "column_details['policy']| text",
             "column_name| text",
             "data_type| text",
             "datetime_precision| integer",
@@ -777,10 +777,14 @@ public class InformationSchemaTest extends IntegTestCase {
         assertThat(response.rows()[4][cols.get("numeric_precision")]).isEqualTo(53);
         assertThat(response.rows()[5][cols.get("numeric_precision")]).isEqualTo(24);
 
-        assertThat(response.rows()[7][cols.get("column_details")]).isEqualTo(Map.of("name","stuff","path", List.of())); // column_details
-        assertThat(response.rows()[8][cols.get("column_details")]).isEqualTo(Map.of("name","stuff","path", List.of("level1"))); // column_details
-        assertThat(response.rows()[9][cols.get("column_details")]).isEqualTo(Map.of("name","stuff","path", List.of("level1","level2"))); // column_details
-        assertThat(response.rows()[10][cols.get("column_details")]).isEqualTo(Map.of("name","stuff","path", List.of("level1","level2_nullable"))); // column_details
+        assertThat(response.rows()[7][cols.get("column_details")])
+            .isEqualTo(Map.of("name","stuff","path", List.of(), "policy", "dynamic"));
+        assertThat(response.rows()[8][cols.get("column_details")])
+            .isEqualTo(Map.of("name","stuff","path", List.of("level1"), "policy", "dynamic"));
+        assertThat(response.rows()[9][cols.get("column_details")])
+            .isEqualTo(Map.of("name","stuff","path", List.of("level1","level2"), "policy", "strict"));
+        assertThat(response.rows()[10][cols.get("column_details")])
+            .isEqualTo(Map.of("name","stuff","path", List.of("level1","level2_nullable"), "policy", "strict"));
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
@@ -664,7 +664,7 @@ public class PrivilegesIntegrationTest extends BaseRolesIntegrationTest {
         //make sure a new user has default accesses to pg tables with information and pg catalog schema related entries
         try (Session testUserSession = testUserSession()) {
             execute("select * from pg_catalog.pg_attribute order by attname", null, testUserSession);
-            assertThat(response).hasRowCount(567L);
+            assertThat(response).hasRowCount(568L);
 
             //create a table with an attribute that a new user is not privileged to access
             executeAsSuperuser("create table test_schema.my_table (my_col int)");


### PR DESCRIPTION
`column_details` is already a custom extension that exposes name and
path.

Closes https://github.com/crate/crate/issues/16662

~(Targets 5.11 or 6.0, will add release notes once 5.10 is out)~
