### PR TITLE
Fix cross-join elimination

### DIFF
--- a/server/src/main/java/io/crate/planner/operators/JoinPlan.java
+++ b/server/src/main/java/io/crate/planner/operators/JoinPlan.java
@@ -46,6 +46,7 @@ public class JoinPlan extends AbstractJoinPlan {
     private final boolean rewriteFilterOnOuterJoinToInnerJoinDone;
     private final boolean lookUpJoinRuleApplied;
     private final boolean moveConstantJoinConditionRuleApplied;
+    private final boolean eliminateCrossJoinRuleIsApplied;
 
     public JoinPlan(LogicalPlan lhs,
                     LogicalPlan rhs,
@@ -55,7 +56,7 @@ public class JoinPlan extends AbstractJoinPlan {
                     boolean rewriteFilterOnOuterJoinToInnerJoinDone,
                     boolean lookUpJoinRuleApplied,
                     LookUpJoin lookUpJoin) {
-        this(lhs, rhs, joinType, joinCondition, isFiltered, rewriteFilterOnOuterJoinToInnerJoinDone, lookUpJoinRuleApplied, false, lookUpJoin);
+        this(lhs, rhs, joinType, joinCondition, isFiltered, rewriteFilterOnOuterJoinToInnerJoinDone, lookUpJoinRuleApplied, false, false, lookUpJoin);
     }
 
     @VisibleForTesting
@@ -63,7 +64,7 @@ public class JoinPlan extends AbstractJoinPlan {
                     LogicalPlan rhs,
                     JoinType joinType,
                     @Nullable Symbol joinCondition) {
-        this(lhs, rhs, joinType, joinCondition, false, false, false, false, LookUpJoin.NONE);
+        this(lhs, rhs, joinType, joinCondition, false, false, false, false, false, LookUpJoin.NONE);
     }
 
     public JoinPlan(LogicalPlan lhs,
@@ -74,12 +75,14 @@ public class JoinPlan extends AbstractJoinPlan {
                      boolean rewriteFilterOnOuterJoinToInnerJoinDone,
                      boolean lookUpJoinRuleApplied,
                      boolean moveConstantJoinConditionRuleApplied,
+                     boolean eliminateCrossJoinRuleIsApplied,
                      LookUpJoin lookUpJoin) {
         super(lhs, rhs, joinCondition, joinType, lookUpJoin);
         this.isFiltered = isFiltered;
         this.rewriteFilterOnOuterJoinToInnerJoinDone = rewriteFilterOnOuterJoinToInnerJoinDone;
         this.lookUpJoinRuleApplied = lookUpJoinRuleApplied;
         this.moveConstantJoinConditionRuleApplied = moveConstantJoinConditionRuleApplied;
+        this.eliminateCrossJoinRuleIsApplied = eliminateCrossJoinRuleIsApplied;
     }
 
     public boolean isLookUpJoinRuleApplied() {
@@ -98,6 +101,10 @@ public class JoinPlan extends AbstractJoinPlan {
         return moveConstantJoinConditionRuleApplied;
     }
 
+    public boolean eliminateCrossJoinRuleIsApplied() {
+        return eliminateCrossJoinRuleIsApplied;
+    }
+
     public JoinPlan withMoveConstantJoinConditionRuleApplied(boolean moveConstantJoinConditionRuleApplied) {
         return new JoinPlan(
             lhs,
@@ -108,6 +115,7 @@ public class JoinPlan extends AbstractJoinPlan {
             rewriteFilterOnOuterJoinToInnerJoinDone,
             lookUpJoinRuleApplied,
             moveConstantJoinConditionRuleApplied,
+            eliminateCrossJoinRuleIsApplied,
             lookupJoin
         );
     }
@@ -158,6 +166,7 @@ public class JoinPlan extends AbstractJoinPlan {
             rewriteFilterOnOuterJoinToInnerJoinDone,
             lookUpJoinRuleApplied,
             moveConstantJoinConditionRuleApplied,
+            eliminateCrossJoinRuleIsApplied,
             lookupJoin
         );
     }
@@ -188,6 +197,7 @@ public class JoinPlan extends AbstractJoinPlan {
             rewriteFilterOnOuterJoinToInnerJoinDone,
             lookUpJoinRuleApplied,
             moveConstantJoinConditionRuleApplied,
+            eliminateCrossJoinRuleIsApplied,
             lookupJoin
         );
     }

--- a/server/src/main/java/io/crate/planner/optimizer/joinorder/JoinGraph.java
+++ b/server/src/main/java/io/crate/planner/optimizer/joinorder/JoinGraph.java
@@ -24,16 +24,13 @@ package io.crate.planner.optimizer.joinorder;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.UnaryOperator;
 
 import io.crate.analyze.relations.QuerySplitter;
 import io.crate.common.collections.Lists;
 import io.crate.common.collections.Maps;
-import io.crate.common.collections.Sets;
 import io.crate.expression.operator.EqOperator;
 import io.crate.expression.symbol.ScopedSymbol;
 import io.crate.expression.symbol.Symbol;
@@ -83,7 +80,7 @@ import io.crate.sql.tree.JoinType;
  * </pre>
  */
 public record JoinGraph(List<LogicalPlan> nodes,
-                        Map<LogicalPlan, Set<Edge>> edges,
+                        Map<LogicalPlan, List<Edge>> edges,
                         List<Symbol> filters,
                         boolean hasCrossJoin) {
 
@@ -95,7 +92,7 @@ public record JoinGraph(List<LogicalPlan> nodes,
         }
 
         var newNodes = Lists.concat(this.nodes, other.nodes);
-        var newEdges = Maps.merge(this.edges, other.edges, Sets::union);
+        var newEdges = Maps.merge(this.edges, other.edges, Lists::concat);
         var newFilters = Lists.concat(this.filters, other.filters);
         var hasCrossJoin = this.hasCrossJoin || other.hasCrossJoin();
 
@@ -107,8 +104,8 @@ public record JoinGraph(List<LogicalPlan> nodes,
         );
     }
 
-    JoinGraph withEdges(Map<LogicalPlan, Set<Edge>> edges) {
-        var newEdges = Maps.merge(this.edges, edges, Sets::union);
+    JoinGraph withEdges(Map<LogicalPlan, List<Edge>> edges) {
+        var newEdges = Maps.merge(this.edges, edges, Lists::concat);
         return new JoinGraph(this.nodes, newEdges, this.filters, this.hasCrossJoin);
     }
 
@@ -128,10 +125,10 @@ public record JoinGraph(List<LogicalPlan> nodes,
         return nodes.size();
     }
 
-    public Set<Edge> edges(LogicalPlan node) {
+    public List<Edge> edges(LogicalPlan node) {
         var result = edges.get(node);
         if (result == null) {
-            return Set.of();
+            return List.of();
         }
         return result;
     }
@@ -204,7 +201,7 @@ public record JoinGraph(List<LogicalPlan> nodes,
 
         private static class EdgeCollector extends SymbolVisitor<Map<Symbol, LogicalPlan>, Void> {
 
-            private final Map<LogicalPlan, Set<Edge>> edges = new HashMap<>();
+            private final Map<LogicalPlan, List<Edge>> edges = new HashMap<>();
             private final List<LogicalPlan> sources = new ArrayList<>();
 
             @Override
@@ -246,9 +243,9 @@ public record JoinGraph(List<LogicalPlan> nodes,
             private void addEdge(LogicalPlan from, Edge edge) {
                 var values = edges.get(from);
                 if (values == null) {
-                    values = Set.of(edge);
+                    values = List.of(edge);
                 } else {
-                    values = new LinkedHashSet<>(values);
+                    values = new ArrayList<>(values);
                     values.add(edge);
                 }
                 edges.put(from, values);

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveConstantJoinConditionsBeneathJoin.java
@@ -136,6 +136,7 @@ public class MoveConstantJoinConditionsBeneathJoin implements Rule<JoinPlan> {
                 joinPlan.isRewriteFilterOnOuterJoinToInnerJoinDone(),
                 joinPlan.isLookUpJoinRuleApplied(),
                 true,
+                joinPlan.eliminateCrossJoinRuleIsApplied(),
                 joinPlan.lookUpJoin()
             );
         } else {


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This PR is a follow-up to https://github.com/crate/crate/pull/17100, which fixes issues with cross-join elimination manifested in a broken sql-logic test as part of crate-qa https://github.com/crate/crate/issues/17381. 

The rule `EliminateCrossJoin` was too strict, only eliminating cross-joins in a join-tree when all cross-joins could be converted to an inner-join, skipping the possibility that only a subset of joins could be converted, e.g.:

```
Join[INNER | ((x = y) AND (z = w))]
  ├ Join[CROSS]
  │  ├ Join[CROSS]
  │  │  ├ Collect[doc.a | [x] | true]
  │  │  └ Collect[doc.b | [y] | true]
  │  └ Collect[doc.c | [z] | true]
  └ Collect[doc.d | [w] | true]
```
can be converted to:

```
Join[INNER | (z = w)]
 ├ Join[CROSS]",
 │  ├ Join[INNER | (x = y)]
 │  │  ├ Collect[doc.a | [x] | true]
 │  │  └ Collect[doc.b | [y] | true]
 │  └ Collect[doc.c | [z] | true]
 └ Collect[doc.d | [w] | true]
```

but was not because the resulting query plan still contained a cross-join. This limitation is now lifted. With these two changes, all sql-logic tests are passing now, and the broken ones result in the same query plans as before.



## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
