### PR TITLE
Deprecate usage of _version

### DIFF
--- a/docs/appendices/release-notes/6.0.0.rst
+++ b/docs/appendices/release-notes/6.0.0.rst
@@ -63,7 +63,9 @@ Breaking Changes
 Deprecations
 ============
 
-None
+ - Usage of :ref:`_version<sql_administration_system_column_version>` has been
+   deprecated completely. Please note that its usage for :ref:`sql_occ` has
+   already been deprecated since :ref:`version_4.0.0`.
 
 
 Changes

--- a/docs/general/ddl/system-columns.rst
+++ b/docs/general/ddl/system-columns.rst
@@ -17,10 +17,10 @@ and might contain underscores in between.
 
 .. NOTE::
 
-   Using the ``_version`` column for `Optimistic Concurrency Control`_ has been
-   deprecated in favour of using the :ref:`_seq_no
+   Usage of the ``_version`` column has been deprecated. For
+   `Optimistic Concurrency Control`_, :ref:`_seq_no
    <sql_administration_system_columns_seq_no>` and :ref:`_primary_term
-   <sql_administration_system_columns_primary_term>`.
+   <sql_administration_system_columns_primary_term>` should be used instead.
    See :ref:`sql_occ` for usage details.
 
 .. _sql_administration_system_columns_seq_no:

--- a/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -2984,4 +2984,14 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         Assertions.assertThat(analyzed.outputs()).hasSize(1);
         assertThat(analyzed.outputs().getFirst()).isFunction("subscript");
     }
+
+    @Test
+    public void test_deprecation_logging_for__version_col() throws Exception {
+        SQLExecutor executor = SQLExecutor.of(clusterService)
+            .addTable("create table t1 (id int)");
+
+        DocTableRelation.DEPRECATION_LOGGER.resetLRU();
+        executor.analyze("select _version from t1");
+        assertWarnings("_version system column is deprecated, please use _seq_no and _primary_term instead.");
+    }
 }

--- a/server/src/testFixtures/java/org/elasticsearch/test/ESTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/ESTestCase.java
@@ -355,7 +355,9 @@ public abstract class ESTestCase extends CrateLuceneTestCase {
                     l -> assertThat(l).anyMatch(s -> s.contains(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey())),
                     l -> assertThat(l).anyMatch(s -> s.contains(IndexSettings.INDEX_TRANSLOG_RETENTION_AGE_SETTING.getKey())),
                     l -> assertThat(l).anyMatch(s -> s.contains(IndexSettings.INDEX_TRANSLOG_RETENTION_SIZE_SETTING.getKey())),
-                    l -> assertThat(l).anyMatch(s -> s.contains(OptimizeTableSettings.UPGRADE_SEGMENTS.getKey())));
+                    l -> assertThat(l).anyMatch(s -> s.contains(OptimizeTableSettings.UPGRADE_SEGMENTS.getKey())),
+                    l -> assertThat(l).anyMatch(s -> s.contains("_version system column is deprecated, " +
+                        "please use _seq_no and _primary_term instead.")));
         } finally {
             DeprecationLogger.resetWarnings();
         }


### PR DESCRIPTION
Since` _version` has already been deprecated in docs for optimistic concurrency control, which was the actual purpose of the column, we deprecate its usage at any place of a query, so that it can be removed completely in the future.

