### PR TITLE
Upgrade to Lucene 10.1.0

### DIFF
--- a/docs/appendices/release-notes/6.0.0.rst
+++ b/docs/appendices/release-notes/6.0.0.rst
@@ -43,7 +43,15 @@ Version 6.0.0 - Unreleased
 Breaking Changes
 ================
 
-None
+- The ``dutch_kp`` and ``lovins`` token filters are no longer available, as they have
+  been removed from Apache Lucene 10.  If users have tables which use these token filters
+  for analysis, they will need to re-index with either plain ``dutch`` or ``english``
+  stemmers before upgrading.
+
+- The ``german2`` and ``german`` token filters now use the same underlying stemmer,
+  which always expands ``ä``, ``ö`` and ``ü`` to ``ae``, ``oe`` and ``ue`` respectively.
+  If users have tables which were using the ``german`` stemmer without a character
+  filter that already did this, they will need to re-index after upgrading.
 
 Deprecations
 ============

--- a/plugins/es-analysis-common/src/main/java/org/elasticsearch/analysis/common/StemmerTokenFilterFactory.java
+++ b/plugins/es-analysis-common/src/main/java/org/elasticsearch/analysis/common/StemmerTokenFilterFactory.java
@@ -48,7 +48,6 @@ import org.apache.lucene.analysis.it.ItalianLightStemFilter;
 import org.apache.lucene.analysis.lv.LatvianStemFilter;
 import org.apache.lucene.analysis.miscellaneous.EmptyTokenStream;
 import org.apache.lucene.analysis.no.NorwegianLightStemFilter;
-import org.apache.lucene.analysis.no.NorwegianLightStemmer;
 import org.apache.lucene.analysis.no.NorwegianMinimalStemFilter;
 import org.apache.lucene.analysis.pt.PortugueseLightStemFilter;
 import org.apache.lucene.analysis.pt.PortugueseMinimalStemFilter;
@@ -69,14 +68,11 @@ import org.tartarus.snowball.ext.DutchStemmer;
 import org.tartarus.snowball.ext.EnglishStemmer;
 import org.tartarus.snowball.ext.FinnishStemmer;
 import org.tartarus.snowball.ext.FrenchStemmer;
-import org.tartarus.snowball.ext.German2Stemmer;
 import org.tartarus.snowball.ext.GermanStemmer;
 import org.tartarus.snowball.ext.HungarianStemmer;
 import org.tartarus.snowball.ext.IrishStemmer;
 import org.tartarus.snowball.ext.ItalianStemmer;
-import org.tartarus.snowball.ext.KpStemmer;
 import org.tartarus.snowball.ext.LithuanianStemmer;
-import org.tartarus.snowball.ext.LovinsStemmer;
 import org.tartarus.snowball.ext.NorwegianStemmer;
 import org.tartarus.snowball.ext.PortugueseStemmer;
 import org.tartarus.snowball.ext.RomanianStemmer;
