### PR TITLE
Try to use optimized subscript function with concrete return type

### DIFF
--- a/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -680,9 +680,17 @@ public class ExpressionAnalyzer {
 
             if (subscriptContext.hasExpression()) {
                 // The left hand side of the expression isn't a column, it's something like a
-                // static array or a cast, so we recurse into it.
+                // static array, function or a cast, so we recurse into it.
                 Symbol base = node.base().accept(this, context);
                 Symbol index = node.index().accept(this, context);
+                if (index.valueType() == DataTypes.STRING) {
+                    // If the index is a string, we can try to optimize the subscript function
+                    // to avoid the function call and directly access the object key.
+                    Function optimizedSubscript = optimizedSubscriptFunction(base, index, subscriptContext.parts(), context, null);
+                    if (optimizedSubscript != null) {
+                        return optimizedSubscript;
+                    }
+                }
                 return allocateFunction(SubscriptFunction.NAME, List.of(base, index), context);
             }
 
@@ -699,6 +707,8 @@ public class ExpressionAnalyzer {
             // - We want to avoid subscript functions if possible (we've nested object values in a column store)
             // - In DDL statement we can't turn a `PRIMARY KEY o['x']` into a subscript either
             // - In DML statements we can have assignments: obj['x'] = 30
+            // - We want a good error message if the subscript is invalid including the column name and relation. This
+            //   is not possible with the subscript function as it misses all these information.
             // We should come up with a design that addresses those and remove the duct-tape logic below.
 
             Symbol ref;
@@ -734,43 +744,71 @@ public class ExpressionAnalyzer {
                     List.of(),
                     operation,
                     context.errorOnUnknownObjectKey());
-                DataType<?> baseType = base.valueType();
-                // Need to double-check that the base type does not hold the inner type before throwing. For instance,
-                //     create table t (o array(object as (a int)));
-                //     select col['a'] from (select unnest(o) as col from t) t_alias;
-                // `col['a']` cannot be resolved(due to unnest), although we know o['a'] exists. Here `col`(the base)
-                // is resolved to a ScopedSymbol which holds `a` as the inner type.
-                // There are test cases that fail without checking inner types:
-                //     SysSnapshotsTest.test_sys_snapshots_returns_table_partition_information
-                //     AlterTableIntegrationTest.test_alter_table_drop_leaf_subcolumn_with_parent_object_array
-                // Another example is selecting sub-column of an object that is union-ed.
-                if (baseType != UndefinedType.INSTANCE
-                    && baseType != ObjectType.UNTYPED
-                    && !DataTypes.hasPath(baseType, parts)) {
-                    DataType<?> currentType = baseType;
-                    ColumnPolicy parentPolicy = baseType.columnPolicy();
-                    for (String p : parts) {
-                        if (ArrayType.unnest(currentType) instanceof ObjectType objectType) {
-                            parentPolicy = objectType.columnPolicy();
-                            currentType = objectType.innerType(p);
-                        }
-                    }
-                    if (parentPolicy == ColumnPolicy.STRICT ||
-                        (parentPolicy == ColumnPolicy.DYNAMIC && context.errorOnUnknownObjectKey())) {
-                        throw e;
-                    }
+                Symbol index = node.index().accept(this, context);
+                Function optimizedSubscript = optimizedSubscriptFunction(base, index, parts, context, e);
+                if (optimizedSubscript != null) {
+                    return optimizedSubscript;
                 }
+
                 return allocateFunction(
                     SubscriptFunction.NAME,
-                    List.of(
-                        node.base().accept(this, context),
-                        node.index().accept(this, context)
-                    ),
+                    List.of(base, index),
                     context
                 );
             } catch (ColumnUnknownException e2) {
                 throw e;
             }
+        }
+
+        /**
+         * Tries to detect the subscript return type based on the given (typed) base type (object or arrayOfObjects).
+         *
+         * @return Subscript function with concrete return type or NULL if it cannot be detected.
+         * @throws ColumnUnknownException if the wanted column cannot be found and the parent policy condition requires
+         *         an error to be thrown. Only thrown if the exception is passed in as an argument. Otherwise, it falls
+         *         through and relies on the SubscriptFunction to throw the error.
+         */
+        @Nullable
+        private Function optimizedSubscriptFunction(Symbol base,
+                                                    Symbol index,
+                                                    List<String> path,
+                                                    ExpressionAnalysisContext context,
+                                                    @Nullable ColumnUnknownException e) {
+            if (path.isEmpty()) {
+                return null;
+            }
+            DataType<?> baseType = base.valueType();
+            DataType<?> innerType = DataTypes.innerType(baseType, path);
+            if (innerType == null) {
+                // Not an object or array of objects
+                return null;
+            }
+            if (innerType != UndefinedType.INSTANCE && !DataTypes.isArrayOfNulls(innerType)) {
+                Signature signature = SubscriptFunction.SIGNATURE_OBJECT;
+                if (baseType instanceof ArrayType<?>) {
+                    signature = SubscriptFunction.SIGNATURE_ARRAY_OF_OBJECTS;
+                }
+                return new Function(
+                    signature,
+                    List.of(base, index),
+                    innerType
+                );
+            }
+            DataType<?> currentType = baseType;
+            ColumnPolicy parentPolicy = baseType.columnPolicy();
+            for (String p : path) {
+                if (ArrayType.unnest(currentType) instanceof ObjectType objectType) {
+                    parentPolicy = objectType.columnPolicy();
+                    currentType = objectType.innerType(p);
+                }
+            }
+            if (parentPolicy == ColumnPolicy.STRICT ||
+                (parentPolicy == ColumnPolicy.DYNAMIC && context.errorOnUnknownObjectKey())) {
+                if (e != null) {
+                    throw e;
+                }
+            }
+            return null;
         }
 
         @Override

--- a/server/src/main/java/io/crate/metadata/Scalar.java
+++ b/server/src/main/java/io/crate/metadata/Scalar.java
@@ -34,6 +34,8 @@ import io.crate.lucene.FunctionToQuery;
 import io.crate.metadata.functions.BoundSignature;
 import io.crate.metadata.functions.Signature;
 import io.crate.role.Roles;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
 
 /**
  * Base class for Scalar functions in crate.
@@ -145,7 +147,12 @@ public abstract class Scalar<ReturnType, InputType> implements FunctionImplement
             inputs[idx] = (Input<?>) arg;
             idx++;
         }
-        return Literal.ofUnchecked(function.valueType(), scalar.evaluate(txnCtx, nodeCtx, inputs));
+        Object result = scalar.evaluate(txnCtx, nodeCtx, inputs);
+        DataType<?> returnType = function.valueType();
+        if (returnType == DataTypes.UNDEFINED) {
+            returnType = DataTypes.guessType(result);
+        }
+        return Literal.ofUnchecked(returnType, result);
     }
 
     public enum Feature {

--- a/server/src/main/java/io/crate/types/ObjectType.java
+++ b/server/src/main/java/io/crate/types/ObjectType.java
@@ -147,11 +147,21 @@ public class ObjectType extends DataType<Map<String, Object>> implements Streame
         }
         DataType<?> innerType = DataTypes.UNDEFINED;
         ObjectType currentObject = this;
+        int arrayNesting = 0;
         for (int i = 0; i < path.size(); i++) {
             innerType = currentObject.innerType(path.get(i));
-            if (innerType.id() == ID) {
-                currentObject = (ObjectType) innerType;
+            while (innerType instanceof ArrayType<?> arrayType) {
+                arrayNesting++;
+                innerType = arrayType.innerType();
             }
+            if (innerType instanceof ObjectType objectType) {
+                currentObject = objectType;
+            } else if (i < path.size() - 1) {
+                return DataTypes.UNDEFINED;
+            }
+        }
+        for (int i = 0; i < arrayNesting; i++) {
+            innerType = new ArrayType<>(innerType);
         }
         return innerType;
     }

--- a/server/src/main/java/io/crate/types/UndefinedType.java
+++ b/server/src/main/java/io/crate/types/UndefinedType.java
@@ -36,6 +36,7 @@ import io.crate.execution.dml.ValueIndexer;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
+import io.crate.sql.tree.ColumnPolicy;
 
 public class UndefinedType extends DataType<Object> implements Streamer<Object> {
 
@@ -54,6 +55,11 @@ public class UndefinedType extends DataType<Object> implements Streamer<Object> 
     @Override
     public Precedence precedence() {
         return Precedence.UNDEFINED;
+    }
+
+    @Override
+    public ColumnPolicy columnPolicy() {
+        return ColumnPolicy.IGNORED;
     }
 
     @Override

--- a/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -94,12 +94,14 @@ import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.sys.SysNodesTableInfo;
 import io.crate.sql.parser.ParsingException;
 import io.crate.sql.tree.BitString;
+import io.crate.sql.tree.ColumnPolicy;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.testing.T3;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
+import io.crate.types.ObjectType;
 import io.crate.types.StringType;
 import io.crate.types.TimeTZ;
 
@@ -2525,16 +2527,10 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         assertThat(analyzed.outputs()).hasSize(1);
         assertThat(analyzed.outputs().getFirst()).isLiteral(null);
 
-        /*
-         * This is documenting a bug. If this fails, it is a breaking change.
-         * select (['{"x":1,"y":2}','{"y":2,"z":3}']::ARRAY(OBJECT))['x'];  --> works --> bug?
-         * set errorOnUnknownObjectKey = false;
-         * select (['{"x":1,"y":2}','{"y":2,"z":3}']::ARRAY(OBJECT))['x'];  --> works
-         */
         executor.getSessionSettings().setErrorOnUnknownObjectKey(true);
-        analyzed = executor.analyze("select (['{\"x\":1,\"y\":2}','{\"y\":2,\"z\":3}']::ARRAY(OBJECT))['x']");
-        assertThat(analyzed.outputs()).hasSize(1);
-        assertThat(analyzed.outputs().getFirst()).hasToString("[1, NULL]");
+        assertThatThrownBy(() -> executor.analyze("select (['{\"x\":1,\"y\":2}','{\"y\":2,\"z\":3}']::ARRAY(OBJECT))['x']"))
+            .isExactlyInstanceOf(ColumnUnknownException.class)
+            .hasMessageContaining("The object `{y=2, z=3}` does not contain the key `x`");
         executor.getSessionSettings().setErrorOnUnknownObjectKey(false);
         analyzed = executor.analyze("select (['{\"x\":1,\"y\":2}','{\"y\":2,\"z\":3}']::ARRAY(OBJECT))['x']");
         assertThat(analyzed.outputs()).hasSize(1);
@@ -2881,38 +2877,41 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
 
         // dynamic
         assertThatThrownBy(() -> executor.analyze(
-            "select alias['u'] from (select obj_dynamic['u'] as alias from t) tbl"))
+            "select alias['b'] from (select obj_dynamic['a'] as alias from t) tbl"))
             .isExactlyInstanceOf(ColumnUnknownException.class)
