### PR TITLE
Fix persistence of metadata's schemas

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -424,6 +424,9 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
         if (metadata1.columnOID != metadata2.columnOID) {
             return false;
         }
+        if (!metadata1.schemas.equals(metadata2.schemas)) {
+            return false;
+        }
 
         // Check if any persistent metadata needs to be saved
         int customCount1 = 0;


### PR DESCRIPTION
The new schemas weren't taken into account when checking if the global state changes. By this, schemas weren't persisted at all.

Follow up of https://github.com/crate/crate/commit/bb09dbc.