### PR TITLE
Fix wrong join results for CASE in join condition

### DIFF
--- a/docs/appendices/release-notes/5.10.1.rst
+++ b/docs/appendices/release-notes/5.10.1.rst
@@ -144,3 +144,14 @@ Fixes
   by the :ref:`sql-restore-snapshot` statement when only a concrete table was
   specified as to be restored. Only the partitioned table definition was falsely
   restored, but not the the actual data.
+
+- Fixed a regression introduced with :ref:`version_5.10.0` that would lead to
+  wrong results for ``LEFT JOIN`` queries when the join condition has a
+  :ref:`CASE<scalar-case-when-then-end>` with an equality condition inside.
+  Previously, the optimizer would use :ref:`Hash Join<available-join-algo_hash>`
+  instead of :ref:`Nested Loop<available-join-algo_nl>` leading to wrong
+  results. e.g.::
+
+    SELECT * FROM tlb
+    LEFT JOIN (SELECT 2 AS col2 FROM tbl) AS tbl2
+      ON (CASE t0.c0 WHEN sub0.col2 THEN t0.c1 ELSE t0.c1 END)

--- a/docs/general/dql/joins.rst
+++ b/docs/general/dql/joins.rst
@@ -233,6 +233,7 @@ Example with ``within`` scalar function::
 Available join algorithms
 -------------------------
 
+.. _available-join-algo_nl:
 
 Nested loop join algorithm
 ..........................
@@ -245,6 +246,8 @@ table.
 
 This is the default algorithm used for all types of joins.
 
+
+.. _available-join-algo_hash:
 
 Block hash join algorithm
 .........................


### PR DESCRIPTION
Previously, a query like the following:
```
SELECT * FROM t0
LEFT JOIN (SELECT 2 AS col2 FROM t0) AS sub0
ON CAST((CASE t0.c0 WHEN sub0.col2 THEN t0.c1 ELSE t0.c1 END )
```
would be wrongly executed with HashJoin instead of NL. As a result, multiple rows could end up with the same hash value, but some of them could evaluate to `true` and others to `false`, thus right side NULLed rows wouldn't be emmitted.

Fix the `EquiJoinDetector` to only drill down to scalars (other than some special cases like AND/OR/NOT operators and CAST) only if those scalars are under a top level Equality operator (`=`).

Fixes: #17380
