### PR TITLE
Update bug issue template: add "bug" label and add to "CrateDB" project 

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,7 +1,8 @@
 name: 🐞 Bug Report
 description: Tell us about something that's not working the way you think it should
 labels:
-  - triage, bug
+  - triage
+  - bug
 body:
   - type: input
     id: cratedb_version

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,7 +1,7 @@
 name: 🐞 Bug Report
 description: Tell us about something that's not working the way you think it should
 labels:
-  - triage
+  - triage, bug
 body:
   - type: input
     id: cratedb_version

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,8 +1,11 @@
 name: 🐞 Bug Report
 description: Tell us about something that's not working the way you think it should
+projects:
+  - crate/21
 labels:
   - triage
   - bug
+
 body:
   - type: input
     id: cratedb_version
@@ -11,6 +14,7 @@ body:
       placeholder: 4.6.1
     validations:
       required: true
+
   - type: textarea
     id: config
     attributes:


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
We might as well add the bug label automatically to issues reported as a bug.
And add it to the CrateDB project.