### PR TITLE
Implement field retrieval for JoinRelation

### DIFF
--- a/server/src/main/java/io/crate/analyze/JoinRelation.java
+++ b/server/src/main/java/io/crate/analyze/JoinRelation.java
@@ -93,7 +93,11 @@ public class JoinRelation implements AnalyzedRelation {
     public Symbol getField(ColumnIdent column,
                            Operation operation,
                            boolean errorOnUnknownObjectKey) throws AmbiguousColumnException, ColumnUnknownException, UnsupportedOperationException {
-        throw new UnsupportedOperationException("Joins do not support this operation");
+        Symbol result = left.getField(column, operation, errorOnUnknownObjectKey);
+        if (result == null) {
+            result = right.getField(column, operation, errorOnUnknownObjectKey);
+        }
+        return result;
     }
 
     @Override


### PR DESCRIPTION
This is needed when a join is used in subqueries and enables multiple nested joins now.

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
