### PR TITLE
Use metadata.getIndices in more transport actions

### DIFF
--- a/server/src/main/java/io/crate/metadata/cluster/DDLClusterStateHelpers.java
+++ b/server/src/main/java/io/crate/metadata/cluster/DDLClusterStateHelpers.java
@@ -23,13 +23,10 @@ package io.crate.metadata.cluster;
 
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.cluster.metadata.ColumnPositionResolver;
-import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.Strings;
@@ -41,9 +38,9 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.mapper.ContentPath;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import io.crate.Constants;
-import org.jetbrains.annotations.VisibleForTesting;
 import io.crate.common.collections.MapBuilder;
 import io.crate.common.collections.Maps;
 import io.crate.metadata.PartitionName;
@@ -87,19 +84,6 @@ public class DDLClusterStateHelpers {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    static Set<IndexMetadata> indexMetadataSetFromIndexNames(Metadata metadata,
-                                                             String[] indices,
-                                                             IndexMetadata.State state) {
-        Set<IndexMetadata> indicesMetadata = new HashSet<>();
-        for (String indexName : indices) {
-            IndexMetadata indexMetadata = metadata.index(indexName);
-            if (indexMetadata != null && indexMetadata.getState() != state) {
-                indicesMetadata.add(indexMetadata);
-            }
-        }
-        return indicesMetadata;
     }
 
     @Nullable

--- a/server/src/main/java/io/crate/metadata/cluster/DropTableClusterStateTaskExecutor.java
+++ b/server/src/main/java/io/crate/metadata/cluster/DropTableClusterStateTaskExecutor.java
@@ -30,6 +30,7 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.MetadataDeleteIndexService;
 import org.elasticsearch.index.Index;
 
+import io.crate.exceptions.RelationUnknown;
 import io.crate.execution.ddl.tables.DropTableRequest;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
@@ -50,6 +51,9 @@ public class DropTableClusterStateTaskExecutor extends DDLClusterStateTaskExecut
         RelationName relationName = request.tableIdent();
         Metadata currentMetadata = currentState.metadata();
 
+        if (!currentMetadata.contains(relationName)) {
+            throw new RelationUnknown(relationName);
+        }
         Collection<Index> indices = currentMetadata.getIndices(
             relationName,
             List.of(),

--- a/server/src/main/java/io/crate/planner/node/ddl/DropTablePlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/DropTablePlan.java
@@ -33,6 +33,7 @@ import io.crate.data.InMemoryBatchIterator;
 import io.crate.data.Row;
 import io.crate.data.Row1;
 import io.crate.data.RowConsumer;
+import io.crate.exceptions.RelationUnknown;
 import io.crate.exceptions.SQLExceptions;
 import io.crate.execution.ddl.tables.DropTableRequest;
 import io.crate.planner.DependencyCarrier;
@@ -80,7 +81,8 @@ public class DropTablePlan implements Plan {
                 consumer.accept(InMemoryBatchIterator.of(ROW_ONE, SENTINEL), null);
             } else {
                 err = SQLExceptions.unwrap(err);
-                if (dropTable.dropIfExists() && err instanceof IndexNotFoundException) {
+                boolean doesntExist = err instanceof IndexNotFoundException || err instanceof RelationUnknown;
+                if (dropTable.dropIfExists() && doesntExist) {
                     consumer.accept(InMemoryBatchIterator.of(ROW_ZERO, SENTINEL), null);
                 } else {
                     consumer.accept(null, err);

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/TransportResizeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/TransportResizeAction.java
@@ -82,11 +82,13 @@ public class TransportResizeAction extends TransportMasterNodeAction<ResizeReque
 
     @Override
     protected ClusterBlockException checkBlock(ResizeRequest request, ClusterState state) {
-        if (request.partitionValues().isEmpty()) {
-            return state.blocks().indexBlockedException(ClusterBlockLevel.METADATA_WRITE, request.table().indexNameOrAlias());
-        }
-        PartitionName partitionName = new PartitionName(request.table(), request.partitionValues());
-        return state.blocks().indexBlockedException(ClusterBlockLevel.METADATA_WRITE, partitionName.asIndexName());
+        String[] indices = state.metadata().getIndices(
+            request.table(),
+            request.partitionValues(),
+            false,
+            idxMd -> idxMd.getIndex().getName()
+        ).toArray(String[]::new);
+        return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_WRITE, indices);
     }
 
     @Override


### PR DESCRIPTION
Required to slowly move towards using relation-metadata for index resolving.
Subset of https://github.com/crate/crate/pull/17127 to make it easier to review