-            .hasMessage("Column obj_dynamic['u'] unknown");
+            .hasMessage("Column obj_dynamic['a'] unknown");
 
         // ignored
-        var analyzed = executor.analyze("select alias['u'] from (select obj_ignored['u'] as alias from t) tbl");
+        var analyzed = executor.analyze("select alias['b'] from (select obj_ignored['a'] as alias from t) tbl");
         Assertions.assertThat(analyzed.outputs()).hasSize(1);
-        assertThat(analyzed.outputs().getFirst()).isFunction("subscript", isField("alias"), isLiteral("u"));
+        assertThat(analyzed.outputs().getFirst()).isFunction("subscript", isField("alias"), isLiteral("b"));
+        assertThat(analyzed.outputs().getFirst()).isFunction("subscript", DataTypes.UNDEFINED);
 
         // strict
         assertThatThrownBy(() -> executor.analyze(
-            "select alias['u'] from (select obj_strict['u'] as alias from t) tbl"))
+            "select alias['b'] from (select obj_strict['a'] as alias from t) tbl"))
             .isExactlyInstanceOf(ColumnUnknownException.class)
-            .hasMessage("Column obj_strict['u'] unknown");
+            .hasMessage("Column obj_strict['a'] unknown");
 
         executor.getSessionSettings().setErrorOnUnknownObjectKey(false);
 
         // dynamic
