### PR TITLE
Fix source matching of RewriteFilterOnCrossJoinToInnerJoin

### DIFF
--- a/server/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnCrossJoinToInnerJoin.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/RewriteFilterOnCrossJoinToInnerJoin.java
@@ -91,7 +91,7 @@ public final class RewriteFilterOnCrossJoinToInnerJoin implements Rule<Filter> {
         sources.addAll(crossJoin.lhs().relationNames());
         sources.addAll(crossJoin.rhs().relationNames());
 
-        if (relationNamesInFilterQuery.containsAll(sources)) {
+        if (sources.containsAll(relationNamesInFilterQuery)) {
             return Filter.create(
                 new JoinPlan(
                     crossJoin.lhs(),


### PR DESCRIPTION
This change makes sure all sources are included in the filter query to convert a cross-join to an inner-join. The logic and the related test were wrong.

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
