### PR TITLE
Fix NPE in StoredRowLookup when _raw was requested before doc lookup

### DIFF
--- a/server/src/test/java/io/crate/execution/dml/MixedVersionStorageTest.java
+++ b/server/src/test/java/io/crate/execution/dml/MixedVersionStorageTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.dml;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.elasticsearch.Version;
+import org.junit.Test;
+
+import io.crate.execution.engine.fetch.ReaderContext;
+import io.crate.expression.reference.doc.lucene.StoredRowLookup;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.QueryTester;
+
+public class MixedVersionStorageTest extends CrateDummyClusterServiceUnitTest {
+
+    @Test
+    public void test_reading_5_9_tables_with_raw() throws Exception {
+
+        var columns = List.of("id", "name", "numbers");
+
+        var builder = new QueryTester.Builder(
+            THREAD_POOL,
+            clusterService,
+            Version.V_5_9_0,
+            "create table t (id int, name text, numbers array(int))"
+        );
+        builder.indexValues(columns, 8, "name8", List.of(8, 80));
+        builder.indexValues(columns, 9, "name9", List.of(9, 90));
+        try (var tester = builder.build()) {
+            var lookup = StoredRowLookup.create(Version.V_5_9_0, tester.tableInfo(), "t");
+            var reader = tester.searcher().getTopReaderContext().leaves().getFirst();
+            var row = lookup.getStoredRow(new ReaderContext(reader), 0);
+            assertThat(row.asRaw()).isNotEmpty();
+            assertThat(row.get(List.of("numbers"))).isOfAnyClassIn(ArrayList.class);
+        }
+    }
+}

--- a/server/src/testFixtures/java/io/crate/testing/IndexEnv.java
+++ b/server/src/testFixtures/java/io/crate/testing/IndexEnv.java
@@ -71,7 +71,8 @@ public final class IndexEnv implements AutoCloseable {
     public IndexEnv(NodeContext nodeContext,
                     ThreadPool threadPool,
                     DocTableInfo table,
-                    ClusterState clusterState, Version indexVersion) throws IOException {
+                    ClusterState clusterState,
+                    Version indexVersion) throws IOException {
         String indexName = table.ident().indexNameOrAlias();
         assert clusterState.metadata().hasIndex(indexName) : "ClusterState must contain the index: " + indexName;
 


### PR DESCRIPTION
FullStoredRowLookup would set docVisited to true in an asRaw() call, but would not actually parse the document, so subsequent calls to asMap() would return null.  This reworks things so that docVisited is checked and set entirely within loadStoredFields(), and asMap() instead checks the value of parsedSource directly.
