### PR TITLE
Change concat object function to return typed object

### DIFF
--- a/server/src/main/java/io/crate/expression/scalar/ConcatFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/ConcatFunction.java
@@ -36,6 +36,7 @@ import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
+import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.TypeSignature;
 
@@ -82,8 +83,15 @@ public abstract class ConcatFunction extends Scalar<String, String> {
                     DataTypes.UNTYPED_OBJECT.getTypeSignature())
                 .returnType(DataTypes.UNTYPED_OBJECT.getTypeSignature())
                 .features(Feature.DETERMINISTIC)
+                .bindActualTypes()
                 .build(),
-            ObjectMergeFunction::new
+            (signature, boundSignature) -> {
+                DataType<?> returnType = ObjectMergeFunction.merge(
+                    boundSignature.argTypes().get(0),
+                    boundSignature.argTypes().get(1)
+                );
+                return new ObjectMergeFunction(signature, boundSignature.withReturnType(returnType));
+            }
         );
 
 
@@ -138,8 +146,15 @@ public abstract class ConcatFunction extends Scalar<String, String> {
                     DataTypes.UNTYPED_OBJECT.getTypeSignature())
                 .returnType(DataTypes.UNTYPED_OBJECT.getTypeSignature())
                 .features(Feature.DETERMINISTIC)
+                .bindActualTypes()
                 .build(),
-            ObjectMergeFunction::new
+            (signature, boundSignature) -> {
+                DataType<?> returnType = ObjectMergeFunction.merge(
+                    boundSignature.argTypes().get(0),
+                    boundSignature.argTypes().get(1)
+                );
+                return new ObjectMergeFunction(signature, boundSignature.withReturnType(returnType));
+            }
         );
     }
 

--- a/server/src/main/java/io/crate/expression/scalar/object/ObjectMergeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/object/ObjectMergeFunction.java
@@ -30,8 +30,19 @@ import io.crate.metadata.Scalar;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
+import io.crate.types.DataType;
+import io.crate.types.ObjectType;
 
 public class ObjectMergeFunction extends Scalar<Map<String, Object>, Map<String, Object>> {
+
+    public static DataType<?> merge(DataType<?> left, DataType<?> right) {
+        if (left instanceof ObjectType == false) {
+            return right;
+        } else if (right instanceof ObjectType == false) {
+            return left;
+        }
+        return ObjectType.merge((ObjectType) left, (ObjectType) right, (l, r) -> r);
+    }
 
     public ObjectMergeFunction(Signature signature, BoundSignature boundSignature) {
         super(signature, boundSignature);

--- a/server/src/main/java/io/crate/metadata/functions/BoundSignature.java
+++ b/server/src/main/java/io/crate/metadata/functions/BoundSignature.java
@@ -34,4 +34,7 @@ public record BoundSignature(List<DataType<?>> argTypes, DataType<?> returnType)
         );
     }
 
+    public BoundSignature withReturnType(DataType<?> returnType) {
+        return new BoundSignature(argTypes(), returnType);
+    }
 }

--- a/server/src/main/java/io/crate/metadata/functions/Signature.java
+++ b/server/src/main/java/io/crate/metadata/functions/Signature.java
@@ -74,6 +74,7 @@ public final class Signature implements Writeable, Accountable {
         private List<TypeSignature> variableArityGroup = Collections.emptyList();
         private boolean variableArity = false;
         private boolean allowCoercion = true;
+        private boolean bindActualTypes = false;
 
         public Builder() {
         }
@@ -160,6 +161,11 @@ public final class Signature implements Writeable, Accountable {
             return this;
         }
 
+        public Builder bindActualTypes() {
+            bindActualTypes = true;
+            return this;
+        }
+
         public Signature build() {
             assert name != null : "Signature requires the 'name' to be set";
             assert type != null : "Signature requires the 'type' to be set";
@@ -173,7 +179,8 @@ public final class Signature implements Writeable, Accountable {
                 features,
                 variableArityGroup,
                 variableArity,
-                allowCoercion);
+                allowCoercion,
+                bindActualTypes);
         }
     }
 
