### PR TITLE
Set new partitions' version created to the smallest non-client node version

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -622,12 +622,9 @@ public class MetadataCreateIndexService {
     }
 
     public static void setIndexVersionCreatedSetting(Settings.Builder indexSettingsBuilder, ClusterState clusterState) {
-        if (indexSettingsBuilder.get(IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey()) == null) {
-            final DiscoveryNodes nodes = clusterState.nodes();
-            final Version createdVersion = Version.min(Version.CURRENT,
-                                                       nodes.getSmallestNonClientNodeVersion());
-            indexSettingsBuilder.put(IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(), createdVersion);
-        }
+        final DiscoveryNodes nodes = clusterState.nodes();
+        final Version createdVersion = Version.min(Version.CURRENT, nodes.getSmallestNonClientNodeVersion());
+        indexSettingsBuilder.put(IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(), createdVersion);
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitionsActionTest.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitionsActionTest.java
@@ -228,4 +228,40 @@ public class TransportCreatePartitionsActionTest extends IntegTestCase {
         // Without do-once logic would have been 2
         verify(actionSpy, times(1)).upgradeTemplates(any(), any());
     }
+
+    @Test
+    public void test_version_created_settings_for_new_partitions_from_old_template_do_not_follow_old_templates_version() throws Exception {
+        execute("create table tbl (a int) partitioned by (a) ");
+        ensureYellow();
+
+        ClusterState clusterState = cluster().clusterService().state();
+        Metadata.Builder metadataBuilder = Metadata.builder(clusterState.metadata());
+
+        String tableTemplateName = PartitionName.templateName("doc", "tbl");
+        IndexTemplateMetadata indexTemplateMetadata = clusterState.metadata().templates().get(tableTemplateName);
+        assertThat(indexTemplateMetadata).isNotNull();
+
+        // modify the template's version created to V_5_7_5
+        metadataBuilder.removeTemplate(tableTemplateName);
+        IndexTemplateMetadata.Builder templateBuilder = IndexTemplateMetadata.builder(tableTemplateName)
+            .version(1)
+            .patterns(indexTemplateMetadata.patterns())
+            .putMapping(indexTemplateMetadata.mapping())
+            .settings(Settings.builder()
+                .put(indexTemplateMetadata.settings())
+                .put(IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(), Version.V_5_7_5)
+            );
+        metadataBuilder.put(templateBuilder);
+        ClusterState artificialState = new ClusterState.Builder(clusterState).metadata(metadataBuilder).build();
+
+        // Imitation of an insert that results in a new partition
+        CreatePartitionsRequest request = new CreatePartitionsRequest(List.of(".partitioned.tbl.012345"));
+
+        ClusterState newState = action.executeCreateIndices(artificialState, request);
+        assertThat(newState.metadata().indices().values().size()).isEqualTo(1);
+        IndexMetadata indexMetadata = newState.metadata().indices().values().iterator().next().value;
+        Version newPartitionVersion = indexMetadata.getSettings().getAsVersion(IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(), Version.V_EMPTY);
+        assertThat(newPartitionVersion).isEqualTo(clusterState.nodes().getSmallestNonClientNodeVersion());
+        assertThat(newPartitionVersion).isNotEqualTo(Version.V_5_7_5);
+    }
 }


### PR DESCRIPTION
This is a manual backport of https://github.com/crate/crate/pull/17190.

The expected behaviour is that on a `5.9` node, a new partition for a `5.8` partitioned table must be `5.9` **not** `5.8`(not to follow the table's version created). On `master`, it is fixed by https://github.com/crate/crate/pull/17190 but it was not backported thinking that it was a regression on `master`.