### PR TITLE
Fix: show custom pk name in pg_class & key_column_usage

### DIFF
--- a/docs/appendices/release-notes/5.10.1.rst
+++ b/docs/appendices/release-notes/5.10.1.rst
@@ -116,3 +116,8 @@ Fixes
 - Fixed an issue that led to ``ArithmeticException`` when using
   :ref:`AVG <aggregation-avg>` with ``NUMERIC`` type and result was an infinite
   fraction, like 1/3.
+
+- Fixed an issue that would lead to returning a default name for
+  :ref:`PRIMARY KEY constraint<primary_key_constraint>` in
+  :ref:`information_schema_key_column_usage` and ``pg_class`` tables even if a
+  custom name was explicitly provided during table creation.

--- a/docs/appendices/release-notes/5.10.1.rst
+++ b/docs/appendices/release-notes/5.10.1.rst
@@ -121,3 +121,9 @@ Fixes
   :ref:`PRIMARY KEY constraint<primary_key_constraint>` in
   :ref:`information_schema_key_column_usage` and ``pg_class`` tables even if a
   custom name was explicitly provided during table creation.
+
+- Fixed an issue that would lead to returning a different default name for
+  :ref:`PRIMARY KEY constraint<primary_key_constraint>` in
+  :ref:`information_schema_key_column_usage` and ``pg_class`` tables,
+  ``<table_name>_pk`` and ``<table_name>_pkey`` respectively, when a custom
+  name is not explicitly provided during table creation.

--- a/docs/appendices/release-notes/5.9.10.rst
+++ b/docs/appendices/release-notes/5.9.10.rst
@@ -87,3 +87,8 @@ Fixes
 - Fixed an issue that led to ``ArithmeticException`` when using
   :ref:`AVG <aggregation-avg>` with ``NUMERIC`` type and result was an infinite
   fraction, like 1/3.
+
+- Fixed an issue that would lead to returning a default name for
+  :ref:`PRIMARY KEY constraint<primary_key_constraint>` in
+  :ref:`information_schema_key_column_usage` and ``pg_class`` tables even if a
+  custom name was explicitly provided during table creation.

--- a/docs/appendices/release-notes/5.9.10.rst
+++ b/docs/appendices/release-notes/5.9.10.rst
@@ -92,3 +92,9 @@ Fixes
   :ref:`PRIMARY KEY constraint<primary_key_constraint>` in
   :ref:`information_schema_key_column_usage` and ``pg_class`` tables even if a
   custom name was explicitly provided during table creation.
+
+- Fixed an issue that would lead to returning a different default name for
+  :ref:`PRIMARY KEY constraint<primary_key_constraint>` in
+  :ref:`information_schema_key_column_usage` and ``pg_class`` tables,
+  ``<table_name>_pk`` and ``<table_name>_pkey`` respectively, when a custom
+  name is not explicitly provided during table creation.

--- a/docs/general/information-schema.rst
+++ b/docs/general/information-schema.rst
@@ -527,8 +527,8 @@ type, name and which table they are defined in.
     +--------------------+------------+------------------------+-------------+
     | table_schema       | table_name | constraint_name        | type        |
     +--------------------+------------+------------------------+-------------+
-    | information_schema | tables     | tables_pk              | PRIMARY KEY |
-    | doc                | quotes     | quotes_pk              | PRIMARY KEY |
+    | information_schema | tables     | tables_pkey            | PRIMARY KEY |
+    | doc                | quotes     | quotes_pkey            | PRIMARY KEY |
     | doc                | quotes     | doc_quotes_id_not_null | CHECK       |
     | doc                | tbl        | doc_tbl_col_not_null   | CHECK       |
     +--------------------+------------+------------------------+-------------+
@@ -555,8 +555,8 @@ tables:
     +-----------------+------------+-------------+------------------+
     | constraint_name | table_name | column_name | ordinal_position |
     +-----------------+------------+-------------+------------------+
-    | students_pk     | students   | id          |                1 |
-    | students_pk     | students   | department  |                2 |
+    | students_pkey   | students   | id          |                1 |
+    | students_pkey   | students   | department  |                2 |
     +-----------------+------------+-------------+------------------+
     SELECT 2 rows in set (... sec)
 

