### PR TITLE
CI: Use `uv` on GHA and RTD

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,17 +14,27 @@ jobs:
   linkcheck:
     name: Sphinx linkcheck
     runs-on: ubuntu-latest
+    env:
+      UV_SYSTEM_PYTHON: true
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.13
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          cache-dependency-glob: |
+            blackbox/requirements.txt
+          enable-cache: true
+          version: "latest"
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip setuptools
-          python -m pip install -r blackbox/requirements.txt
+          uv pip install --upgrade pip setuptools
+          uv pip install -r blackbox/requirements.txt
 
       - name: Run linkcheck
         run: |

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,14 +1,28 @@
+# RTD configuration using the `uv` package and project manager.
+# https://docs.readthedocs.io/en/stable/build-customization.html#install-dependencies-with-uv
 ---
 version: 2
 
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.11"
+    python: "3.13"
 
-python:
-  install:
-  - requirements: docs/requirements.txt
+  jobs:
+
+    # Install dependencies using `uv`.
+    create_environment:
+      - asdf plugin add uv
+      - asdf install uv latest
+      - asdf global uv latest
+      - uv venv
+    install:
+      - uv pip install -r docs/requirements.txt
+
+    # Invoke the build using `uv`.
+    build:
+      html:
+        - uv run sphinx-build -T -b html docs $READTHEDOCS_OUTPUT/html
 
 sphinx:
   builder: html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,6 +25,7 @@ extensions.append('crate.sphinx.csv')
 
 linkcheck_ignore = [
     'https://www.iso.org/obp/ui/.*',  # Breaks accessibility via JS ¯\_(ツ)_/¯
+    'https://dev.mysql.com/.*',  # 403 Client Error: Forbidden for url
 ]
 linkcheck_retries = 3
 


### PR DESCRIPTION
## About
Add the `uv` program to the toolbox, in this case to speed up documentation rebuilds, both on GHA and RTD.

## Review
_Please commandeer backport labels and merge at your disposal. Thanks!_

## Preview
_Works as expected:_ https://crate--17277.org.readthedocs.build/en/17277/

## References
- https://docs.astral.sh/uv/
- https://about.readthedocs.com/blog/2025/01/override-build-process-with-build-jobs/
- https://docs.readthedocs.io/en/stable/build-customization.html#install-dependencies-with-uv
- https://github.com/readthedocs/readthedocs.org/issues/11289
- https://github.com/crate/crate-docs-theme/pull/569
