### PR TITLE
Avoid byte copy operations to decompress data for snapshots

### DIFF
--- a/docs/appendices/release-notes/5.10.2.rst
+++ b/docs/appendices/release-notes/5.10.2.rst
@@ -74,3 +74,7 @@ Fixes
   E.g.::
 
     SELECT * FROM tbl WHERE boolean_pk_col OR boolean_pk_col = false
+
+- Fixed a performance regression introduced in :ref:`version_5.10.0` that
+  caused ``CREATE SNAPSHOT`` to use more memory. That could cause the
+  statement to fail with ``OutOfMemoryError`` under memory pressure.

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/ChecksumBlobStoreFormat.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/ChecksumBlobStoreFormat.java
@@ -39,6 +39,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressorFactory;
 import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.InputStreamStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.OutputStreamStreamOutput;
@@ -128,7 +129,8 @@ public final class ChecksumBlobStoreFormat<T extends Writeable> {
                 }
             } else {
                 StreamInput streamInput = CompressorFactory.COMPRESSOR.isCompressed(slice)
-                    ? CompressorFactory.COMPRESSOR.uncompress(slice).streamInput()
+                    // Ensure that 5.10+ uses threadLocalInputStream, similar to 5.9
+                    ? new InputStreamStreamInput(CompressorFactory.COMPRESSOR.threadLocalInputStream(slice.streamInput()))
                     : slice.streamInput();
                 try (StreamInput in = new NamedWriteableAwareStreamInput(streamInput, namedWritableRegistry)) {
                     Version version = Version.readVersion(in);


### PR DESCRIPTION
Follow up to https://github.com/crate/crate/commit/8f941f829d1fe4193f968af9a96bd3e120708fd4

5.10 specific code path uses `CompressorFactory.COMPRESSOR.uncompress(slice)` which, in turn, uses `INFLATER_REF` that is not supposed to be used for decompressing stream

From the `INFLATER_REF` docs:
>Note: This is a separate instance from the one used for the decompressing stream wrapper...

Also, `INFLATER_REF` used in 5.10 doesn't hold a `ReleasableReference` and dedicated `Inflater` used in 5.9 is a `ReleasableReference`

This PR basically re-applies https://github.com/crate/crate/commit/975d237753ff7082380cd36f03721f6dc1d930c8 again

Another (and a bigger) problem with CompressorFactory.COMPRESSOR.uncompress() is that it creates another slice and also copies a buffer. 5.9 was creating a compressed stream and XContentParser has a ctor that can consume such stream. In this PR we are creating a StreamInput that is pointed to compressed InputStream, so no extra copies.


Relates to https://github.com/crate/support/issues/558
