### PR TITLE
Fix return types of functions evaluated with literal arguments

### DIFF
--- a/server/src/main/java/io/crate/metadata/Scalar.java
+++ b/server/src/main/java/io/crate/metadata/Scalar.java
@@ -34,6 +34,9 @@ import io.crate.lucene.FunctionToQuery;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 import io.crate.role.Roles;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+import io.crate.types.UndefinedType;
 
 /**
  * Base class for Scalar functions in crate.
@@ -145,7 +148,9 @@ public abstract class Scalar<ReturnType, InputType> implements FunctionImplement
             inputs[idx] = (Input<?>) arg;
             idx++;
         }
-        return Literal.ofUnchecked(function.valueType(), scalar.evaluate(txnCtx, nodeCtx, inputs));
+        Object value = scalar.evaluate(txnCtx, nodeCtx, inputs);
+        DataType<?> type = function.valueType();
+        return Literal.ofUnchecked(type == UndefinedType.INSTANCE ? DataTypes.guessType(value) : type, value);
     }
 
     public enum Feature {

--- a/server/src/test/java/io/crate/expression/scalar/SubscriptFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/SubscriptFunctionTest.java
@@ -34,6 +34,7 @@ import io.crate.exceptions.ColumnUnknownException;
 import io.crate.exceptions.ConversionException;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.SelectSymbol;
+import io.crate.types.DataTypes;
 
 
 public class SubscriptFunctionTest extends ScalarTestCase {
@@ -119,5 +120,10 @@ public class SubscriptFunctionTest extends ScalarTestCase {
     @Test
     public void test_lookup_by_name_with_missing_key_returns_null_if_type_information_are_available() throws Exception {
         assertEvaluateNull("{}::object(strict) as (y int)['y']");
+    }
+
+    @Test
+    public void test_returned_literal_from_subscript_function_on_object_literal_is_not_undefined_type() {
+        assertNormalize("{a=10}['a']", isLiteral(10, DataTypes.INTEGER));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

When evaluating a subscript function on an object literal, we end up with a resulting literal with `UNDEFINED` type.
i.e. for `select {a=1}['a']` we get `subscript(_map('a', 1), 'a')`. The return type of `_map('a', 1)` is as expected but the return type of `subscript(_map('a', 1), 'a')` becomes `undefined`.

This is a workaround similar to https://github.com/crate/crate/pull/17292. Basically these workarounds are needed because object types returned from functions are missing inner types.

Follows https://github.com/crate/crate/pull/17139.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
