### PR TITLE
Add storage compat change to release notes

### DIFF
--- a/docs/admin/system-information.rst
+++ b/docs/admin/system-information.rst
@@ -1648,6 +1648,9 @@ before you can upgrade to a future major version of CrateDB.
 If you try to upgrade to a later major CrateDB version without reindexing the
 tables, CrateDB will refuse to start.
 
+
+.. _table_version_compatibility:
+
 CrateDB table version compatibility scheme
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/appendices/release-notes/6.0.0.rst
+++ b/docs/appendices/release-notes/6.0.0.rst
@@ -43,15 +43,22 @@ Version 6.0.0 - Unreleased
 Breaking Changes
 ================
 
-- The ``dutch_kp`` and ``lovins`` token filters are no longer available, as they have
-  been removed from Apache Lucene 10.  If users have tables which use these token filters
-  for analysis, they will need to re-index with either plain ``dutch`` or ``english``
-  stemmers before upgrading.
+- Updated Lucene from 9.12 to 10.0 which brings the following user facing changes:
 
-- The ``german2`` and ``german`` token filters now use the same underlying stemmer,
-  which always expands ``ä``, ``ö`` and ``ü`` to ``ae``, ``oe`` and ``ue`` respectively.
-  If users have tables which were using the ``german`` stemmer without a character
-  filter that already did this, they will need to re-index after upgrading.
+  - Tables created in 4.x can't be read anymore. If you're running CrateDB 5.x
+    and have any tables created in 4.x they need to be reindexed before moving
+    to CrateDB 6.0. Make sure there are no warnings in the admin console and see
+    :ref:`table_version_compatibility` for more information.
+
+  - The ``dutch_kp`` and ``lovins`` token filters are no longer available. If
+    users have tables which use these token filters for analysis, they will need
+    to re-index with either plain ``dutch`` or ``english`` stemmers before
+    upgrading.
+
+  - The ``german2`` and ``german`` token filters now use the same underlying stemmer,
+    which always expands ``ä``, ``ö`` and ``ü`` to ``ae``, ``oe`` and ``ue`` respectively.
+    If users have tables which were using the ``german`` stemmer without a character
+    filter that already did this, they will need to re-index after upgrading.
 
 Deprecations
 ============


### PR DESCRIPTION
That tables created in 4.x won't work is already mentioned in the
warning block further above, but having no mention of it in the breaking
changes sections seems strange.
