### PR TITLE
Allow vector module and native access in surefire tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
           <!-- by default is false but is set to true by `serverTest` profile to avoid running tests
                for modules on which `server` module depends on, when running `mvn -Pserver test` -->
           <skip>${skipRunTests}</skip>
-          <argLine>@{argLine} -XX:+UseSerialGC -XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=512M</argLine>
+          <argLine>@{argLine} -XX:+UseSerialGC -XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=512M --add-modules jdk.incubator.vector --enable-native-access=ALL-UNNAMED</argLine>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Fixes warnings from Lucene
We do the same when running bin/crate, see https://github.com/crate/crate/pull/16693
