### PR TITLE
Add native access/vector flags to jvm settings in debug config

### DIFF
--- a/.idea/runConfigurations/CrateDB.xml
+++ b/.idea/runConfigurations/CrateDB.xml
@@ -3,7 +3,7 @@
     <option name="MAIN_CLASS_NAME" value="io.crate.bootstrap.CrateDB" />
     <module name="crate-app" />
     <option name="PROGRAM_PARAMETERS" value="-Cpath.home=$PROJECT_DIR$/sandbox/crate" />
-    <option name="VM_PARAMETERS" value="-Dlog4j.shutdownHookEnabled=false -Dlog4j.skipJansi=true" />
+    <option name="VM_PARAMETERS" value="-Dlog4j.shutdownHookEnabled=false -Dlog4j.skipJansi=true --enable-native-access=ALL-UNNAMED --add-modules jdk.incubator.vector" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/app" />
     <RunnerSettings RunnerId="Debug">
       <option name="DEBUG_PORT" value="" />

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
             "name": "Debug CrateDB",
             "args": "-Cpath.home=${workspaceFolder}/sandbox/crate",
             "cwd": "${workspaceFolder}/app",
-            "vmArgs": "-Xms2G -Xmx2G",
+            "vmArgs": "-Xms2G -Xmx2G --enable-native-access=ALL-UNNAMED --add-modules jdk.incubator.vector",
             "mainClass": "io.crate.bootstrap.CrateDB",
             "console": "integratedTerminal"
         },
@@ -17,7 +17,7 @@
             "name": "Debug CrateDB Node 2",
             "args": "-Cpath.home=${workspaceFolder}/sandbox/crate2",
             "cwd": "${workspaceFolder}/app",
-            "vmArgs": "-Xms2G -Xmx2G",
+            "vmArgs": "-Xms2G -Xmx2G --enable-native-access=ALL-UNNAMED --add-modules jdk.incubator.vector",
             "mainClass": "io.crate.bootstrap.CrateDB",
             "console": "integratedTerminal"
         },
@@ -27,7 +27,7 @@
             "name": "Run CrateDB",
             "args": "-Cpath.home=${workspaceFolder}/sandbox/crate",
             "cwd": "${workspaceFolder}/app",
-            "vmArgs": "-Xms2G -Xmx2G",
+            "vmArgs": "-Xms2G -Xmx2G --enable-native-access=ALL-UNNAMED --add-modules jdk.incubator.vector",
             "mainClass": "io.crate.bootstrap.CrateDB",
             "console": "integratedTerminal",
             "noDebug": true


### PR DESCRIPTION
To avoid warnings from Lucene
