### PR TITLE
Fix distributed execution of window functions with partition on a sub-column

### DIFF
--- a/docs/appendices/release-notes/5.9.7.rst
+++ b/docs/appendices/release-notes/5.9.7.rst
@@ -83,3 +83,15 @@ Fixes
 
 - Fixed an issue that caused new partitions' versions created to follow the
   table's version instead of the minimum node version of the cluster.
+
+- Fixed an issue that caused an error when running a distributed query with a
+  window function on a virtual table, partitioned by a sub-column that is not
+  explicitly selected from the virtual table. Example::
+
+    SELECT ROW_NUMBER() OVER (
+         PARTITION BY obj ['a']
+    ) AS RK
+    FROM (
+        SELECT obj
+        FROM test
+    ) t;


### PR DESCRIPTION
Fixes https://github.com/crate/crate/issues/17201

If source plan doesn't have a sub-column in outputs (and only has a top level column) and partition is by a sub-column, `distributedByColumn` resolution can't find corresponding output symbol and we create a plan that tries to access column with index -1.

