### PR TITLE
Allow comparing a non-boolean column to a boolean literal in WHERE clause

### DIFF
--- a/docs/appendices/release-notes/5.10.2.rst
+++ b/docs/appendices/release-notes/5.10.2.rst
@@ -62,3 +62,8 @@ Fixes
 
 - Fixed an issue that caused a ``NullPointerException`` when binding to a
   non-existing prepared statement via PostgreSQL wire protocol.
+
+- Fixed an issue that caused a ``SELECT`` query to fail if a ``WHERE`` clause
+  had a comparison of a non-boolean column with a boolean literal, e.g.::
+
+    SELECT int_col FROM t where int_col = true;

--- a/server/src/main/java/io/crate/planner/optimizer/symbol/rule/SwapCastsInComparisonOperators.java
+++ b/server/src/main/java/io/crate/planner/optimizer/symbol/rule/SwapCastsInComparisonOperators.java
@@ -60,10 +60,11 @@ public class SwapCastsInComparisonOperators implements Rule<Function> {
             Reference ref = (Reference) cast.arguments().getFirst();
             DataType<?> refInnerType = ArrayType.unnest(ref.valueType());
             DataType<?> literalInnerType = ArrayType.unnest(literal.valueType());
+            var value = literal.value();
             if (!DataTypes.isNumeric(literalInnerType) || !DataTypes.isNumeric(refInnerType)) {
-                return true;
+                return literalInnerType.isConvertableTo(refInnerType, false);
             }
-            return isNarrowingConversionPossible(literal.value(), ref.valueType());
+            return isNarrowingConversionPossible(value, ref.valueType());
         }
         return true;
     }

--- a/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -833,6 +833,13 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
         assertThat(query).hasToString("(f = 0.99999999)");
     }
 
+    @Test
+    public void test_can_compare_any_type_with_boolean() {
+        Query query = convert("x = true");
+        assertThat(query).isExactlyInstanceOf(GenericFunctionQuery.class);
+        assertThat(query).hasToString("(x = true)");
+    }
+
     public void test_all_eq_on_empty_array_literal() {
         Query query = convert("y = all([])");
         assertThat(query).hasToString("*:*");


### PR DESCRIPTION
Follow up to https://github.com/crate/crate/commit/77caeaf06fa6b211f18995099e99c0ab74c0a267

It's also a pre-requisite for another fix, see https://github.com/crate/crate/pull/17483#issuecomment-2671730562

