### PR TITLE
Fix MIN/MAX for NUMERIC values

### DIFF
--- a/docs/appendices/release-notes/5.10.1.rst
+++ b/docs/appendices/release-notes/5.10.1.rst
@@ -107,3 +107,8 @@ Fixes
         ) u
     ORDER BY name
 
+- Fixed an issue that would lead to wrong results when using
+  :ref:`MIN <aggregation-min>` or :ref:`MAX <aggregation-max>` aggregations on
+  :ref:`numeric <type-numeric>` values. Previously, the values where implicitly
+  casted to ``STRING`` and the aggregations where using alphanumeric ordering,
+  instead of numeric ordering.

--- a/docs/appendices/release-notes/5.9.10.rst
+++ b/docs/appendices/release-notes/5.9.10.rst
@@ -77,3 +77,9 @@ Fixes
         SELECT id, other_id, name FROM users
         ) u
     ORDER BY name
+
+- Fixed an issue that would lead to wrong results when using
+  :ref:`MIN <aggregation-min>` or :ref:`MAX <aggregation-max>` aggregations on
+  :ref:`numeric <type-numeric>` values. Previously, the values where implicitly
+  casted to ``STRING`` and the aggregations where using alphanumeric ordering,
+  instead of numeric ordering.

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/Aggregations.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/Aggregations.java
@@ -40,7 +40,9 @@ public class Aggregations implements FunctionsProvider {
         NumericAverageAggregation.register(builder);
         IntervalAverageAggregation.register(builder);
         MinimumAggregation.register(builder);
+        NumericMinAggregation.register(builder);
         MaximumAggregation.register(builder);
+        NumericMaxAggregation.register(builder);
         ArbitraryAggregation.register(builder);
         CmpByAggregation.register(builder);
 

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/NumericMaxAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/NumericMaxAggregation.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.engine.aggregation.impl;
+
+import java.math.BigDecimal;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
+
+import io.crate.data.Input;
+import io.crate.data.breaker.RamAccounting;
+import io.crate.execution.engine.aggregation.AggregationFunction;
+import io.crate.memory.MemoryManager;
+import io.crate.metadata.FunctionType;
+import io.crate.metadata.Functions;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.functions.BoundSignature;
+import io.crate.metadata.functions.Signature;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+import io.crate.types.NumericType;
+
+public class NumericMaxAggregation extends AggregationFunction<BigDecimal, BigDecimal> {
+
+    public static final String NAME = "max";
+    public static final Signature SIGNATURE = Signature.builder(NAME, FunctionType.AGGREGATE)
+            .argumentTypes(DataTypes.NUMERIC.getTypeSignature())
+            .returnType(DataTypes.NUMERIC.getTypeSignature())
+            .features(Scalar.Feature.DETERMINISTIC)
+            .build();
+    private static final long INIT_BIG_DECIMAL_SIZE = NumericType.size(BigDecimal.ZERO);
+
+    public static void register(Functions.Builder builder) {
+        builder.add(SIGNATURE, NumericMaxAggregation::new);
+    }
+
+    private final Signature signature;
+    private final BoundSignature boundSignature;
+    private final DataType<BigDecimal> returnType;
+
+    @VisibleForTesting
+    private NumericMaxAggregation(Signature signature, BoundSignature boundSignature) {
+        this.signature = signature;
+        this.boundSignature = boundSignature;
+
+        // We want to preserve the scale and precision from the
+        // numeric argument type for the return type. So we use
+        // the incoming numeric type as return type instead of
+        // the return type from the signature `sum(count::numeric(16, 2))`
+        // should return the type `numeric(16, 2)` not `numeric`
+        var argumentType = boundSignature.argTypes().get(0);
+        assert argumentType.id() == DataTypes.NUMERIC.id();
+        //noinspection unchecked
+        this.returnType = (DataType<BigDecimal>) argumentType;
+    }
+
+    @Nullable
+    @Override
+    public BigDecimal newState(RamAccounting ramAccounting,
+                               Version indexVersionCreated,
+                               Version minNodeInCluster,
+                               MemoryManager memoryManager) {
+        ramAccounting.addBytes(INIT_BIG_DECIMAL_SIZE);
+        return null;
+    }
+
+    @Override
+    public BigDecimal iterate(RamAccounting ramAccounting,
+                              MemoryManager memoryManager,
+                              BigDecimal state,
+                              Input<?>... args) throws CircuitBreakingException {
+        BigDecimal value = returnType.implicitCast(args[0].value());
+        if (value != null) {
+            if (state != null) {
+                if (state.compareTo(value) < 0) {
+                    state = value;
+                }
+            } else {
+                state = value;
+            }
+        }
+        return state;
+    }
+
+    @Override
+    public BigDecimal reduce(RamAccounting ramAccounting,
+                             BigDecimal state1,
+                             BigDecimal state2) {
+        if (state1 == null) {
+            return state2;
+        }
+        if (state2 == null) {
+            return state1;
+        }
+        if (state1.compareTo(state2) >= 0) {
+            return state1;
+        } else {
+            return state2;
+        }
+    }
+
+    @Override
+    public BigDecimal terminatePartial(RamAccounting ramAccounting, BigDecimal state) {
+        if (state != null) {
+            ramAccounting.addBytes(NumericType.size(state));
+        }
+        return state;
+    }
+
+    @Override
+    public DataType<?> partialType() {
+        return returnType;
+    }
+
+    @Override
+    public Signature signature() {
+        return signature;
+    }
+
+    @Override
+    public BoundSignature boundSignature() {
+        return boundSignature;
+    }
+}

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/NumericMinAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/NumericMinAggregation.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.engine.aggregation.impl;
+
+import java.math.BigDecimal;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
+
+import io.crate.data.Input;
+import io.crate.data.breaker.RamAccounting;
+import io.crate.execution.engine.aggregation.AggregationFunction;
+import io.crate.memory.MemoryManager;
+import io.crate.metadata.FunctionType;
+import io.crate.metadata.Functions;
+import io.crate.metadata.Scalar;
+import io.crate.metadata.functions.BoundSignature;
+import io.crate.metadata.functions.Signature;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+import io.crate.types.NumericType;
+
+public class NumericMinAggregation extends AggregationFunction<BigDecimal, BigDecimal> {
+
+    public static final String NAME = "min";
+    public static final Signature SIGNATURE = Signature.builder(NAME, FunctionType.AGGREGATE)
+        .argumentTypes(DataTypes.NUMERIC.getTypeSignature())
+        .returnType(DataTypes.NUMERIC.getTypeSignature())
+        .features(Scalar.Feature.DETERMINISTIC)
+        .build();
+    private static final long INIT_BIG_DECIMAL_SIZE = NumericType.size(BigDecimal.ZERO);
+
+    public static void register(Functions.Builder builder) {
+        builder.add(SIGNATURE, NumericMinAggregation::new);
+    }
+
+    private final Signature signature;
+    private final BoundSignature boundSignature;
+    private final DataType<BigDecimal> returnType;
+
+    @VisibleForTesting
+    private NumericMinAggregation(Signature signature, BoundSignature boundSignature) {
+        this.signature = signature;
+        this.boundSignature = boundSignature;
+
+        // We want to preserve the scale and precision from the
+        // numeric argument type for the return type. So we use
+        // the incoming numeric type as return type instead of
+        // the return type from the signature `sum(count::numeric(16, 2))`
+        // should return the type `numeric(16, 2)` not `numeric`
+        var argumentType = boundSignature.argTypes().get(0);
+        assert argumentType.id() == DataTypes.NUMERIC.id();
+        //noinspection unchecked
+        this.returnType = (DataType<BigDecimal>) argumentType;
+    }
+
+    @Nullable
+    @Override
+    public BigDecimal newState(RamAccounting ramAccounting,
+                               Version indexVersionCreated,
+                               Version minNodeInCluster,
+                               MemoryManager memoryManager) {
+        ramAccounting.addBytes(INIT_BIG_DECIMAL_SIZE);
+        return null;
+    }
+
+    @Override
+    public BigDecimal iterate(RamAccounting ramAccounting,
+                              MemoryManager memoryManager,
+                              BigDecimal state,
+                              Input<?>... args) throws CircuitBreakingException {
+        BigDecimal value = returnType.implicitCast(args[0].value());
+        if (value != null) {
+            if (state != null) {
+                if (state.compareTo(value) >= 0) {
+                    state = value;
+                }
+            } else {
+                state = value;
+            }
+        }
+        return state;
+    }
+
+    @Override
+    public BigDecimal reduce(RamAccounting ramAccounting,
+                             BigDecimal state1,
+                             BigDecimal state2) {
+        if (state1 == null) {
+            return state2;
+        }
+        if (state2 == null) {
+            return state1;
+        }
+        if (state1.compareTo(state2) < 0) {
+            return state1;
+        } else {
+            return state2;
+        }
+    }
+
+    @Override
+    public BigDecimal terminatePartial(RamAccounting ramAccounting, BigDecimal state) {
+        if (state != null) {
+            ramAccounting.addBytes(NumericType.size(state));
+        }
+        return state;
+    }
+
+    @Override
+    public DataType<?> partialType() {
+        return returnType;
+    }
+
+    @Override
+    public Signature signature() {
+        return signature;
+    }
+
+    @Override
+    public BoundSignature boundSignature() {
+        return boundSignature;
+    }
+}

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/MaximumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/MaximumAggregationTest.java
@@ -24,6 +24,7 @@ package io.crate.execution.engine.aggregation.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 import org.joda.time.Period;
@@ -36,6 +37,7 @@ import io.crate.metadata.functions.Signature;
 import io.crate.operation.aggregation.AggregationTestCase;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
+import io.crate.types.NumericType;
 
 public class MaximumAggregationTest extends AggregationTestCase {
 
@@ -56,6 +58,13 @@ public class MaximumAggregationTest extends AggregationTestCase {
         for (var dataType : DataTypes.NUMERIC_PRIMITIVE_TYPES) {
             assertHasDocValueAggregator(MaximumAggregation.NAME, List.of(dataType));
         }
+    }
+
+    @Test
+    public void testNumeric() throws Exception {
+        Object result = executeAggregation(new NumericType(6, 4),
+            new Object[][]{{new BigDecimal("97.6543")}, {new BigDecimal("97.6542")}});
+        assertThat(result).isEqualTo(new BigDecimal("97.6543"));
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/MinimumAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/MinimumAggregationTest.java
@@ -24,6 +24,7 @@ package io.crate.execution.engine.aggregation.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 import org.joda.time.Period;
@@ -36,6 +37,7 @@ import io.crate.metadata.functions.Signature;
 import io.crate.operation.aggregation.AggregationTestCase;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
+import io.crate.types.NumericType;
 
 public class MinimumAggregationTest extends AggregationTestCase {
 
@@ -56,6 +58,13 @@ public class MinimumAggregationTest extends AggregationTestCase {
         for (var dataType : DataTypes.NUMERIC_PRIMITIVE_TYPES) {
             assertHasDocValueAggregator(MinimumAggregation.NAME, List.of(dataType));
         }
+    }
+
+    @Test
+    public void testNumeric() throws Exception {
+        Object result = executeAggregation(new NumericType(6, 4),
+            new Object[][]{{new BigDecimal("97.6543")}, {new BigDecimal("97.6542")}});
+        assertThat(result).isEqualTo(new BigDecimal("97.6542"));
     }
 
     @Test

--- a/server/src/test/java/io/crate/metadata/functions/SignatureBinderTest.java
+++ b/server/src/test/java/io/crate/metadata/functions/SignatureBinderTest.java
@@ -36,6 +36,8 @@ import org.elasticsearch.test.ESTestCase;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Test;
 
+import io.crate.execution.engine.aggregation.impl.NumericMaxAggregation;
+import io.crate.execution.engine.aggregation.impl.NumericMinAggregation;
 import io.crate.execution.engine.aggregation.impl.NumericSumAggregation;
 import io.crate.sql.tree.ColumnPolicy;
 import io.crate.types.BitStringType;
@@ -556,6 +558,12 @@ public class SignatureBinderTest extends ESTestCase {
     public void testNumericParameters() {
         NumericType dt = new NumericType(10, 2);
         assertThatSignature(NumericSumAggregation.SIGNATURE)
+            .boundTo(dt)
+            .hasReturnType(dt);
+        assertThatSignature(NumericMinAggregation.SIGNATURE)
+            .boundTo(dt)
+            .hasReturnType(dt);
+        assertThatSignature(NumericMaxAggregation.SIGNATURE)
             .boundTo(dt)
             .hasReturnType(dt);
     }


### PR DESCRIPTION
Previously, there was no `NUMERIC` signature registered, and as a result, the `NUMERIC` values where implicitly casted to `STRING` leading to wrong results, as an alphanumeric ordering was used instead of the numeric one.

Fixes: #17360
