### PR TITLE
Ensure UDFs are available for generated col validations as part of node upgrade

### DIFF
--- a/docs/appendices/release-notes/5.10.2.rst
+++ b/docs/appendices/release-notes/5.10.2.rst
@@ -78,3 +78,7 @@ Fixes
 - Fixed a performance regression introduced in :ref:`version_5.10.0` that
   caused ``CREATE SNAPSHOT`` to use more memory. That could cause the
   statement to fail with ``OutOfMemoryError`` under memory pressure.
+
+- Fixed an issue that prevented nodes from starting when upgrading to >= 5.8
+  with tables containing a :ref:`generated column <ddl-generated-columns>`
+  using a :ref:`user defined function <user-defined-functions>`.

--- a/docs/appendices/release-notes/5.8.7.rst
+++ b/docs/appendices/release-notes/5.8.7.rst
@@ -47,4 +47,6 @@ See the :ref:`version_5.8.0` release notes for a full list of changes in the
 Fixes
 =====
 
-None
+- Fixed an issue that prevented nodes from starting when upgrading to >= 5.8
+  with tables containing a :ref:`generated column <ddl-generated-columns>`
+  using a :ref:`user defined function <user-defined-functions>`.

--- a/docs/appendices/release-notes/5.9.11.rst
+++ b/docs/appendices/release-notes/5.9.11.rst
@@ -46,3 +46,7 @@ See the :ref:`version_5.9.0` release notes for a full list of changes in the
 
 Fixes
 =====
+
+- Fixed an issue that prevented nodes from starting when upgrading to >= 5.8
+  with tables containing a :ref:`generated column <ddl-generated-columns>`
+  using a :ref:`user defined function <user-defined-functions>`.

--- a/server/src/main/java/io/crate/metadata/cluster/OpenTableClusterStateTaskExecutor.java
+++ b/server/src/main/java/io/crate/metadata/cluster/OpenTableClusterStateTaskExecutor.java
@@ -113,7 +113,7 @@ public class OpenTableClusterStateTaskExecutor extends DDLClusterStateTaskExecut
 
             // The index might be closed because we couldn't import it due to old incompatible version
             // We need to check that this index can be upgraded to the current version
-            updatedIndexMetadata = metadataIndexUpgradeService.upgradeIndexMetadata(updatedIndexMetadata, templateMetadata, minIndexCompatibilityVersion);
+            updatedIndexMetadata = metadataIndexUpgradeService.upgradeIndexMetadata(updatedIndexMetadata, templateMetadata, minIndexCompatibilityVersion, null);
             try {
                 indicesService.verifyIndexMetadata(updatedIndexMetadata, updatedIndexMetadata);
             } catch (Exception e) {

--- a/server/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
+++ b/server/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
@@ -69,6 +69,7 @@ import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import io.crate.common.collections.Tuple;
 import io.crate.common.exceptions.Exceptions;
 import io.crate.common.io.IOUtils;
+import io.crate.expression.udf.UserDefinedFunctionsMetadata;
 import io.crate.metadata.IndexName;
 import io.crate.metadata.PartitionName;
 
@@ -246,7 +247,8 @@ public class GatewayMetaState implements Closeable {
                 IndexName.isPartitioned(indexName) ?
                     upgradedIndexTemplateMetadata.get(PartitionName.templateName(indexName)) :
                     null,
-                Version.CURRENT.minimumIndexCompatibilityVersion());
+                Version.CURRENT.minimumIndexCompatibilityVersion(),
+                metadata.custom(UserDefinedFunctionsMetadata.TYPE));
             changed |= indexMetadata != newMetadata;
             upgradedMetadata.put(newMetadata, false);
         }

