### PR TITLE
Reduce MockNode constructors

### DIFF
--- a/app/src/main/java/org/elasticsearch/bootstrap/BootstrapProxy.java
+++ b/app/src/main/java/org/elasticsearch/bootstrap/BootstrapProxy.java
@@ -203,7 +203,7 @@ public class BootstrapProxy {
 
         IfConfig.logIfNecessary();
 
-        node = new Node(environment, DEFAULT_PLUGINS, true) {
+        node = new Node(environment, DEFAULT_PLUGINS) {
 
             @Override
             protected void validateNodeBeforeAcceptingRequests(BoundTransportAddress boundTransportAddress,

--- a/app/src/test/java/io/crate/node/NodeSettingsTest.java
+++ b/app/src/test/java/io/crate/node/NodeSettingsTest.java
@@ -93,7 +93,7 @@ public class NodeSettingsTest extends ESTestCase {
         settings.put("legacy.table_function_column_naming", "true");
 
         Environment environment = InternalSettingsPreparer.prepareEnvironment(Settings.EMPTY, settings, configPath, () -> "node-test");
-        node = new Node(environment, List.of(), true);
+        node = new Node(environment, List.of());
         node.start();
         sqlOperations = node.injector().getInstance(Sessions.class);
     }

--- a/benchmarks/src/main/java/io/crate/analyze/PreExecutionBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/analyze/PreExecutionBenchmark.java
@@ -42,16 +42,16 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 
-import io.crate.session.BaseResultReceiver;
-import io.crate.session.Cursors;
-import io.crate.session.Session;
-import io.crate.session.Sessions;
 import io.crate.data.Row;
 import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.RoutingProvider;
 import io.crate.planner.Plan;
 import io.crate.planner.Planner;
 import io.crate.protocols.postgres.TransactionState;
+import io.crate.session.BaseResultReceiver;
+import io.crate.session.Cursors;
+import io.crate.session.Session;
+import io.crate.session.Sessions;
 import io.crate.sql.parser.SqlParser;
 import io.crate.sql.tree.Statement;
 
@@ -72,11 +72,7 @@ public class PreExecutionBenchmark {
             .put("path.home", tempDir.toAbsolutePath().toString())
             .build();
         Environment environment = new Environment(settings, tempDir);
-        node = new Node(
-            environment,
-            List.of(),
-            true
-        );
+        node = new Node(environment, List.of());
         node.start();
         Injector injector = node.injector();
         sqlOperations = injector.getInstance(Sessions.class);

--- a/benchmarks/src/main/java/io/crate/execution/dml/IndexerBenchmark.java
+++ b/benchmarks/src/main/java/io/crate/execution/dml/IndexerBenchmark.java
@@ -45,9 +45,6 @@ import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
-import io.crate.session.BaseResultReceiver;
-import io.crate.session.Session;
-import io.crate.session.Sessions;
 import io.crate.data.Row;
 import io.crate.execution.dml.IndexItem.StaticItem;
 import io.crate.metadata.ColumnIdent;
@@ -55,6 +52,9 @@ import io.crate.metadata.CoordinatorTxnCtx;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.doc.DocTableInfo;
+import io.crate.session.BaseResultReceiver;
+import io.crate.session.Session;
+import io.crate.session.Sessions;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
@@ -75,11 +75,7 @@ public class IndexerBenchmark {
             .put("path.home", tempDir.toAbsolutePath().toString())
             .build();
         Environment environment = new Environment(settings, tempDir);
-        node = new Node(
-            environment,
-            List.of(),
-            true
-        );
+        node = new Node(environment, List.of());
         node.start();
         Injector injector = node.injector();
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -116,7 +116,6 @@ public class MetadataCreateIndexService {
     private final Environment env;
     private final IndexScopedSettings indexScopedSettings;
     private final ActiveShardsObserver activeShardsObserver;
-    private final boolean forbidPrivateIndexSettings;
     private final ShardLimitValidator shardLimitValidator;
 
     public MetadataCreateIndexService(NodeContext nodeContext,
@@ -127,8 +126,7 @@ public class MetadataCreateIndexService {
                                       ShardLimitValidator shardLimitValidator,
                                       Environment env,
                                       IndexScopedSettings indexScopedSettings,
-                                      ThreadPool threadPool,
-                                      boolean forbidPrivateIndexSettings) {
+                                      ThreadPool threadPool) {
         this.nodeContext = nodeContext;
         this.clusterService = clusterService;
         this.indicesService = indicesService;
@@ -136,7 +134,6 @@ public class MetadataCreateIndexService {
         this.env = env;
         this.indexScopedSettings = indexScopedSettings;
         this.activeShardsObserver = new ActiveShardsObserver(clusterService);
-        this.forbidPrivateIndexSettings = forbidPrivateIndexSettings;
         this.shardLimitValidator = shardLimitValidator;
     }
 
@@ -594,7 +591,7 @@ public class MetadataCreateIndexService {
         String indexName = tableName.indexNameOrAlias();
 
         validateIndexName(indexName, currentState);
-        validateIndexSettings(indexName, request.settings(), forbidPrivateIndexSettings);
+        validateIndexSettings(indexName, request.settings(), true);
         shardLimitValidator.validateShardLimit(settings, currentState);
 
         Metadata.Builder metadataBuilder = Metadata.builder(currentState.metadata());

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -295,7 +295,7 @@ public class Node implements Closeable {
     private final NodeService nodeService;
 
     public Node(Environment environment) {
-        this(environment, Collections.emptyList(), true);
+        this(environment, Collections.emptyList());
     }
 
     /**
@@ -303,12 +303,8 @@ public class Node implements Closeable {
      *
      * @param environment                the environment for this node
      * @param classpathPlugins           the plugins to be loaded from the classpath
-     * @param forbidPrivateIndexSettings whether or not private index settings are forbidden when creating an index; this is used in the
-     *                                   test framework for tests that rely on being able to set private settings
      */
-    public Node(final Environment environment,
-                Collection<Class<? extends Plugin>> classpathPlugins,
-                boolean forbidPrivateIndexSettings) {
+    public Node(final Environment environment, Collection<Class<? extends Plugin>> classpathPlugins) {
         logger = LogManager.getLogger(Node.class);
         final List<Closeable> resourcesToClose = new ArrayList<>(); // register everything we need to release in the case of an error
         boolean success = false;
@@ -538,8 +534,7 @@ public class Node implements Closeable {
                 shardLimitValidator,
                 environment,
                 indexScopedSettings,
-                threadPool,
-                forbidPrivateIndexSettings
+                threadPool
             );
 
             final Collection<Object> pluginComponents = pluginsService.filterPlugins(Plugin.class).stream()

--- a/server/src/test/java/org/elasticsearch/indices/IndicesServiceCloseTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndicesServiceCloseTests.java
@@ -46,13 +46,13 @@ import org.elasticsearch.test.MockHttpTransport;
 import org.elasticsearch.test.TestCluster;
 import org.junit.Test;
 
-import io.crate.session.CollectingResultReceiver;
-import io.crate.session.Session;
-import io.crate.session.Sessions;
 import io.crate.auth.Protocol;
 import io.crate.data.Row;
 import io.crate.protocols.postgres.ConnectionProperties;
 import io.crate.role.Role;
+import io.crate.session.CollectingResultReceiver;
+import io.crate.session.Session;
+import io.crate.session.Sessions;
 
 public class IndicesServiceCloseTests extends ESTestCase {
 
@@ -77,7 +77,7 @@ public class IndicesServiceCloseTests extends ESTestCase {
             .build();
 
         Collection<Class<? extends Plugin>> plugins = Arrays.asList(MockHttpTransport.TestPlugin.class);
-        Node node = new MockNode(settings, plugins, true);
+        Node node = new MockNode(settings, plugins);
         node.start();
         return node;
     }

--- a/server/src/testFixtures/java/org/elasticsearch/node/MockNode.java
+++ b/server/src/testFixtures/java/org/elasticsearch/node/MockNode.java
@@ -38,7 +38,6 @@ import org.elasticsearch.common.util.MockBigArrays;
 import org.elasticsearch.common.util.MockPageCacheRecycler;
 import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
-import org.elasticsearch.env.Environment;
 import org.elasticsearch.http.HttpServerTransport;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.indices.recovery.RecoverySettings;
@@ -50,7 +49,6 @@ import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.transport.netty4.Netty4Transport;
 
-import io.crate.session.Sessions;
 import io.crate.auth.Authentication;
 import io.crate.blob.BlobService;
 import io.crate.netty.NettyBootstrap;
@@ -58,6 +56,7 @@ import io.crate.protocols.postgres.MockPgClientFactory;
 import io.crate.protocols.postgres.PgClientFactory;
 import io.crate.protocols.ssl.SslContextProvider;
 import io.crate.role.Roles;
+import io.crate.session.Sessions;
 
 /**
  * A node for testing which allows:
@@ -71,32 +70,17 @@ public class MockNode extends Node {
     private final Collection<Class<? extends Plugin>> classpathPlugins;
 
     public MockNode(final Settings settings, final Collection<Class<? extends Plugin>> classpathPlugins) {
-        this(settings, classpathPlugins, true);
+        this(settings, classpathPlugins, null);
     }
 
     public MockNode(
             final Settings settings,
             final Collection<Class<? extends Plugin>> classpathPlugins,
-            final boolean forbidPrivateIndexSettings) {
-        this(settings, classpathPlugins, null, forbidPrivateIndexSettings);
-    }
-
-    public MockNode(
-            final Settings settings,
-            final Collection<Class<? extends Plugin>> classpathPlugins,
-            final Path configPath,
-            final boolean forbidPrivateIndexSettings) {
-        this(
-                InternalSettingsPreparer.prepareEnvironment(settings, Collections.emptyMap(), configPath, () -> "mock_ node"),
-                classpathPlugins,
-                forbidPrivateIndexSettings);
-    }
-
-    private MockNode(
-            final Environment environment,
-            final Collection<Class<? extends Plugin>> classpathPlugins,
-            final boolean forbidPrivateIndexSettings) {
-        super(environment, classpathPlugins, forbidPrivateIndexSettings);
+            final Path configPath) {
+        super(
+            InternalSettingsPreparer.prepareEnvironment(settings, Collections.emptyMap(), configPath, () -> "mock_ node"),
+            classpathPlugins
+        );
         this.classpathPlugins = classpathPlugins;
     }
 

--- a/server/src/testFixtures/java/org/elasticsearch/test/TestCluster.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/TestCluster.java
@@ -756,10 +756,9 @@ public final class TestCluster implements Closeable {
         assert reuseExisting || nodeAndClient == null : "node name [" + name + "] already exists but not allowed to use it";
 
         MockNode node = new MockNode(
-                settings,
-                plugins,
-                nodeConfigurationSource.nodeConfigPath(nodeId),
-                forbidPrivateIndexSettings);
+            settings,
+            plugins,
+            nodeConfigurationSource.nodeConfigPath(nodeId));
         node.injector().getInstance(TransportService.class).addLifecycleListener(new LifecycleListener() {
             @Override
             public void afterStart() {


### PR DESCRIPTION
`forbidPrivateIndexSettings` was always set to true, so we can remove
it.
