### PR TITLE
Fix flaky testShrinkShardsOfTable

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -206,7 +206,11 @@ public class MetadataCreateIndexService {
             request,
             indicesService,
             shardId -> {
-                DocsStats docs = indexShards.get(shardId.id()).getPrimary().getDocs();
+                IndexShardStats indexShardStats = indexShards.get(shardId.id());
+                if (indexShardStats == null) {
+                    return 0;
+                }
+                DocsStats docs = indexShardStats.getPrimary().getDocs();
                 return docs == null ? 0 : docs.getCount();
             },
             shardLimitValidator,


### PR DESCRIPTION
Follow up to https://github.com/crate/crate/pull/17406

    java.lang.NullPointerException: Cannot invoke "org.elasticsearch.action.admin.indices.stats.IndexShardStats.getPrimary()" because the return value of "java.util.Map.get(Object)" is null
        at __randomizedtesting.SeedInfo.seed([280DF1FE2994C57C:9B026A9201698F59]:0)
        at org.elasticsearch.cluster.metadata.MetadataCreateIndexService.lambda$resizeIndex$2(MetadataCreateIndexService.java:209)
        at org.elasticsearch.cluster.metadata.MetadataCreateIndexService$ResizeIndexTask.execute(MetadataCreateIndexService.java:417)
        at org.elasticsearch.cluster.ClusterStateUpdateTask.execute(ClusterStateUpdateTask.java:45)
