### PR TITLE
Handle `double` input in sanitizeValue for numeric type

### DIFF
--- a/docs/appendices/release-notes/5.9.7.rst
+++ b/docs/appendices/release-notes/5.9.7.rst
@@ -47,6 +47,9 @@ See the :ref:`version_5.9.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that could lead to a ``class java.lang.Double cannot be cast to
+  class java.math.BigDecimal`` error when using the ``numeric`` type.
+
 - Fixed an issue that could cause queries to run into a ``NullPointerException``
   if having a query condition like ``(nonPrimaryKey = ? AND primaryKeyPart =
   ?)``

--- a/server/src/main/java/io/crate/types/NumericType.java
+++ b/server/src/main/java/io/crate/types/NumericType.java
@@ -163,6 +163,12 @@ public class NumericType extends DataType<BigDecimal> implements Streamer<BigDec
             BigInteger bigInt = BigInteger.valueOf(longValue);
             return new BigDecimal(bigInt, scale == null ? 0 : scale, mathContext());
         }
+        // Can be double if coming from source
+        if (value instanceof Double doubleVal) {
+            MathContext mathContext = mathContext();
+            BigDecimal bd = new BigDecimal(doubleVal, mathContext);
+            return scale == null ? bd : bd.setScale(scale, mathContext.getRoundingMode());
+        }
         return (BigDecimal) value;
     }
 


### PR DESCRIPTION
`BigDecimal` values can be stored as `double` in the source, leading to
class cast exceptions when reading out the value again.

Fixes https://github.com/crate/crate/issues/17217
On 5.10/master this doesn't happen due to https://github.com/crate/crate/pull/16569
