### PR TITLE
Align with Postgres: stddev should return sample standard deviation

### DIFF
--- a/docs/appendices/release-notes/6.0.0.rst
+++ b/docs/appendices/release-notes/6.0.0.rst
@@ -85,6 +85,9 @@ SQL Standard and PostgreSQL Compatibility
   :ref:`information_schema.administrable_role_authorizations <administrable_role_authorizations>`
   and :ref:`information_schema.role_table_grants <role_table_grants>` tables.
 
+- Fixed the behavior of :ref:`stddev` to use the sample standard deviation
+  instead of the population standard deviation.
+
 Data Types
 ----------
 

--- a/docs/general/builtins/aggregation.rst
+++ b/docs/general/builtins/aggregation.rst
@@ -595,7 +595,7 @@ An Example::
 ``stddev(column)``
 ------------------
 
-The ``stddev`` aggregate function computes the `Standard Deviation`_ of the
+The ``stddev`` aggregate function computes the sample `Standard Deviation`_ of the
 set of non-null values in a column. It is a measure of the variation of data
 values. A low standard deviation indicates that the values tend to be near the
 mean.

--- a/docs/general/builtins/aggregation.rst
+++ b/docs/general/builtins/aggregation.rst
@@ -979,7 +979,7 @@ Limitations
 .. _Geometric Mean: https://en.wikipedia.org/wiki/Geometric_mean
 .. _HyperLogLog++: https://static.googleusercontent.com/media/research.google.com/en//pubs/archive/40671.pdf
 .. _Percentile: https://en.wikipedia.org/wiki/Percentile
-.. _Standard Deviation: https://en.wikipedia.org/wiki/Standard_deviation
+.. _Standard Deviation: https://en.wikipedia.org/wiki/Standard_deviation#Corrected_sample_standard_deviation
 .. _TDigest: https://github.com/tdunning/t-digest/blob/master/docs/t-digest-paper/histo.pdf
 .. _Variance: https://en.wikipedia.org/wiki/Variance
 .. _Frequency Sketch: https://datasketches.apache.org/docs/Frequency/FrequencySketches.html

--- a/server/src/main/java/io/crate/execution/engine/aggregation/statistics/StandardDeviation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/statistics/StandardDeviation.java
@@ -37,6 +37,10 @@ public class StandardDeviation extends Variance {
 
     @Override
     public double result() {
-        return FastMath.sqrt(super.result());
+        long count = super.count();
+        if (count <= 1) {
+            return Double.NaN;
+        }
+        return FastMath.sqrt(super.result() * count / (count - 1));
     }
 }

--- a/server/src/main/java/io/crate/execution/engine/aggregation/statistics/Variance.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/statistics/Variance.java
@@ -72,6 +72,10 @@ public class Variance implements Writeable, Comparable<Variance> {
         return (sumOfSqrs - ((sum * sum) / count)) / count;
     }
 
