### PR TITLE
Restore RelationMetadata.Table from snapshots and use indexUUIDs to resolve indices

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -1273,6 +1273,26 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
             }
             return List.of();
         }
+        if (relation instanceof RelationMetadata.Table table) {
+            List<String> indexUUIDs = table.indexUUIDs();
+            ArrayList<T> result = new ArrayList<>(indexUUIDs.size());
+            for (String indexUUID : indexUUIDs) {
+                IndexMetadata imd = indexByUUID(indexUUID);
+                if (imd == null) {
+                    if (strict) {
+                        throw new RelationUnknown(relationName);
+                    }
+                    continue;
+                }
+                if (!partitionValues.isEmpty() && !partitionValues.equals(imd.partitionValues())) {
+                    continue;
+                }
+                T item = as.apply(imd);
+                if (item != null) {
+                    result.add(item);
+                }
+            }
+        }
         IndicesOptions indicesOptions = strict
             ? IndicesOptions.STRICT_EXPAND_OPEN
             : IndicesOptions.LENIENT_EXPAND_OPEN;

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoryData.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoryData.java
@@ -437,17 +437,6 @@ public final class RepositoryData {
     }
 
     /**
-     * Resolve the given index names to index ids.
-     */
-    public List<IndexId> resolveIndices(final List<String> indices) {
-        List<IndexId> resolvedIndices = new ArrayList<>(indices.size());
-        for (final String indexName : indices) {
-            resolvedIndices.add(resolveIndexId(indexName));
-        }
-        return resolvedIndices;
-    }
-
-    /**
      * Resolve the given index names to index ids, creating new index ids for
      * new indices in the repository.
      *


### PR DESCRIPTION
Note this doesn't yet create RelationMetadata for snapshots which don't
have them (< 6.0 snapshots) but only restores it if it was part of the
snapshots
