### PR TITLE
Fix link to HLL++ publication, use archive, original starts failing

### DIFF
--- a/docs/general/builtins/aggregation.rst
+++ b/docs/general/builtins/aggregation.rst
@@ -977,7 +977,7 @@ Limitations
 
 .. _Aggregate function: https://en.wikipedia.org/wiki/Aggregate_function
 .. _Geometric Mean: https://en.wikipedia.org/wiki/Geometric_mean
-.. _HyperLogLog++: https://research.google.com/pubs/archive/40671.pdf
+.. _HyperLogLog++: https://static.googleusercontent.com/media/research.google.com/en//pubs/archive/40671.pdf
 .. _Percentile: https://en.wikipedia.org/wiki/Percentile
 .. _Standard Deviation: https://en.wikipedia.org/wiki/Standard_deviation
 .. _TDigest: https://github.com/tdunning/t-digest/blob/master/docs/t-digest-paper/histo.pdf


### PR DESCRIPTION
Original link is redirected to a broken new google link from today on. Use static archive link to fix this.
