### PR TITLE
Backport of sparse docvalues indexes to CustomLucene90DocValuesFormat

### DIFF
--- a/server/src/main/java/io/crate/lucene/codec/CustomLucene90DocValuesConsumer.java
+++ b/server/src/main/java/io/crate/lucene/codec/CustomLucene90DocValuesConsumer.java
@@ -20,9 +20,13 @@ package io.crate.lucene.codec;
 import static io.crate.lucene.codec.CustomLucene90DocValuesFormat.DIRECT_MONOTONIC_BLOCK_SHIFT;
 import static io.crate.lucene.codec.CustomLucene90DocValuesFormat.NUMERIC_BLOCK_SHIFT;
 import static io.crate.lucene.codec.CustomLucene90DocValuesFormat.NUMERIC_BLOCK_SIZE;
+import static io.crate.lucene.codec.CustomLucene90DocValuesFormat.SKIP_INDEX_LEVEL_SHIFT;
+import static io.crate.lucene.codec.CustomLucene90DocValuesFormat.SKIP_INDEX_MAX_LEVEL;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.codecs.DocValuesConsumer;
@@ -31,6 +35,7 @@ import org.apache.lucene.codecs.lucene90.IndexedDISI;
 import org.apache.lucene.codecs.lucene90.Lucene90DocValuesFormat;
 import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.DocValuesSkipIndexType;
 import org.apache.lucene.index.EmptyDocValuesProducer;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.IndexFileNames;
