### PR TITLE
Fix `~` operator behavior regarding complement

### DIFF
--- a/server/src/main/java/io/crate/expression/operator/RegexpMatchOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/RegexpMatchOperator.java
@@ -81,7 +81,8 @@ public class RegexpMatchOperator extends Operator<String> {
         if (isPcrePattern(pattern)) {
             return source.matches(pattern);
         } else {
-            RegExp regexp = new RegExp(pattern);
+            // In Lucene 10, COMPLEMENT FLAG is deprecated and not included in ALL
+            RegExp regexp = new RegExp(pattern, RegExp.ALL | RegExp.DEPRECATED_COMPLEMENT);
             var auto = Operations.determinize(regexp.toAutomaton(), Operations.DEFAULT_DETERMINIZE_WORK_LIMIT);
             ByteRunAutomaton regexpRunAutomaton = new ByteRunAutomaton(auto);
             byte[] bytes = source.getBytes(StandardCharsets.UTF_8);
@@ -96,7 +97,8 @@ public class RegexpMatchOperator extends Operator<String> {
         if (RegexpFlags.isPcrePattern(pattern)) {
             return new CrateRegexQuery(term);
         } else {
-            return new ConstantScoreQuery(new RegexpQuery(term, RegExp.ALL));
+            // In Lucene 10, COMPLEMENT FLAG is deprecated and not included in ALL
+            return new ConstantScoreQuery(new RegexpQuery(term, RegExp.ALL | RegExp.DEPRECATED_COMPLEMENT));
         }
     }
 }

--- a/server/src/test/java/io/crate/expression/operator/RegexpMatchOperatorTest.java
+++ b/server/src/test/java/io/crate/expression/operator/RegexpMatchOperatorTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import io.crate.expression.scalar.ScalarTestCase;
 import io.crate.types.DataTypes;
 
-public class RegexpMatchOperatortest extends ScalarTestCase {
+public class RegexpMatchOperatorTest extends ScalarTestCase {
 
     @Test
     public void testNormalize() throws Exception {
@@ -55,5 +55,9 @@ public class RegexpMatchOperatortest extends ScalarTestCase {
         assertEvaluate("'1000 $' ~ '(<1-9999>) $|€'", true);
         assertEvaluate("'10000 $' ~ '(<1-9999>) $|€'", false);
         assertEvaluate("'' ~ ''", true);
+
+        // complement operator
+        assertEvaluate("'This is foo bar' ~ '~(This is foo bar)'", false);
+        assertEvaluate("'This is not foo bar' ~ '~(This is foo bar)'", true);
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/RegexpIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/RegexpIntegrationTest.java
@@ -106,6 +106,21 @@ public class RegexpIntegrationTest extends IntegTestCase {
             "Galactic Sector QQ7 Active J Gamma",
             "North West Ripple",
             "Outer Eastern Rim");
+
+        execute("select name from locations where name ~ '~(Galactic Sector QQ7 Active J Gamma)' order by name");
+        assertThat(response).hasRows(
+            "",
+            "Aldebaran",
+            "Algol",
+            "Allosimanius Syneca",
+            "Alpha Centauri",
+            "Altair",
+            "Argabuthon",
+            "Arkintoofle Minor",
+            "Bartledan",
+            "End of the Galaxy",
+            "North West Ripple",
+            "Outer Eastern Rim");
     }
 
     /**


### PR DESCRIPTION
Lucene 10 deprecated the COMPLEMENT flag, see:
https://github.com/apache/lucene/pull/13732

With: https://github.com/apache/lucene/pull/13739 bwc was added
and the flag was renamed from COMPLEMENT to DEPRECATED_COMPLEMENT,
but the support will be droped in future Lucene 11. Additionally,
the `RegExp.ALL` flags no longer contain the `DEPRECATED_COMPLEMENT`.

Therefore, to make the `~` operator work correctly add the flag,
explicitly on top of `ALL` flags.

Closes: #17442