### PR TITLE
Fixes a handshake issue between different major versions

### DIFF
--- a/docs/appendices/release-notes/5.10.1.rst
+++ b/docs/appendices/release-notes/5.10.1.rst
@@ -58,3 +58,7 @@ Fixes
 
     SELECT * FROM tbl WHERE pk_col = ? OR pk_col = ?
     -- Bind the same value to both query parameters
+
+- Fixed a handshake version compatibility issue that causes a node with a
+  higher major version (e.g. ``6.x``) to fail to join a cluster of version
+  < :ref:`version_5.10.1` (rolling upgrade scenario).

--- a/docs/appendices/release-notes/6.0.0.rst
+++ b/docs/appendices/release-notes/6.0.0.rst
@@ -19,7 +19,7 @@ Version 6.0.0 - Unreleased
     We recommend that you upgrade to the latest 5.10 release before moving to
     6.0.0.
 
-    A rolling upgrade from 5.10.x to 6.0.0 is supported.
+    A rolling upgrade from >= 5.10.1 to 6.0.0 is supported.
     Before upgrading, you should `back up your data`_.
 
 .. WARNING::

--- a/server/src/main/java/io/crate/protocols/postgres/PgClient.java
+++ b/server/src/main/java/io/crate/protocols/postgres/PgClient.java
@@ -597,7 +597,6 @@ public class PgClient extends AbstractClient {
                 action,
                 request,
                 options,
-                version,
                 connectionProfile.getCompressionEnabled(),
                 false // isHandshake
             );

