### PR TITLE
Fix NPE due to JobContext.stmt incorrectly set to null

### DIFF
--- a/docs/appendices/release-notes/5.10.2.rst
+++ b/docs/appendices/release-notes/5.10.2.rst
@@ -59,3 +59,6 @@ Fixes
     DELETE FROM t WHERE day < now() - INTERVAL '3 days';
 
   where 'day' is ``TIMESTAMP`` type that is also the ``PARTITIONED BY`` column.
+
+- Fixed an issue that caused a ``NullPointerException`` when binding to a
+  non-existing prepared statement via PostgreSQL wire protocol.

--- a/server/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
+++ b/server/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
@@ -602,6 +602,8 @@ public class PostgresWireProtocol {
     private void handleBindMessage(ByteBuf buffer, Channel channel) {
         String portalName = readCString(buffer);
         String statementName = readCString(buffer);
+        assert portalName != null : "portalName cannot be null";
+        assert statementName != null : "statementName cannot be null";
 
         FormatCodes.FormatCode[] formatCodes = FormatCodes.fromBuffer(buffer);
 

--- a/server/src/main/java/io/crate/session/Session.java
+++ b/server/src/main/java/io/crate/session/Session.java
@@ -393,7 +393,7 @@ public class Session implements AutoCloseable {
         try {
             preparedStmt = getSafeStmt(statementName);
         } catch (Throwable t) {
-            jobsLogs.logPreExecutionFailure(UUIDs.dirtyUUID(), null, SQLExceptions.messageOf(t), sessionSettings.sessionUser());
+            jobsLogs.logPreExecutionFailure(UUIDs.dirtyUUID(), statementName, SQLExceptions.messageOf(t), sessionSettings.sessionUser());
             throw t;
         }
 

--- a/server/src/test/java/io/crate/session/SessionTest.java
+++ b/server/src/test/java/io/crate/session/SessionTest.java
@@ -434,4 +434,16 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
         }
     }
 
+    @Test
+    public void test_binding_with_removed_prepared_statement_throws() {
+        SQLExecutor sqlExecutor = SQLExecutor.builder(clusterService).build();
+        try (Session session = sqlExecutor.createSession()) {
+            session.parse("", "SELECT 1", Collections.emptyList());
+            session.close((byte) 'S', "");
+            assertThatThrownBy(() -> session.bind("", "", List.of(), null))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("No statement found with name: ");
+        }
+    }
+
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Fixes part of https://github.com/crate/crate/issues/17456.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
