### PR TITLE
Fix InputColumns resolution of the parametrized outputs in the Fetch operator

### DIFF
--- a/docs/appendices/release-notes/5.10.1.rst
+++ b/docs/appendices/release-notes/5.10.1.rst
@@ -62,3 +62,9 @@ Fixes
 - Fixed a handshake version compatibility issue that causes a node with a
   higher major version (e.g. ``6.x``) to fail to join a cluster of version
   < :ref:`version_5.10.1` (rolling upgrade scenario).
+
+- Fixed an issue that caused an error when using a PreparedStatement and
+  selecting an expression, involving a parameter and a column used in
+  ``ORDER BY`` and query had a ``LIMIT`` clause. Example.::
+
+    SELECT a, b + ? as sum FROM tbl ORDER BY sum LIMIT 10

--- a/docs/appendices/release-notes/5.9.9.rst
+++ b/docs/appendices/release-notes/5.9.9.rst
@@ -61,3 +61,9 @@ Fixes
 
     SELECT * FROM tbl WHERE pk_col = ? OR pk_col = ?
     -- Bind the same value to both query parameters
+
+- Fixed an issue that caused an error when using a PreparedStatement and
+  selecting an expression, involving a parameter and a column used in
+  ``ORDER BY`` and query had a ``LIMIT`` clause. Example.::
+
+    SELECT a, b + ? as sum FROM tbl ORDER BY sum LIMIT 10


### PR DESCRIPTION
Relates to https://github.com/crate/crate/issues/17272.

Doesn't fully fix the reported query as error is gone but execution trips somewhere further on `SharedShardContexts` creation.