@@ -70,11 +75,13 @@ final class CustomLucene90DocValuesConsumer extends DocValuesConsumer {
     final int maxDoc;
     private byte[] termsDictBuffer;
     private final Mode mode;
+    private final int skipIndexIntervalSize;
 
     /** expert: Creates a new writer
      * @param mode*/
     public CustomLucene90DocValuesConsumer(
             SegmentWriteState state,
+            int skipIndexIntervalSize,
             String dataCodec,
             String dataExtension,
             String metaCodec,
@@ -85,6 +92,7 @@ final class CustomLucene90DocValuesConsumer extends DocValuesConsumer {
         if (CustomLucene90DocValuesFormat.Mode.BEST_COMPRESSION == this.mode) {
             this.termsDictBuffer = new byte[1 << 14];
         }
+        this.skipIndexIntervalSize = skipIndexIntervalSize;
         boolean success = false;
         try {
             String dataName = IndexFileNames.segmentFileName(
@@ -142,15 +150,17 @@ final class CustomLucene90DocValuesConsumer extends DocValuesConsumer {
         meta.writeInt(field.number);
         meta.writeByte(CustomLucene90DocValuesFormat.NUMERIC);
 
-        writeValues(
-                field,
+        DocValuesProducer producer =
                 new EmptyDocValuesProducer() {
                     @Override
                     public SortedNumericDocValues getSortedNumeric(FieldInfo field) throws IOException {
                         return DocValues.singleton(valuesProducer.getNumeric(field));
                     }
-                },
-                false);
+                };
+        if (field.docValuesSkipIndexType() != DocValuesSkipIndexType.NONE) {
+            writeSkipIndex(field, producer);
+        }
+        writeValues(field, producer, false);
     }
 
     private static class MinMaxTracker {
@@ -197,8 +207,167 @@ final class CustomLucene90DocValuesConsumer extends DocValuesConsumer {
         }
     }
 
+    private static class SkipAccumulator {
+        int minDocID;
+        int maxDocID;
+        int docCount;
+        long minValue;
+        long maxValue;
+
+        SkipAccumulator(int docID) {
+            minDocID = docID;
+            minValue = Long.MAX_VALUE;
+            maxValue = Long.MIN_VALUE;
+            docCount = 0;
+        }
+
+        boolean isDone(int skipIndexIntervalSize, int valueCount, long nextValue, int nextDoc) {
+            if (docCount < skipIndexIntervalSize) {
+                return false;
+            }
+            // Once we reach the interval size, we will keep accepting documents if
+            // - next doc value is not a multi-value
+            // - current accumulator only contains a single value and next value is the same value
+            // - the accumulator is dense and the next doc keeps the density (no gaps)
+            return valueCount > 1
+                || minValue != maxValue
+                || minValue != nextValue
+                || docCount != nextDoc - minDocID;
+        }
+
+        void accumulate(long value) {
+            minValue = Math.min(minValue, value);
+            maxValue = Math.max(maxValue, value);
+        }
+
+        void accumulate(SkipAccumulator other) {
+            assert minDocID <= other.minDocID && maxDocID < other.maxDocID;
+            maxDocID = other.maxDocID;
+            minValue = Math.min(minValue, other.minValue);
+            maxValue = Math.max(maxValue, other.maxValue);
+            docCount += other.docCount;
+        }
+
+        void nextDoc(int docID) {
+            maxDocID = docID;
+            ++docCount;
+        }
+
+        public static SkipAccumulator merge(List<SkipAccumulator> list, int index, int length) {
+            SkipAccumulator acc = new SkipAccumulator(list.get(index).minDocID);
+            for (int i = 0; i < length; i++) {
+                acc.accumulate(list.get(index + i));
+            }
+            return acc;
+        }
+    }
+
+    private void writeSkipIndex(FieldInfo field, DocValuesProducer valuesProducer)
+        throws IOException {
+        assert field.docValuesSkipIndexType() != DocValuesSkipIndexType.NONE;
+        // TODO: This disk compression once we introduce levels
+        final long start = data.getFilePointer();
+        final SortedNumericDocValues values = valuesProducer.getSortedNumeric(field);
+        long globalMaxValue = Long.MIN_VALUE;
+        long globalMinValue = Long.MAX_VALUE;
+        int globalDocCount = 0;
+        int maxDocId = -1;
+        final List<SkipAccumulator> accumulators = new ArrayList<>();
+        SkipAccumulator accumulator = null;
+        final int maxAccumulators = 1 << (SKIP_INDEX_LEVEL_SHIFT * (SKIP_INDEX_MAX_LEVEL - 1));
+        for (int doc = values.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = values.nextDoc()) {
+            final long firstValue = values.nextValue();
+            if (accumulator != null
+                && accumulator.isDone(skipIndexIntervalSize, values.docValueCount(), firstValue, doc)) {
+                globalMaxValue = Math.max(globalMaxValue, accumulator.maxValue);
+                globalMinValue = Math.min(globalMinValue, accumulator.minValue);
+                globalDocCount += accumulator.docCount;
+                maxDocId = accumulator.maxDocID;
+                accumulator = null;
+                if (accumulators.size() == maxAccumulators) {
+                    writeLevels(accumulators);
+                    accumulators.clear();
+                }
+            }
+            if (accumulator == null) {
+                accumulator = new SkipAccumulator(doc);
+                accumulators.add(accumulator);
+            }
+            accumulator.nextDoc(doc);
+            accumulator.accumulate(firstValue);
+            for (int i = 1, end = values.docValueCount(); i < end; ++i) {
+                accumulator.accumulate(values.nextValue());
+            }
+        }
+
+        if (accumulators.isEmpty() == false) {
+            globalMaxValue = Math.max(globalMaxValue, accumulator.maxValue);
+            globalMinValue = Math.min(globalMinValue, accumulator.minValue);
+            globalDocCount += accumulator.docCount;
+            maxDocId = accumulator.maxDocID;
+            writeLevels(accumulators);
+        }
+        meta.writeLong(start); // record the start in meta
+        meta.writeLong(data.getFilePointer() - start); // record the length
+        assert globalDocCount == 0 || globalMaxValue >= globalMinValue;
+        meta.writeLong(globalMaxValue);
+        meta.writeLong(globalMinValue);
+        assert globalDocCount <= maxDocId + 1;
+        meta.writeInt(globalDocCount);
+        meta.writeInt(maxDocId);
+    }
+
+    private void writeLevels(List<SkipAccumulator> accumulators) throws IOException {
+        final List<List<SkipAccumulator>> accumulatorsLevels = new ArrayList<>(SKIP_INDEX_MAX_LEVEL);
+        accumulatorsLevels.add(accumulators);
+        for (int i = 0; i < SKIP_INDEX_MAX_LEVEL - 1; i++) {
+            accumulatorsLevels.add(buildLevel(accumulatorsLevels.get(i)));
+        }
+        int totalAccumulators = accumulators.size();
+        for (int index = 0; index < totalAccumulators; index++) {
+            // compute how many levels we need to write for the current accumulator
+            final int levels = getLevels(index, totalAccumulators);
+            // write the number of levels
+            data.writeByte((byte) levels);
+            // write intervals in reverse order. This is done so we don't
+            // need to read all of them in case of slipping
+            for (int level = levels - 1; level >= 0; level--) {
+                final SkipAccumulator accumulator =
+                    accumulatorsLevels.get(level).get(index >> (SKIP_INDEX_LEVEL_SHIFT * level));
+                data.writeInt(accumulator.maxDocID);
+                data.writeInt(accumulator.minDocID);
+                data.writeLong(accumulator.maxValue);
+                data.writeLong(accumulator.minValue);
+                data.writeInt(accumulator.docCount);
+            }
+        }
+    }
+
+    private static List<SkipAccumulator> buildLevel(List<SkipAccumulator> accumulators) {
+        final int levelSize = 1 << SKIP_INDEX_LEVEL_SHIFT;
+        final List<SkipAccumulator> collector = new ArrayList<>();
+        for (int i = 0; i < accumulators.size() - levelSize + 1; i += levelSize) {
+            collector.add(SkipAccumulator.merge(accumulators, i, levelSize));
+        }
+        return collector;
+    }
+
+    private static int getLevels(int index, int size) {
+        if (Integer.numberOfTrailingZeros(index) >= SKIP_INDEX_LEVEL_SHIFT) {
+            // TODO: can we do it in constant time rather than linearly with SKIP_INDEX_MAX_LEVEL?
+            final int left = size - index;
+            for (int level = SKIP_INDEX_MAX_LEVEL - 1; level > 0; level--) {
+                final int numberIntervals = 1 << (SKIP_INDEX_LEVEL_SHIFT * level);
+                if (left >= numberIntervals && index % numberIntervals == 0) {
+                    return level + 1;
+                }
+            }
+        }
+        return 1;
+    }
+
     private long[] writeValues(FieldInfo field, DocValuesProducer valuesProducer, boolean ords)
-            throws IOException {
+        throws IOException {
         SortedNumericDocValues values = valuesProducer.getSortedNumeric(field);
         final long firstValue;
         if (values.nextDoc() != DocIdSetIterator.NO_MORE_DOCS) {
@@ -499,13 +668,12 @@ final class CustomLucene90DocValuesConsumer extends DocValuesConsumer {
     public void addSortedField(FieldInfo field, DocValuesProducer valuesProducer) throws IOException {
         meta.writeInt(field.number);
         meta.writeByte(CustomLucene90DocValuesFormat.SORTED);
-        doAddSortedField(field, valuesProducer);
+        doAddSortedField(field, valuesProducer, false);
     }
 
-    private void doAddSortedField(FieldInfo field, DocValuesProducer valuesProducer)
+    private void doAddSortedField(FieldInfo field, DocValuesProducer valuesProducer, boolean addTypeByte)
             throws IOException {
-        writeValues(
-                field,
+        DocValuesProducer producer =
                 new EmptyDocValuesProducer() {
                     @Override
                     public SortedNumericDocValues getSortedNumeric(FieldInfo field) throws IOException {
@@ -543,8 +711,14 @@ final class CustomLucene90DocValuesConsumer extends DocValuesConsumer {
                         };
                         return DocValues.singleton(sortedOrds);
                     }
-                },
-                true);
+                };
+        if (field.docValuesSkipIndexType() != DocValuesSkipIndexType.NONE) {
+            writeSkipIndex(field, producer);
+        }
+        if (addTypeByte) {
+            meta.writeByte((byte) 0); // multivalued (0 = singlevalued)
+        }
+        writeValues(field, producer, true);
         addTermsDict(DocValues.singleton(valuesProducer.getSorted(field)));
     }
 
@@ -729,6 +903,12 @@ final class CustomLucene90DocValuesConsumer extends DocValuesConsumer {
 
     private void doAddSortedNumericField(
             FieldInfo field, DocValuesProducer valuesProducer, boolean ords) throws IOException {
+        if (field.docValuesSkipIndexType() != DocValuesSkipIndexType.NONE) {
+            writeSkipIndex(field, valuesProducer);
+        }
+        if (ords) {
+            meta.writeByte((byte) 1); // multiValued (1 = multiValued)
+        }
         long[] stats = writeValues(field, valuesProducer, ords);
         int numDocsWithField = Math.toIntExact(stats[0]);
         long numValues = stats[1];
@@ -777,19 +957,18 @@ final class CustomLucene90DocValuesConsumer extends DocValuesConsumer {
         meta.writeByte(CustomLucene90DocValuesFormat.SORTED_SET);
 
         if (isSingleValued(valuesProducer.getSortedSet(field))) {
-            meta.writeByte((byte) 0); // multiValued (0 = singleValued)
             doAddSortedField(
-                    field,
-                    new EmptyDocValuesProducer() {
-                        @Override
-                        public SortedDocValues getSorted(FieldInfo field) throws IOException {
-                            return SortedSetSelector.wrap(
-                                    valuesProducer.getSortedSet(field), SortedSetSelector.Type.MIN);
-                        }
-                    });
+                field,
+                new EmptyDocValuesProducer() {
+                    @Override
+                    public SortedDocValues getSorted(FieldInfo field) throws IOException {
+                        return SortedSetSelector.wrap(
+                            valuesProducer.getSortedSet(field), SortedSetSelector.Type.MIN);
+                    }
+                },
+                true);
             return;
         }
-        meta.writeByte((byte) 1); // multiValued (1 = multiValued)
 
         doAddSortedNumericField(
                 field,

--- a/server/src/main/java/io/crate/lucene/codec/CustomLucene90DocValuesFormat.java
+++ b/server/src/main/java/io/crate/lucene/codec/CustomLucene90DocValuesFormat.java
@@ -37,21 +37,31 @@ public final class CustomLucene90DocValuesFormat extends DocValuesFormat {
     }
 
     private final Mode mode;
+    private final int skipIndexIntervalSize;
 
     /** Default constructor. */
     public CustomLucene90DocValuesFormat() {
-        this(Mode.BEST_SPEED);
+        this(Mode.BEST_SPEED, DEFAULT_SKIP_INDEX_INTERVAL_SIZE);
     }
 
     public CustomLucene90DocValuesFormat(Mode mode) {
+        this(mode, DEFAULT_SKIP_INDEX_INTERVAL_SIZE);
+    }
+
+    public CustomLucene90DocValuesFormat(Mode mode, int skipIndexIntervalSize) {
         super("CrateDBLucene90");
         this.mode = mode;
+        if (skipIndexIntervalSize < 2) {
+            throw new IllegalArgumentException(
+                "skipIndexIntervalSize must be > 1, got [" + skipIndexIntervalSize + "]");
+        }
+        this.skipIndexIntervalSize = skipIndexIntervalSize;
     }
 
     @Override
     public DocValuesConsumer fieldsConsumer(SegmentWriteState state) throws IOException {
         return new CustomLucene90DocValuesConsumer(
-                state, DATA_CODEC, DATA_EXTENSION, META_CODEC, META_EXTENSION, mode);
+                state, skipIndexIntervalSize, DATA_CODEC, DATA_EXTENSION, META_CODEC, META_EXTENSION, mode);
     }
 
     @Override
@@ -96,5 +106,38 @@ public final class CustomLucene90DocValuesFormat extends DocValuesFormat {
     // Writing a special code so we know this is a LZ4-compressed block.
     static final int TERMS_DICT_BLOCK_LZ4_CODE =
         TERMS_DICT_BLOCK_LZ4_SHIFT << 16 | TERMS_DICT_COMPRESSOR_LZ4_CODE;
+
+    // number of documents in an interval
+    private static final int DEFAULT_SKIP_INDEX_INTERVAL_SIZE = 4096;
+    // bytes on an interval:
+    //   * 1 byte : number of levels
+    //   * 16 bytes: min / max value,
+    //   * 8 bytes:  min / max docID
+    //   * 4 bytes: number of documents
+    private static final long SKIP_INDEX_INTERVAL_BYTES = 29L;
+    // number of intervals represented as a shift to create a new level, this is 1 << 3 == 8
+    // intervals.
+    static final int SKIP_INDEX_LEVEL_SHIFT = 3;
+    // max number of levels
+    // Increasing this number, it increases how much heap we need at index time.
+    // we currently need (1 * 8 * 8 * 8)  = 512 accumulators on heap
+    static final int SKIP_INDEX_MAX_LEVEL = 4;
+    // number of bytes to skip when skipping a level. It does not take into account the
+    // current interval that is being read.
+    static final long[] SKIP_INDEX_JUMP_LENGTH_PER_LEVEL = new long[SKIP_INDEX_MAX_LEVEL];
+
+    static {
+        // Size of the interval minus read bytes (1 byte for level and 4 bytes for maxDocID)
+        SKIP_INDEX_JUMP_LENGTH_PER_LEVEL[0] = SKIP_INDEX_INTERVAL_BYTES - 5L;
+        for (int level = 1; level < SKIP_INDEX_MAX_LEVEL; level++) {
+            // jump from previous level
+            SKIP_INDEX_JUMP_LENGTH_PER_LEVEL[level] = SKIP_INDEX_JUMP_LENGTH_PER_LEVEL[level - 1];
+            // nodes added by new level
+            SKIP_INDEX_JUMP_LENGTH_PER_LEVEL[level] +=
+                (1 << (level * SKIP_INDEX_LEVEL_SHIFT)) * SKIP_INDEX_INTERVAL_BYTES;
+            // remove the byte levels added in the previous level
+            SKIP_INDEX_JUMP_LENGTH_PER_LEVEL[level] -= (1 << ((level - 1) * SKIP_INDEX_LEVEL_SHIFT));
+        }
+    }
 
 }

--- a/server/src/main/java/io/crate/lucene/codec/CustomLucene90DocValuesProducer.java
+++ b/server/src/main/java/io/crate/lucene/codec/CustomLucene90DocValuesProducer.java
@@ -18,6 +18,9 @@
 package io.crate.lucene.codec;
 
 
+import static io.crate.lucene.codec.CustomLucene90DocValuesFormat.SKIP_INDEX_JUMP_LENGTH_PER_LEVEL;
+import static io.crate.lucene.codec.CustomLucene90DocValuesFormat.SKIP_INDEX_MAX_LEVEL;
+
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -30,6 +33,7 @@ import org.apache.lucene.index.BaseTermsEnum;
 import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.DocValuesSkipIndexType;
 import org.apache.lucene.index.DocValuesSkipper;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
@@ -43,6 +47,7 @@ import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.index.TermsEnum.SeekStatus;
+import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.store.ByteArrayDataInput;
 import org.apache.lucene.store.ChecksumIndexInput;
 import org.apache.lucene.store.DataInput;
@@ -56,26 +61,31 @@ import org.apache.lucene.util.compress.LZ4;
 import org.apache.lucene.util.packed.DirectMonotonicReader;
 import org.apache.lucene.util.packed.DirectReader;
 
-/** reader for {@link Lucene90DocValuesFormat} */
+/**
+ * reader for {@link Lucene90DocValuesFormat}
+ */
 final class CustomLucene90DocValuesProducer extends DocValuesProducer {
     private final Map<String, NumericEntry> numerics;
     private final Map<String, BinaryEntry> binaries;
     private final Map<String, SortedEntry> sorted;
     private final Map<String, SortedSetEntry> sortedSets;
     private final Map<String, SortedNumericEntry> sortedNumerics;
+    private final Map<String, DocValuesSkipperEntry> skippers;
     private final IndexInput data;
     private final int maxDoc;
     private int version = -1;
     private final boolean merging;
 
-    /** expert: instantiates a new reader */
+    /**
+     * expert: instantiates a new reader
+     */
     CustomLucene90DocValuesProducer(
-            SegmentReadState state,
-            String dataCodec,
-            String dataExtension,
-            String metaCodec,
-            String metaExtension)
-            throws IOException {
+        SegmentReadState state,
+        String dataCodec,
+        String dataExtension,
+        String metaCodec,
+        String metaExtension)
+        throws IOException {
         String metaName = IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, metaExtension);
         this.maxDoc = state.segmentInfo.maxDoc();
         numerics = new HashMap<>();
@@ -83,6 +93,7 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
         sorted = new HashMap<>();
         sortedSets = new HashMap<>();
         sortedNumerics = new HashMap<>();
+        skippers = new HashMap<>();
         merging = false;
 
         // read in the entries from the metadata file.
@@ -91,12 +102,12 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
 
             try {
                 version = CodecUtil.checkIndexHeader(
-                        in,
-                        metaCodec,
-                        CustomLucene90DocValuesFormat.VERSION_START,
-                        CustomLucene90DocValuesFormat.VERSION_CURRENT,
-                        state.segmentInfo.getId(),
-                        state.segmentSuffix);
+                    in,
+                    metaCodec,
+                    CustomLucene90DocValuesFormat.VERSION_START,
+                    CustomLucene90DocValuesFormat.VERSION_CURRENT,
+                    state.segmentInfo.getId(),
+                    state.segmentSuffix);
 
                 readFields(in, state.fieldInfos);
 
@@ -115,15 +126,15 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
         boolean success = false;
         try {
             final int version2 = CodecUtil.checkIndexHeader(
-                    data,
-                    dataCodec,
-                    CustomLucene90DocValuesFormat.VERSION_START,
-                    CustomLucene90DocValuesFormat.VERSION_CURRENT,
-                    state.segmentInfo.getId(),
-                    state.segmentSuffix);
+                data,
+                dataCodec,
+                CustomLucene90DocValuesFormat.VERSION_START,
+                CustomLucene90DocValuesFormat.VERSION_CURRENT,
+                state.segmentInfo.getId(),
+                state.segmentSuffix);
             if (version != version2) {
                 throw new CorruptIndexException(
-                        "Format versions mismatch: meta=" + version + ", data=" + version2, data);
+                    "Format versions mismatch: meta=" + version + ", data=" + version2, data);
             }
 
             // NOTE: data file is too costly to verify checksum against all the bytes on
@@ -145,20 +156,22 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
 
     // Used for cloning
     private CustomLucene90DocValuesProducer(
-            Map<String, NumericEntry> numerics,
-            Map<String, BinaryEntry> binaries,
-            Map<String, SortedEntry> sorted,
-            Map<String, SortedSetEntry> sortedSets,
-            Map<String, SortedNumericEntry> sortedNumerics,
-            IndexInput data,
-            int maxDoc,
-            int version,
-            boolean merging) {
+        Map<String, NumericEntry> numerics,
+        Map<String, BinaryEntry> binaries,
+        Map<String, SortedEntry> sorted,
+        Map<String, SortedSetEntry> sortedSets,
+        Map<String, SortedNumericEntry> sortedNumerics,
+        Map<String, DocValuesSkipperEntry> skippers,
+        IndexInput data,
+        int maxDoc,
+        int version,
+        boolean merging) {
         this.numerics = numerics;
         this.binaries = binaries;
         this.sorted = sorted;
         this.sortedSets = sortedSets;
         this.sortedNumerics = sortedNumerics;
+        this.skippers = skippers;
         this.data = data.clone();
         this.maxDoc = maxDoc;
         this.version = version;
@@ -168,7 +181,7 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
     @Override
     public DocValuesProducer getMergeInstance() {
         return new CustomLucene90DocValuesProducer(
-                numerics, binaries, sorted, sortedSets, sortedNumerics, data, maxDoc, version, true);
+            numerics, binaries, sorted, sortedSets, sortedNumerics, skippers, data, maxDoc, version, true);
     }
 
     private void readFields(IndexInput meta, FieldInfos infos) throws IOException {
@@ -178,6 +191,9 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
                 throw new CorruptIndexException("Invalid field number: " + fieldNumber, meta);
             }
             byte type = meta.readByte();
+            if (info.docValuesSkipIndexType() != DocValuesSkipIndexType.NONE) {
+                skippers.put(info.name, readDocValueSkipperMeta(meta));
+            }
             if (type == CustomLucene90DocValuesFormat.NUMERIC) {
                 numerics.put(info.name, readNumeric(meta));
             } else if (type == CustomLucene90DocValuesFormat.BINARY) {
@@ -192,6 +208,21 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
                 throw new CorruptIndexException("invalid type: " + type, meta);
             }
         }
+    }
+
+    private record DocValuesSkipperEntry(
+        long offset, long length, long minValue, long maxValue, int docCount, int maxDocId) {
+    }
+
+    private DocValuesSkipperEntry readDocValueSkipperMeta(IndexInput meta) throws IOException {
+        long offset = meta.readLong();
+        long length = meta.readLong();
+        long maxValue = meta.readLong();
+        long minValue = meta.readLong();
+        int docCount = meta.readInt();
+        int maxDocID = meta.readInt();
+
+        return new DocValuesSkipperEntry(offset, length, minValue, maxValue, docCount, maxDocID);
     }
 
     private NumericEntry readNumeric(IndexInput meta) throws IOException {
@@ -306,7 +337,7 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
         entry.termsAddressesLength = meta.readLong();
         entry.termsDictIndexShift = meta.readInt();
         final long indexSize = (entry.termsDictSize + (1L << entry.termsDictIndexShift)
-                - 1) >>> entry.termsDictIndexShift;
+            - 1) >>> entry.termsDictIndexShift;
         entry.termsIndexAddressesMeta = DirectMonotonicReader.loadMeta(meta, 1 + indexSize, blockShift);
         entry.termsIndexOffset = meta.readLong();
         entry.termsIndexLength = meta.readLong();
@@ -321,7 +352,7 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
     }
 
     private SortedNumericEntry readSortedNumeric(IndexInput meta, SortedNumericEntry entry)
-            throws IOException {
+        throws IOException {
         readNumeric(meta, entry);
         entry.numDocsWithField = meta.readInt();
         if (entry.numDocsWithField != entry.numValues) {
@@ -487,7 +518,7 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
     }
 
     private LongValues getDirectReaderInstance(
-            RandomAccessInput slice, int bitsPerValue, long offset, long numValues) {
+        RandomAccessInput slice, int bitsPerValue, long offset, long numValues) {
         if (merging) {
             return DirectReader.getMergeInstance(slice, bitsPerValue, offset, numValues);
         } else {
@@ -557,12 +588,12 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
         } else {
             // sparse
             final IndexedDISI disi = new IndexedDISI(
-                    data,
-                    entry.docsWithFieldOffset,
-                    entry.docsWithFieldLength,
-                    entry.jumpTableEntryCount,
-                    entry.denseRankPower,
-                    entry.numValues);
+                data,
+                entry.docsWithFieldOffset,
+                entry.docsWithFieldLength,
+                entry.jumpTableEntryCount,
+                entry.denseRankPower,
+                entry.numValues);
             if (entry.bitsPerValue == 0) {
                 return new SparseNumericDocValues(disi) {
                     @Override
@@ -785,13 +816,13 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
             } else {
                 // variable length
                 final RandomAccessInput addressesData = this.data.randomAccessSlice(entry.addressesOffset,
-                        entry.addressesLength);
+                    entry.addressesLength);
                 // Prefetch the first page of data.  Following pages are expected to be prefetched through read-ahead
                 if (addressesData.length() > 0) {
                     addressesData.prefetch(0, 1);
                 }
                 final LongValues addresses = DirectMonotonicReader.getInstance(entry.addressesMeta, addressesData,
-                        merging);
+                    merging);
                 return new DenseBinaryDocValues(maxDoc) {
                     final BytesRef bytes = new BytesRef(new byte[entry.maxLength], 0, entry.maxLength);
 
@@ -808,12 +839,12 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
         } else {
             // sparse
             final IndexedDISI disi = new IndexedDISI(
-                    data,
-                    entry.docsWithFieldOffset,
-                    entry.docsWithFieldLength,
-                    entry.jumpTableEntryCount,
-                    entry.denseRankPower,
-                    entry.numDocsWithField);
+                data,
+                entry.docsWithFieldOffset,
+                entry.docsWithFieldLength,
+                entry.jumpTableEntryCount,
+                entry.denseRankPower,
+                entry.numDocsWithField);
             if (entry.minLength == entry.maxLength) {
                 // fixed length
                 final int length = entry.maxLength;
@@ -830,7 +861,7 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
             } else {
                 // variable length
                 final RandomAccessInput addressesData = this.data.randomAccessSlice(entry.addressesOffset,
-                        entry.addressesLength);
+                    entry.addressesLength);
                 // Prefetch the first page of data.  Following pages are expected to be prefetched through read-ahead
                 if (addressesData.length() > 0) {
                     addressesData.prefetch(0, 1);
@@ -863,7 +894,7 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
         // Specialize the common case for ordinals: single block of packed integers.
         final NumericEntry ordsEntry = entry.ordsEntry;
         if (ordsEntry.blockShift < 0 // single block
-                && ordsEntry.bitsPerValue > 0) { // more than 1 value
+            && ordsEntry.bitsPerValue > 0) { // more than 1 value
 
             if (ordsEntry.gcd != 1 || ordsEntry.minValue != 0 || ordsEntry.table != null) {
                 throw new IllegalStateException("Ordinals shouldn't use GCD, offset or table compression");
@@ -918,12 +949,12 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
                 };
             } else if (ordsEntry.docsWithFieldOffset >= 0) { // sparse but non-empty
                 final IndexedDISI disi = new IndexedDISI(
-                        data,
-                        ordsEntry.docsWithFieldOffset,
-                        ordsEntry.docsWithFieldLength,
-                        ordsEntry.jumpTableEntryCount,
-                        ordsEntry.denseRankPower,
-                        ordsEntry.numValues);
+                    data,
+                    ordsEntry.docsWithFieldOffset,
+                    ordsEntry.docsWithFieldLength,
+                    ordsEntry.jumpTableEntryCount,
+                    ordsEntry.denseRankPower,
+                    ordsEntry.numValues);
 
                 return new BaseSortedDocValues(entry) {
 
@@ -1097,14 +1128,14 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
         TermsDict(TermsDictEntry entry, IndexInput data) throws IOException {
             this.entry = entry;
             RandomAccessInput addressesSlice = data.randomAccessSlice(entry.termsAddressesOffset,
-                    entry.termsAddressesLength);
+                entry.termsAddressesLength);
             blockAddresses = DirectMonotonicReader.getInstance(entry.termsAddressesMeta, addressesSlice, merging);
             bytes = data.slice("terms", entry.termsDataOffset, entry.termsDataLength);
             blockMask = (1L << entry.termsDictBlockShift) - 1;
             RandomAccessInput indexAddressesSlice = data.randomAccessSlice(entry.termsIndexAddressesOffset,
-                    entry.termsIndexAddressesLength);
+                entry.termsIndexAddressesLength);
             indexAddresses = DirectMonotonicReader.getInstance(
-                    entry.termsIndexAddressesMeta, indexAddressesSlice, merging);
+                entry.termsIndexAddressesMeta, indexAddressesSlice, merging);
             indexBytes = data.slice("terms-index", entry.termsIndexOffset, entry.termsIndexLength);
             term = new BytesRef(entry.maxTermLength);
 
@@ -1192,7 +1223,7 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
 
             assert hi < 0 || getTermFromIndex(hi).compareTo(text) <= 0;
             assert hi == ((entry.termsDictSize - 1) >> entry.termsDictIndexShift)
-                    || getTermFromIndex(hi + 1).compareTo(text) > 0;
+                || getTermFromIndex(hi + 1).compareTo(text) > 0;
 
             return hi;
         }
@@ -1231,7 +1262,7 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
 
             assert blockHi < 0 || getFirstTermFromBlock(blockHi).compareTo(text) <= 0;
             assert blockHi == ((entry.termsDictSize - 1) >>> entry.termsDictBlockShift)
-                    || getFirstTermFromBlock(blockHi + 1).compareTo(text) > 0;
+                || getFirstTermFromBlock(blockHi + 1).compareTo(text) > 0;
 
             return blockHi;
         }
@@ -1406,12 +1437,12 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
         } else {
             // sparse
             final IndexedDISI disi = new IndexedDISI(
-                    data,
-                    entry.docsWithFieldOffset,
-                    entry.docsWithFieldLength,
-                    entry.jumpTableEntryCount,
-                    entry.denseRankPower,
-                    entry.numDocsWithField);
+                data,
+                entry.docsWithFieldOffset,
+                entry.docsWithFieldLength,
+                entry.jumpTableEntryCount,
+                entry.denseRankPower,
+                entry.numDocsWithField);
             return new SortedNumericDocValues() {
 
                 boolean set;
@@ -1486,7 +1517,7 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
             }
 
             final RandomAccessInput addressesInput = data.randomAccessSlice(ordsEntry.addressesOffset,
-                    ordsEntry.addressesLength);
+                ordsEntry.addressesLength);
             // Prefetch the first page of data.  Following pages are expected to be prefetched through read-ahead
             if (addressesInput.length() > 0) {
                 addressesInput.prefetch(0, 1);
@@ -1555,12 +1586,12 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
                 };
             } else if (ordsEntry.docsWithFieldOffset >= 0) { // sparse but non-empty
                 final IndexedDISI disi = new IndexedDISI(
-                        data,
-                        ordsEntry.docsWithFieldOffset,
-                        ordsEntry.docsWithFieldLength,
-                        ordsEntry.jumpTableEntryCount,
-                        ordsEntry.denseRankPower,
-                        ordsEntry.numValues);
+                    data,
+                    ordsEntry.docsWithFieldOffset,
+                    ordsEntry.docsWithFieldLength,
+                    ordsEntry.jumpTableEntryCount,
+                    ordsEntry.denseRankPower,
+                    ordsEntry.numValues);
 
                 return new BaseSortedSetDocValues(entry, data) {
 
@@ -1673,7 +1704,111 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
 
     @Override
     public DocValuesSkipper getSkipper(FieldInfo field) throws IOException {
-        throw new UnsupportedOperationException("CrateDB does not implement DocValuesSkippers");
+        final DocValuesSkipperEntry entry = skippers.get(field.name);
+
+        final IndexInput input = data.slice("doc value skipper", entry.offset, entry.length);
+        // Prefetch the first page of data. Following pages are expected to get prefetched through
+        // read-ahead.
+        if (input.length() > 0) {
+            input.prefetch(0, 1);
+        }
+
+        return new DocValuesSkipper() {
+            final int[] minDocID = new int[SKIP_INDEX_MAX_LEVEL];
+            final int[] maxDocID = new int[SKIP_INDEX_MAX_LEVEL];
+
+            {
+                for (int i = 0; i < SKIP_INDEX_MAX_LEVEL; i++) {
+                    minDocID[i] = maxDocID[i] = -1;
+                }
+            }
+
+            final long[] minValue = new long[SKIP_INDEX_MAX_LEVEL];
+            final long[] maxValue = new long[SKIP_INDEX_MAX_LEVEL];
+            final int[] docCount = new int[SKIP_INDEX_MAX_LEVEL];
+            int levels = 1;
+
+            @Override
+            public void advance(int target) throws IOException {
+                if (target > entry.maxDocId) {
+                    // skipper is exhausted
+                    for (int i = 0; i < SKIP_INDEX_MAX_LEVEL; i++) {
+                        minDocID[i] = maxDocID[i] = DocIdSetIterator.NO_MORE_DOCS;
+                    }
+                } else {
+                    while (true) {
+                        levels = input.readByte();
+                        assert levels <= SKIP_INDEX_MAX_LEVEL && levels > 0
+                            : "level out of range [" + levels + "]";
+                        boolean valid = true;
+                        // check if current interval is competitive or we can jump to the next position
+                        for (int level = levels - 1; level >= 0; level--) {
+                            if ((maxDocID[level] = input.readInt()) < target) {
+                                input.skipBytes(SKIP_INDEX_JUMP_LENGTH_PER_LEVEL[level]); // the jump for the level
+                                valid = false;
+                                break;
+                            }
+                            minDocID[level] = input.readInt();
+                            maxValue[level] = input.readLong();
+                            minValue[level] = input.readLong();
+                            docCount[level] = input.readInt();
+                        }
+                        if (valid) {
+                            // adjust levels
+                            while (levels < SKIP_INDEX_MAX_LEVEL && maxDocID[levels] >= target) {
+                                levels++;
+                            }
+                            break;
+                        }
+                    }
+                }
+            }
+
+            @Override
+            public int numLevels() {
+                return levels;
+            }
+
+            @Override
+            public int minDocID(int level) {
+                return minDocID[level];
+            }
+
+            @Override
+            public int maxDocID(int level) {
+                return maxDocID[level];
+            }
+
+            @Override
+            public long minValue(int level) {
+                return minValue[level];
+            }
+
+            @Override
+            public long maxValue(int level) {
+                return maxValue[level];
+            }
+
+            @Override
+            public int docCount(int level) {
+                return docCount[level];
+            }
+
+            @Override
+            public long minValue() {
+                return entry.minValue;
+            }
+
+            @Override
+            public long maxValue() {
+                return entry.maxValue;
+            }
+
+            @Override
+            public int docCount() {
+                return entry.docCount;
+            }
+        };
     }
 
     @Override
@@ -1709,7 +1844,7 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
             this.entry = entry;
             this.slice = slice;
             this.rankSlice = entry.valueJumpTableOffset == -1
-                    ? null
+                ? null
                 : data.randomAccessSlice(
                 entry.valueJumpTableOffset, data.length() - entry.valueJumpTableOffset);
             if (rankSlice != null && rankSlice.length() > 0) {
@@ -1749,8 +1884,8 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
                 } while (this.block != block);
                 final int numValues = Math.toIntExact(Math.min(1 << shift, entry.numValues - (block << shift)));
                 values = bitsPerValue == 0
-                        ? LongValues.ZEROES
-                        : getDirectReaderInstance(slice, bitsPerValue, offset, numValues);
+                    ? LongValues.ZEROES
+                    : getDirectReaderInstance(slice, bitsPerValue, offset, numValues);
             }
             return mul * values.get(index & mask) + delta;
         }

--- a/server/src/main/java/io/crate/lucene/codec/CustomLucene90DocValuesProducer.java
+++ b/server/src/main/java/io/crate/lucene/codec/CustomLucene90DocValuesProducer.java
@@ -48,6 +48,7 @@ import org.apache.lucene.store.ChecksumIndexInput;
 import org.apache.lucene.store.DataInput;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.RandomAccessInput;
+import org.apache.lucene.store.ReadAdvice;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.IOUtils;
 import org.apache.lucene.util.LongValues;
@@ -107,7 +108,10 @@ final class CustomLucene90DocValuesProducer extends DocValuesProducer {
         }
 
         String dataName = IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, dataExtension);
-        this.data = state.directory.openInput(dataName, state.context);
+        // Doc-values have a forward-only access pattern, so pass ReadAdvice.NORMAL to perform
+        // readahead.
+        this.data =
+            state.directory.openInput(dataName, state.context.withReadAdvice(ReadAdvice.NORMAL));
         boolean success = false;
         try {
             final int version2 = CodecUtil.checkIndexHeader(

--- a/server/src/test/java/io/crate/lucene/codec/TestCustomLucene90DocValuesFormat.java
+++ b/server/src/test/java/io/crate/lucene/codec/TestCustomLucene90DocValuesFormat.java
@@ -72,7 +72,7 @@ import org.apache.lucene.store.ByteBuffersDataOutput;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.codecs.asserting.AssertingCodec;
-import org.apache.lucene.tests.index.LegacyBaseDocValuesFormatTestCase;
+import org.apache.lucene.tests.index.BaseDocValuesFormatTestCase;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.BytesRef;
@@ -80,7 +80,7 @@ import org.apache.lucene.util.BytesRefBuilder;
 import org.apache.lucene.util.CollectionUtil;
 import org.elasticsearch.index.codec.CrateCodec;
 
-public class TestCustomLucene90DocValuesFormat extends LegacyBaseDocValuesFormatTestCase {
+public class TestCustomLucene90DocValuesFormat extends BaseDocValuesFormatTestCase {
 
     private final Codec codec = new CrateCodec(Lucene101Codec.Mode.BEST_SPEED);
 

--- a/server/src/test/java/io/crate/lucene/codec/TestCustomLucene90DocValuesFormat.java
+++ b/server/src/test/java/io/crate/lucene/codec/TestCustomLucene90DocValuesFormat.java
@@ -1,0 +1,1026 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.lucene.codec;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.function.Function;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.DocValuesFormat;
+import org.apache.lucene.codecs.PostingsFormat;
+import org.apache.lucene.codecs.lucene101.Lucene101Codec;
+import org.apache.lucene.codecs.perfield.PerFieldDocValuesFormat;
+import org.apache.lucene.document.BinaryDocValuesField;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.document.SortedDocValuesField;
+import org.apache.lucene.document.SortedNumericDocValuesField;
+import org.apache.lucene.document.SortedSetDocValuesField;
+import org.apache.lucene.document.StoredField;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.NumericDocValues;
+import org.apache.lucene.index.SerialMergeScheduler;
+import org.apache.lucene.index.SortedDocValues;
+import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.index.StoredFields;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.store.ByteBuffersDataInput;
+import org.apache.lucene.store.ByteBuffersDataOutput;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.analysis.MockAnalyzer;
+import org.apache.lucene.tests.codecs.asserting.AssertingCodec;
+import org.apache.lucene.tests.index.LegacyBaseDocValuesFormatTestCase;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.apache.lucene.tests.util.TestUtil;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefBuilder;
+import org.apache.lucene.util.CollectionUtil;
+import org.elasticsearch.index.codec.CrateCodec;
+
+public class TestCustomLucene90DocValuesFormat extends LegacyBaseDocValuesFormatTestCase {
+
+    private final Codec codec = new CrateCodec(Lucene101Codec.Mode.BEST_SPEED);
+
+    @Override
+    protected Codec getCodec() {
+        return codec;
+    }
+
+    // TODO: these big methods can easily blow up some of the other ram-hungry codecs...
+    // for now just keep them here, as we want to test this for this format.
+
+    public void testSortedSetVariableLengthBigVsStoredFields() throws Exception {
+        int numIterations = atLeast(1);
+        for (int i = 0; i < numIterations; i++) {
+            int numDocs = TEST_NIGHTLY ? atLeast(100) : atLeast(10);
+            doTestSortedSetVsStoredFields(numDocs, 1, 32766, 16, 100);
+        }
+    }
+
+    @Nightly
+    public void testSortedSetVariableLengthManyVsStoredFields() throws Exception {
+        int numIterations = atLeast(1);
+        for (int i = 0; i < numIterations; i++) {
+            doTestSortedSetVsStoredFields(TestUtil.nextInt(random(), 1024, 2049), 1, 500, 16, 100);
+        }
+    }
+
+    public void testSortedVariableLengthBigVsStoredFields() throws Exception {
+        int numIterations = atLeast(1);
+        for (int i = 0; i < numIterations; i++) {
+            doTestSortedVsStoredFields(atLeast(100), 1d, 1, 32766);
+        }
+    }
+
+    @Nightly
+    public void testSortedVariableLengthManyVsStoredFields() throws Exception {
+        int numIterations = atLeast(1);
+        for (int i = 0; i < numIterations; i++) {
+            doTestSortedVsStoredFields(TestUtil.nextInt(random(), 1024, 2049), 1d, 1, 500);
+        }
+    }
+
+    @Nightly
+    public void testTermsEnumFixedWidth() throws Exception {
+        int numIterations = atLeast(1);
+        for (int i = 0; i < numIterations; i++) {
+            doTestTermsEnumRandom(
+                TestUtil.nextInt(random(), 1025, 5121),
+                () -> TestUtil.randomSimpleString(random(), 10, 10));
+        }
+    }
+
+    @Nightly
+    public void testTermsEnumVariableWidth() throws Exception {
+        int numIterations = atLeast(1);
+        for (int i = 0; i < numIterations; i++) {
+            doTestTermsEnumRandom(
+                TestUtil.nextInt(random(), 1025, 5121),
+                () -> TestUtil.randomSimpleString(random(), 1, 500));
+        }
+    }
+
+    @Nightly
+    public void testTermsEnumRandomMany() throws Exception {
+        int numIterations = atLeast(1);
+        for (int i = 0; i < numIterations; i++) {
+            doTestTermsEnumRandom(
+                TestUtil.nextInt(random(), 1025, 8121),
+                () -> TestUtil.randomSimpleString(random(), 1, 500));
+        }
+    }
+
+    @Nightly
+    public void testTermsEnumLongSharedPrefixes() throws Exception {
+        int numIterations = atLeast(1);
+        for (int i = 0; i < numIterations; i++) {
+            doTestTermsEnumRandom(
+                TestUtil.nextInt(random(), 1025, 5121),
+                () -> {
+                    char[] chars = new char[random().nextInt(500)];
+                    Arrays.fill(chars, 'a');
+                    if (chars.length > 0) {
+                        chars[random().nextInt(chars.length)] = 'b';
+                    }
+                    return new String(chars);
+                });
+        }
+    }
+
+    public void testSparseDocValuesVsStoredFields() throws Exception {
+        int numIterations = atLeast(1);
+        for (int i = 0; i < numIterations; i++) {
+            doTestSparseDocValuesVsStoredFields();
+        }
+    }
+
+    private void doTestSparseDocValuesVsStoredFields() throws Exception {
+        final long[] values = new long[TestUtil.nextInt(random(), 1, 500)];
+        for (int i = 0; i < values.length; ++i) {
+            values[i] = random().nextLong();
+        }
+
+        Directory dir = newFSDirectory(createTempDir());
+        IndexWriterConfig conf = newIndexWriterConfig(new MockAnalyzer(random()));
+        conf.setMergeScheduler(new SerialMergeScheduler());
+        RandomIndexWriter writer = new RandomIndexWriter(random(), dir, conf);
+
+        // sparse compression is only enabled if less than 1% of docs have a value
+        final int avgGap = 100;
+
+        final int numDocs = atLeast(200);
+        for (int i = random().nextInt(avgGap * 2); i >= 0; --i) {
+            writer.addDocument(new Document());
+        }
+        final int maxNumValuesPerDoc = random().nextBoolean() ? 1 : TestUtil.nextInt(random(), 2, 5);
+        for (int i = 0; i < numDocs; ++i) {
+            Document doc = new Document();
+
+            // single-valued
+            long docValue = values[random().nextInt(values.length)];
+            doc.add(new NumericDocValuesField("numeric", docValue));
+            doc.add(new SortedDocValuesField("sorted", new BytesRef(Long.toString(docValue))));
+            doc.add(new BinaryDocValuesField("binary", new BytesRef(Long.toString(docValue))));
+            doc.add(new StoredField("value", docValue));
+
+            // multi-valued
+            final int numValues = TestUtil.nextInt(random(), 1, maxNumValuesPerDoc);
+            for (int j = 0; j < numValues; ++j) {
+                docValue = values[random().nextInt(values.length)];
+                doc.add(new SortedNumericDocValuesField("sorted_numeric", docValue));
+                doc.add(new SortedSetDocValuesField("sorted_set", new BytesRef(Long.toString(docValue))));
+                doc.add(new StoredField("values", docValue));
+            }
+
+            writer.addDocument(doc);
+
+            // add a gap
+            for (int j = TestUtil.nextInt(random(), 0, avgGap * 2); j >= 0; --j) {
+                writer.addDocument(new Document());
+            }
+        }
+
+        if (random().nextBoolean()) {
+            writer.forceMerge(1);
+        }
+
+        final IndexReader indexReader = writer.getReader();
+        writer.close();
+
+        for (LeafReaderContext context : indexReader.leaves()) {
+            final LeafReader reader = context.reader();
+            final NumericDocValues numeric = DocValues.getNumeric(reader, "numeric");
+
+            final SortedDocValues sorted = DocValues.getSorted(reader, "sorted");
+
+            final BinaryDocValues binary = DocValues.getBinary(reader, "binary");
+
+            final SortedNumericDocValues sortedNumeric =
+                DocValues.getSortedNumeric(reader, "sorted_numeric");
+
+            final SortedSetDocValues sortedSet = DocValues.getSortedSet(reader, "sorted_set");
+
+            StoredFields storedFields = reader.storedFields();
+            for (int i = 0; i < reader.maxDoc(); ++i) {
+                final Document doc = storedFields.document(i);
+                final IndexableField valueField = doc.getField("value");
+                final Long value = valueField == null ? null : valueField.numericValue().longValue();
+
+                if (value == null) {
+                    assertTrue(numeric.docID() + " vs " + i, numeric.docID() < i);
+                } else {
+                    assertEquals(i, numeric.nextDoc());
+                    assertEquals(i, binary.nextDoc());
+                    assertEquals(i, sorted.nextDoc());
+                    assertEquals(value.longValue(), numeric.longValue());
+                    assertTrue(sorted.ordValue() >= 0);
+                    assertEquals(new BytesRef(Long.toString(value)), sorted.lookupOrd(sorted.ordValue()));
+                    assertEquals(new BytesRef(Long.toString(value)), binary.binaryValue());
+                }
+
+                final IndexableField[] valuesFields = doc.getFields("values");
+                if (valuesFields.length == 0) {
+                    assertTrue(sortedNumeric.docID() + " vs " + i, sortedNumeric.docID() < i);
+                } else {
+                    final Set<Long> valueSet = new HashSet<>();
+                    for (IndexableField sf : valuesFields) {
+                        valueSet.add(sf.numericValue().longValue());
+                    }
+
+                    assertEquals(i, sortedNumeric.nextDoc());
+                    assertEquals(valuesFields.length, sortedNumeric.docValueCount());
+                    for (int j = 0; j < sortedNumeric.docValueCount(); ++j) {
+                        assertTrue(valueSet.contains(sortedNumeric.nextValue()));
+                    }
+                    assertEquals(i, sortedSet.nextDoc());
+
+                    assertEquals(valueSet.size(), sortedSet.docValueCount());
+                    for (int j = 0; j < sortedSet.docValueCount(); ++j) {
+                        long ord = sortedSet.nextOrd();
+                        assertTrue(valueSet.contains(Long.parseLong(sortedSet.lookupOrd(ord).utf8ToString())));
+                    }
+                }
+            }
+        }
+
+        indexReader.close();
+        dir.close();
+    }
+
+    // TODO: try to refactor this and some termsenum tests into the base class.
+    // to do this we need to fix the test class to get a DVF not a Codec so we can setup
+    // the postings format correctly.
+    private void doTestTermsEnumRandom(int numDocs, Supplier<String> valuesProducer)
+        throws Exception {
+        Directory dir = newFSDirectory(createTempDir());
+        IndexWriterConfig conf = newIndexWriterConfig(new MockAnalyzer(random()));
+        conf.setMergeScheduler(new SerialMergeScheduler());
+        // set to duel against a codec which has ordinals:
+        final PostingsFormat pf = TestUtil.getPostingsFormatWithOrds(random());
+        final DocValuesFormat dv =
+            ((PerFieldDocValuesFormat) getCodec().docValuesFormat())
+                .getDocValuesFormatForField("random_field_name");
+        conf.setCodec(
+            new AssertingCodec() {
+                @Override
+                public PostingsFormat getPostingsFormatForField(String field) {
+                    return pf;
+                }
+
+                @Override
+                public DocValuesFormat getDocValuesFormatForField(String field) {
+                    return dv;
+                }
+            });
+        RandomIndexWriter writer = new RandomIndexWriter(random(), dir, conf);
+
+        // index some docs
+        for (int i = 0; i < numDocs; i++) {
+            Document doc = new Document();
+            Field idField = new StringField("id", Integer.toString(i), Field.Store.NO);
+            doc.add(idField);
+            int numValues = random().nextInt(17);
+            // create a random list of strings
+            List<String> values = new ArrayList<>();
+            for (int v = 0; v < numValues; v++) {
+                values.add(valuesProducer.get());
+            }
+
+            // add in any order to the indexed field
+            ArrayList<String> unordered = new ArrayList<>(values);
+            Collections.shuffle(unordered, random());
+            for (String v : values) {
+                doc.add(newStringField("indexed", v, Field.Store.NO));
+            }
+
+            // add in any order to the dv field
+            ArrayList<String> unordered2 = new ArrayList<>(values);
+            Collections.shuffle(unordered2, random());
+            for (String v : unordered2) {
+                doc.add(new SortedSetDocValuesField("dv", new BytesRef(v)));
+            }
+
+            writer.addDocument(doc);
+            if (random().nextInt(31) == 0) {
+                writer.commit();
+            }
+        }
+
+        // delete some docs
+        int numDeletions = random().nextInt(numDocs / 10);
+        for (int i = 0; i < numDeletions; i++) {
+            int id = random().nextInt(numDocs);
+            writer.deleteDocuments(new Term("id", Integer.toString(id)));
+        }
+
+        // compare per-segment
+        DirectoryReader ir = writer.getReader();
+        for (LeafReaderContext context : ir.leaves()) {
+            LeafReader r = context.reader();
+            Terms terms = r.terms("indexed");
+            if (terms != null) {
+                SortedSetDocValues ssdv = r.getSortedSetDocValues("dv");
+                assertEquals(terms.size(), ssdv.getValueCount());
+                TermsEnum expected = terms.iterator();
+                TermsEnum actual = r.getSortedSetDocValues("dv").termsEnum();
+                assertEquals(terms.size(), expected, actual);
+
+                doTestSortedSetEnumAdvanceIndependently(ssdv);
+            }
+        }
+        ir.close();
+
+        writer.forceMerge(1);
+
+        // now compare again after the merge
+        ir = writer.getReader();
+        LeafReader ar = getOnlyLeafReader(ir);
+        Terms terms = ar.terms("indexed");
+        if (terms != null) {
+            assertEquals(terms.size(), ar.getSortedSetDocValues("dv").getValueCount());
+            TermsEnum expected = terms.iterator();
+            TermsEnum actual = ar.getSortedSetDocValues("dv").termsEnum();
+            assertEquals(terms.size(), expected, actual);
+        }
+        ir.close();
+
+        writer.close();
+        dir.close();
+    }
+
+    private void assertEquals(long numOrds, TermsEnum expected, TermsEnum actual) throws Exception {
+        BytesRef ref;
+
+        // sequential next() through all terms
+        while ((ref = expected.next()) != null) {
+            assertEquals(ref, actual.next());
+            assertEquals(expected.ord(), actual.ord());
+            assertEquals(expected.term(), actual.term());
+        }
+        assertNull(actual.next());
+
+        // sequential seekExact(ord) through all terms
+        for (long i = 0; i < numOrds; i++) {
+            expected.seekExact(i);
+            actual.seekExact(i);
+            assertEquals(expected.ord(), actual.ord());
+            assertEquals(expected.term(), actual.term());
+        }
+
+        // sequential seekExact(BytesRef) through all terms
+        for (long i = 0; i < numOrds; i++) {
+            expected.seekExact(i);
+            assertTrue(actual.seekExact(expected.term()));
+            assertEquals(expected.ord(), actual.ord());
+            assertEquals(expected.term(), actual.term());
+        }
+
+        // sequential seekCeil(BytesRef) through all terms
+        for (long i = 0; i < numOrds; i++) {
+            expected.seekExact(i);
+            assertEquals(TermsEnum.SeekStatus.FOUND, actual.seekCeil(expected.term()));
+            assertEquals(expected.ord(), actual.ord());
+            assertEquals(expected.term(), actual.term());
+        }
+
+        // random seekExact(ord)
+        for (long i = 0; i < numOrds; i++) {
+            long randomOrd = TestUtil.nextLong(random(), 0, numOrds - 1);
+            expected.seekExact(randomOrd);
+            actual.seekExact(randomOrd);
+            assertEquals(expected.ord(), actual.ord());
+            assertEquals(expected.term(), actual.term());
+        }
+
+        // random seekExact(BytesRef)
+        for (long i = 0; i < numOrds; i++) {
+            long randomOrd = TestUtil.nextLong(random(), 0, numOrds - 1);
+            expected.seekExact(randomOrd);
+            actual.seekExact(expected.term());
+            assertEquals(expected.ord(), actual.ord());
+            assertEquals(expected.term(), actual.term());
+        }
+
+        // random seekCeil(BytesRef)
+        for (long i = 0; i < numOrds; i++) {
+            BytesRef target = new BytesRef(TestUtil.randomUnicodeString(random()));
+            TermsEnum.SeekStatus expectedStatus = expected.seekCeil(target);
+            assertEquals(expectedStatus, actual.seekCeil(target));
+            if (expectedStatus != TermsEnum.SeekStatus.END) {
+                assertEquals(expected.ord(), actual.ord());
+                assertEquals(expected.term(), actual.term());
+            }
+        }
+    }
+
+    @Nightly
+    public void testSortedSetAroundBlockSize() throws IOException {
+        final int frontier = 1 << CustomLucene90DocValuesFormat.DIRECT_MONOTONIC_BLOCK_SHIFT;
+        for (int maxDoc = frontier - 1; maxDoc <= frontier + 1; ++maxDoc) {
+            final Directory dir = newDirectory();
+            IndexWriter w =
+                new IndexWriter(dir, newIndexWriterConfig().setMergePolicy(newLogMergePolicy()));
+            ByteBuffersDataOutput out = new ByteBuffersDataOutput();
+            Document doc = new Document();
+            SortedSetDocValuesField field1 = new SortedSetDocValuesField("sset", new BytesRef());
+            doc.add(field1);
+            SortedSetDocValuesField field2 = new SortedSetDocValuesField("sset", new BytesRef());
+            doc.add(field2);
+            for (int i = 0; i < maxDoc; ++i) {
+                BytesRef s1 = new BytesRef(TestUtil.randomSimpleString(random(), 2));
+                BytesRef s2 = new BytesRef(TestUtil.randomSimpleString(random(), 2));
+                field1.setBytesValue(s1);
+                field2.setBytesValue(s2);
+                w.addDocument(doc);
+                Set<BytesRef> set = new TreeSet<>(Arrays.asList(s1, s2));
+                out.writeVInt(set.size());
+                for (BytesRef ref : set) {
+                    out.writeVInt(ref.length);
+                    out.writeBytes(ref.bytes, ref.offset, ref.length);
+                }
+            }
+
+            w.forceMerge(1);
+            DirectoryReader r = DirectoryReader.open(w);
+            w.close();
+            LeafReader sr = getOnlyLeafReader(r);
+            assertEquals(maxDoc, sr.maxDoc());
+            SortedSetDocValues values = sr.getSortedSetDocValues("sset");
+            assertNotNull(values);
+            ByteBuffersDataInput in = out.toDataInput();
+            BytesRefBuilder b = new BytesRefBuilder();
+            for (int i = 0; i < maxDoc; ++i) {
+                assertEquals(i, values.nextDoc());
+                final int numValues = in.readVInt();
+                assertEquals(numValues, values.docValueCount());
+
+                for (int j = 0; j < numValues; ++j) {
+                    b.setLength(in.readVInt());
+                    b.grow(b.length());
+                    in.readBytes(b.bytes(), 0, b.length());
+                    assertEquals(b.get(), values.lookupOrd(values.nextOrd()));
+                }
+            }
+            r.close();
+            dir.close();
+        }
+    }
+
+    @Nightly
+    public void testSortedNumericAroundBlockSize() throws IOException {
+        final int frontier = 1 << CustomLucene90DocValuesFormat.DIRECT_MONOTONIC_BLOCK_SHIFT;
+        for (int maxDoc = frontier - 1; maxDoc <= frontier + 1; ++maxDoc) {
+            final Directory dir = newDirectory();
+            IndexWriter w =
+                new IndexWriter(dir, newIndexWriterConfig().setMergePolicy(newLogMergePolicy()));
+            ByteBuffersDataOutput buffer = new ByteBuffersDataOutput();
+
+            Document doc = new Document();
+            SortedNumericDocValuesField field1 = new SortedNumericDocValuesField("snum", 0L);
+            doc.add(field1);
+            SortedNumericDocValuesField field2 = new SortedNumericDocValuesField("snum", 0L);
+            doc.add(field2);
+            for (int i = 0; i < maxDoc; ++i) {
+                long s1 = random().nextInt(100);
+                long s2 = random().nextInt(100);
+                field1.setLongValue(s1);
+                field2.setLongValue(s2);
+                w.addDocument(doc);
+                buffer.writeVLong(Math.min(s1, s2));
+                buffer.writeVLong(Math.max(s1, s2));
+            }
+
+            w.forceMerge(1);
+            DirectoryReader r = DirectoryReader.open(w);
+            w.close();
+            LeafReader sr = getOnlyLeafReader(r);
+            assertEquals(maxDoc, sr.maxDoc());
+            SortedNumericDocValues values = sr.getSortedNumericDocValues("snum");
+            assertNotNull(values);
+            ByteBuffersDataInput dataInput = buffer.toDataInput();
+            for (int i = 0; i < maxDoc; ++i) {
+                assertEquals(i, values.nextDoc());
+                assertEquals(2, values.docValueCount());
+                assertEquals(dataInput.readVLong(), values.nextValue());
+                assertEquals(dataInput.readVLong(), values.nextValue());
+            }
+            r.close();
+            dir.close();
+        }
+    }
+
+    @Nightly
+    public void testSortedNumericBlocksOfVariousBitsPerValue() throws Exception {
+        doTestSortedNumericBlocksOfVariousBitsPerValue(() -> TestUtil.nextInt(random(), 1, 3));
+    }
+
+    @Nightly
+    public void testSparseSortedNumericBlocksOfVariousBitsPerValue() throws Exception {
+        doTestSortedNumericBlocksOfVariousBitsPerValue(() -> TestUtil.nextInt(random(), 0, 2));
+    }
+
+    @Nightly
+    public void testNumericBlocksOfVariousBitsPerValue() throws Exception {
+        doTestSparseNumericBlocksOfVariousBitsPerValue(1);
+    }
+
+    @Nightly
+    public void testSparseNumericBlocksOfVariousBitsPerValue() throws Exception {
+        doTestSparseNumericBlocksOfVariousBitsPerValue(random().nextDouble());
+    }
+
+    // The LUCENE-8585 jump-tables enables O(1) skipping of IndexedDISI blocks, DENSE block lookup
+    // and numeric multi blocks. This test focuses on testing these jumps.
+    @Nightly
+    public void testNumericFieldJumpTables() throws Exception {
+        // IndexedDISI block skipping only activated if target >= current+2, so we need at least 5
+        // blocks to
+        // trigger consecutive block skips
+        final int maxDoc = atLeast(5 * 65536);
+
+        Directory dir = newDirectory();
+        IndexWriter iw = createFastIndexWriter(dir, maxDoc);
+
+        Field idField = newStringField("id", "", Field.Store.NO);
+        Field storedField = newStringField("stored", "", Field.Store.YES);
+        Field dvField = new NumericDocValuesField("dv", 0);
+
+        for (int i = 0; i < maxDoc; i++) {
+            Document doc = new Document();
+            idField.setStringValue(Integer.toBinaryString(i));
+            doc.add(idField);
+            if (random().nextInt(100) > 10) { // Skip 10% to make DENSE blocks
+                int value = random().nextInt(100000);
+                storedField.setStringValue(Integer.toString(value));
+                doc.add(storedField);
+                dvField.setLongValue(value);
+                doc.add(dvField);
+            }
+            iw.addDocument(doc);
+        }
+        iw.flush();
+        iw.forceMerge(1, true); // Single segment to force large enough structures
+        iw.commit();
+        iw.close();
+
+        assertDVIterate(dir);
+        assertDVAdvance(
+            dir, rarely() ? 1 : 7); // 1 is heavy (~20 s), so we do it rarely. 7 is a lot faster (8 s)
+
+        dir.close();
+    }
+
+    private IndexWriter createFastIndexWriter(Directory dir, int maxBufferedDocs) throws IOException {
+        IndexWriterConfig conf = newIndexWriterConfig(new MockAnalyzer(random()));
+        conf.setMaxBufferedDocs(maxBufferedDocs);
+        conf.setRAMBufferSizeMB(-1);
+        conf.setMergePolicy(newLogMergePolicy(random().nextBoolean()));
+        return new IndexWriter(dir, conf);
+    }
+
+    private static LongSupplier blocksOfVariousBPV() {
+        // this helps exercise GCD compression:
+        final long mul = TestUtil.nextInt(random(), 1, 100);
+        final long min = random().nextInt();
+        return new LongSupplier() {
+            int i = CustomLucene90DocValuesFormat.NUMERIC_BLOCK_SIZE;
+            int maxDelta;
+
+            @Override
+            public long getAsLong() {
+                if (i == CustomLucene90DocValuesFormat.NUMERIC_BLOCK_SIZE) {
+                    // change the range of the random generated values on block boundaries, so we exercise
+                    // different bits-per-value for each block, and encourage block compression
+                    maxDelta = 1 << random().nextInt(5);
+                    i = 0;
+                }
+                i++;
+                return min + mul * random().nextInt(maxDelta);
+            }
+        };
+    }
+
+    private void doTestSortedNumericBlocksOfVariousBitsPerValue(LongSupplier counts)
+        throws Exception {
+        Directory dir = newDirectory();
+        IndexWriterConfig conf = newIndexWriterConfig(new MockAnalyzer(random()));
+        conf.setMaxBufferedDocs(atLeast(CustomLucene90DocValuesFormat.NUMERIC_BLOCK_SIZE));
+        conf.setRAMBufferSizeMB(-1);
+        conf.setMergePolicy(newLogMergePolicy(random().nextBoolean()));
+        IndexWriter writer = new IndexWriter(dir, conf);
+
+        final int numDocs = atLeast(CustomLucene90DocValuesFormat.NUMERIC_BLOCK_SIZE * 3);
+        final LongSupplier values = blocksOfVariousBPV();
+        List<long[]> writeDocValues = new ArrayList<>();
+        for (int i = 0; i < numDocs; i++) {
+            Document doc = new Document();
+
+            int valueCount = (int) counts.getAsLong();
+            long[] valueArray = new long[valueCount];
+            for (int j = 0; j < valueCount; j++) {
+                long value = values.getAsLong();
+                valueArray[j] = value;
+                doc.add(new SortedNumericDocValuesField("dv", value));
+            }
+            Arrays.sort(valueArray);
+            writeDocValues.add(valueArray);
+            for (int j = 0; j < valueCount; j++) {
+                doc.add(new StoredField("stored", Long.toString(valueArray[j])));
+            }
+            writer.addDocument(doc);
+            if (random().nextInt(31) == 0) {
+                writer.commit();
+            }
+        }
+        writer.forceMerge(1);
+
+        writer.close();
+
+        // compare
+        DirectoryReader ir = DirectoryReader.open(dir);
+        TestUtil.checkReader(ir);
+        for (LeafReaderContext context : ir.leaves()) {
+            LeafReader r = context.reader();
+            SortedNumericDocValues docValues = DocValues.getSortedNumeric(r, "dv");
+            StoredFields storedFields = r.storedFields();
+            for (int i = 0; i < r.maxDoc(); i++) {
+                if (i > docValues.docID()) {
+                    docValues.nextDoc();
+                }
+                String[] expectedStored = storedFields.document(i).getValues("stored");
+                if (i < docValues.docID()) {
+                    assertEquals(0, expectedStored.length);
+                } else {
+                    long[] readValueArray = new long[docValues.docValueCount()];
+                    String[] actualDocValue = new String[docValues.docValueCount()];
+                    for (int j = 0; j < docValues.docValueCount(); ++j) {
+                        long actualDV = docValues.nextValue();
+                        readValueArray[j] = actualDV;
+                        actualDocValue[j] = Long.toString(readValueArray[j]);
+                    }
+                    long[] writeValueArray = writeDocValues.get(i);
+                    // compare write values and read values
+                    assertArrayEquals(readValueArray, writeValueArray);
+
+                    // compare dv and stored values
+                    assertArrayEquals(expectedStored, actualDocValue);
+                }
+            }
+        }
+        ir.close();
+        dir.close();
+    }
+
+    private void doTestSparseNumericBlocksOfVariousBitsPerValue(double density) throws Exception {
+        Directory dir = newDirectory();
+        IndexWriterConfig conf = newIndexWriterConfig(new MockAnalyzer(random()));
+        conf.setMaxBufferedDocs(atLeast(CustomLucene90DocValuesFormat.NUMERIC_BLOCK_SIZE));
+        conf.setRAMBufferSizeMB(-1);
+        conf.setMergePolicy(newLogMergePolicy(random().nextBoolean()));
+        IndexWriter writer = new IndexWriter(dir, conf);
+        Document doc = new Document();
+        Field storedField = newStringField("stored", "", Field.Store.YES);
+        Field dvField = new NumericDocValuesField("dv", 0);
+        doc.add(storedField);
+        doc.add(dvField);
+
+        final int numDocs = atLeast(CustomLucene90DocValuesFormat.NUMERIC_BLOCK_SIZE * 3);
+        final LongSupplier longs = blocksOfVariousBPV();
+        for (int i = 0; i < numDocs; i++) {
+            if (random().nextDouble() > density) {
+                writer.addDocument(new Document());
+                continue;
+            }
+            long value = longs.getAsLong();
+            storedField.setStringValue(Long.toString(value));
+            dvField.setLongValue(value);
+            writer.addDocument(doc);
+        }
+
+        writer.forceMerge(1);
+
+        writer.close();
+
+        // compare
+        assertDVIterate(dir);
+        assertDVAdvance(
+            dir, 1); // Tests all jump-lengths from 1 to maxDoc (quite slow ~= 1 minute for 200K docs)
+
+        dir.close();
+    }
+
+    // Tests that advanceExact does not change the outcome
+    private void assertDVAdvance(Directory dir, int jumpStep) throws IOException {
+        DirectoryReader ir = DirectoryReader.open(dir);
+        TestUtil.checkReader(ir);
+        for (LeafReaderContext context : ir.leaves()) {
+            LeafReader r = context.reader();
+            StoredFields storedFields = r.storedFields();
+
+            for (int jump = jumpStep; jump < r.maxDoc(); jump += jumpStep) {
+                // Create a new instance each time to ensure jumps from the beginning
+                NumericDocValues docValues = DocValues.getNumeric(r, "dv");
+                for (int docID = 0; docID < r.maxDoc(); docID += jump) {
+                    String base =
+                        "document #"
+                            + docID
+                            + "/"
+                            + r.maxDoc()
+                            + ", jumping "
+                            + jump
+                            + " from #"
+                            + (docID - jump);
+                    String storedValue = storedFields.document(docID).get("stored");
+                    if (storedValue == null) {
+                        assertFalse("There should be no DocValue for " + base, docValues.advanceExact(docID));
+                    } else {
+                        assertTrue("There should be a DocValue for " + base, docValues.advanceExact(docID));
+                        assertEquals(
+                            "The doc value should be correct for " + base,
+                            Long.parseLong(storedValue),
+                            docValues.longValue());
+                    }
+                }
+            }
+        }
+        ir.close();
+    }
+
+    public void testReseekAfterSkipDecompression() throws IOException {
+        final int CARDINALITY = (CustomLucene90DocValuesFormat.TERMS_DICT_BLOCK_LZ4_SIZE << 1) + 11;
+        Set<String> valueSet = CollectionUtil.newHashSet(CARDINALITY);
+        for (int i = 0; i < CARDINALITY; i++) {
+            valueSet.add(TestUtil.randomSimpleString(random(), 64));
+        }
+        List<String> values = new ArrayList<>(valueSet);
+        Collections.sort(values);
+        // Create one non-existent value just between block-1 and block-2.
+        String nonexistentValue =
+            values.get(CustomLucene90DocValuesFormat.TERMS_DICT_BLOCK_LZ4_SIZE - 1)
+                + TestUtil.randomSimpleString(random(), 64, 128);
+        int docValues = values.size();
+
+        try (Directory directory = newDirectory()) {
+            Analyzer analyzer = new StandardAnalyzer();
+            IndexWriterConfig config = new IndexWriterConfig(analyzer);
+            config.setCodec(getCodec());
+            config.setUseCompoundFile(false);
+            IndexWriter writer = new IndexWriter(directory, config);
+            for (int i = 0; i < 280; i++) {
+                Document doc = new Document();
+                doc.add(new StringField("id", "Doc" + i, Field.Store.NO));
+                doc.add(new SortedDocValuesField("sdv", new BytesRef(values.get(i % docValues))));
+                writer.addDocument(doc);
+            }
+            writer.commit();
+            writer.forceMerge(1);
+            DirectoryReader dReader = DirectoryReader.open(writer);
+            writer.close();
+
+            LeafReader reader = getOnlyLeafReader(dReader);
+            // Check values count.
+            SortedDocValues ssdvMulti = reader.getSortedDocValues("sdv");
+            assertEquals(docValues, ssdvMulti.getValueCount());
+
+            // Seek to first block.
+            int ord1 = ssdvMulti.lookupTerm(new BytesRef(values.get(0)));
+            assertTrue(ord1 >= 0);
+            int ord2 = ssdvMulti.lookupTerm(new BytesRef(values.get(1)));
+            assertTrue(ord2 >= ord1);
+            // Ensure re-seek logic is correct after skip-decompression.
+            int nonexistentOrd2 = ssdvMulti.lookupTerm(new BytesRef(nonexistentValue));
+            assertTrue(nonexistentOrd2 < 0);
+            dReader.close();
+        }
+    }
+
+    public void testLargeTermsCompression() throws IOException {
+        final int CARDINALITY = 64;
+        Set<String> valuesSet = new HashSet<>();
+        for (int i = 0; i < CARDINALITY; ++i) {
+            final int length = TestUtil.nextInt(random(), 512, 1024);
+            valuesSet.add(TestUtil.randomSimpleString(random(), length));
+        }
+        int valuesCount = valuesSet.size();
+        List<String> values = new ArrayList<>(valuesSet);
+
+        try (Directory directory = newDirectory()) {
+            Analyzer analyzer = new StandardAnalyzer();
+            IndexWriterConfig config = new IndexWriterConfig(analyzer);
+            config.setCodec(getCodec());
+            config.setUseCompoundFile(false);
+            IndexWriter writer = new IndexWriter(directory, config);
+            for (int i = 0; i < 256; i++) {
+                Document doc = new Document();
+                doc.add(new StringField("id", "Doc" + i, Field.Store.NO));
+                doc.add(new SortedDocValuesField("sdv", new BytesRef(values.get(i % valuesCount))));
+                writer.addDocument(doc);
+            }
+            writer.commit();
+            writer.forceMerge(1);
+            DirectoryReader ireader = DirectoryReader.open(writer);
+            writer.close();
+
+            LeafReader reader = getOnlyLeafReader(ireader);
+            // Check values count.
+            SortedDocValues ssdvMulti = reader.getSortedDocValues("sdv");
+            assertEquals(valuesCount, ssdvMulti.getValueCount());
+            ireader.close();
+        }
+    }
+
+    public void testSortedTermsDictLookupOrd() throws IOException {
+        Directory dir = newDirectory();
+        IndexWriter writer = new IndexWriter(dir, newIndexWriterConfig());
+        Document doc = new Document();
+        SortedDocValuesField field = new SortedDocValuesField("foo", new BytesRef());
+        doc.add(field);
+        final int numDocs = atLeast(CustomLucene90DocValuesFormat.TERMS_DICT_BLOCK_LZ4_SIZE + 1);
+        for (int i = 0; i < numDocs; ++i) {
+            field.setBytesValue(new BytesRef("" + i));
+            writer.addDocument(doc);
+        }
+        writer.forceMerge(1);
+        IndexReader reader = DirectoryReader.open(writer);
+        LeafReader leafReader = getOnlyLeafReader(reader);
+        doTestTermsDictLookupOrd(leafReader.getSortedDocValues("foo").termsEnum());
+        reader.close();
+        writer.close();
+        dir.close();
+    }
+
+    public void testSortedSetTermsDictLookupOrd() throws IOException {
+        Directory dir = newDirectory();
+        IndexWriter writer = new IndexWriter(dir, newIndexWriterConfig());
+        Document doc = new Document();
+        SortedSetDocValuesField field = new SortedSetDocValuesField("foo", new BytesRef());
+        doc.add(field);
+        final int numDocs = atLeast(2 * CustomLucene90DocValuesFormat.TERMS_DICT_BLOCK_LZ4_SIZE + 1);
+        for (int i = 0; i < numDocs; ++i) {
+            field.setBytesValue(new BytesRef("" + i));
+            writer.addDocument(doc);
+        }
+        writer.forceMerge(1);
+        IndexReader reader = DirectoryReader.open(writer);
+        LeafReader leafReader = getOnlyLeafReader(reader);
+        doTestTermsDictLookupOrd(leafReader.getSortedSetDocValues("foo").termsEnum());
+        reader.close();
+        writer.close();
+        dir.close();
+    }
+
+    private void doTestTermsDictLookupOrd(TermsEnum te) throws IOException {
+        List<BytesRef> terms = new ArrayList<>();
+        for (BytesRef term = te.next(); term != null; term = te.next()) {
+            terms.add(BytesRef.deepCopyOf(term));
+        }
+
+        // iterate in order
+        for (int i = 0; i < terms.size(); ++i) {
+            te.seekExact(i);
+            assertEquals(terms.get(i), te.term());
+        }
+
+        // iterate in reverse order
+        for (int i = terms.size() - 1; i >= 0; --i) {
+            te.seekExact(i);
+            assertEquals(terms.get(i), te.term());
+        }
+
+        // iterate in forward order with random gaps
+        for (int i = random().nextInt(5); i < terms.size(); i += random().nextInt(5)) {
+            te.seekExact(i);
+            assertEquals(terms.get(i), te.term());
+        }
+    }
+
+    // Exercise the logic that leverages the first term of a block as a dictionary for suffixes of
+    // other terms
+    public void testTermsEnumDictionary() throws IOException {
+        Directory directory = newDirectory();
+        IndexWriterConfig conf = newIndexWriterConfig();
+        RandomIndexWriter iwriter = new RandomIndexWriter(random(), directory, conf);
+        Document doc = new Document();
+        SortedDocValuesField field = new SortedDocValuesField("field", new BytesRef("abc0defghijkl"));
+        doc.add(field);
+        iwriter.addDocument(doc);
+        field.setBytesValue(new BytesRef("abc1defghijkl"));
+        iwriter.addDocument(doc);
+        field.setBytesValue(new BytesRef("abc2defghijkl"));
+        iwriter.addDocument(doc);
+        iwriter.forceMerge(1);
+        iwriter.close();
+
+        IndexReader reader = DirectoryReader.open(directory);
+        LeafReader leafReader = getOnlyLeafReader(reader);
+        SortedDocValues values = leafReader.getSortedDocValues("field");
+        TermsEnum termsEnum = values.termsEnum();
+        assertEquals(new BytesRef("abc0defghijkl"), termsEnum.next());
+        assertEquals(new BytesRef("abc1defghijkl"), termsEnum.next());
+        assertEquals(new BytesRef("abc2defghijkl"), termsEnum.next());
+        assertNull(termsEnum.next());
+
+        reader.close();
+        directory.close();
+    }
+
+    // Testing termsEnum seekCeil edge case, where inconsistent internal state led to
+    // IndexOutOfBoundsException
+    // see https://github.com/apache/lucene/pull/12555 for details
+    public void testTermsEnumConsistency() throws IOException {
+        int numTerms =
+            CustomLucene90DocValuesFormat.TERMS_DICT_BLOCK_LZ4_SIZE
+                + 10; // need more than one block of unique terms.
+        Directory directory = newDirectory();
+        IndexWriterConfig conf = newIndexWriterConfig();
+        RandomIndexWriter iwriter = new RandomIndexWriter(random(), directory, conf);
+        Document doc = new Document();
+
+        // for simplicity, we will generate sorted list of terms which are a) unique b) all greater than
+        // the term that we want to use for the test
+        char termA = 'A';
+        Function<Integer, String> stringSupplier =
+            (Integer n) -> {
+                assert n < 25 * 25;
+                char[] chars = new char[] {(char) (termA + 1 + n / 25), (char) (termA + 1 + n % 25)};
+                return new String(chars);
+            };
+        SortedDocValuesField field =
+            new SortedDocValuesField("field", new BytesRef(stringSupplier.apply(0)));
+        doc.add(field);
+        iwriter.addDocument(doc);
+        for (int i = 1; i < numTerms; i++) {
+            field.setBytesValue(new BytesRef(stringSupplier.apply(i)));
+            iwriter.addDocument(doc);
+        }
+        // merging to one segment to make sure we have more than one block (TERMS_DICT_BLOCK_LZ4_SIZE)
+        // in a segment, to trigger next block decompression.
+        iwriter.forceMerge(1);
+        iwriter.close();
+
+        IndexReader reader = DirectoryReader.open(directory);
+        LeafReader leafReader = getOnlyLeafReader(reader);
+        SortedDocValues values = leafReader.getSortedDocValues("field");
+        TermsEnum termsEnum = values.termsEnum();
+
+        // Position terms enum at 0
+        termsEnum.seekExact(0L);
+        assertEquals(0, termsEnum.ord());
+        // seekCeil to a term which doesn't exist in the index
+        assertEquals(TermsEnum.SeekStatus.NOT_FOUND, termsEnum.seekCeil(new BytesRef("A")));
+        // ... and before any other term in the index
+        assertEquals(0, termsEnum.ord());
+
+        assertEquals(new BytesRef(stringSupplier.apply(0)), termsEnum.term());
+        // read more than one block of terms to trigger next block decompression
+        for (int i = 1; i < numTerms; i++) {
+            assertEquals(new BytesRef(stringSupplier.apply(i)), termsEnum.next());
+        }
+        assertNull(termsEnum.next());
+        reader.close();
+        directory.close();
+    }
+}

--- a/server/src/test/java/io/crate/lucene/codec/TestCustomLucene90DocValuesFormatMergeInstance.java
+++ b/server/src/test/java/io/crate/lucene/codec/TestCustomLucene90DocValuesFormatMergeInstance.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.lucene.codec;
+
+public class TestCustomLucene90DocValuesFormatMergeInstance extends TestCustomLucene90DocValuesFormat {
+
+    @Override
+    protected boolean shouldTestMergeInstance() {
+        return true;
+    }
+}

--- a/server/src/test/java/io/crate/lucene/codec/TestCustomLucene90DocValuesFormatVariableSkipInterval.java
+++ b/server/src/test/java/io/crate/lucene/codec/TestCustomLucene90DocValuesFormatVariableSkipInterval.java
@@ -1,0 +1,213 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.lucene.codec;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.NumericDocValuesField;
+import org.apache.lucene.document.SortedNumericDocValuesField;
+import org.apache.lucene.index.DocValuesSkipper;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.Sort;
+import org.apache.lucene.search.SortField;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.index.BaseDocValuesFormatTestCase;
+import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.apache.lucene.tests.util.TestUtil;
+
+public class TestCustomLucene90DocValuesFormatVariableSkipInterval extends BaseDocValuesFormatTestCase {
+
+    @Override
+    protected Codec getCodec() {
+        // small interval size to test with many intervals
+        return TestUtil.alwaysDocValuesFormat(
+            new CustomLucene90DocValuesFormat(CustomLucene90DocValuesFormat.Mode.BEST_SPEED, random().nextInt(4, 16)));
+    }
+
+    public void testSkipIndexIntervalSize() {
+        IllegalArgumentException ex =
+            expectThrows(
+                IllegalArgumentException.class,
+                () -> new CustomLucene90DocValuesFormat(CustomLucene90DocValuesFormat.Mode.BEST_SPEED, random().nextInt(Integer.MIN_VALUE, 2)));
+        assertTrue(ex.getMessage().contains("skipIndexIntervalSize must be > 1"));
+    }
+
+    public void testSkipperAllEqualValue() throws IOException {
+        final IndexWriterConfig config = new IndexWriterConfig().setCodec(getCodec());
+        try (Directory directory = newDirectory();
+             RandomIndexWriter writer = new RandomIndexWriter(random(), directory, config)) {
+            final int numDocs = atLeast(100);
+            for (int i = 0; i < numDocs; i++) {
+                final Document doc = new Document();
+                doc.add(NumericDocValuesField.indexedField("dv", 0L));
+                writer.addDocument(doc);
+            }
+            writer.forceMerge(1);
+            try (IndexReader reader = writer.getReader()) {
+                assertEquals(1, reader.leaves().size());
+                final DocValuesSkipper skipper = reader.leaves().get(0).reader().getDocValuesSkipper("dv");
+                assertNotNull(skipper);
+                skipper.advance(0);
+                assertEquals(0L, skipper.minValue(0));
+                assertEquals(0L, skipper.maxValue(0));
+                assertEquals(numDocs, skipper.docCount(0));
+                skipper.advance(skipper.maxDocID(0) + 1);
+                assertEquals(DocIdSetIterator.NO_MORE_DOCS, skipper.minDocID(0));
+            }
+        }
+    }
+
+    // break on different value
+    public void testSkipperFewValuesSorted() throws IOException {
+        final IndexWriterConfig config = new IndexWriterConfig().setCodec(getCodec());
+        boolean reverse = random().nextBoolean();
+        config.setIndexSort(new Sort(new SortField("dv", SortField.Type.LONG, reverse)));
+        try (Directory directory = newDirectory();
+             RandomIndexWriter writer = new RandomIndexWriter(random(), directory, config)) {
+            final int intervals = random().nextInt(2, 10);
+            final int[] numDocs = new int[intervals];
+            for (int i = 0; i < intervals; i++) {
+                numDocs[i] = random().nextInt(10) + 16;
+                for (int j = 0; j < numDocs[i]; j++) {
+                    final Document doc = new Document();
+                    doc.add(NumericDocValuesField.indexedField("dv", i));
+                    writer.addDocument(doc);
+                }
+            }
+            writer.forceMerge(1);
+            try (IndexReader reader = writer.getReader()) {
+                assertEquals(1, reader.leaves().size());
+                final DocValuesSkipper skipper = reader.leaves().get(0).reader().getDocValuesSkipper("dv");
+                assertNotNull(skipper);
+                assertEquals(Arrays.stream(numDocs).sum(), skipper.docCount());
+                skipper.advance(0);
+                if (reverse) {
+                    for (int i = intervals - 1; i >= 0; i--) {
+                        assertEquals(i, skipper.minValue(0));
+                        assertEquals(i, skipper.maxValue(0));
+                        assertEquals(numDocs[i], skipper.docCount(0));
+                        skipper.advance(skipper.maxDocID(0) + 1);
+                    }
+                } else {
+                    for (int i = 0; i < intervals; i++) {
+                        assertEquals(i, skipper.minValue(0));
+                        assertEquals(i, skipper.maxValue(0));
+                        assertEquals(numDocs[i], skipper.docCount(0));
+                        skipper.advance(skipper.maxDocID(0) + 1);
+                    }
+                }
+                assertEquals(DocIdSetIterator.NO_MORE_DOCS, skipper.minDocID(0));
+            }
+        }
+    }
+
+    // break on empty doc values
+    public void testSkipperAllEqualValueWithGaps() throws IOException {
+        final IndexWriterConfig config = new IndexWriterConfig().setCodec(getCodec());
+        config.setIndexSort(new Sort(new SortField("sort", SortField.Type.LONG, false)));
+        try (Directory directory = newDirectory();
+             RandomIndexWriter writer = new RandomIndexWriter(random(), directory, config)) {
+            final int gaps = random().nextInt(2, 10);
+            final int[] numDocs = new int[gaps];
+            long totaldocs = 0;
+            for (int i = 0; i < gaps; i++) {
+                numDocs[i] = random().nextInt(10) + 16;
+                for (int j = 0; j < numDocs[i]; j++) {
+                    final Document doc = new Document();
+                    doc.add(new NumericDocValuesField("sort", totaldocs++));
+                    doc.add(SortedNumericDocValuesField.indexedField("dv", 0L));
+                    writer.addDocument(doc);
+                }
+                // add doc with empty "dv"
+                final Document doc = new Document();
+                doc.add(new NumericDocValuesField("sort", totaldocs++));
+                writer.addDocument(doc);
+            }
+            writer.forceMerge(1);
+            try (IndexReader reader = writer.getReader()) {
+                assertEquals(1, reader.leaves().size());
+                final DocValuesSkipper skipper = reader.leaves().get(0).reader().getDocValuesSkipper("dv");
+                assertNotNull(skipper);
+                assertEquals(Arrays.stream(numDocs).sum(), skipper.docCount());
+                skipper.advance(0);
+                for (int i = 0; i < gaps; i++) {
+                    assertEquals(0L, skipper.minValue(0));
+                    assertEquals(0L, skipper.maxValue(0));
+                    assertEquals(numDocs[i], skipper.docCount(0));
+                    skipper.advance(skipper.maxDocID(0) + 1);
+                }
+                assertEquals(DocIdSetIterator.NO_MORE_DOCS, skipper.minDocID(0));
+            }
+        }
+    }
+
+    // break on multi-values
+    public void testSkipperAllEqualValueWithMultiValues() throws IOException {
+        final IndexWriterConfig config = new IndexWriterConfig().setCodec(getCodec());
+        config.setIndexSort(new Sort(new SortField("sort", SortField.Type.LONG, false)));
+        try (Directory directory = newDirectory();
+             RandomIndexWriter writer = new RandomIndexWriter(random(), directory, config)) {
+            final int gaps = random().nextInt(2, 10);
+            final int[] numDocs = new int[gaps];
+            long totaldocs = 0;
+            for (int i = 0; i < gaps; i++) {
+                int docs = random().nextInt(10) + 16;
+                numDocs[i] += docs;
+                for (int j = 0; j < docs; j++) {
+                    final Document doc = new Document();
+                    doc.add(new NumericDocValuesField("sort", totaldocs++));
+                    doc.add(SortedNumericDocValuesField.indexedField("dv", 0L));
+                    writer.addDocument(doc);
+                }
+                if (i != gaps - 1) {
+                    // add doc with mutivalues
+                    final Document doc = new Document();
+                    doc.add(new NumericDocValuesField("sort", totaldocs++));
+                    doc.add(SortedNumericDocValuesField.indexedField("dv", 0L));
+                    doc.add(SortedNumericDocValuesField.indexedField("dv", 0L));
+                    writer.addDocument(doc);
+                    numDocs[i + 1] = 1;
+                }
+            }
+            writer.forceMerge(1);
+            try (IndexReader reader = writer.getReader()) {
+                assertEquals(1, reader.leaves().size());
+                final DocValuesSkipper skipper = reader.leaves().get(0).reader().getDocValuesSkipper("dv");
+                assertNotNull(skipper);
+                assertEquals(Arrays.stream(numDocs).sum(), skipper.docCount());
+                skipper.advance(0);
+                for (int i = 0; i < gaps; i++) {
+                    assertEquals(0L, skipper.minValue(0));
+                    assertEquals(0L, skipper.maxValue(0));
+                    assertEquals(numDocs[i], skipper.docCount(0));
+                    skipper.advance(skipper.maxDocID(0) + 1);
+                }
+                assertEquals(DocIdSetIterator.NO_MORE_DOCS, skipper.minDocID(0));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This will allow us to use DocValueSkippers in future versions of Crate:
* We can remove the BKD index for some numeric columns in future, further reducing disk footprint
* Some range queries can use sparse indexes to skip over large blocks of rows
* Some aggregations can use sparse index metadata to avoid running queries entirely

Relates to #17344 
