### PR TITLE
Remove soft_deletes.enabled setting

### DIFF
--- a/docs/appendices/release-notes/6.0.0.rst
+++ b/docs/appendices/release-notes/6.0.0.rst
@@ -60,6 +60,10 @@ Breaking Changes
     If users have tables which were using the ``german`` stemmer without a character
     filter that already did this, they will need to re-index after upgrading.
 
+- Removed the deprecated ``soft_deletes.enabled`` setting for ``CREATE TABLE``.
+  The setting defaulted to ``true`` since 4.3.0, was deprecated in 4.5.0 and
+  soft deletes became mandatory in 5.0.0.
+
 Deprecations
 ============
 

--- a/server/src/main/java/io/crate/analyze/TableParameters.java
+++ b/server/src/main/java/io/crate/analyze/TableParameters.java
@@ -121,7 +121,6 @@ public class TableParameters {
             EngineConfig.INDEX_CODEC_SETTING,
             IndexModule.INDEX_STORE_TYPE_SETTING,
             MergeSchedulerConfig.MAX_THREAD_COUNT_SETTING,
-            IndexSettings.INDEX_SOFT_DELETES_SETTING,
             IndexSettings.INDEX_SOFT_DELETES_RETENTION_LEASE_PERIOD_SETTING,
 
             // this setting is needed for tests and is not documented. see ClusterDisruptionIT for usages.

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportCreateTableAction.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportCreateTableAction.java
@@ -21,7 +21,6 @@
 
 package io.crate.execution.ddl.tables;
 
-import static org.elasticsearch.cluster.metadata.MetadataCreateIndexService.validateSoftDeletesSetting;
 
 import java.io.IOException;
 import java.util.List;
@@ -156,7 +155,6 @@ public class TransportCreateTableAction extends TransportMasterNodeAction<Create
 
         Settings normalizedSettings = settingsBuilder.build();
 
-        validateSoftDeletesSetting(normalizedSettings);
         indexScopedSettings.validate(normalizedSettings, true);
 
         boolean isPartitioned = !request.partitionedBy().isEmpty();

--- a/server/src/main/java/io/crate/replication/logical/analyze/LogicalReplicationAnalyzer.java
+++ b/server/src/main/java/io/crate/replication/logical/analyze/LogicalReplicationAnalyzer.java
@@ -21,10 +21,6 @@
 
 package io.crate.replication.logical.analyze;
 
-import java.util.Locale;
-
-import org.elasticsearch.index.IndexSettings;
-
 import io.crate.analyze.ParamTypeHints;
 import io.crate.analyze.expressions.ExpressionAnalysisContext;
 import io.crate.analyze.expressions.ExpressionAnalyzer;
@@ -83,17 +79,6 @@ public class LogicalReplicationAnalyzer {
                     sessionSettings.sessionUser(),
                     sessionSettings.searchPath()
                 );
-                boolean softDeletes = IndexSettings.INDEX_SOFT_DELETES_SETTING.get(tableInfo.parameters());
-                if (softDeletes == false) {
-                    throw new UnsupportedOperationException(
-                        String.format(
-                            Locale.ENGLISH,
-                            "Tables included in a publication must have the table setting " +
-                            "'soft_deletes.enabled' set to `true`, current setting for table '%s': %b",
-                            tableInfo.ident(),
-                            softDeletes)
-                    );
-                }
                 return tableInfo.ident();
             }
         );

--- a/server/src/main/java/io/crate/replication/logical/metadata/Publication.java
+++ b/server/src/main/java/io/crate/replication/logical/metadata/Publication.java
@@ -37,7 +37,6 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.index.IndexSettings;
 
 import io.crate.metadata.IndexName;
 import io.crate.metadata.IndexParts;
@@ -115,7 +114,6 @@ public class Publication implements Writeable {
         return "Publication{forAllTables=" + forAllTables + ", owner=" + owner + ", tables=" + tables + "}";
     }
 
