### PR TITLE
Add BWC code to blob tables resolution

### DIFF
--- a/server/src/main/java/io/crate/metadata/blob/BlobTableInfoFactory.java
+++ b/server/src/main/java/io/crate/metadata/blob/BlobTableInfoFactory.java
@@ -23,13 +23,20 @@ package io.crate.metadata.blob;
 
 import java.nio.file.Path;
 
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
-import org.elasticsearch.cluster.metadata.RelationMetadata.BlobTable;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.RelationMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexNotFoundException;
+import org.jetbrains.annotations.Nullable;
 
+import io.crate.blob.v2.BlobIndex;
 import io.crate.blob.v2.BlobIndicesService;
 import io.crate.exceptions.RelationUnknown;
 import io.crate.metadata.RelationName;
@@ -51,14 +58,36 @@ public class BlobTableInfoFactory {
         this.globalBlobPath = BlobIndicesService.getGlobalBlobPath(settings);
     }
 
-    public BlobTableInfo create(RelationName ident, ClusterState clusterState) {
-        BlobTable blobTable = clusterState.metadata().getRelation(ident);
-        if (blobTable == null) {
-            throw new RelationUnknown(ident);
+    @Nullable
+    private IndexMetadata resolveIndexMetadata(String tableName, Metadata metadata) {
+        String indexName = BlobIndex.fullIndexName(tableName);
+        Index index;
+        try {
+            index = IndexNameExpressionResolver.concreteIndices(metadata, IndicesOptions.STRICT_EXPAND_OPEN, indexName)[0];
+        } catch (IndexNotFoundException ex) {
+            // Fallback to 6.0+
+            return null;
         }
-        IndexMetadata indexMetadata = clusterState.metadata().indexByUUID(blobTable.indexUUID());
+        return metadata.index(index);
+    }
+
+    public BlobTableInfo create(RelationName ident, ClusterState clusterState) {
+
+        // Blob tables can be read from pre-6.0 state, try to resolve it in the old way
+        // TODO: Remove BWC code on a version that won't read persisted state from <6.0.0
+        IndexMetadata indexMetadata = resolveIndexMetadata(ident.name(), clusterState.metadata());
+
         if (indexMetadata == null) {
-            throw new RelationUnknown(ident);
+            // Read blob table persisted in version 6.0+
+            RelationMetadata.BlobTable blobTable = clusterState.metadata().getRelation(ident);
+            if (blobTable == null) {
+
+                throw new RelationUnknown(ident);
+            }
+            indexMetadata = clusterState.metadata().indexByUUID(blobTable.indexUUID());
+            if (indexMetadata == null) {
+                throw new RelationUnknown(ident);
+            }
         }
         Settings settings = indexMetadata.getSettings();
         return new BlobTableInfo(


### PR DESCRIPTION
Follow up to https://github.com/crate/crate/commit/bb09dbc18b915a7feaf5c85282334bdd89a32438 and https://github.com/crate/crate/commit/f0fdbbccd3fcc0f2b1dbba83fa49c4963af55b19

6.0 can read metadata from earlier versions. We store blobs differently from 6.0, need to keep BWC code.

No tests because crate-qa upgrade tests already catches that  (https://github.com/crate/crate-qa/pull/336)