### PR TITLE
Fix Nullability for array_position

### DIFF
--- a/docs/appendices/release-notes/5.10.1.rst
+++ b/docs/appendices/release-notes/5.10.1.rst
@@ -132,3 +132,9 @@ Fixes
   :ref:`information_schema_key_column_usage` and ``pg_class`` tables,
   ``<table_name>_pk`` and ``<table_name>_pkey`` respectively, when a custom
   name is not explicitly provided during table creation.
+
+- Fixed an issue that would cause :ref:`array_position<scalar-array_position>`
+  to return wrong results when used on a column with NULL values in the
+  ``WHERE`` combined with a ``NOT`` predicate. e.g.::
+
+    SELECT * FROM tbl WHERE NOT array_position(string_array_col, 'foo');

--- a/docs/appendices/release-notes/5.9.10.rst
+++ b/docs/appendices/release-notes/5.9.10.rst
@@ -103,3 +103,9 @@ Fixes
   :ref:`information_schema_key_column_usage` and ``pg_class`` tables,
   ``<table_name>_pk`` and ``<table_name>_pkey`` respectively, when a custom
   name is not explicitly provided during table creation.
+
+- Fixed an issue that would cause :ref:`array_position<scalar-array_position>`
+  to return wrong results when used on a column with NULL values in the
+  ``WHERE`` combined with a ``NOT`` predicate. e.g.::
+
+    SELECT * FROM tbl WHERE NOT array_position(string_array_col, 'foo');

--- a/server/src/main/java/io/crate/expression/scalar/ArrayPositionFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ArrayPositionFunction.java
@@ -54,7 +54,7 @@ public class ArrayPositionFunction extends Scalar<Integer, List<Object>> {
                                 TypeSignature.parse("T"))
                         .returnType(DataTypes.INTEGER.getTypeSignature())
                         .typeVariableConstraints(typeVariable("T"))
-                        .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
+                        .features(Feature.DETERMINISTIC)
                         .build(),
                 ArrayPositionFunction::new);
 
@@ -65,15 +65,15 @@ public class ArrayPositionFunction extends Scalar<Integer, List<Object>> {
                                 DataTypes.INTEGER.getTypeSignature())
                         .returnType(DataTypes.INTEGER.getTypeSignature())
                         .typeVariableConstraints(typeVariable("T"))
-                        .features(Feature.DETERMINISTIC, Feature.STRICTNULL)
+                        .features(Feature.DETERMINISTIC)
                         .build(),
                 ArrayPositionFunction::new);
     }
 
     @Override
-    public Integer evaluate(TransactionContext txnCtx, NodeContext nodeContext, Input[] args) {
+    public Integer evaluate(TransactionContext txnCtx, NodeContext nodeContext, Input<List<Object>>[] args) {
 
-        List<Object> elements = (List<Object>) args[0].value();
+        List<Object> elements = args[0].value();
         if (elements == null || elements.isEmpty()) {
             return null;
         }
@@ -90,7 +90,7 @@ public class ArrayPositionFunction extends Scalar<Integer, List<Object>> {
             return null;
         }
 
-        Object element = null;
+        Object element;
         for (int i = beginIndex; i < elements.size(); i++) {
             element = elements.get(i);
             if (Objects.equals(targetValue, element)) {
@@ -107,7 +107,7 @@ public class ArrayPositionFunction extends Scalar<Integer, List<Object>> {
             return 0;
         }
 
-        Integer beginPosition = (Integer) position;
+        int beginPosition = (Integer) position;
         if (beginPosition < 1 || beginPosition > elementsSize) {
             return null;
         }

--- a/server/src/test/java/io/crate/lucene/ThreeValuedLogicQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/ThreeValuedLogicQueryBuilderTest.java
@@ -141,4 +141,12 @@ public class ThreeValuedLogicQueryBuilderTest extends LuceneQueryBuilderTest {
         assertThat(convert("NOT (cast(obj as string))")).hasToString(
             "+(+*:* -cast(obj AS TEXT)) #(NOT cast(obj AS TEXT))");
     }
+
+    @Test
+    public void test_not_on_array_position() {
+        assertThat(convert("NOT (array_position(string_array, 'foo'))")).hasToString(
+            "+(+*:* -array_position(string_array, 'foo')) #(NOT array_position(string_array, 'foo'))");
+        assertThat(convert("NOT (array_position(string_array, 'foo', 10))")).hasToString(
+            "+(+*:* -array_position(string_array, 'foo', 10)) #(NOT array_position(string_array, 'foo', 10))");
+    }
 }


### PR DESCRIPTION
Remove `STRICTNULL` from `array_position` as with the flag it returns wrong results when used on the `WHERE` clause on a table cols wrapped with the `NOT` predicate.

Fixes: #17378