-        analyzed = executor.analyze("select alias['u'] from (select obj_dynamic['u'] as alias from t) tbl");
+        analyzed = executor.analyze("select alias['b'] from (select obj_dynamic['a'] as alias from t) tbl");
         Assertions.assertThat(analyzed.outputs()).hasSize(1);
-        assertThat(analyzed.outputs().getFirst()).isFunction("subscript", isField("alias"), isLiteral("u"));
+        assertThat(analyzed.outputs().getFirst()).isFunction("subscript", isField("alias"), isLiteral("b"));
+        assertThat(analyzed.outputs().getFirst()).isFunction("subscript", DataTypes.UNDEFINED);
 
         // ignored
-        executor.analyze("select alias['u'] from (select obj_ignored['u'] as alias from t) tbl");
+        executor.analyze("select alias['b'] from (select obj_ignored['a'] as alias from t) tbl");
         Assertions.assertThat(analyzed.outputs()).hasSize(1);
-        assertThat(analyzed.outputs().getFirst()).isFunction("subscript", isField("alias"), isLiteral("u"));
+        assertThat(analyzed.outputs().getFirst()).isFunction("subscript", isField("alias"), isLiteral("b"));
+        assertThat(analyzed.outputs().getFirst()).isFunction("subscript", DataTypes.UNDEFINED);
 
         // strict
         assertThatThrownBy(() -> executor.analyze(
-            "select alias['u'] from (select obj_strict['u'] as alias from t) tbl"))
+            "select alias['b'] from (select obj_strict['a'] as alias from t) tbl"))
             .isExactlyInstanceOf(ColumnUnknownException.class)