--- a/docs/general/information-schema.rst
+++ b/docs/general/information-schema.rst
@@ -534,6 +534,7 @@ type, name and which table they are defined in.
     +--------------------+------------+------------------------+-------------+
     SELECT 4 rows in set (... sec)
 
+.. _information_schema_key_column_usage:
 
 ``key_column_usage``
 --------------------

--- a/server/src/main/java/io/crate/analyze/TableInfoToAST.java
+++ b/server/src/main/java/io/crate/analyze/TableInfoToAST.java
@@ -250,7 +250,9 @@ public class TableInfoToAST {
             if (tableInfo.primaryKey().size() == 1 && tableInfo.primaryKey().get(0).isSystemColumn()) {
                 return null;
             }
-            return new PrimaryKeyConstraint<>(tableInfo.pkConstraintName(), expressionsFromColumns(tableInfo.primaryKey()));
+            return new PrimaryKeyConstraint<>(
+                tableInfo.pkConstraintName(),
+                expressionsFromColumns(tableInfo.primaryKey()));
         }
         return null;
     }

--- a/server/src/main/java/io/crate/execution/engine/collect/sources/InformationSchemaIterables.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/sources/InformationSchemaIterables.java
@@ -41,6 +41,7 @@ import java.util.stream.StreamSupport;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.jetbrains.annotations.NotNull;
 
 import io.crate.execution.engine.collect.files.SqlFeatureContext;
 import io.crate.execution.engine.collect.files.SqlFeatures;
@@ -214,7 +215,7 @@ public class InformationSchemaIterables {
             info.ident().name(),
             toEntryType(info.relationType()),
             info.columns().size(),
-            info.primaryKey().size() > 0);
+            !info.primaryKey().isEmpty());
     }
 
     private PgClassTable.Entry primaryKeyToPgClassEntry(RelationInfo info) {
@@ -222,10 +223,12 @@ public class InformationSchemaIterables {
             Regclass.primaryOid(info),
             OidHash.schemaOid(info.ident().schema()),
             info.ident(),
-            info.ident().name() + "_pkey",
+            info.pkConstraintName() != null
+                ? info.pkConstraintName()
+                : info.ident().name() + "_pkey",
             PgClassTable.Entry.Type.INDEX,
             info.columns().size(),
-            info.primaryKey().size() > 0);
+            !info.primaryKey().isEmpty());
     }
 
     private static PgClassTable.Entry.Type toEntryType(RelationInfo.RelationType type) {
@@ -334,11 +337,14 @@ public class InformationSchemaIterables {
         return sequentialStream(primaryKeys)
             .filter(tableInfo -> !IGNORED_SCHEMAS.contains(tableInfo.ident().schema()))
             .flatMap(tableInfo -> {
+                String pkName = tableInfo.pkConstraintName() != null
+                    ? tableInfo.pkConstraintName()
+                    : tableInfo.ident().name() + PK_SUFFIX;
                 List<ColumnIdent> pks = tableInfo.primaryKey();
                 PrimitiveIterator.OfInt ids = IntStream.range(1, pks.size() + 1).iterator();
                 RelationName ident = tableInfo.ident();
                 return pks.stream().map(
-                    pk -> new KeyColumnUsage(ident, pk, ids.next()));
+                    pk -> new KeyColumnUsage(ident, pkName, pk, ids.next()));
             })::iterator;
     }
 
@@ -396,6 +402,7 @@ public class InformationSchemaIterables {
         }
 
         @Override
+        @NotNull
         public Iterator<ConstraintInfo> iterator() {
             return new NotNullConstraintIterator(info);
         }
