### PR TITLE
Reflect 5.9.10 on 5.10

### DIFF
--- a/docs/appendices/release-notes/5.9.10.rst
+++ b/docs/appendices/release-notes/5.9.10.rst
@@ -1,16 +1,10 @@
 .. _version_5.9.10:
 
-===========================
-Version 5.9.10 - Unreleased
-===========================
+==============
+Version 5.9.10
+==============
 
-.. comment 1. Remove the " - Unreleased" from the header above and adjust the ==
-.. comment 2. Remove the NOTE below and replace with: "Released on 20XX-XX-XX."
-.. comment    (without a NOTE entry, simply starting from col 1 of the line)
-.. NOTE::
-
-    In development. 5.9.9 isn't released yet. These are the release notes for
-    the upcoming release.
+Released on 2025-02-12.
 
 .. NOTE::
     If you are upgrading a cluster, you must be running CrateDB 4.0.2 or higher

--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -221,6 +221,7 @@ public class Version implements Comparable<Version> {
     public static final Version V_5_9_7 = new Version(8_09_07_99, false, org.apache.lucene.util.Version.LUCENE_9_11_1);
     public static final Version V_5_9_8 = new Version(8_09_08_99, false, org.apache.lucene.util.Version.LUCENE_9_11_1);
     public static final Version V_5_9_9 = new Version(8_09_09_99, false, org.apache.lucene.util.Version.LUCENE_9_11_1);
+    public static final Version V_5_9_10 = new Version(8_09_10_99, false, org.apache.lucene.util.Version.LUCENE_9_11_1);
 
     public static final Version V_5_10_0 = new Version(8_10_00_99, false, org.apache.lucene.util.Version.LUCENE_9_12_0);
     public static final Version V_5_10_1 = new Version(8_10_01_99, false, org.apache.lucene.util.Version.LUCENE_9_12_0);


### PR DESCRIPTION
No 5.9.11 file because we didn't bump 5.9 version (EOL)