### PR TITLE
Use upstream Lucene90 DocValuesFormat

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/CrateCodec.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/CrateCodec.java
@@ -22,7 +22,6 @@ package org.elasticsearch.index.codec;
 import java.io.IOException;
 
 import org.apache.lucene.codecs.Codec;
-import org.apache.lucene.codecs.DocValuesFormat;
 import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.codecs.KnnVectorsReader;
 import org.apache.lucene.codecs.KnnVectorsWriter;
@@ -31,7 +30,6 @@ import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentWriteState;
 import org.elasticsearch.common.lucene.Lucene;
 
-import io.crate.lucene.codec.CustomLucene90DocValuesFormat;
 import io.crate.types.FloatVectorType;
 
 
@@ -49,11 +47,6 @@ public class CrateCodec extends Lucene101Codec {
 
     public CrateCodec(Mode compressionMode) {
         super(compressionMode);
-    }
-
-    @Override
-    public DocValuesFormat getDocValuesFormatForField(String field) {
-        return new CustomLucene90DocValuesFormat(CustomLucene90DocValuesFormat.Mode.BEST_SPEED);
     }
 
     @Override


### PR DESCRIPTION
With https://github.com/crate/crate/pull/17458 the compression patch
shouldn't be necessary anymore.

Can't remove the codec entirely because we need it to read old data.

---

crate-qa storage bwc test with a build of this version passes:

```
2025-02-24T19:46:00 Upgrade to: 5.10.x
2025-02-24T19:46:05 Upgrade to: crate/app/target/crate-6.0.0-2025-02-24-19-37-110e4d2.tar.gz
|
2025-02-24T19:46:13 Start version: 5.10.x
2025-02-24T19:46:18 Upgrade to: crate/app/target/crate-6.0.0-2025-02-24-19-37-110e4d2.tar.gz
```

---

Looks like there would be regressions on some joins:

```
# Results (server side duration in ms)
V1: 6.0.0-6e18150a3937176f863d24c4449a8f7c95e84331
V2: 6.0.0-110e4d248a83ff019ac81b98e4bf292ba579ad29

Q: select * from articles inner join colors on articles.id = colors.id order by articles.id limit 1000
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |       29.205 ±    8.681 |     24.685 |     26.650 |     29.876 |    135.979 |
|   V2    |       28.345 ±    8.380 |     24.425 |     26.007 |     28.239 |    131.650 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -   2.99%                           -   2.44%
There is a 68.59% probability that the observed difference is not random, and the best estimate of that difference is 2.99%
The test has no statistical significance

Q: select articles.name as article from articles, colors order by article limit 10000
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |        6.855 ±    1.616 |      5.831 |      6.670 |      6.967 |     53.812 |
|   V2    |        9.006 ±    0.766 |      7.970 |      8.810 |      9.181 |     14.495 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               +  27.12%                           +  27.65%
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 27.12%
The test has statistical significance

Q: select * from articles CROSS JOIN colors limit 1 offset 10000
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |        3.786 ±    0.979 |      3.393 |      3.583 |      3.696 |     15.608 |
|   V2    |        3.814 ±    0.927 |      3.402 |      3.640 |      3.776 |     15.353 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               +   0.75%                           +   1.57%
There is a 23.49% probability that the observed difference is not random, and the best estimate of that difference is 0.75%
The test has no statistical significance

Q: select * from articles inner join colors on articles.id = colors.id where colors.id = -1
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |       25.678 ±    4.065 |     23.246 |     23.839 |     24.550 |     46.788 |
|   V2    |       41.797 ±    3.671 |     39.752 |     40.375 |     41.026 |     61.496 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               +  47.78%                           +  51.50%
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 47.78%
The test has statistical significance
```