### PR TITLE
Fix race-condition while handling row-consumer suspend

### DIFF
--- a/docs/appendices/release-notes/5.9.7.rst
+++ b/docs/appendices/release-notes/5.9.7.rst
@@ -1,17 +1,11 @@
 .. _version_5.9.7:
 
-==========================
-Version 5.9.7 - Unreleased
-==========================
+=============
+Version 5.9.7
+=============
 
 
-.. comment 1. Remove the " - Unreleased" from the header above and adjust the ==
-.. comment 2. Remove the NOTE below and replace with: "Released on 20XX-XX-XX."
-.. comment    (without a NOTE entry, simply starting from col 1 of the line)
-.. NOTE::
-
-    In development. 5.9.7 isn't released yet. These are the release notes for
-    the upcoming release.
+Released on 2024-01-21.
 
 .. NOTE::
     If you are upgrading a cluster, you must be running CrateDB 4.0.2 or higher

--- a/docs/appendices/release-notes/5.9.8.rst
+++ b/docs/appendices/release-notes/5.9.8.rst
@@ -1,0 +1,50 @@
+.. _version_5.9.8:
+
+==========================
+Version 5.9.8 - Unreleased
+==========================
+
+
+.. comment 1. Remove the " - Unreleased" from the header above and adjust the ==
+.. comment 2. Remove the NOTE below and replace with: "Released on 20XX-XX-XX."
+.. comment    (without a NOTE entry, simply starting from col 1 of the line)
+.. NOTE::
+
+    In development. 5.9.8 isn't released yet. These are the release notes for
+    the upcoming release.
+
+.. NOTE::
+    If you are upgrading a cluster, you must be running CrateDB 4.0.2 or higher
+    before you upgrade to 5.9.8.
+
+    We recommend that you upgrade to the latest 5.8 release before moving to
+    5.9.8.
+
+    A rolling upgrade from 5.8.x to 5.9.8 is supported.
+
+    Before upgrading, you should `back up your data`_.
+
+.. WARNING::
+
+    Tables that were created before CrateDB 4.x will not function with 5.x
+    and must be recreated before moving to 5.x.x.
+
+    You can recreate tables using ``COPY TO`` and ``COPY FROM`` or by
+    `inserting the data into a new table`_.
+
+.. _back up your data: https://crate.io/docs/crate/reference/en/latest/admin/snapshots.html
+
+.. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
+
+.. rubric:: Table of contents
+
+.. contents::
+   :local:
+
+See the :ref:`version_5.9.0` release notes for a full list of changes in the
+5.9 series.
+
+Fixes
+=====
+
+None

--- a/docs/appendices/release-notes/5.9.8.rst
+++ b/docs/appendices/release-notes/5.9.8.rst
@@ -47,4 +47,5 @@ See the :ref:`version_5.9.0` release notes for a full list of changes in the
 Fixes
 =====
 
-None
+- Fixed a race-condition regression introduced in :ref:`version_5.9.7` that could
+  lead to a ``NullPointerException`` when using the PostgreSQL protocol.

--- a/docs/appendices/release-notes/index.rst
+++ b/docs/appendices/release-notes/index.rst
@@ -34,6 +34,7 @@ Versions
 .. toctree::
     :maxdepth: 1
 
+    5.9.8
     5.9.7
     5.9.6
     5.9.5

