### PR TITLE
Fix restore resolve indices logic to not include all templates

### DIFF
--- a/docs/appendices/release-notes/5.10.1.rst
+++ b/docs/appendices/release-notes/5.10.1.rst
@@ -138,3 +138,9 @@ Fixes
   ``WHERE`` combined with a ``NOT`` predicate. e.g.::
 
     SELECT * FROM tbl WHERE NOT array_position(string_array_col, 'foo');
+
+- Fixed a regression introduced with :ref:`version_5.6.0` that caused any
+  partitioned table contained inside the snapshot to be restored, if not exists,
+  by the :ref:`sql-restore-snapshot` statement when only a concrete table was
+  specified as to be restored. Only the partitioned table definition was falsely
+  restored, but not the the actual data.

--- a/docs/appendices/release-notes/5.9.10.rst
+++ b/docs/appendices/release-notes/5.9.10.rst
@@ -109,3 +109,9 @@ Fixes
   ``WHERE`` combined with a ``NOT`` predicate. e.g.::
 
     SELECT * FROM tbl WHERE NOT array_position(string_array_col, 'foo');
+
+- Fixed a regression introduced with :ref:`version_5.6.0` that caused any
+  partitioned table contained inside the snapshot to be restored, if not exists,
+  by the :ref:`sql-restore-snapshot` statement when only a concrete table was
+  specified as to be restored. Only the partitioned table definition was falsely
+  restored, but not the the actual data.

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -384,9 +384,10 @@ public class RestoreService implements ClusterStateApplier {
             }
         }
 
-        if (request.includeIndices() && resolvedTemplates.isEmpty()) {
+        if (request.restoreAllTables() && (tablesToRestore == null || tablesToRestore.isEmpty())) {
             resolvedTemplates.add(Metadata.ALL);
         }
+
     }
 
     public static boolean isIndexPartitionOfTable(String index, RelationName relationName) {
@@ -1447,6 +1448,10 @@ public class RestoreService implements ClusterStateApplier {
                 || !tableRenameReplacement().equals(TABLE_RENAME_REPLACEMENT.getDefault(Settings.EMPTY))
                 || !schemaRenamePattern().equals(SCHEMA_RENAME_PATTERN.getDefault(Settings.EMPTY))
                 || !schemaRenameReplacement().equals(SCHEMA_RENAME_REPLACEMENT.getDefault(Settings.EMPTY));
+        }
+
+        public boolean restoreAllTables() {
+            return indices.length == 0 && templates.length == 0 && includeIndices && includeAliases;
         }
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
@@ -27,7 +27,6 @@ import static io.crate.testing.Asserts.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.CONFLICT;
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -809,6 +808,32 @@ public class SnapshotRestoreIntegrationTest extends IntegTestCase {
         assertThat(response).hasRows(
             "empty_parted1",
             "empty_parted2");
+    }
+
+    @Test
+    public void test_restore_table_does_not_restore_any_partitioned_table() {
+        execute("CREATE TABLE schema1.table1 (id int)");
+        execute("CREATE TABLE schema2.table2 (id int, p int) PARTITIONED BY (p)");
+        execute("CREATE TABLE schema3.table3 (id int, p int) PARTITIONED BY (p)");
+
+        execute("INSERT INTO schema3.table3 (id, p) VALUES (1, 1)");
+
+        File repoDir = TEMPORARY_FOLDER.getRoot().toPath().toAbsolutePath().toFile();
+        execute(
+            "CREATE REPOSITORY repo1 TYPE \"fs\" with (location=?, compress=true)",
+            new Object[]{repoDir.getAbsolutePath()}
+        );
+        execute("CREATE SNAPSHOT repo1.snap1 ALL WITH (wait_for_completion=true)");
+        execute("DROP TABLE schema1.table1");
+        execute("DROP TABLE schema2.table2");
+        execute("DROP TABLE schema3.table3");
+
+        execute("RESTORE SNAPSHOT repo1.snap1 TABLE schema1.table1 WITH (wait_for_completion=true)");
+
+        execute("SELECT table_schema, table_name FROM information_schema.tables WHERE table_schema not in ('sys', 'information_schema', 'pg_catalog') ORDER BY 1, 2");
+        assertThat(response).hasRows(
+            "schema1| table1"
+        );
     }
 
     @Test

--- a/server/src/test/java/org/elasticsearch/snapshots/RestoreServiceTest.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/RestoreServiceTest.java
@@ -67,7 +67,8 @@ public class RestoreServiceTest {
         );
 
         assertThat(resolvedIndices).containsAll(availableIndices);
-        assertThat(resolvedTemplates).containsExactly("_all");
+        // No partitioned table selected, templates must be empty
+        assertThat(resolvedTemplates).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
All templates must only be included if no concrete table is defined by the restore statement.

Follow up of https://github.com/crate/crate/commit/b0016d5.
