### PR TITLE
TranslogIndexer should use shard created version

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -500,7 +500,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
             return;
         }
         var tableInfo = tableFactory.create(RelationName.fromIndexName(indexName), metadata);
-        var indexer = new TranslogIndexer(tableInfo);
+        var indexer = new TranslogIndexer(tableInfo, this.indexSettings.getIndexVersionCreated());
         this.getTranslogIndexer = () -> indexer;
     }
 

--- a/server/src/test/java/io/crate/execution/dml/IndexerTest.java
+++ b/server/src/test/java/io/crate/execution/dml/IndexerTest.java
@@ -1293,7 +1293,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
                 """
         );
 
-        assertTranslogParses(doc, e.resolveTableInfo("tbl"));
+        assertTranslogParses(doc, e.resolveTableInfo("tbl"), Version.V_5_4_0);
     }
 
     @UseNewCluster
@@ -1336,7 +1336,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
                 """
         );
 
-        assertTranslogParses(doc, e.resolveTableInfo("tbl"));
+        assertTranslogParses(doc, e.resolveTableInfo("tbl"), Version.V_5_4_0);
     }
 
     /**
@@ -1466,8 +1466,12 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(storedField.binaryValue().utf8ToString()).isEqualTo("{\"1\":[{\"2\":[{\"3\":1}]}]}");
     }
 
-    public static void assertTranslogParses(ParsedDocument doc, DocTableInfo info) throws Exception {
-        TranslogIndexer ti = new TranslogIndexer(info);
+    public static void assertTranslogParses(ParsedDocument doc, DocTableInfo info) {
+        assertTranslogParses(doc, info, Version.CURRENT);
+    }
+
+    public static void assertTranslogParses(ParsedDocument doc, DocTableInfo info, Version shardCreatedVersion) {
+        TranslogIndexer ti = new TranslogIndexer(info, shardCreatedVersion);
         ParsedDocument d = ti.index(doc.id(), doc.source());
         assertThat(doc).parsesTo(d);
     }

--- a/server/src/test/java/io/crate/execution/dml/TranslogIndexerTest.java
+++ b/server/src/test/java/io/crate/execution/dml/TranslogIndexerTest.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.junit.Test;
@@ -42,7 +43,7 @@ public class TranslogIndexerTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo table = executor.resolveTableInfo("tbl");
         assertThat(table).isNotNull();
 
-        TranslogIndexer ti = new TranslogIndexer(table);
+        TranslogIndexer ti = new TranslogIndexer(table, Version.CURRENT);
         BytesReference source = new BytesArray("{\"1\":1,\"2\":2}");
         assertThatThrownBy(() -> ti.index("1", source))
             .isExactlyInstanceOf(TranslogMappingUpdateException.class)
@@ -54,7 +55,7 @@ public class TranslogIndexerTest extends CrateDummyClusterServiceUnitTest {
         SQLExecutor executor = SQLExecutor.of(clusterService)
             .addTable("create table tbl (id int, x int)");
         DocTableInfo table = executor.resolveTableInfo("tbl");
-        TranslogIndexer ti = new TranslogIndexer(table);
+        TranslogIndexer ti = new TranslogIndexer(table, Version.CURRENT);
         BytesReference source = new BytesArray("{\"1\":1,\"2\":\"bar\"}");
         var doc = ti.index("1", source);
         // the value of field 2 is not indexed as it contains an invalid value (sanitize failed)

--- a/server/src/testFixtures/java/org/elasticsearch/index/engine/TranslogHandler.java
+++ b/server/src/testFixtures/java/org/elasticsearch/index/engine/TranslogHandler.java
@@ -85,7 +85,7 @@ public class TranslogHandler implements Engine.TranslogRecoveryRunner {
             Set.of(),
             0
         );
-        return new TranslogIndexer(table);
+        return new TranslogIndexer(table, Version.CURRENT);
     }
 
     private void applyOperation(Engine engine, Engine.Operation operation) throws IOException {

--- a/server/src/testFixtures/java/org/elasticsearch/index/shard/IndexShardTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/index/shard/IndexShardTestCase.java
@@ -525,7 +525,7 @@ public abstract class IndexShardTestCase extends ESTestCase {
                 store,
                 queryCache,
                 testAnalysis.indexAnalyzers.getDefaultIndexAnalyzer(),
-                () -> new TranslogIndexer(getDocTable(indexSettings::getIndexMetadata)),
+                () -> new TranslogIndexer(getDocTable(indexSettings::getIndexMetadata), Version.CURRENT),
                 engineFactoryProviders,
                 indexEventListener,
                 threadPool,


### PR DESCRIPTION
Some data structures (for example, storage formats) can change across different partitions of a table, so the TranslogIndexer needs to key changes on the per- partition shard version, rather than the table version.  The regular Indexer already does this.
