### PR TITLE
Add stddev_pop()

### DIFF
--- a/docs/appendices/release-notes/6.0.0.rst
+++ b/docs/appendices/release-notes/6.0.0.rst
@@ -105,6 +105,10 @@ Scalar and Aggregation Functions
 - Added support for the :ref:`array_overlap<scalar-array_overlap>` scalar
   function and the associated :ref:`&&<array_overlap_operator>` operator.
 
+- Added support for the :ref:`aggregation-stddev-pop` function to compute
+  the population standard deviation.
+
+
 Performance and Resilience Improvements
 ---------------------------------------
 

--- a/docs/general/builtins/aggregation.rst
+++ b/docs/general/builtins/aggregation.rst
@@ -595,34 +595,41 @@ An Example::
 ``stddev(column)``
 ------------------
 
-The ``stddev`` aggregate function computes the `Standard Deviation`_ of the
-set of non-null values in a column. It is a measure of the variation of data
-values. A low standard deviation indicates that the values tend to be near the
-mean.
+``stddev`` is an alias for :ref:`aggregation-stddev-pop`.
 
-``stddev`` is defined on all numeric types and on timestamp. It always returns
+
+.. _aggregation-stddev-pop:
+
+``stddev_pop(column)``
+----------------------
+
+The ``stddev_pop`` aggregate function computes the population  `Standard Deviation`_
+of the set of non-null values in a column. It is a measure of the variation
+of data values. A low standard deviation indicates that the values tend to be
+near the mean.
+
+``stddev_pop`` is defined on all numeric types and on timestamp. It always returns
 ``double precision`` values. If all values were null or we got no value at all
 ``NULL`` is returned.
 
 Example::
 
-    cr> select stddev(position), kind from locations
+    cr> select stddev_pop(position), kind from locations
     ... group by kind order by kind;
-    +--------------------+-------------+
-    |   stddev(position) | kind        |
-    +--------------------+-------------+
-    | 1.920286436967152  | Galaxy      |
-    | 1.4142135623730951 | Planet      |
-    | 1.118033988749895  | Star System |
-    +--------------------+-------------+
+    +----------------------+-------------+
+    | stddev_pop(position) | kind        |
+    +----------------------+-------------+
+    |   1.920286436967152  | Galaxy      |
+    |   1.4142135623730951 | Planet      |
+    |   1.118033988749895  | Star System |
+    +----------------------+-------------+
     SELECT 3 rows in set (... sec)
 
 .. CAUTION::
 
-    Due to java double precision arithmetic it is possible that any two
+    Due to Java double precision arithmetic it is possible that any two
     executions of the aggregate function on the same data produce slightly
     differing results.
-
 
 .. _aggregation-string-agg:
 

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationAggregation.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationAggregation.java
@@ -62,7 +62,7 @@ import io.crate.types.TimestampType;
 
 public class StandardDeviationAggregation extends AggregationFunction<StandardDeviation, Double> {
 
-    public static final String NAME = "stddev";
+    public static final List<String> NAMES = List.of("stddev", "stddev_pop");
 
     static {
         DataTypes.register(StdDevStateType.ID, in -> StdDevStateType.INSTANCE);
@@ -72,15 +72,17 @@ public class StandardDeviationAggregation extends AggregationFunction<StandardDe
         DataTypes.NUMERIC_PRIMITIVE_TYPES, DataTypes.TIMESTAMPZ);
 
     public static void register(Functions.Builder builder) {
-        for (var supportedType : SUPPORTED_TYPES) {
-            builder.add(
-                    Signature.builder(NAME, FunctionType.AGGREGATE)
+        for (var name: NAMES) {
+            for (var supportedType : SUPPORTED_TYPES) {
+                builder.add(
+                        Signature.builder(name, FunctionType.AGGREGATE)
                             .argumentTypes(supportedType.getTypeSignature())
                             .returnType(DataTypes.DOUBLE.getTypeSignature())
                             .features(Scalar.Feature.DETERMINISTIC)
                             .build(),
-                    StandardDeviationAggregation::new
-            );
+                        StandardDeviationAggregation::new
+                );
+            }
         }
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The aggregation function `stddev_pop()` is added as an alias for `stddev()`. In the SQL:2023 standard, it is a [reserved keyword](https://en.wikipedia.org/wiki/List_of_SQL_reserved_words). In Postgres, the function is [defined](https://www.postgresql.org/docs/17/functions-aggregate.html), and this PR will enhance the compatibility with the standard and Postgres

Relates to: https://github.com/crate/crate/issues/15638


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
