### PR TITLE
Fix transport handshake, handshake response sent wrong version

### DIFF
--- a/server/src/main/java/io/crate/protocols/postgres/PgClient.java
+++ b/server/src/main/java/io/crate/protocols/postgres/PgClient.java
@@ -597,6 +597,7 @@ public class PgClient extends AbstractClient {
                 action,
                 request,
                 options,
+                version,
                 connectionProfile.getCompressionEnabled(),
                 false // isHandshake
             );

--- a/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
@@ -89,9 +89,10 @@ public final class OutboundHandler {
                             final String action,
                             final TransportRequest request,
                             final TransportRequestOptions options,
+                            final Version channelVersion,
                             final boolean compressRequest,
                             final boolean isHandshake) throws IOException, TransportException {
-        Version version = this.version;
+        Version version = Version.min(this.version, channelVersion);
         OutboundMessage.Request message = new OutboundMessage.Request(
             request,
             version,
@@ -109,13 +110,14 @@ public final class OutboundHandler {
      * objects back to the caller.
      *
      */
-    void sendResponse(final CloseableChannel channel,
+    void sendResponse(final Version nodeVersion,
+                      final CloseableChannel channel,
                       final long requestId,
                       final String action,
                       final TransportResponse response,
                       final boolean compress,
                       final boolean isHandshake) throws IOException {
-        Version version = this.version;
+        Version version = Version.min(this.version, nodeVersion);
         OutboundMessage.Response message = new OutboundMessage.Response(
             response,
             version,
@@ -130,11 +132,12 @@ public final class OutboundHandler {
     /**
      * Sends back an error response to the caller via the given channel
      */
-    void sendErrorResponse(final CloseableChannel channel,
+    void sendErrorResponse(final Version nodeVersion,
+                           final CloseableChannel channel,
                            final long requestId,
                            final String action,
                            final Exception error) throws IOException {
-        Version version = this.version;
+        Version version = Version.min(this.version, nodeVersion);
         TransportAddress address = new TransportAddress(channel.getLocalAddress());
         RemoteTransportException tx = new RemoteTransportException(nodeName, address, action, error);
         OutboundMessage.Response message = new OutboundMessage.Response(

--- a/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -145,7 +145,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
         this.handshaker = new TransportHandshaker(version, threadPool,
             (node, channel, requestId, v) -> outboundHandler.sendRequest(node, channel, requestId,
                 TransportHandshaker.HANDSHAKE_ACTION_NAME, new TransportHandshaker.HandshakeRequest(version),
-                TransportRequestOptions.EMPTY, false, true));
+                TransportRequestOptions.EMPTY, v, false, true));
         this.keepAlive = new TransportKeepAlive(threadPool, this.outboundHandler::sendBytes);
         this.inboundHandler = new InboundHandler(threadPool, outboundHandler, namedWriteableRegistry, handshaker, keepAlive,
             requestHandlers, responseHandlers);
@@ -246,7 +246,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
                 throw new NodeNotConnectedException(node, "connection already closed");
             }
             CloseableChannel channel = channel(options.type());
-            outboundHandler.sendRequest(node, channel, requestId, action, request, options, compress, false);
+            outboundHandler.sendRequest(node, channel, requestId, action, request, options, getVersion(), compress, false);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/transport/TcpTransportChannel.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransportChannel.java
@@ -59,7 +59,7 @@ public final class TcpTransportChannel implements TransportChannel {
     @Override
     public void sendResponse(TransportResponse response) throws IOException {
         try {
-            outboundHandler.sendResponse(channel, requestId, action, response, compressResponse, isHandshake);
+            outboundHandler.sendResponse(version, channel, requestId, action, response, compressResponse, isHandshake);
         } finally {
             release(false);
         }
@@ -68,7 +68,7 @@ public final class TcpTransportChannel implements TransportChannel {
     @Override
     public void sendResponse(Exception exception) throws IOException {
         try {
-            outboundHandler.sendErrorResponse(channel, requestId, action, exception);
+            outboundHandler.sendErrorResponse(version, channel, requestId, action, exception);
         } finally {
             release(true);
         }

--- a/server/src/test/java/org/elasticsearch/transport/OutboundHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/OutboundHandlerTests.java
@@ -126,7 +126,7 @@ public class OutboundHandlerTests extends ESTestCase {
 
     @Test
     public void testSendRequest() throws IOException {
-        Version version = Version.CURRENT;
+        Version version = randomFrom(Version.CURRENT, Version.CURRENT.minimumCompatibilityVersion());;
         String action = "handshake";
         long requestId = randomLongBetween(0, 300);
         boolean isHandshake = randomBoolean();
@@ -148,7 +148,7 @@ public class OutboundHandlerTests extends ESTestCase {
                 requestRef.set(request);
             }
         });
-        handler.sendRequest(node, channel, requestId, action, request, options, compress, isHandshake);
+        handler.sendRequest(node, channel, requestId, action, request, options, version, compress, isHandshake);
 
         ByteBuf msg = (ByteBuf) embeddedChannel.outboundMessages().poll();
         BytesReference reference = Netty4Utils.toBytesReference(msg);
@@ -182,7 +182,7 @@ public class OutboundHandlerTests extends ESTestCase {
 
     @Test
     public void testSendResponse() throws IOException {
-        Version version = Version.CURRENT;
+        Version version = randomFrom(Version.CURRENT, Version.CURRENT.minimumCompatibilityVersion());;
         String action = "handshake";
         long requestId = randomLongBetween(0, 300);
         boolean isHandshake = randomBoolean();
@@ -201,7 +201,7 @@ public class OutboundHandlerTests extends ESTestCase {
                 responseRef.set(response);
             }
         });
-        handler.sendResponse(channel, requestId, action, response, compress, isHandshake);
+        handler.sendResponse(version, channel, requestId, action, response, compress, isHandshake);
 
         ByteBuf msg = (ByteBuf) embeddedChannel.outboundMessages().poll();
         BytesReference reference = Netty4Utils.toBytesReference(msg);
@@ -236,7 +236,7 @@ public class OutboundHandlerTests extends ESTestCase {
 
     @Test
     public void testErrorResponse() throws IOException {
-        Version version = Version.CURRENT;
+        Version version = randomFrom(Version.CURRENT, Version.CURRENT.minimumCompatibilityVersion());;
         String action = "handshake";
         long requestId = randomLongBetween(0, 300);
         ElasticsearchException error = new ElasticsearchException("boom");
@@ -252,7 +252,7 @@ public class OutboundHandlerTests extends ESTestCase {
                 responseRef.set(error);
             }
         });
-        handler.sendErrorResponse(channel, requestId, action, error);
+        handler.sendErrorResponse(version, channel, requestId, action, error);
 
         ByteBuf msg = (ByteBuf) embeddedChannel.outboundMessages().poll();
         BytesReference reference = Netty4Utils.toBytesReference(msg);


### PR DESCRIPTION
Fix the handshake response and outbound message handler to sent the minimum compatible version in the handshake response header to allow the handshake transport message decoding to work before a possible higher version is used after the handshake.

Follow up of https://github.com/crate/crate/commit/1773a41.

I've pushed a `crate-qa` draft to verify the rolling upgrade using this fix (branches) on both 5.10.1 and master:
 - 5.9.x -> 5.10.1
 - 5.10.1 -> 6.x

See https://github.com/crate/crate-qa/pull/338.