### PR TITLE
WIP: add equality proxy for a standalone boolean column

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/WherePKIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/WherePKIntegrationTest.java
@@ -334,5 +334,15 @@ public class WherePKIntegrationTest extends IntegTestCase {
         execute("select id from t1 where id = 1 and x = 1");
         assertThat(response).hasRowCount(1L);
     }
+
+    @Test
+    @UseRandomizedOptimizerRules(0)
+    public void debug_test_to_be_removed() {
+        execute("CREATE  TABLE t0(c0 BOOLEAN, PRIMARY KEY(c0))");
+        execute("INSERT INTO t0(c0) VALUES (true), (false)");
+        execute("REFRESH TABLE t0;");
+        execute("SELECT t0.c0 FROM t0 WHERE t0.c0 OR t0.c0 IN (false) order by t0.c0");
+        assertThat(response).hasRows("false", "true");
+    }
 }
 

--- a/server/src/testFixtures/java/io/crate/testing/T3.java
+++ b/server/src/testFixtures/java/io/crate/testing/T3.java
@@ -38,7 +38,8 @@ public class T3 {
         "create table doc.t1 (" +
         "  a text," +
         "  x int," +
-        "  i int" +
+        "  i int," +
+        "  b boolean" +
         ")";
 
     public static final String T2_DEFINITION =


### PR DESCRIPTION
Relates to https://github.com/crate/crate/issues/17379

Alternatives

1. PK on a boolean column is not a realistic scenario. Don't increase complexity and fall back to Collect
2. tweak `ExpressionAnalyzer` to turn `bool_col OPERATOR expression` into `bool_col = true OPERATOR expression`

Reported scenario works if we explicitly use col = true instead of standalone column, because in this case we hit existing logic to add EqualityProxy in `visitFunction`
3. Re-use existing code in `visitFunction`? Tried it, wouldn't work because of different semantics - see https://github.com/crate/crate/commit/b73861eaf74c8da1b0f522a3d59e138a7eb6b123#diff-4d83999a3b344afb026b44aaa3f001ebfbd663cf440b18979ef00e546926e009R496-R498