### PR TITLE
Fix BWC handling in MetadataDiff for schemas

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -513,7 +513,11 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
             if (in.getVersion().onOrAfter(Version.V_6_0_0)) {
                 schemas = Diffs.readMapDiff(in, Diffs.stringKeySerializer(), SCHEMA_DIFF_VALUE_READER);
             } else {
-                schemas = Diffs.empty();
+                schemas = Diffs.diff(
+                    ImmutableOpenMap.<String, SchemaMetadata>of(),
+                    ImmutableOpenMap.<String, SchemaMetadata>of(),
+                    Diffs.stringKeySerializer()
+                );
             }
         }
 


### PR DESCRIPTION
`schemas` must be a `ImmutableMapDiff` instance. The
`apply(immutableMap)` call fails otherwise.

Noticed this while investigating failures on https://github.com/crate/crate-qa/pull/337 
