### PR TITLE
Add RelationMetadata.Table on SQLExecutor.addTable

### DIFF
--- a/server/src/main/java/io/crate/metadata/DocReferences.java
+++ b/server/src/main/java/io/crate/metadata/DocReferences.java
@@ -125,7 +125,7 @@ public final class DocReferences {
                 for (var sourceRef : indexReference.columns()) {
                     newSources.add(referencesMap.get(sourceRef.column()));
                 }
-                references.set(i, indexReference.updateColumns(newSources));
+                references.set(i, indexReference.withColumns(newSources));
             }
         }
         return references;

--- a/server/src/main/java/io/crate/metadata/IndexReference.java
+++ b/server/src/main/java/io/crate/metadata/IndexReference.java
@@ -313,7 +313,7 @@ public class IndexReference extends SimpleReference {
         return mapping;
     }
 
-    public IndexReference updateColumns(List<Reference> newColumns) {
+    public IndexReference withColumns(List<Reference> newColumns) {
         return new IndexReference(
                 ident,
                 granularity,

--- a/server/src/main/java/io/crate/metadata/Schemas.java
+++ b/server/src/main/java/io/crate/metadata/Schemas.java
@@ -409,6 +409,9 @@ public class Schemas extends AbstractLifecycleComponent implements Iterable<Sche
                 .map(IndexParts::schema)
                 .forEach(schemas::add);
         }
+        for (var cursor : metadata.schemas().keys()) {
+            schemas.add(cursor.value);
+        }
         return schemas;
     }
 

--- a/server/src/main/java/io/crate/metadata/doc/DocSchemaInfo.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocSchemaInfo.java
@@ -38,6 +38,7 @@ import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.RelationMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.index.Index;
@@ -167,11 +168,16 @@ public class DocSchemaInfo implements SchemaInfo {
         }
     }
 