--- a/server/src/main/java/io/crate/protocols/postgres/ResultSetReceiver.java
+++ b/server/src/main/java/io/crate/protocols/postgres/ResultSetReceiver.java
@@ -66,9 +66,6 @@ class ResultSetReceiver extends BaseResultReceiver {
 
     /**
      * Writes the row to the pg channel and flushes the channel if necessary.
-     * The caller should check {@link #isWritable()} after each call, and if it's false, the consumer should be
-     * suspended until the receiver becomes writable again. Otherwise, this can lead to OOM errors as the channel
-     * outbound buffer keeps growing.
      *
      * @return a future that is completed once the row was successfully written (flushed)
      */
@@ -78,7 +75,7 @@ class ResultSetReceiver extends BaseResultReceiver {
         rowCount++;
         ChannelFuture sendDataRow = Messages.sendDataRow(directChannel, row, columnTypes, formatCodes);
         CompletableFuture<Void> future;
-        boolean isWritable = isWritable();
+        boolean isWritable = directChannel.isWritable();
         if (isWritable) {
             future = null;
         } else {
@@ -129,10 +126,5 @@ class ResultSetReceiver extends BaseResultReceiver {
         channel.writePendingMessages(delayedWrites);
         channel.flush();
         sendErrorResponse.addListener(f -> super.fail(throwable));
-    }
-
-    @Override
-    public boolean isWritable() {
-        return directChannel.isWritable();
     }
 }

--- a/server/src/main/java/io/crate/session/ResultReceiver.java
+++ b/server/src/main/java/io/crate/session/ResultReceiver.java
@@ -34,8 +34,8 @@ import io.crate.data.Row;
 public interface ResultReceiver<T> extends CompletionListenable<T> {
 
     /**
-     * @return CompletableFuture that will be completed when the row has been processed or null if the processing is
-     *         done immediately (avoid unnecessary allocations).
+     * @return CompletableFuture or null. If a future, the callee must wait for its completion before
+     *         calling `setNextRow` again.
      */
     @Nullable
     CompletableFuture<Void> setNextRow(Row row);
@@ -48,8 +48,4 @@ public interface ResultReceiver<T> extends CompletionListenable<T> {
     void allFinished();
 
     void fail(Throwable t);
-
-    default boolean isWritable() {
-        return true;
-    }
 }

--- a/server/src/main/java/io/crate/session/RetryOnFailureResultReceiver.java
+++ b/server/src/main/java/io/crate/session/RetryOnFailureResultReceiver.java
@@ -118,9 +118,4 @@ public class RetryOnFailureResultReceiver<T> implements ResultReceiver<T> {
                ", attempt=" + attempt +
                '}';
     }
-
-    @Override
-    public boolean isWritable() {
-        return delegate.isWritable();
-    }
 }

--- a/server/src/main/java/io/crate/session/RowConsumerToResultReceiver.java
+++ b/server/src/main/java/io/crate/session/RowConsumerToResultReceiver.java
@@ -79,8 +79,7 @@ public class RowConsumerToResultReceiver implements RowConsumer {
                 while (iterator.moveNext()) {
                     rowCount++;
                     CompletableFuture<Void> writeFuture = resultReceiver.setNextRow(iterator.currentElement());
-                    if (!resultReceiver.isWritable()) {
-                        assert writeFuture != null : "writeFuture must not be null if resultReceiver is not writable";
+                    if (writeFuture != null) {
                         LOGGER.trace("Suspended execution after {} rows as the receiver is not writable anymore", rowCount);
                         activeIt = iterator;
                         writeFuture.thenRun(() -> {

--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -216,6 +216,7 @@ public class Version implements Comparable<Version> {
     public static final Version V_5_9_4 = new Version(8_09_04_99, false, org.apache.lucene.util.Version.LUCENE_9_11_1);
     public static final Version V_5_9_5 = new Version(8_09_05_99, false, org.apache.lucene.util.Version.LUCENE_9_11_1);
     public static final Version V_5_9_6 = new Version(8_09_06_99, false, org.apache.lucene.util.Version.LUCENE_9_11_1);
+    public static final Version V_5_9_7 = new Version(8_09_07_99, false, org.apache.lucene.util.Version.LUCENE_9_11_1);
 
     public static final Version V_5_10_0 = new Version(8_10_00_99, true, org.apache.lucene.util.Version.LUCENE_9_12_0);
 

--- a/server/src/test/java/io/crate/session/RowConsumerToResultReceiverTest.java
+++ b/server/src/test/java/io/crate/session/RowConsumerToResultReceiverTest.java
@@ -92,18 +92,12 @@ public class RowConsumerToResultReceiverTest {
 
         AtomicReference<CompletableFuture<Void>> writeFutureRef = new AtomicReference<>(new CompletableFuture<>());
         int[] rowCount = new int[1];
-        boolean[] writable = new boolean[]{false};
         BaseResultReceiver resultReceiver = new BaseResultReceiver() {
             @Override
             @Nullable
             public CompletableFuture<Void> setNextRow(Row row) {
                 rowCount[0]++;
                 return writeFutureRef.get();
-            }
-
-            @Override
-            public boolean isWritable() {
-                return writable[0];
             }
         };
         RowConsumerToResultReceiver batchConsumer =
@@ -114,7 +108,6 @@ public class RowConsumerToResultReceiverTest {
         assertThat(rowCount[0]).isEqualTo(1);
         assertThat(batchConsumer.suspended()).isTrue();
 
-        writable[0] = true;
         writeFutureRef.get().complete(null);
         resultReceiver.completionFuture().get(10, TimeUnit.SECONDS);
 


### PR DESCRIPTION
There can be a race-condition on the writability while processing a row and handling a suspend case later on.

Follow up of #17230.
