### PR TITLE
Suspend row consumer once netty outbound buffers are full

### DIFF
--- a/docs/appendices/release-notes/5.9.7.rst
+++ b/docs/appendices/release-notes/5.9.7.rst
@@ -95,3 +95,6 @@ Fixes
         SELECT obj
         FROM test
     ) t;
+
+- Fixed an issue which could lead to OutOfMemory errors when requesting large
+  result sets over the PostgreSQL protocol.

--- a/server/src/main/java/io/crate/protocols/postgres/Messages.java
+++ b/server/src/main/java/io/crate/protocols/postgres/Messages.java
@@ -320,7 +320,7 @@ public class Messages {
      * The value of the column, in the format indicated by the associated format code. n is the above length.
      */
     @SuppressWarnings({"unchecked","rawtypes"})
-    static void sendDataRow(Channel channel, Row row, List<PGType<?>> columnTypes, @Nullable FormatCodes.FormatCode[] formatCodes) {
+    static ChannelFuture sendDataRow(Channel channel, Row row, List<PGType<?>> columnTypes, @Nullable FormatCodes.FormatCode[] formatCodes) {
         int length = 4 + 2;
         assert columnTypes.size() == row.numColumns()
             : "Number of columns in the row must match number of columnTypes. Row: " + row + " types: " + columnTypes;
@@ -360,7 +360,7 @@ public class Messages {
         }
 
         buffer.setInt(1, length);
-        channel.write(buffer);
+        return channel.write(buffer);
     }
 
     static void writeCString(ByteBuf buffer, byte[] valBytes) {

--- a/server/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
+++ b/server/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
@@ -730,7 +730,6 @@ public class PostgresWireProtocol {
                 query,
                 channel,
                 delayedWrites,
-                session.transactionState(),
                 getAccessControl.apply(session.sessionSettings()),
                 Lists.map(outputTypes, PGTypes::get),
                 session.getResultFormatCodes(portalName)
@@ -847,7 +846,6 @@ public class PostgresWireProtocol {
                     query,
                     channel,
                     delayedWrites,
-                    TransactionState.IDLE,
                     accessControl,
                     Lists.map(fields, x -> PGTypes.get(x.valueType())),
                     null

--- a/server/src/main/java/io/crate/protocols/postgres/RowCountReceiver.java
+++ b/server/src/main/java/io/crate/protocols/postgres/RowCountReceiver.java
@@ -21,7 +21,10 @@
 
 package io.crate.protocols.postgres;
 
+import java.util.concurrent.CompletableFuture;
+
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import io.crate.session.BaseResultReceiver;
 import io.crate.auth.AccessControl;
@@ -48,7 +51,8 @@ class RowCountReceiver extends BaseResultReceiver {
     }
 
     @Override
-    public void setNextRow(Row row) {
+    @Nullable
+    public CompletableFuture<Void> setNextRow(Row row) {
         rowCount = (long) row.get(0);
         /*
          * In Crate -1 means row-count unknown, and -2 means error. In JDBC -2 means row-count unknown and -3 means error.
@@ -57,6 +61,7 @@ class RowCountReceiver extends BaseResultReceiver {
         if (rowCount < 0) {
             rowCount--;
         }
+        return null;
     }
 
     @Override

--- a/server/src/main/java/io/crate/rest/action/RestBulkRowCountReceiver.java
+++ b/server/src/main/java/io/crate/rest/action/RestBulkRowCountReceiver.java
@@ -21,6 +21,8 @@
 
 package io.crate.rest.action;
 
+import java.util.concurrent.CompletableFuture;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -41,12 +43,14 @@ class RestBulkRowCountReceiver extends BaseResultReceiver {
     }
 
     @Override
-    public void setNextRow(Row row) {
+    @Nullable
+    public CompletableFuture<Void> setNextRow(Row row) {
         rowCount = (long) row.get(0);
         // Can be an optimized bulk request with only 1 bulk arg/operation which carries only 1 column (row count).
         if (results.length > 1) {
             failure = (Throwable) row.get(1);
         }
+        return null;
     }
 
     @Override

--- a/server/src/main/java/io/crate/rest/action/RestResultSetReceiver.java
+++ b/server/src/main/java/io/crate/rest/action/RestResultSetReceiver.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.jetbrains.annotations.Nullable;
 
 import io.crate.session.ResultReceiver;
 import io.crate.data.Row;
@@ -59,13 +60,16 @@ class RestResultSetReceiver implements ResultReceiver<XContentBuilder> {
     }
 
     @Override
-    public void setNextRow(Row row) {
+    @Nullable
+    public CompletableFuture<Void> setNextRow(Row row) {
         try {
             rowAccounting.accountForAndMaybeBreak(row);
             builder.addRow(row, outputFields.size());
             rowCount++;
+            return null;
         } catch (IOException e) {
             fail(e);
+            return null;
         }
     }
 

--- a/server/src/main/java/io/crate/rest/action/RestRowCountReceiver.java
+++ b/server/src/main/java/io/crate/rest/action/RestRowCountReceiver.java
@@ -26,6 +26,7 @@ import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.jetbrains.annotations.Nullable;
 
 import io.crate.session.ResultReceiver;
 import io.crate.data.Row;
@@ -48,8 +49,10 @@ class RestRowCountReceiver implements ResultReceiver<XContentBuilder> {
     }
 
     @Override
-    public void setNextRow(Row row) {
+    @Nullable
+    public CompletableFuture<Void> setNextRow(Row row) {
         rowCount = (long) row.get(0);
+        return null;
     }
 
     @Override

--- a/server/src/main/java/io/crate/session/BaseResultReceiver.java
+++ b/server/src/main/java/io/crate/session/BaseResultReceiver.java
@@ -23,15 +23,19 @@ package io.crate.session;
 
 import java.util.concurrent.CompletableFuture;
 
+import org.jetbrains.annotations.Nullable;
+
 import io.crate.common.annotations.OverridingMethodsMustInvokeSuper;
 import io.crate.data.Row;
 
 public class BaseResultReceiver implements ResultReceiver<Void> {
 
-    private CompletableFuture<Void> completionFuture = new CompletableFuture<>();
+    private final CompletableFuture<Void> completionFuture = new CompletableFuture<>();
 
     @Override
-    public void setNextRow(Row row) {
+    @Nullable
+    public CompletableFuture<Void> setNextRow(Row row) {
+        return null;
     }
 
     @Override

--- a/server/src/main/java/io/crate/session/CollectingResultReceiver.java
+++ b/server/src/main/java/io/crate/session/CollectingResultReceiver.java
@@ -26,6 +26,8 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.stream.Collector;
 
+import org.jetbrains.annotations.Nullable;
+
 import io.crate.data.Row;
 
 /**
@@ -51,8 +53,10 @@ public final class CollectingResultReceiver<A, R> implements ResultReceiver<R> {
     }
 
     @Override
-    public void setNextRow(Row row) {
+    @Nullable
+    public CompletableFuture<Void> setNextRow(Row row) {
         accumulator.accept(state, row);
+        return null;
     }
 
     @Override

--- a/server/src/main/java/io/crate/session/ResultReceiver.java
+++ b/server/src/main/java/io/crate/session/ResultReceiver.java
@@ -21,6 +21,10 @@
 
 package io.crate.session;
 
+import java.util.concurrent.CompletableFuture;
+
+import org.jetbrains.annotations.Nullable;
+
 import io.crate.concurrent.CompletionListenable;
 import io.crate.data.Row;
 
@@ -29,7 +33,12 @@ import io.crate.data.Row;
  */
 public interface ResultReceiver<T> extends CompletionListenable<T> {
 
-    void setNextRow(Row row);
+    /**
+     * @return CompletableFuture that will be completed when the row has been processed or null if the processing is
+     *         done immediately (avoid unnecessary allocations).
+     */
+    @Nullable
+    CompletableFuture<Void> setNextRow(Row row);
 
     void batchFinished();
 
@@ -39,4 +48,8 @@ public interface ResultReceiver<T> extends CompletionListenable<T> {
     void allFinished();
 
     void fail(Throwable t);
+
+    default boolean isWritable() {
+        return true;
+    }
 }

--- a/server/src/main/java/io/crate/session/RetryOnFailureResultReceiver.java
+++ b/server/src/main/java/io/crate/session/RetryOnFailureResultReceiver.java
@@ -33,6 +33,7 @@ import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.transport.ConnectTransportException;
+import org.jetbrains.annotations.Nullable;
 
 import io.crate.data.Row;
 import io.crate.exceptions.SQLExceptions;
@@ -64,8 +65,9 @@ public class RetryOnFailureResultReceiver<T> implements ResultReceiver<T> {
     }
 
     @Override
-    public void setNextRow(Row row) {
-        delegate.setNextRow(row);
+    @Nullable
+    public CompletableFuture<Void> setNextRow(Row row) {
+        return delegate.setNextRow(row);
     }
 
     @Override
@@ -115,5 +117,10 @@ public class RetryOnFailureResultReceiver<T> implements ResultReceiver<T> {
                ", jobId=" + jobId +
                ", attempt=" + attempt +
                '}';
+    }
+
+    @Override
+    public boolean isWritable() {
+        return delegate.isWritable();
     }
 }

--- a/server/src/test/java/io/crate/protocols/postgres/BatchPortalTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/BatchPortalTest.java
@@ -27,8 +27,10 @@ import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
+import org.jetbrains.annotations.Nullable;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -79,8 +81,10 @@ public class BatchPortalTest extends CrateDummyClusterServiceUnitTest {
         final ArrayList<Object[]> s1Rows = new ArrayList<>();
         session.execute("Portal", 0, new BaseResultReceiver() {
             @Override
-            public void setNextRow(Row row) {
+            @Nullable
+            public CompletableFuture<Void> setNextRow(Row row) {
                 s1Rows.add(row.materialize());
+                return null;
             }
         });
 
@@ -89,8 +93,10 @@ public class BatchPortalTest extends CrateDummyClusterServiceUnitTest {
         final ArrayList<Object[]> s2Rows = new ArrayList<>();
         session.execute("Portal", 0, new BaseResultReceiver() {
             @Override
-            public void setNextRow(Row row) {
+            @Nullable
+            public CompletableFuture<Void> setNextRow(Row row) {
                 s2Rows.add(row.materialize());
+                return null;
             }
         });
         session.sync().get(5, TimeUnit.SECONDS);

--- a/server/src/test/java/io/crate/protocols/postgres/ResultSetReceiverTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/ResultSetReceiverTest.java
@@ -21,11 +21,14 @@
 
 package io.crate.protocols.postgres;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.Collections;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Test;
 import org.mockito.Answers;
@@ -35,20 +38,25 @@ import io.crate.data.Row1;
 import io.crate.protocols.postgres.DelayableWriteChannel.DelayedWrites;
 import io.crate.protocols.postgres.types.PGTypes;
 import io.crate.types.DataTypes;
+import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.DefaultChannelPromise;
+import io.netty.channel.embedded.EmbeddedChannel;
 
 public class ResultSetReceiverTest {
 
     @Test
     public void testChannelIsPeriodicallyFlushedToAvoidConsumingTooMuchMemory() {
         Channel channel = mock(Channel.class, Answers.RETURNS_DEEP_STUBS);
+        when(channel.isWritable()).thenReturn(true);
         DelayableWriteChannel delayableWriteChannel = new DelayableWriteChannel(channel);
         DelayedWrites delayWrites = delayableWriteChannel.delayWrites();
         ResultSetReceiver resultSetReceiver = new ResultSetReceiver(
             "select * from t",
             delayableWriteChannel,
             delayWrites,
-            TransactionState.IDLE,
             AccessControl.DISABLED,
             Collections.singletonList(PGTypes.get(DataTypes.INTEGER)),
             null
@@ -58,5 +66,63 @@ public class ResultSetReceiverTest {
             resultSetReceiver.setNextRow(row1);
         }
         verify(channel, times(1)).flush();
+    }
+
+    @Test
+    public void test_channel_is_flushed_if_not_writable_anymore() {
+        Channel channel = mock(Channel.class, Answers.RETURNS_DEEP_STUBS);
+        DelayableWriteChannel delayableWriteChannel = new DelayableWriteChannel(channel);
+        DelayedWrites delayWrites = delayableWriteChannel.delayWrites();
+        ResultSetReceiver resultSetReceiver = new ResultSetReceiver(
+            "select * from t",
+            delayableWriteChannel,
+            delayWrites,
+            AccessControl.DISABLED,
+            Collections.singletonList(PGTypes.get(DataTypes.INTEGER)),
+            null
+        );
+
+        when(channel.isWritable()).thenReturn(false);
+        Row1 row1 = new Row1(1);
+        resultSetReceiver.setNextRow(row1);
+        verify(channel, times(1)).flush();
+    }
+
+    @Test
+    public void test_sendNextRow_future_is_called_once_message_is_written() {
+        AtomicReference<ChannelPromise> promiseRef = new AtomicReference<>();
+        Channel channel = new EmbeddedChannel() {
+            @Override
+            public boolean isWritable() {
+                return false;
+            }
+
+            @Override
+            public ChannelFuture write(Object msg) {
+                if (msg instanceof ByteBuf b) {
+                    b.release();
+                }
+                var promise = new DefaultChannelPromise(this);
+                promiseRef.set(promise);
+                return promise;
+            }
+        };
+        DelayableWriteChannel delayableWriteChannel = new DelayableWriteChannel(channel);
+        DelayedWrites delayWrites = delayableWriteChannel.delayWrites();
+        ResultSetReceiver resultSetReceiver = new ResultSetReceiver(
+            "select * from t",
+            delayableWriteChannel,
+            delayWrites,
+            AccessControl.DISABLED,
+            Collections.singletonList(PGTypes.get(DataTypes.INTEGER)),
+            null
+        );
+
+        Row1 row1 = new Row1(1);
+        var future = resultSetReceiver.setNextRow(row1);
+        assertThat(future.isDone()).isFalse();
+
+        promiseRef.get().setSuccess();
+        assertThat(future.isDone()).isTrue();
     }
 }

--- a/server/src/testFixtures/java/io/crate/testing/SQLTransportExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLTransportExecutor.java
@@ -565,8 +565,10 @@ public class SQLTransportExecutor {
         }
 
         @Override
-        public void setNextRow(Row row) {
+        @Nullable
+        public CompletableFuture<Void> setNextRow(Row row) {
             rows.add(row.materialize());
+            return null;
         }
 
         @Override
@@ -621,8 +623,9 @@ public class SQLTransportExecutor {
         }
 
         @Override
-        public void setNextRow(Row row) {
+        public CompletableFuture<Void> setNextRow(Row row) {
             rowCount = (long) row.get(0);
+            return CompletableFuture.completedFuture(null);
         }
 
         @Override
@@ -660,7 +663,8 @@ public class SQLTransportExecutor {
         }
 
         @Override
-        public void setNextRow(Row row) {
+        @Nullable
+        public CompletableFuture<Void> setNextRow(Row row) {
             long rowCount = (long) row.get(0);
             Throwable failure = null;
             // Can be an optimized bulk request with only 1 bulk arg/operation which carries only 1 column (row count).
@@ -668,6 +672,7 @@ public class SQLTransportExecutor {
                 failure = (Throwable) row.get(1);
             }
             bulkResponse.update(resultIdx, rowCount, failure);
+            return null;
         }
 
         @Override


### PR DESCRIPTION
Avoid to fill up netty outbound buffers when the data cannot be written to the I/O fast enough (e.g. clients aren't reading the responses at-all (broken client) or too slow).
This can result in OOM's and should be protected by taking the channel's `isWritable` flag/state which get flipped once the configured `writeBufferWaterMark` is reached to protect from OOM's.

Benchmark results (require https://github.com/crate/crate-benchmarks/pull/332) did not raise any performance issues, see below.

<details>

<summary>Benchmark results (V1: master, V2: this PR)</summary>

``` 
~% ./compare_run.py --v1 branch:master --v2 branch:s/netty-channel-writable --spec specs/select.toml --protocol pg
# Results (server side duration in ms)
V1: 5.10.0-6ff7b3cf2f24405510388232ee40845f34c41604
V2: 5.10.0-b35cdfa6f53333b24ac44eaf91cde110880c5e52

Q: select * from uservisits where "sourceIP" = '25.193.131.52'
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |        0.144 ±    0.106 |      0.060 |      0.099 |      0.167 |      0.846 |
|   V2    |        0.147 ±    0.124 |      0.060 |      0.092 |      0.157 |      0.911 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               +   2.23%                           -   7.25%   
There is a 47.08% probability that the observed difference is not random, and the best estimate of that difference is 2.23%
The test has no statistical significance

Q: SELECT * FROM uservisits WHERE abs("adRevenue") > 10 LIMIT 5
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |        3.819 ±    8.174 |      2.220 |      2.510 |      2.626 |     82.044 |
|   V2    |        3.684 ±    8.310 |      1.958 |      2.297 |      2.474 |     75.648 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -   3.61%                           -   8.85%   
There is a 13.03% probability that the observed difference is not random, and the best estimate of that difference is 3.61%
The test has no statistical significance

Q: select * from uservisits where
"sourceIP" = '162.122.2.75' or
"sourceIP" = '25.193.131.52' or
"sourceIP" = '138.43.129.246' or
"sourceIP" = '180.121.127.93' or
"sourceIP" = '55.104.52.130' or
"sourceIP" = '97.146.166.179' or
"sourceIP" = '166.53.95.120' or
"sourceIP" = '211.65.2.20' or
"sourceIP" = '40.65.238.81' or
"sourceIP" = '113.247.109.52' or
"sourceIP" = '100.8.41.251' or
"sourceIP" = '99.204.192.162' or
"sourceIP" = '182.165.186.253' or
"sourceIP" = '180.199.220.52' or
"sourceIP" = '38.9.148.224' or
"sourceIP" = '251.127.173.45' or
"sourceIP" = '214.48.17.113' or
"sourceIP" = '174.208.34.96' or
"sourceIP" = '49.53.176.22' or
"sourceIP" = '5.189.189.64'
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |        0.468 ±    0.215 |      0.396 |      0.443 |      0.465 |      5.772 |
|   V2    |        0.455 ±    0.483 |      0.377 |      0.420 |      0.454 |     15.515 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -   2.79%                           -   5.20%   
There is a 55.98% probability that the observed difference is not random, and the best estimate of that difference is 2.79%
The test has no statistical significance

Q: select * from uservisits order by "cCode" limit 10 offset 1000000
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |     1515.374 ±   65.633 |   1449.560 |   1490.388 |   1500.334 |   1638.278 |
|   V2    |     1476.004 ±   44.902 |   1391.491 |   1473.373 |   1480.102 |   1579.262 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -   2.63%                           -   1.15%   
There is a 86.51% probability that the observed difference is not random, and the best estimate of that difference is 2.63%
The test has no statistical significance

Q: select * from uservisits order by "cCode" limit 1000000
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |     4294.890 ±   85.587 |   4211.070 |   4269.076 |   4296.568 |   4506.037 |
|   V2    |     4248.797 ±  115.677 |   4124.934 |   4206.537 |   4225.247 |   4469.939 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -   1.08%                           -   1.48%   
There is a 67.55% probability that the observed difference is not random, and the best estimate of that difference is 1.08%
The test has no statistical significance


System/JVM Metrics (durations in ms, byte-values in MB)
    |    YOUNG GC            |       OLD GC           |      HEAP         |     ALLOC     
    |  cnt      avg      max |  cnt      avg      max |  initial     used |     rate      total
 V1 |  115     9.29     1.80 |   32    74.22    67.95 |      268     1062 |  1521.58     107486
 V2 |  115    10.04     7.47 |   32    82.13    76.52 |      268      659 |  1560.70     107737
    
Top allocation frames
  V1
    ArrayUtil.growExact(...) total=44052214111, count=4832
    StreamSpliterators$WrappingSpliterator.initPartialTraversalState() total=16658478328, count=71
    Arrays.copyOf(...) total=7365954552, count=108
    BytesRef.utf8ToString() total=6401495625, count=1664
    StringUTF16.compress(...) total=5396427248, count=1169
    ArrayUtil.growNoCopy(...) total=3280589816, count=575
    HashMap.newNode(...) total=2190282568, count=269
    FieldValueHitQueue.fillFields(...) total=2041900819, count=1664
    AbstractBigArray.newBytePage(int) total=1958935720, count=157
    Long.valueOf(long) total=1257268228, count=534
  V2
    ArrayUtil.growExact(...) total=43496497870, count=4439
    StreamSpliterators$WrappingSpliterator.initPartialTraversalState() total=16443581240, count=48
    Arrays.copyOf(...) total=7398358361, count=117
    BytesRef.utf8ToString() total=5988625704, count=1693
    StringUTF16.compress(...) total=5444141136, count=1117
    ArrayUtil.growNoCopy(...) total=3028673657, count=540
    HashMap.newNode(...) total=2851932024, count=232
    FieldValueHitQueue.fillFields(...) total=2107118634, count=1526
    AbstractBigArray.newBytePage(int) total=1495187552, count=158
    Lucene90CompressingStoredFieldsReader$BlockState.document(int) total=1414191669, count=105

Top frames (by count)
  V1
    ArrayUtil.growExact(...) total=44052214111, count=4832
    PriorityQueue.downHeap(int) total=2441, count=2441
    ArraysSupport.vectorizedMismatch(...) total=1749, count=1749
    FieldValueHitQueue.fillFields(...) total=2041900819, count=1664
    BytesRef.utf8ToString() total=6401495625, count=1664
    MemorySessionImpl.checkValidStateRaw() total=1618, count=1618
    StringUTF16.compress(...) total=5396427248, count=1169
    ArraysSupport.mismatch(...) total=874, count=874
    LZ4.decompress(...) total=854, count=854
    ArrayUtil.growNoCopy(...) total=3280589816, count=575
  V2
    ArrayUtil.growExact(...) total=43496497870, count=4439
    ArraysSupport.mismatch(...) total=2460, count=2460
    PriorityQueue.downHeap(int) total=2284, count=2284
    BytesRef.utf8ToString() total=5988625704, count=1693
    MemorySessionImpl.checkValidStateRaw() total=1574, count=1574
    FieldValueHitQueue.fillFields(...) total=2107118634, count=1526
    StringUTF16.compress(...) total=5444141136, count=1117
    LZ4.decompress(...) total=875, count=875
    ArraysSupport.vectorizedMismatch(...) total=874, count=874
    Long.valueOf(long) total=1274854645, count=633
```

</details>