### PR TITLE
Fix resolving indices from RelationMetadata.Table

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -1292,6 +1292,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
                     result.add(item);
                 }
             }
+            return result;
         }
         IndicesOptions indicesOptions = strict
             ? IndicesOptions.STRICT_EXPAND_OPEN


### PR DESCRIPTION
See https://github.com/crate/crate/pull/17514#discussion_r1977445285

Due to the current compatibility layer the issue wasn't detected as it
falls back to the old resolve logic.
