### PR TITLE
Use shard created version in ColumnFieldVisitor

### DIFF
--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/ColumnFieldVisitor.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/ColumnFieldVisitor.java
@@ -50,16 +50,16 @@ public class ColumnFieldVisitor extends StoredFieldVisitor {
     private final Map<String, Field> fields = new HashMap<>();
     private final Set<ColumnIdent> droppedColumns;
     private final SourceParser storedSourceParser;
-    private final Version tableVersion;
+    private final Version shardVersion;
 
     /**
      * Creates a new ColumnFieldVisitor for the given table
      */
-    public ColumnFieldVisitor(DocTableInfo table) {
+    public ColumnFieldVisitor(DocTableInfo table, Version shardVersionCreated) {
         this.droppedColumns
             = table.droppedColumns().stream().map(Reference::column).collect(Collectors.toUnmodifiableSet());
         this.storedSourceParser = new SourceParser(table.droppedColumns(), table.lookupNameBySourceKey(), true);
-        this.tableVersion = table.versionCreated();
+        this.shardVersion = shardVersionCreated;
     }
 
     private record Field(StorageSupport<?> storageSupport, ColumnIdent column) implements Comparable<Field> {
@@ -127,7 +127,7 @@ public class ColumnFieldVisitor extends StoredFieldVisitor {
     @Override
     public void binaryField(FieldInfo fieldInfo, byte[] value) throws IOException {
         var field = fields.get(fieldInfo.name);
-        var v = field.decode(storedSourceParser, tableVersion, value);
+        var v = field.decode(storedSourceParser, shardVersion, value);
         this.doc.put(field, v);
     }
 

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/StoredRowLookup.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/StoredRowLookup.java
@@ -75,7 +75,7 @@ public abstract class StoredRowLookup implements StoredRow {
         if (shardCreatedVersion.before(PARTIAL_STORED_SOURCE_VERSION) || fromTranslog) {
             return new FullStoredRowLookup(table, indexName, columns);
         }
-        return new ColumnAndStoredRowLookup(table, indexName, columns);
+        return new ColumnAndStoredRowLookup(table, shardCreatedVersion, indexName, columns);
     }
 
     private StoredRowLookup(DocTableInfo table, String indexName) {
@@ -195,9 +195,9 @@ public abstract class StoredRowLookup implements StoredRow {
         private final List<ColumnExpression> expressions = new ArrayList<>();
         private final ColumnFieldVisitor fieldsVisitor;
 
-        private ColumnAndStoredRowLookup(DocTableInfo table, String indexName, List<Symbol> columns) {
+        private ColumnAndStoredRowLookup(DocTableInfo table, Version shardVersionCreated, String indexName, List<Symbol> columns) {
             super(table, indexName);
-            this.fieldsVisitor = new ColumnFieldVisitor(table);
+            this.fieldsVisitor = new ColumnFieldVisitor(table, shardVersionCreated);
             register(columns);
         }
 


### PR DESCRIPTION
Storage formats are per-partition, so we need to ensure we use the correct version when loading data.  Currently the version is only used for reading streamed data from stored fields, and we have no data types that have a versioned streamer, so there are no data issues with using the table version.  However, this may change in future.

