### PR TITLE
Do not allow rename or drop columns without OIDs assigned

### DIFF
--- a/server/src/main/java/io/crate/analyze/AlterTableDropColumnAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/AlterTableDropColumnAnalyzer.java
@@ -24,9 +24,11 @@ package io.crate.analyze;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.Metadata;
 
 import io.crate.analyze.expressions.ExpressionAnalysisContext;
 import io.crate.analyze.expressions.ExpressionAnalyzer;
@@ -98,6 +100,12 @@ public class AlterTableDropColumnAnalyzer {
 
     /** Validate restrictions based on properties that cannot change */
     private static void validateStatic(DocTableInfo tableInfo, List<DropColumn> dropColumns) {
+        for (DropColumn c : dropColumns) {
+            if (c.ref().oid() == Metadata.COLUMN_OID_UNASSIGNED) {
+                throw new IllegalStateException(
+                    String.format(Locale.ENGLISH, "Cannot rename a column that does not have an OID assigned: %s", c.ref().column()));
+            }
+        }
         if (tableInfo.versionCreated().before(Version.V_5_5_0)) {
             throw new UnsupportedOperationException(
                 "Dropping columns of a table created before version 5.5 is not supported"

--- a/server/src/main/java/io/crate/analyze/AlterTableRenameColumnAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/AlterTableRenameColumnAnalyzer.java
@@ -26,6 +26,7 @@ import java.util.Locale;
 import java.util.Objects;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -88,6 +89,11 @@ public class AlterTableRenameColumnAnalyzer {
         Reference targetRef = (Reference) expressionAnalyzer.convert(renameColumn.newName(), expressionContext);
         ColumnIdent sourceCol = sourceRef.column();
         ColumnIdent targetCol = targetRef.column();
+
+        if (sourceRef.oid() == Metadata.COLUMN_OID_UNASSIGNED) {
+            throw new IllegalStateException(
+                String.format(Locale.ENGLISH, "Cannot rename a column that does not have an OID assigned: %s", sourceCol));
+        }
 
         if (sourceCol.path().size() != targetCol.path().size()) {
             throw new IllegalArgumentException(


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

There are existing partitioned tables with falsely updated created versions, https://github.com/crate/crate/pull/17178. This PR prevents dropping and renaming columns from such tables. i.e. a partitioned table created in `5.4` falsely updated to `5.6`. The existing version checks are avoided and the statements would go through.

## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
