### PR TITLE
Remove redundant properties from RestoreSnapshotRequest

### DIFF
--- a/docs/sql/statements/restore-snapshot.rst
+++ b/docs/sql/statements/restore-snapshot.rst
@@ -32,8 +32,6 @@ where ``data_section``::
 
    {  TABLES |
       VIEWS |
-      USERS |      -- Deprecated, use USERMANAGEMENT instead
-      PRIVILEGES | -- Deprecated, use USERMANAGEMENT instead
       USERMANAGEMENT |
       ANALYZERS |
       UDFS }

--- a/server/src/main/java/io/crate/planner/node/ddl/RestoreSnapshotPlan.java
+++ b/server/src/main/java/io/crate/planner/node/ddl/RestoreSnapshotPlan.java
@@ -22,11 +22,6 @@
 package io.crate.planner.node.ddl;
 
 import static io.crate.analyze.SnapshotSettings.IGNORE_UNAVAILABLE;
-import static io.crate.analyze.SnapshotSettings.SCHEMA_RENAME_PATTERN;
-import static io.crate.analyze.SnapshotSettings.SCHEMA_RENAME_REPLACEMENT;
-import static io.crate.analyze.SnapshotSettings.TABLE_RENAME_PATTERN;
-import static io.crate.analyze.SnapshotSettings.TABLE_RENAME_REPLACEMENT;
-import static io.crate.analyze.SnapshotSettings.WAIT_FOR_COMPLETION;
 
 import java.util.HashSet;
 import java.util.List;
@@ -116,28 +111,18 @@ public class RestoreSnapshotPlan implements Plan {
             })
             .toList();
 
-        String tableRenamePattern = TABLE_RENAME_PATTERN.get(settings);
-        String tableRenameReplacement = TABLE_RENAME_REPLACEMENT.get(settings);
-        String schemaRenamePattern = SCHEMA_RENAME_PATTERN.get(settings);
-        String schemaRenameReplacement = SCHEMA_RENAME_REPLACEMENT.get(settings);
-
         RestoreSnapshotRequest request = new RestoreSnapshotRequest(
             restoreSnapshot.repository(),
-            restoreSnapshot.snapshot())
-            .tablesToRestore(tablesToRestore)
-            .tableRenamePattern(tableRenamePattern)
-            .tableRenameReplacement(tableRenameReplacement)
-            .schemaRenamePattern(schemaRenamePattern)
-            .schemaRenameReplacement(schemaRenameReplacement)
-            .indicesOptions(indicesOptions)
-            .settings(settings)
-            .waitForCompletion(WAIT_FOR_COMPLETION.get(settings))
-            .includeIndices(includeTables)
-            .includeAliases(includeTables)
-            .includeCustomMetadata(stmt.includeCustomMetadata())
-            .customMetadataTypes(stmt.customMetadataTypes())
-            .includeGlobalSettings(stmt.includeGlobalSettings())
-            .globalSettings(stmt.globalSettings());
+            restoreSnapshot.snapshot(),
+            tablesToRestore,
+            indicesOptions,
+            settings,
+            includeTables,
+            stmt.includeCustomMetadata(),
+            stmt.customMetadataTypes(),
+            stmt.includeGlobalSettings(),
+            stmt.globalSettings()
+        );
         dependencies.client().execute(RestoreSnapshotAction.INSTANCE, request)
             .whenComplete(new OneRowActionListener<>(consumer, r -> new Row1(r == null ? -1L : 1L)));
     }

