### PR TITLE
Fix eval projection to support fewer outputs than its source

### DIFF
--- a/docs/appendices/release-notes/5.10.1.rst
+++ b/docs/appendices/release-notes/5.10.1.rst
@@ -96,3 +96,14 @@ Fixes
     (SELECT y FROM unnest([2]) as t2(y))
     FROM tbl t
 
+- Fixed an issue that caused a planner exception when using a query containing
+  an ``ORDER BY`` clause on top of a ``UNION`` clause, while the ordering column
+  is not part of the most-top select items. Example::
+
+    SELECT id FROM (
+        SELECT id, other_id, name FROM users
+        UNION ALL
+        SELECT id, other_id, name FROM users
+        ) u
+    ORDER BY name
+

--- a/server/src/main/java/io/crate/execution/dsl/projection/EvalProjection.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/EvalProjection.java
@@ -53,7 +53,8 @@ public class EvalProjection extends Projection {
     public static EvalProjection castValues(List<DataType<?>> targetTypes, List<Symbol> sources) {
         ArrayList<Symbol> casts = new ArrayList<>(targetTypes.size());
         boolean requiresCasts = false;
-        for (int i = 0; i < sources.size(); i++) {
+        assert sources.size() >= targetTypes.size() : "sources size must be >= targetTypes size";
+        for (int i = 0; i < targetTypes.size(); i++) {
             Symbol source = sources.get(i);
             DataType<?> targetType = targetTypes.get(i);
             InputColumn inputColumn = new InputColumn(i, source.valueType());

--- a/server/src/test/java/io/crate/execution/dsl/projection/EvalProjectionTest.java
+++ b/server/src/test/java/io/crate/execution/dsl/projection/EvalProjectionTest.java
@@ -30,7 +30,10 @@ import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
 
 import io.crate.expression.symbol.Literal;
+import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.RowGranularity;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
 
 public class EvalProjectionTest extends ESTestCase {
 
@@ -44,5 +47,14 @@ public class EvalProjectionTest extends ESTestCase {
         var inProjection = new EvalProjection(in);
         assertThat(projection.requiredGranularity()).isEqualTo(inProjection.requiredGranularity());
         assertThat(projection.outputs()).isEqualTo(inProjection.outputs());
+    }
+
+    @Test
+    public void test_cast_target_types_can_be_less_than_source_outputs() {
+        List<DataType<?>> targetTypes = List.of(DataTypes.INTEGER);
+        List<Symbol> sources = List.of(Literal.of("1"), Literal.of("2"));
+        EvalProjection projection = EvalProjection.castValues(targetTypes, sources);
+        assertThat(projection).isNotNull();
+        assertThat(projection.outputs().size()).isEqualTo(targetTypes.size());
     }
 }


### PR DESCRIPTION
The Eval projection has a logic to add casts to its source outputs to a given list of target types (its own outputs). This is e.g. needed for Union's to ensure that all source outputs are cast to the same type.
In some situations the source can contain more symbols than the given target types to cast to.

Closes #17341.
