### PR TITLE
Do not throw missing key errors for object types with missing inner types

### DIFF
--- a/docs/appendices/release-notes/5.10.1.rst
+++ b/docs/appendices/release-notes/5.10.1.rst
@@ -44,6 +44,9 @@ See the :ref:`version_5.10.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed a regression from ``5.10.0`` that caused a ``ColumnUnknownException``
+  when accessing a child of an object literal from an aliased table.
+
 - Fixed an issue that could lead to a ``Scale of numeric must be less than the
   precision`` error when using the ``AVG`` aggregation in a way that involved
   values of type ``NUMERIC``.

--- a/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -744,17 +744,9 @@ public class ExpressionAnalyzer {
                 //     SysSnapshotsTest.test_sys_snapshots_returns_table_partition_information
                 //     AlterTableIntegrationTest.test_alter_table_drop_leaf_subcolumn_with_parent_object_array
                 // Another example is selecting sub-column of an object that is union-ed.
-                if (DataTypes.hasPath(baseType, parts)) {
-                    return allocateFunction(
-                        SubscriptFunction.NAME,
-                        List.of(
-                            node.base().accept(this, context),
-                            node.index().accept(this, context)
-                        ),
-                        context
-                    );
-                }
-                if ((baseType == UndefinedType.INSTANCE) == false) {
+                if (baseType != UndefinedType.INSTANCE
+                    && baseType != ObjectType.UNTYPED
+                    && !DataTypes.hasPath(baseType, parts)) {
                     DataType<?> currentType = baseType;
                     ColumnPolicy parentPolicy = baseType.columnPolicy();
                     for (String p : parts) {

--- a/server/src/main/java/io/crate/types/TypeSignature.java
+++ b/server/src/main/java/io/crate/types/TypeSignature.java
@@ -173,6 +173,7 @@ public class TypeSignature implements Writeable, Accountable {
             DataType<?> innerType = parameters.get(0).createType();
             return new ArrayType<>(innerType);
         } else if (baseTypeName.equalsIgnoreCase(ObjectType.NAME)) {
+            boolean objectIsEmpty = true;
             var builder = ObjectType.of(ColumnPolicy.DYNAMIC);
             // Only build typed objects if we receive parameter key-value pairs which may not exist on generic
             // object signatures with type information only, no key strings
@@ -182,10 +183,11 @@ public class TypeSignature implements Writeable, Accountable {
                     if (valTypeSignature instanceof ParameterTypeSignature p) {
                         var innerTypeName = p.unescapedParameterName();
                         builder.setInnerType(innerTypeName, valTypeSignature.createType());
+                        objectIsEmpty = false;
                     }
                 }
             }
-            return builder.build();
+            return objectIsEmpty ? ObjectType.UNTYPED : builder.build();
         } else if (baseTypeName.equalsIgnoreCase(RowType.NAME)) {
             ArrayList<String> fields = new ArrayList<>(parameters.size());
             ArrayList<DataType<?>> dataTypes = new ArrayList<>(parameters.size());

--- a/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -2976,4 +2976,16 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
             output -> assertThat(output.valueType()).isEqualTo(makeArray(DataTypes.INTEGER, 2))
         );
     }
+
+    @Test
+    public void test_subscript_expressions_over_object_types_returned_from_functions_are_resolved_to_subscript_functions() {
+        var executor = SQLExecutor.of(clusterService);
+        var analyzed = executor.analyze("select o['a'] from (select {a=1} as o) tbl"); // `o` is an object literal returned from MapFunction
+        Assertions.assertThat(analyzed.outputs()).hasSize(1);
+        assertThat(analyzed.outputs().getFirst()).isFunction("subscript");
+
+        analyzed = executor.analyze("select o3['a'] from (select ({a=1} || {b=1}) as o3) t2"); // `o3` is an object literal returned from ConcatFunction
+        Assertions.assertThat(analyzed.outputs()).hasSize(1);
+        assertThat(analyzed.outputs().getFirst()).isFunction("subscript");
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Second attempt to fix https://github.com/crate/crate/issues/17270.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
