### PR TITLE
Fix issue when binding the same values to PK lookup

### DIFF
--- a/docs/appendices/release-notes/5.10.1.rst
+++ b/docs/appendices/release-notes/5.10.1.rst
@@ -43,3 +43,10 @@ See the :ref:`version_5.10.0` release notes for a full list of changes in the
 
 Fixes
 =====
+
+- Fixed an issue that could cause duplicate records to be returned when
+  filtering on a table by PRIMARY KEY, using query parameters, and binding the
+  same value to them, e.g.::
+
+    SELECT * FROM tbl WHERE pk_col = ? OR pk_col = ?
+    -- Bind the same value to both query parameters

--- a/docs/appendices/release-notes/5.9.9.rst
+++ b/docs/appendices/release-notes/5.9.9.rst
@@ -46,3 +46,10 @@ See the :ref:`version_5.9.0` release notes for a full list of changes in the
 
 Fixes
 =====
+
+- Fixed an issue that could cause duplicate records to be returned when
+  filtering on a table by PRIMARY KEY, using query parameters, and binding the
+  same value to them, e.g.::
+
+    SELECT * FROM tbl WHERE pk_col = ? OR pk_col = ?
+    -- Bind the same value to both query parameters

--- a/server/src/main/java/io/crate/execution/dsl/phases/PKLookupPhase.java
+++ b/server/src/main/java/io/crate/execution/dsl/phases/PKLookupPhase.java
@@ -26,8 +26,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -47,14 +49,14 @@ public final class PKLookupPhase extends AbstractProjectionsPhase implements Col
 
     private final List<ColumnIdent> partitionedByColumns;
     private final List<Symbol> toCollect;
