### PR TITLE
Don't treat warnings as errors during sphinx build

### DIFF
--- a/blackbox/bin/sphinx
+++ b/blackbox/bin/sphinx
@@ -36,5 +36,5 @@ elif [ "$1" == "linkcheck" ]; then
     sphinx-build -n -W --keep-going -c "$DOCS_DIR" -b linkcheck -E "$DOCS_DIR" "$DOCS_DIR/_out/html"
 else
     printf "\033[1;44mBuilding server docs ...\033[0m\n"
-    sphinx-build -n -W -b html "$DOCS_DIR" "$DOCS_DIR/_out/html"
+    sphinx-build -n -b html "$DOCS_DIR" "$DOCS_DIR/_out/html"
 fi


### PR DESCRIPTION
There are currently a lot of 503 errors when trying to retrieve the
intersphinx artifacts.

Until the infrastructure related issues are resolved this removes the
`-W` flag to avoid having the build fail
