### PR TITLE
TranslogIndexer must add dedicated fulltext indices to sub-columns

### DIFF
--- a/docs/appendices/release-notes/5.10.1.rst
+++ b/docs/appendices/release-notes/5.10.1.rst
@@ -44,6 +44,11 @@ See the :ref:`version_5.10.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed a recovery issue that led to records of a table with an ``OBJECT``
+  sub-column being part of a standalone ``FULLTEXT`` index to be never visible
+  for ``MATCH`` queries. This issue cannot be mitigated and a full re-index of
+  the data is required.
+
 - Fixed an issue that would lead to errors when attempting to select a
   sub-column from a virtual table or view participating in a join, e.g.::
 

--- a/docs/appendices/release-notes/5.9.10.rst
+++ b/docs/appendices/release-notes/5.9.10.rst
@@ -46,6 +46,11 @@ See the :ref:`version_5.9.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed a recovery issue that led to records of a table with an ``OBJECT``
+  sub-column being part of a standalone ``FULLTEXT`` index to be never visible
+  for ``MATCH`` queries. This issue cannot be mitigated and a full re-index of
+  the data is required.
+
 - Fixed an issue that would lead to errors when attempting to select a
   sub-column from a virtual table or view participating in a join, e.g.::
 

--- a/libs/shared/src/main/java/io/crate/common/collections/Lists.java
+++ b/libs/shared/src/main/java/io/crate/common/collections/Lists.java
@@ -74,6 +74,13 @@ public final class Lists {
         return xs;
     }
 
+    public static <T> List<T> concat(T item, Collection<? extends T> list1) {
+        ArrayList<T> xs = new ArrayList<>(list1.size() + 1);
+        xs.add(item);
+        xs.addAll(list1);
+        return xs;
+    }
+
     @SafeVarargs
     public static final <T> List<T> concat(T first, T ... tail) {
         ArrayList<T> result = new ArrayList<>(1 + tail.length);

--- a/server/src/test/java/io/crate/execution/dml/IndexerTest.java
+++ b/server/src/test/java/io/crate/execution/dml/IndexerTest.java
@@ -672,6 +672,28 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
+    public void test_can_add_dedicated_fulltext_to_sub_column() throws Exception {
+        SQLExecutor e = SQLExecutor.of(clusterService)
+            .addTable("""
+                create table tbl (
+                    id int,
+                    author object as (
+                        name string
+                    ),
+                    index nested_ft using fulltext(author['name'])
+                )
+            """);
+        DocTableInfo table = e.resolveTableInfo("tbl");
+        var ref = table.indexColumn(ColumnIdent.of("nested_ft"));
+
+        var indexer = getIndexer(e, "tbl", "id", "author");
+        ParsedDocument doc = indexer.index(item(1, Map.of("name", "sub_col_name")));
+        IndexableField[] fields = doc.doc().getFields(ref.storageIdent());
+        assertThat(fields).hasSize(1);
+        assertTranslogParses(doc, table);
+    }
+
+    @Test
     public void test_can_index_all_storable_types() throws Exception {
         StringBuilder stmtBuilder = new StringBuilder()
             .append("create table tbl (");


### PR DESCRIPTION
Fix flaky MATCH on crate-qa (happens on translog recovery that missed to add some FT fields)