-    private static long getTableVersion(Metadata metadata, RelationName relation) {
-        String templateName = PartitionName.templateName(relation.schema(), relation.name());
+    private static long getTableVersion(Metadata metadata, RelationName name) {
+        RelationMetadata relation = metadata.getRelation(name);
+        if (relation instanceof RelationMetadata.Table) {
+            // TODO: add versioning to table (tracked in https://github.com/crate/crate/issues/17518)
+            return 0;
+        }
+        String templateName = PartitionName.templateName(name.schema(), name.name());
         IndexTemplateMetadata indexTemplateMetadata = metadata.templates().get(templateName);
         if (indexTemplateMetadata == null) {
-            IndexMetadata index = metadata.index(relation.indexNameOrAlias());
+            IndexMetadata index = metadata.index(name.indexNameOrAlias());
             return index == null ? 0 : index.getVersion();
         } else {
             return indexTemplateMetadata.version() == null ? 0 : indexTemplateMetadata.version();

--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
@@ -969,7 +969,7 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
         };
 
         UnaryOperator<IndexReference> renameIndexRefs = idxRef -> {
-            var updatedRef = idxRef.updateColumns(
+            var updatedRef = idxRef.withColumns(
                 Lists.map(idxRef.columns(), r -> oldNameToRenamedRefs.getOrDefault(r.column(), r)));
             if (toBeRenamed.test(idxRef.column())) {
                 return (IndexReference) updatedRef.withReferenceIdent(

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -1308,6 +1308,16 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
         }
     }
 
+    /**
+     * <p>
+     * Resolve the indices for a relation and return their data either as
+     * {@link IndexMetadata} or derived from it using the {@code as} parameter.
+     * </p>
+     * <p>
+     * {@code null} values returned from {@code as} are excluded from the result.
+     * This can be used to filter based on state or similar.
+     * </p>
+     **/
     public <T> List<T> getIndices(RelationName relationName,
                                   List<String> partitionValues,
                                   boolean strict,

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -30,6 +30,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -71,6 +72,7 @@ import org.jetbrains.annotations.VisibleForTesting;
 import com.carrotsearch.hppc.cursors.ObjectCursor;
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 
+import io.crate.common.collections.Lists;
 import io.crate.exceptions.OperationOnInaccessibleRelationException;
 import io.crate.exceptions.RelationUnknown;
 import io.crate.execution.ddl.tables.AlterTableClient;
@@ -78,6 +80,7 @@ import io.crate.expression.symbol.RefReplacer;
 import io.crate.fdw.ForeignTablesMetadata;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.GeneratedReference;
+import io.crate.metadata.IndexReference;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
@@ -929,7 +932,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
             return this;
         }
 
-        public ColumnOidSupplier columnOidSupplier() {
+        public LongSupplier columnOidSupplier() {
             return columnOidSupplier;
         }
 
@@ -1103,28 +1106,35 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
         }
 
         /**
+         * <p>
          * Adds the table, overriding it if a table with the same schema and name exists.
+         * </p>
+         *
+         * oidSupplier is only parameterized for testing.
+         * For production code use {@link #setTable(RelationName, List, Settings, ColumnIdent, ColumnPolicy, String, Map, List, List, State, List)
          **/
-        public Builder setTable(RelationName relationName,
+        @VisibleForTesting
+        public Builder setTable(LongSupplier oidSupplier,
+                                RelationName relationName,
                                 List<Reference> columns,
                                 Settings settings,
                                 @Nullable ColumnIdent routingColumn,
                                 ColumnPolicy columnPolicy,
                                 @Nullable String pkConstraintName,
-                                Map<String,
-                                String> checkConstraints,
+                                Map<String, String> checkConstraints,
                                 List<ColumnIdent> primaryKeys,
                                 List<ColumnIdent> partitionedBy,
                                 State state,
                                 List<String> indexUUIDs) {
             AtomicInteger positions = new AtomicInteger(0);
-            LongSupplier oidSupplier = columnOidSupplier;
             Map<ColumnIdent, Reference> columnMap = columns.stream()
                 .filter(ref -> !ref.isDropped())
                 .map(ref -> ref.withOidAndPosition(oidSupplier, positions::incrementAndGet))
                 .collect(Collectors.toMap(ref -> ref.column(), ref -> ref));
 
             ArrayList<Reference> finalColumns = new ArrayList<>(columns.size());
+            // Need to update linked columns for generated and index refs to ensure these have oid+position
+            // Otherwise .contains/.equals on those refs is broken.
             for (var column : columnMap.values()) {
                 Reference newRef;
                 if (column instanceof GeneratedReference genRef) {
@@ -1132,6 +1142,9 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
                         genRef.reference(),
                         RefReplacer.replaceRefs(genRef.generatedExpression(), ref -> columnMap.get(ref.column()))
                     );
+                } else if (column instanceof IndexReference indexRef) {
+                    List<Reference> newColumns = Lists.map(indexRef.columns(), x -> Objects.requireNonNull(columnMap.get(x.column())));
+                    newRef = indexRef.withColumns(newColumns);
                 } else {
                     newRef = column;
                 }
@@ -1155,6 +1168,36 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
             );
             setRelation(table);
             return this;
+        }
+
+        /**
+         * Adds the table, overriding it if a table with the same schema and name exists.
+         **/
+        public Builder setTable(RelationName relationName,
+                                List<Reference> columns,
+                                Settings settings,
+                                @Nullable ColumnIdent routingColumn,
+                                ColumnPolicy columnPolicy,
+                                @Nullable String pkConstraintName,
+                                Map<String, String> checkConstraints,
+                                List<ColumnIdent> primaryKeys,
+                                List<ColumnIdent> partitionedBy,
+                                State state,
+                                List<String> indexUUIDs) {
+            return setTable(
+                columnOidSupplier,
+                relationName,
+                columns,
+                settings,
+                routingColumn,
+                columnPolicy,
+                pkConstraintName,
+                checkConstraints,
+                primaryKeys,
+                partitionedBy,
+                state,
+                indexUUIDs
+            );
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -364,6 +364,10 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
         return this.templates;
     }
 
+    public ImmutableOpenMap<String, SchemaMetadata> schemas() {
+        return this.schemas;
+    }
+
     public ImmutableOpenMap<String, Custom> customs() {
         return this.customs;
     }
@@ -791,7 +795,11 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
             ImmutableOpenMap<String, RelationMetadata> newRelations = ImmutableOpenMap.builder(schemaMetadata.relations())
                 .fRemove(relationName.name())
                 .build();
-            schemas.put(relationName.schema(), new SchemaMetadata(newRelations));
+            if (newRelations.isEmpty()) {
+                schemas.remove(relationName.schema());
+            } else {
+                schemas.put(relationName.schema(), new SchemaMetadata(newRelations));
+            }
             return this;
         }
 

--- a/server/src/test/java/io/crate/analyze/AlterTableAddColumnAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/AlterTableAddColumnAnalyzerTest.java
@@ -82,7 +82,7 @@ public class AlterTableAddColumnAnalyzerTest extends CrateDummyClusterServiceUni
     @Test
     public void testAddColumnOnSinglePartitionNotAllowed() throws Exception {
         e = SQLExecutor.of(clusterService)
-            .addPartitionedTable(
+            .addTable(
                 TableDefinitions.TEST_PARTITIONED_TABLE_DEFINITION,
                 TableDefinitions.TEST_PARTITIONED_TABLE_PARTITIONS);
 

--- a/server/src/test/java/io/crate/analyze/AlterTableDropColumnAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/AlterTableDropColumnAnalyzerTest.java
@@ -243,7 +243,7 @@ public class AlterTableDropColumnAnalyzerTest extends CrateDummyClusterServiceUn
     @Test
     public void test_drop_column_from_single_partition_is_not_allowed() throws Exception {
         e = SQLExecutor.of(clusterService)
-            .addPartitionedTable(
+            .addTable(
                 TableDefinitions.TEST_PARTITIONED_TABLE_DEFINITION,
                 TableDefinitions.TEST_PARTITIONED_TABLE_PARTITIONS);
 
@@ -255,10 +255,10 @@ public class AlterTableDropColumnAnalyzerTest extends CrateDummyClusterServiceUn
     @Test
     public void test_drop_partition_by_column_is_not_allowed() throws Exception {
         e = SQLExecutor.of(clusterService)
-            .addPartitionedTable(
+            .addTable(
                 TableDefinitions.TEST_PARTITIONED_TABLE_DEFINITION,
                 TableDefinitions.TEST_PARTITIONED_TABLE_PARTITIONS)
-            .addPartitionedTable("CREATE TABLE t2 (o object AS (oo object AS(ooa int))) PARTITIONED BY (o['oo']['ooa'])",
+            .addTable("CREATE TABLE t2 (o object AS (oo object AS(ooa int))) PARTITIONED BY (o['oo']['ooa'])",
                                  new PartitionName(new RelationName("doc", "t2"), singletonList("1")).asIndexName());
 
         assertThatThrownBy(() -> e.analyze("ALTER TABLE parted DROP COLUMN date"))

--- a/server/src/test/java/io/crate/analyze/AlterTableRenameColumnAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/AlterTableRenameColumnAnalyzerTest.java
@@ -119,7 +119,7 @@ public class AlterTableRenameColumnAnalyzerTest extends CrateDummyClusterService
     @Test
     public void test_cannot_rename_column_from_single_partition() throws Exception {
         e = SQLExecutor.of(clusterService)
-            .addPartitionedTable(
+            .addTable(
                 TableDefinitions.TEST_PARTITIONED_TABLE_DEFINITION,
                 TableDefinitions.TEST_PARTITIONED_TABLE_PARTITIONS);
 

--- a/server/src/test/java/io/crate/analyze/AlterTableRerouteAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/AlterTableRerouteAnalyzerTest.java
@@ -56,7 +56,7 @@ public class AlterTableRerouteAnalyzerTest extends CrateDummyClusterServiceUnitT
         e = SQLExecutor.of(clusterService)
             .addBlobTable("create blob table blobs;")
             .addTable(TableDefinitions.USER_TABLE_DEFINITION)
-            .addPartitionedTable(
+            .addTable(
                 TableDefinitions.TEST_PARTITIONED_TABLE_DEFINITION,
                 TableDefinitions.TEST_PARTITIONED_TABLE_PARTITIONS
             );

--- a/server/src/test/java/io/crate/analyze/CopyAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CopyAnalyzerTest.java
@@ -27,6 +27,7 @@ import static io.crate.analyze.TableDefinitions.USER_TABLE_IDENT;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.isFunction;
 import static io.crate.testing.Asserts.isLiteral;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
@@ -69,7 +70,7 @@ public class CopyAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     public void prepare() throws IOException {
         e = SQLExecutor.of(clusterService)
             .addTable(TableDefinitions.USER_TABLE_DEFINITION)
-            .addPartitionedTable(
+            .addTable(
                 TableDefinitions.TEST_PARTITIONED_TABLE_DEFINITION,
                 TableDefinitions.TEST_PARTITIONED_TABLE_PARTITIONS
             );

--- a/server/src/test/java/io/crate/analyze/CreateAlterPartitionedTableAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateAlterPartitionedTableAnalyzerTest.java
@@ -92,10 +92,10 @@ public class CreateAlterPartitionedTableAnalyzerTest extends CrateDummyClusterSe
         RelationName multiPartName = new RelationName("doc", "multi_parted");
         e = SQLExecutor.of(clusterService)
             .addTable(TableDefinitions.USER_TABLE_DEFINITION)
-            .addPartitionedTable(
+            .addTable(
                 TableDefinitions.TEST_PARTITIONED_TABLE_DEFINITION,
                 TableDefinitions.TEST_PARTITIONED_TABLE_PARTITIONS)
-            .addPartitionedTable(
+            .addTable(
                 "create table doc.multi_parted (" +
                 "   id int," +
                 "   date timestamp with time zone," +

--- a/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -108,7 +108,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
             .setNumNodes(3)
             .build()
             .addTable(TableDefinitions.USER_TABLE_DEFINITION)
-            .addPartitionedTable(
+            .addTable(
                 TableDefinitions.TEST_PARTITIONED_TABLE_DEFINITION,
                 TableDefinitions.TEST_PARTITIONED_TABLE_PARTITIONS)
             .addTable(

--- a/server/src/test/java/io/crate/analyze/DeleteAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/DeleteAnalyzerTest.java
@@ -27,6 +27,7 @@ import static io.crate.testing.Asserts.exactlyInstanceOf;
 import static io.crate.testing.Asserts.isFunction;
 import static io.crate.testing.Asserts.isLiteral;
 import static io.crate.testing.Asserts.isReference;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
@@ -56,7 +57,7 @@ public class DeleteAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     public void prepare() throws IOException {
         e = SQLExecutor.of(clusterService)
             .addTable(TableDefinitions.USER_TABLE_DEFINITION)
-            .addPartitionedTable(
+            .addTable(
                 TableDefinitions.TEST_PARTITIONED_TABLE_DEFINITION,
                 TableDefinitions.TEST_PARTITIONED_TABLE_PARTITIONS);
     }

--- a/server/src/test/java/io/crate/analyze/OptimizeTableAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/OptimizeTableAnalyzerTest.java
@@ -51,7 +51,7 @@ public class OptimizeTableAnalyzerTest extends CrateDummyClusterServiceUnitTest 
     public void prepare() throws IOException {
         e = SQLExecutor.of(clusterService)
             .addTable(TableDefinitions.USER_TABLE_DEFINITION)
-            .addPartitionedTable(
+            .addTable(
                 TableDefinitions.TEST_PARTITIONED_TABLE_DEFINITION,
                 TableDefinitions.TEST_PARTITIONED_TABLE_PARTITIONS)
             .addBlobTable("create blob table blobs");

--- a/server/src/test/java/io/crate/analyze/RefreshAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/RefreshAnalyzerTest.java
@@ -23,6 +23,7 @@ package io.crate.analyze;
 
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.isLiteral;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
@@ -47,7 +48,7 @@ public class RefreshAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Before
     public void prepare() throws IOException {
         e = SQLExecutor.of(clusterService)
-            .addPartitionedTable(
+            .addTable(
                 TableDefinitions.TEST_PARTITIONED_TABLE_DEFINITION,
                 TableDefinitions.TEST_PARTITIONED_TABLE_PARTITIONS)
             .addBlobTable("create blob table blobs");

--- a/server/src/test/java/io/crate/analyze/RestoreSnapshotAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/RestoreSnapshotAnalyzerTest.java
@@ -86,7 +86,7 @@ public class RestoreSnapshotAnalyzerTest extends CrateDummyClusterServiceUnitTes
         e = SQLExecutor.of(clusterService)
             .addTable(USER_TABLE_DEFINITION)
             .addTable(TEST_DOC_LOCATIONS_TABLE_DEFINITION)
-            .addPartitionedTable(TEST_PARTITIONED_TABLE_DEFINITION, TEST_PARTITIONED_TABLE_PARTITIONS)
+            .addTable(TEST_PARTITIONED_TABLE_DEFINITION, TEST_PARTITIONED_TABLE_PARTITIONS)
             .addBlobTable("create blob table my_blobs");
         plannerContext = e.getPlannerContext();
     }

--- a/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -33,6 +33,7 @@ import static io.crate.testing.Asserts.isReference;
 import static io.crate.testing.Asserts.toCondition;
 import static io.crate.types.ArrayType.makeArray;
 import static org.assertj.core.api.Assertions.anyOf;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
@@ -766,7 +767,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testNotTimestamp() throws Exception {
         var executor = SQLExecutor.of(clusterService)
-            .addPartitionedTable(TableDefinitions.TEST_PARTITIONED_TABLE_DEFINITION);
+            .addTable(TableDefinitions.TEST_PARTITIONED_TABLE_DEFINITION);
 
         assertThatThrownBy(() -> executor.analyze("select id, name from parted where not date"))
             .isExactlyInstanceOf(UnsupportedFunctionException.class)
@@ -1805,7 +1806,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     public void testSelectPartitionedTableOrderBy() throws Exception {
         RelationName multiPartName = new RelationName("doc", "multi_parted");
         var executor = SQLExecutor.of(clusterService)
-            .addPartitionedTable(
+            .addTable(
                 "create table doc.multi_parted (" +
                 "   id int," +
                 "   date timestamp with time zone," +

--- a/server/src/test/java/io/crate/analyze/TableInfoToASTTest.java
+++ b/server/src/test/java/io/crate/analyze/TableInfoToASTTest.java
@@ -207,7 +207,7 @@ public class TableInfoToASTTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testBuildCreateTableClusteredByPartitionedBy() throws Exception {
         SQLExecutor e = SQLExecutor.of(clusterService)
-            .addPartitionedTable("""
+            .addTable("""
                 create table myschema.test (id long, partition_column string, cluster_column string)
                 partitioned by (partition_column)
                 clustered by (cluster_column) into 5 shards

--- a/server/src/test/java/io/crate/analyze/TableInfoToASTTest.java
+++ b/server/src/test/java/io/crate/analyze/TableInfoToASTTest.java
@@ -220,7 +220,7 @@ public class TableInfoToASTTest extends CrateDummyClusterServiceUnitTest {
         assertThat(SqlFormatter.formatSql(node)).isEqualTo("""
             CREATE TABLE IF NOT EXISTS "myschema"."test" (
                "id" BIGINT,
-               "partition_column" TEXT,
+               "partition_column" TEXT INDEX OFF,
                "cluster_column" TEXT
             )
             CLUSTERED BY ("cluster_column") INTO 5 SHARDS

--- a/server/src/test/java/io/crate/analyze/TableInfoToASTTest.java
+++ b/server/src/test/java/io/crate/analyze/TableInfoToASTTest.java
@@ -270,9 +270,7 @@ public class TableInfoToASTTest extends CrateDummyClusterServiceUnitTest {
                "col_d" OBJECT(DYNAMIC) AS (
                   "a" TEXT
                ),
-               INDEX "col_a_col_b_plain" USING FULLTEXT ("col_a", "col_b") WITH (
-                  analyzer = 'keyword'
-               ),
+               INDEX "col_a_col_b_plain" USING PLAIN ("col_a", "col_b"),
                INDEX "col_d_a_ft" USING FULLTEXT ("col_d"['a']) WITH (
                   analyzer = 'custom_analyzer'
                ),

--- a/server/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
@@ -29,6 +29,7 @@ import static io.crate.testing.Asserts.isLiteral;
 import static io.crate.testing.Asserts.isReference;
 import static io.crate.testing.Asserts.toCondition;
 import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
@@ -83,7 +84,7 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         e = SQLExecutor.of(clusterService)
             .addTable(TableDefinitions.USER_TABLE_DEFINITION)
             .addTable(TableDefinitions.USER_TABLE_CLUSTERED_BY_ONLY_DEFINITION)
-            .addPartitionedTable(
+            .addTable(
                 TableDefinitions.TEST_PARTITIONED_TABLE_DEFINITION,
                 TableDefinitions.TEST_PARTITIONED_TABLE_PARTITIONS)
             .addTable(
@@ -103,13 +104,13 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
                 ")"
             )
             .addTable("create table bag (id short primary key, ob array(object))")
-            .addPartitionedTable(
+            .addTable(
                 "create table doc.parted_generated_column (" +
                 "   ts timestamp with time zone," +
                 "   day as date_trunc('day', ts)" +
                 ") partitioned by (day) "
             )
-            .addPartitionedTable(
+            .addTable(
                 "create table doc.nested_parted_generated_column (" +
                 "   \"user\" object as (" +
                 "       name string" +

--- a/server/src/test/java/io/crate/analyze/where/WhereClauseAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/where/WhereClauseAnalyzerTest.java
@@ -26,6 +26,7 @@ import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.isLiteral;
 import static io.crate.testing.Asserts.isReference;
 import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
@@ -72,7 +73,7 @@ public class WhereClauseAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         registerTables(e);
 
         RelationName docGeneratedCol = new RelationName("doc", "generated_col");
-        e.addPartitionedTable(
+        e.addTable(
             "create table doc.generated_col (" +
             "   ts timestamp with time zone ," +
             "   x integer," +
@@ -85,7 +86,7 @@ public class WhereClauseAnalyzerTest extends CrateDummyClusterServiceUnitTest {
             new PartitionName(docGeneratedCol, List.of("1420156800000", "-2")).asIndexName()
         );
         RelationName docDoubleGenParted = new RelationName(DocSchemaInfo.NAME, "double_gen_parted");
-        e.addPartitionedTable(
+        e.addTable(
             "create table doc.double_gen_parted (" +
             "   x integer," +
             "   x1 as x + 1," +
@@ -104,7 +105,7 @@ public class WhereClauseAnalyzerTest extends CrateDummyClusterServiceUnitTest {
              "  tags array(string)" +
              ") clustered by (id)");
         RelationName docParted = new RelationName("doc", "parted");
-        builder.addPartitionedTable(
+        builder.addTable(
             "create table doc.parted (" +
             "   id integer," +
             "   name string," +

--- a/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
+++ b/server/src/test/java/io/crate/auth/AccessControlMayExecuteTest.java
@@ -135,7 +135,7 @@ public class AccessControlMayExecuteTest extends CrateDummyClusterServiceUnitTes
             .addTable(TableDefinitions.USER_TABLE_DEFINITION)
             .addTable(T3.T1_DEFINITION)
             .addTable(T3.T2_DEFINITION)
-            .addPartitionedTable(
+            .addTable(
                 TableDefinitions.TEST_PARTITIONED_TABLE_DEFINITION,
                 TableDefinitions.TEST_PARTITIONED_TABLE_PARTITIONS)
             .setUser(superUser)

--- a/server/src/test/java/io/crate/execution/ddl/tables/DropColumnTaskTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/tables/DropColumnTaskTest.java
@@ -279,7 +279,7 @@ public class DropColumnTaskTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void test_drop_column_with_check_constraint_from_partitioned_table() throws Exception {
         var e = SQLExecutor.of(clusterService)
-            .addPartitionedTable("create table doc.parted(x int check (x > 0), y int check (y > 0)) " +
+            .addTable("create table doc.parted(x int check (x > 0), y int check (y > 0)) " +
                                  "partitioned by (x)" ,
                 new PartitionName(new RelationName("doc", "parted"), singletonList("1")).asIndexName(),
                 new PartitionName(new RelationName("doc", "parted"), singletonList("2")).asIndexName(),

--- a/server/src/test/java/io/crate/execution/ddl/tables/RenameColumnTaskTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/tables/RenameColumnTaskTest.java
@@ -22,6 +22,7 @@
 package io.crate.execution.ddl.tables;
 
 import static io.crate.testing.Asserts.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
@@ -103,7 +104,7 @@ public class RenameColumnTaskTest extends CrateDummyClusterServiceUnitTest {
     public void test_rename_partitioned_by_columns() throws Exception {
         // alter table tbl rename column x to y; -- where y is a partitioned by col
         var e = SQLExecutor.of(clusterService)
-            .addPartitionedTable("create table doc.tbl (o object as (o2 object as (x int)), x int) partitioned by (o['o2']['x'], x)",
+            .addTable("create table doc.tbl (o object as (o2 object as (x int)), x int) partitioned by (o['o2']['x'], x)",
                 new PartitionName(new RelationName("doc", "tbl"), List.of("1", "2")).asIndexName(),
                 new PartitionName(new RelationName("doc", "tbl"), List.of("3", "4")).asIndexName());
         DocTableInfo tbl = e.resolveTableInfo("doc.tbl");

--- a/server/src/test/java/io/crate/execution/dml/IndexerTest.java
+++ b/server/src/test/java/io/crate/execution/dml/IndexerTest.java
@@ -355,7 +355,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
     public void test_generated_partitioned_column_is_not_indexed_or_included_in_source() throws Exception {
         String partition = new PartitionName(new RelationName("doc", "tbl"), List.of("3")).asIndexName();
         SQLExecutor executor = SQLExecutor.of(clusterService)
-            .addPartitionedTable(
+            .addTable(
                 "create table doc.tbl (x int, p int as x + 2) partitioned by (p)",
                 partition
             );
@@ -1220,7 +1220,7 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
     public void test_generated_column_can_refer_to_a_non_string_partitioned_by_column() throws Exception {
         String partition = new PartitionName(new RelationName("doc", "t"), List.of("2")).asIndexName();
         SQLExecutor executor = SQLExecutor.of(clusterService)
-            .addPartitionedTable("""
+            .addTable("""
              CREATE TABLE t (
                  a INT,
                  parted INT CHECK (parted > 1),

--- a/server/src/test/java/io/crate/expression/reference/doc/lucene/LuceneReferenceResolverTest.java
+++ b/server/src/test/java/io/crate/expression/reference/doc/lucene/LuceneReferenceResolverTest.java
@@ -131,7 +131,7 @@ public class LuceneReferenceResolverTest extends CrateDummyClusterServiceUnitTes
     public void test_can_lookup_generated_partition_column_if_casted() throws Exception {
         // See https://github.com/crate/crate/issues/14307
         SQLExecutor e = SQLExecutor.of(clusterService)
-            .addPartitionedTable("""
+            .addTable("""
                 create table tbl (
                     ts timestamp,
                     year as date_trunc('year', ts)

--- a/server/src/test/java/io/crate/expression/udf/UserDefinedFunctionServiceTest.java
+++ b/server/src/test/java/io/crate/expression/udf/UserDefinedFunctionServiceTest.java
@@ -137,7 +137,7 @@ public class UserDefinedFunctionServiceTest extends UdfUnitTest {
         sqlExecutor
             .addUDFLanguage(DUMMY_LANG)
             .addUDF(FOO)
-            .addPartitionedTable("create table doc.p1 (id int, p int, gen as foo(id)) partitioned by (p)");
+            .addTable("create table doc.p1 (id int, p int, gen as foo(id)) partitioned by (p)");
 
         assertThatThrownBy(() -> udfService.ensureFunctionIsUnused(Schemas.DOC_SCHEMA_NAME, "foo", List.of(DataTypes.INTEGER)))
             .isExactlyInstanceOf(IllegalArgumentException.class)
@@ -149,7 +149,7 @@ public class UserDefinedFunctionServiceTest extends UdfUnitTest {
         sqlExecutor
             .addUDFLanguage(DUMMY_LANG)
             .addUDF(FOO)
-            .addPartitionedTable("create table doc.p1 (o object as (id int), gen as foo(o['id'])) partitioned by (o['id'])");
+            .addTable("create table doc.p1 (o object as (id int), gen as foo(o['id'])) partitioned by (o['id'])");
 
         assertThatThrownBy(() -> udfService.ensureFunctionIsUnused(Schemas.DOC_SCHEMA_NAME, "foo", List.of(DataTypes.INTEGER)))
             .isExactlyInstanceOf(IllegalArgumentException.class)

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -24,6 +24,7 @@ package io.crate.integrationtests;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
 import java.util.List;
@@ -1205,18 +1206,26 @@ public class InformationSchemaTest extends IntegTestCase {
     @Test
     @UseRandomizedSchema(random = false)
     public void testSelectSchemata() throws Exception {
-        execute("select * from information_schema.schemata order by schema_name asc");
-        assertThat(response.rowCount()).isEqualTo(5L);
-        assertThat(TestingHelpers.getColumn(response.rows(), 0))
-            .containsExactly("blob", "doc", "information_schema", "pg_catalog", "sys");
+        execute("select schema_name from information_schema.schemata order by schema_name asc");
+        assertThat(response).hasRows(
+            "blob",
+            "doc",
+            "information_schema",
+            "pg_catalog",
+            "sys"
+        );
 
         execute("create table t1 (col string) with (number_of_replicas=0)");
         ensureGreen();
 
-        execute("select * from information_schema.schemata order by schema_name asc");
-        assertThat(response.rowCount()).isEqualTo(5L);
-        assertThat(TestingHelpers.getColumn(response.rows(), 0))
-            .containsExactly("blob", "doc", "information_schema", "pg_catalog", "sys");
+        execute("select schema_name from information_schema.schemata order by schema_name asc");
+        assertThat(response).hasRows(
+            "blob",
+            "doc",
+            "information_schema",
+            "pg_catalog",
+            "sys"
+        );
     }
 
     @Test

--- a/server/src/test/java/io/crate/metadata/IndexReferenceTest.java
+++ b/server/src/test/java/io/crate/metadata/IndexReferenceTest.java
@@ -21,7 +21,6 @@
 
 package io.crate.metadata;
 
-import static io.crate.metadata.ReferenceTest.columnMapping;
 import static io.crate.testing.Asserts.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -82,8 +81,11 @@ public class IndexReferenceTest extends CrateDummyClusterServiceUnitTest {
             .containsEntry("oid", 3L)
             .containsEntry("analyzer", "stop");
         IndexMetadata indexMetadata = clusterService.state().metadata().indices().valuesIt().next();
-        Map<String, Object> sourceAsMap = indexMetadata.mapping().sourceAsMap();
-        assertThat(columnMapping(sourceAsMap, "properties.title_desc_fulltext")).isEqualTo(mapping);
+        assertThat(indexMetadata.mapping()).isNull();
+        assertThat(reference.columns()).satisfiesExactly(
+            x -> assertThat(x).isEqualTo(titleRef),
+            x -> assertThat(x).isEqualTo(descRef)
+        );
     }
 
 

--- a/server/src/test/java/io/crate/metadata/PartitionInfosTest.java
+++ b/server/src/test/java/io/crate/metadata/PartitionInfosTest.java
@@ -54,7 +54,7 @@ public class PartitionInfosTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testPartitionWithMeta() throws Exception {
         PartitionName partitionName = new PartitionName(new RelationName("doc", "tbl"), List.of("1"));
-        e.addPartitionedTable(
+        e.addTable(
             """
                 create table doc.tbl (
                     x int,
@@ -79,7 +79,7 @@ public class PartitionInfosTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testPartitionWithMetaMultiCol() throws Exception {
         PartitionName partitionName = new PartitionName(new RelationName("doc", "tbl"), List.of("foo", "2"));
-        e.addPartitionedTable(
+        e.addTable(
             """
                 create table doc.tbl (
                     x int,

--- a/server/src/test/java/io/crate/metadata/PartitionNameTest.java
+++ b/server/src/test/java/io/crate/metadata/PartitionNameTest.java
@@ -262,7 +262,7 @@ public class PartitionNameTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void test_PartitionName_from_assignment_with_partitioned_table() throws Exception {
         SQLExecutor e = SQLExecutor.of(clusterService)
-            .addPartitionedTable(
+            .addTable(
                 "create table doc.users (x int, p1 int) partitioned by (p1)",
                 ".partitioned.users.041j2c0"
             );

--- a/server/src/test/java/io/crate/metadata/ReferenceTest.java
+++ b/server/src/test/java/io/crate/metadata/ReferenceTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.metadata;
 
+import static io.crate.testing.Asserts.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
 
@@ -44,6 +45,7 @@ import io.crate.testing.SQLExecutor;
 import io.crate.types.ArrayType;
 import io.crate.types.DataTypes;
 import io.crate.types.ObjectType;
+import io.crate.types.StringType;
 
 public class ReferenceTest extends CrateDummyClusterServiceUnitTest {
 
@@ -152,8 +154,8 @@ public class ReferenceTest extends CrateDummyClusterServiceUnitTest {
             .doesNotContainKey("dropped")
             .hasSize(4);
         IndexMetadata indexMetadata = clusterService.state().metadata().indices().valuesIt().next();
-        Map<String, Object> sourceAsMap = indexMetadata.mapping().sourceAsMap();
-        assertThat(columnMapping(sourceAsMap, "properties.xs")).isEqualTo(mapping);
+        assertThat(indexMetadata.mapping()).isNull();;
+        assertThat(reference.valueType()).isEqualTo(StringType.of(40));
     }
 
     @Test
@@ -171,8 +173,8 @@ public class ReferenceTest extends CrateDummyClusterServiceUnitTest {
             .containsEntry("doc_values", "false")
             .hasSize(4);
         IndexMetadata indexMetadata = clusterService.state().metadata().indices().valuesIt().next();
-        Map<String, Object> sourceAsMap = indexMetadata.mapping().sourceAsMap();
-        assertThat(columnMapping(sourceAsMap, "properties.xs")).isEqualTo(mapping);
+        assertThat(indexMetadata.mapping()).isNull();
+        assertThat(reference.hasDocValues()).isFalse();
     }
 
     @Test
@@ -190,8 +192,9 @@ public class ReferenceTest extends CrateDummyClusterServiceUnitTest {
             .containsEntry("doc_values", "false")
             .hasSize(4);
         IndexMetadata indexMetadata = clusterService.state().metadata().indices().valuesIt().next();
-        Map<String, Object> sourceAsMap = indexMetadata.mapping().sourceAsMap();
-        assertThat(columnMapping(sourceAsMap, "properties.xs")).isEqualTo(mapping);
+        assertThat(indexMetadata.mapping()).isNull();
+        assertThat(reference.hasDocValues()).isFalse();
+        assertThat(reference.valueType()).isEqualTo(DataTypes.FLOAT);
     }
 
     @Test
@@ -245,8 +248,8 @@ public class ReferenceTest extends CrateDummyClusterServiceUnitTest {
             .containsEntry("default_expr", "'foo'")
             .hasSize(4);
         IndexMetadata indexMetadata = clusterService.state().metadata().indices().valuesIt().next();
-        Map<String, Object> sourceAsMap = indexMetadata.mapping().sourceAsMap();
-        assertThat(columnMapping(sourceAsMap, "properties.xs")).isEqualTo(mapping);
+        assertThat(indexMetadata.mapping()).isNull();
+        assertThat(reference.defaultExpression()).isLiteral("foo");
     }
 
     /**

--- a/server/src/test/java/io/crate/metadata/doc/DocTableInfoTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocTableInfoTest.java
@@ -235,7 +235,7 @@ public class DocTableInfoTest extends CrateDummyClusterServiceUnitTest {
             .put(IndexMetadata.SETTING_VERSION_CREATED, Version.V_5_0_0)
             .build();
         var e = SQLExecutor.of(clusterService)
-            .addPartitionedTable("CREATE TABLE p1 (id INT, p INT) PARTITIONED BY (p)", customSettings);
+            .addTable("CREATE TABLE p1 (id INT, p INT) PARTITIONED BY (p)", customSettings);
 
         DocTableInfo tableInfo = e.resolveTableInfo("p1");
         assertThat(IndexMetadata.SETTING_INDEX_VERSION_CREATED.get(tableInfo.parameters())).isEqualTo(Version.V_5_0_0);
@@ -244,7 +244,7 @@ public class DocTableInfoTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void test_version_created_is_set_to_current_version_if_unavailable_at_partitioned_template() throws Exception {
         var e = SQLExecutor.of(clusterService)
-            .addPartitionedTable("CREATE TABLE p1 (id INT, p INT) PARTITIONED BY (p)", Settings.EMPTY);
+            .addTable("CREATE TABLE p1 (id INT, p INT) PARTITIONED BY (p)", Settings.EMPTY);
 
         DocTableInfo tableInfo = e.resolveTableInfo("p1");
         assertThat(IndexMetadata.SETTING_INDEX_VERSION_CREATED.get(tableInfo.parameters())).isEqualTo(Version.CURRENT);
@@ -585,7 +585,7 @@ public class DocTableInfoTest extends CrateDummyClusterServiceUnitTest {
     public void test_write_to_preserves_number_of_shards_of_partitions() throws Exception {
         var partitionIndexName = new PartitionName(new RelationName("doc", "tbl"), singletonList("1")).asIndexName();
         SQLExecutor e = SQLExecutor.of(clusterService)
-            .addPartitionedTable(
+            .addTable(
                 """
                     create table tbl (
                         id int,

--- a/server/src/test/java/io/crate/planner/DeletePlannerTest.java
+++ b/server/src/test/java/io/crate/planner/DeletePlannerTest.java
@@ -23,6 +23,7 @@ package io.crate.planner;
 
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.exactlyInstanceOf;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
@@ -60,7 +61,7 @@ public class DeletePlannerTest extends CrateDummyClusterServiceUnitTest {
     public void prepare() throws IOException {
         e = SQLExecutor.of(clusterService)
             .addTable(TableDefinitions.USER_TABLE_DEFINITION)
-            .addPartitionedTable(
+            .addTable(
                 TableDefinitions.PARTED_PKS_TABLE_DEFINITION,
                 new PartitionName(new RelationName("doc", "parted_pks"), List.of("1395874800000")).asIndexName(),
                 new PartitionName(new RelationName("doc", "parted_pks"), List.of("1395961200000")).asIndexName());

--- a/server/src/test/java/io/crate/planner/DropTablePlannerTest.java
+++ b/server/src/test/java/io/crate/planner/DropTablePlannerTest.java
@@ -42,7 +42,7 @@ public class DropTablePlannerTest extends CrateDummyClusterServiceUnitTest {
     public void prepare() throws IOException {
         e = SQLExecutor.of(clusterService)
             .addTable(TableDefinitions.USER_TABLE_DEFINITION)
-            .addPartitionedTable(
+            .addTable(
                 TableDefinitions.TEST_PARTITIONED_TABLE_DEFINITION,
                 TableDefinitions.TEST_PARTITIONED_TABLE_PARTITIONS)
             .addBlobTable("create blob table screenshots");

--- a/server/src/test/java/io/crate/planner/InsertPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/InsertPlannerTest.java
@@ -74,7 +74,7 @@ public class InsertPlannerTest extends CrateDummyClusterServiceUnitTest {
         e = SQLExecutor.builder(clusterService)
             .setNumNodes(2)
             .build()
-            .addPartitionedTable(
+            .addTable(
                 "create table parted_pks (" +
                 "   id int," +
                 "   name string," +
@@ -93,7 +93,7 @@ public class InsertPlannerTest extends CrateDummyClusterServiceUnitTest {
                 "   date timestamp with time zone" +
                 ") clustered into 4 shards")
             .addTable("create table source (id int primary key, name string)")
-            .addPartitionedTable("CREATE TABLE double_parted(x int, y int) PARTITIONED BY (x, y)");
+            .addTable("CREATE TABLE double_parted(x int, y int) PARTITIONED BY (x, y)");
     }
 
     @Test

--- a/server/src/test/java/io/crate/planner/InsertPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/InsertPlannerTest.java
@@ -24,6 +24,7 @@ package io.crate.planner;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.isReference;
 import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.List;
@@ -368,17 +369,19 @@ public class InsertPlannerTest extends CrateDummyClusterServiceUnitTest {
         List<Symbol> toCollect = collectPhase.toCollect();
         assertThat(toCollect).hasSize(2);
         assertThat(toCollect.get(0)).isReference().hasName("_doc['id']");
-        assertThat(toCollect.get(1)).isEqualTo(new SimpleReference(
+        SimpleReference expected = new SimpleReference(
             new ReferenceIdent(new RelationName(Schemas.DOC_SCHEMA_NAME, "parted_pks"), "date"),
             RowGranularity.PARTITION,
             DataTypes.TIMESTAMPZ,
-            IndexType.PLAIN,
+            IndexType.NONE,
             false,
             true,
             3,
             3,
             false,
-            null));
+            null
+        );
+        assertThat(toCollect.get(1)).isEqualTo(expected);
     }
 
     @Test

--- a/server/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -24,6 +24,7 @@ package io.crate.planner;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.isReference;
 import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Collection;
@@ -168,7 +169,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         SQLExecutor e = SQLExecutor.builder(clusterService)
             .setNumNodes(2)
             .build()
-            .addPartitionedTable(
+            .addTable(
                 TableDefinitions.PARTED_PKS_TABLE_DEFINITION,
                 new PartitionName(new RelationName("doc", "parted_pks"), singletonList("1395874800000")).asIndexName(),
                 new PartitionName(new RelationName("doc", "parted_pks"), singletonList("1395961200000")).asIndexName()
@@ -322,7 +323,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         SQLExecutor e = SQLExecutor.builder(clusterService)
             .setNumNodes(2)
             .build()
-            .addPartitionedTable(
+            .addTable(
                 TableDefinitions.PARTED_PKS_TABLE_DEFINITION,
                 new PartitionName(new RelationName("doc", "parted_pks"), singletonList("1395874800000")).asIndexName(),
                 new PartitionName(new RelationName("doc", "parted_pks"), singletonList("1395961200000")).asIndexName()
@@ -441,7 +442,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         SQLExecutor e = SQLExecutor.builder(clusterService)
             .setNumNodes(2)
             .build()
-            .addPartitionedTable(
+            .addTable(
                 "create table parted (" +
                 "   id int," +
                 "   name string," +
@@ -466,7 +467,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         SQLExecutor e = SQLExecutor.builder(clusterService)
             .setNumNodes(2)
             .build()
-            .addPartitionedTable(
+            .addTable(
                 "create table parted (" +
                 "   id int," +
                 "   name string," +
@@ -524,7 +525,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         SQLExecutor e = SQLExecutor.builder(clusterService)
             .setNumNodes(2)
             .build()
-            .addPartitionedTable(
+            .addTable(
                 "create table parted (" +
                 "   id int," +
                 "   name string," +
@@ -1048,7 +1049,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         SQLExecutor e = SQLExecutor.builder(clusterService)
             .setNumNodes(2)
             .build()
-            .addPartitionedTable(
+            .addTable(
                 "create table parted (" +
                 "   id int," +
                 "   name string," +
@@ -1413,7 +1414,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         SQLExecutor e = SQLExecutor.builder(clusterService)
             .setNumNodes(2)
             .build()
-            .addPartitionedTable(
+            .addTable(
                 "create table doc.parted_by_generated (" +
                 "   ts timestamp without time zone, " +
                 "   p as date_trunc('month', ts) " +

--- a/server/src/test/java/io/crate/planner/UpdatePlannerTest.java
+++ b/server/src/test/java/io/crate/planner/UpdatePlannerTest.java
@@ -80,11 +80,11 @@ public class UpdatePlannerTest extends CrateDummyClusterServiceUnitTest {
             .setNumNodes(2)
             .build()
             .addTable(TableDefinitions.USER_TABLE_DEFINITION)
-            .addPartitionedTable(
+            .addTable(
                 TableDefinitions.PARTED_PKS_TABLE_DEFINITION,
                 new PartitionName(new RelationName("doc", "parted_pks"), singletonList("1395874800000")).asIndexName(),
                 new PartitionName(new RelationName("doc", "parted_pks"), singletonList("1395961200000")).asIndexName())
-            .addPartitionedTable(
+            .addTable(
                 "create table doc.empty_parted (" +
                 "  name text," +
                 "  date timestamp with time zone" +

--- a/server/src/test/java/io/crate/planner/WhereClauseOptimizerTest.java
+++ b/server/src/test/java/io/crate/planner/WhereClauseOptimizerTest.java
@@ -24,6 +24,7 @@ package io.crate.planner;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.isLiteral;
 import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
@@ -53,13 +54,13 @@ public class WhereClauseOptimizerTest extends CrateDummyClusterServiceUnitTest {
             .addTable("create table bystring (name string primary key, score double) " +
                       "clustered by (name) ")
             .addTable("create table clustered_by_only (x int) clustered by (x)")
-            .addPartitionedTable(
+            .addTable(
                 "create table parted (" +
                 "   id int," +
                 "   date timestamp with time zone" +
                 ") partitioned by (date)"
             )
-            .addPartitionedTable(
+            .addTable(
                 "create table parted_pk (" +
                 "   id int primary key, " +
                 "   date timestamp with time zone primary key" +
@@ -68,7 +69,7 @@ public class WhereClauseOptimizerTest extends CrateDummyClusterServiceUnitTest {
                 new PartitionName(new RelationName("doc", "parted_pk"), List.of("1395961200000")).asIndexName(),
                 new PartitionName(new RelationName("doc", "parted_pk"), singletonList(null)).asIndexName()
             )
-            .addPartitionedTable("""
+            .addTable("""
                 create table partdatebin (
                     id int,
                     ts timestamp,
@@ -79,7 +80,7 @@ public class WhereClauseOptimizerTest extends CrateDummyClusterServiceUnitTest {
                 new PartitionName(new RelationName("doc", "partdatebin"), List.of("1687767893000")).asIndexName()
             )
             // Important, ts_month has a type different from date_trunc return type to provoke implicit cast addition
-            .addPartitionedTable("""
+            .addTable("""
                 create table partdatetrunc (
                     ts TIMESTAMP WITHOUT TIME ZONE,
                     ts_month TIMESTAMP as date_trunc('month', ts)
@@ -89,7 +90,7 @@ public class WhereClauseOptimizerTest extends CrateDummyClusterServiceUnitTest {
                 new PartitionName(new RelationName("doc", "partdatetrunc"), List.of("1687767893000")).asIndexName()
             )
             // Important, ts_month doesn't have type declared and expression is just a CAST.
-            .addPartitionedTable("""
+            .addTable("""
                 create table partcast (
                     ts TIMESTAMP WITHOUT TIME ZONE,
                     ts_month as cast(ts as TIMESTAMP WITH TIME ZONE)

--- a/server/src/test/java/io/crate/planner/consumer/GroupByPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/consumer/GroupByPlannerTest.java
@@ -24,6 +24,7 @@ package io.crate.planner.consumer;
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.isReference;
 import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.List;
@@ -574,7 +575,7 @@ public class GroupByPlannerTest extends CrateDummyClusterServiceUnitTest {
         var e = SQLExecutor.builder(clusterService)
             .setNumNodes(2)
             .build()
-            .addPartitionedTable(
+            .addTable(
                 "create table doc.empty_parted (" +
                 "   id integer primary key," +
                 "   date timestamp with time zone primary key" +
@@ -595,7 +596,7 @@ public class GroupByPlannerTest extends CrateDummyClusterServiceUnitTest {
         var e = SQLExecutor.builder(clusterService)
             .setNumNodes(2)
             .build()
-            .addPartitionedTable(
+            .addTable(
                 "create table doc.empty_parted (" +
                 "   id integer primary key," +
                 "   date timestamp with time zone primary key" +
@@ -677,7 +678,7 @@ public class GroupByPlannerTest extends CrateDummyClusterServiceUnitTest {
         var e = SQLExecutor.builder(clusterService)
             .setNumNodes(2)
             .build()
-            .addPartitionedTable(
+            .addTable(
                 "create table doc.clustered_parted (" +
                 "   id integer," +
                 "   date timestamp with time zone," +
@@ -709,7 +710,7 @@ public class GroupByPlannerTest extends CrateDummyClusterServiceUnitTest {
         var e = SQLExecutor.builder(clusterService)
             .setNumNodes(2)
             .build()
-            .addPartitionedTable(
+            .addTable(
                 "create table doc.clustered_parted (" +
                 "   id integer," +
                 "   date timestamp with time zone," +

--- a/server/src/test/java/io/crate/planner/node/ddl/DeletePartitionsTest.java
+++ b/server/src/test/java/io/crate/planner/node/ddl/DeletePartitionsTest.java
@@ -43,7 +43,7 @@ public class DeletePartitionsTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testIndexNameGeneration() throws Exception {
         SQLExecutor e = SQLExecutor.of(clusterService)
-            .addPartitionedTable(
+            .addTable(
                 TableDefinitions.PARTED_PKS_TABLE_DEFINITION,
                 new PartitionName(new RelationName("doc", "parted_pks"), singletonList("1395874800000")).asIndexName(),
                 new PartitionName(new RelationName("doc", "parted_pks"), singletonList("1395961200000")).asIndexName());

--- a/server/src/test/java/io/crate/planner/statement/CopyToPlannerTest.java
+++ b/server/src/test/java/io/crate/planner/statement/CopyToPlannerTest.java
@@ -61,7 +61,7 @@ public class CopyToPlannerTest extends CrateDummyClusterServiceUnitTest {
             .setNumNodes(2)
             .build()
             .addTable(TableDefinitions.USER_TABLE_DEFINITION)
-            .addPartitionedTable(
+            .addTable(
                 "create table parted (" +
                 "   id int," +
                 "   name string," +
@@ -72,7 +72,7 @@ public class CopyToPlannerTest extends CrateDummyClusterServiceUnitTest {
                 new PartitionName(new RelationName("doc", "parted"), singletonList("1395961200000")).asIndexName(),
                 new PartitionName(new RelationName("doc", "parted"), singletonList(null)).asIndexName()
             )
-            .addPartitionedTable(
+            .addTable(
                 "create table parted_generated (" +
                 "   ts timestamp with time zone," +
                 "   day as date_trunc('day', ts)" +

--- a/server/src/test/java/io/crate/replication/logical/action/PublicationsStateActionTest.java
+++ b/server/src/test/java/io/crate/replication/logical/action/PublicationsStateActionTest.java
@@ -263,7 +263,7 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
         };
 
         SQLExecutor.of(clusterService)
-            .addPartitionedTable(
+            .addTable(
                 "CREATE TABLE doc.p1 (id int, p int) partitioned by (p)",
                 new PartitionName(new RelationName("doc", "p1"), singletonList("1")).asIndexName()
             );
@@ -296,7 +296,7 @@ public class PublicationsStateActionTest extends CrateDummyClusterServiceUnitTes
         };
 
         SQLExecutor.of(clusterService)
-            .addPartitionedTable(
+            .addTable(
                 "CREATE TABLE doc.p1 (id int, p int) partitioned by (p)",
                 new PartitionName(new RelationName("doc", "p1"), singletonList("1")).asIndexName()
             );


### PR DESCRIPTION
To ensure unit tests reflect production code logic.
This also uncovered an issue with `IndexReference` not having updated `columns`.

The second commit uncovered an issue where if we don't create template data the
custom schemas wouldn't show up for empty partitioned tables. I included a fix,
but ended up also always creating template data because otherwise
`docTableInfo.writeTo` failed with an error that it can't create template
metadata.

Adapting that needs to be a follow up. Will track that in https://github.com/crate/crate/issues/17518
