### PR TITLE
Use empty statement for jobs logs entry on missing prepared statements

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/collect/stats/JobsLogs.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/stats/JobsLogs.java
@@ -32,6 +32,7 @@ import java.util.function.BooleanSupplier;
 import java.util.function.LongSupplier;
 
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import io.crate.common.annotations.ThreadSafe;
 import io.crate.expression.reference.sys.job.JobContext;
@@ -227,7 +228,8 @@ public class JobsLogs {
         }
     }
 
-    void updateJobsLog(LogSink<JobContextLog> sink) {
+    @VisibleForTesting
+    public void updateJobsLog(LogSink<JobContextLog> sink) {
         long stamp = jobsLogLock.writeLock();
         try {
             sink.addAll(jobsLog);

--- a/server/src/main/java/io/crate/session/Session.java
+++ b/server/src/main/java/io/crate/session/Session.java
@@ -393,7 +393,7 @@ public class Session implements AutoCloseable {
         try {
             preparedStmt = getSafeStmt(statementName);
         } catch (Throwable t) {
-            jobsLogs.logPreExecutionFailure(UUIDs.dirtyUUID(), statementName, SQLExceptions.messageOf(t), sessionSettings.sessionUser());
+            jobsLogs.logPreExecutionFailure(UUIDs.dirtyUUID(), "", SQLExceptions.messageOf(t), sessionSettings.sessionUser());
             throw t;
         }
 


### PR DESCRIPTION
Follow up to https://github.com/crate/crate/pull/17480
