### PR TITLE
Revert "The root endpoint JSON response now reflects the actual HTTP status code"

### DIFF
--- a/docs/appendices/release-notes/5.10.2.rst
+++ b/docs/appendices/release-notes/5.10.2.rst
@@ -43,6 +43,3 @@ See the :ref:`version_5.10.0` release notes for a full list of changes in the
 
 Fixes
 =====
-
-- The root endpoint ``(/)`` JSON response now reflects the actual HTTP status
-  code instead of always defaulting to 200 OK.

--- a/server/src/main/java/io/crate/protocols/http/MainAndStaticFileHandler.java
+++ b/server/src/main/java/io/crate/protocols/http/MainAndStaticFileHandler.java
@@ -170,7 +170,7 @@ public class MainAndStaticFileHandler extends SimpleChannelInboundHandler<FullHt
         builder.prettyPrint().lfAtEnd();
         builder.startObject();
         builder.field("ok", status == HttpResponseStatus.OK);
-        builder.field("status", status.code());
+        builder.field("status", HttpResponseStatus.OK.code());
         if (nodeName != null && !nodeName.isEmpty()) {
             builder.field("name", nodeName);
         }


### PR DESCRIPTION
This reverts commit 6b37f9eb470a18a19c0899f25873b8eaf435a655.

This was a breaking change, not a fix.
Example that would change:

https://github.com/crate/crate-python/blob/4c7945fefcb151c04d9ad12547e683ae366985c7/src/crate/client/http.py#L461-L465
