### PR TITLE
Utilize array length index for AllEqOperator

### DIFF
--- a/server/src/main/java/io/crate/execution/dml/ArrayIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/ArrayIndexer.java
@@ -41,6 +41,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import io.crate.Streamer;
+import io.crate.expression.scalar.NumNullTermsPerDocQuery;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
 import io.crate.metadata.table.TableInfo;
@@ -66,7 +67,11 @@ public class ArrayIndexer<T> implements ValueIndexer<List<T>> {
         return new FieldExistsQuery(toArrayLengthFieldName(arrayRef, getRef));
     }
 
-    static String toArrayLengthFieldName(Reference arrayRef, Function<ColumnIdent, Reference> getRef) {
+    public static Query arraysWithoutNullElementsQuery(Reference arrayRef, Function<ColumnIdent, Reference> getRef) {
+        return NumNullTermsPerDocQuery.of(arrayRef, getRef, nullElementCount -> nullElementCount == 0);
+    }
+
+    public static String toArrayLengthFieldName(Reference arrayRef, Function<ColumnIdent, Reference> getRef) {
         // If the arrayRef is a descendant of an object array its type can be a readType. i.e. the type of
         // obj_array['int_col'] is 'int' BUT its readType is 'array(int)'. If so, there is no '_array_length_' indexed
         // for obj_array['int_col']. Imagine indexing obj_array = [{int_col = 1}, {int_col = 2}], '_array_length_obj_array'

--- a/server/src/main/java/io/crate/expression/scalar/NumNullTermsPerDocQuery.java
+++ b/server/src/main/java/io/crate/expression/scalar/NumNullTermsPerDocQuery.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.expression.scalar;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.function.Function;
+import java.util.function.IntPredicate;
+import java.util.function.IntUnaryOperator;
+
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.SortedNumericDocValues;
+
+import io.crate.execution.dml.ArrayIndexer;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.Reference;
+import io.crate.types.ArrayType;
+import io.crate.types.BitStringType;
+import io.crate.types.BooleanType;
+import io.crate.types.ByteType;
+import io.crate.types.CharacterType;
+import io.crate.types.DataType;
+import io.crate.types.DoubleType;
+import io.crate.types.FloatType;
+import io.crate.types.GeoPointType;
+import io.crate.types.IntegerType;
+import io.crate.types.IpType;
+import io.crate.types.LongType;
+import io.crate.types.NumericStorage;
+import io.crate.types.NumericType;
+import io.crate.types.ShortType;
+import io.crate.types.StringType;
+import io.crate.types.TimestampType;
+
+public class NumNullTermsPerDocQuery extends NumTermsPerDocQuery {
+
+    public static NumNullTermsPerDocQuery of(Reference ref,
+                                             Function<ColumnIdent, Reference> getRef,
+                                             IntPredicate matches) {
+        if (!hasArrayLengthIndexAndSortedNumericDocValues(ref.valueType(), ref.hasDocValues())) {
+            return null;
+        }
+        return new NumNullTermsPerDocQuery(ref, getRef, matches);
+    }
+
+    /**
+     * NumNullTermsPerDocQuery requires array length indexes and doc-values that can count the number of non-null
+     * terms per docs.
+     * Therefore,
+     * multidimensional arrays (dim > 1) which do not index array lengths,
+     * 1D arrays with element types using SortedSetDocValues or doc-values disabled
+     * cannot use this query.
+     * In other words, only 1D arrays using SortedNumericDocValues are supported.
+     */
+    private static boolean hasArrayLengthIndexAndSortedNumericDocValues(DataType<?> type, boolean hasDocValues) {
+        if (ArrayType.dimensions(type) != 1 || !hasDocValues) {
+            return false;
+        }
+        type = ArrayType.unnest(type);
+        switch (type.id()) {
+            case BooleanType.ID:
+            case ByteType.ID:
+            case ShortType.ID:
+            case IntegerType.ID:
+            case LongType.ID:
+            case TimestampType.ID_WITH_TZ:
+            case TimestampType.ID_WITHOUT_TZ:
+            case FloatType.ID:
+            case DoubleType.ID:
+            case GeoPointType.ID:
+                return true;
+            case NumericType.ID: {
+                NumericType numericType = (NumericType) type;
+                Integer precision = numericType.numericPrecision();
+                return (precision != null && precision <= NumericStorage.COMPACT_PRECISION);
+            }
+            case StringType.ID:
+            case CharacterType.ID:
+            case BitStringType.ID:
+            case IpType.ID:
+            default:
+                return false;
+        }
+    }
+
+    private static IntUnaryOperator getNumNullTermsPerDocFunction(LeafReader reader, Reference ref, Function<ColumnIdent, Reference> getRef) {
+        return numValuesPerDocForSortedNumeric(reader, ref, getRef);
+    }
+
+    private static IntUnaryOperator numValuesPerDocForSortedNumeric(LeafReader reader, Reference ref, Function<ColumnIdent, Reference> getRef) {
+        final SortedNumericDocValues numNonNullTerms;
+        final SortedNumericDocValues numAllTerms;
+        try {
+            numNonNullTerms = DocValues.getSortedNumeric(reader, ref.storageIdent());
+            numAllTerms = DocValues.getSortedNumeric(reader, ArrayIndexer.toArrayLengthFieldName(ref, getRef));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        return doc -> {
+            try {
+                return numAllTerms.advanceExact(doc) && numNonNullTerms.advanceExact(doc) ?
+                    Math.toIntExact(numAllTerms.nextValue() - numNonNullTerms.docValueCount()) : -1;
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        };
+    }
+
+    private NumNullTermsPerDocQuery(Reference ref,
+                                    Function<ColumnIdent, Reference> getRef,
+                                    IntPredicate matches) {
+        super(
+            ref.storageIdent(),
+            leafReaderContext -> getNumNullTermsPerDocFunction(leafReaderContext.reader(), ref, getRef),
+            matches);
+    }
+
+    @Override
+    public String toString(String field) {
+        return "NumNullTermsPerDoc: " + column;
+    }
+}

--- a/server/src/main/java/io/crate/expression/scalar/NumTermsPerDocQuery.java
+++ b/server/src/main/java/io/crate/expression/scalar/NumTermsPerDocQuery.java
@@ -63,7 +63,7 @@ import io.crate.types.TimestampType;
 
 public class NumTermsPerDocQuery extends Query {
 
-    private final String column;
+    protected final String column;
     private final java.util.function.Function<LeafReaderContext, IntUnaryOperator> numTermsPerDocFactory;
     private final IntPredicate matches;
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Since we introduced array length indices in `5.9`, AllEq operator can utilize it.
```
// 1 = all(array_ref) --> returns true for arrays satisfying the following conditions:
// 1) array_ref containing 1 only OR 2) empty
// where 1) is equivalent to `array_ref that does not contain null` AND `array_ref that does not contain values other than 1`
```

However, string arrays or char arrays, etc that are indexed with SortedSetDocValues cannot see the perf improvements because SortedSetDocValues can only return the unique counts instead of total counts, please see the commit for details.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
