### PR TITLE
Add default traversal for join, union and QS to AnalyzedRelationVisitor

### DIFF
--- a/server/src/main/java/io/crate/analyze/RelationNames.java
+++ b/server/src/main/java/io/crate/analyze/RelationNames.java
@@ -32,7 +32,6 @@ import io.crate.analyze.relations.AnalyzedRelationVisitor;
 import io.crate.analyze.relations.DocTableRelation;
 import io.crate.analyze.relations.TableFunctionRelation;
 import io.crate.analyze.relations.TableRelation;
-import io.crate.analyze.relations.UnionSelect;
 import io.crate.expression.symbol.ScopedSymbol;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
@@ -104,13 +103,6 @@ public final class RelationNames {
     private static class TableIdentRelationVisitor extends AnalyzedRelationVisitor<Collection<RelationName>, Void> {
 
         @Override
-        public Void visitUnionSelect(UnionSelect unionSelect, Collection<RelationName> context) {
-            unionSelect.left().accept(this, context);
-            unionSelect.right().accept(this, context);
-            return null;
-        }
-
-        @Override
         public Void visitForeignTable(ForeignTableRelation foreignTableRelation, Collection<RelationName> context) {
             context.add(foreignTableRelation.relationName());
             return null;
@@ -149,21 +141,6 @@ public final class RelationNames {
         @Override
         public Void visitExplain(ExplainAnalyzedStatement explainAnalyzedStatement, Collection<RelationName> context) {
             context.add(explainAnalyzedStatement.relationName());
-            return null;
-        }
-
-        @Override
-        public Void visitJoinRelation(JoinRelation joinRelation, Collection<RelationName> context) {
-            joinRelation.left().accept(this, context);
-            joinRelation.right().accept(this, context);
-            return null;
-        }
-
-        @Override
-        public Void visitQueriedSelectRelation(QueriedSelectRelation relation, Collection<RelationName> context) {
-            for (AnalyzedRelation analyzedRelation : relation.from()) {
-                analyzedRelation.accept(this, context);
-            }
             return null;
         }
     }

--- a/server/src/main/java/io/crate/analyze/Relations.java
+++ b/server/src/main/java/io/crate/analyze/Relations.java
@@ -26,12 +26,9 @@ import java.util.function.Consumer;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.AnalyzedRelationVisitor;
 import io.crate.analyze.relations.AnalyzedView;
-import io.crate.analyze.relations.DocTableRelation;
 import io.crate.analyze.relations.TableFunctionRelation;
-import io.crate.analyze.relations.TableRelation;
 import io.crate.analyze.relations.UnionSelect;
 import io.crate.expression.symbol.Symbol;
-import io.crate.fdw.ForeignTableRelation;
 
 public class Relations {
 
@@ -73,21 +70,14 @@ public class Relations {
         }
 
         @Override
+        protected Void visitAnalyzedRelation(AnalyzedRelation relation, Consumer<? super Symbol> context) {
+            return null;
+        }
+
+        @Override
         public Void visitUnionSelect(UnionSelect unionSelect, Consumer<? super Symbol> consumer) {
             unionSelect.visitSymbols(consumer);
-            unionSelect.left().accept(this, consumer);
-            unionSelect.right().accept(this, consumer);
-            return null;
-        }
-
-        @Override
-        public Void visitTableRelation(TableRelation tableRelation, Consumer<? super Symbol> consumer) {
-            return null;
-        }
-
-        @Override
-        public Void visitDocTableRelation(DocTableRelation relation, Consumer<? super Symbol> consumer) {
-            return null;
+            return super.visitUnionSelect(unionSelect, consumer);
         }
 
         @Override
@@ -99,31 +89,21 @@ public class Relations {
         }
 
         @Override
-        public Void visitForeignTable(ForeignTableRelation foreignTableRelation,
-                                      Consumer<? super Symbol> context) {
-            return null;
-        }
-
-        @Override
         public Void visitQueriedSelectRelation(QueriedSelectRelation relation, Consumer<? super Symbol> consumer) {
             relation.visitSymbols(consumer);
-            for (AnalyzedRelation analyzedRelation : relation.from()) {
-                analyzedRelation.accept(this, consumer);
-            }
-            return null;
+            return super.visitQueriedSelectRelation(relation, consumer);
         }
 
         @Override
         public Void visitJoinRelation(JoinRelation joinRelation, Consumer<? super Symbol> consumer) {
             joinRelation.visitSymbols(consumer);
-            return null;
+            return super.visitJoinRelation(joinRelation, consumer);
         }
 
         @Override
         public Void visitView(AnalyzedView analyzedView, Consumer<? super Symbol> consumer) {
             analyzedView.visitSymbols(consumer);
-            analyzedView.relation().accept(this, consumer);
-            return null;
+            return super.visitView(analyzedView, consumer);
         }
     }
 }

--- a/server/src/main/java/io/crate/analyze/relations/AnalyzedRelationVisitor.java
+++ b/server/src/main/java/io/crate/analyze/relations/AnalyzedRelationVisitor.java
@@ -32,11 +32,13 @@ import io.crate.fdw.ForeignTableRelation;
 public abstract class AnalyzedRelationVisitor<C, R> {
 
     protected R visitAnalyzedRelation(AnalyzedRelation relation, C context) {
-        throw new UnsupportedOperationException(String.format(Locale.ENGLISH, "relation \"%s\" is not supported", relation));
+        throw new UnsupportedOperationException(String.format(Locale.ENGLISH, "relation \"%s\" is not supported by %s", relation, this.getClass().getSimpleName()));
     }
 
     public R visitUnionSelect(UnionSelect unionSelect, C context) {
-        return visitAnalyzedRelation(unionSelect, context);
+        unionSelect.left().accept(this, context);
+        unionSelect.right().accept(this, context);
+        return null;
     }
 
     public R visitTableRelation(TableRelation tableRelation, C context) {
@@ -60,7 +62,10 @@ public abstract class AnalyzedRelationVisitor<C, R> {
     }
 
     public R visitQueriedSelectRelation(QueriedSelectRelation relation, C context) {
-        return visitAnalyzedRelation(relation, context);
+        for (AnalyzedRelation from : relation.from()) {
+            from.accept(this, context);
+        }
+        return null;
     }
 
     public R visitView(AnalyzedView analyzedView, C context) {
@@ -80,7 +85,8 @@ public abstract class AnalyzedRelationVisitor<C, R> {
     }
 
     public R visitJoinRelation(JoinRelation joinRelation, C context) {
-        return visitAnalyzedRelation(joinRelation, context);
+        joinRelation.left().accept(this, context);
+        joinRelation.right().accept(this, context);
+        return null;
     }
-
 }

--- a/server/src/main/java/io/crate/auth/AccessControlImpl.java
+++ b/server/src/main/java/io/crate/auth/AccessControlImpl.java
@@ -88,7 +88,6 @@ import io.crate.analyze.AnalyzedSwapTable;
 import io.crate.analyze.AnalyzedUpdateStatement;
 import io.crate.analyze.CreateViewStmt;
 import io.crate.analyze.ExplainAnalyzedStatement;
-import io.crate.analyze.JoinRelation;
 import io.crate.analyze.QueriedSelectRelation;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.AnalyzedRelationVisitor;
@@ -96,7 +95,6 @@ import io.crate.analyze.relations.AnalyzedView;
 import io.crate.analyze.relations.DocTableRelation;
 import io.crate.analyze.relations.TableFunctionRelation;
 import io.crate.analyze.relations.TableRelation;
-import io.crate.analyze.relations.UnionSelect;
 import io.crate.exceptions.ClusterScopeException;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.exceptions.CrateException;
@@ -192,25 +190,6 @@ public final class AccessControlImpl implements AccessControl {
         }
 
         @Override
-        protected Void visitAnalyzedRelation(AnalyzedRelation relation, RelationContext context) {
-            throw new UnsupportedOperationException(String.format(Locale.ENGLISH, "Can't handle \"%s\"", relation));
-        }
-
-        @Override
-        public Void visitJoinRelation(JoinRelation joinRelation, RelationContext context) {
-            joinRelation.left().accept(this, context);
-            joinRelation.right().accept(this, context);
-            return null;
-        }
-
-        @Override
-        public Void visitUnionSelect(UnionSelect unionSelect, RelationContext context) {
-            unionSelect.left().accept(this, context);
-            unionSelect.right().accept(this, context);
-            return null;
-        }
-
-        @Override
         public Void visitTableRelation(TableRelation tableRelation, RelationContext context) {
             Privileges.ensureUserHasPrivilege(
                 roles,
@@ -262,12 +241,9 @@ public final class AccessControlImpl implements AccessControl {
 
         @Override
         public Void visitQueriedSelectRelation(QueriedSelectRelation relation, RelationContext context) {
-            for (var source : relation.from()) {
-                source.accept(this, context);
-            }
             relation.visitSymbols(tree ->
                 tree.visit(SelectSymbol.class, selectSymbol -> selectSymbol.relation().accept(this, context)));
-            return null;
+            return super.visitQueriedSelectRelation(relation, context);
         }
 
         @Override

--- a/server/src/main/java/io/crate/execution/dsl/projection/builder/SplitPointsBuilder.java
+++ b/server/src/main/java/io/crate/execution/dsl/projection/builder/SplitPointsBuilder.java
@@ -31,10 +31,8 @@ import java.util.List;
 import io.crate.analyze.JoinRelation;
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.QueriedSelectRelation;
-import io.crate.analyze.relations.AliasedAnalyzedRelation;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.AnalyzedRelationVisitor;
-import io.crate.analyze.relations.UnionSelect;
 import io.crate.expression.symbol.Aggregation;
 import io.crate.expression.symbol.DefaultTraversalSymbolVisitor;
 import io.crate.expression.symbol.Function;
@@ -279,36 +277,12 @@ public final class SplitPointsBuilder extends DefaultTraversalSymbolVisitor<Spli
         }
 
         @Override
-        public Void visitAliasedAnalyzedRelation(AliasedAnalyzedRelation relation, LinkedHashSet<Symbol> context) {
-            relation.relation().accept(this, context);
-            return null;
-        }
-
-        @Override
-        public Void visitUnionSelect(UnionSelect unionSelect, LinkedHashSet<Symbol> context) {
-            unionSelect.left().accept(this,context);
-            unionSelect.right().accept(this,context);
-            return null;
-        }
-
-        @Override
         public Void visitJoinRelation(JoinRelation joinRelation, LinkedHashSet<Symbol> context) {
             Symbol joinCondition = joinRelation.joinCondition();
             if (joinCondition != null) {
                 context.add(joinCondition);
             }
-            joinRelation.left().accept(this, context);
-            joinRelation.right().accept(this, context);
-            return null;
-
-        }
-
-        @Override
-        public Void visitQueriedSelectRelation(QueriedSelectRelation relation, LinkedHashSet<Symbol> context) {
-            for (AnalyzedRelation analyzedRelation : relation.from()) {
-                analyzedRelation.accept(this, context);
-            }
-            return null;
+            return super.visitJoinRelation(joinRelation, context);
         }
     }
 }


### PR DESCRIPTION
The `AnalyzedRelationVisitor` already had default traversal for views
and aliased relations but not for joins, union or
queried-select-relation.

This adds them because most concrete implementations benefit from it and
it makes it consistent.
