### PR TITLE
docs: Replace link for Google Service Account

### DIFF
--- a/docs/sql/statements/create-repository.rst
+++ b/docs/sql/statements/create-repository.rst
@@ -798,6 +798,6 @@ Parameters
 .. _plugins: https://github.com/crate/crate/blob/master/devs/docs/plugins.rst
 .. _regional endpoint: https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints
 .. _Google Cloud Storage: https://cloud.google.com/storage/
-.. _Google Service account: https://cloud.google.com/iam/docs/overview#service-account
-.. _Google Service account credentials: https://cloud.google.com/storage/docs/authentication?hl=en
+.. _Google Service account: https://cloud.google.com/iam/docs/service-account-overview
+.. _Google Service account credentials: https://cloud.google.com/storage/docs/authentication
 .. _PKCS 8: https://en.wikipedia.org/wiki/PKCS_8


### PR DESCRIPTION
Seems that the previous link (specifically the `#service-account` anchor) is not working anymore. Replacing it with a link to the overview page for the service account.
