### PR TITLE
Increase timeout for the resize action

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/ResizeRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/ResizeRequest.java
@@ -28,11 +28,14 @@ import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
+import io.crate.common.unit.TimeValue;
 import io.crate.metadata.RelationName;
 
 
 /**
  * Request resize of a table or partition
+ * Uses double of the default master node timeout and ack timeout.
+ * default 30 seconds might be not enough and resizing operation fails.
  */
 public class ResizeRequest extends AcknowledgedRequest<ResizeRequest> {
 
@@ -44,6 +47,8 @@ public class ResizeRequest extends AcknowledgedRequest<ResizeRequest> {
         this.table = table;
         this.partitionValues = partitionValues;
         this.newNumShards = newNumShards;
+        this.masterNodeTimeout = TimeValue.timeValueSeconds(60);
+        this.timeout = TimeValue.timeValueSeconds(60);
     }
 
     public ResizeRequest(StreamInput in) throws IOException {
@@ -60,6 +65,8 @@ public class ResizeRequest extends AcknowledgedRequest<ResizeRequest> {
             throw new UnsupportedOperationException(
                 "Cannot stream ResizeRequest in mixed 6.0.0/<5.10 clusters. All nodes need to be >= 5.10");
         }
+        this.masterNodeTimeout = TimeValue.timeValueSeconds(60);
+        this.timeout = TimeValue.timeValueSeconds(60);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/shrink/ResizeRequestTest.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/shrink/ResizeRequestTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.junit.Test;
 
+import io.crate.common.unit.TimeValue;
 import io.crate.metadata.RelationName;
 
 public class ResizeRequestTest {
@@ -47,6 +48,8 @@ public class ResizeRequestTest {
                     assertThat(request.table()).isEqualTo(table);
                     assertThat(request.partitionValues()).isEqualTo(originalReq.partitionValues());
                     assertThat(request.newNumShards()).isEqualTo(originalReq.newNumShards());
+                    assertThat(request.masterNodeTimeout()).isEqualTo(TimeValue.timeValueSeconds(60));
+                    assertThat(request.ackTimeout()).isEqualTo(TimeValue.timeValueSeconds(60));
                 }
             }
         }


### PR DESCRIPTION
Otherwise doc tests for shards resizing fails with

`IllegalStateException[Resize operation wasn't acknowledged. Check shard allocation and retry]`

Follow up to https://github.com/crate/crate/commit/240e0a7b1930ffddcbd74cd391d6fa85c33a4f05

