### PR TITLE
Revert "The root endpoint JSON response now reflects the actual HTTP status code"

### DIFF
--- a/docs/appendices/release-notes/5.10.2.rst
+++ b/docs/appendices/release-notes/5.10.2.rst
@@ -43,6 +43,3 @@ See the :ref:`version_5.10.0` release notes for a full list of changes in the
 
 Fixes
 =====
-
-- The root endpoint ``(/)`` JSON response now reflects the actual HTTP status
-  code instead of always defaulting to 200 OK.

--- a/server/src/main/java/io/crate/protocols/http/MainAndStaticFileHandler.java
+++ b/server/src/main/java/io/crate/protocols/http/MainAndStaticFileHandler.java
@@ -170,7 +170,7 @@ public class MainAndStaticFileHandler extends SimpleChannelInboundHandler<FullHt
         builder.prettyPrint().lfAtEnd();
         builder.startObject();
         builder.field("ok", status == HttpResponseStatus.OK);
-        builder.field("status", status.code());
+        builder.field("status", HttpResponseStatus.OK.code());
         if (nodeName != null && !nodeName.isEmpty()) {
             builder.field("name", nodeName);
         }


### PR DESCRIPTION
This reverts commit 6b37f9eb470a18a19c0899f25873b8eaf435a655.

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