+    protected long count() {
+        return count;
+    }
+    
     public void merge(Variance other) {
         sumOfSqrs += other.sumOfSqrs;
         sum += other.sum;

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/StdDevAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/StdDevAggregationTest.java
@@ -78,19 +78,19 @@ public class StdDevAggregationTest extends AggregationTestCase {
     @Test
     public void withSomeNullArgs() throws Exception {
         assertThat(executeAggregation(DataTypes.DOUBLE, new Object[][]{{10.7d}, {42.9D}, {0.3d}, {null}}))
-            .isEqualTo(18.13455878212156);
+            .isEqualTo(22.210207863352682);
     }
 
     @Test
     public void testDouble() throws Exception {
         assertThat(executeAggregation(DataTypes.DOUBLE, new Object[][]{{10.7d}, {42.9D}, {0.3d}}))
-            .isEqualTo(18.13455878212156);
+            .isEqualTo(22.210207863352682);
     }
 
     @Test
     public void testFloat() throws Exception {
         assertThat(executeAggregation(DataTypes.FLOAT, new Object[][]{{1.5f}, {1.25f}, {1.75f}}))
-            .isEqualTo(0.2041241452319315);
+            .isEqualTo(0.25);
     }
 
     @Test
@@ -102,19 +102,24 @@ public class StdDevAggregationTest extends AggregationTestCase {
     @Test
     public void testLong() throws Exception {
         assertThat(executeAggregation(DataTypes.LONG, new Object[][]{{7L}, {3L}}))
-            .isEqualTo(2d);
+            .isEqualTo(2.8284271247461903);
     }
 
     @Test
     public void testShort() throws Exception {
         assertThat(executeAggregation(DataTypes.SHORT, new Object[][]{{(short) 7}, {(short) 3}}))
-            .isEqualTo(2d);
+            .isEqualTo(2.8284271247461903d);
     }
 
     @Test
     public void testByte() throws Exception {
         assertThat(executeAggregation(DataTypes.SHORT, new Object[][]{{(short) 1}, {(short) 1}}))
             .isEqualTo(0d);
+    }
+
+    @Test
+    public void testTooFewNumbers() throws Exception {
+        assertThat(executeAggregation(DataTypes.DOUBLE, new Object[][]{{10.7d}})).isNull();
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/StdDevAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/StdDevAggregationTest.java
@@ -96,7 +96,7 @@ public class StdDevAggregationTest extends AggregationTestCase {
     @Test
     public void testInteger() throws Exception {
         assertThat(executeAggregation(DataTypes.INTEGER, new Object[][]{{7}, {3}}))
-            .isEqualTo(2d);
+            .isEqualTo(2.8284271247461903);
     }
 
     @Test

--- a/server/src/test/java/io/crate/execution/engine/window/AggregationWindowFunctionsTest.java
+++ b/server/src/test/java/io/crate/execution/engine/window/AggregationWindowFunctionsTest.java
@@ -103,7 +103,7 @@ public class AggregationWindowFunctionsTest extends AbstractWindowFunctionTest {
 
     @Test
     public void testStdDevOverUnboundedFollowingFrames() throws Throwable {
-        Object[] expected = new Object[]{0.47140452079103146, 0.0, 0.0, 0.816496580927726, 0.5, 0.0, null};
+        Object[] expected = new Object[]{0.5773502691896255, 0.0, 0.0, 1.0, 0.7071067811865476, null, null};
         assertEvaluate(
             "stddev(x) OVER(" +
             "   PARTITION BY x>2 ORDER BY x RANGE BETWEEN CURRENT ROW and UNBOUNDED FOLLOWING" +

--- a/server/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
+++ b/server/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
@@ -26,6 +26,7 @@ import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 import java.util.Arrays;
@@ -1081,8 +1082,8 @@ public class GroupByAggregateTest extends IntegTestCase {
 
         execute("select stddev(age), gender from characters group by gender order by gender");
         assertThat(response.rowCount()).isEqualTo(2L);
-        assertThat(response.rows()[0][0]).isEqualTo(5.5d);
-        assertThat(response.rows()[1][0]).isEqualTo(39.0d);
+        assertThat(response.rows()[0][0]).isEqualTo(7.7781745930520225d);
+        assertThat(response.rows()[1][0]).isEqualTo(55.154328932550705d);
     }
 
     @Test
@@ -1101,8 +1102,8 @@ public class GroupByAggregateTest extends IntegTestCase {
 
         execute("select stddev(age), gender from characters group by gender order by gender");
         assertThat(response.rowCount()).isEqualTo(2L);
-        assertThat(response.rows()[0][0]).isEqualTo(5.5d);
-        assertThat(response.rows()[1][0]).isEqualTo(39.0d);
+        assertThat(response.rows()[0][0]).isEqualTo(7.7781745930520225d);
+        assertThat(response.rows()[1][0]).isEqualTo(55.154328932550705d);
     }
 
     @Test
@@ -1116,7 +1117,7 @@ public class GroupByAggregateTest extends IntegTestCase {
         assertThat((double) row[2]).isCloseTo(47.84415001097868d, Percentage.withPercentage(0.01));
         assertThat(row[3]).isEqualTo((short) 112);
         assertThat(row[4]).isEqualTo(1090.6875d);
-        assertThat(row[5]).isEqualTo(33.025558284456d);
+        assertThat(row[5]).isEqualTo(38.13462993133669d);
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

As outlined in #15638, Postgres' `stddev` is returning sample standard deviation while CrateDB is returning population standard deviation. This PR changes the behavior of `stddev` to be aligned with Postgres and improve Postgres compatibility.

I don't consider the change to be a breaking change but more of a fix of undesired behavior of `stddev`.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
 