-            .hasMessage("Column obj_strict['u'] unknown");
+            .hasMessage("Column obj_strict['a'] unknown");
     }
 
     @Test
@@ -2981,11 +2980,11 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         var executor = SQLExecutor.of(clusterService);
         var analyzed = executor.analyze("select o['a'] from (select {a=1} as o) tbl"); // `o` is an object literal returned from MapFunction
         Assertions.assertThat(analyzed.outputs()).hasSize(1);
-        assertThat(analyzed.outputs().getFirst()).isFunction("subscript");
+        assertThat(analyzed.outputs().getFirst()).isFunction("subscript", DataTypes.INTEGER);
 
         analyzed = executor.analyze("select o3['a'] from (select ({a=1} || {b=1}) as o3) t2"); // `o3` is an object literal returned from ConcatFunction
         Assertions.assertThat(analyzed.outputs()).hasSize(1);
-        assertThat(analyzed.outputs().getFirst()).isFunction("subscript");
+        assertThat(analyzed.outputs().getFirst()).isFunction("subscript", DataTypes.INTEGER);
     }
 
     @Test
@@ -3026,5 +3025,31 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
                 """);
         assertThat(querySelectRelation.outputs()).hasSize(1);
         assertThat(querySelectRelation.outputs().getFirst()).isScopedSymbol("attributes['storage']");
+    }
+
+    @Test
+    public void test_error_on_missing_key_of_subscript_on_aliased_object_literals() {
+        SQLExecutor executor = SQLExecutor.of(clusterService);
+
+        // Field exists
+        // DYNAMIC
+        var analyzed = executor.analyze("SELECT o['b'] FROM (SELECT {a = {b = {c = 1}}}['a'] AS o) tbl");
+        var expectedDataType = ObjectType.of(ColumnPolicy.DYNAMIC).setInnerType("c", DataTypes.INTEGER).build();
+        assertThat(analyzed.outputs().getFirst()).isFunction("subscript", expectedDataType);
+
+        // Field does not exist
+        // DYNAMIC
+        assertThatThrownBy(() -> executor.analyze("SELECT o['x'] FROM (SELECT {a = {b = {c = 1}}}['a'] AS o) tbl"))
+            .isExactlyInstanceOf(ColumnUnknownException.class)
+            .hasMessage("Column o['x'] unknown");
+        // INGORED
+        analyzed = executor.analyze("SELECT o['x'] FROM (SELECT {a = {b = {c = 1}}}['a']::object(ignored) AS o) tbl");
+        assertThat(analyzed.outputs().getFirst()).isFunction("subscript", DataTypes.UNDEFINED);
+
+        executor.getSessionSettings().setErrorOnUnknownObjectKey(false);
+
+        // DYNAMIC (errors disabled)
+        executor.analyze("SELECT o['x'] FROM (SELECT {a = {b = {c = 1}}}['a'] AS o) tbl");
+        assertThat(analyzed.outputs().getFirst()).isFunction("subscript", DataTypes.UNDEFINED);
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/ScalarIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ScalarIntegrationTest.java
@@ -53,10 +53,11 @@ public class ScalarIntegrationTest extends IntegTestCase {
                         session))
                 .isExactlyInstanceOf(ColumnUnknownException.class)
                 .hasMessageContaining("The object `{y=2, z=3}` does not contain the key `x`");
-            // This is documenting a bug. If this fails, it is a breaking change.
-            var response = sqlExecutor.exec("SELECT [unnest]['x'] FROM UNNEST(['{\"x\":1,\"y\":2}','{\"y\":2,\"z\":3}']::ARRAY(OBJECT))",
-                            session);
-            assertThat(TestingHelpers.printedTable(response.rows())).isEqualTo("[1]\n[NULL]\n");
+            Assertions.assertThatThrownBy(() -> sqlExecutor.exec(
+                    "SELECT [unnest]['x'] FROM UNNEST(['{\"x\":1,\"y\":2}','{\"y\":2,\"z\":3}']::ARRAY(OBJECT))",
+                    session))
+                .isExactlyInstanceOf(ColumnUnknownException.class)
+                .hasMessageContaining("The object `{y=2, z=3}` does not contain the key `x`");
         }
 
         try (var session2 = sqlExecutor.newSession()) {

--- a/server/src/test/java/io/crate/types/ObjectTypeTest.java
+++ b/server/src/test/java/io/crate/types/ObjectTypeTest.java
@@ -188,7 +188,23 @@ public class ObjectTypeTest extends DataTypeTestCase<Map<String, Object>> {
                 .build())
             .build();
 
-        assertThat(type.innerType(List.of("s", "inner", "i"))).isEqualTo(DataTypes.INTEGER);
+        assertThat(type.innerType(List.of("s", "inner", "i"))).isEqualTo(DataTypes.UNDEFINED);
+        assertThat(type.innerType(List.of("inner", "i"))).isEqualTo(DataTypes.INTEGER);
+    }
+
+    @Test
+    public void test_inner_type_with_nested_array() {
+        ObjectType type = ObjectType.of(ColumnPolicy.DYNAMIC)
+            .setInnerType("nested_array", new ArrayType<>(ObjectType.of(ColumnPolicy.DYNAMIC)
+                .setInnerType("i", DataTypes.INTEGER)
+                .build()))
+            .setInnerType("nested_nested_array", new ArrayType<>(new ArrayType<>(ObjectType.of(ColumnPolicy.DYNAMIC)
+                .setInnerType("i", DataTypes.INTEGER)
+                .build())))
+            .build();
+
+        assertThat(type.innerType(List.of("nested_array", "i"))).isEqualTo(new ArrayType<>(DataTypes.INTEGER));
+        assertThat(type.innerType(List.of("nested_nested_array", "i"))).isEqualTo(new ArrayType<>(new ArrayType<>(DataTypes.INTEGER)));
     }
 
     @Test

--- a/server/src/testFixtures/java/io/crate/expression/scalar/ScalarTestCase.java
+++ b/server/src/testFixtures/java/io/crate/expression/scalar/ScalarTestCase.java
@@ -107,6 +107,7 @@ public abstract class ScalarTestCase extends CrateDummyClusterServiceUnitTest {
             "  float_val real," +
             "  short_val smallint," +
             "  obj object," +
+            "  obj_typed object as (a object as (b int))," +
             "  obj_ignored object(ignored)" +
             ")";
 

--- a/server/src/testFixtures/java/io/crate/testing/Asserts.java
+++ b/server/src/testFixtures/java/io/crate/testing/Asserts.java
@@ -259,6 +259,10 @@ public class Asserts extends Assertions {
         return s -> assertThat(s).isFunction(expectedName);
     }
 
+    public static Consumer<Symbol> isFunction(String expectedName, DataType<?> expectedReturnType) {
+        return s -> assertThat(s).isFunction(expectedName, expectedReturnType);
+    }
+
     public static Consumer<Symbol> isFunction(String expectedName, List<DataType<?>> expectedArgTypes) {
         return s -> assertThat(s).isFunction(expectedName, expectedArgTypes);
     }

--- a/server/src/testFixtures/java/io/crate/testing/SymbolAssert.java
+++ b/server/src/testFixtures/java/io/crate/testing/SymbolAssert.java
@@ -168,6 +168,19 @@ public final class SymbolAssert extends AbstractAssert<SymbolAssert, Symbol> {
         return isFunction(expectedName, (List<DataType<?>>) null);
     }
 
+    public SymbolAssert isFunction(final String expectedName, DataType<?> expectedReturnType) {
+        isNotNull();
+        isInstanceOf(Function.class);
+        Function f = ((Function) actual);
+        assertThat(f.name())
+            .as("Function name")
+            .isEqualTo(expectedName);
+        assertThat(f.valueType())
+            .as("Return type")
+            .isEqualTo(expectedReturnType);
+        return this;
+    }
+
     public SymbolAssert isFunction(final String expectedName, @Nullable final List<DataType<?>> expectedArgumentTypes) {
         isNotNull();
         isInstanceOf(Function.class);


### PR DESCRIPTION
Try to detect the data type a subscript function will return an allocate the function directly with this return type.
This is only possible if the subscript path value is known (is a literal expression), such this does not work with the generic function matching as this is working purely on argument data types not values.

This is especially needed if a subscript's return type is used as the input to any other expression, e.g. a nested subscript
call. With the concrete return type, the sub-sequent call receives an undefined type and any column policy based
error handling isn't possible anymore.

Related to https://github.com/crate/crate/issues/14828.

Requires #17528 to be merged first.