@@ -222,7 +229,8 @@ public final class Signature implements Writeable, Accountable {
                       Set<Scalar.Feature> features,
                       List<TypeSignature> variableArityGroup,
                       boolean variableArity,
-                      boolean allowCoercion) {
+                      boolean allowCoercion,
+                      boolean bindActualTypes) {
         this.name = name;
         this.type = type;
         this.argumentTypes = argumentTypes;
@@ -232,7 +240,8 @@ public final class Signature implements Writeable, Accountable {
             typeVariableConstraints,
             variableArityGroup,
             variableArity,
-            allowCoercion
+            allowCoercion,
+            bindActualTypes
         );
     }
 

--- a/server/src/main/java/io/crate/metadata/functions/SignatureBindingInfo.java
+++ b/server/src/main/java/io/crate/metadata/functions/SignatureBindingInfo.java
@@ -21,9 +21,9 @@
 
 package io.crate.metadata.functions;
 
-import io.crate.types.TypeSignature;
-
 import java.util.List;
+
+import io.crate.types.TypeSignature;
 
 /**
  * Containing {@link Signature} properties which are only required for signature binding/matching.
@@ -35,15 +35,18 @@ public class SignatureBindingInfo {
     private final List<TypeSignature> variableArityGroup;
     private final boolean variableArity;
     private final boolean allowCoercion;
+    private final boolean bindActualTypes;
 
     public SignatureBindingInfo(List<TypeVariableConstraint> typeVariableConstraints,
                                 List<TypeSignature> variableArityGroup,
                                 boolean variableArity,
-                                boolean allowCoercion) {
+                                boolean allowCoercion,
+                                boolean bindActualTypes) {
         this.typeVariableConstraints = typeVariableConstraints;
         this.variableArityGroup = variableArityGroup;
         this.variableArity = variableArity;
         this.allowCoercion = allowCoercion;
+        this.bindActualTypes = bindActualTypes;
     }
 
     public List<TypeVariableConstraint> getTypeVariableConstraints() {
@@ -60,5 +63,9 @@ public class SignatureBindingInfo {
 
     public boolean isCoercionAllowed() {
         return allowCoercion;
+    }
+
+    public boolean bindActualTypes() {
+        return bindActualTypes;
     }
 }

--- a/server/src/main/java/io/crate/types/ObjectType.java
+++ b/server/src/main/java/io/crate/types/ObjectType.java
@@ -299,12 +299,18 @@ public class ObjectType extends DataType<Map<String, Object>> implements Streame
     }
 
     private static ObjectType merge(ObjectType left, ObjectType right) {
+        return merge(left, right, DataTypes::merge);
+    }
+
+    public static ObjectType merge(ObjectType left,
+                                   ObjectType right,
+                                   BiFunction<DataType<?>, DataType<?>, DataType<?>> remappingFunction) {
         ObjectType.Builder mergedObjectBuilder = ObjectType.of(ColumnPolicy.DYNAMIC);
         for (var e : left.innerTypes().entrySet()) {
             mergedObjectBuilder.setInnerType(e.getKey(), e.getValue());
         }
         for (var e : right.innerTypes().entrySet()) {
-            mergedObjectBuilder.mergeInnerType(e.getKey(), e.getValue(), DataTypes::merge);
+            mergedObjectBuilder.mergeInnerType(e.getKey(), e.getValue(), remappingFunction);
         }
         return mergedObjectBuilder.build();
     }

--- a/server/src/test/java/io/crate/expression/scalar/ConcatFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ConcatFunctionTest.java
@@ -23,6 +23,7 @@ package io.crate.expression.scalar;
 
 import static io.crate.testing.Asserts.isLiteral;
 import static io.crate.testing.Asserts.isNull;
+import static io.crate.testing.Asserts.isObjectLiteral;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -116,7 +117,7 @@ public class ConcatFunctionTest extends ScalarTestCase {
 
     @Test
     public void test_two_objects() {
-        assertEvaluate("concat({a=1},{a=2,b=2})", Map.of("a",2,"b",2));
+        assertNormalize("concat({a=1},{a=2,b=2})", isObjectLiteral(Map.of("a",2,"b",2)));
     }
 
     @Test
@@ -138,7 +139,7 @@ public class ConcatFunctionTest extends ScalarTestCase {
     }
 
     public void test_concat_operator_with_objects() {
-        assertEvaluate("{a=1} || {a=2,b=2}", Map.of("a",2,"b",2));
+        assertNormalize("{a=1} || {a=2,b=2}", isObjectLiteral(Map.of("a",2,"b",2)));
     }
 
     @Test

--- a/server/src/test/java/io/crate/metadata/functions/SignatureBinderTest.java
+++ b/server/src/test/java/io/crate/metadata/functions/SignatureBinderTest.java
@@ -237,31 +237,26 @@ public class SignatureBinderTest extends ESTestCase {
     }
 
     @Test
-    public void testMap() {
-        Signature getValueFunction = functionSignature()
-            .returnType(TypeSignature.parse("V"))
-            .argumentTypes(TypeSignature.parse("object(K,V)"), TypeSignature.parse("K"))
-            .typeVariableConstraints(List.of(typeVariable("K"), typeVariable("V")))
+    public void test_actual_type_is_bound() {
+        Signature signature = functionSignature()
+            .argumentTypes(TypeSignature.parse("object"))
+            .returnType(TypeSignature.parse("object"))
+            .bindActualTypes()
             .build();
 
-        assertThatSignature(getValueFunction)
-            .boundTo(
-                ObjectType.of(ColumnPolicy.DYNAMIC)
-                    .setInnerType("V", DataTypes.LONG).build(),
-                DataTypes.STRING)
-            .produces(new BoundVariables(
-                Map.of(
-                    "K", type("text"),
-                    "V", type("bigint"))
-            ));
+        ObjectType objectType = ObjectType.of(ColumnPolicy.DYNAMIC)
+            .setInnerType("x", DataTypes.LONG)
+            .setInnerType("y", DataTypes.STRING)
+            .build();
 
-        assertThatSignature(getValueFunction)
-            .boundTo(
-                ObjectType.of(ColumnPolicy.DYNAMIC)
-                    .setInnerType("V", DataTypes.LONG).build(),
-                DataTypes.LONG)
-            .withoutCoercion()
-            .fails();
+        BoundSignature expected = new BoundSignature(
+            List.of(objectType),
+            ObjectType.UNTYPED
+        );
+
+        assertThatSignature(signature)
+            .boundTo(objectType)
+            .hasBoundSignature(expected);
     }
 
     @Test

--- a/server/src/testFixtures/java/io/crate/testing/Asserts.java
+++ b/server/src/testFixtures/java/io/crate/testing/Asserts.java
@@ -26,6 +26,7 @@ import static org.elasticsearch.test.ESTestCase.assertBusy;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -214,6 +215,14 @@ public class Asserts extends Assertions {
             assertThat(s).hasDataType(DataTypes.NUMERIC);
             BigDecimal value = (BigDecimal) ((Input<?>) s).value();
             assertThat(value).isCloseTo(expectedValue, Offset.offset(precisionError));
+        };
+    }
+
+    public static Consumer<Symbol> isObjectLiteral(Map<String, Object> expectedValue) {
+        return s -> {
+            assertThat(s).isNotNull();
+            assertThat(s).isLiteral(expectedValue);
+            assertThat(s).hasDataType(DataTypes.guessType(expectedValue));
         };
     }
 


### PR DESCRIPTION
By using the `bindActualTypes` feature of the signature binding,
the bound signature will contain the actual (typed) object types
and the concrete return type can be specified.

Relates to https://github.com/crate/crate/issues/14828.

This is a prerequisite for other improvements.
The first commit is required to implement this, but is a generic improvement, so I left it as a dedicated commit.