-
     public Map<RelationName, RelationMetadata> resolveCurrentRelations(ClusterState state,
                                                                        Roles roles,
                                                                        Role publicationOwner,
@@ -125,16 +123,6 @@ public class Publication implements Writeable {
         Predicate<String> indexFilter = indexName -> {
             var indexMetadata = state.metadata().index(indexName);
             if (indexMetadata != null) {
-                boolean softDeletes = IndexSettings.INDEX_SOFT_DELETES_SETTING.get(indexMetadata.getSettings());
-                if (softDeletes == false) {
-                    LOGGER.warn(
-                        "Table '{}' won't be replicated as the required table setting " +
-                            "'soft_deletes.enabled' is set to: {}",
-                        RelationName.fromIndexName(indexName),
-                        softDeletes
-                    );
-                    return false;
-                }
                 var routingTable = state.routingTable().index(indexName);
                 assert routingTable != null : "routingTable must not be null";
                 return routingTable.allPrimaryShardsActive();

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitionsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitionsAction.java
@@ -23,7 +23,6 @@ package org.elasticsearch.action.admin.indices.create;
 
 import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_WAIT_FOR_ACTIVE_SHARDS;
-import static org.elasticsearch.cluster.metadata.MetadataCreateIndexService.validateSoftDeletesSetting;
 import static org.elasticsearch.gateway.GatewayMetaState.applyPluginUpgraders;
 
 import java.io.IOException;
@@ -375,8 +374,6 @@ public class TransportCreatePartitionsAction extends TransportMasterNodeAction<C
 
         Version minVersion = currentState.nodes().getSmallestNonClientNodeVersion();
         indexSettingsBuilder.put(IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(), minVersion);
-
-        validateSoftDeletesSetting(indexSettingsBuilder.build());
 
         if (indexSettingsBuilder.get(IndexMetadata.SETTING_CREATION_DATE) == null) {
             indexSettingsBuilder.put(IndexMetadata.SETTING_CREATION_DATE, new DateTime(DateTimeZone.UTC).getMillis());

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -75,7 +75,6 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.IndexService;
-import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.analysis.IndexAnalyzers;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.index.shard.DocsStats;
@@ -549,16 +548,6 @@ public class MetadataCreateIndexService {
                 " must have all shards allocated on the same node to shrink index");
         }
         return nodesToAllocateOn;
-    }
-
-    public static void validateSoftDeletesSetting(Settings settings) {
-        if (IndexSettings.INDEX_SOFT_DELETES_SETTING.get(settings) == false
-            && IndexMetadata.SETTING_INDEX_VERSION_CREATED.get(settings).onOrAfter(Version.V_5_0_0)) {
-            throw new IllegalArgumentException(
-                "Creating tables with soft-deletes disabled is no longer supported. "
-                + "Please do not specify a value for setting [soft_deletes.enabled]."
-            );
-        }
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -92,7 +92,6 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
         IndexSettings.MAX_REFRESH_LISTENERS_PER_SHARD,
         ShardsLimitAllocationDecider.INDEX_TOTAL_SHARDS_PER_NODE_SETTING,
         IndexSettings.INDEX_GC_DELETES_SETTING,
-        IndexSettings.INDEX_SOFT_DELETES_SETTING,
         IndexSettings.INDEX_SOFT_DELETES_RETENTION_OPERATIONS_SETTING,
         IndexSettings.INDEX_SOFT_DELETES_RETENTION_LEASE_PERIOD_SETTING,
         UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING,

--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -43,7 +43,6 @@ import java.util.stream.Stream;
 
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.document.Document;
-import org.apache.lucene.document.Field;
 import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.index.DirectoryReader;
@@ -51,7 +50,6 @@ import org.apache.lucene.index.IndexCommit;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
-import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.LiveIndexWriterConfig;
@@ -164,7 +162,6 @@ public class InternalEngine extends Engine {
     private final CounterMetric numDocAppends = new CounterMetric();
     private final CounterMetric numDocUpdates = new CounterMetric();
     private final NumericDocValuesField softDeletesField = Lucene.newSoftDeletesField();
-    private final boolean softDeleteEnabled;
     private final SoftDeletesPolicy softDeletesPolicy;
     private final LastRefreshedCheckpointListener lastRefreshedCheckpointListener;
 
@@ -232,7 +229,6 @@ public class InternalEngine extends Engine {
                     });
                 assert translog.getGeneration() != null;
                 this.translog = translog;
-                this.softDeleteEnabled = engineConfig.getIndexSettings().isSoftDeleteEnabled();
                 this.softDeletesPolicy = newSoftDeletesPolicy();
                 this.combinedDeletionPolicy =
                     new CombinedDeletionPolicy(logger, translogDeletionPolicy, softDeletesPolicy, translog::getLastSyncedGlobalCheckpoint);
@@ -271,7 +267,7 @@ public class InternalEngine extends Engine {
             this.lastRefreshedCheckpointListener = new LastRefreshedCheckpointListener(localCheckpointTracker.getProcessedCheckpoint());
             this.internalReaderManager.addListener(lastRefreshedCheckpointListener);
             maxSeqNoOfUpdatesOrDeletes = new AtomicLong(SequenceNumbers.max(localCheckpointTracker.getMaxSeqNo(), translog.getMaxSeqNo()));
-            if (softDeleteEnabled && localCheckpointTracker.getPersistedCheckpoint() < localCheckpointTracker.getMaxSeqNo()) {
+            if (localCheckpointTracker.getPersistedCheckpoint() < localCheckpointTracker.getMaxSeqNo()) {
                 try (Searcher searcher =
                          acquireSearcher("restore_version_map_and_checkpoint_tracker", SearcherScope.INTERNAL)) {
                     restoreVersionMapAndCheckpointTracker(Lucene.wrapAllDocsLive(searcher.getDirectoryReader()));
@@ -523,7 +519,6 @@ public class InternalEngine extends Engine {
     public Translog.Snapshot readHistoryOperations(String reason, HistorySource historySource,
                                                    long startingSeqNo) throws IOException {
         if (historySource == HistorySource.INDEX) {
-            ensureSoftDeletesEnabled();
             return newChangesSnapshot(reason, Math.max(0, startingSeqNo), Long.MAX_VALUE, false);
         } else {
             return getTranslog().newSnapshot(startingSeqNo, Long.MAX_VALUE);
@@ -537,7 +532,6 @@ public class InternalEngine extends Engine {
     public int estimateNumberOfHistoryOperations(String reason, HistorySource historySource,
                                                  long startingSeqNo) throws IOException {
         if (historySource == HistorySource.INDEX) {
-            ensureSoftDeletesEnabled();
             try (Translog.Snapshot snapshot = newChangesSnapshot(reason, Math.max(0, startingSeqNo),
                 Long.MAX_VALUE, false)) {
                 return snapshot.totalOperations();
@@ -738,7 +732,7 @@ public class InternalEngine extends Engine {
                 } else if (op.seqNo() > docAndSeqNo.seqNo) {
                     status = OpVsLuceneDocStatus.OP_NEWER;
                 } else if (op.seqNo() == docAndSeqNo.seqNo) {
-                    assert localCheckpointTracker.hasProcessed(op.seqNo()) || softDeleteEnabled == false :
+                    assert localCheckpointTracker.hasProcessed(op.seqNo()) :
                         "local checkpoint tracker is not updated seq_no=" + op.seqNo() + " id=" + op.id();
                     status = OpVsLuceneDocStatus.OP_STALE_OR_EQUAL;
                 } else {
@@ -996,7 +990,7 @@ public class InternalEngine extends Engine {
             versionMap.enforceSafeAccess();
             final OpVsLuceneDocStatus opVsLucene = compareOpToLuceneDocBasedOnSeqNo(index);
             if (opVsLucene == OpVsLuceneDocStatus.OP_STALE_OR_EQUAL) {
-                plan = IndexingStrategy.processAsStaleOp(softDeleteEnabled, index.version());
+                plan = IndexingStrategy.processAsStaleOp(index.version());
             } else {
                 plan = IndexingStrategy.processNormally(opVsLucene == OpVsLuceneDocStatus.LUCENE_DOC_NOT_FOUND, index.version(), 0);
             }
@@ -1167,7 +1161,6 @@ public class InternalEngine extends Engine {
     }
 
     private void addStaleDoc(Document doc, final IndexWriter indexWriter) throws IOException {
-        assert softDeleteEnabled : "Add history documents but soft-deletes is disabled";
         doc.add(softDeletesField);
         indexWriter.addDocument(doc);
     }
@@ -1227,8 +1220,8 @@ public class InternalEngine extends Engine {
             return new IndexingStrategy(currentNotFoundOrDeleted, false, false, false, versionForIndexing, 0, null);
         }
 
-        static IndexingStrategy processAsStaleOp(boolean addStaleOpToLucene, long versionForIndexing) {
-            return new IndexingStrategy(false, false, false, addStaleOpToLucene, versionForIndexing, 0, null);
+        static IndexingStrategy processAsStaleOp(long versionForIndexing) {
+            return new IndexingStrategy(false, false, false, true, versionForIndexing, 0, null);
         }
 
         static IndexingStrategy failAsTooManyDocs(Exception e) {
@@ -1260,11 +1253,7 @@ public class InternalEngine extends Engine {
     }
 
     private void updateDoc(final Term uid, Document doc, final IndexWriter indexWriter) throws IOException {
-        if (softDeleteEnabled) {
-            indexWriter.softUpdateDocument(uid, doc, softDeletesField);
-        } else {
-            indexWriter.updateDocument(uid, doc);
-        }
+        indexWriter.softUpdateDocument(uid, doc, softDeletesField);
         numDocUpdates.inc();
     }
 
@@ -1391,7 +1380,7 @@ public class InternalEngine extends Engine {
         } else {
             final OpVsLuceneDocStatus opVsLucene = compareOpToLuceneDocBasedOnSeqNo(delete);
             if (opVsLucene == OpVsLuceneDocStatus.OP_STALE_OR_EQUAL) {
-                plan = DeletionStrategy.processAsStaleOp(softDeleteEnabled, delete.version());
+                plan = DeletionStrategy.processAsStaleOp(delete.version());
             } else {
                 plan = DeletionStrategy.processNormally(opVsLucene == OpVsLuceneDocStatus.LUCENE_DOC_NOT_FOUND, delete.version(), 0);
             }
@@ -1460,23 +1449,17 @@ public class InternalEngine extends Engine {
     private DeleteResult deleteInLucene(Delete delete, DeletionStrategy plan) throws IOException {
         assert assertMaxSeqNoOfUpdatesIsAdvanced(delete.uid(), delete.seqNo(), false, false);
         try {
-            if (softDeleteEnabled) {
-                final ParsedDocument tombstone = engineConfig.getTombstoneDocSupplier().newDeleteTombstoneDoc(delete.id());
-                tombstone.updateSeqID(delete.seqNo(), delete.primaryTerm());
-                tombstone.version().setLongValue(plan.versionOfDeletion);
-                final Document doc = tombstone.doc();
-                assert doc.getField(SysColumns.Names.TOMBSTONE) != null :
-                    "Delete tombstone document but _tombstone field is not set [" + doc + " ]";
-                doc.add(softDeletesField);
-                if (plan.addStaleOpToLucene || plan.currentlyDeleted) {
-                    indexWriter.addDocument(doc);
-                } else {
-                    indexWriter.softUpdateDocument(delete.uid(), doc, softDeletesField);
-                }
-            } else if (plan.currentlyDeleted == false) {
-                // any exception that comes from this is a either an ACE or a fatal exception there
-                // can't be any document failures  coming from this
-                indexWriter.deleteDocuments(delete.uid());
+            final ParsedDocument tombstone = engineConfig.getTombstoneDocSupplier().newDeleteTombstoneDoc(delete.id());
+            tombstone.updateSeqID(delete.seqNo(), delete.primaryTerm());
+            tombstone.version().setLongValue(plan.versionOfDeletion);
+            final Document doc = tombstone.doc();
+            assert doc.getField(SysColumns.Names.TOMBSTONE) != null :
+                "Delete tombstone document but _tombstone field is not set [" + doc + " ]";
+            doc.add(softDeletesField);
+            if (plan.addStaleOpToLucene || plan.currentlyDeleted) {
+                indexWriter.addDocument(doc);
+            } else {
+                indexWriter.softUpdateDocument(delete.uid(), doc, softDeletesField);
             }
             if (plan.deleteFromLucene) {
                 numDocDeletes.inc();
@@ -1546,8 +1529,8 @@ public class InternalEngine extends Engine {
             return new DeletionStrategy(false, false, currentlyDeleted, versionOfDeletion, 0, null);
         }
 
-        static DeletionStrategy processAsStaleOp(boolean addStaleOpToLucene, long versionOfDeletion) {
-            return new DeletionStrategy(false, addStaleOpToLucene, false, versionOfDeletion, 0, null);
+        static DeletionStrategy processAsStaleOp(long versionOfDeletion) {
+            return new DeletionStrategy(false, true, false, versionOfDeletion, 0, null);
         }
 
         static DeletionStrategy failAsTooManyDocs(Exception e) {
@@ -1598,7 +1581,7 @@ public class InternalEngine extends Engine {
                 );
             } else {
                 markSeqNoAsSeen(noOp.seqNo());
-                if (softDeleteEnabled && hasBeenProcessedBefore(noOp) == false) {
+                if (hasBeenProcessedBefore(noOp) == false) {
                     try {
                         final ParsedDocument tombstone = engineConfig.getTombstoneDocSupplier().newNoopTombstoneDoc(noOp.reason());
                         tombstone.updateSeqID(noOp.seqNo(), noOp.primaryTerm());
@@ -2268,17 +2251,15 @@ public class InternalEngine extends Engine {
         MergePolicy mergePolicy = config().getMergePolicy();
         // always configure soft-deletes field so an engine with soft-deletes disabled can open a Lucene index with soft-deletes.
         iwc.setSoftDeletesField(Lucene.SOFT_DELETES_FIELD);
-        if (softDeleteEnabled) {
-            mergePolicy = new RecoverySourcePruneMergePolicy(
-                SysColumns.Source.RECOVERY_NAME,
+        mergePolicy = new RecoverySourcePruneMergePolicy(
+            SysColumns.Source.RECOVERY_NAME,
+            softDeletesPolicy::getRetentionQuery,
+            new SoftDeletesRetentionMergePolicy(
+                Lucene.SOFT_DELETES_FIELD,
                 softDeletesPolicy::getRetentionQuery,
-                new SoftDeletesRetentionMergePolicy(
-                    Lucene.SOFT_DELETES_FIELD,
-                    softDeletesPolicy::getRetentionQuery,
-                    new PrunePostingsMergePolicy(mergePolicy, SysColumns.Names.ID)
-                )
-            );
-        }
+                new PrunePostingsMergePolicy(mergePolicy, SysColumns.Names.ID)
+            )
+        );
         boolean shuffleForcedMerge = Booleans.parseBoolean(System.getProperty("es.shuffle_forced_merge", Boolean.TRUE.toString()));
         if (shuffleForcedMerge) {
             // We wrap the merge policy for all indices even though it is mostly useful for time-based indices
@@ -2442,9 +2423,7 @@ public class InternalEngine extends Engine {
                 if (currentForceMergeUUID != null) {
                     commitData.put(FORCE_MERGE_UUID_KEY, currentForceMergeUUID);
                 }
-                if (softDeleteEnabled) {
-                    commitData.put(Engine.MIN_RETAINED_SEQNO, Long.toString(softDeletesPolicy.getMinRetainedSeqNo()));
-                }
+                commitData.put(Engine.MIN_RETAINED_SEQNO, Long.toString(softDeletesPolicy.getMinRetainedSeqNo()));
                 logger.trace("committing writer with commit data [{}]", commitData);
                 return commitData.entrySet().iterator();
             });
@@ -2598,17 +2577,9 @@ public class InternalEngine extends Engine {
         return numDocUpdates.count();
     }
 
-    private void ensureSoftDeletesEnabled() {
-        if (softDeleteEnabled == false) {
-            assert false : "index " + shardId.getIndex() + " does not have soft-deletes enabled";
-            throw new IllegalStateException("index " + shardId.getIndex() + " does not have soft-deletes enabled");
-        }
-    }
-
     @Override
     public Translog.Snapshot newChangesSnapshot(String source,
                                                 long fromSeqNo, long toSeqNo, boolean requiredFullRange) throws IOException {
-        ensureSoftDeletesEnabled();
         ensureOpen();
         refreshIfNeeded(source, toSeqNo);
         Searcher searcher = acquireSearcher(source, SearcherScope.INTERNAL);
@@ -2633,7 +2604,6 @@ public class InternalEngine extends Engine {
     public boolean hasCompleteOperationHistory(String reason, HistorySource historySource,
                                                long startingSeqNo) throws IOException {
         if (historySource == HistorySource.INDEX) {
-            ensureSoftDeletesEnabled();
             return getMinRetainedSeqNo() <= startingSeqNo;
         } else {
             final long currentLocalCheckpoint = localCheckpointTracker.getProcessedCheckpoint();
@@ -2665,14 +2635,12 @@ public class InternalEngine extends Engine {
      */
     @Override
     public final long getMinRetainedSeqNo() {
-        ensureSoftDeletesEnabled();
         return softDeletesPolicy.getMinRetainedSeqNo();
     }
 
     @Override
     public Closeable acquireHistoryRetentionLock(HistorySource historySource) {
         if (historySource == HistorySource.INDEX) {
-            ensureSoftDeletesEnabled();
             return softDeletesPolicy.acquireRetentionLock();
         } else {
             return translog.acquireRetentionLock();
@@ -2699,20 +2667,8 @@ public class InternalEngine extends Engine {
 
         @Override
         public long deleteDocuments(Term... terms) throws IOException {
-            assert softDeleteEnabled == false : "Call #deleteDocuments but soft-deletes is enabled";
+            assert false : "Call #deleteDocuments but soft-deletes is enabled";
             return super.deleteDocuments(terms);
-        }
-
-        @Override
-        public long softUpdateDocument(Term term, Iterable<? extends IndexableField> doc, Field... softDeletes) throws IOException {
-            assert softDeleteEnabled : "Call #softUpdateDocument but soft-deletes is disabled";
-            return super.softUpdateDocument(term, doc, softDeletes);
-        }
-
-        @Override
-        public long softUpdateDocuments(Term term, Iterable<? extends Iterable<? extends IndexableField>> docs, Field... softDeletes) throws IOException {
-            assert softDeleteEnabled : "Call #softUpdateDocuments but soft-deletes is disabled";
-            return super.softUpdateDocuments(term, docs, softDeletes);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/engine/NoOpEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/NoOpEngine.java
@@ -52,7 +52,7 @@ public final class NoOpEngine extends ReadOnlyEngine {
     public NoOpEngine(EngineConfig config) {
         super(config, null, null, true, UnaryOperator.identity(), true);
         Directory directory = store.directory();
-        try (DirectoryReader reader = openDirectory(directory, config.getIndexSettings().isSoftDeleteEnabled())) {
+        try (DirectoryReader reader = openDirectory(directory)) {
             this.docsStats = docsStats(reader);
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/server/src/main/java/org/elasticsearch/index/seqno/ReplicationTracker.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/ReplicationTracker.java
@@ -831,7 +831,7 @@ public class ReplicationTracker extends AbstractIndexShardComponent implements L
             assert checkpoints.get(aId) != null : "aId [" + aId + "] is pending in sync but isn't tracked";
         }
 
-        if (primaryMode && indexSettings.isSoftDeleteEnabled() && hasAllPeerRecoveryRetentionLeases) {
+        if (primaryMode && hasAllPeerRecoveryRetentionLeases) {
             // all tracked shard copies have a corresponding peer-recovery retention lease
             for (final ShardRouting shardRouting : routingTable.assignedShards()) {
                 if (checkpoints.get(shardRouting.allocationId().getId()).tracked) {
@@ -916,8 +916,7 @@ public class ReplicationTracker extends AbstractIndexShardComponent implements L
         this.routingTable = null;
         this.replicationGroup = null;
         this.hasAllPeerRecoveryRetentionLeases = indexSettings.getIndexVersionCreated().onOrAfter(Version.V_4_5_0)
-            || (indexSettings.isSoftDeleteEnabled() &&
-               (indexSettings.getIndexVersionCreated().onOrAfter(Version.V_4_4_0) ||
+            || ((indexSettings.getIndexVersionCreated().onOrAfter(Version.V_4_4_0) ||
                (indexSettings.getIndexVersionCreated().onOrAfter(Version.V_4_3_0) &&
                 indexSettings.getIndexMetadata().getState() == IndexMetadata.State.OPEN)));
 

--- a/server/src/main/java/org/elasticsearch/index/shard/PrimaryReplicaSyncer.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/PrimaryReplicaSyncer.java
@@ -79,9 +79,7 @@ public class PrimaryReplicaSyncer {
             // Wrap translog snapshot to make it synchronized as it is accessed by different threads through SnapshotSender.
             // Even though those calls are not concurrent, snapshot.next() uses non-synchronized state and is not multi-thread-compatible
             // Also fail the resync early if the shard is shutting down
-            snapshot = indexShard.getHistoryOperations("resync",
-                indexShard.indexSettings.isSoftDeleteEnabled() ? Engine.HistorySource.INDEX : Engine.HistorySource.TRANSLOG,
-                startingSeqNo);
+            snapshot = indexShard.getHistoryOperations("resync", Engine.HistorySource.INDEX, startingSeqNo);
             final Translog.Snapshot originalSnapshot = snapshot;
             final Translog.Snapshot wrappedSnapshot = new Translog.Snapshot() {
                 @Override

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
@@ -332,8 +332,9 @@ public class RecoveryTarget extends AbstractRefCounted implements RecoveryTarget
 
     private boolean hasUncommittedOperations() throws IOException {
         long localCheckpointOfCommit = Long.parseLong(indexShard.commitStats().getUserData().get(SequenceNumbers.LOCAL_CHECKPOINT_KEY));
-        return indexShard.estimateNumberOfHistoryOperations("peer-recovery",
-            indexShard.indexSettings().isSoftDeleteEnabled() ? Engine.HistorySource.INDEX : Engine.HistorySource.TRANSLOG,
+        return indexShard.estimateNumberOfHistoryOperations(
+            "peer-recovery",
+            Engine.HistorySource.INDEX,
             localCheckpointOfCommit + 1) > 0;
     }
 

--- a/server/src/test/java/io/crate/integrationtests/AlterTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/AlterTableIntegrationTest.java
@@ -52,7 +52,7 @@ public class AlterTableIntegrationTest extends IntegTestCase {
                 "create table test(i int) partitioned by (i) WITH(\"soft_deletes.enabled\" = false) "))
             .hasPGError(INTERNAL_ERROR)
             .hasHTTPError(BAD_REQUEST, 4000)
-            .hasMessageContaining("Creating tables with soft-deletes disabled is no longer supported.");
+            .hasMessageContaining("Invalid property \"soft_deletes.enabled\" passed to [ALTER | CREATE] TABLE statement");
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/CreateTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CreateTableIntegrationTest.java
@@ -168,16 +168,7 @@ public class CreateTableIntegrationTest extends IntegTestCase {
             () -> execute("create table test(t timestamp) with (\"soft_deletes.enabled\" = false)"))
             .hasPGError(INTERNAL_ERROR)
             .hasHTTPError(BAD_REQUEST, 4000)
-            .hasMessageContaining("Creating tables with soft-deletes disabled is no longer supported.");
-
-    }
-
-    public void test_enforce_soft_deletes_on_partitioned_tables() {
-        Asserts.assertSQLError(
-            () -> execute("create table test(t timestamp) partitioned by (t) with (\"soft_deletes.enabled\" = false)"))
-            .hasPGError(INTERNAL_ERROR)
-            .hasHTTPError(BAD_REQUEST, 4000)
-            .hasMessageContaining("Creating tables with soft-deletes disabled is no longer supported.");
+            .hasMessageContaining("Invalid property \"soft_deletes.enabled\" passed to [ALTER | CREATE] TABLE statement");
 
     }
 

--- a/server/src/test/java/io/crate/replication/logical/analyze/LogicalReplicationAnalyzerTest.java
+++ b/server/src/test/java/io/crate/replication/logical/analyze/LogicalReplicationAnalyzerTest.java
@@ -25,9 +25,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.assertj.core.api.Assertions;
-import org.elasticsearch.Version;
-import org.elasticsearch.cluster.metadata.Metadata;
-import org.elasticsearch.common.settings.Setting;
 import org.junit.Test;
 
 import io.crate.analyze.ParamTypeHints;
@@ -84,22 +81,6 @@ public class LogicalReplicationAnalyzerTest extends CrateDummyClusterServiceUnit
         AnalyzedCreatePublication stmt = e.analyze("CREATE PUBLICATION pub1");
         assertThat(stmt.tables()).isEmpty();
         assertThat(stmt.isForAllTables()).isFalse();
-    }
-
-    @Test
-    public void test_create_publication_with_table_having_soft_deletes_disabled() throws Exception {
-        // Soft-deletes are mandatory from 5.0, so let's use 4.8 to create a table with soft-deletes disabled
-        clusterService = createClusterService(additionalClusterSettings().stream().filter(Setting::hasNodeScope).toList(),
-                                                  Metadata.EMPTY_METADATA,
-                                                  Version.V_4_8_0);
-
-        var e = SQLExecutor.of(clusterService).addTable(
-                "create table doc.t1 (x int) with (\"soft_deletes.enabled\" = false)");
-        Assertions.assertThatThrownBy(() -> e.analyze("CREATE PUBLICATION pub1 FOR TABLE doc.t1"))
-            .isExactlyInstanceOf(UnsupportedOperationException.class)
-            .hasMessageContaining(
-                    "Tables included in a publication must have the table setting 'soft_deletes.enabled' " +
-                    "set to `true`, current setting for table 'doc.t1': false");
     }
 
     @Test

--- a/server/src/test/java/org/elasticsearch/index/IndexServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexServiceTests.java
@@ -402,9 +402,7 @@ public class IndexServiceTests extends IntegTestCase {
                 for (IndexShard indexShard : indexService) {
                     flushShard(indexShard, true);
                 }
-                if (indexService.getIndexSettings().isSoftDeleteEnabled()) {
-                    translogOps = 0;
-                }
+                translogOps = 0;
             }
         }
         assertThat(translog.totalOperations()).isEqualTo(translogOps);

--- a/server/src/test/java/org/elasticsearch/index/engine/LuceneChangesSnapshotTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/LuceneChangesSnapshotTests.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.index.engine;
 
 import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
@@ -31,8 +32,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.test.IndexSettingsModule;
@@ -41,13 +40,6 @@ import org.junit.Test;
 import io.crate.common.io.IOUtils;
 
 public class LuceneChangesSnapshotTests extends EngineTestCase {
-
-    @Override
-    protected Settings indexSettings() {
-        return Settings.builder().put(super.indexSettings())
-            .put(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), true) // always enable soft-deletes
-            .build();
-    }
 
     public void testBasics() throws Exception {
         long fromSeqNo = randomNonNegativeLong();

--- a/server/src/test/java/org/elasticsearch/index/engine/ReadOnlyEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/ReadOnlyEngineTests.java
@@ -339,7 +339,6 @@ public class ReadOnlyEngineTests extends EngineTestCase {
         try (Store store = createStore()) {
             final AtomicLong globalCheckpoint = new AtomicLong(SequenceNumbers.NO_OPS_PERFORMED);
             EngineConfig config = config(defaultSettings, store, createTempDir(), newMergePolicy(), null, null, globalCheckpoint::get);
-            final boolean softDeletesEnabled = config.getIndexSettings().isSoftDeleteEnabled();
             final int numDocs = frequently() ? scaledRandomIntBetween(10, 200) : 0;
             int uncommittedDocs = 0;
 
@@ -357,7 +356,7 @@ public class ReadOnlyEngineTests extends EngineTestCase {
                     }
                 }
 
-                assertThat(engine.getTranslogStats().estimatedNumberOfOperations()).isEqualTo(softDeletesEnabled ? uncommittedDocs : numDocs);
+                assertThat(engine.getTranslogStats().estimatedNumberOfOperations()).isEqualTo(uncommittedDocs);
                 assertThat(engine.getTranslogStats().getUncommittedOperations()).isEqualTo(uncommittedDocs);
                 assertThat(engine.getTranslogStats().getTranslogSizeInBytes()).isGreaterThan(0L);
                 assertThat(engine.getTranslogStats().getUncommittedSizeInBytes()).isGreaterThan(0L);
@@ -366,7 +365,7 @@ public class ReadOnlyEngineTests extends EngineTestCase {
             }
 
             try (ReadOnlyEngine readOnlyEngine = new ReadOnlyEngine(config, null, null, true, UnaryOperator.identity(), true)) {
-                assertThat(readOnlyEngine.getTranslogStats().estimatedNumberOfOperations()).isEqualTo(softDeletesEnabled ? 0 : numDocs);
+                assertThat(readOnlyEngine.getTranslogStats().estimatedNumberOfOperations()).isEqualTo(0);
                 assertThat(readOnlyEngine.getTranslogStats().getUncommittedOperations()).isEqualTo(0);
                 assertThat(readOnlyEngine.getTranslogStats().getTranslogSizeInBytes()).isGreaterThan(0L);
                 assertThat(readOnlyEngine.getTranslogStats().getUncommittedSizeInBytes()).isGreaterThan(0L);

--- a/server/src/test/java/org/elasticsearch/index/seqno/PeerRecoveryRetentionLeaseExpiryTests.java
+++ b/server/src/test/java/org/elasticsearch/index/seqno/PeerRecoveryRetentionLeaseExpiryTests.java
@@ -60,14 +60,11 @@ public class PeerRecoveryRetentionLeaseExpiryTests extends ReplicationTrackerTes
 
         if (randomBoolean()) {
             settings = Settings.builder()
-                .put(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), true)
                 .put(IndexSettings.INDEX_SOFT_DELETES_RETENTION_LEASE_PERIOD_SETTING.getKey(),
                     TimeValue.timeValueMillis(randomLongBetween(1, TimeValue.timeValueHours(12).millis())).getStringRep())
                 .build();
         } else {
-            settings = Settings.builder()
-                .put(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), true)
-                .build();
+            settings = Settings.EMPTY;
         }
 
         safeCommitInfo = null; // must be set in each test

--- a/server/src/test/java/org/elasticsearch/index/seqno/ReplicationTrackerRetentionLeaseTests.java
+++ b/server/src/test/java/org/elasticsearch/index/seqno/ReplicationTrackerRetentionLeaseTests.java
@@ -64,10 +64,7 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
         final ReplicationTracker replicationTracker = new ReplicationTracker(
             new ShardId("test", "_na", 0),
             allocationId.getId(),
-            IndexSettingsModule.newIndexSettings("test", Settings.builder()
-                .put(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), true)
-                .build()
-            ),
+            IndexSettingsModule.newIndexSettings("test", Settings.EMPTY),
             primaryTerm,
             UNASSIGNED_SEQ_NO,
             value -> {},
@@ -351,12 +348,7 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
         final ReplicationTracker replicationTracker = new ReplicationTracker(
                 new ShardId("test", "_na", 0),
                 allocationId.getId(),
-                IndexSettingsModule.newIndexSettings(
-                    "test",
-                    Settings.builder()
-                        .put(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), true)
-                        .build()
-                ),
+                IndexSettingsModule.newIndexSettings("test", Settings.EMPTY),
                 randomNonNegativeLong(),
                 UNASSIGNED_SEQ_NO,
                 value -> {},
@@ -412,7 +404,6 @@ public class ReplicationTrackerRetentionLeaseTests extends ReplicationTrackerTes
         final long retentionLeaseMillis = randomLongBetween(1, TimeValue.timeValueHours(12).millis());
         final Settings settings = Settings
             .builder()
-            .put(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), true)
             .put(
                 IndexSettings.INDEX_SOFT_DELETES_RETENTION_LEASE_PERIOD_SETTING.getKey(),
                 TimeValue.timeValueMillis(retentionLeaseMillis).getStringRep())

--- a/server/src/test/java/org/elasticsearch/index/seqno/RetentionLeaseBackgroundSyncIT.java
+++ b/server/src/test/java/org/elasticsearch/index/seqno/RetentionLeaseBackgroundSyncIT.java
@@ -45,7 +45,6 @@ public class RetentionLeaseBackgroundSyncIT extends IntegTestCase {
             "create table doc.tbl (x int) clustered into 1 shards " +
             "with (" +
             "   \"soft_deletes.retention_lease.sync_interval\" = '1s', " +
-            "   \"soft_deletes.enabled\" = true, " +
             "   number_of_replicas = ?)",
             new Object[] { numberOfReplicas }
         );

--- a/server/src/test/java/org/elasticsearch/index/seqno/RetentionLeaseIT.java
+++ b/server/src/test/java/org/elasticsearch/index/seqno/RetentionLeaseIT.java
@@ -80,7 +80,7 @@ public class RetentionLeaseIT extends IntegTestCase  {
         cluster().ensureAtLeastNumDataNodes(1 + numberOfReplicas);
         execute(
             "create table doc.tbl (x int) clustered into 1 shards " +
-            "with (number_of_replicas = ?, \"soft_deletes.enabled\" = true)",
+            "with (number_of_replicas = ?)",
             new Object[] { numberOfReplicas }
         );
         ensureGreen("tbl");
@@ -194,7 +194,6 @@ public class RetentionLeaseIT extends IntegTestCase  {
             "create table doc.tbl (x int) clustered into 1 shards " +
             "with (" +
             "   number_of_replicas = ?, " +
-            "   \"soft_deletes.enabled\" = true, " +
             "   \"soft_deletes.retention_lease.sync_interval\" = ?)",
             new Object[] {
                 numberOfReplicas,
@@ -332,7 +331,6 @@ public class RetentionLeaseIT extends IntegTestCase  {
             "create table doc.tbl (x int) clustered into 1 shards " +
             "with (" +
             "   number_of_replicas = 0, " +
-            "   \"soft_deletes.enabled\" = true, " +
             "   \"soft_deletes.retention_lease.sync_interval\" = ?)",
             new Object[] {
                 TimeValue.timeValueHours(24).getStringRep()
@@ -466,7 +464,6 @@ public class RetentionLeaseIT extends IntegTestCase  {
             "create table doc.tbl (x int) clustered into 1 shards " +
             "with (" +
             "   number_of_replicas = 0, " +
-            "   \"soft_deletes.enabled\" = true, " +
             "   \"soft_deletes.retention_lease.sync_interval\" = '1s' " +
             ")"
         );
@@ -582,7 +579,6 @@ public class RetentionLeaseIT extends IntegTestCase  {
             "create table doc.tbl (x int) clustered into 1 shards " +
             "with (" +
             "   number_of_replicas = ?, " +
-            "   \"soft_deletes.enabled\" = true," +
             "   \"soft_deletes.retention_lease.sync_interval\" = ?)",
             new Object[] {
                 numDataNodes == 1 ? 0 : numDataNodes - 1,

--- a/server/src/test/java/org/elasticsearch/index/shard/PrimaryReplicaSyncerTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/PrimaryReplicaSyncerTests.java
@@ -121,11 +121,7 @@ public class PrimaryReplicaSyncerTests extends IndexShardTestCase {
         if (syncNeeded && globalCheckPoint < numDocs - 1) {
             assertThat(resyncTask.getSkippedOperations()).isEqualTo(0);
             assertThat(resyncTask.getResyncedOperations()).isEqualTo(Math.toIntExact(numDocs - 1 - globalCheckPoint));
-            if (shard.indexSettings.isSoftDeleteEnabled()) {
-                assertThat(resyncTask.getTotalOperations()).isEqualTo(Math.toIntExact(numDocs - 1 - globalCheckPoint));
-            } else {
-                assertThat(resyncTask.getTotalOperations()).isEqualTo(numDocs);
-            }
+            assertThat(resyncTask.getTotalOperations()).isEqualTo(Math.toIntExact(numDocs - 1 - globalCheckPoint));
          } else {
              assertThat(resyncTask.getSkippedOperations()).isEqualTo(0);
              assertThat(resyncTask.getResyncedOperations()).isEqualTo(0);
@@ -215,8 +211,7 @@ public class PrimaryReplicaSyncerTests extends IndexShardTestCase {
             operations.add(new Translog.Index(
                 Integer.toString(i), randomBoolean() ? SequenceNumbers.UNASSIGNED_SEQ_NO : i, primaryTerm, new byte[]{1}));
         }
-        Engine.HistorySource source =
-            shard.indexSettings.isSoftDeleteEnabled() ? Engine.HistorySource.INDEX : Engine.HistorySource.TRANSLOG;
+        Engine.HistorySource source = Engine.HistorySource.INDEX;
         doReturn(TestTranslog.newSnapshotFromOperations(operations)).when(shard).getHistoryOperations(anyString(), eq(source), anyLong());
         List<Translog.Operation> sentOperations = new ArrayList<>();
         PrimaryReplicaSyncer.SyncAction syncAction = (request, allocationId, primaryTerm, listener) -> {

--- a/server/src/test/java/org/elasticsearch/index/translog/TranslogHistoryTest.java
+++ b/server/src/test/java/org/elasticsearch/index/translog/TranslogHistoryTest.java
@@ -30,7 +30,7 @@ import org.elasticsearch.test.IntegTestCase;
 public class TranslogHistoryTest extends IntegTestCase {
 
     public void test_translog_is_trimmed_with_soft_deletes_enabled() throws Exception {
-        execute("create table doc.test(x int) clustered into 1 shards with(number_of_replicas=1, \"soft_deletes.enabled\"='true')");
+        execute("create table doc.test(x int) clustered into 1 shards with(number_of_replicas=1)");
         ensureGreen();
 
         int numDocs = randomIntBetween(1, 10);

--- a/server/src/test/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
@@ -24,6 +24,7 @@ package org.elasticsearch.indices.recovery;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.biasedDoubleBetween;
 import static io.crate.testing.Asserts.assertThat;
 import static java.util.Collections.singletonMap;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.elasticsearch.node.RecoverySettingsChunkSizePlugin.CHUNK_SIZE_SETTING;
 
 import java.io.IOException;
@@ -1399,8 +1400,7 @@ public class IndexRecoveryIT extends IntegTestCase {
                 " CLUSTERED INTO 1 SHARDS" +
                 " WITH (" +
                 "  number_of_replicas = 1," +
-                "  \"unassigned.node_left.delayed_timeout\"='12h'," +
-                "  \"soft_deletes.enabled\"=true" +
+                "  \"unassigned.node_left.delayed_timeout\"='12h'" +
                 " )");
         int numDocs = randomIntBetween(1, 100);
         var args = new Object[numDocs][];
@@ -1454,8 +1454,7 @@ public class IndexRecoveryIT extends IntegTestCase {
                 " CLUSTERED INTO 1 SHARDS" +
                 " WITH (" +
                 "  number_of_replicas = 1," +
-                "  \"unassigned.node_left.delayed_timeout\"='12h'," +
-                "  \"soft_deletes.enabled\"=true" +
+                "  \"unassigned.node_left.delayed_timeout\"='12h'" +
                 " )");
         int numDocs = randomIntBetween(1, 100);
         var args = new Object[numDocs][];
@@ -1519,7 +1518,6 @@ public class IndexRecoveryIT extends IntegTestCase {
         var settings = new ArrayList<String>();
         settings.add("number_of_replicas = 1");
         settings.add("\"unassigned.node_left.delayed_timeout\"='12h'");
-        settings.add("\"soft_deletes.enabled\"=true");
         settings.add("\"soft_deletes.retention_lease.sync_interval\"='100ms'");
 
         final double reasonableOperationsBasedRecoveryProportion;
@@ -1636,8 +1634,7 @@ public class IndexRecoveryIT extends IntegTestCase {
         execute("CREATE TABLE doc.test (num INT)" +
                 " CLUSTERED INTO 1 SHARDS" +
                 " WITH (" +
-                "  number_of_replicas = 0," +
-                "  \"soft_deletes.enabled\"=true" +
+                "  number_of_replicas = 0" +
                 " )");
         int numDocs = randomIntBetween(1, 100);
         var args = new Object[numDocs][];

--- a/server/src/test/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
@@ -559,7 +559,6 @@ public class RecoverySourceHandlerTests extends ESTestCase {
         final IndexMetadata.Builder indexMetadata = IndexMetadata.builder("test").settings(Settings.builder()
             .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, between(0,5))
             .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, between(1,5))
-            .put(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), randomBoolean())
             .put(IndexMetadata.SETTING_VERSION_CREATED, VersionUtils.randomVersion(random()))
             .put(IndexMetadata.SETTING_INDEX_UUID, UUIDs.randomBase64UUID(random())));
         if (randomBoolean()) {

--- a/server/src/testFixtures/java/org/elasticsearch/index/shard/IndexShardTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/index/shard/IndexShardTestCase.java
@@ -347,7 +347,6 @@ public abstract class IndexShardTestCase extends ESTestCase {
         Settings indexSettings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
                 .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
                 .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
-                .put(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey(), randomBoolean())
                 .put(IndexSettings.INDEX_SOFT_DELETES_RETENTION_OPERATIONS_SETTING.getKey(),
                 randomBoolean() ? IndexSettings.INDEX_SOFT_DELETES_RETENTION_OPERATIONS_SETTING.get(Settings.EMPTY) : between(0, 1000))
                 .put(settings)

--- a/server/src/testFixtures/java/org/elasticsearch/test/ESTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/ESTestCase.java
@@ -352,7 +352,6 @@ public abstract class ESTestCase extends CrateLuceneTestCase {
                     // As long as these settings are deprecated but still used in
                     // tests we need to exclude them from the warning here.
                     l -> assertThat(l).isEmpty(),
-                    l -> assertThat(l).anyMatch(s -> s.contains(IndexSettings.INDEX_SOFT_DELETES_SETTING.getKey())),
                     l -> assertThat(l).anyMatch(s -> s.contains(IndexSettings.INDEX_TRANSLOG_RETENTION_AGE_SETTING.getKey())),
                     l -> assertThat(l).anyMatch(s -> s.contains(IndexSettings.INDEX_TRANSLOG_RETENTION_SIZE_SETTING.getKey())),
                     l -> assertThat(l).anyMatch(s -> s.contains(OptimizeTableSettings.UPGRADE_SEGMENTS.getKey())),


### PR DESCRIPTION
This removes the setting from the allowed table parameters and all
usages internally except for some spots in the logical replication where
we need to verify that published tables from another cluster have
soft-deletes enabled.

Logical replication was added in 4.8.0 and soft-deletes only became
mandatory with 5.0.0.