--- a/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
@@ -89,10 +89,9 @@ public final class OutboundHandler {
                             final String action,
                             final TransportRequest request,
                             final TransportRequestOptions options,
-                            final Version channelVersion,
                             final boolean compressRequest,
                             final boolean isHandshake) throws IOException, TransportException {
-        Version version = Version.min(this.version, channelVersion);
+        Version version = this.version;
         OutboundMessage.Request message = new OutboundMessage.Request(
             request,
             version,
@@ -110,14 +109,13 @@ public final class OutboundHandler {
      * objects back to the caller.
      *
      */
-    void sendResponse(final Version nodeVersion,
-                      final CloseableChannel channel,
+    void sendResponse(final CloseableChannel channel,
                       final long requestId,
                       final String action,
                       final TransportResponse response,
                       final boolean compress,
                       final boolean isHandshake) throws IOException {
-        Version version = Version.min(this.version, nodeVersion);
+        Version version = this.version;
         OutboundMessage.Response message = new OutboundMessage.Response(
             response,
             version,
@@ -132,12 +130,11 @@ public final class OutboundHandler {
     /**
      * Sends back an error response to the caller via the given channel
      */
-    void sendErrorResponse(final Version nodeVersion,
-                           final CloseableChannel channel,
+    void sendErrorResponse(final CloseableChannel channel,
                            final long requestId,
                            final String action,
                            final Exception error) throws IOException {
-        Version version = Version.min(this.version, nodeVersion);
+        Version version = this.version;
         TransportAddress address = new TransportAddress(channel.getLocalAddress());
         RemoteTransportException tx = new RemoteTransportException(nodeName, address, action, error);
         OutboundMessage.Response message = new OutboundMessage.Response(

--- a/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -145,7 +145,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
         this.handshaker = new TransportHandshaker(version, threadPool,
             (node, channel, requestId, v) -> outboundHandler.sendRequest(node, channel, requestId,
                 TransportHandshaker.HANDSHAKE_ACTION_NAME, new TransportHandshaker.HandshakeRequest(version),
-                TransportRequestOptions.EMPTY, v, false, true));
+                TransportRequestOptions.EMPTY, false, true));
         this.keepAlive = new TransportKeepAlive(threadPool, this.outboundHandler::sendBytes);
         this.inboundHandler = new InboundHandler(threadPool, outboundHandler, namedWriteableRegistry, handshaker, keepAlive,
             requestHandlers, responseHandlers);
@@ -246,7 +246,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
                 throw new NodeNotConnectedException(node, "connection already closed");
             }
             CloseableChannel channel = channel(options.type());
-            outboundHandler.sendRequest(node, channel, requestId, action, request, options, getVersion(), compress, false);
+            outboundHandler.sendRequest(node, channel, requestId, action, request, options, compress, false);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/transport/TcpTransportChannel.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransportChannel.java
@@ -59,7 +59,7 @@ public final class TcpTransportChannel implements TransportChannel {
     @Override
     public void sendResponse(TransportResponse response) throws IOException {
         try {
-            outboundHandler.sendResponse(version, channel, requestId, action, response, compressResponse, isHandshake);
+            outboundHandler.sendResponse(channel, requestId, action, response, compressResponse, isHandshake);
         } finally {
             release(false);
         }
@@ -68,7 +68,7 @@ public final class TcpTransportChannel implements TransportChannel {
     @Override
     public void sendResponse(Exception exception) throws IOException {
         try {
-            outboundHandler.sendErrorResponse(version, channel, requestId, action, exception);
+            outboundHandler.sendErrorResponse(channel, requestId, action, exception);
         } finally {
             release(true);
         }

--- a/server/src/test/java/org/elasticsearch/VersionTest.java
+++ b/server/src/test/java/org/elasticsearch/VersionTest.java
@@ -28,14 +28,33 @@ import org.junit.Test;
 public class VersionTest {
 
     @Test
-    public void test_compatible_current_version_is_compatible_to_4_0_0() {
-        assertThat(Version.CURRENT.isCompatible(Version.V_4_0_0)).isFalse();
-        assertThat(Version.CURRENT.isCompatible(Version.V_5_0_0)).isTrue();
+    public void test_compatible_current_version() {
+        assertThat(Version.CURRENT.isCompatible(Version.V_4_8_4)).isFalse();
+        assertThat(Version.CURRENT.isCompatible(Version.V_5_10_0)).isFalse();
+        // 5.10.1 is compatible with current version even that it's minimum compatibility version is lower
+        // -> real version precedes minimum compatibility version
+        assertThat(Version.CURRENT.isCompatible(Version.V_5_10_1)).isTrue();
+        // Current version is compatible with 5.10.1 as it's minimum compatibility version is compatible with 5.10.1
+        assertThat(Version.V_5_10_1.isCompatible(Version.CURRENT)).isTrue();
     }
 
     @Test
-    public void test_min_version_is_5_0_0() {
-        assertThat(Version.CURRENT.minimumCompatibilityVersion()).isEqualTo(Version.V_5_0_0);
+    public void test_min_version_is_5_10_1() {
+        assertThat(Version.CURRENT.minimumCompatibilityVersion()).isEqualTo(Version.V_5_10_1);
+    }
+
+    @Test
+    public void test_version_minimum_compatibility() {
+        assertThat(Version.fromString("2.0.0").minimumCompatibilityVersion()).isEqualTo(Version.fromString("1.1.0"));
+        assertThat(Version.fromString("3.0.0").minimumCompatibilityVersion()).isEqualTo(Version.fromString("2.3.0"));
+
+        assertThat(Version.V_4_0_0.minimumCompatibilityVersion()).isEqualTo(Version.fromString("3.0.0"));
+        assertThat(Version.V_4_1_0.minimumCompatibilityVersion()).isEqualTo(Version.V_4_0_0);
+
+        assertThat(Version.V_5_0_0.minimumCompatibilityVersion()).isEqualTo(Version.V_4_0_0);
+        assertThat(Version.V_5_10_1.minimumCompatibilityVersion()).isEqualTo(Version.V_4_0_0);
+
+        assertThat(Version.CURRENT.minimumCompatibilityVersion()).isEqualTo(Version.V_5_10_1);
     }
 
     @Test

--- a/server/src/test/java/org/elasticsearch/transport/OutboundHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/OutboundHandlerTests.java
@@ -126,7 +126,7 @@ public class OutboundHandlerTests extends ESTestCase {
 
     @Test
     public void testSendRequest() throws IOException {
-        Version version = randomFrom(Version.CURRENT, Version.CURRENT.minimumCompatibilityVersion());
+        Version version = Version.CURRENT;
         String action = "handshake";
         long requestId = randomLongBetween(0, 300);
         boolean isHandshake = randomBoolean();
@@ -148,7 +148,7 @@ public class OutboundHandlerTests extends ESTestCase {
                 requestRef.set(request);
             }
         });
-        handler.sendRequest(node, channel, requestId, action, request, options, version, compress, isHandshake);
+        handler.sendRequest(node, channel, requestId, action, request, options, compress, isHandshake);
 
         ByteBuf msg = (ByteBuf) embeddedChannel.outboundMessages().poll();
         BytesReference reference = Netty4Utils.toBytesReference(msg);
@@ -182,7 +182,7 @@ public class OutboundHandlerTests extends ESTestCase {
 
     @Test
     public void testSendResponse() throws IOException {
-        Version version = randomFrom(Version.CURRENT, Version.CURRENT.minimumCompatibilityVersion());
+        Version version = Version.CURRENT;
         String action = "handshake";
         long requestId = randomLongBetween(0, 300);
         boolean isHandshake = randomBoolean();
@@ -201,7 +201,7 @@ public class OutboundHandlerTests extends ESTestCase {
                 responseRef.set(response);
             }
         });
-        handler.sendResponse(version, channel, requestId, action, response, compress, isHandshake);
+        handler.sendResponse(channel, requestId, action, response, compress, isHandshake);
 
         ByteBuf msg = (ByteBuf) embeddedChannel.outboundMessages().poll();
         BytesReference reference = Netty4Utils.toBytesReference(msg);
@@ -236,7 +236,7 @@ public class OutboundHandlerTests extends ESTestCase {
 
     @Test
     public void testErrorResponse() throws IOException {
-        Version version = randomFrom(Version.CURRENT, Version.CURRENT.minimumCompatibilityVersion());
+        Version version = Version.CURRENT;
         String action = "handshake";
         long requestId = randomLongBetween(0, 300);
         ElasticsearchException error = new ElasticsearchException("boom");
@@ -252,7 +252,7 @@ public class OutboundHandlerTests extends ESTestCase {
                 responseRef.set(error);
             }
         });
-        handler.sendErrorResponse(version, channel, requestId, action, error);
+        handler.sendErrorResponse(channel, requestId, action, error);
 
         ByteBuf msg = (ByteBuf) embeddedChannel.outboundMessages().poll();
         BytesReference reference = Netty4Utils.toBytesReference(msg);

--- a/server/src/test/java/org/elasticsearch/transport/TransportActionProxyTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportActionProxyTests.java
@@ -46,13 +46,13 @@ import io.crate.netty.NettyBootstrap;
 public class TransportActionProxyTests extends ESTestCase {
     protected ThreadPool threadPool;
     // we use always a non-alpha or beta version here otherwise minimumCompatibilityVersion will be different for the two used versions
-    private static final Version CURRENT_VERSION = Version.fromString(String.valueOf(Version.CURRENT.major) + ".0.0");
+    private static final Version CURRENT_VERSION = Version.fromId(Version.CURRENT.major * 1000000 + 99);
     protected static final Version version0 = CURRENT_VERSION.minimumCompatibilityVersion();
 
     protected DiscoveryNode nodeA;
     protected MockTransportService serviceA;
 
-    protected static final Version version1 = Version.fromId(CURRENT_VERSION.externalId + 1);
+    protected static final Version version1 = Version.fromId(CURRENT_VERSION.major * 1000000 + 199);
     protected DiscoveryNode nodeB;
     protected MockTransportService serviceB;
 


### PR DESCRIPTION
To support rolling upgrades between different major versions which in general can have a different `minimumCompatibilityVersion` (lower compatibility bound), the handshake logic must also take the version into account (upper compatibility bound).