### PR TITLE
Flush instead of synced-flush inactive shards

### DIFF
--- a/docs/appendices/release-notes/6.0.0.rst
+++ b/docs/appendices/release-notes/6.0.0.rst
@@ -96,6 +96,10 @@ Performance and Resilience Improvements
 
 - Improved the performance of the queries involving ``= ALL`` array operator.
 
+- Improved the performance of :ref:`shard recovery<gloss-shard-recovery>` in
+  certain cases, where a shard has become idle after 5 minutes of no write
+  activity.
+
 Administration and Operations
 -----------------------------
 

--- a/server/src/main/java/org/elasticsearch/index/CompositeIndexEventListener.java
+++ b/server/src/main/java/org/elasticsearch/index/CompositeIndexEventListener.java
@@ -115,18 +115,6 @@ final class CompositeIndexEventListener implements IndexEventListener {
     }
 
     @Override
-    public void onShardInactive(IndexShard indexShard) {
-        for (IndexEventListener listener : listeners) {
-            try {
-                listener.onShardInactive(indexShard);
-            } catch (Exception e) {
-                logger.warn(() -> new ParameterizedMessage("[{}] failed to invoke on shard inactive callback", indexShard.shardId().id()), e);
-                throw e;
-            }
-        }
-    }
-
-    @Override
     public void indexShardStateChanged(IndexShard indexShard, @Nullable IndexShardState previousState, IndexShardState currentState, @Nullable String reason) {
         for (IndexEventListener listener : listeners) {
             try {

--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -21,7 +21,6 @@ package org.elasticsearch.index.engine;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -101,7 +100,6 @@ import org.elasticsearch.index.seqno.LocalCheckpointTracker;
 import org.elasticsearch.index.seqno.SeqNoStats;
 import org.elasticsearch.index.seqno.SequenceNumbers;
 import org.elasticsearch.index.shard.ShardId;
-import org.elasticsearch.index.store.Store;
 import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.index.translog.TranslogConfig;
 import org.elasticsearch.index.translog.TranslogCorruptedException;
@@ -222,7 +220,7 @@ public class InternalEngine extends Engine {
             mergeScheduler = scheduler = new EngineMergeScheduler(engineConfig.getShardId(), engineConfig.getIndexSettings());
             throttle = new IndexThrottle();
             try {
-                trimUnsafeCommits(engineConfig);
+                store.trimUnsafeCommits(engineConfig.getTranslogConfig().getTranslogPath());
                 translog = openTranslog(engineConfig, translogDeletionPolicy, engineConfig.getGlobalCheckpointSupplier(),
                     seqNo -> {
                         final LocalCheckpointTracker tracker = getLocalCheckpointTracker();
@@ -293,15 +291,6 @@ public class InternalEngine extends Engine {
             }
         }
         logger.trace("created new InternalEngine");
-    }
-
-    private static void trimUnsafeCommits(EngineConfig engineConfig) throws IOException {
-        final Store store = engineConfig.getStore();
-        final String translogUUID = store.readLastCommittedSegmentsInfo().getUserData().get(Translog.TRANSLOG_UUID_KEY);
-        final Path translogPath = engineConfig.getTranslogConfig().getTranslogPath();
-        final long globalCheckpoint = Translog.readGlobalCheckpoint(translogPath, translogUUID);
-        final long minRetainedTranslogGen = Translog.readMinTranslogGeneration(translogPath, translogUUID);
-        store.trimUnsafeCommits(globalCheckpoint, minRetainedTranslogGen, engineConfig.getIndexSettings().getIndexVersionCreated());
     }
 
     private LocalCheckpointTracker createLocalCheckpointTracker(

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexEventListener.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexEventListener.java
@@ -96,14 +96,6 @@ public interface IndexEventListener {
     }
 
     /**
-     * Called when a shard is marked as inactive
-     *
-     * @param indexShard The shard that was marked inactive
-     */
-    default void onShardInactive(IndexShard indexShard) {
-    }
-
-    /**
      * Called before the index gets created. Note that this is also called
      * when the index is created on data nodes
      */

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -1699,20 +1699,29 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     }
 
     /**
-     * Called by {@link IndexingMemoryController} to check whether more than {@code inactiveTimeNS} has passed since the last
-     * indexing operation, and notify listeners that we are now inactive so e.g. sync'd flush can happen.
+     * Called by {@link IndexingMemoryController} to check whether more than {@code inactiveTimeNS} has passed
+     * since the last indexing operation, so we can flush the index.
      */
-    public void checkIdle(long inactiveTimeNS) {
+    public void flushOnIdle(long inactiveTimeNS) {
         Engine engineOrNull = getEngineOrNull();
         if (engineOrNull != null && System.nanoTime() - engineOrNull.getLastWriteNanos() >= inactiveTimeNS) {
             boolean wasActive = active.getAndSet(false);
             if (wasActive) {
-                logger.debug("shard is now inactive");
-                try {
-                    indexEventListener.onShardInactive(this);
-                } catch (Exception e) {
-                    logger.warn("failed to notify index event listener", e);
-                }
+                logger.debug("flushing shard on inactive");
+                threadPool.executor(ThreadPool.Names.FLUSH).execute(new AbstractRunnable() {
+                    @Override
+                    public void onFailure(Exception e) {
+                        if (state != IndexShardState.CLOSED) {
+                            logger.warn("failed to flush shard on inactive", e);
+                        }
+                    }
+
+                    @Override
+                    protected void doRun() {
+                        flush(new FlushRequest().waitIfOngoing(false).force(false));
+                        periodicFlushMetric.inc();
+                    }
+                });
             }
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/server/src/main/java/org/elasticsearch/index/store/Store.java
@@ -1492,30 +1492,17 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
      * commit on the replica will cause exception as the new last commit c3 will have recovery_translog_gen=1. The recovery
      * translog generation of a commit is calculated based on the current local checkpoint. The local checkpoint of c3 is 1
      * while the local checkpoint of c2 is 2.
-     * <p>
-     * 3. Commit without translog can be used in recovery. An old index, which was created before multiple-commits is introduced
-     * (v6.2), may not have a safe commit. If that index has a snapshotted commit without translog and an unsafe commit,
-     * the policy can consider the snapshotted commit as a safe commit for recovery even the commit does not have translog.
      */
-    public void trimUnsafeCommits(final long lastSyncedGlobalCheckpoint, final long minRetainedTranslogGen,
-                                  final org.elasticsearch.Version indexVersionCreated) throws IOException {
+    public void trimUnsafeCommits(final Path translogPath) throws IOException {
         metadataLock.writeLock().lock();
         try {
             final List<IndexCommit> existingCommits = DirectoryReader.listCommits(directory);
-            if (existingCommits.isEmpty()) {
-                throw new IllegalArgumentException("No index found to trim");
-            }
-            final IndexCommit lastIndexCommitCommit = existingCommits.get(existingCommits.size() - 1);
-            final String translogUUID = lastIndexCommitCommit.getUserData().get(Translog.TRANSLOG_UUID_KEY);
+            assert existingCommits.isEmpty() == false;
+            final IndexCommit lastIndexCommit = existingCommits.get(existingCommits.size() - 1);
+            final String translogUUID = lastIndexCommit.getUserData().get(Translog.TRANSLOG_UUID_KEY);
+            final long lastSyncedGlobalCheckpoint = Translog.readGlobalCheckpoint(translogPath, translogUUID);
             final IndexCommit startingIndexCommit = CombinedDeletionPolicy.findSafeCommitPoint(existingCommits, lastSyncedGlobalCheckpoint);
-
-            if (translogUUID.equals(startingIndexCommit.getUserData().get(Translog.TRANSLOG_UUID_KEY)) == false) {
-                throw new IllegalStateException("starting commit translog uuid ["
-                    + startingIndexCommit.getUserData().get(Translog.TRANSLOG_UUID_KEY) + "] is not equal to last commit's translog uuid ["
-                    + translogUUID + "]");
-            }
-            logger.debug("starting index commit [{}]", startingIndexCommit.getUserData());
-            if (startingIndexCommit.equals(lastIndexCommitCommit) == false) {
+            if (startingIndexCommit.equals(lastIndexCommit) == false) {
                 try (IndexWriter writer = newAppendingIndexWriter(directory, startingIndexCommit)) {
                     // this achieves two things:
                     // - by committing a new commit based on the starting commit, it make sure the starting commit will be opened

--- a/server/src/main/java/org/elasticsearch/indices/IndexingMemoryController.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndexingMemoryController.java
@@ -291,7 +291,7 @@ public class IndexingMemoryController implements IndexingOperationListener, Clos
             List<IndexShard> availableShards = availableShards();
             for (IndexShard shard : availableShards) {
 
-                // Give shard a chance to transition to inactive so sync'd flush can happen:
+                // Give shard a chance to transition to inactive so we can flush:
                 checkIdle(shard, inactiveTime.nanos());
 
                 // How many bytes this shard is currently (async'd) moving from heap to disk:
@@ -384,7 +384,7 @@ public class IndexingMemoryController implements IndexingOperationListener, Clos
      */
     protected void checkIdle(IndexShard shard, long inactiveTimeNS) {
         try {
-            shard.checkIdle(inactiveTimeNS);
+            shard.flushOnIdle(inactiveTimeNS);
         } catch (AlreadyClosedException e) {
             LOGGER.trace(() -> new ParameterizedMessage("ignore exception while checking if shard {} is inactive", shard.shardId()), e);
         }

--- a/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -85,7 +85,6 @@ import org.elasticsearch.index.shard.PrimaryReplicaSyncer.ResyncTask;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.ShardNotFoundException;
 import org.elasticsearch.indices.IndicesService;
-import org.elasticsearch.indices.flush.SyncedFlushService;
 import org.elasticsearch.indices.recovery.PeerRecoverySourceService;
 import org.elasticsearch.indices.recovery.PeerRecoveryTargetService;
 import org.elasticsearch.indices.recovery.RecoveryFailedException;
@@ -134,7 +133,6 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
                                       PeerRecoveryTargetService recoveryTargetService,
                                       ShardStateAction shardStateAction,
                                       RepositoriesService repositoriesService,
-                                      SyncedFlushService syncedFlushService,
                                       PeerRecoverySourceService peerRecoverySourceService,
                                       SnapshotShardsService snapshotShardsService,
                                       PrimaryReplicaSyncer primaryReplicaSyncer,
@@ -150,7 +148,6 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
             recoveryTargetService,
             shardStateAction,
             repositoriesService,
-            syncedFlushService,
             peerRecoverySourceService,
             snapshotShardsService,
             primaryReplicaSyncer,
@@ -170,7 +167,6 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
                                PeerRecoveryTargetService recoveryTargetService,
                                ShardStateAction shardStateAction,
                                RepositoriesService repositoriesService,
-                               SyncedFlushService syncedFlushService,
                                PeerRecoverySourceService peerRecoverySourceService,
                                SnapshotShardsService snapshotShardsService,
                                PrimaryReplicaSyncer primaryReplicaSyncer,
@@ -182,7 +178,6 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
         this.buildInIndexListener = List.of(
             peerRecoverySourceService,
             recoveryTargetService,
-            syncedFlushService,
             snapshotShardsService,
             blobIndicesService,
             shardCollectSource,

--- a/server/src/main/java/org/elasticsearch/indices/flush/SyncedFlushService.java
+++ b/server/src/main/java/org/elasticsearch/indices/flush/SyncedFlushService.java
@@ -51,16 +51,13 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.logging.DeprecationLogger;
-import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.CountDown;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.engine.CommitStats;
 import org.elasticsearch.index.engine.Engine;
-import org.elasticsearch.index.shard.IndexEventListener;
 import org.elasticsearch.index.shard.IndexShard;
-import org.elasticsearch.index.shard.IndexShardState;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.ShardNotFoundException;
 import org.elasticsearch.indices.IndexClosedException;
@@ -75,7 +72,7 @@ import org.elasticsearch.transport.TransportResponseHandler;
 import org.elasticsearch.transport.TransportService;
 import org.jetbrains.annotations.Nullable;
 
-public class SyncedFlushService implements IndexEventListener {
+public class SyncedFlushService {
 
     private static final Logger LOGGER = LogManager.getLogger(SyncedFlushService.class);
     private static final DeprecationLogger DEPRECATION_LOGGER = new DeprecationLogger(LOGGER);
@@ -115,45 +112,6 @@ public class SyncedFlushService implements IndexEventListener {
             InFlightOpsRequest::new,
             new InFlightOpCountTransportHandler()
         );
-    }
-
-    @Override
-    public void onShardInactive(final IndexShard indexShard) {
-        // A normal flush has the same effect as a synced flush if all nodes are on 4.4 or later.
-        final boolean preferNormalFlush = clusterService.state().nodes().getMinNodeVersion().onOrAfter(Version.V_4_4_0);
-        if (preferNormalFlush) {
-            performNormalFlushOnInactive(indexShard);
-        } else if (indexShard.routingEntry().primary()) {
-            // we only want to call sync flush once, so only trigger it when we are on a primary
-            attemptSyncedFlush(indexShard.shardId(), new ActionListener<ShardsSyncedFlushResult>() {
-                @Override
-                public void onResponse(ShardsSyncedFlushResult syncedFlushResult) {
-                    LOGGER.trace("{} sync flush on inactive shard returned successfully for sync_id: {}", syncedFlushResult.getShardId(), syncedFlushResult.syncId());
-                }
-
-                @Override
-                public void onFailure(Exception e) {
-                    LOGGER.debug(() -> new ParameterizedMessage("{} sync flush on inactive shard failed", indexShard.shardId()), e);
-                }
-            });
-        }
-    }
-
-    private void performNormalFlushOnInactive(IndexShard shard) {
-        LOGGER.debug("flushing shard {} on inactive", shard.routingEntry());
-        shard.getThreadPool().executor(ThreadPool.Names.FLUSH).execute(new AbstractRunnable() {
-            @Override
-            public void onFailure(Exception e) {
-                if (shard.state() != IndexShardState.CLOSED) {
-                    LOGGER.warn(new ParameterizedMessage("failed to flush shard {} on inactive", shard.routingEntry()), e);
-                }
-            }
-
-            @Override
-            protected void doRun() {
-                shard.flush(new FlushRequest().force(false).waitIfOngoing(false));
-            }
-        });
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -5390,7 +5390,7 @@ public class InternalEngineTests extends EngineTestCase {
                 minTranslogGen = engine.getTranslog().getMinFileGeneration();
             }
 
-            store.trimUnsafeCommits(globalCheckpoint.get(), minTranslogGen,config.getIndexSettings().getIndexVersionCreated());
+            store.trimUnsafeCommits(config.getTranslogConfig().getTranslogPath());
             long safeMaxSeqNo =
                 commitMaxSeqNo.stream().filter(s -> s <= globalCheckpoint.get())
                     .reduce((s1, s2) -> s2) // get the last one.

--- a/server/src/testFixtures/java/org/elasticsearch/test/MockIndexEventListener.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/MockIndexEventListener.java
@@ -116,11 +116,6 @@ public final class MockIndexEventListener {
         }
 
         @Override
-        public void onShardInactive(IndexShard indexShard) {
-            delegate.onShardInactive(indexShard);
-        }
-
-        @Override
         public void beforeIndexCreated(Index index, Settings indexSettings) {
             delegate.beforeIndexCreated(index, indexSettings);
         }


### PR DESCRIPTION
- With peer recovery retention leases and sequence-number based replica allocation, a regular flush can speed up recovery as a synced-flush. With this change, we will flush instead of synced-flush when a shard becomes inactive.

   ES backport of: https://github.com/elastic/elasticsearch/commit/725dda37ea5

- Tidy up Store#trimUnsafeCommits

   This change removes unused parameters and simplifies the logic.

   ES backport of: https://github.com/elastic/elasticsearch/commit/65374c9c010