@@ -433,14 +440,13 @@ public class InformationSchemaIterables {
             // Currently the longest not null constraint of information_schema
             // is 56 characters long, that's why default string length is set to
             // 60.
-            String constraintName = new StringBuilder(60)
-                .append(this.relationInfo.ident().schema())
-                .append("_")
-                .append(this.relationInfo.ident().name())
-                .append("_")
-                .append(this.notNullableColumns.next().column().name())
-                .append("_not_null")
-                .toString();
+            String constraintName =
+                this.relationInfo.ident().schema() +
+                "_" +
+                this.relationInfo.ident().name() +
+                "_" +
+                this.notNullableColumns.next().column().name() +
+                "_not_null";
 
             // Return nullable columns instead.
             return new ConstraintInfo(
@@ -460,6 +466,7 @@ public class InformationSchemaIterables {
         }
 
         @Override
+        @NotNull
         public Iterator<ColumnContext> iterator() {
             return new ColumnsIterator(relationInfo);
         }
@@ -492,28 +499,10 @@ public class InformationSchemaIterables {
         }
     }
 
-    public static class KeyColumnUsage {
-
-        private final RelationName relationName;
-        private final ColumnIdent pkColumnIdent;
-        private final int ordinal;
-
-        KeyColumnUsage(RelationName relationName, ColumnIdent pkColumnIdent, int ordinal) {
-            this.relationName = relationName;
-            this.pkColumnIdent = pkColumnIdent;
-            this.ordinal = ordinal;
-        }
+    public record KeyColumnUsage(RelationName relationName, String pkName, ColumnIdent pkColumnIdent, int ordinal) {
 
         public String getSchema() {
             return relationName.schema();
-        }
-
-        public String getPkColumnIdent() {
-            return pkColumnIdent.name();
-        }
-
-        public int getOrdinal() {
-            return ordinal;
         }
 
         public String getTableName() {

--- a/server/src/main/java/io/crate/execution/engine/collect/sources/InformationSchemaIterables.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/sources/InformationSchemaIterables.java
@@ -83,8 +83,6 @@ import io.crate.types.Regproc;
 
 public class InformationSchemaIterables {
 
-    public static final String PK_SUFFIX = "_pk";
-
     private static final Set<String> IGNORED_SCHEMAS = Set.of(
         InformationSchemaInfo.NAME,
         SysSchemaInfo.NAME,
@@ -139,7 +137,7 @@ public class InformationSchemaIterables {
         Iterable<ConstraintInfo> primaryKeyConstraints = () -> sequentialStream(primaryKeys)
             .map(t -> new ConstraintInfo(
                 t,
-                t.pkConstraintName() == null ? t.ident().name() + PK_SUFFIX : t.pkConstraintName(),
+                t.pkConstraintNameOrDefault(),
                 ConstraintInfo.Type.PRIMARY_KEY))
             .iterator();
 
@@ -223,9 +221,7 @@ public class InformationSchemaIterables {
             Regclass.primaryOid(info),
             OidHash.schemaOid(info.ident().schema()),
             info.ident(),
-            info.pkConstraintName() != null
-                ? info.pkConstraintName()
-                : info.ident().name() + "_pkey",
+            info.pkConstraintNameOrDefault(),
             PgClassTable.Entry.Type.INDEX,
             info.columns().size(),
             !info.primaryKey().isEmpty());
@@ -337,14 +333,11 @@ public class InformationSchemaIterables {
         return sequentialStream(primaryKeys)
             .filter(tableInfo -> !IGNORED_SCHEMAS.contains(tableInfo.ident().schema()))
             .flatMap(tableInfo -> {
-                String pkName = tableInfo.pkConstraintName() != null
-                    ? tableInfo.pkConstraintName()
-                    : tableInfo.ident().name() + PK_SUFFIX;
                 List<ColumnIdent> pks = tableInfo.primaryKey();
                 PrimitiveIterator.OfInt ids = IntStream.range(1, pks.size() + 1).iterator();
                 RelationName ident = tableInfo.ident();
                 return pks.stream().map(
-                    pk -> new KeyColumnUsage(ident, pkName, pk, ids.next()));
+                    pk -> new KeyColumnUsage(ident, tableInfo.pkConstraintNameOrDefault(), pk, ids.next()));
             })::iterator;
     }
 

--- a/server/src/main/java/io/crate/metadata/RelationInfo.java
+++ b/server/src/main/java/io/crate/metadata/RelationInfo.java
@@ -37,6 +37,8 @@ import io.crate.sql.tree.CheckConstraint;
  */
 public interface RelationInfo extends Iterable<Reference> {
 
+    String PK_SUFFIX = "_pkey";
+
     enum RelationType {
         BASE_TABLE("BASE TABLE"),
         VIEW("VIEW"),
@@ -77,6 +79,19 @@ public interface RelationInfo extends Iterable<Reference> {
     @Nullable
     default String pkConstraintName() {
         return null;
+    }
+
+    @Nullable
+    default String pkConstraintNameOrDefault() {
+        String pkName = pkConstraintName();
+        if (pkName != null) {
+            return pkName;
+        }
+        if (primaryKey().isEmpty() || (primaryKey().size() == 1 && primaryKey().get(0).isSystemColumn())) {
+            return null;
+        } else {
+            return ident().name() + PK_SUFFIX;
+        }
     }
 
     List<ColumnIdent> primaryKey();

--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
@@ -431,11 +431,11 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
     }
 
     @Override
-    @Nullable
     public String pkConstraintName() {
         return pkConstraintName;
     }
 
+    @Override
     public List<ColumnIdent> primaryKey() {
         return primaryKeys;
     }

--- a/server/src/main/java/io/crate/metadata/information/InformationKeyColumnUsageTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/information/InformationKeyColumnUsageTableInfo.java
@@ -21,7 +21,6 @@
 
 package io.crate.metadata.information;
 
-import static io.crate.execution.engine.collect.sources.InformationSchemaIterables.PK_SUFFIX;
 import static io.crate.types.DataTypes.INTEGER;
 import static io.crate.types.DataTypes.STRING;
 
@@ -42,12 +41,12 @@ public class InformationKeyColumnUsageTableInfo {
     public static SystemTable<InformationSchemaIterables.KeyColumnUsage> INSTANCE = SystemTable.<InformationSchemaIterables.KeyColumnUsage>builder(IDENT)
         .add("constraint_catalog", STRING, k -> Constants.DB_NAME)
         .add("constraint_schema", STRING, InformationSchemaIterables.KeyColumnUsage::getSchema)
-        .add("constraint_name", STRING, k -> k.getTableName() + PK_SUFFIX)
+        .add("constraint_name", STRING, InformationSchemaIterables.KeyColumnUsage::pkName)
         .add("table_catalog", STRING, k -> Constants.DB_NAME)
         .add("table_schema", STRING, InformationSchemaIterables.KeyColumnUsage::getSchema)
         .add("table_name", STRING, InformationSchemaIterables.KeyColumnUsage::getTableName)
-        .add("column_name", STRING, InformationSchemaIterables.KeyColumnUsage::getPkColumnIdent)
-        .add("ordinal_position", INTEGER, InformationSchemaIterables.KeyColumnUsage::getOrdinal)
+        .add("column_name", STRING, k -> k.pkColumnIdent().name())
+        .add("ordinal_position", INTEGER, InformationSchemaIterables.KeyColumnUsage::ordinal)
         .setPrimaryKeys(
             ColumnIdent.of("constraint_catalog"),
             ColumnIdent.of("constraint_schema"),

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgCatalogTableDefinitions.java
@@ -84,10 +84,10 @@ public final class PgCatalogTableDefinitions {
                 false)),
             Map.entry(PgClassTable.IDENT, new StaticTableDefinition<>(
                 informationSchemaIterables::pgClasses,
-                (user, t) -> roles.hasAnyPrivilege(user, Securable.TABLE, t.ident.fqn())
+                (user, t) -> roles.hasAnyPrivilege(user, Securable.TABLE, t.ident().fqn())
                             // we also need to check for views which have privileges set
-                            || roles.hasAnyPrivilege(user, Securable.VIEW, t.ident.fqn())
-                            || isPgCatalogOrInformationSchema(t.ident.schema()),
+                            || roles.hasAnyPrivilege(user, Securable.VIEW, t.ident().fqn())
+                            || isPgCatalogOrInformationSchema(t.ident().schema()),
                 pgCatalogSchemaInfo.pgClassTable().expressions()
             )),
             Map.entry(PgProcTable.IDENT, new StaticTableDefinition<>(

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgClassTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgClassTable.java
@@ -82,7 +82,13 @@ public final class PgClassTable {
             .build();
     }
 
-    public static final class Entry {
+    public record Entry(Regclass oid,
+                        int schemaOid,
+                        RelationName ident,
+                        String name,
+                        Type type,
+                        int numberOfAttributes,
+                        boolean hasPrimaryKey) {
 
         public enum Type {
             VIEW("v"),
@@ -95,30 +101,6 @@ public final class PgClassTable {
             Type(String relKind) {
                 this.relKind = relKind;
             }
-        }
-
-        final Regclass oid;
-        final boolean hasPrimaryKey;
-        final int schemaOid;
-        final RelationName ident;
-        final Type type;
-        final int numberOfAttributes;
-        final String name;
-
-        public Entry(Regclass oid,
-                     int schemaOid,
-                     RelationName ident,
-                     String name,
-                     Type type,
-                     int numberOfAttributes,
-                     boolean hasPrimaryKey) {
-            this.oid = oid;
-            this.schemaOid = schemaOid;
-            this.hasPrimaryKey = hasPrimaryKey;
-            this.ident = ident;
-            this.type = type;
-            this.name = name;
-            this.numberOfAttributes = numberOfAttributes;
         }
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
@@ -421,14 +421,14 @@ public class DDLIntegrationTest extends IntegTestCase {
             "doc| t| CHECK| check_id_ge_zero",
             "doc| t| CHECK| check_qty_gt_zero",
             "doc| t| CHECK| doc_t_id_not_null",
-            "doc| t| PRIMARY KEY| t_pk"
+            "doc| t| PRIMARY KEY| t_pkey"
         );
         execute("alter table t drop constraint check_id_ge_zero");
         execute(selectCheckConstraintsStmt);
         assertThat(response).hasRows(
             "doc| t| CHECK| check_qty_gt_zero",
             "doc| t| CHECK| doc_t_id_not_null",
-            "doc| t| PRIMARY KEY| t_pk"
+            "doc| t| PRIMARY KEY| t_pkey"
         );
         execute("insert into t(id, qty) values(-42, 100)");
         Asserts.assertSQLError(() -> execute("insert into t(id, qty) values(0, 0)"))
@@ -450,7 +450,7 @@ public class DDLIntegrationTest extends IntegTestCase {
         execute(selectCheckConstraintsStmt);
         assertThat(response).hasRows(
             "doc| t| CHECK| doc_t_id_not_null",
-            "doc| t| PRIMARY KEY| t_pk"
+            "doc| t| PRIMARY KEY| t_pkey"
         );
 
         execute("insert into t(id) values(-1)");
@@ -496,7 +496,7 @@ public class DDLIntegrationTest extends IntegTestCase {
             "where table_name = 't' and table_schema = 'doc' order by constraint_name");
         assertThat(response).hasRows(
             "doc_t_id_not_null",
-            "t_pk"
+            "t_pkey"
         );
 
         execute("alter table t add column name string primary key");
@@ -506,7 +506,7 @@ public class DDLIntegrationTest extends IntegTestCase {
         assertThat(response).hasRows(
             "doc_t_id_not_null",
             "doc_t_name_not_null",
-            "t_pk"
+            "t_pkey"
         );
     }
 

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -401,7 +401,7 @@ public class InformationSchemaTest extends IntegTestCase {
         execute("SELECT constraint_name, constraint_type, table_name, table_schema FROM " +
                 "information_schema.table_constraints ORDER BY table_schema ASC, table_name ASC");
         assertThat(response).hasRows(
-            "columns_pk| PRIMARY KEY| columns| information_schema",
+            "columns_pkey| PRIMARY KEY| columns| information_schema",
             "information_schema_columns_column_name_not_null| CHECK| columns| information_schema",
             "information_schema_columns_data_type_not_null| CHECK| columns| information_schema",
             "information_schema_columns_is_generated_not_null| CHECK| columns| information_schema",
@@ -410,29 +410,29 @@ public class InformationSchemaTest extends IntegTestCase {
             "information_schema_columns_table_catalog_not_null| CHECK| columns| information_schema",
             "information_schema_columns_table_name_not_null| CHECK| columns| information_schema",
             "information_schema_columns_table_schema_not_null| CHECK| columns| information_schema",
-            "key_column_usage_pk| PRIMARY KEY| key_column_usage| information_schema",
-            "referential_constraints_pk| PRIMARY KEY| referential_constraints| information_schema",
-            "schemata_pk| PRIMARY KEY| schemata| information_schema",
-            "sql_features_pk| PRIMARY KEY| sql_features| information_schema",
-            "table_constraints_pk| PRIMARY KEY| table_constraints| information_schema",
-            "table_partitions_pk| PRIMARY KEY| table_partitions| information_schema",
-            "tables_pk| PRIMARY KEY| tables| information_schema",
-            "views_pk| PRIMARY KEY| views| information_schema",
-            "allocations_pk| PRIMARY KEY| allocations| sys",
-            "checks_pk| PRIMARY KEY| checks| sys",
-            "jobs_pk| PRIMARY KEY| jobs| sys",
-            "jobs_log_pk| PRIMARY KEY| jobs_log| sys",
-            "node_checks_pk| PRIMARY KEY| node_checks| sys",
-            "nodes_pk| PRIMARY KEY| nodes| sys",
-            "privileges_pk| PRIMARY KEY| privileges| sys",
-            "repositories_pk| PRIMARY KEY| repositories| sys",
-            "roles_pk| PRIMARY KEY| roles| sys",
-            "sessions_pk| PRIMARY KEY| sessions| sys",
-            "shards_pk| PRIMARY KEY| shards| sys",
-            "snapshot_restore_pk| PRIMARY KEY| snapshot_restore| sys",
-            "snapshots_pk| PRIMARY KEY| snapshots| sys",
-            "summits_pk| PRIMARY KEY| summits| sys",
-            "users_pk| PRIMARY KEY| users| sys"
+            "key_column_usage_pkey| PRIMARY KEY| key_column_usage| information_schema",
+            "referential_constraints_pkey| PRIMARY KEY| referential_constraints| information_schema",
+            "schemata_pkey| PRIMARY KEY| schemata| information_schema",
+            "sql_features_pkey| PRIMARY KEY| sql_features| information_schema",
+            "table_constraints_pkey| PRIMARY KEY| table_constraints| information_schema",
+            "table_partitions_pkey| PRIMARY KEY| table_partitions| information_schema",
+            "tables_pkey| PRIMARY KEY| tables| information_schema",
+            "views_pkey| PRIMARY KEY| views| information_schema",
+            "allocations_pkey| PRIMARY KEY| allocations| sys",
+            "checks_pkey| PRIMARY KEY| checks| sys",
+            "jobs_pkey| PRIMARY KEY| jobs| sys",
+            "jobs_log_pkey| PRIMARY KEY| jobs_log| sys",
+            "node_checks_pkey| PRIMARY KEY| node_checks| sys",
+            "nodes_pkey| PRIMARY KEY| nodes| sys",
+            "privileges_pkey| PRIMARY KEY| privileges| sys",
+            "repositories_pkey| PRIMARY KEY| repositories| sys",
+            "roles_pkey| PRIMARY KEY| roles| sys",
+            "sessions_pkey| PRIMARY KEY| sessions| sys",
+            "shards_pkey| PRIMARY KEY| shards| sys",
+            "snapshot_restore_pkey| PRIMARY KEY| snapshot_restore| sys",
+            "snapshots_pkey| PRIMARY KEY| snapshots| sys",
+            "summits_pkey| PRIMARY KEY| summits| sys",
+            "users_pkey| PRIMARY KEY| users| sys"
         );
 
         execute("CREATE TABLE test (\n" +
@@ -449,7 +449,7 @@ public class InformationSchemaTest extends IntegTestCase {
             new Object[]{sqlExecutor.getCurrentSchema()});
         assertThat(response.rowCount()).isEqualTo(6L); // 4 explicit constraints + 2 NOT NULL derived from composite PK
         assertThat(response.rows()[0][0]).isEqualTo("PRIMARY KEY");
-        assertThat(response.rows()[0][1]).isEqualTo("test_pk");
+        assertThat(response.rows()[0][1]).isEqualTo("test_pkey");
         assertThat(response.rows()[0][2]).isEqualTo("test");
         assertThat(response.rows()[1][0]).isEqualTo("CHECK");
         assertThat((String) response.rows()[1][1]).isEqualTo(sqlExecutor.getCurrentSchema() + "_test_col1_not_null");
@@ -476,7 +476,7 @@ public class InformationSchemaTest extends IntegTestCase {
                 ".table_constraints WHERE table_schema = ?", new Object[]{sqlExecutor.getCurrentSchema()});
         assertThat(response.rowCount()).isEqualTo(2L); // 1 PK + 1 NOT NULL derived from PK
         assertThat(response.rows()[0][0]).isEqualTo("test");
-        assertThat(response.rows()[0][1]).isEqualTo("test_pk");
+        assertThat(response.rows()[0][1]).isEqualTo("test_pkey");
         assertThat(response.rows()[1][0]).isEqualTo("test");
         assertThat((String) response.rows()[1][1]).isEqualTo(sqlExecutor.getCurrentSchema() + "_test_col1_not_null");
 
@@ -490,7 +490,7 @@ public class InformationSchemaTest extends IntegTestCase {
 
         assertThat(response.rowCount()).isEqualTo(5L); // 2 PK + 1 explicit NOT NULL + 2 NOT NULL derived from PK-s.
         assertThat(response.rows()[2][0]).isEqualTo("test2");
-        assertThat(response.rows()[2][1]).isEqualTo("test2_pk");
+        assertThat(response.rows()[2][1]).isEqualTo("test2_pkey");
         assertThat(response.rows()[3][0]).isEqualTo("test2");
         assertThat((String) response.rows()[3][1]).isEqualTo(sqlExecutor.getCurrentSchema() + "_test2_col1a_not_null");
         assertThat(response.rows()[4][0]).isEqualTo("test2");
@@ -1335,7 +1335,7 @@ public class InformationSchemaTest extends IntegTestCase {
 
         final String defaultSchema = sqlExecutor.getCurrentSchema();
         Object[][] expectedRows = new Object[][] {
-            new Object[]{"id2", "crate", "table2_pk", defaultSchema, 1, "crate", "table2", defaultSchema},
+            new Object[]{"id2", "crate", "table2_pkey", defaultSchema, 1, "crate", "table2", defaultSchema},
             new Object[]{"id3", "crate", "pk_of_table3", defaultSchema, 1, "crate", "table3", defaultSchema},
             new Object[]{"name", "crate", "pk_of_table3", defaultSchema, 2, "crate", "table3", defaultSchema}
         };

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -24,7 +24,6 @@ package io.crate.integrationtests;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
 import java.util.List;
@@ -1317,7 +1316,8 @@ public class InformationSchemaTest extends IntegTestCase {
     public void testSelectFromKeyColumnUsage() {
         execute("create table table1 (id1 integer)");
         execute("create table table2 (id2 integer primary key)");
-        execute("create table table3 (id3 integer, name string, other double, primary key (id3, name))");
+        execute("create table table3 (id3 integer, name string, other double, " +
+                "constraint pk_of_table3 primary key (id3, name))");
         ensureYellow();
 
         execute("select * from information_schema.key_column_usage order by table_name, ordinal_position asc");
@@ -1336,8 +1336,8 @@ public class InformationSchemaTest extends IntegTestCase {
         final String defaultSchema = sqlExecutor.getCurrentSchema();
         Object[][] expectedRows = new Object[][] {
             new Object[]{"id2", "crate", "table2_pk", defaultSchema, 1, "crate", "table2", defaultSchema},
-            new Object[]{"id3", "crate", "table3_pk", defaultSchema, 1, "crate", "table3", defaultSchema},
-            new Object[]{"name", "crate", "table3_pk", defaultSchema, 2, "crate", "table3", defaultSchema}
+            new Object[]{"id3", "crate", "pk_of_table3", defaultSchema, 1, "crate", "table3", defaultSchema},
+            new Object[]{"name", "crate", "pk_of_table3", defaultSchema, 2, "crate", "table3", defaultSchema}
         };
         assertThat(response.rows()).isEqualTo(expectedRows);
 

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -290,6 +290,19 @@ public class PgCatalogITest extends IntegTestCase {
     }
 
     @Test
+    public void test_primary_key__with_custom_name_in_pg_class() {
+        execute("""
+            create table doc.t_with_custom_pk_name (
+                id int,
+                constraint custom_pk_name primary key(id)
+            )""");
+        execute("select ct.oid, ct.relkind, ct.relname, ct.relnamespace, ct.relnatts, ct.relpersistence, ct.relreplident, ct.reltuples" +
+                " from pg_class ct, (select * from pg_index i, pg_class c where c.relname = 't_with_custom_pk_name' and c.oid = i.indrelid) i" +
+                " where ct.oid = i.indexrelid;");
+        assertThat(response).hasRows("128167471| i| custom_pk_name| -2048275947| 1| p| p| 0.0");
+    }
+
+    @Test
     public void test_pg_proc_return_correct_column_names() {
         execute("select * from pg_proc");
         assertThat(response).hasColumns(

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -178,8 +178,8 @@ public class PgCatalogITest extends IntegTestCase {
     public void testPgConstraintTable() {
         execute("select cn.* from pg_constraint cn, pg_class c where cn.conrelid = c.oid and c.relname = 't1'");
         assertThat(response).hasRows(
-            "NULL| false| false| NULL| a| NULL| NULL| s| 0| a| 0| 0| true| [1]| t1_pk| -2048275947| true| 0| NULL| " +
-            "NULL| 728874843| p| 0| true| -874078436");
+            "NULL| false| false| NULL| a| NULL| NULL| s| 0| a| 0| 0| true| [1]| t1_pkey| -2048275947| true| 0| NULL| " +
+            "NULL| 728874843| p| 0| true| -1310475467");
     }
 
     @Test
@@ -408,7 +408,7 @@ public class PgCatalogITest extends IntegTestCase {
     }
 
     @Test
-    public void test_pg_constrains_conkey_array_populated() throws Exception {
+    public void test_pg_constraints_conkey_array_populated() throws Exception {
         execute("CREATE TABLE doc.tbl (" +
             "not_null int not null," +
             "int_col int," +
@@ -422,7 +422,7 @@ public class PgCatalogITest extends IntegTestCase {
         assertThat(response).hasRows(
             "[2, 1, 3]| many_cols_and_functions| c",
             "[4]| positive| c",
-            "[2, 3]| tbl_pk| p"
+            "[2, 3]| tbl_pkey| p"
         );
     }
 

--- a/server/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
@@ -29,7 +29,6 @@ import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static io.netty.handler.codec.http.HttpResponseStatus.UNAUTHORIZED;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.After;
 import org.junit.Before;
@@ -304,7 +303,7 @@ public class PrivilegesIntegrationTest extends BaseRolesIntegrationTest {
                 testUserSession);
             assertThat(response).hasRows(
                 "t2| my_schema_t2_x_not_null",
-                "t2| t2_pk");
+                "t2| t2_pkey");
             execute("select routine_schema from information_schema.routines order by routine_schema",
                     null,
                     testUserSession);
@@ -698,15 +697,15 @@ public class PrivilegesIntegrationTest extends BaseRolesIntegrationTest {
         try (Session testUserSession = testUserSession()) {
             execute("select conname from pg_catalog.pg_constraint order by conname", null, testUserSession);
             assertThat(response).hasRows(
-                    "columns_pk",
-                    "key_column_usage_pk",
-                    "referential_constraints_pk",
-                    "schemata_pk",
-                    "sql_features_pk",
-                    "table_constraints_pk",
-                    "table_partitions_pk",
-                    "tables_pk",
-                    "views_pk");
+                    "columns_pkey",
+                    "key_column_usage_pkey",
+                    "referential_constraints_pkey",
+                    "schemata_pkey",
+                    "sql_features_pkey",
+                    "table_constraints_pkey",
+                    "table_partitions_pkey",
+                    "tables_pkey",
+                    "views_pkey");
 
             //create a table with constraints that a new user is not privileged to access
             executeAsSuperuser("""
@@ -727,7 +726,7 @@ public class PrivilegesIntegrationTest extends BaseRolesIntegrationTest {
             assertThat(response)
                 .as("user sees constraints after having granted privileges")
                 .hasRows(
-                    "my_table_pk",
+                    "my_table_pkey",
                     "positive_num"
                 );
         }
@@ -736,7 +735,7 @@ public class PrivilegesIntegrationTest extends BaseRolesIntegrationTest {
         assertThat(response)
             .as("super user sees same constraints")
             .hasRows(
-                "my_table_pk",
+                "my_table_pkey",
                 "positive_num"
             );
     }


### PR DESCRIPTION
- Previously, even if a custom name was provided for the PK during table creation, the `pg_class.relname` and
`information_schema.key_column_usage.constraint_name` columns where showing an artificial pkName, based on the table name and a suffix.

- Consolidate default pk name in `informaion_schema.key_column_usage` & `pg_class`
   Use `<table_name>_pkey` in both cases, whereas previously, for
   `information_schema.key_column_usage` `<table_name>_pk` was used.

Fixes: #17377
