### PR TITLE
Enable HTTP response compression

### DIFF
--- a/docs/appendices/release-notes/6.0.0.rst
+++ b/docs/appendices/release-notes/6.0.0.rst
@@ -113,3 +113,6 @@ Administration and Operations
 
 Client interfaces
 -----------------
+
+- Added support for HTTP response compression (gzip, deflate) when the
+  ``Accept-Encoding`` header is present in the request.

--- a/docs/interfaces/http.rst
+++ b/docs/interfaces/http.rst
@@ -9,6 +9,17 @@ HTTP endpoint
 CrateDB provides a HTTP Endpoint that can be used to submit SQL queries. The
 endpoint is accessible under ``<servername:port>/_sql``.
 
+The endpoint supports response compression (gzip, deflate) when the ``Accept-Encoding``
+header is included in the request::
+
+    sh$ curl -sS -H 'Content-Type: application/json' \
+    ... -H 'Accept-Encoding: gzip' \
+    ... -X POST '127.0.0.1:4200/_sql' \
+    ... -d '{"stmt":"select 1"}'
+
+When compression is requested, the response will include a ``Content-Encoding`` header
+indicating the compression method used.
+
 SQL statements are sent to the ``_sql`` endpoint in ``json`` format, whereby
 the statement is sent as value associated to the key ``stmt``.
 

--- a/server/src/test/java/io/crate/rest/action/SqlHttpHandlerTest.java
+++ b/server/src/test/java/io/crate/rest/action/SqlHttpHandlerTest.java
@@ -24,17 +24,28 @@ package io.crate.rest.action;
 import static io.crate.role.metadata.RolesHelper.JWT_TOKEN;
 import static io.crate.role.metadata.RolesHelper.JWT_USER;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.atLeast;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.times;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.net.InetAddress;
 import java.util.List;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.InflaterInputStream;
 
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.http.netty4.cors.Netty4CorsConfig;
 import org.elasticsearch.http.netty4.cors.Netty4CorsConfigBuilder;
+import org.elasticsearch.test.ESTestCase;
 import org.junit.Test;
 
 import io.crate.session.Session;
@@ -44,11 +55,34 @@ import io.crate.auth.Protocol;
 import io.crate.metadata.settings.CoordinatorSessionSettings;
 import io.crate.protocols.postgres.ConnectionProperties;
 import io.crate.role.Role;
+import io.crate.role.Roles;
 import io.crate.role.metadata.RolesHelper;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.FullHttpRequest;
 
-public class SqlHttpHandlerTest {
+public class SqlHttpHandlerTest extends ESTestCase {
+
+    private final Settings settings = Settings.EMPTY;
+    private final Sessions sessions = mock(Sessions.class);
+    private final Roles roles = mock(Roles.class);
+    private final Netty4CorsConfig corsConfig = mock(Netty4CorsConfig.class);
+    private final CircuitBreaker circuitBreaker = new NoopCircuitBreaker("test");
+
+    private SqlHttpHandler handler;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        handler = new SqlHttpHandler(
+            settings,
+            sessions,
+            name -> circuitBreaker,
+            roles,
+            corsConfig
+        );
+    }
 
     @Test
     public void testDefaultUserIfHttpHeaderNotPresent() {
@@ -121,7 +155,7 @@ public class SqlHttpHandlerTest {
 
         // 1st call to ensureSession creates a session instance bound to 'dummyUser'
         var session = handler.ensureSession(connectionProperties, mockedRequest);
-        verify(mockedRequest, atLeast(1)).headers();
+        verify(mockedRequest, times(2)).headers();
         assertThat(session.sessionSettings().authenticatedUser()).isEqualTo(dummyUser);
         assertThat(session.sessionSettings().searchPath().currentSchema()).contains("doc");
         assertThat(session.sessionSettings().hashJoinsEnabled()).isTrue();
@@ -149,5 +183,60 @@ public class SqlHttpHandlerTest {
         Role resolvedUser = handler.userFromAuthHeader("bearer " + JWT_TOKEN);
         assertThat(resolvedUser.name()).isEqualTo(JWT_USER.name());
     }
-}
 
+    @Test
+    public void testGzipCompression() throws IOException {
+        byte[] testData = "test data with some length to make compression useful".repeat(100).getBytes();
+        ByteBuf content = Unpooled.wrappedBuffer(testData);
+
+        ByteBuf compressed = handler.compressResponse(content, "gzip");
+        byte[] compressedArray = new byte[compressed.readableBytes()];
+        compressed.readBytes(compressedArray);
+
+        assertThat(compressedArray.length).isLessThan(testData.length);
+
+        try (GZIPInputStream gzipInputStream = new GZIPInputStream(new ByteArrayInputStream(compressedArray))) {
+            byte[] decompressed = gzipInputStream.readAllBytes();
+            assertThat(decompressed).isEqualTo(testData);
+        }
+    }
+
+    @Test
+    public void testDeflateCompression() throws IOException {
+        byte[] testData = "test data with some length to make compression useful".repeat(100).getBytes();
+        ByteBuf content = Unpooled.wrappedBuffer(testData);
+
+        ByteBuf compressed = handler.compressResponse(content, "deflate");
+        byte[] compressedArray = new byte[compressed.readableBytes()];
+        compressed.readBytes(compressedArray);
+
+        assertThat(compressedArray.length).isLessThan(testData.length);
+
+        try (InflaterInputStream inflaterInputStream = new InflaterInputStream(new ByteArrayInputStream(compressedArray))) {
+            byte[] decompressed = inflaterInputStream.readAllBytes();
+            assertThat(decompressed).isEqualTo(testData);
+        }
+    }
+
+    @Test
+    public void test_circuit_breaker_triggers_on_compression() throws IOException {
+        byte[] testData = "test data".repeat(100).getBytes();
+        ByteBuf content = Unpooled.wrappedBuffer(testData);
+        
+        CircuitBreaker breakingBreaker = mock(CircuitBreaker.class);
+        when(breakingBreaker.addEstimateBytesAndMaybeBreak(anyLong(), eq("http-compression")))
+            .thenThrow(new CircuitBreakingException("Data too large"));
+
+        SqlHttpHandler handlerWithBreaker = new SqlHttpHandler(
+            Settings.EMPTY,
+            mock(Sessions.class),
+            _ -> breakingBreaker,
+            mock(Roles.class),
+            mock(Netty4CorsConfig.class)
+        );
+
+        assertThatThrownBy(() -> handlerWithBreaker.compressResponse(content, "gzip"))
+            .isInstanceOf(CircuitBreakingException.class)
+            .hasMessage("Data too large");
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Enable HTTP response compression, to clients accepting compressed data via `'Accept-Encoding'` header for `gzip` and `deflate`

`SELECT * FROM sys.summits`

Content: 158 **KiB** -> 42 **KiB**  (- 73%)

<img width="300" alt="image" src="https://github.com/user-attachments/assets/dcc07dae-2c0a-49f6-9d95-e49bb0b0ca4b" />

Simple test on localhost to measure impact on query performance: 

```
Running 5000 requests with Accept-Encoding: gzip
GZIP - Total time: 19143 ms, Average time: 3.83 ms, Total response size: 210.82 MB

Running 5000 requests with Accept-Encoding: deflate
DEFLATE - Total time: 19392 ms, Average time: 3.88 ms, Total response size: 210.76 MB

Running 5000 requests without Accept-Encoding header
No Accept-Encoding - Total time: 3983 ms, Average time: 0.80 ms, Total response size: 770.82 MB
```

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
