### PR TITLE
Rename getRelationNames in RelationNames for consistency

### DIFF
--- a/server/src/main/java/io/crate/analyze/QueriedSelectRelation.java
+++ b/server/src/main/java/io/crate/analyze/QueriedSelectRelation.java
@@ -186,7 +186,7 @@ public class QueriedSelectRelation implements AnalyzedRelation {
             + Lists.joinOn(", ", outputs(), x -> x.toColumn().sqlFqn())
             + " FROM ("
             + from.stream()
-            .flatMap(rel -> RelationNames.getRelationNames(rel).stream())
+            .flatMap(rel -> RelationNames.getShallow(rel).stream())
             .map(RelationName::toString)
             .collect(Collectors.joining(", "))
             + ')';

--- a/server/src/main/java/io/crate/analyze/RelationNames.java
+++ b/server/src/main/java/io/crate/analyze/RelationNames.java
@@ -72,9 +72,10 @@ public final class RelationNames {
     }
 
     /**
-     * Extracts all relation names from the AnalyzedRelation and the underlying nested AnalyzedRelations.
+     * Extracts relation names from the AnalyzedRelation including its descendants.
+     * Does not traverse into scalar subqueries.
      */
-    public static SequencedSet<RelationName> getRelationNames(AnalyzedRelation relation) {
+    public static SequencedSet<RelationName> getShallow(AnalyzedRelation relation) {
         LinkedHashSet<RelationName> relationNames = new LinkedHashSet<>();
         relation.accept(RELATION_TABLE_IDENT_EXTRACTOR, relationNames);
         return relationNames;

--- a/server/src/main/java/io/crate/planner/CorrelatedSubQueries.java
+++ b/server/src/main/java/io/crate/planner/CorrelatedSubQueries.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jetbrains.annotations.Nullable;
+
+import io.crate.analyze.relations.QuerySplitter;
+import io.crate.expression.symbol.SelectSymbol;
+import io.crate.expression.symbol.Symbol;
+
+public record CorrelatedSubQueries(List<Symbol> correlatedSubQueries, List<Symbol> remainder) {
+
+    /**
+     * Splits the given Symbol tree into a list of symbols containing
+     * correlated sub-queries and a list of symbols without correlated
+     * subqueries (=remainder)
+     */
+    public static CorrelatedSubQueries of(@Nullable Symbol from) {
+        if (from == null) {
+            return new CorrelatedSubQueries(List.of(), List.of());
+        }
+        var values = QuerySplitter.split(from).values();
+        var remainder = new ArrayList<Symbol>(values.size());
+        var correlatedSubQueries = new ArrayList<Symbol>(values.size());
+        for (var symbol : values) {
+            if (symbol.any(s -> s instanceof SelectSymbol x && x.isCorrelated())) {
+                correlatedSubQueries.add(symbol);
+            } else {
+                remainder.add(symbol);
+            }
+        }
+        return new CorrelatedSubQueries(correlatedSubQueries, remainder);
+    }
+}

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -500,7 +500,7 @@ public class LogicalPlanner {
             // a) introduce a column pruning
             // b) Make sure tableRelations contain all columns (incl. sys-columns) in `outputs`
             LinkedHashSet<Symbol> result = new LinkedHashSet<>();
-            SequencedSet<RelationName> relationNamesFromRelation = RelationNames.getRelationNames(relation);
+            SequencedSet<RelationName> relationNamesFromRelation = RelationNames.getShallow(relation);
             Predicate<Symbol> filter = node -> {
                 SequencedSet<RelationName> relationNamesFromSymbol = RelationNames.getDeep(node);
                 for (RelationName relationName : relationNamesFromSymbol) {

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -21,8 +21,6 @@
 
 package io.crate.planner.operators;
 
-import static io.crate.planner.optimizer.rule.MoveFilterBeneathCorrelatedJoin.extractCorrelatedSubQueries;
-
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -86,6 +84,7 @@ import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.settings.CoordinatorSessionSettings;
+import io.crate.planner.CorrelatedSubQueries;
 import io.crate.planner.DependencyCarrier;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.PlannerContext;
@@ -384,8 +383,7 @@ public class LogicalPlanner {
             List<Symbol> lhsOutputs = getOutputsForRelation(joinRelation.left(), allOutputs);
             List<Symbol> rhsOutputs = getOutputsForRelation(joinRelation.right(), allOutputs);
 
-            var correlatedSubQueries = extractCorrelatedSubQueries(joinCondition);
-
+            var correlatedSubQueries = CorrelatedSubQueries.of(joinCondition);
             if (correlatedSubQueries.correlatedSubQueries().isEmpty()) {
                 return new JoinPlan(
                     joinRelation.left().accept(this, lhsOutputs),

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathCorrelatedJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathCorrelatedJoin.java
@@ -24,16 +24,12 @@ package io.crate.planner.optimizer.rule;
 import static io.crate.planner.optimizer.matcher.Pattern.typeOf;
 import static io.crate.planner.optimizer.matcher.Patterns.source;
 
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 
-import org.jetbrains.annotations.Nullable;
-
 import io.crate.analyze.relations.QuerySplitter;
 import io.crate.expression.operator.AndOperator;
-import io.crate.expression.symbol.SelectSymbol;
-import io.crate.expression.symbol.Symbol;
+import io.crate.planner.CorrelatedSubQueries;
 import io.crate.planner.operators.CorrelatedJoin;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
@@ -71,7 +67,7 @@ public final class MoveFilterBeneathCorrelatedJoin implements Rule<Filter> {
             return null;
         }
         // Only push down filters which are not part of the correlated sub-queries
-        var correlatedSubQueries = extractCorrelatedSubQueries(inputQuery);
+        var correlatedSubQueries = CorrelatedSubQueries.of(inputQuery);
         if (correlatedSubQueries.remainder().isEmpty()) {
             return null;
         }
@@ -79,28 +75,5 @@ public final class MoveFilterBeneathCorrelatedJoin implements Rule<Filter> {
         var newInputPlan = new Filter(inputPlan, AndOperator.join(correlatedSubQueries.remainder()));
         var newJoin = join.replaceSources(List.of(newInputPlan));
         return new Filter(newJoin, AndOperator.join(splitQuery.values()));
-    }
-
-    /**
-     * Splits the given Symbol tree into a list of correlated sub-queries and a list of remaining symbols.
-     */
-    public static CorrelatedSubQueries extractCorrelatedSubQueries(@Nullable Symbol from) {
-        if (from == null) {
-            return new CorrelatedSubQueries(List.of(), List.of());
-        }
-        var values = QuerySplitter.split(from).values();
-        var remainder = new ArrayList<Symbol>(values.size());
-        var correlatedSubQueries = new ArrayList<Symbol>(values.size());
-        for (var symbol : values) {
-            if (symbol.any(s -> s instanceof SelectSymbol x && x.isCorrelated())) {
-                correlatedSubQueries.add(symbol);
-            } else {
-                remainder.add(symbol);
-            }
-        }
-        return new CorrelatedSubQueries(correlatedSubQueries, remainder);
-    }
-
-    public record CorrelatedSubQueries(List<Symbol> correlatedSubQueries, List<Symbol> remainder) {
     }
 }


### PR DESCRIPTION
The other methods are called `getDeep`/`getShallow` to indicate if they
do traverse into scalar subqueries. `getRelationNames` didn't follow
that pattern.

That it is about relation names is clear from the class name and
signature, no need to repeat it in the method name.