-    private final Map<String, Map<ShardId, List<PKAndVersion>>> idsByShardByNode;
+    private final Map<String, Map<ShardId, Set<PKAndVersion>>> idsByShardByNode;
     private DistributionInfo distInfo = DistributionInfo.DEFAULT_BROADCAST;
 
     public PKLookupPhase(UUID jobId,
                          int phaseId,
                          List<ColumnIdent> partitionedByColumns,
                          List<Symbol> toCollect,
-                         Map<String, Map<ShardId, List<PKAndVersion>>> idsByShardByNode) {
+                         Map<String, Map<ShardId, Set<PKAndVersion>>> idsByShardByNode) {
         super(jobId, phaseId, "pkLookup", Collections.emptyList());
         assert toCollect.stream().noneMatch(
             st -> st.any(s -> s instanceof ScopedSymbol || s instanceof SelectSymbol))
@@ -74,12 +76,12 @@ public final class PKLookupPhase extends AbstractProjectionsPhase implements Col
         for (int nodeIdx = 0; nodeIdx < numNodes; nodeIdx++) {
             String nodeId = in.readString();
             int numShards = in.readVInt();
-            HashMap<ShardId, List<PKAndVersion>> idsByShard = new HashMap<>(numShards);
+            HashMap<ShardId, Set<PKAndVersion>> idsByShard = new HashMap<>(numShards);
             idsByShardByNode.put(nodeId, idsByShard);
             for (int shardIdx = 0; shardIdx < numShards; shardIdx++) {
                 ShardId shardId = new ShardId(in);
                 int numPks = in.readVInt();
-                ArrayList<PKAndVersion> pks = new ArrayList<>(numPks);
+                Set<PKAndVersion> pks = new LinkedHashSet<>(numPks);
                 for (int pkIdx = 0; pkIdx < numPks; pkIdx++) {
                     pks.add(new PKAndVersion(in));
                 }
@@ -105,12 +107,12 @@ public final class PKLookupPhase extends AbstractProjectionsPhase implements Col
         Symbols.toStream(toCollect, out);
 
         out.writeVInt(idsByShardByNode.size());
-        for (Map.Entry<String, Map<ShardId, List<PKAndVersion>>> byNodeEntry : idsByShardByNode.entrySet()) {
-            Map<ShardId, List<PKAndVersion>> idsByShard = byNodeEntry.getValue();
+        for (Map.Entry<String, Map<ShardId, Set<PKAndVersion>>> byNodeEntry : idsByShardByNode.entrySet()) {
+            Map<ShardId, Set<PKAndVersion>> idsByShard = byNodeEntry.getValue();
             out.writeString(byNodeEntry.getKey());
             out.writeVInt(idsByShard.size());
-            for (Map.Entry<ShardId, List<PKAndVersion>> shardEntry : idsByShard.entrySet()) {
-                List<PKAndVersion> ids = shardEntry.getValue();
+            for (Map.Entry<ShardId, Set<PKAndVersion>> shardEntry : idsByShard.entrySet()) {
+                Set<PKAndVersion> ids = shardEntry.getValue();
 
                 shardEntry.getKey().writeTo(out);
                 out.writeVInt(ids.size());
@@ -164,7 +166,7 @@ public final class PKLookupPhase extends AbstractProjectionsPhase implements Col
         return visitor.visitPKLookup(this, context);
     }
 
-    public Map<ShardId,List<PKAndVersion>> getIdsByShardId(String nodeId) {
+    public Map<ShardId, Set<PKAndVersion>> getIdsByShardId(String nodeId) {
         return idsByShardByNode.getOrDefault(nodeId, Collections.emptyMap());
     }
 

--- a/server/src/main/java/io/crate/execution/engine/collect/PKLookupOperation.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/PKLookupOperation.java
@@ -28,7 +28,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
+import java.util.SequencedSet;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -124,14 +124,14 @@ public final class PKLookupOperation {
                                      Supplier<RamAccounting> ramAccountingSupplier,
                                      Supplier<MemoryManager> memoryManagerSupplier,
                                      boolean ignoreMissing,
-                                     Map<ShardId, Set<PKAndVersion>> idsByShard,
+                                     Map<ShardId, SequencedSet<PKAndVersion>> idsByShard,
                                      Collection<? extends Projection> projections,
                                      boolean requiresScroll,
                                      Function<Doc, Row> resultToRow,
                                      DocTableInfo table,
                                      List<Symbol> columns) {
         ArrayList<BatchIterator<Row>> iterators = new ArrayList<>(idsByShard.size());
-        for (Map.Entry<ShardId, Set<PKAndVersion>> idsByShardEntry : idsByShard.entrySet()) {
+        for (Map.Entry<ShardId, SequencedSet<PKAndVersion>> idsByShardEntry : idsByShard.entrySet()) {
             ShardId shardId = idsByShardEntry.getKey();
             IndexService indexService = indicesService.indexService(shardId.getIndex());
             if (indexService == null) {

--- a/server/src/main/java/io/crate/execution/engine/collect/PKLookupOperation.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/PKLookupOperation.java
@@ -28,6 +28,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -123,14 +124,14 @@ public final class PKLookupOperation {
                                      Supplier<RamAccounting> ramAccountingSupplier,
                                      Supplier<MemoryManager> memoryManagerSupplier,
                                      boolean ignoreMissing,
-                                     Map<ShardId, List<PKAndVersion>> idsByShard,
+                                     Map<ShardId, Set<PKAndVersion>> idsByShard,
                                      Collection<? extends Projection> projections,
                                      boolean requiresScroll,
                                      Function<Doc, Row> resultToRow,
                                      DocTableInfo table,
                                      List<Symbol> columns) {
         ArrayList<BatchIterator<Row>> iterators = new ArrayList<>(idsByShard.size());
-        for (Map.Entry<ShardId, List<PKAndVersion>> idsByShardEntry : idsByShard.entrySet()) {
+        for (Map.Entry<ShardId, Set<PKAndVersion>> idsByShardEntry : idsByShard.entrySet()) {
             ShardId shardId = idsByShardEntry.getKey();
             IndexService indexService = indicesService.indexService(shardId.getIndex());
             if (indexService == null) {

--- a/server/src/main/java/io/crate/execution/jobs/JobSetup.java
+++ b/server/src/main/java/io/crate/execution/jobs/JobSetup.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -593,7 +594,7 @@ public class JobSetup {
             Collection<? extends Projection> shardProjections = shardProjections(pkLookupPhase.projections());
             Collection<? extends Projection> nodeProjections = nodeProjections(pkLookupPhase.projections());
 
-            Map<ShardId, List<PKAndVersion>> idsByShardId =
+            Map<ShardId, Set<PKAndVersion>> idsByShardId =
                 pkLookupPhase.getIdsByShardId(clusterService.localNode().getId());
 
             CircuitBreaker breaker = breaker();

--- a/server/src/main/java/io/crate/execution/jobs/JobSetup.java
+++ b/server/src/main/java/io/crate/execution/jobs/JobSetup.java
@@ -31,7 +31,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
+import java.util.SequencedSet;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -594,7 +594,7 @@ public class JobSetup {
             Collection<? extends Projection> shardProjections = shardProjections(pkLookupPhase.projections());
             Collection<? extends Projection> nodeProjections = nodeProjections(pkLookupPhase.projections());
 
-            Map<ShardId, Set<PKAndVersion>> idsByShardId =
+            Map<ShardId, SequencedSet<PKAndVersion>> idsByShardId =
                 pkLookupPhase.getIdsByShardId(clusterService.localNode().getId());
 
             CircuitBreaker breaker = breaker();

--- a/server/src/main/java/io/crate/execution/jobs/PKLookupTask.java
+++ b/server/src/main/java/io/crate/execution/jobs/PKLookupTask.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
@@ -60,7 +61,7 @@ public final class PKLookupTask extends AbstractTask {
     private final TransactionContext txnCtx;
     private final PKLookupOperation pkLookupOperation;
     private final boolean ignoreMissing;
-    private final Map<ShardId, List<PKAndVersion>> idsByShard;
+    private final Map<ShardId, Set<PKAndVersion>> idsByShard;
     private final Collection<? extends Projection> shardProjections;
     private final RowConsumer consumer;
     private final InputRow inputRow;
@@ -87,7 +88,7 @@ public final class PKLookupTask extends AbstractTask {
                  PKLookupOperation pkLookupOperation,
                  List<ColumnIdent> partitionedByColumns,
                  List<Symbol> toCollect,
-                 Map<ShardId, List<PKAndVersion>> idsByShard,
+                 Map<ShardId, Set<PKAndVersion>> idsByShard,
                  Collection<? extends Projection> shardProjections,
                  RowConsumer consumer) {
         super(phaseId);

--- a/server/src/main/java/io/crate/execution/jobs/PKLookupTask.java
+++ b/server/src/main/java/io/crate/execution/jobs/PKLookupTask.java
@@ -25,7 +25,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
+import java.util.SequencedSet;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
@@ -61,7 +61,7 @@ public final class PKLookupTask extends AbstractTask {
     private final TransactionContext txnCtx;
     private final PKLookupOperation pkLookupOperation;
     private final boolean ignoreMissing;
-    private final Map<ShardId, Set<PKAndVersion>> idsByShard;
+    private final Map<ShardId, SequencedSet<PKAndVersion>> idsByShard;
     private final Collection<? extends Projection> shardProjections;
     private final RowConsumer consumer;
     private final InputRow inputRow;
@@ -88,7 +88,7 @@ public final class PKLookupTask extends AbstractTask {
                  PKLookupOperation pkLookupOperation,
                  List<ColumnIdent> partitionedByColumns,
                  List<Symbol> toCollect,
-                 Map<ShardId, Set<PKAndVersion>> idsByShard,
+                 Map<ShardId, SequencedSet<PKAndVersion>> idsByShard,
                  Collection<? extends Projection> shardProjections,
                  RowConsumer consumer) {
         super(phaseId);

--- a/server/src/main/java/io/crate/planner/operators/Get.java
+++ b/server/src/main/java/io/crate/planner/operators/Get.java
@@ -27,6 +27,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.SequencedCollection;
+import java.util.SequencedSet;
 import java.util.Set;
 
 import org.elasticsearch.cluster.routing.ShardRouting;
@@ -101,7 +102,7 @@ public class Get implements LogicalPlan {
                                @Nullable Integer pageSizeHint,
                                Row params,
                                SubQueryResults subQueryResults) {
-        HashMap<String, Map<ShardId, Set<PKAndVersion>>> idsByShardByNode = new HashMap<>();
+        HashMap<String, Map<ShardId, SequencedSet<PKAndVersion>>> idsByShardByNode = new HashMap<>();
         DocTableInfo docTableInfo = tableRelation.tableInfo();
         for (DocKeys.DocKey docKey : docKeys) {
             String id = docKey.getId(plannerContext.transactionContext(), plannerContext.nodeContext(), params, subQueryResults);
@@ -141,12 +142,12 @@ public class Get implements LogicalPlan {
             long primaryTerm = docKey.primaryTerm(plannerContext.transactionContext(), plannerContext.nodeContext(), params, subQueryResults)
                 .orElse(SequenceNumbers.UNASSIGNED_PRIMARY_TERM);
 
-            Map<ShardId, Set<PKAndVersion>> idsByShard = idsByShardByNode.get(currentNodeId);
+            Map<ShardId, SequencedSet<PKAndVersion>> idsByShard = idsByShardByNode.get(currentNodeId);
             if (idsByShard == null) {
                 idsByShard = new HashMap<>();
                 idsByShardByNode.put(currentNodeId, idsByShard);
             }
-            Set<PKAndVersion> pkAndVersions = idsByShard.get(shardRouting.shardId());
+            SequencedSet<PKAndVersion> pkAndVersions = idsByShard.get(shardRouting.shardId());
             if (pkAndVersions == null) {
                 pkAndVersions = new LinkedHashSet<>();
                 idsByShard.put(shardRouting.shardId(), pkAndVersions);

--- a/server/src/main/java/io/crate/planner/operators/Get.java
+++ b/server/src/main/java/io/crate/planner/operators/Get.java
@@ -101,7 +101,7 @@ public class Get implements LogicalPlan {
                                @Nullable Integer pageSizeHint,
                                Row params,
                                SubQueryResults subQueryResults) {
-        HashMap<String, Map<ShardId, List<PKAndVersion>>> idsByShardByNode = new HashMap<>();
+        HashMap<String, Map<ShardId, Set<PKAndVersion>>> idsByShardByNode = new HashMap<>();
         DocTableInfo docTableInfo = tableRelation.tableInfo();
         for (DocKeys.DocKey docKey : docKeys) {
             String id = docKey.getId(plannerContext.transactionContext(), plannerContext.nodeContext(), params, subQueryResults);
@@ -132,16 +132,7 @@ public class Get implements LogicalPlan {
                     throw new ShardNotFoundException(shardRouting.shardId());
                 }
             }
-            Map<ShardId, List<PKAndVersion>> idsByShard = idsByShardByNode.get(currentNodeId);
-            if (idsByShard == null) {
-                idsByShard = new HashMap<>();
-                idsByShardByNode.put(currentNodeId, idsByShard);
-            }
-            List<PKAndVersion> pkAndVersions = idsByShard.get(shardRouting.shardId());
-            if (pkAndVersions == null) {
-                pkAndVersions = new ArrayList<>();
-                idsByShard.put(shardRouting.shardId(), pkAndVersions);
-            }
+
             long version = docKey
                 .version(plannerContext.transactionContext(), plannerContext.nodeContext(), params, subQueryResults)
                 .orElse(Versions.MATCH_ANY);
@@ -149,6 +140,17 @@ public class Get implements LogicalPlan {
                 .orElse(SequenceNumbers.UNASSIGNED_SEQ_NO);
             long primaryTerm = docKey.primaryTerm(plannerContext.transactionContext(), plannerContext.nodeContext(), params, subQueryResults)
                 .orElse(SequenceNumbers.UNASSIGNED_PRIMARY_TERM);
+
+            Map<ShardId, Set<PKAndVersion>> idsByShard = idsByShardByNode.get(currentNodeId);
+            if (idsByShard == null) {
+                idsByShard = new HashMap<>();
+                idsByShardByNode.put(currentNodeId, idsByShard);
+            }
+            Set<PKAndVersion> pkAndVersions = idsByShard.get(shardRouting.shardId());
+            if (pkAndVersions == null) {
+                pkAndVersions = new LinkedHashSet<>();
+                idsByShard.put(shardRouting.shardId(), pkAndVersions);
+            }
             pkAndVersions.add(new PKAndVersion(id, version, sequenceNumber, primaryTerm));
         }
 

--- a/server/src/main/java/io/crate/planner/operators/PKAndVersion.java
+++ b/server/src/main/java/io/crate/planner/operators/PKAndVersion.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 
 import java.io.IOException;
+import java.util.Objects;
 
 public final class PKAndVersion implements Writeable {
 
@@ -70,5 +71,23 @@ public final class PKAndVersion implements Writeable {
 
     public long primaryTerm() {
         return primaryTerm;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PKAndVersion that = (PKAndVersion) o;
+        return version == that.version && seqNo == that.seqNo && primaryTerm == that.primaryTerm
+            && Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, version, seqNo, primaryTerm);
     }
 }

--- a/server/src/main/java/io/crate/planner/operators/PKAndVersion.java
+++ b/server/src/main/java/io/crate/planner/operators/PKAndVersion.java
@@ -21,32 +21,16 @@
 
 package io.crate.planner.operators;
 
+import java.io.IOException;
+
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 
-import java.io.IOException;
-import java.util.Objects;
-
-public final class PKAndVersion implements Writeable {
-
-    private final String id;
-    private final long version;
-    private final long seqNo;
-    private final long primaryTerm;
-
-    public PKAndVersion(String id, long version, long seqNo, long primaryTerm) {
-        this.id = id;
-        this.version = version;
-        this.seqNo = seqNo;
-        this.primaryTerm = primaryTerm;
-    }
+public record PKAndVersion(String id, long version, long seqNo, long primaryTerm) implements Writeable {
 
     public PKAndVersion(StreamInput in) throws IOException {
-        this.id = in.readString();
-        this.version = in.readLong();
-        this.seqNo = in.readLong();
-        this.primaryTerm = in.readLong();
+        this(in.readString(), in.readLong(), in.readLong(), in.readLong());
     }
 
     @Override
@@ -71,23 +55,5 @@ public final class PKAndVersion implements Writeable {
 
     public long primaryTerm() {
         return primaryTerm;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        PKAndVersion that = (PKAndVersion) o;
-        return version == that.version && seqNo == that.seqNo && primaryTerm == that.primaryTerm
-            && Objects.equals(id, that.id);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(id, version, seqNo, primaryTerm);
     }
 }

--- a/server/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -30,6 +30,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.SequencedSet;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -1654,7 +1655,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             .addTable("create table tbl (x int primary key)");
         Collect plan = e.plan("SELECT * FROM tbl WHERE x = ? OR x = ?", UUID.randomUUID(), 10, new RowN(1, 1));
         assertThat(plan.collectPhase()).isInstanceOf(PKLookupPhase.class);
-        Collection<Set<PKAndVersion>> pkAndVersions = ((PKLookupPhase) plan.collectPhase())
+        Collection<SequencedSet<PKAndVersion>> pkAndVersions = ((PKLookupPhase) plan.collectPhase())
             .getIdsByShardId("n1").values();
         assertThat(pkAndVersions).hasSize(1);
         assertThat(pkAndVersions.iterator().next()).hasSize(1);
@@ -1671,7 +1672,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             """,
             UUID.randomUUID(), 10, new RowN(1, 2, 1, 2));
         assertThat(plan.collectPhase()).isInstanceOf(PKLookupPhase.class);
-        Collection<Set<PKAndVersion>> pkAndVersions = ((PKLookupPhase) plan.collectPhase())
+        Collection<SequencedSet<PKAndVersion>> pkAndVersions = ((PKLookupPhase) plan.collectPhase())
             .getIdsByShardId("n1").values();
         assertThat(pkAndVersions).hasSize(1);
         assertThat(pkAndVersions.iterator().next()).hasSize(1);


### PR DESCRIPTION
When querying by PK (also when additionally using _seq_no and _primary_term), and bound parameters are used, then since the WHERE clause optimization takes place before binding values to the params, a query like: `SELECT * FROM tbl WHERE pkCol = ? OR pkCol = ?` will result in 2 DocKey entries, since at that point we don't know the actual values which will be bound, and therefore normalize and eliminate duplicates. As a consequence, and since PkAndVersion objects were returned in a `List`, if duplicate values are bound, the `PKLookupPhase` will fetch duplicate records.

Use `LinkedHashSet` (to keep also the order of the values) instead of `List` to eliminate `PkAndVersion` resuling duplicates after query parameters are bound (in `Get#build()`).

Fixes: #17266
