### PR TITLE
Turn standalone boolean column references into equality comparison

### DIFF
--- a/docs/appendices/release-notes/5.10.2.rst
+++ b/docs/appendices/release-notes/5.10.2.rst
@@ -71,6 +71,6 @@ Fixes
 - Fixed an issue that caused a ``SELECT`` query with a ``WHERE`` clause to
   return incorrect result if a table had a ``PRIMARY KEY`` a Boolean column and
   the column was referenced as a standalone operand in a logical expression.
-  Example::
+  e.g.::
 
     SELECT * FROM tbl WHERE boolean_pk_col OR boolean_pk_col = false

--- a/docs/appendices/release-notes/5.10.2.rst
+++ b/docs/appendices/release-notes/5.10.2.rst
@@ -67,3 +67,10 @@ Fixes
   had a comparison of a non-boolean column with a boolean literal, e.g.::
 
     SELECT int_col FROM t where int_col = true;
+
+- Fixed an issue that caused a ``SELECT`` query with a ``WHERE`` clause to
+  return incorrect result if a table had a ``PRIMARY KEY`` a Boolean column and
+  the column was referenced as a standalone operand in a logical expression.
+  Example::
+
+    SELECT * FROM tbl WHERE boolean_pk_col OR boolean_pk_col = false

--- a/libs/sql-parser/src/main/java/io/crate/sql/tree/LogicalBinaryExpression.java
+++ b/libs/sql-parser/src/main/java/io/crate/sql/tree/LogicalBinaryExpression.java
@@ -37,8 +37,8 @@ public class LogicalBinaryExpression extends Expression {
 
     public LogicalBinaryExpression(Type type, Expression left, Expression right) {
         this.type = type;
-        this.left = requireNonNull(left, "left is null");
-        this.right = requireNonNull(right, "right is null");
+        this.left = maybeAddEqTrue(requireNonNull(left, "left is null"));
+        this.right = maybeAddEqTrue(requireNonNull(right, "right is null"));
     }
 
     public Type getType() {
@@ -51,6 +51,17 @@ public class LogicalBinaryExpression extends Expression {
 
     public Expression getRight() {
         return right;
+    }
+
+    /**
+     * Turns a standalone QualifiedNameReference into comparison QualifiedNameReference = true.
+     * This turns statements like 'boolean_column OR expression' into 'boolean_column = true OR expression'.
+     */
+    private static Expression maybeAddEqTrue(Expression expression) {
+        if (expression instanceof QualifiedNameReference ref) {
+            return new ComparisonExpression(ComparisonExpression.Type.EQUAL, ref, BooleanLiteral.TRUE_LITERAL);
+        }
+        return expression;
     }
 
     @Override

--- a/libs/sql-parser/src/test/java/io/crate/sql/parser/TestSqlParser.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/parser/TestSqlParser.java
@@ -600,6 +600,19 @@ public class TestSqlParser {
         assertThat(createFunction).hasToString(expected.toString());
     }
 
+    @Test
+    public void test_standalone_boolean_columns_in_logical_expressions_expanded_into_equality_with_true() {
+        // Expression in SELECT list
+        var statement = SqlParser.createStatement("SELECT x OR x = false FROM t");
+        var expected = SqlParser.createStatement("SELECT x = true OR x = false FROM t");
+        assertThat(statement).hasToString(expected.toString());
+
+        // Expression in WHERE
+        statement = SqlParser.createStatement("SELECT * FROM t WHERE x OR x = false");
+        expected = SqlParser.createStatement("SELECT * FROM t WHERE x = true OR x = false");
+        assertThat(statement).hasToString(expected.toString());
+    }
+
     private static void assertStatement(String query, Statement expected) {
         assertParsed(query, expected, SqlParser.createStatement(query));
     }

--- a/server/src/test/java/io/crate/expression/operator/AndOperatorTest.java
+++ b/server/src/test/java/io/crate/expression/operator/AndOperatorTest.java
@@ -22,6 +22,7 @@
 package io.crate.expression.operator;
 
 import static io.crate.testing.Asserts.assertList;
+import static io.crate.testing.Asserts.isFunction;
 import static io.crate.testing.Asserts.isLiteral;
 import static io.crate.testing.Asserts.isReference;
 
@@ -36,7 +37,10 @@ public class AndOperatorTest extends ScalarTestCase {
 
     @Test
     public void test_normalize_boolean_true_and_reference() throws Exception {
-        assertNormalize("is_awesome and true", isReference("is_awesome"));
+        assertNormalize(
+            "is_awesome and true",
+            isFunction("op_=", isReference("is_awesome"), isLiteral(true))
+        );
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/operator/OrOperatorTest.java
+++ b/server/src/test/java/io/crate/expression/operator/OrOperatorTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.expression.operator;
 
+import static io.crate.testing.Asserts.isFunction;
 import static io.crate.testing.Asserts.isLiteral;
 import static io.crate.testing.Asserts.isReference;
 
@@ -37,7 +38,9 @@ public class OrOperatorTest extends ScalarTestCase {
 
     @Test
     public void test_normalize_boolean_false_or_reference() throws Exception {
-        assertNormalize("is_awesome or false", isReference("is_awesome"));
+        assertNormalize("is_awesome or false",
+            isFunction("op_=", isReference("is_awesome"), isLiteral(true))
+        );
     }
 
     @Test

--- a/server/src/test/java/io/crate/lucene/ThreeValuedLogicQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/ThreeValuedLogicQueryBuilderTest.java
@@ -64,7 +64,7 @@ public class ThreeValuedLogicQueryBuilderTest extends LuceneQueryBuilderTest {
     public void test_negated_and_three_value_query() {
         // make sure there is no field-exists-query for the references
         assertThat(convert("NOT (x AND f)")).hasToString(
-            "+(+*:* -(+x +f)) #(NOT (x AND f))");
+            "+(+*:* -(+(x = true) +(f = true))) #(NOT ((x = true) AND (f = true)))");
     }
 
     @Test
@@ -89,7 +89,7 @@ public class ThreeValuedLogicQueryBuilderTest extends LuceneQueryBuilderTest {
     @Test
     public void test_negated_or() {
         assertThat(convert("NOT (x OR y) > true")).hasToString(
-            "+(+*:* -((x OR y) > true)) #(NOT ((x OR y) > true))");
+            "+(+*:* -(((x = true) OR (y = true)) > true)) #(NOT (((x = true) OR (y = true)) > true))");
     }
 
     @Test

--- a/server/src/test/java/io/crate/planner/operators/JoinTest.java
+++ b/server/src/test/java/io/crate/planner/operators/JoinTest.java
@@ -870,7 +870,7 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
         );
 
         assertThat(logicalPlan).hasOperators(
-            "Eval[oid, attnum, attname, relname, nspname, (attnotnull OR ((typtype = 'd') AND typnotnull)), ((NOT (attidentity = '')) OR (pg_catalog.pg_get_expr(adbin, adrelid) LIKE '%nextval(%'))]",
+            "Eval[oid, attnum, attname, relname, nspname, ((attnotnull = true) OR ((typtype = 'd') AND (typnotnull = true))), ((NOT (attidentity = '')) OR (pg_catalog.pg_get_expr(adbin, adrelid) LIKE '%nextval(%'))]",
             "  └ HashJoin[INNER | ((oid = oid) AND (attnum = attnum))]",
             "    ├ HashJoin[LEFT | ((adrelid = attrelid) AND (adnum = attnum))]",
             "    │  ├ HashJoin[INNER | (atttypid = oid)]",

--- a/server/src/testFixtures/java/io/crate/testing/T3.java
+++ b/server/src/testFixtures/java/io/crate/testing/T3.java
@@ -38,8 +38,7 @@ public class T3 {
         "create table doc.t1 (" +
         "  a text," +
         "  x int," +
-        "  i int," +
-        "  b boolean" +
+        "  i int" +
         ")";
 
     public static final String T2_DEFINITION =

--- a/server/src/testFixtures/java/io/crate/testing/T3.java
+++ b/server/src/testFixtures/java/io/crate/testing/T3.java
@@ -38,7 +38,8 @@ public class T3 {
         "create table doc.t1 (" +
         "  a text," +
         "  x int," +
-        "  i int" +
+        "  i int," +
+        "  b boolean" +
         ")";
 
     public static final String T2_DEFINITION =


### PR DESCRIPTION
Closes https://github.com/crate/crate/issues/17379

Reported scenario works if we explicitly use `col = true` instead of standalone column, because in this case we hit existing logic to add an EqualityProxy in `visitFunction`

Attempts to apply the same idea in the EqualityExtractor were affecting other parts of logical expressions (https://github.com/crate/crate/pull/17477) and had to do more hacks to make it work.

A simpler solution which might be useful in general is to turn standalone boolean columns into equality comparison inside logical expressions because that's what it in fact means.
