### PR TITLE
Improve ConcurrentRamAccounting.addBytes to use releaseBytes when adding negative bytes

### DIFF
--- a/server/src/main/java/io/crate/breaker/ConcurrentRamAccounting.java
+++ b/server/src/main/java/io/crate/breaker/ConcurrentRamAccounting.java
@@ -66,6 +66,9 @@ public final class ConcurrentRamAccounting implements RamAccounting {
 
     @Override
     public void addBytes(long bytes) {
+        if (bytes == 0) {
+            return;
+        }
         long currentUsedBytes = usedBytes.addAndGet(bytes);
         if (operationMemoryLimit > 0 && currentUsedBytes > operationMemoryLimit) {
             usedBytes.addAndGet(- bytes);
@@ -77,7 +80,11 @@ public final class ConcurrentRamAccounting implements RamAccounting {
             ));
         }
         try {
-            reserveBytes.accept(bytes);
+            if (bytes > 0) {
+                reserveBytes.accept(bytes);
+            } else {
+                releaseBytes.accept(- bytes);
+            }
         } catch (Exception e) {
             usedBytes.addAndGet(- bytes);
             throw e;

--- a/server/src/test/java/io/crate/breaker/ConcurrentRamAccountingTest.java
+++ b/server/src/test/java/io/crate/breaker/ConcurrentRamAccountingTest.java
@@ -43,5 +43,28 @@ public class ConcurrentRamAccountingTest {
         assertThat(usedBytes).as("value is not reserved if above limit").hasValue(19);
         assertThat(ramAccounting.totalBytes()).isEqualTo(19);
     }
+
+    @Test
+    void test_adding_positive_bytes_calls_reserveBytes_and_adding_negative_bytes_calls_releaseBytes() {
+        AtomicLong reserveBytes = new AtomicLong();
+        AtomicLong releaseBytes = new AtomicLong();
+        var ramAccounting = new ConcurrentRamAccounting(
+            reserveBytes::addAndGet, // verify it is called to reserve bytes
+            releaseBytes::addAndGet, // verify it is called to release bytes
+            "dummy",
+            20);
+
+        ramAccounting.addBytes(0);
+        assertThat(reserveBytes.get()).isEqualTo(0L);
+        assertThat(releaseBytes.get()).isEqualTo(0L);
+
+        ramAccounting.addBytes(1);
+        assertThat(reserveBytes.get()).isEqualTo(1L);
+        assertThat(releaseBytes.get()).isEqualTo(0L);
+
+        ramAccounting.addBytes(-1);
+        assertThat(reserveBytes.get()).isEqualTo(1L);
+        assertThat(releaseBytes.get()).isEqualTo(1L);
+    }
 }
 


### PR DESCRIPTION
For example, when HashJoinBatchIterator is resetting its buffer, `leftRowAccounting.release()` is called which results in a call to `ConcurrentRamAccounting.addBytes()` with a negative bytes. However, `addBytes` uses `circuitBreaker.addEstimateBytesAndMaybeBreak()` but we know for sure that it won't break(we are releasing not allocating) so we should use `circuitBreaker.addWithoutBreaking()` instead which is less expensive and manages heap better(because with this change, releasing heap does not need to wait anymore).