### PR TITLE
Docs: Fix `COPY FROM` Azure example

### DIFF
--- a/docs/sql/statements/copy-from.rst
+++ b/docs/sql/statements/copy-from.rst
@@ -313,8 +313,8 @@ For example:
 
 .. code-block:: text
 
-    COPY source
-    TO DIRECTORY 'az://myaccount.blob.core.windows.net/my-container/dir1/dir2/file1.json'
+    COPY t
+    FROM 'az://myaccount.blob.core.windows.net/my-container/dir1/dir2/file1.json'
     WITH (
         key = 'key'
     )


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The example for `COPY FROM` using Azure was using `COPY TO`. The commit adjusts the example to use `COPY FROM` as well as the same table name (`t`) as in the S3 example above.

## Checklist

 - [X] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [X] Updated documentation & `sql_features` table for user facing changes
 - [X] Touched code is covered by tests
 - [X] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
