### PR TITLE
Mitigate wrong template createdVersion by inferring it from partitions

### DIFF
--- a/docs/appendices/release-notes/5.9.7.rst
+++ b/docs/appendices/release-notes/5.9.7.rst
@@ -74,4 +74,5 @@ Fixes
   :ref:`information_schema.tables <information_schema_tables>` and
   :ref:`information_schema.table_partitions <is_table_partitions>` for
   partitioned tables and their new partitions to the latest version following a
-  node upgrade.
+  node upgrade. The fix can't fully repair incorrectly updated versions but
+  includes mitigation logic that infers the version based on existing partitions.

--- a/server/src/main/java/io/crate/analyze/AlterTableDropColumnAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/AlterTableDropColumnAnalyzer.java
@@ -26,8 +26,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.elasticsearch.Version;
-
 import io.crate.analyze.expressions.ExpressionAnalysisContext;
 import io.crate.analyze.expressions.ExpressionAnalyzer;
 import io.crate.analyze.relations.DocTableRelation;
@@ -98,7 +96,7 @@ public class AlterTableDropColumnAnalyzer {
 
     /** Validate restrictions based on properties that cannot change */
     private static void validateStatic(DocTableInfo tableInfo, List<DropColumn> dropColumns) {
-        if (tableInfo.versionCreated().before(Version.V_5_5_0)) {
+        if (tableInfo.versionCreated().before(DocTableInfo.COLUMN_OID_VERSION)) {
             throw new UnsupportedOperationException(
                 "Dropping columns of a table created before version 5.5 is not supported"
             );

--- a/server/src/main/java/io/crate/analyze/AlterTableRenameColumnAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/AlterTableRenameColumnAnalyzer.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 
-import org.elasticsearch.Version;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -70,9 +69,9 @@ public class AlterTableRenameColumnAnalyzer {
             sessionSettings.sessionUser(),
             sessionSettings.searchPath()
         );
-        if (tableInfo.versionCreated().before(Version.V_5_5_0)) {
+        if (tableInfo.versionCreated().before(DocTableInfo.COLUMN_OID_VERSION)) {
             throw new UnsupportedOperationException(
-                "Renaming columns of a table created before version 5.5 is not supported"
+                "Renaming columns of a table created before version " + DocTableInfo.COLUMN_OID_VERSION + " is not supported"
             );
         }
         var expressionAnalyzer = new ExpressionAnalyzer(

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportAddColumnAction.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportAddColumnAction.java
@@ -21,7 +21,6 @@
 
 package io.crate.execution.ddl.tables;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateTaskExecutor;
@@ -37,6 +36,7 @@ import org.jetbrains.annotations.VisibleForTesting;
 
 import io.crate.execution.ddl.AbstractDDLTransportAction;
 import io.crate.metadata.NodeContext;
+import io.crate.metadata.doc.DocTableInfo;
 
 @Singleton
 public class TransportAddColumnAction extends AbstractDDLTransportAction<AddColumnRequest, AcknowledgedResponse> {
@@ -45,7 +45,7 @@ public class TransportAddColumnAction extends AbstractDDLTransportAction<AddColu
     public static final AlterTableTask.AlterTableOperator<AddColumnRequest> ADD_COLUMN_OPERATOR =
         (req, doctableInfo, metadataBuilder, nodeCtx) -> doctableInfo.addColumns(
             nodeCtx,
-            doctableInfo.versionCreated().onOrAfter(Version.V_5_5_0) ?
+            doctableInfo.versionCreated().onOrAfter(DocTableInfo.COLUMN_OID_VERSION) ?
                 metadataBuilder.columnOidSupplier() :
                 () -> Metadata.COLUMN_OID_UNASSIGNED,
             req.references(),

--- a/server/src/main/java/io/crate/execution/dml/Indexer.java
+++ b/server/src/main/java/io/crate/execution/dml/Indexer.java
@@ -398,7 +398,7 @@ public class Indexer {
                    Symbol[] returnValues) {
         this.columns = targetColumns;
         this.synthetics = new HashMap<>();
-        this.writeOids = table.versionCreated().onOrAfter(Version.V_5_5_0);
+        this.writeOids = table.versionCreated().onOrAfter(DocTableInfo.COLUMN_OID_VERSION);
         this.getRef = table::getReference;
         PartitionName partitionName = table.isPartitioned()
             ? PartitionName.fromIndexOrTemplate(indexName)

--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
@@ -167,6 +167,11 @@ import io.crate.types.ObjectType;
  */
 public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
 
+    /**
+     * Tables created on or after this version use oids in the mapping
+     **/
+    public static final Version COLUMN_OID_VERSION = Version.V_5_5_0;
+
     public static final Setting<Long> TOTAL_COLUMNS_LIMIT =
         Setting.longSetting("index.mapping.total_fields.limit", 1000L, 0, Property.Dynamic, Property.IndexScope);
     public static final Setting<Long> DEPTH_LIMIT_SETTING =

--- a/server/src/test/java/io/crate/analyze/AlterTableRenameColumnAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/AlterTableRenameColumnAnalyzerTest.java
@@ -138,7 +138,7 @@ public class AlterTableRenameColumnAnalyzerTest extends CrateDummyClusterService
 
         assertThatThrownBy(() -> e.analyze("ALTER TABLE t RENAME COLUMN a to b"))
             .isExactlyInstanceOf(UnsupportedOperationException.class)
-            .hasMessage("Renaming columns of a table created before version 5.5 is not supported");
+            .hasMessage("Renaming columns of a table created before version 5.5.0 is not supported");
     }
 
     @Test


### PR DESCRIPTION
Follow up to https://github.com/crate/crate/pull/17178
Alternative to:

- https://github.com/crate/crate/pull/17216
- https://github.com/crate/crate/pull/17186

Instead of doing additional sanity checks in places where the created
version is used, this instead tries to repair the `versionCreated` on
read by using the min version across partitions.


Note that this will break once the old partitions are deleted.
To account for that, we could additionally check if oids are missing, and if so set the version to before OIDs were introduced.
