### PR TITLE
Remove v/5.6 from mergify backport rules

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -59,13 +59,3 @@ pull_request_rules:
     conditions:
       - label=ready-to-merge
       - label=v/5.7
-
-  - name: backport 5.6
-    actions:
-      backport:
-        ignore_conflicts: true
-        branches:
-          - '5.6'
-    conditions:
-      - label=ready-to-merge
-      - label=v/5.6


### PR DESCRIPTION
5.6 is EOL and doesn't receive bugfixes anymore, even if they are
severe.
