### PR TITLE
Fix link to ISO ISO 19107:2003 used in `GEO` search docs

### DIFF
--- a/docs/general/dql/geo.rst
+++ b/docs/general/dql/geo.rst
@@ -291,4 +291,4 @@ query where scalar functions are allowed.
 
 .. _GeoJSON: https://geojson.org/
 .. _WKT: https://en.wikipedia.org/wiki/Well-known_text
-.. _ISO 19107: https://www.iso.org/iso/catalogue_detail.htm?csnumber=26012
+.. _ISO 19107: https://www.iso.org/standard/26012.html


### PR DESCRIPTION
Resource was moved to new URI location.