--- a/server/src/main/java/io/crate/replication/logical/LogicalReplicationService.java
+++ b/server/src/main/java/io/crate/replication/logical/LogicalReplicationService.java
@@ -296,8 +296,8 @@ public class LogicalReplicationService implements ClusterStateListener, Closeabl
             new RestoreService.RestoreRequest(
                 publisherClusterRepoName,
                 LogicalReplicationRepository.LATEST,
-                indicesToRestore.toArray(new String[0]),
-                templatesToRestore.toArray(new String[0]),
+                indicesToRestore.toArray(String[]::new),
+                templatesToRestore.toArray(String[]::new),
                 IndicesOptions.LENIENT_EXPAND_OPEN,
                 TABLE_RENAME_PATTERN.getDefault(Settings.EMPTY),
                 TABLE_RENAME_REPLACEMENT.getDefault(Settings.EMPTY),

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequest.java
@@ -25,11 +25,9 @@ import static org.elasticsearch.common.settings.Settings.writeSettingsToStream;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-import org.elasticsearch.ElasticsearchGenerationException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.MasterNodeRequest;
@@ -38,11 +36,9 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.jetbrains.annotations.Nullable;
 
+import io.crate.analyze.SnapshotSettings;
 import io.crate.metadata.RelationName;
 
 /**
@@ -50,35 +46,20 @@ import io.crate.metadata.RelationName;
  */
 public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotRequest> {
 
-    private String snapshot;
-    private String repository;
+    private final String snapshot;
+    private final String repository;
 
-    @Deprecated
-    private String[] indices = Strings.EMPTY_ARRAY;
+    private final IndicesOptions indicesOptions;
+    private final boolean includeAliases;
+    private final Settings settings;
 
-    @Deprecated
-    private String[] templates = Strings.EMPTY_ARRAY;
-    private IndicesOptions indicesOptions = IndicesOptions.STRICT_EXPAND_OPEN;
-    private String tableRenamePattern;
-    private String tableRenameReplacement;
-    private String schemaRenamePattern;
-    private String schemaRenameReplacement;
-    private boolean waitForCompletion;
-    private boolean includeGlobalState = false;
-    private boolean partial = false;
-    private boolean includeAliases = true;
-    private Settings settings = Settings.EMPTY;
-    private Settings indexSettings = Settings.EMPTY;
-    private String[] ignoreIndexSettings = Strings.EMPTY_ARRAY;
+    private final boolean includeIndices;
+    private final boolean includeCustomMetadata;
+    private final String[] customMetadataTypes;
+    private final boolean includeGlobalSettings;
+    private final String[] globalSettings;
 
-    private boolean includeIndices = true;
-    private boolean includeCustomMetadata = false;
-    private String[] customMetadataTypes = Strings.EMPTY_ARRAY;
-    private boolean includeGlobalSettings = false;
-    private String[] globalSettings = Strings.EMPTY_ARRAY;
-
-    private List<TableOrPartition> tablesToRestore = List.of();
-
+    private final List<TableOrPartition> tablesToRestore;
 
 
     public record TableOrPartition(RelationName table, @Nullable String partitionIdent) implements Writeable {
@@ -94,29 +75,33 @@ public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotReq
         }
     }
 
-    public RestoreSnapshotRequest() {
-    }
-
     /**
      * Constructs a new put repository request with the provided repository and snapshot names.
      *
      * @param repository repository name
      * @param snapshot   snapshot name
      */
-    public RestoreSnapshotRequest(String repository, String snapshot) {
-        this.snapshot = snapshot;
+    public RestoreSnapshotRequest(String repository,
+                                  String snapshot,
+                                  List<TableOrPartition> tablesToRestore,
+                                  IndicesOptions indicesOptions,
+                                  Settings settings,
+                                  boolean includeTables,
+                                  boolean includeCustomMetadata,
+                                  Set<String> metadataTypes,
+                                  boolean includeGlobalSettings,
+                                  List<String> globalSettings) {
         this.repository = repository;
-    }
-
-    /**
-     * Sets the name of the snapshot.
-     *
-     * @param snapshot snapshot name
-     * @return this request
-     */
-    public RestoreSnapshotRequest snapshot(String snapshot) {
         this.snapshot = snapshot;
-        return this;
+        this.tablesToRestore = tablesToRestore;
+        this.indicesOptions = indicesOptions;
+        this.settings = settings;
+        this.includeIndices = includeTables;
+        this.includeAliases = includeTables;
+        this.includeCustomMetadata = includeCustomMetadata;
+        this.customMetadataTypes = metadataTypes.toArray(String[]::new);
+        this.includeGlobalSettings = includeGlobalSettings;
+        this.globalSettings = globalSettings.toArray(String[]::new);
     }
 
     /**
@@ -129,81 +114,12 @@ public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotReq
     }
 
     /**
-     * Sets repository name
-     *
-     * @param repository repository name
-     * @return this request
-     */
-    public RestoreSnapshotRequest repository(String repository) {
-        this.repository = repository;
-        return this;
-    }
-
-    /**
      * Returns repository name
      *
      * @return repository name
      */
     public String repository() {
         return this.repository;
-    }
-
-    /**
-     * Sets the list of indices that should be restored from snapshot
-     * <p>
-     * The list of indices supports multi-index syntax. For example: "+test*" ,"-test42" will index all indices with
-     * prefix "test" except index "test42". Aliases are not supported. An empty list or {"_all"} will restore all open
-     * indices in the snapshot.
-     *
-     * @param indices list of indices
-     * @return this request
-     */
-    public RestoreSnapshotRequest indices(String... indices) {
-        this.indices = indices;
-        return this;
-    }
-
-    /**
-     * Sets the list of indices that should be restored from snapshot
-     * <p>
-     * The list of indices supports multi-index syntax. For example: "+test*" ,"-test42" will index all indices with
-     * prefix "test" except index "test42". Aliases are not supported. An empty list or {"_all"} will restore all open
-     * indices in the snapshot.
-     *
-     * @param indices list of indices
-     * @return this request
-     */
-    public RestoreSnapshotRequest indices(List<String> indices) {
-        this.indices = indices.toArray(new String[indices.size()]);
-        return this;
-    }
-
-    /**
-     * Returns list of indices that should be restored from snapshot
-     */
-    public String[] indices() {
-        return indices;
-    }
-
-    public RestoreSnapshotRequest templates(String... templates) {
-        this.templates = templates;
-        return this;
-    }
-
-    /**
-     * Returns list of templates that should be restored from snapshot
-     */
-    public String[] templates() {
-        return templates;
-    }
-
-    /**
-     * Sets the list of tables that should be restored from snapshot
-     * An empty list will restore all open indices in the snapshot.
-     */
-    public RestoreSnapshotRequest tablesToRestore(List<TableOrPartition> tablesToRestore) {
-        this.tablesToRestore = tablesToRestore;
-        return this;
     }
 
     public List<TableOrPartition> tablesToRestore() {
@@ -221,51 +137,12 @@ public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotReq
     }
 
     /**
-     * Specifies what type of requested indices to ignore and how to deal with wildcard expressions.
-     * For example indices that don't exist.
-     *
-     * @param indicesOptions the desired behaviour regarding indices to ignore and wildcard indices expressions
-     * @return this request
-     */
-    public RestoreSnapshotRequest indicesOptions(IndicesOptions indicesOptions) {
-        this.indicesOptions = indicesOptions;
-        return this;
-    }
-
-    /**
-     * Sets table rename pattern that should be applied to restored indices.
-     * <p>
-     * Indices that match the rename pattern will be renamed according to {@link #renameReplacement(String)}. The
-     * rename pattern is applied according to the {@link java.util.regex.Matcher#appendReplacement(StringBuffer, String)}
-     * The request will fail if two or more tables will be renamed into the same FQN.
-     *
-     * @param tableRenamePattern rename pattern
-     * @return this request
-     */
-    public RestoreSnapshotRequest tableRenamePattern(String tableRenamePattern) {
-        this.tableRenamePattern = tableRenamePattern;
-        return this;
-    }
-
-    /**
      * Returns rename pattern
      *
      * @return rename pattern
      */
     public String tableRenamePattern() {
-        return tableRenamePattern;
-    }
-
-    /**
-     * Sets table rename replacement
-     * <p>
-     * See {@link #tableRenamePattern(String)} for more information.
-     *
-     * @param tableRenameReplacement rename replacement
-     */
-    public RestoreSnapshotRequest tableRenameReplacement(String tableRenameReplacement) {
-        this.tableRenameReplacement = tableRenameReplacement;
-        return this;
+        return SnapshotSettings.TABLE_RENAME_PATTERN.get(settings);
     }
 
     /**
@@ -274,51 +151,15 @@ public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotReq
      * @return table rename replacement
      */
     public String tableRenameReplacement() {
-        return tableRenameReplacement;
-    }
-
-    /**
-     * Sets schema rename pattern that should be applied to restored indices.
-     * <p>
-     * Schemas that match the rename pattern will be renamed according to {@link #tableRenameReplacement(String)}. The
-     * rename pattern is applied according to the {@link java.util.regex.Matcher#appendReplacement(StringBuffer, String)}
-     * The request will fail if two or more tables will be renamed into the same FQN.
-     *
-     * @param schemaRenamePattern rename pattern
-     * @return this request
-     */
-    public RestoreSnapshotRequest schemaRenamePattern(String schemaRenamePattern) {
-        this.schemaRenamePattern = schemaRenamePattern;
-        return this;
+        return SnapshotSettings.TABLE_RENAME_REPLACEMENT.get(settings);
     }
 
     public String schemaRenamePattern() {
-        return schemaRenamePattern;
-    }
-
-    /**
-     * Sets schema rename replacement
-     * <p>
-     * See {@link #schemaRenamePattern()} (String)} for more information.
-     */
-    public RestoreSnapshotRequest schemaRenameReplacement(String schemaRenameReplacement) {
-        this.schemaRenameReplacement = schemaRenameReplacement;
-        return this;
+        return SnapshotSettings.SCHEMA_RENAME_PATTERN.get(settings);
     }
 
     public String schemaRenameReplacement() {
-        return schemaRenameReplacement;
-    }
-
-    /**
-     * If this parameter is set to true the operation will wait for completion of restore process before returning.
-     *
-     * @param waitForCompletion if true the operation will wait for completion
-     * @return this request
-     */
-    public RestoreSnapshotRequest waitForCompletion(boolean waitForCompletion) {
-        this.waitForCompletion = waitForCompletion;
-        return this;
+        return SnapshotSettings.SCHEMA_RENAME_REPLACEMENT.get(settings);
     }
 
     /**
@@ -327,86 +168,7 @@ public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotReq
      * @return true if the operation will wait for completion
      */
     public boolean waitForCompletion() {
-        return waitForCompletion;
-    }
-
-    /**
-     * Returns true if indices with failed to snapshot shards should be partially restored.
-     *
-     * @return true if indices with failed to snapshot shards should be partially restored
-     */
-    public boolean partial() {
-        return partial;
-    }
-
-    /**
-     * Set to true to allow indices with failed to snapshot shards should be partially restored.
-     *
-     * @param partial true if indices with failed to snapshot shards should be partially restored.
-     * @return this request
-     */
-    public RestoreSnapshotRequest partial(boolean partial) {
-        this.partial = partial;
-        return this;
-    }
-
-    /**
-     * Sets repository-specific restore settings.
-     * <p>
-     * See repository documentation for more information.
-     *
-     * @param settings repository-specific snapshot settings
-     * @return this request
-     */
-    public RestoreSnapshotRequest settings(Settings settings) {
-        this.settings = settings;
-        return this;
-    }
-
-    /**
-     * Sets repository-specific restore settings.
-     * <p>
-     * See repository documentation for more information.
-     *
-     * @param settings repository-specific snapshot settings
-     * @return this request
-     */
-    public RestoreSnapshotRequest settings(Settings.Builder settings) {
-        this.settings = settings.build();
-        return this;
-    }
-
-    /**
-     * Sets repository-specific restore settings in JSON or YAML format
-     * <p>
-     * See repository documentation for more information.
-     *
-     * @param source repository-specific snapshot settings
-     * @param xContentType the content type of the source
-     * @return this request
-     */
-    public RestoreSnapshotRequest settings(String source, XContentType xContentType) {
-        this.settings = Settings.builder().loadFromSource(source, xContentType).build();
-        return this;
-    }
-
-    /**
-     * Sets repository-specific restore settings
-     * <p>
-     * See repository documentation for more information.
-     *
-     * @param source repository-specific snapshot settings
-     * @return this request
-     */
-    public RestoreSnapshotRequest settings(Map<String, Object> source) {
-        try {
-            XContentBuilder builder = JsonXContent.builder();
-            builder.map(source);
-            settings(Strings.toString(builder), builder.contentType());
-        } catch (IOException e) {
-            throw new ElasticsearchGenerationException("Failed to generate [" + source + "]", e);
-        }
-        return this;
+        return SnapshotSettings.WAIT_FOR_COMPLETION.get(settings);
     }
 
     /**
@@ -419,40 +181,6 @@ public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotReq
     }
 
     /**
-     * Sets the list of index settings and index settings groups that shouldn't be restored from snapshot
-     */
-    public RestoreSnapshotRequest ignoreIndexSettings(String... ignoreIndexSettings) {
-        this.ignoreIndexSettings = ignoreIndexSettings;
-        return this;
-    }
-
-    /**
-     * Sets the list of index settings and index settings groups that shouldn't be restored from snapshot
-     */
-    public RestoreSnapshotRequest ignoreIndexSettings(List<String> ignoreIndexSettings) {
-        this.ignoreIndexSettings = ignoreIndexSettings.toArray(new String[ignoreIndexSettings.size()]);
-        return this;
-    }
-
-    /**
-     * Returns the list of index settings and index settings groups that shouldn't be restored from snapshot
-     */
-    public String[] ignoreIndexSettings() {
-        return ignoreIndexSettings;
-    }
-
-    /**
-     * If set to true the restore procedure will restore aliases
-     *
-     * @param includeAliases true if aliases should be restored from the snapshot
-     * @return this request
-     */
-    public RestoreSnapshotRequest includeAliases(boolean includeAliases) {
-        this.includeAliases = includeAliases;
-        return this;
-    }
-
-    /**
      * Returns true if aliases should be restored from this snapshot
      *
      * @return true if aliases should be restored
@@ -461,90 +189,20 @@ public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotReq
         return includeAliases;
     }
 
-    /**
-     * Sets settings that should be added/changed in all restored indices
-     */
-    public RestoreSnapshotRequest indexSettings(Settings settings) {
-        this.indexSettings = settings;
-        return this;
-    }
-
-    /**
-     * Sets settings that should be added/changed in all restored indices
-     */
-    public RestoreSnapshotRequest indexSettings(Settings.Builder settings) {
-        this.indexSettings = settings.build();
-        return this;
-    }
-
-    /**
-     * Sets settings that should be added/changed in all restored indices
-     */
-    public RestoreSnapshotRequest indexSettings(String source, XContentType xContentType) {
-        this.indexSettings = Settings.builder().loadFromSource(source, xContentType).build();
-        return this;
-    }
-
-    /**
-     * Sets settings that should be added/changed in all restored indices
-     */
-    public RestoreSnapshotRequest indexSettings(Map<String, Object> source) {
-        try {
-            XContentBuilder builder = JsonXContent.builder();
-            builder.map(source);
-            indexSettings(Strings.toString(builder), builder.contentType());
-        } catch (IOException e) {
-            throw new ElasticsearchGenerationException("Failed to generate [" + source + "]", e);
-        }
-        return this;
-    }
-
-    /**
-     * Returns settings that should be added/changed in all restored indices
-     */
-    public Settings indexSettings() {
-        return this.indexSettings;
-    }
-
-    public RestoreSnapshotRequest includeIndices(boolean includeIndices) {
-        this.includeIndices = includeIndices;
-        return this;
-    }
-
     public boolean includeIndices() {
         return includeIndices;
-    }
-
-    public RestoreSnapshotRequest includeCustomMetadata(boolean includeCustomMetadata) {
-        this.includeCustomMetadata = includeCustomMetadata;
-        return this;
     }
 
     public boolean includeCustomMetadata() {
         return includeCustomMetadata;
     }
 
-    public RestoreSnapshotRequest customMetadataTypes(Set<String> types) {
-        this.customMetadataTypes = types.toArray(new String[0]);
-        return this;
-    }
-
     public String[] customMetadataTypes() {
         return customMetadataTypes;
     }
 
-    public RestoreSnapshotRequest includeGlobalSettings(boolean includeGlobalSettings) {
-        this.includeGlobalSettings = includeGlobalSettings;
-        return this;
-    }
-
     public boolean includeGlobalSettings() {
         return includeGlobalSettings;
-    }
-
-    public RestoreSnapshotRequest globalSettings(List<String> globalSettings) {
-        this.globalSettings = globalSettings.toArray(new String[0]);
-        return this;
     }
 
     public String[] globalSettings() {
@@ -555,38 +213,42 @@ public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotReq
         super(in);
         snapshot = in.readString();
         repository = in.readString();
-        indices = in.readStringArray();
-        indicesOptions = IndicesOptions.readIndicesOptions(in);
-        if (in.getVersion().before(Version.V_5_6_0)) {
-            tableRenamePattern = in.readOptionalString();
-            tableRenameReplacement = in.readOptionalString();
-        } else {
-            // Since 5.6 there are default values which behave similarly as pre-5.6 with NULL values.
-            tableRenamePattern = in.readString();
-            tableRenameReplacement = in.readString();
+        Version version = in.getVersion();
+        assert version.onOrAfter(Version.V_5_10_0) : "Rolling upgrade is only supported for 5.10 -> 6.0";
+
+        if (version.before(Version.V_6_0_0)) {
+            in.readStringArray(); // indices
         }
-        waitForCompletion = in.readBoolean();
-        if (in.getVersion().before(Version.V_4_5_0)) {
-            // ensure streaming BWC, read in unused `includeGlobalState`
+        indicesOptions = IndicesOptions.readIndicesOptions(in);
+        if (version.before(Version.V_6_0_0)) {
+            // Since 5.6 there are default values which behave similarly as pre-5.6 with NULL values.
+            // tableRenamePattern
+            in.readString();
+            // tableRenameReplacement
+            in.readString();
+            // waitForCompletion
+            in.readBoolean();
+            // partial
             in.readBoolean();
         }
-        partial = in.readBoolean();
         includeAliases = in.readBoolean();
         settings = readSettingsFromStream(in);
-        indexSettings = readSettingsFromStream(in);
-        ignoreIndexSettings = in.readStringArray();
-        templates = in.readStringArray();
-        if (in.getVersion().onOrAfter(Version.V_4_5_0)) {
-            includeIndices = in.readBoolean();
-            includeCustomMetadata = in.readBoolean();
-            customMetadataTypes = in.readStringArray();
-            includeGlobalSettings = in.readBoolean();
-            globalSettings = in.readStringArray();
+        if (version.before(Version.V_6_0_0)) {
+            readSettingsFromStream(in); // indexSettings
+            in.readStringArray(); // ignoreIndexSettings
+            in.readStringArray(); // templates
         }
-        if (in.getVersion().onOrAfter(Version.V_5_6_0)) {
-            tablesToRestore = in.readList(TableOrPartition::new);
-            schemaRenamePattern = in.readString();
-            schemaRenameReplacement = in.readString();
+        includeIndices = in.readBoolean();
+        includeCustomMetadata = in.readBoolean();
+        customMetadataTypes = in.readStringArray();
+        includeGlobalSettings = in.readBoolean();
+        globalSettings = in.readStringArray();
+        tablesToRestore = in.readList(TableOrPartition::new);
+        if (version.before(Version.V_6_0_0)) {
+            // schemaRenamePattern
+            in.readString();
+            // schemaRenameReplacement
+            in.readString();
         }
     }
 
@@ -595,38 +257,36 @@ public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotReq
         super.writeTo(out);
         out.writeString(snapshot);
         out.writeString(repository);
-        out.writeStringArray(indices);
+        Version version = out.getVersion();
+        assert version.onOrAfter(Version.V_5_10_0) : "Rolling upgrade is only supported for 5.10 -> 6.0";
+
+        if (version.before(Version.V_6_0_0)) {
+            // indices
+            out.writeStringArray(Strings.EMPTY_ARRAY);
+        }
         indicesOptions.writeIndicesOptions(out);
-        if (out.getVersion().before(Version.V_5_6_0)) {
-            out.writeOptionalString(tableRenamePattern);
-            out.writeOptionalString(tableRenameReplacement);
-        } else {
-            // Since 5.6 there are default values which behave similarly as pre-5.6 with NULL values.
-            out.writeString(tableRenamePattern);
-            out.writeString(tableRenameReplacement);
+        if (version.before(Version.V_6_0_0)) {
+            out.writeString(tableRenamePattern());
+            out.writeString(tableRenameReplacement());
+            out.writeBoolean(waitForCompletion());
+            out.writeBoolean(false); // partial; was never set to true
         }
-        out.writeBoolean(waitForCompletion);
-        if (out.getVersion().before(Version.V_4_5_0)) {
-            // streaming BWC, write remmoved `includeGlobalState`
-            out.writeBoolean(false);
-        }
-        out.writeBoolean(partial);
         out.writeBoolean(includeAliases);
         writeSettingsToStream(out, settings);
-        writeSettingsToStream(out, indexSettings);
-        out.writeStringArray(ignoreIndexSettings);
-        out.writeStringArray(templates);
-        if (out.getVersion().onOrAfter(Version.V_4_5_0)) {
-            out.writeBoolean(includeIndices);
-            out.writeBoolean(includeCustomMetadata);
-            out.writeStringArray(customMetadataTypes);
-            out.writeBoolean(includeGlobalSettings);
-            out.writeStringArray(globalSettings);
+        if (version.before(Version.V_6_0_0)) {
+            writeSettingsToStream(out, Settings.EMPTY); // indexSettings
+            out.writeStringArray(Strings.EMPTY_ARRAY); // ignoreIndexSettings
+            out.writeStringArray(Strings.EMPTY_ARRAY); // templates
         }
-        if (out.getVersion().onOrAfter(Version.V_5_6_0)) {
-            out.writeCollection(tablesToRestore);
-            out.writeString(schemaRenamePattern);
-            out.writeString(schemaRenameReplacement);
+        out.writeBoolean(includeIndices);
+        out.writeBoolean(includeCustomMetadata);
+        out.writeStringArray(customMetadataTypes);
+        out.writeBoolean(includeGlobalSettings);
+        out.writeStringArray(globalSettings);
+        out.writeCollection(tablesToRestore);
+        if (version.before(Version.V_6_0_0)) {
+            out.writeString(schemaRenamePattern());
+            out.writeString(schemaRenameReplacement());
         }
     }
 
@@ -640,21 +300,11 @@ public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotReq
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         RestoreSnapshotRequest that = (RestoreSnapshotRequest) o;
-        return waitForCompletion == that.waitForCompletion &&
-            includeGlobalState == that.includeGlobalState &&
-            partial == that.partial &&
-            includeAliases == that.includeAliases &&
+        return includeAliases == that.includeAliases &&
             Objects.equals(snapshot, that.snapshot) &&
             Objects.equals(repository, that.repository) &&
-            Arrays.equals(indices, that.indices) &&
             Objects.equals(indicesOptions, that.indicesOptions) &&
-            Objects.equals(tableRenamePattern, that.tableRenamePattern) &&
-            Objects.equals(tableRenameReplacement, that.tableRenameReplacement) &&
-            Objects.equals(schemaRenamePattern, that.schemaRenamePattern) &&
-            Objects.equals(schemaRenameReplacement, that.schemaRenameReplacement) &&
             Objects.equals(settings, that.settings) &&
-            Objects.equals(indexSettings, that.indexSettings) &&
-            Arrays.equals(ignoreIndexSettings, that.ignoreIndexSettings) &&
             includeIndices == that.includeIndices &&
             includeCustomMetadata == that.includeCustomMetadata &&
             Arrays.equals(customMetadataTypes, that.customMetadataTypes) &&
@@ -664,13 +314,16 @@ public class RestoreSnapshotRequest extends MasterNodeRequest<RestoreSnapshotReq
 
     @Override
     public int hashCode() {
-        int result = Objects.hash(snapshot, repository, indicesOptions, tableRenamePattern, tableRenameReplacement,waitForCompletion,
-            includeGlobalState, partial, includeAliases, settings, indexSettings,
-            includeIndices, includeCustomMetadata, includeGlobalSettings,
-            schemaRenamePattern, schemaRenameReplacement
+        int result = Objects.hash(
+            snapshot,
+            repository,
+            indicesOptions,
+            includeAliases,
+            settings,
+            includeIndices,
+            includeCustomMetadata,
+            includeGlobalSettings
         );
-        result = 31 * result + Arrays.hashCode(indices);
-        result = 31 * result + Arrays.hashCode(ignoreIndexSettings);
         result = 31 * result + Arrays.hashCode(customMetadataTypes);
         result = 31 * result + Arrays.hashCode(globalSettings);
         return result;

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/TransportRestoreSnapshotAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/TransportRestoreSnapshotAction.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.admin.cluster.snapshots.restore;
 
 import java.io.IOException;
 
+import org.apache.logging.log4j.util.Strings;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.ClusterState;
@@ -29,6 +30,7 @@ import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.snapshots.RestoreService;
 import org.elasticsearch.snapshots.RestoreService.RestoreCompletionResponse;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -77,18 +79,29 @@ public class TransportRestoreSnapshotAction extends TransportMasterNodeAction<Re
     protected void masterOperation(final RestoreSnapshotRequest request,
                                    final ClusterState state,
                                    final ActionListener<RestoreSnapshotResponse> listener) {
-        RestoreService.RestoreRequest restoreRequest = new RestoreService.RestoreRequest(request.repository(), request.snapshot(),
-                request.indices(), request.templates(), request.indicesOptions(),
-                request.tableRenamePattern(), request.tableRenameReplacement(),
-                request.schemaRenamePattern(), request.schemaRenameReplacement(),
-                request.settings(), request.masterNodeTimeout(), request.partial(), request.includeAliases(),
-                request.indexSettings(), request.ignoreIndexSettings(), "restore_snapshot[" + request.snapshot() + "]",
-                request.includeIndices(),
-                request.includeCustomMetadata(),
-                request.customMetadataTypes(),
-                request.includeGlobalSettings(),
-                request.globalSettings());
-
+        RestoreService.RestoreRequest restoreRequest = new RestoreService.RestoreRequest(
+            request.repository(),
+            request.snapshot(),
+            Strings.EMPTY_ARRAY,
+            Strings.EMPTY_ARRAY,
+            request.indicesOptions(),
+            request.tableRenamePattern(),
+            request.tableRenameReplacement(),
+            request.schemaRenamePattern(),
+            request.schemaRenameReplacement(),
+            request.settings(),
+            request.masterNodeTimeout(),
+            false,
+            request.includeAliases(),
+            Settings.EMPTY,
+            Strings.EMPTY_ARRAY,
+            "restore_snapshot[" + request.snapshot() + "]",
+            request.includeIndices(),
+            request.includeCustomMetadata(),
+            request.customMetadataTypes(),
+            request.includeGlobalSettings(),
+            request.globalSettings()
+        );
         restoreService.restoreSnapshot(restoreRequest, request.tablesToRestore(), new ActionListener<>() {
             @Override
             public void onResponse(RestoreCompletionResponse restoreCompletionResponse) {

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -947,7 +947,7 @@ public class RestoreService implements ClusterStateApplier {
          */
         private Updates changes(RecoverySource recoverySource) {
             assert recoverySource.getType() == RecoverySource.Type.SNAPSHOT;
-            return shardChanges.computeIfAbsent(((SnapshotRecoverySource) recoverySource).restoreUUID(), k -> new Updates());
+            return shardChanges.computeIfAbsent(((SnapshotRecoverySource) recoverySource).restoreUUID(), _ -> new Updates());
         }
 
         private static class Updates {
@@ -1251,12 +1251,22 @@ public class RestoreService implements ClusterStateApplier {
          * @param includeGlobalSettings include any cluster settings on restore
          * @param globalSettings     global settings to restore
          */
-        public RestoreRequest(String repositoryName, String snapshotName, String[] indices, String[] templates, IndicesOptions indicesOptions,
-                              String tableRenamePattern, String tableRenameReplacement,
-                              String schemaRenamePattern, String schemaRenameReplacement,
+        public RestoreRequest(String repositoryName,
+                              String snapshotName,
+                              String[] indices,
+                              String[] templates,
+                              IndicesOptions indicesOptions,
+                              String tableRenamePattern,
+                              String tableRenameReplacement,
+                              String schemaRenamePattern,
+                              String schemaRenameReplacement,
                               Settings settings,
-                              TimeValue masterNodeTimeout, boolean partial, boolean includeAliases,
-                              Settings indexSettings, String[] ignoreIndexSettings, String cause,
+                              TimeValue masterNodeTimeout,
+                              boolean partial,
+                              boolean includeAliases,
+                              Settings indexSettings,
+                              String[] ignoreIndexSettings,
+                              String cause,
                               boolean includeIndices,
                               boolean includeCustomMetadata,
                               String[] customMetadataTypes,

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequestTest.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequestTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package org.elasticsearch.action.admin.cluster.snapshots.restore;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Set;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.settings.Settings;
+import org.junit.Test;
+
+import io.crate.metadata.RelationName;
+
+public class RestoreSnapshotRequestTest {
+
+    @Test
+    public void test_serialization_bwc() throws Exception {
+        var req = new RestoreSnapshotRequest(
+            "repoName",
+            "snapshotName",
+            List.of(
+                new RestoreSnapshotRequest.TableOrPartition(new RelationName("s", "t1"), null)
+            ),
+            IndicesOptions.LENIENT_EXPAND_OPEN_CLOSED,
+            Settings.EMPTY,
+            true,
+            true,
+            Set.of("x"),
+            true,
+            List.of("a", "b")
+        );
+
+        try (var out = new BytesStreamOutput()) {
+            req.writeTo(out);
+            try (var in = out.bytes().streamInput()) {
+                assertThat(new RestoreSnapshotRequest(in)).isEqualTo(req);
+            }
+        }
+
+        try (var out = new BytesStreamOutput()) {
+            out.setVersion(Version.V_5_10_1);
+            req.writeTo(out);
+            try (var in = out.bytes().streamInput()) {
+                in.setVersion(Version.V_5_10_1);
+                assertThat(new RestoreSnapshotRequest(in)).isEqualTo(req);
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
A few of them were derived from the `settings` which is also always
streamed - making them redundant.
Others were never used and we can remove some more because with 6.0.0 we
only need to support BWC with 5.10.