--- a/server/src/main/java/org/elasticsearch/gateway/LocalAllocateDangledIndices.java
+++ b/server/src/main/java/org/elasticsearch/gateway/LocalAllocateDangledIndices.java
@@ -152,7 +152,8 @@ public class LocalAllocateDangledIndices {
                                 IndexName.isPartitioned(indexName) ?
                                     currentState.metadata().templates().get(PartitionName.templateName(indexName)) :
                                     null,
-                                minIndexCompatibilityVersion);
+                                minIndexCompatibilityVersion,
+                                null);
                             upgradedIndexMetadata = IndexMetadata.builder(upgradedIndexMetadata).settings(
                                 Settings.builder().put(upgradedIndexMetadata.getSettings()).put(
                                     IndexMetadata.SETTING_HISTORY_UUID, UUIDs.randomBase64UUID())).build();

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -587,7 +587,8 @@ public class Node implements Closeable {
             final MetadataIndexUpgradeService metadataIndexUpgradeService = new MetadataIndexUpgradeService(
                 nodeContext,
                 indexScopedSettings,
-                indexMetadataUpgraders);
+                indexMetadataUpgraders,
+                udfService);
             final Netty4Transport transport = new Netty4Transport(
                 settings,
                 Version.CURRENT,

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -455,7 +455,8 @@ public class RestoreService implements ClusterStateApplier {
                             IndexName.isPartitioned(indexName) ?
                                 currentState.metadata().templates().get(PartitionName.templateName(indexName)) :
                                 null,
-                            minIndexCompatibilityVersion);
+                            minIndexCompatibilityVersion,
+                            null);
                     } catch (Exception ex) {
                         throw new SnapshotRestoreException(snapshot, "cannot restore index [" + index +
                                                                         "] because it cannot be upgraded", ex);

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexUpgradeServiceTest.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexUpgradeServiceTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package org.elasticsearch.cluster.metadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.settings.IndexScopedSettings;
+import org.junit.Test;
+
+import io.crate.expression.udf.UdfUnitTest;
+import io.crate.expression.udf.UserDefinedFunctionMetadata;
+import io.crate.expression.udf.UserDefinedFunctionsMetadata;
+import io.crate.metadata.FunctionImplementation;
+import io.crate.metadata.SearchPath;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+import io.crate.types.DataTypes;
+
+public class MetadataIndexUpgradeServiceTest extends CrateDummyClusterServiceUnitTest {
+
+    @Test
+    public void test_upgradeIndexMetadata_ensure_UDFs_are_loaded_before_checkMappingsCompatibility_is_called() throws IOException {
+        SQLExecutor e = SQLExecutor.of(clusterService);
+        e.udfService().registerLanguage(UdfUnitTest.DUMMY_LANG);
+        var metadataIndexUpgradeService = new MetadataIndexUpgradeService(
+            e.nodeCtx,
+            IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
+            List.of(),
+            e.udfService()
+        );
+        metadataIndexUpgradeService.upgradeIndexMetadata(
+            IndexMetadata.builder("test")
+                .settings(settings(Version.V_5_7_0))
+                .numberOfShards(1)
+                .numberOfReplicas(1)
+                .build(),
+            IndexTemplateMetadata.builder("test")
+                .patterns(List.of("*"))
+                .putMapping("{\"default\": {}}")
+                .build(),
+            Version.V_5_7_0,
+            UserDefinedFunctionsMetadata.of(new UserDefinedFunctionMetadata(
+                "custom",
+                "foo",
+                List.of(),
+                DataTypes.INTEGER,
+                "dummy",
+                "def foo(): return 1"
+            )));
+        FunctionImplementation functionImplementation = e.nodeCtx.functions().get(
+            "custom",
+            "foo",
+            List.of(),
+            SearchPath.pathWithPGCatalogAndDoc()
+        );
+        assertThat(functionImplementation).isNotNull();
+    }
+}

--- a/server/src/test/java/org/elasticsearch/gateway/GatewayMetaStateTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/GatewayMetaStateTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.gateway;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -43,6 +44,8 @@ import org.elasticsearch.test.TestCustomMetadata;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import io.crate.expression.udf.UserDefinedFunctionService;
+import io.crate.expression.udf.UserDefinedFunctionsMetadata;
 import io.crate.metadata.NodeContext;
 
 public class GatewayMetaStateTests extends ESTestCase {
@@ -204,12 +207,12 @@ public class GatewayMetaStateTests extends ESTestCase {
         private final boolean upgrade;
 
         public MockMetadataIndexUpgradeService(boolean upgrade) {
-            super(Mockito.mock(NodeContext.class), null, null);
+            super(mock(NodeContext.class), null, null, mock(UserDefinedFunctionService.class));
             this.upgrade = upgrade;
         }
 
         @Override
-        public IndexMetadata upgradeIndexMetadata(IndexMetadata indexMetadata, IndexTemplateMetadata indexTemplateMetadata, Version minimumIndexCompatibilityVersion) {
+        public IndexMetadata upgradeIndexMetadata(IndexMetadata indexMetadata, IndexTemplateMetadata indexTemplateMetadata, Version minimumIndexCompatibilityVersion, UserDefinedFunctionsMetadata userDefinedFunctionsMetadata) {
             return upgrade ? IndexMetadata.builder(indexMetadata).build() : indexMetadata;
         }
     }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes https://github.com/crate/crate/issues/17478.

The root cause is a refactoring task https://github.com/crate/crate/commit/ce63eef2db36826689af358e36f539ca1562ed97#diff-3bf370b7d01348460fd817752d5aa353646f7bce5b17df76b9616cb486f3f047R122. The `validateSchema()`(which also validates generated columns utilizing UDFs) is called before the UDFs are loaded causing UnsupportedFunctionException.

My initial plan was to instantiate a temporary NodeContext just for `validateSchema()` but it became more invasive, not sure if it is safe to setUDFs.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
