### PR TITLE
Removed unused docvalues path for some type indexer

### DIFF
--- a/server/src/main/java/io/crate/execution/dml/GeoShapeIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/GeoShapeIndexer.java
@@ -90,6 +90,12 @@ public class GeoShapeIndexer implements ValueIndexer<Map<String, Object>> {
     @Override
     public void indexValue(@NotNull Map<String, Object> value, IndexDocumentBuilder docBuilder) throws IOException {
         indexableFieldsFactory.create(value, docBuilder::addField);
+
+        var storageSupport = ref.valueType().storageSupport();
+        assert ref.hasDocValues() == false &&
+            storageSupport != null && storageSupport.supportsDocValuesOff() == false :
+            "Should only be used with disabled doc values";
+
         docBuilder.addField(new Field(
             SysColumns.FieldNames.NAME,
             name,


### PR DESCRIPTION
Some data types do not support to disable (or enable) docvalues, such the related indexer contained code which was never used (dead code). Removed it and added assertions to ensure the expected storage support settings.