@@ -89,7 +85,7 @@ public class StemmerTokenFilterFactory extends AbstractTokenFilterFactory {
 
     private static final TokenStream EMPTY_TOKEN_STREAM = new EmptyTokenStream();
 
-    private String language;
+    private final String language;
 
     StemmerTokenFilterFactory(IndexSettings indexSettings, Environment environment, String name, Settings settings) throws IOException {
         super(indexSettings, name, settings);
@@ -122,8 +118,6 @@ public class StemmerTokenFilterFactory extends AbstractTokenFilterFactory {
             // Dutch stemmers
         } else if ("dutch".equalsIgnoreCase(language)) {
             return new SnowballFilter(tokenStream, new DutchStemmer());
-        } else if ("dutch_kp".equalsIgnoreCase(language) || "dutchKp".equalsIgnoreCase(language) || "kp".equalsIgnoreCase(language)) {
-            return new SnowballFilter(tokenStream, new KpStemmer());
 
             // English stemmers
         } else if ("english".equalsIgnoreCase(language)) {
@@ -131,8 +125,6 @@ public class StemmerTokenFilterFactory extends AbstractTokenFilterFactory {
         } else if ("light_english".equalsIgnoreCase(language) || "lightEnglish".equalsIgnoreCase(language)
                 || "kstem".equalsIgnoreCase(language)) {
             return new KStemFilter(tokenStream);
-        } else if ("lovins".equalsIgnoreCase(language)) {
-            return new SnowballFilter(tokenStream, new LovinsStemmer());
         } else if ("porter".equalsIgnoreCase(language)) {
             return new PorterStemFilter(tokenStream);
         } else if ("porter2".equalsIgnoreCase(language)) {
@@ -169,7 +161,7 @@ public class StemmerTokenFilterFactory extends AbstractTokenFilterFactory {
         } else if ("german".equalsIgnoreCase(language)) {
             return new SnowballFilter(tokenStream, new GermanStemmer());
         } else if ("german2".equalsIgnoreCase(language)) {
-            return new SnowballFilter(tokenStream, new German2Stemmer());
+            return new SnowballFilter(tokenStream, new GermanStemmer());
         } else if ("light_german".equalsIgnoreCase(language) || "lightGerman".equalsIgnoreCase(language)) {
             return new GermanLightStemFilter(tokenStream);
         } else if ("minimal_german".equalsIgnoreCase(language) || "minimalGerman".equalsIgnoreCase(language)) {
@@ -215,9 +207,9 @@ public class StemmerTokenFilterFactory extends AbstractTokenFilterFactory {
 
             // Norwegian (Nynorsk) stemmers
         } else if ("light_nynorsk".equalsIgnoreCase(language) || "lightNynorsk".equalsIgnoreCase(language)) {
-            return new NorwegianLightStemFilter(tokenStream, NorwegianLightStemmer.NYNORSK);
+            return new NorwegianLightStemFilter(tokenStream, 2 /* = NorwegianLightStemmer.NYNORSK */);
         } else if ("minimal_nynorsk".equalsIgnoreCase(language) || "minimalNynorsk".equalsIgnoreCase(language)) {
-            return new NorwegianMinimalStemFilter(tokenStream, NorwegianLightStemmer.NYNORSK);
+            return new NorwegianMinimalStemFilter(tokenStream, 2 /* = NorwegianLightStemmer.NYNORSK */);
 
             // Portuguese stemmers
         } else if ("portuguese".equalsIgnoreCase(language)) {

--- a/pom.xml
+++ b/pom.xml
@@ -325,7 +325,7 @@
     <versions.quickcheck>1.0</versions.quickcheck>
     <versions.hppc>0.8.2</versions.hppc>
     <versions.netty>4.1.117.Final</versions.netty>
-    <versions.lucene>9.12.0</versions.lucene>
+    <versions.lucene>10.1.0</versions.lucene>
     <versions.spatial4j>0.8</versions.spatial4j>
     <versions.jts>1.20.0</versions.jts>
     <versions.jna>5.15.0</versions.jna>

--- a/server/src/main/java/io/crate/execution/engine/collect/collectors/DummyScorer.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/collectors/DummyScorer.java
@@ -41,9 +41,4 @@ class DummyScorer extends Scorable {
         return score;
     }
 
-
-    @Override
-    public int docID() {
-        return 0;
-    }
 }

--- a/server/src/main/java/io/crate/expression/operator/RegexpMatchOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/RegexpMatchOperator.java
@@ -30,6 +30,7 @@ import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.RegexpQuery;
 import org.apache.lucene.util.automaton.ByteRunAutomaton;
+import org.apache.lucene.util.automaton.Operations;
 import org.apache.lucene.util.automaton.RegExp;
 
 import io.crate.data.Input;
@@ -81,7 +82,8 @@ public class RegexpMatchOperator extends Operator<String> {
             return source.matches(pattern);
         } else {
             RegExp regexp = new RegExp(pattern);
-            ByteRunAutomaton regexpRunAutomaton = new ByteRunAutomaton(regexp.toAutomaton());
+            var auto = Operations.determinize(regexp.toAutomaton(), Operations.DEFAULT_DETERMINIZE_WORK_LIMIT);
+            ByteRunAutomaton regexpRunAutomaton = new ByteRunAutomaton(auto);
             byte[] bytes = source.getBytes(StandardCharsets.UTF_8);
             return regexpRunAutomaton.run(bytes, 0, bytes.length);
         }

--- a/server/src/main/java/io/crate/lucene/GenericFunctionQuery.java
+++ b/server/src/main/java/io/crate/lucene/GenericFunctionQuery.java
@@ -36,6 +36,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryVisitor;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.ScorerSupplier;
 import org.apache.lucene.search.TwoPhaseIterator;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.Bits;
@@ -109,8 +110,18 @@ public class GenericFunctionQuery extends Query {
             }
 
             @Override
-            public Scorer scorer(LeafReaderContext context) throws IOException {
-                return new ConstantScoreScorer(this, 0f, scoreMode, getTwoPhaseIterator(context));
+            public ScorerSupplier scorerSupplier(LeafReaderContext context) {
+                return new ScorerSupplier() {
+                    @Override
+                    public Scorer get(long leadCost) throws IOException {
+                        return new ConstantScoreScorer(0f, scoreMode, getTwoPhaseIterator(context));
+                    }
+
+                    @Override
+                    public long cost() {
+                        return context.reader().maxDoc();
+                    }
+                };
             }
         };
     }

--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -33,6 +33,7 @@ import org.elasticsearch.common.collect.ImmutableOpenIntMap;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.monitor.jvm.JvmInfo;
 
@@ -47,7 +48,7 @@ public class Version implements Comparable<Version> {
      */
     private static final int V_EMPTY_ID = 0;
     public static final Version V_EMPTY = new Version(V_EMPTY_ID, 0, false, org.apache.lucene.util.Version.LATEST);
-    public static final Version V_3_0_1 = new Version(6_01_04_99, 3_00_01_99, false, org.apache.lucene.util.Version.fromBits(7, 1, 0));
+    public static final Version V_3_0_1 = new Version(6_01_04_99, 3_00_01_99, false, Lucene.luceneVersion(7, 1, 0));
     /**
      * Before CrateDB 4.0 we've had ES versions (internalId) and CrateDB (externalId) versions.
      * The internalId is stored in indices, so we keep using it for compatibility.
@@ -65,77 +66,35 @@ public class Version implements Comparable<Version> {
      */
     private static final int INTERNAL_OFFSET = 3_00_00_00;
 
-    public static final Version V_4_0_0 = new Version(7_00_00_99, false, org.apache.lucene.util.Version.LUCENE_8_0_0);
-    public static final Version V_4_0_1 = new Version(7_00_01_99, false, org.apache.lucene.util.Version.LUCENE_8_0_0);
-    public static final Version V_4_0_2 = new Version(7_00_02_99, false, org.apache.lucene.util.Version.LUCENE_8_0_0);
-    public static final Version V_4_0_3 = new Version(7_00_03_99, false, org.apache.lucene.util.Version.LUCENE_8_0_0);
-    public static final Version V_4_0_4 = new Version(7_00_04_99, false, org.apache.lucene.util.Version.LUCENE_8_0_0);
-    public static final Version V_4_0_5 = new Version(7_00_05_99, false, org.apache.lucene.util.Version.LUCENE_8_0_0);
-    public static final Version V_4_0_6 = new Version(7_00_06_99, false, org.apache.lucene.util.Version.LUCENE_8_0_0);
-    public static final Version V_4_0_7 = new Version(7_00_07_99, false, org.apache.lucene.util.Version.LUCENE_8_0_0);
-    public static final Version V_4_0_8 = new Version(7_00_08_99, false, org.apache.lucene.util.Version.LUCENE_8_0_0);
-    public static final Version V_4_0_9 = new Version(7_00_09_99, false, org.apache.lucene.util.Version.LUCENE_8_0_0);
-    public static final Version V_4_0_10 = new Version(7_00_10_99, false, org.apache.lucene.util.Version.LUCENE_8_0_0);
-    public static final Version V_4_0_11 = new Version(7_00_11_99, false, org.apache.lucene.util.Version.LUCENE_8_0_0);
-    public static final Version V_4_0_12 = new Version(7_00_12_99, false, org.apache.lucene.util.Version.LUCENE_8_0_0);
+    public static final Version V_4_0_0 = new Version(7_00_00_99, false, Lucene.luceneVersion(8, 0, 0));
+    public static final Version V_4_0_9 = new Version(7_00_09_99, false, Lucene.luceneVersion(8, 0, 0));
 
-    public static final Version V_4_1_0 = new Version(7_01_00_99, false, org.apache.lucene.util.Version.LUCENE_8_4_0);
-    public static final Version V_4_1_1 = new Version(7_01_01_99, false, org.apache.lucene.util.Version.LUCENE_8_4_0);
-    public static final Version V_4_1_2 = new Version(7_01_02_99, false, org.apache.lucene.util.Version.LUCENE_8_4_0);
-    public static final Version V_4_1_3 = new Version(7_01_03_99, false, org.apache.lucene.util.Version.LUCENE_8_4_0);
-    public static final Version V_4_1_4 = new Version(7_01_04_99, false, org.apache.lucene.util.Version.LUCENE_8_4_0);
-    public static final Version V_4_1_5 = new Version(7_01_05_99, false, org.apache.lucene.util.Version.LUCENE_8_4_0);
-    public static final Version V_4_1_6 = new Version(7_01_06_99, false, org.apache.lucene.util.Version.LUCENE_8_4_0);
-    public static final Version V_4_1_7 = new Version(7_01_07_99, false, org.apache.lucene.util.Version.LUCENE_8_4_0);
-    public static final Version V_4_1_8 = new Version(7_01_08_99, false, org.apache.lucene.util.Version.LUCENE_8_4_0);
+    public static final Version V_4_1_0 = new Version(7_01_00_99, false, Lucene.luceneVersion(8, 4, 0));
+    public static final Version V_4_1_8 = new Version(7_01_08_99, false, Lucene.luceneVersion(8, 4, 0));
 
-    public static final Version V_4_2_0 = new Version(7_02_00_99, false, org.apache.lucene.util.Version.LUCENE_8_5_1);
-    public static final Version V_4_2_1 = new Version(7_02_01_99, false, org.apache.lucene.util.Version.LUCENE_8_5_1);
-    public static final Version V_4_2_2 = new Version(7_02_02_99, false, org.apache.lucene.util.Version.LUCENE_8_5_1);
-    public static final Version V_4_2_3 = new Version(7_02_03_99, false, org.apache.lucene.util.Version.LUCENE_8_5_1);
-    public static final Version V_4_2_4 = new Version(7_02_04_99, false, org.apache.lucene.util.Version.LUCENE_8_5_1);
-    public static final Version V_4_2_5 = new Version(7_02_05_99, false, org.apache.lucene.util.Version.LUCENE_8_5_1);
-    public static final Version V_4_2_6 = new Version(7_02_06_99, false, org.apache.lucene.util.Version.LUCENE_8_5_1);
-    public static final Version V_4_2_7 = new Version(7_02_07_99, false, org.apache.lucene.util.Version.LUCENE_8_5_1);
+    public static final Version V_4_2_0 = new Version(7_02_00_99, false, Lucene.luceneVersion(8, 5, 1));
+    public static final Version V_4_2_1 = new Version(7_02_01_99, false, Lucene.luceneVersion(8, 5, 1));
+    public static final Version V_4_2_4 = new Version(7_02_04_99, false, Lucene.luceneVersion(8, 5, 1));
 
-    public static final Version V_4_3_0 = new Version(7_03_00_99, false, org.apache.lucene.util.Version.LUCENE_8_6_2);
-    public static final Version V_4_3_1 = new Version(7_03_01_99, false, org.apache.lucene.util.Version.LUCENE_8_6_2);
-    public static final Version V_4_3_2 = new Version(7_03_02_99, false, org.apache.lucene.util.Version.LUCENE_8_6_2);
-    public static final Version V_4_3_3 = new Version(7_03_03_99, false, org.apache.lucene.util.Version.LUCENE_8_6_2);
-    public static final Version V_4_3_4 = new Version(7_03_04_99, false, org.apache.lucene.util.Version.LUCENE_8_6_2);
+    public static final Version V_4_3_0 = new Version(7_03_00_99, false, Lucene.luceneVersion(8, 6, 2));
+    public static final Version V_4_3_4 = new Version(7_03_04_99, false, Lucene.luceneVersion(8, 6, 2));
 
-    public static final Version V_4_4_0 = new Version(7_04_00_99, false, org.apache.lucene.util.Version.LUCENE_8_7_0);
-    public static final Version V_4_4_1 = new Version(7_04_01_99, false, org.apache.lucene.util.Version.LUCENE_8_7_0);
-    public static final Version V_4_4_2 = new Version(7_04_02_99, false, org.apache.lucene.util.Version.LUCENE_8_7_0);
-    public static final Version V_4_4_3 = new Version(7_04_03_99, false, org.apache.lucene.util.Version.LUCENE_8_7_0);
+    public static final Version V_4_4_0 = new Version(7_04_00_99, false, Lucene.luceneVersion(8, 7, 0));
+    public static final Version V_4_4_1 = new Version(7_04_01_99, false, Lucene.luceneVersion(8, 7, 0));
+    public static final Version V_4_4_2 = new Version(7_04_02_99, false, Lucene.luceneVersion(8, 7, 0));
 
-    public static final Version V_4_5_0 = new Version(7_05_00_99, false, org.apache.lucene.util.Version.LUCENE_8_7_0);
-    public static final Version V_4_5_1 = new Version(7_05_01_99, false, org.apache.lucene.util.Version.LUCENE_8_7_0);
-    public static final Version V_4_5_2 = new Version(7_05_02_99, false, org.apache.lucene.util.Version.LUCENE_8_7_0);
-    public static final Version V_4_5_3 = new Version(7_05_03_99, false, org.apache.lucene.util.Version.LUCENE_8_7_0);
-    public static final Version V_4_5_4 = new Version(7_05_04_99, false, org.apache.lucene.util.Version.LUCENE_8_7_0);
-    public static final Version V_4_5_5 = new Version(7_05_05_99, false, org.apache.lucene.util.Version.LUCENE_8_7_0);
+    public static final Version V_4_5_0 = new Version(7_05_00_99, false, Lucene.luceneVersion(8, 7, 0));
+    public static final Version V_4_5_1 = new Version(7_05_01_99, false, Lucene.luceneVersion(8, 7, 0));
+    public static final Version V_4_5_3 = new Version(7_05_03_99, false, Lucene.luceneVersion(8, 7, 0));
 
-    public static final Version V_4_6_0 = new Version(7_06_00_99, false, org.apache.lucene.util.Version.LUCENE_8_8_2);
-    public static final Version V_4_6_1 = new Version(7_06_01_99, false, org.apache.lucene.util.Version.LUCENE_8_8_2);
-    public static final Version V_4_6_2 = new Version(7_06_02_99, false, org.apache.lucene.util.Version.LUCENE_8_8_2);
-    public static final Version V_4_6_3 = new Version(7_06_03_99, false, org.apache.lucene.util.Version.LUCENE_8_8_2);
-    public static final Version V_4_6_4 = new Version(7_06_04_99, false, org.apache.lucene.util.Version.LUCENE_8_8_2);
-    public static final Version V_4_6_5 = new Version(7_06_05_99, false, org.apache.lucene.util.Version.LUCENE_8_8_2);
-    public static final Version V_4_6_6 = new Version(7_06_06_99, false, org.apache.lucene.util.Version.LUCENE_8_8_2);
-    public static final Version V_4_6_7 = new Version(7_06_07_99, false, org.apache.lucene.util.Version.LUCENE_8_8_2);
-    public static final Version V_4_6_8 = new Version(7_06_08_99, false, org.apache.lucene.util.Version.LUCENE_8_8_2);
+    public static final Version V_4_6_0 = new Version(7_06_00_99, false, Lucene.luceneVersion(8, 8, 2));
 
-    public static final Version V_4_7_0 = new Version(7_07_00_99, false, org.apache.lucene.util.Version.LUCENE_8_11_0);
-    public static final Version V_4_7_1 = new Version(7_07_01_99, false, org.apache.lucene.util.Version.LUCENE_8_11_0);
-    public static final Version V_4_7_2 = new Version(7_07_02_99, false, org.apache.lucene.util.Version.LUCENE_8_11_0);
-    public static final Version V_4_7_3 = new Version(7_07_03_99, false, org.apache.lucene.util.Version.LUCENE_8_11_0);
+    public static final Version V_4_7_0 = new Version(7_07_00_99, false, Lucene.luceneVersion(8, 11, 0));
+    public static final Version V_4_7_1 = new Version(7_07_01_99, false, Lucene.luceneVersion(8, 11, 0));
+    public static final Version V_4_7_2 = new Version(7_07_02_99, false, Lucene.luceneVersion(8, 11, 0));
 
-    public static final Version V_4_8_0 = new Version(7_08_00_99, false, org.apache.lucene.util.Version.LUCENE_8_11_0);
-    public static final Version V_4_8_1 = new Version(7_08_01_99, false, org.apache.lucene.util.Version.LUCENE_8_11_0);
-    public static final Version V_4_8_2 = new Version(7_08_02_99, false, org.apache.lucene.util.Version.LUCENE_8_11_0);
-    public static final Version V_4_8_3 = new Version(7_08_03_99, false, org.apache.lucene.util.Version.LUCENE_8_11_0);
-    public static final Version V_4_8_4 = new Version(7_08_04_99, false, org.apache.lucene.util.Version.LUCENE_8_11_0);
+    public static final Version V_4_8_0 = new Version(7_08_00_99, false, Lucene.luceneVersion(8, 11, 0));
+    public static final Version V_4_8_4 = new Version(7_08_04_99, false, Lucene.luceneVersion(8, 11, 0));
 
     public static final Version V_5_0_0 = new Version(8_00_00_99, false, org.apache.lucene.util.Version.LUCENE_9_2_0);
     public static final Version V_5_0_1 = new Version(8_00_01_99, false, org.apache.lucene.util.Version.LUCENE_9_2_0);
@@ -225,7 +184,7 @@ public class Version implements Comparable<Version> {
     public static final Version V_5_10_0 = new Version(8_10_00_99, false, org.apache.lucene.util.Version.LUCENE_9_12_0);
     public static final Version V_5_10_1 = new Version(8_10_01_99, true, org.apache.lucene.util.Version.LUCENE_9_12_0);
 
-    public static final Version V_6_0_0 = new Version(9_00_00_99, true, org.apache.lucene.util.Version.LUCENE_9_12_0);
+    public static final Version V_6_0_0 = new Version(9_00_00_99, true, org.apache.lucene.util.Version.LUCENE_10_1_0);
 
     public static final Version CURRENT = V_6_0_0;
 

--- a/server/src/main/java/org/elasticsearch/common/lucene/Lucene.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/Lucene.java
@@ -65,7 +65,7 @@ import io.crate.common.collections.Iterables;
 import io.crate.exceptions.SQLExceptions;
 
 public class Lucene {
-    public static final String LATEST_CODEC = "Lucene912";
+    public static final String LATEST_CODEC = "Lucene101";
 
     public static final String SOFT_DELETES_FIELD = "__soft_deletes";
 
@@ -82,6 +82,10 @@ public class Lucene {
             logger.warn(() -> new ParameterizedMessage("no version match {}, default to {}", version, defaultVersion), e);
             return defaultVersion;
         }
+    }
+
+    public static org.apache.lucene.util.Version luceneVersion(int major, int minor, int bugfix) {
+        return org.apache.lucene.util.Version.fromBits(major, minor, bugfix);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/common/lucene/search/MultiPhrasePrefixQuery.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/search/MultiPhrasePrefixQuery.java
@@ -33,6 +33,7 @@ import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.MultiPhraseQuery;
 import org.apache.lucene.search.Query;
@@ -142,8 +143,8 @@ public class MultiPhrasePrefixQuery extends Query {
     }
 
     @Override
-    public Query rewrite(IndexReader reader) throws IOException {
-        Query rewritten = super.rewrite(reader);
+    public Query rewrite(IndexSearcher searcher) throws IOException {
+        Query rewritten = super.rewrite(searcher);
         if (rewritten != this) {
             return rewritten;
         }
@@ -160,7 +161,7 @@ public class MultiPhrasePrefixQuery extends Query {
         int position = positions.get(sizeMinus1);
         ObjectHashSet<Term> terms = new ObjectHashSet<>();
         for (Term term : suffixTerms) {
-            getPrefixTerms(terms, term, reader);
+            getPrefixTerms(terms, term, searcher.getIndexReader());
             if (terms.size() > maxExpansions) {
                 break;
             }

--- a/server/src/main/java/org/elasticsearch/common/lucene/search/Queries.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/search/Queries.java
@@ -51,10 +51,10 @@ public class Queries {
             List<BooleanClause> clauses = booleanQuery.clauses();
             BooleanClause fst = clauses.get(0);
             BooleanClause snd = clauses.get(1);
-            if (fst.getQuery() instanceof MatchAllDocsQuery
-                && fst.getOccur() == Occur.MUST
-                && snd.getOccur() == Occur.MUST_NOT) {
-                return snd.getQuery();
+            if (fst.query() instanceof MatchAllDocsQuery
+                && fst.occur() == Occur.MUST
+                && snd.occur() == Occur.MUST_NOT) {
+                return snd.query();
             }
         }
         return new BooleanQuery.Builder()
@@ -69,7 +69,7 @@ public class Queries {
         }
         int optionalClauses = 0;
         for (BooleanClause c : query.clauses()) {
-            if (c.getOccur() == BooleanClause.Occur.SHOULD) {
+            if (c.occur() == BooleanClause.Occur.SHOULD) {
                 optionalClauses++;
             }
         }

--- a/server/src/main/java/org/elasticsearch/index/IndexModule.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexModule.java
@@ -35,7 +35,6 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.apache.lucene.search.QueryCache;
-import org.apache.lucene.store.MMapDirectory;
 import org.apache.lucene.util.Constants;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
@@ -260,7 +259,7 @@ public final class IndexModule {
     }
 
     public static Type defaultStoreType(final boolean allowMmap) {
-        if (allowMmap && Constants.JRE_IS_64BIT && MMapDirectory.UNMAP_SUPPORTED) {
+        if (allowMmap && Constants.JRE_IS_64BIT) {
             return Type.HYBRIDFS;
         } else {
             return Type.NIOFS;

--- a/server/src/main/java/org/elasticsearch/index/codec/CodecService.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/CodecService.java
@@ -23,7 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.lucene.codecs.Codec;
-import org.apache.lucene.codecs.lucene912.Lucene912Codec;
+import org.apache.lucene.codecs.lucene101.Lucene101Codec;
 
 /**
  * Since Lucene 4.0 low level index segments are read and written through a
@@ -45,9 +45,9 @@ public class CodecService {
     public CodecService() {
         final var codecs = new HashMap<String, Codec>();
         codecs.put(DEFAULT_CODEC,
-            new CrateCodec(Lucene912Codec.Mode.BEST_SPEED));
+            new CrateCodec(Lucene101Codec.Mode.BEST_SPEED));
         codecs.put(BEST_COMPRESSION_CODEC,
-            new CrateCodec(Lucene912Codec.Mode.BEST_COMPRESSION));
+            new CrateCodec(Lucene101Codec.Mode.BEST_COMPRESSION));
         codecs.put(LUCENE_DEFAULT_CODEC, Codec.getDefault());
         for (String codec : Codec.availableCodecs()) {
             codecs.put(codec, Codec.forName(codec));

--- a/server/src/main/java/org/elasticsearch/index/codec/CrateCodec.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/CrateCodec.java
@@ -26,7 +26,7 @@ import org.apache.lucene.codecs.DocValuesFormat;
 import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.codecs.KnnVectorsReader;
 import org.apache.lucene.codecs.KnnVectorsWriter;
-import org.apache.lucene.codecs.lucene912.Lucene912Codec;
+import org.apache.lucene.codecs.lucene101.Lucene101Codec;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
 import org.elasticsearch.common.lucene.Lucene;
@@ -41,7 +41,7 @@ import io.crate.types.FloatVectorType;
  * the max supported vector dimension to {@link FloatVectorType#MAX_DIMENSIONS}
  */
 // LUCENE UPGRADE: make sure to move to a new codec depending on the lucene version
-public class CrateCodec extends Lucene912Codec {
+public class CrateCodec extends Lucene101Codec {
 
     static {
         assert Codec.forName(Lucene.LATEST_CODEC).getClass().isAssignableFrom(CrateCodec.class) : "CrateCodec must subclass the latest lucene codec: " + Lucene.LATEST_CODEC;

--- a/server/src/main/java/org/elasticsearch/index/engine/LuceneChangesSnapshot.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/LuceneChangesSnapshot.java
@@ -103,7 +103,7 @@ final class LuceneChangesSnapshot implements Translog.Snapshot {
         this.indexSearcher.setQueryCache(null);
         this.parallelArray = new ParallelArray(this.searchBatchSize);
         final TopDocs topDocs = searchOperations(null);
-        this.totalHits = Math.toIntExact(topDocs.totalHits.value);
+        this.totalHits = Math.toIntExact(topDocs.totalHits.value());
         this.scoreDocs = topDocs.scoreDocs;
         fillParallelArray(scoreDocs, parallelArray);
     }

--- a/server/src/main/java/org/elasticsearch/index/engine/RecoverySourcePruneMergePolicy.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/RecoverySourcePruneMergePolicy.java
@@ -28,6 +28,7 @@ import org.apache.lucene.codecs.DocValuesProducer;
 import org.apache.lucene.codecs.StoredFieldsReader;
 import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.CodecReader;
+import org.apache.lucene.index.DocValuesSkipper;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FilterCodecReader;
 import org.apache.lucene.index.FilterNumericDocValues;
@@ -178,6 +179,11 @@ final class RecoverySourcePruneMergePolicy extends OneMergeWrappingMergePolicy {
             @Override
             public SortedSetDocValues getSortedSet(FieldInfo field) throws IOException {
                 return in.getSortedSet(field);
+            }
+
+            @Override
+            public DocValuesSkipper getSkipper(FieldInfo field) throws IOException {
+                return in.getSkipper(field);
             }
 
             @Override

--- a/server/src/main/java/org/elasticsearch/index/engine/TranslogLeafReader.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/TranslogLeafReader.java
@@ -24,10 +24,11 @@ import java.util.Collections;
 
 import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.ByteVectorValues;
+import org.apache.lucene.index.DocValuesSkipIndexType;
+import org.apache.lucene.index.DocValuesSkipper;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
-import org.apache.lucene.index.Fields;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.LeafMetaData;
@@ -56,10 +57,10 @@ final class TranslogLeafReader extends LeafReader {
 
     private final Translog.Index operation;
     private static final FieldInfo FAKE_SOURCE_FIELD
-        = new FieldInfo(SysColumns.Source.NAME, 1, false, false, false, IndexOptions.NONE, DocValuesType.NONE, -1, Collections.emptyMap(),
+        = new FieldInfo(SysColumns.Source.NAME, 1, false, false, false, IndexOptions.NONE, DocValuesType.NONE, DocValuesSkipIndexType.NONE, -1, Collections.emptyMap(),
         0, 0, 0, 0, VectorEncoding.BYTE, VectorSimilarityFunction.EUCLIDEAN, false, false);
     private static final FieldInfo FAKE_ID_FIELD
-        = new FieldInfo(SysColumns.Names.ID, 3, false, false, false, IndexOptions.NONE, DocValuesType.NONE, -1, Collections.emptyMap(),
+        = new FieldInfo(SysColumns.Names.ID, 3, false, false, false, IndexOptions.NONE, DocValuesType.NONE, DocValuesSkipIndexType.NONE, -1, Collections.emptyMap(),
         0, 0, 0, 0, VectorEncoding.BYTE, VectorSimilarityFunction.EUCLIDEAN, false, false);
 
     TranslogLeafReader(Translog.Index operation) {
@@ -106,6 +107,10 @@ final class TranslogLeafReader extends LeafReader {
         throw new UnsupportedOperationException();
     }
 
+    @Override
+    public DocValuesSkipper getDocValuesSkipper(String field) throws IOException {
+        throw new UnsupportedOperationException();
+    }
 
     @Override
     public FieldInfos getFieldInfos() {
@@ -133,11 +138,6 @@ final class TranslogLeafReader extends LeafReader {
     }
 
     @Override
-    public Fields getTermVectors(int docID) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public int numDocs() {
         return 1;
     }
@@ -145,11 +145,6 @@ final class TranslogLeafReader extends LeafReader {
     @Override
     public int maxDoc() {
         return 1;
-    }
-
-    @Override
-    public void document(int docID, StoredFieldVisitor visitor) throws IOException {
-        docFromOperation(docID, visitor, operation);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/query/RegexpFlag.java
+++ b/server/src/main/java/org/elasticsearch/index/query/RegexpFlag.java
@@ -35,9 +35,6 @@ import java.util.Locale;
  *     <li>{@code NONE} - Disable support for all syntax options</li>
  *     <li>{@code ALL} - Enables support for all syntax options</li>
  * </ul>
- *
- * @see RegexpQueryBuilder#flags(RegexpFlag...)
- * @see RegexpQueryBuilder#flags(RegexpFlag...)
  */
 public enum RegexpFlag {
 
@@ -49,7 +46,7 @@ public enum RegexpFlag {
     /**
      * Enables complement expression of the form: {@code ~&lt;expression&gt;}
      */
-    COMPLEMENT(RegExp.COMPLEMENT),
+    COMPLEMENT(RegExp.DEPRECATED_COMPLEMENT),
 
     /**
      * Enables empty language expression: {@code #}

--- a/server/src/main/java/org/elasticsearch/index/search/MatchQuery.java
+++ b/server/src/main/java/org/elasticsearch/index/search/MatchQuery.java
@@ -361,10 +361,11 @@ public class MatchQuery {
                                                      float maxTermFrequency) {
             ExtendedCommonTermsQuery query = new ExtendedCommonTermsQuery(highFreqOccur, lowFreqOccur, maxTermFrequency);
             for (BooleanClause clause : bq.clauses()) {
-                if ((clause.getQuery() instanceof TermQuery) == false) {
+                if (clause.query() instanceof TermQuery tq) {
+                    query.add(tq.getTerm());
+                } else {
                     return bq;
                 }
-                query.add(((TermQuery) clause.getQuery()).getTerm());
             }
             return query;
         }

--- a/server/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/server/src/main/java/org/elasticsearch/index/store/Store.java
@@ -598,7 +598,7 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
         List<CorruptIndexException> ex = new ArrayList<>();
         for (String file : files) {
             if (file.startsWith(CORRUPTED_MARKER_NAME_PREFIX)) {
-                try (ChecksumIndexInput input = directory.openChecksumInput(file, IOContext.READONCE)) {
+                try (ChecksumIndexInput input = directory.openChecksumInput(file)) {
                     CodecUtil.checkHeader(input, CODEC, CORRUPTED_MARKER_CODEC_VERSION, CORRUPTED_MARKER_CODEC_VERSION);
                     final int size = input.readVInt();
                     final byte[] buffer = new byte[size];

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -988,7 +988,7 @@ public class RecoverySourceHandler {
                     // Segments* files require IOContext.READONCE
                     // https://github.com/apache/lucene/blob/b2d3a2b37e00f19a74949097736be8fd64745f61/lucene/test-framework/src/java/org/apache/lucene/tests/store/MockDirectoryWrapper.java#L817
                     if (md.name().startsWith(IndexFileNames.SEGMENTS) == false) {
-                        final IndexInput indexInput = store.directory().openInput(md.name(), IOContext.READ);
+                        final IndexInput indexInput = store.directory().openInput(md.name(), IOContext.DEFAULT);
                         currentInput = new InputStreamIndexInput(indexInput, md.length()) {
                             @Override
                             public void close() throws IOException {

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -2298,7 +2298,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                               IndexShardSnapshotStatus snapshotStatus, Store store) throws IOException {
         final BlobContainer shardContainer = shardContainer(indexId, shardId);
         final String file = fileInfo.physicalName();
-        try (IndexInput indexInput = store.openVerifyingInput(file, IOContext.READ, fileInfo.metadata())) {
+        try (IndexInput indexInput = store.openVerifyingInput(file, IOContext.DEFAULT, fileInfo.metadata())) {
             for (int i = 0; i < fileInfo.numberOfParts(); i++) {
                 final long partBytes = fileInfo.partBytes(i);
 

--- a/server/src/main/java/org/elasticsearch/search/profile/query/ProfileWeight.java
+++ b/server/src/main/java/org/elasticsearch/search/profile/query/ProfileWeight.java
@@ -19,16 +19,15 @@
 
 package org.elasticsearch.search.profile.query;
 
+import java.io.IOException;
+
 import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.search.BulkScorer;
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.ScorerSupplier;
 import org.apache.lucene.search.Weight;
 import org.elasticsearch.search.profile.Timer;
-
-import java.io.IOException;
 
 /**
  * Weight wrapper that will compute how much time it takes to build the
@@ -44,15 +43,6 @@ public final class ProfileWeight extends Weight {
         super(query);
         this.subQueryWeight = subQueryWeight;
         this.profile = profile;
-    }
-
-    @Override
-    public Scorer scorer(LeafReaderContext context) throws IOException {
-        ScorerSupplier supplier = scorerSupplier(context);
-        if (supplier == null) {
-            return null;
-        }
-        return supplier.get(Long.MAX_VALUE);
     }
 
     @Override
@@ -92,18 +82,6 @@ public final class ProfileWeight extends Weight {
                 }
             }
         };
-    }
-
-    @Override
-    public BulkScorer bulkScorer(LeafReaderContext context) throws IOException {
-        // We use the default bulk scorer instead of the specialized one. The reason
-        // is that Lucene's BulkScorers do everything at once: finding matches,
-        // scoring them and calling the collector, so they make it impossible to
-        // see where time is spent, which is the purpose of query profiling.
-        // The default bulk scorer will pull a scorer and iterate over matches,
-        // this might be a significantly different execution path for some queries
-        // like disjunctions, but in general this is what is done anyway
-        return super.bulkScorer(context);
     }
 
     @Override

--- a/server/src/test/java/io/crate/execution/engine/collect/collectors/OptimizeQueryForSearchAfterTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/collectors/OptimizeQueryForSearchAfterTest.java
@@ -84,7 +84,7 @@ public class OptimizeQueryForSearchAfterTest {
                 .isExactlyInstanceOf(BooleanQuery.class);
         BooleanQuery booleanQuery = (BooleanQuery) query;
         assertThat(booleanQuery.clauses()).satisfiesExactly(
-                x -> assertThat(x.getQuery().getClass().getName()).endsWith("IntPoint$1")); // the query class is anonymous
+                x -> assertThat(x.query().getClass().getName()).endsWith("IntPoint$1")); // the query class is anonymous
 
         orderBy = new OrderBy(List.of(
                 new SimpleReference(referenceIdent, RowGranularity.DOC, DataTypes.SHORT,
@@ -98,7 +98,7 @@ public class OptimizeQueryForSearchAfterTest {
                 .isExactlyInstanceOf(BooleanQuery.class);
         booleanQuery = (BooleanQuery) query;
         assertThat(booleanQuery.clauses()).satisfiesExactly(
-                x -> assertThat(x.getQuery()).isNotInstanceOf(IndexOrDocValuesQuery.class));
+                x -> assertThat(x.query()).isNotInstanceOf(IndexOrDocValuesQuery.class));
     }
 
     @Test

--- a/server/src/test/java/io/crate/lucene/BitStringEqQueryTest.java
+++ b/server/src/test/java/io/crate/lucene/BitStringEqQueryTest.java
@@ -86,7 +86,7 @@ public class BitStringEqQueryTest extends LuceneQueryBuilderTest {
         Query query = convert("arr1 = [" + BIT_STRING + "]");
         assertThat(query).isExactlyInstanceOf(BooleanQuery.class);
         BooleanClause clause = ((BooleanQuery) query).clauses().get(0);
-        query = clause.getQuery();
+        query = clause.query();
         assertThat(query).isExactlyInstanceOf(TermInSetQuery.class);
         TermInSetQuery q = (TermInSetQuery) query;
         assertThat(q).hasToString("arr1:(" + BIT_STRING_IN_BYTES_REF.utf8ToString() + ")");
@@ -94,7 +94,7 @@ public class BitStringEqQueryTest extends LuceneQueryBuilderTest {
         query = convert("arr2 = [" + BIT_STRING + "]");
         assertThat(query).isExactlyInstanceOf(BooleanQuery.class);
         clause = ((BooleanQuery) query).clauses().get(0);
-        query = clause.getQuery();
+        query = clause.query();
         // SortedSetDocValuesField.newSlowSetQuery is equal to TermInSetQuery + MultiTermQuery.DOC_VALUES_REWRITE
         assertThat(query).isExactlyInstanceOf(TermInSetQuery.class);
         q = (TermInSetQuery) query;

--- a/server/src/test/java/io/crate/lucene/BooleanEqQueryTest.java
+++ b/server/src/test/java/io/crate/lucene/BooleanEqQueryTest.java
@@ -97,13 +97,13 @@ public class BooleanEqQueryTest extends LuceneQueryBuilderTest {
         Query query = convert("arr1 = [true, false, null]");
         assertThat(query).isExactlyInstanceOf(BooleanQuery.class);
         BooleanClause clause = ((BooleanQuery) query).clauses().get(0);
-        query = clause.getQuery();
+        query = clause.query();
         assertThat(query).hasToString("arr1:(F T)");
 
         query = convert("arr2 = [true, false, null]");
         assertThat(query).isExactlyInstanceOf(BooleanQuery.class);
         clause = ((BooleanQuery) query).clauses().get(0);
-        query = clause.getQuery();
+        query = clause.query();
         assertThat(query.getClass().getName()).endsWith("SortedNumericDocValuesSetQuery");
         assertThat(query).hasToString("arr2: [0, 1]");
     }

--- a/server/src/test/java/io/crate/lucene/CharacterEqQueryTest.java
+++ b/server/src/test/java/io/crate/lucene/CharacterEqQueryTest.java
@@ -100,7 +100,7 @@ public class CharacterEqQueryTest extends LuceneQueryBuilderTest {
         Query query = convert("arr1 = ['abc  ']");
         assertThat(query).isExactlyInstanceOf(BooleanQuery.class);
         BooleanClause clause = ((BooleanQuery) query).clauses().getFirst();
-        query = clause.getQuery();
+        query = clause.query();
         assertThat(query)
             .isExactlyInstanceOf(TermInSetQuery.class)
             .hasToString("arr1:(abc)");
@@ -108,7 +108,7 @@ public class CharacterEqQueryTest extends LuceneQueryBuilderTest {
         query = convert("arr2 = ['ab  c  ']");
         assertThat(query).isExactlyInstanceOf(BooleanQuery.class);
         clause = ((BooleanQuery) query).clauses().getFirst();
-        query = clause.getQuery();
+        query = clause.query();
         // SortedSetDocValuesField.newSlowSetQuery is equal to TermInSetQuery + MultiTermQuery.DOC_VALUES_REWRITE
         assertThat(query).isExactlyInstanceOf(TermInSetQuery.class);
         assertThat(((TermInSetQuery) query).getRewriteMethod()).isEqualTo(MultiTermQuery.DOC_VALUES_REWRITE);
@@ -117,7 +117,7 @@ public class CharacterEqQueryTest extends LuceneQueryBuilderTest {
         query = convert("arr3 = ['abc   ']");
         assertThat(query).isExactlyInstanceOf(BooleanQuery.class);
         clause = ((BooleanQuery) query).clauses().getFirst();
-        query = clause.getQuery();
+        query = clause.query();
         assertThat(query)
             .isExactlyInstanceOf(TermInSetQuery.class)
             .hasToString("arr3:(abc)");

--- a/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -152,8 +152,8 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
         Query query = convert("y_array = [10, 20, 30]");
         assertThat(query).isExactlyInstanceOf(BooleanQuery.class);
         BooleanQuery booleanQuery = (BooleanQuery) query;
-        assertThat(booleanQuery.clauses().get(0).getQuery()).isInstanceOf(PointInSetQuery.class);
-        assertThat(booleanQuery.clauses().get(1).getQuery()).isExactlyInstanceOf(GenericFunctionQuery.class);
+        assertThat(booleanQuery.clauses().get(0).query()).isInstanceOf(PointInSetQuery.class);
+        assertThat(booleanQuery.clauses().get(1).query()).isExactlyInstanceOf(GenericFunctionQuery.class);
     }
 
     @Test
@@ -169,8 +169,8 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
         Query query = convert("y_array = ?", new Object[] { values });
         assertThat(query).isExactlyInstanceOf(BooleanQuery.class);
         BooleanQuery booleanQuery = (BooleanQuery) query;
-        assertThat(booleanQuery.clauses().get(0).getQuery()).isInstanceOf(PointInSetQuery.class);
-        assertThat(booleanQuery.clauses().get(1).getQuery()).isExactlyInstanceOf(GenericFunctionQuery.class);
+        assertThat(booleanQuery.clauses().get(0).query()).isInstanceOf(PointInSetQuery.class);
+        assertThat(booleanQuery.clauses().get(1).query()).isExactlyInstanceOf(GenericFunctionQuery.class);
     }
 
     @Test
@@ -338,8 +338,8 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
         BooleanClause existsClause = ((BooleanQuery) booleanQuery).clauses().get(0);
         BooleanClause intersectsClause = ((BooleanQuery) booleanQuery).clauses().get(1);
 
-        assertThat(existsClause.getQuery()).isExactlyInstanceOf(TermRangeQuery.class);
-        assertThat(intersectsClause.getQuery()).isExactlyInstanceOf(IntersectsPrefixTreeQuery.class);
+        assertThat(existsClause.query()).isExactlyInstanceOf(TermRangeQuery.class);
+        assertThat(intersectsClause.query()).isExactlyInstanceOf(IntersectsPrefixTreeQuery.class);
     }
 
     @Test
@@ -627,8 +627,8 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
         BooleanQuery booleanQuery = (BooleanQuery) query;
         assertThat(booleanQuery.clauses()).satisfiesExactly(
             // the query class is anonymous
-            x -> assertThat(x.getQuery().getClass().getName()).endsWith("LongPoint$1"),
-            x -> assertThat(x.getQuery().getClass().getName()).endsWith("LongPoint$1")
+            x -> assertThat(x.query().getClass().getName()).endsWith("LongPoint$1"),
+            x -> assertThat(x.query().getClass().getName()).endsWith("LongPoint$1")
         );
 
         query = convert("10 != ANY(x_array_no_docvalues)");
@@ -638,8 +638,8 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
         booleanQuery = (BooleanQuery) query;
         assertThat(booleanQuery.clauses()).satisfiesExactly(
             // the query class is anonymous
-            x -> assertThat(x.getQuery().getClass().getName()).doesNotEndWith("LongPoint$1"),
-            x -> assertThat(x.getQuery().getClass().getName()).doesNotEndWith("LongPoint$1")
+            x -> assertThat(x.query().getClass().getName()).doesNotEndWith("LongPoint$1"),
+            x -> assertThat(x.query().getClass().getName()).doesNotEndWith("LongPoint$1")
         );
     }
 

--- a/server/src/test/java/io/crate/lucene/DoubleEqQueryTest.java
+++ b/server/src/test/java/io/crate/lucene/DoubleEqQueryTest.java
@@ -95,14 +95,14 @@ public class DoubleEqQueryTest extends LuceneQueryBuilderTest {
         Query query = convert("arr1 = [1.1]");
         assertThat(query).isExactlyInstanceOf(BooleanQuery.class);
         BooleanClause clause = ((BooleanQuery) query).clauses().get(0);
-        query = clause.getQuery();
+        query = clause.query();
         assertThat(query.getClass().getName()).endsWith("DoublePoint$3"); // the query class is anonymous
         assertThat(query).hasToString("arr1:{1.1}");
 
         query = convert("arr2 = [1.1]");
         assertThat(query).isExactlyInstanceOf(BooleanQuery.class);
         clause = ((BooleanQuery) query).clauses().get(0);
-        query = clause.getQuery();
+        query = clause.query();
         // SortedNumericDocValuesRangeQuery.class is not public
         assertThat(query.getClass().getName()).endsWith("SortedNumericDocValuesSetQuery");
         long l = NumericUtils.doubleToSortableLong(1.1);
@@ -111,7 +111,7 @@ public class DoubleEqQueryTest extends LuceneQueryBuilderTest {
         query = convert("arr3 = [1.1]");
         assertThat(query).isExactlyInstanceOf(BooleanQuery.class);
         clause = ((BooleanQuery) query).clauses().get(0);
-        query = clause.getQuery();
+        query = clause.query();
         assertThat(query.getClass().getName()).endsWith("DoublePoint$3"); // the query class is anonymous
         assertThat(query).hasToString("arr3:{1.1}");
 

--- a/server/src/test/java/io/crate/lucene/FloatEqQueryTest.java
+++ b/server/src/test/java/io/crate/lucene/FloatEqQueryTest.java
@@ -95,14 +95,14 @@ public class FloatEqQueryTest extends LuceneQueryBuilderTest {
         Query query = convert("arr1 = [1.1]");
         assertThat(query).isExactlyInstanceOf(BooleanQuery.class);
         BooleanClause clause = ((BooleanQuery) query).clauses().get(0);
-        query = clause.getQuery();
+        query = clause.query();
         assertThat(query.getClass().getName()).endsWith("FloatPoint$3"); // the query class is anonymous
         assertThat(query).hasToString("arr1:{1.1}");
 
         query = convert("arr2 = [1.1]");
         assertThat(query).isExactlyInstanceOf(BooleanQuery.class);
         clause = ((BooleanQuery) query).clauses().get(0);
-        query = clause.getQuery();
+        query = clause.query();
         // SortedNumericDocValuesRangeQuery.class is not public
         assertThat(query.getClass().getName()).endsWith("SortedNumericDocValuesSetQuery");
         long l = NumericUtils.floatToSortableInt(1.1f);
@@ -111,7 +111,7 @@ public class FloatEqQueryTest extends LuceneQueryBuilderTest {
         query = convert("arr3 = [1.1]");
         assertThat(query).isExactlyInstanceOf(BooleanQuery.class);
         clause = ((BooleanQuery) query).clauses().get(0);
-        query = clause.getQuery();
+        query = clause.query();
         assertThat(query.getClass().getName()).endsWith("FloatPoint$3"); // the query class is anonymous
         assertThat(query).hasToString("arr3:{1.1}");
 

--- a/server/src/test/java/io/crate/lucene/IntEqQueryTest.java
+++ b/server/src/test/java/io/crate/lucene/IntEqQueryTest.java
@@ -90,21 +90,21 @@ public class IntEqQueryTest extends LuceneQueryBuilderTest {
         Query query = convert("arr1 = [1,2,3]");
         assertThat(query).isExactlyInstanceOf(BooleanQuery.class);
         BooleanClause clause = ((BooleanQuery) query).clauses().get(0);
-        query = clause.getQuery();
+        query = clause.query();
         assertThat(query.getClass().getName()).endsWith("IntPoint$3");
         assertThat(query).hasToString("arr1:{1 2 3}");
 
         query = convert("arr2 = [1,2,3]");
         assertThat(query).isExactlyInstanceOf(BooleanQuery.class);
         clause = ((BooleanQuery) query).clauses().get(0);
-        query = clause.getQuery();
+        query = clause.query();
         assertThat(query.getClass().getName()).endsWith("SortedNumericDocValuesSetQuery");
         assertThat(query).hasToString("arr2: [1, 2, 3]");
 
         query = convert("arr3 = [1,2,3]");
         assertThat(query).isExactlyInstanceOf(BooleanQuery.class);
         clause = ((BooleanQuery) query).clauses().get(0);
-        query = clause.getQuery();
+        query = clause.query();
         assertThat(query.getClass().getName()).endsWith("IntPoint$3");
         assertThat(query).hasToString("arr3:{1 2 3}");
 

--- a/server/src/test/java/io/crate/lucene/IpEqQueryTest.java
+++ b/server/src/test/java/io/crate/lucene/IpEqQueryTest.java
@@ -73,14 +73,14 @@ public class IpEqQueryTest extends LuceneQueryBuilderTest {
         Query query = convert("arr1 = ['1.1.1.1']");
         assertThat(query).isExactlyInstanceOf(BooleanQuery.class);
         BooleanClause clause = ((BooleanQuery) query).clauses().getFirst();
-        query = clause.getQuery();
+        query = clause.query();
         assertThat(query.getClass().getName()).endsWith("InetAddressPoint$3"); // the query class is anonymous
         assertThat(query).hasToString("arr1:{1.1.1.1}");
 
         query = convert("arr2 = ['1.1.1.1']");
         assertThat(query).isExactlyInstanceOf(BooleanQuery.class);
         clause = ((BooleanQuery) query).clauses().getFirst();
-        query = clause.getQuery();
+        query = clause.query();
         // SortedSetDocValuesField.newSlowSetQuery is equal to TermInSetQuery + MultiTermQuery.DOC_VALUES_REWRITE
         assertThat(query).isExactlyInstanceOf(TermInSetQuery.class);
         assertThat(((TermInSetQuery) query).getRewriteMethod()).isEqualTo(MultiTermQuery.DOC_VALUES_REWRITE);

--- a/server/src/test/java/io/crate/lucene/LikeQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/LikeQueryBuilderTest.java
@@ -51,7 +51,7 @@ public class LikeQueryBuilderTest extends LuceneQueryBuilderTest {
         assertThat(likeBQuery.clauses()).hasSize(3);
         for (int i = 0; i < 2; i++) {
             // like --> ConstantScoreQuery with regexp-filter
-            Query filteredQuery = likeBQuery.clauses().get(i).getQuery();
+            Query filteredQuery = likeBQuery.clauses().get(i).query();
             assertThat(filteredQuery).isExactlyInstanceOf(WildcardQuery.class);
         }
     }
@@ -63,7 +63,7 @@ public class LikeQueryBuilderTest extends LuceneQueryBuilderTest {
         BooleanQuery likeBQuery = (BooleanQuery) likeQuery;
         assertThat(likeBQuery.clauses()).hasSize(3);
         for (int i = 0; i < 2; i++) {
-            Query filteredQuery = likeBQuery.clauses().get(i).getQuery();
+            Query filteredQuery = likeBQuery.clauses().get(i).query();
             assertThat(filteredQuery).isExactlyInstanceOf(CrateRegexQuery.class);
         }
     }
@@ -75,11 +75,11 @@ public class LikeQueryBuilderTest extends LuceneQueryBuilderTest {
         BooleanQuery notLikeBQuery = (BooleanQuery) notLikeQuery;
         assertThat(notLikeBQuery.clauses()).hasSize(2);
         BooleanClause clause = notLikeBQuery.clauses().get(1);
-        assertThat(clause.getOccur()).isEqualTo(BooleanClause.Occur.MUST_NOT);
-        assertThat(((BooleanQuery) clause.getQuery()).clauses()).hasSize(3);
-        for (BooleanClause innerClause : ((BooleanQuery) clause.getQuery()).clauses()) {
-            assertThat(innerClause.getOccur()).isEqualTo(BooleanClause.Occur.MUST);
-            assertThat(innerClause.getQuery()).isExactlyInstanceOf(WildcardQuery.class);
+        assertThat(clause.occur()).isEqualTo(BooleanClause.Occur.MUST_NOT);
+        assertThat(((BooleanQuery) clause.query()).clauses()).hasSize(3);
+        for (BooleanClause innerClause : ((BooleanQuery) clause.query()).clauses()) {
+            assertThat(innerClause.occur()).isEqualTo(BooleanClause.Occur.MUST);
+            assertThat(innerClause.query()).isExactlyInstanceOf(WildcardQuery.class);
         }
     }
 
@@ -90,11 +90,11 @@ public class LikeQueryBuilderTest extends LuceneQueryBuilderTest {
         BooleanQuery notLikeBQuery = (BooleanQuery) notLikeQuery;
         assertThat(notLikeBQuery.clauses()).hasSize(2);
         BooleanClause clause = notLikeBQuery.clauses().get(1);
-        assertThat(clause.getOccur()).isEqualTo(BooleanClause.Occur.MUST_NOT);
-        assertThat(((BooleanQuery) clause.getQuery()).clauses()).hasSize(3);
-        for (BooleanClause innerClause : ((BooleanQuery) clause.getQuery()).clauses()) {
-            assertThat(innerClause.getOccur()).isEqualTo(BooleanClause.Occur.MUST);
-            assertThat(innerClause.getQuery()).isExactlyInstanceOf(CrateRegexQuery.class);
+        assertThat(clause.occur()).isEqualTo(BooleanClause.Occur.MUST_NOT);
+        assertThat(((BooleanQuery) clause.query()).clauses()).hasSize(3);
+        for (BooleanClause innerClause : ((BooleanQuery) clause.query()).clauses()) {
+            assertThat(innerClause.occur()).isEqualTo(BooleanClause.Occur.MUST);
+            assertThat(innerClause.query()).isExactlyInstanceOf(CrateRegexQuery.class);
         }
     }
 

--- a/server/src/test/java/io/crate/lucene/StringEqQueryTest.java
+++ b/server/src/test/java/io/crate/lucene/StringEqQueryTest.java
@@ -114,14 +114,14 @@ public class StringEqQueryTest extends LuceneQueryBuilderTest {
         Query query = convert("arr1 = ['abc']");
         assertThat(query).isExactlyInstanceOf(BooleanQuery.class);
         BooleanClause clause = ((BooleanQuery) query).clauses().get(0);
-        query = clause.getQuery();
+        query = clause.query();
         assertThat(query).isExactlyInstanceOf(TermInSetQuery.class);
         assertThat(query).hasToString("arr1:(abc)");
 
         query = convert("arr2 = ['abc']");
         assertThat(query).isExactlyInstanceOf(BooleanQuery.class);
         clause = ((BooleanQuery) query).clauses().get(0);
-        query = clause.getQuery();
+        query = clause.query();
         // SortedSetDocValuesField.newSlowSetQuery is equal to TermInSetQuery + MultiTermQuery.DOC_VALUES_REWRITE
         assertThat(query).isExactlyInstanceOf(TermInSetQuery.class);
         assertThat(((TermInSetQuery) query).getRewriteMethod()).isEqualTo(MultiTermQuery.DOC_VALUES_REWRITE);
@@ -130,7 +130,7 @@ public class StringEqQueryTest extends LuceneQueryBuilderTest {
         query = convert("arr3 = ['abc']");
         assertThat(query).isExactlyInstanceOf(BooleanQuery.class);
         clause = ((BooleanQuery) query).clauses().get(0);
-        query = clause.getQuery();
+        query = clause.query();
         assertThat(query).isExactlyInstanceOf(TermInSetQuery.class);
         assertThat(query).hasToString("arr3:(abc)");
 
@@ -141,14 +141,14 @@ public class StringEqQueryTest extends LuceneQueryBuilderTest {
         query = convert("arr5 = ['abc']");
         assertThat(query).isExactlyInstanceOf(BooleanQuery.class);
         clause = ((BooleanQuery) query).clauses().get(0);
-        query = clause.getQuery();
+        query = clause.query();
         assertThat(query).isExactlyInstanceOf(TermInSetQuery.class);
         assertThat(query).hasToString("arr5:(abc)");
 
         query = convert("arr6 = ['abc']");
         assertThat(query).isExactlyInstanceOf(BooleanQuery.class);
         clause = ((BooleanQuery) query).clauses().get(0);
-        query = clause.getQuery();
+        query = clause.query();
         assertThat(query).isExactlyInstanceOf(TermInSetQuery.class);
         assertThat(query).hasToString("arr6:(abc)");
     }

--- a/server/src/test/java/io/crate/lucene/WithinQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/WithinQueryBuilderTest.java
@@ -66,13 +66,13 @@ public class WithinQueryBuilderTest extends LuceneQueryBuilderTest {
         // dateline crossing happens in a geo context when a polygon rectangle is wider than 180 degrees
         Query eqWithinQuery = convert("within(point, 'POLYGON((-95.0 10.0, -95.0 20.0, 95.0 20.0, 95.0 10.0, -95.0 10.0))')");
         assertThat(eqWithinQuery).hasToString(
-            "LatLonPointQuery: field=point:[[10.0, 180.0] [20.0, 180.0] [20.0, 95.0] [10.0, 95.0] [10.0, 180.0] [10.0, -180.0] [10.0, -95.0] [20.0, -95.0] [20.0, -180.0] [10.0, -180.0] [10.0, 180.0] ,]");
+            "LatLonPointQuery: field=point:[Polygon[10.0, 180.0] [20.0, 180.0] [20.0, 95.0] [10.0, 95.0] [10.0, 180.0] [10.0, -180.0] [10.0, -95.0] [20.0, -95.0] [20.0, -180.0] [10.0, -180.0] [10.0, 180.0] ,]");
     }
 
     @Test
     public void test_point_within_rectangle_with_explicit_bool_equality_check_optimizes_to_lat_lon_point_query() throws Exception {
         Query query = convert("within(point, 'POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))') = true");
         assertThat(query).hasToString(
-            "LatLonPointQuery: field=point:[[40.0, 40.0] [40.0, 20.0] [20.0, 10.0] [10.0, 30.0] [40.0, 40.0] ,]");
+            "LatLonPointQuery: field=point:[Polygon[40.0, 40.0] [40.0, 20.0] [20.0, 10.0] [10.0, 30.0] [40.0, 40.0] ,]");
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/IndexServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexServiceTests.java
@@ -299,7 +299,7 @@ public class IndexServiceTests extends IntegTestCase {
             // we are running on updateMetadata if the interval changes
             try (Engine.Searcher searcher = shard.acquireSearcher(indexName)) {
                 TopDocs search = searcher.search(new MatchAllDocsQuery(), 10);
-                assertThat(search.totalHits.value).isEqualTo(1);
+                assertThat(search.totalHits.value()).isEqualTo(1);
             }
         });
         assertThat(refreshTask.isClosed()).isFalse();
@@ -312,7 +312,7 @@ public class IndexServiceTests extends IntegTestCase {
             // this one becomes visible due to the force refresh we are running on updateMetadata if the interval changes
             try (Engine.Searcher searcher = shard.acquireSearcher(indexName)) {
                 TopDocs search = searcher.search(new MatchAllDocsQuery(), 10);
-                assertThat(search.totalHits.value).isEqualTo(2);
+                assertThat(search.totalHits.value()).isEqualTo(2);
             }
         });
         execute("insert into test (x, data) values (3, 'foo')");
@@ -321,7 +321,7 @@ public class IndexServiceTests extends IntegTestCase {
             // this one becomes visible due to the scheduled refresh
             try (Engine.Searcher searcher = shard.acquireSearcher("test")) {
                 TopDocs search = searcher.search(new MatchAllDocsQuery(), 10);
-                assertThat(search.totalHits.value).isEqualTo(3);
+                assertThat(search.totalHits.value()).isEqualTo(3);
             }
         });
     }

--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -790,7 +790,7 @@ public class InternalEngineTests extends EngineTestCase {
             recoveringEngine.refresh("test");
             try (Engine.Searcher searcher = recoveringEngine.acquireSearcher("test")) {
                 TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), docs);
-                assertThat(topDocs.totalHits.value).isEqualTo(docs);
+                assertThat(topDocs.totalHits.value()).isEqualTo(docs);
             }
         } finally {
             IOUtils.close(initialEngine, recoveringEngine, store);
@@ -3071,7 +3071,7 @@ public class InternalEngineTests extends EngineTestCase {
             engine.skipTranslogRecovery();
             try (Engine.Searcher searcher = engine.acquireSearcher("test", Engine.SearcherScope.INTERNAL)) {
                 TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), randomIntBetween(numDocs, numDocs + 10));
-                assertThat(topDocs.totalHits.value).isEqualTo(0L);
+                assertThat(topDocs.totalHits.value()).isEqualTo(0L);
             }
         }
     }
@@ -3124,7 +3124,7 @@ public class InternalEngineTests extends EngineTestCase {
         assertThat(result.getVersion()).isEqualTo(2L);
         try (Engine.Searcher searcher = engine.acquireSearcher("test")) {
             TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), numDocs + 1);
-            assertThat(topDocs.totalHits.value).isEqualTo(numDocs + 1L);
+            assertThat(topDocs.totalHits.value()).isEqualTo(numDocs + 1L);
         }
 
         engine.close();
@@ -3133,7 +3133,7 @@ public class InternalEngineTests extends EngineTestCase {
         engine.refresh("warm_up");
         try (Engine.Searcher searcher = engine.acquireSearcher("test")) {
             TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), numDocs + 1);
-            assertThat(topDocs.totalHits.value).isEqualTo(numDocs + 1L);
+            assertThat(topDocs.totalHits.value()).isEqualTo(numDocs + 1L);
         }
         engine.delete(new Engine.Delete(
             Integer.toString(randomId),
@@ -3154,7 +3154,7 @@ public class InternalEngineTests extends EngineTestCase {
         engine.refresh("test");
         try (Engine.Searcher searcher = engine.acquireSearcher("test")) {
             TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), numDocs);
-            assertThat(topDocs.totalHits.value).isEqualTo((long) numDocs);
+            assertThat(topDocs.totalHits.value()).isEqualTo((long) numDocs);
         }
     }
 
@@ -3510,7 +3510,7 @@ public class InternalEngineTests extends EngineTestCase {
         engine.refresh("test");
         try (Engine.Searcher searcher = engine.acquireSearcher("test")) {
             TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), 10);
-            assertThat(topDocs.totalHits.value).isEqualTo(1);
+            assertThat(topDocs.totalHits.value()).isEqualTo(1);
         }
         operation = appendOnlyPrimary(doc, false, 1, create);
         retry = appendOnlyPrimary(doc, true, 1, create);
@@ -3545,7 +3545,7 @@ public class InternalEngineTests extends EngineTestCase {
         engine.refresh("test");
         try (Engine.Searcher searcher = engine.acquireSearcher("test")) {
             TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), 10);
-            assertThat(topDocs.totalHits.value).isEqualTo(1);
+            assertThat(topDocs.totalHits.value()).isEqualTo(1);
         }
     }
 
@@ -3599,7 +3599,7 @@ public class InternalEngineTests extends EngineTestCase {
         engine.refresh("test");
         try (Engine.Searcher searcher = engine.acquireSearcher("test")) {
             TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), 10);
-            assertThat(topDocs.totalHits.value).isEqualTo(0);
+            assertThat(topDocs.totalHits.value()).isEqualTo(0);
         }
     }
 
@@ -3619,7 +3619,7 @@ public class InternalEngineTests extends EngineTestCase {
         engine.refresh("test");
         try (Engine.Searcher searcher = engine.acquireSearcher("test")) {
             TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), 10);
-            assertThat(topDocs.totalHits.value).isEqualTo(1);
+            assertThat(topDocs.totalHits.value()).isEqualTo(1);
         }
 
         final boolean create = randomBoolean();
@@ -3659,7 +3659,7 @@ public class InternalEngineTests extends EngineTestCase {
         engine.refresh("test");
         try (Engine.Searcher searcher = engine.acquireSearcher("test")) {
             TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), 10);
-            assertThat(topDocs.totalHits.value).isEqualTo(1);
+            assertThat(topDocs.totalHits.value()).isEqualTo(1);
         }
     }
 
@@ -3700,12 +3700,12 @@ public class InternalEngineTests extends EngineTestCase {
         engine.refresh("test");
         try (Engine.Searcher searcher = engine.acquireSearcher("test")) {
             TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), 10);
-            assertThat(topDocs.totalHits.value).isEqualTo(1);
+            assertThat(topDocs.totalHits.value()).isEqualTo(1);
         }
         engine.refresh("test");
         try (Engine.Searcher searcher = engine.acquireSearcher("test")) {
             TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), 10);
-            assertThat(topDocs.totalHits.value).isEqualTo(1);
+            assertThat(topDocs.totalHits.value()).isEqualTo(1);
         }
         if (engine.engineConfig.getIndexSettings().isSoftDeleteEnabled()) {
             List<Translog.Operation> ops = readAllOperationsInLucene(engine);
@@ -3764,7 +3764,7 @@ public class InternalEngineTests extends EngineTestCase {
         engine.refresh("test");
         try (Engine.Searcher searcher = engine.acquireSearcher("test")) {
             TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), 10);
-            assertThat(topDocs.totalHits.value).isEqualTo(1);
+            assertThat(topDocs.totalHits.value()).isEqualTo(1);
         }
 
         index = new Engine.Index(newUid(doc), doc, indexResult.getSeqNo(), index.primaryTerm(), indexResult.getVersion(),
@@ -3774,7 +3774,7 @@ public class InternalEngineTests extends EngineTestCase {
         replicaEngine.refresh("test");
         try (Engine.Searcher searcher = replicaEngine.acquireSearcher("test")) {
             TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), 10);
-            assertThat(topDocs.totalHits.value).isEqualTo(1);
+            assertThat(topDocs.totalHits.value()).isEqualTo(1);
         }
     }
 
@@ -3827,7 +3827,7 @@ public class InternalEngineTests extends EngineTestCase {
         engine.refresh("test");
         try (Engine.Searcher searcher = engine.acquireSearcher("test")) {
             TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), 10);
-            assertThat(topDocs.totalHits.value).isEqualTo(1);
+            assertThat(topDocs.totalHits.value()).isEqualTo(1);
         }
 
         Engine.Index secondIndexRequestReplica = new Engine.Index(newUid(doc), doc, result.getSeqNo(), secondIndexRequest.primaryTerm(),
@@ -3836,7 +3836,7 @@ public class InternalEngineTests extends EngineTestCase {
         replicaEngine.refresh("test");
         try (Engine.Searcher searcher = replicaEngine.acquireSearcher("test")) {
             TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), 10);
-            assertThat(topDocs.totalHits.value).isEqualTo(1);
+            assertThat(topDocs.totalHits.value()).isEqualTo(1);
         }
     }
 
@@ -5847,7 +5847,7 @@ public class InternalEngineTests extends EngineTestCase {
                 engine.refresh("test");
                 try (Engine.Searcher searcher = engine.acquireSearcher("test")) {
                     LeafReader leafReader = getOnlyLeafReader(searcher.getIndexReader());
-                    assertThat(leafReader.getMetaData().getCreatedVersionMajor()).isEqualTo(createdVersion.luceneVersion.major);
+                    assertThat(leafReader.getMetaData().createdVersionMajor()).isEqualTo(createdVersion.luceneVersion.major);
                 }
             }
         }

--- a/server/src/test/java/org/elasticsearch/index/store/FsDirectoryFactoryTests.java
+++ b/server/src/test/java/org/elasticsearch/index/store/FsDirectoryFactoryTests.java
@@ -79,7 +79,7 @@ public class FsDirectoryFactoryTests extends ESTestCase {
                     assertThat(directory instanceof MMapDirectory).as(type + " " + directory.toString()).isTrue();
                     break;
                 case FS:
-                    if (Constants.JRE_IS_64BIT && MMapDirectory.UNMAP_SUPPORTED) {
+                    if (Constants.JRE_IS_64BIT) {
                         assertThat(FsDirectoryFactory.isHybridFs(directory)).isTrue();
                     } else {
                         assertThat(directory instanceof NIOFSDirectory).as(directory.toString()).isTrue();

--- a/server/src/testFixtures/java/org/elasticsearch/indices/analysis/AnalysisFactoryTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/indices/analysis/AnalysisFactoryTestCase.java
@@ -144,6 +144,7 @@ public abstract class AnalysisFactoryTestCase extends ESTestCase {
         entry("portugueselightstem", MovedToAnalysisCommon.class),
         entry("portugueseminimalstem", MovedToAnalysisCommon.class),
         entry("reversestring", MovedToAnalysisCommon.class),
+        entry("romaniannormalization", MovedToAnalysisCommon.class),
         entry("russianlightstem", MovedToAnalysisCommon.class),
         entry("scandinavianfolding", MovedToAnalysisCommon.class),
         entry("scandinaviannormalization", MovedToAnalysisCommon.class),

--- a/server/src/testFixtures/java/org/elasticsearch/test/CorruptionUtils.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/CorruptionUtils.java
@@ -84,7 +84,7 @@ public final class CorruptionUtils {
 
             long checksumAfterCorruption;
             long actualChecksumAfterCorruption;
-            try (ChecksumIndexInput input = dir.openChecksumInput(fileToCorrupt.getFileName().toString(), IOContext.READONCE)) {
+            try (ChecksumIndexInput input = dir.openChecksumInput(fileToCorrupt.getFileName().toString())) {
                 assertThat(input.getFilePointer()).isEqualTo(0L);
                 input.seek(input.length() - 8); // one long is the checksum... 8 bytes
                 checksumAfterCorruption = input.getChecksum();

--- a/server/src/testFixtures/java/org/elasticsearch/test/engine/ThrowingLeafReaderWrapper.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/engine/ThrowingLeafReaderWrapper.java
@@ -19,8 +19,9 @@
 
 package org.elasticsearch.test.engine;
 
+import java.io.IOException;
+
 import org.apache.lucene.index.BinaryDocValues;
-import org.apache.lucene.index.Fields;
 import org.apache.lucene.index.FilterLeafReader;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.NumericDocValues;
@@ -31,8 +32,6 @@ import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.automaton.CompiledAutomaton;
-
-import java.io.IOException;
 
 /**
  * An FilterLeafReader that allows to throw exceptions if certain methods
@@ -89,35 +88,6 @@ public class ThrowingLeafReaderWrapper extends FilterLeafReader {
             return terms == null ? null : new ThrowingTerms(terms, thrower);
         }
         return terms;
-    }
-
-    @Override
-    public Fields getTermVectors(int docID) throws IOException {
-        Fields fields = super.getTermVectors(docID);
-        thrower.maybeThrow(Flags.TermVectors);
-        return fields == null ? null : new ThrowingFields(fields, thrower);
-    }
-
-    /**
-     * Wraps a Fields but with additional asserts
-     */
-    public static class ThrowingFields extends FilterFields {
-        private final Thrower thrower;
-
-        public ThrowingFields(Fields in, Thrower thrower) {
-            super(in);
-            this.thrower = thrower;
-        }
-
-        @Override
-        public Terms terms(String field) throws IOException {
-            Terms terms = super.terms(field);
-            if (thrower.wrapTerms(field)) {
-                thrower.maybeThrow(Flags.Terms);
-                return terms == null ? null : new ThrowingTerms(terms, thrower);
-            }
-            return terms;
-        }
     }
 
     /**


### PR DESCRIPTION
User facing changes:
- Removal of `dutch_kp` and `lovins` stemmers - users will need to reindex with different stemmers before upgrade
- `german` and `german2` stemmers now both fold umlauts - users will need to reindex after upgrade