### PR TITLE
The root endpoint JSON response now reflects the actual HTTP status code

### DIFF
--- a/docs/appendices/release-notes/5.10.2.rst
+++ b/docs/appendices/release-notes/5.10.2.rst
@@ -43,3 +43,6 @@ See the :ref:`version_5.10.0` release notes for a full list of changes in the
 
 Fixes
 =====
+
+- The root endpoint ``(/)`` JSON response now reflects the actual HTTP status
+  code instead of always defaulting to 200 OK.

--- a/server/src/main/java/io/crate/protocols/http/MainAndStaticFileHandler.java
+++ b/server/src/main/java/io/crate/protocols/http/MainAndStaticFileHandler.java
@@ -170,7 +170,7 @@ public class MainAndStaticFileHandler extends SimpleChannelInboundHandler<FullHt
         builder.prettyPrint().lfAtEnd();
         builder.startObject();
         builder.field("ok", status == HttpResponseStatus.OK);
-        builder.field("status", HttpResponseStatus.OK.code());
+        builder.field("status", status.code());
         if (nodeName != null && !nodeName.isEmpty()) {
             builder.field("name", nodeName);
         }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The **root endpoint (`/`) JSON response** now **reflects the actual HTTP status code** instead of always defaulting to `200 OK`.  

Haven’t found any tests for this. The change is mostly cosmetic, as the HTTP response already includes the status code, making it available to the client regardless. I just found it strange that it always returns 200.

<img width="498" alt="image" src="https://github.com/user-attachments/assets/30a0ac47-cb78-41bd-9177-27810382a56d" />


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
