### PR TITLE
Add `last_write_before` column to sys.shards

### DIFF
--- a/docs/admin/system-information.rst
+++ b/docs/admin/system-information.rst
@@ -1107,6 +1107,13 @@ Table schema
     * - ``flush_stats['total_time_ns']``
       - The total time spent on flush operations on the shard.
       - ``BIGINT``
+    * - ``last_write_before``
+      - A timestamp showing the latest time that a write operation could have
+        executed against this shard.  The value is held in memory and not
+        persisted through node restarts, so it may only indicate the point at
+        which the node holding the shard started, but the last write is
+        guaranteed to have happened before this timestamp.
+      - ``TIMESTAMP WITH TIME ZONE``
 
 
 .. NOTE::

--- a/docs/appendices/release-notes/6.0.0.rst
+++ b/docs/appendices/release-notes/6.0.0.rst
@@ -331,5 +331,8 @@ Administration and Operations
   session setting that allows partial failures of ``INSERT FROM SELECT``
   statements.
 
+- Added ``last_write_before`` column to the sys.shards table, reporting a
+  timestamp before which the last write operation to the shard has taken place.
+
 Client interfaces
 -----------------

--- a/server/src/main/java/io/crate/metadata/sys/SysShardsTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/sys/SysShardsTableInfo.java
@@ -98,6 +98,7 @@ public class SysShardsTableInfo {
         static final ColumnIdent TRANSLOG_STATS = ColumnIdent.of("translog_stats");
         static final ColumnIdent RETENTION_LEASES = ColumnIdent.of("retention_leases");
         static final ColumnIdent FLUSH_STATS = ColumnIdent.of("flush_stats");
+        static final ColumnIdent LAST_WRITE_BEFORE = ColumnIdent.of("last_write_before");
     }
 
     public static Map<ColumnIdent, RowCollectExpressionFactory<UnassignedShard>> unassignedShardsExpressions() {
@@ -123,7 +124,8 @@ public class SysShardsTableInfo {
             entry(Columns.SEQ_NO_STATS, NestedNullObjectExpression::new),
             entry(Columns.TRANSLOG_STATS, NestedNullObjectExpression::new),
             entry(Columns.RETENTION_LEASES, NestedNullObjectExpression::new),
-            entry(Columns.FLUSH_STATS, NestedNullObjectExpression::new)
+            entry(Columns.FLUSH_STATS, NestedNullObjectExpression::new),
+            entry(Columns.LAST_WRITE_BEFORE, () -> constant(null))
         );
     }
 
@@ -197,6 +199,7 @@ public class SysShardsTableInfo {
                 .add("periodic_count", LONG, ShardRowContext::flushPeriodicCount)
                 .add("total_time_ns", LONG, ShardRowContext::flushTotalTimeNs)
             .endObject()
+            .add(Columns.LAST_WRITE_BEFORE.name(), DataTypes.TIMESTAMPZ, r -> r.indexShard().lastWriteTimestamp())
             .setPrimaryKeys(
                 Columns.SCHEMA_NAME,
                 Columns.TABLE_NAME,

--- a/server/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -122,8 +122,14 @@ public abstract class Engine implements Closeable {
      *    and suddenly merges kick in.
      *  NOTE: don't use this value for anything accurate it's a best effort for freeing up diskspace after merges and on a shard level to reduce index buffer sizes on
      *  inactive shards.
+     *
+     *  We also store the startTimeMillis to have the initial real timestamp of the engine start and
+     *  startTimeNanos to be able to calculate elapsed time in nanos
      */
-    protected volatile long lastWriteNanos = System.nanoTime();
+    private long startTimeMillis = System.currentTimeMillis();
+    private long startTimeNanos = System.nanoTime();
+    protected volatile long lastWriteNanos = startTimeNanos;
+
 
     protected Engine(EngineConfig engineConfig) {
         Objects.requireNonNull(engineConfig.getStore(), "Store must be provided to the engine");
@@ -1578,6 +1584,13 @@ public abstract class Engine implements Closeable {
      */
     public long getLastWriteNanos() {
         return this.lastWriteNanos;
+    }
+
+    /**
+     * Returns the real timestamp of the last write in milliseconds.
+     */
+    public long lastWriteTimestamp() {
+        return this.startTimeMillis + ((lastWriteNanos - startTimeNanos) / 1_000_000);
     }
 
 

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -3142,6 +3142,11 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         return lastSearcherAccess.get();
     }
 
+    public Long lastWriteTimestamp() {
+        Engine engine = getEngineOrNull();
+        return engine == null ? null : engine.lastWriteTimestamp();
+    }
+
     /**
      * Returns true if this shard has some scheduled refresh that is pending because of search-idle.
      */

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -24,7 +24,6 @@ package io.crate.integrationtests;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
 import java.util.List;
@@ -572,7 +571,7 @@ public class InformationSchemaTest extends IntegTestCase {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertThat(response.rowCount()).isEqualTo(1049);
+        assertThat(response.rowCount()).isEqualTo(1050);
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/SysShardsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysShardsTest.java
@@ -68,11 +68,11 @@ public class SysShardsTest extends IntegTestCase {
         execute("create table t1 (x int) clustered into 1 shards with (number_of_replicas = 0)");
         execute("create blob table b1 clustered into 1 shards with (number_of_replicas = 0)");
         execute("create blob table b2 " +
-                "clustered into 1 shards with (number_of_replicas = 0, blobs_path = '" + blobs.toString() + "')");
+            "clustered into 1 shards with (number_of_replicas = 0, blobs_path = '" + blobs.toString() + "')");
         ensureYellow();
 
         execute("select path, blob_path from sys.shards where table_name in ('t1', 'b1', 'b2') " +
-                "order by table_name asc");
+            "order by table_name asc");
         // b1
         // path + /blobs == blob_path without custom blob path
         assertThat(response.rows()[0][0] + resolveCanonicalString("/blobs")).isEqualTo(response.rows()[0][1]);
@@ -100,14 +100,14 @@ public class SysShardsTest extends IntegTestCase {
     public void testSelectGroupByWhereTable() throws Exception {
         SQLResponse response = execute(
             "select count(*), num_docs from sys.shards where table_name = 'characters' " +
-                 "group by num_docs order by count(*)");
+                "group by num_docs order by count(*)");
         assertThat(response.rowCount()).isGreaterThan(0L);
     }
 
     @Test
     public void testSelectGroupByAllTables() throws Exception {
         SQLResponse response = execute("select count(*), table_name from sys.shards " +
-                                       "group by table_name order by table_name");
+            "group by table_name order by table_name");
         assertThat(response.rowCount()).isEqualTo(3L);
         assertThat(response.rows()[0][0]).isEqualTo(10L);
         assertThat(response.rows()[0][1]).isEqualTo("blobs");
@@ -135,7 +135,7 @@ public class SysShardsTest extends IntegTestCase {
     @Test
     public void testSelectGroupByWhereNotLike() throws Exception {
         SQLResponse response = execute("select count(*), table_name from sys.shards " +
-                                       "where table_name not like 'my_table%' group by table_name order by table_name");
+            "where table_name not like 'my_table%' group by table_name order by table_name");
         assertThat(response.rowCount()).isEqualTo(3L);
         assertThat(response.rows()[0][0]).isEqualTo(10L);
         assertThat(response.rows()[0][1]).isEqualTo("blobs");
@@ -149,7 +149,7 @@ public class SysShardsTest extends IntegTestCase {
     public void testSelectWhereTable() throws Exception {
         SQLResponse response = execute(
             "select id, size from sys.shards " +
-            "where table_name = 'characters'");
+                "where table_name = 'characters'");
         assertThat(response.rowCount()).isEqualTo(8L);
     }
 
@@ -169,6 +169,7 @@ public class SysShardsTest extends IntegTestCase {
             "closed",
             "flush_stats",
             "id",
+            "last_write_before",
             "min_lucene_version",
             "node",
             "num_docs",
@@ -214,7 +215,7 @@ public class SysShardsTest extends IntegTestCase {
     @Test
     public void test_translog_stats_can_be_retrieved() {
         execute("SELECT translog_stats, translog_stats['size'] FROM sys.shards " +
-                "WHERE id = 0 AND \"primary\" = true AND table_name = 'characters'");
+            "WHERE id = 0 AND \"primary\" = true AND table_name = 'characters'");
         Object[] resultRow = response.rows()[0];
         Map<String, Object> translogStats = (Map<String, Object>) resultRow[0];
         assertThat(((Number) translogStats.get("size")).longValue()).isEqualTo(resultRow[1]);
@@ -234,7 +235,7 @@ public class SysShardsTest extends IntegTestCase {
     @Test
     public void testSelectOrderBy() throws Exception {
         SQLResponse response = execute("select table_name, min_lucene_version, * " +
-                                       "from sys.shards order by table_name");
+            "from sys.shards order by table_name");
         assertThat(response.rowCount()).isEqualTo(26L);
         List<String> tableNames = Arrays.asList("blobs", "characters", "quotes");
         for (Object[] row : response.rows()) {
@@ -301,7 +302,7 @@ public class SysShardsTest extends IntegTestCase {
     @Test
     public void testGroupByUnknownOrderBy() throws Exception {
         Asserts.assertSQLError(() -> execute(
-            "select sum(num_docs), table_name from sys.shards group by table_name order by lol"))
+                "select sum(num_docs), table_name from sys.shards group by table_name order by lol"))
             .hasPGError(UNDEFINED_COLUMN)
             .hasHTTPError(NOT_FOUND, 4043)
             .hasMessageContaining("Column lol unknown");
@@ -310,7 +311,7 @@ public class SysShardsTest extends IntegTestCase {
     @Test
     public void testGroupByUnknownWhere() throws Exception {
         Asserts.assertSQLError(() -> execute(
-            "select sum(num_docs), table_name from sys.shards where lol='funky' group by table_name"))
+                "select sum(num_docs), table_name from sys.shards where lol='funky' group by table_name"))
             .hasPGError(UNDEFINED_COLUMN)
             .hasHTTPError(NOT_FOUND, 4043)
             .hasMessageContaining("Column lol unknown");
@@ -319,7 +320,7 @@ public class SysShardsTest extends IntegTestCase {
     @Test
     public void testGlobalAggregateUnknownWhere() throws Exception {
         Asserts.assertSQLError(() -> execute(
-            "select sum(num_docs) from sys.shards where lol='funky'"))
+                "select sum(num_docs) from sys.shards where lol='funky'"))
             .hasPGError(UNDEFINED_COLUMN)
             .hasHTTPError(NOT_FOUND, 4043)
             .hasMessageContaining("Column lol unknown");
@@ -328,7 +329,7 @@ public class SysShardsTest extends IntegTestCase {
     @Test
     public void testSelectShardIdFromSysNodes() throws Exception {
         Asserts.assertSQLError(() -> execute(
-            "select sys.shards.id from sys.nodes"))
+                "select sys.shards.id from sys.nodes"))
             .hasPGError(UNDEFINED_TABLE)
             .hasHTTPError(NOT_FOUND, 4041)
             .hasMessageContaining("Relation 'sys.shards' unknown");
@@ -345,9 +346,9 @@ public class SysShardsTest extends IntegTestCase {
     @Test
     public void testSelectGroupByHaving() throws Exception {
         SQLResponse response = execute("select count(*) " +
-                                       "from sys.shards " +
-                                       "group by table_name " +
-                                       "having table_name = 'quotes'");
+            "from sys.shards " +
+            "group by table_name " +
+            "having table_name = 'quotes'");
         assertThat(TestingHelpers.printedTable(response.rows())).isEqualTo("8\n");
     }
 
@@ -367,7 +368,7 @@ public class SysShardsTest extends IntegTestCase {
     public void testSelectNodeSysExpressionWithUnassignedShards() throws Exception {
         try {
             execute("create table users (id integer primary key, name string) " +
-                    "clustered into 5 shards with (number_of_replicas=2, \"write.wait_for_active_shards\"=1)");
+                "clustered into 5 shards with (number_of_replicas=2, \"write.wait_for_active_shards\"=1)");
             ensureYellow();
             SQLResponse response = execute(
                 "select node['name'], id from sys.shards where table_name = 'users' order by node['name'] nulls last"
@@ -384,9 +385,9 @@ public class SysShardsTest extends IntegTestCase {
     @Test
     public void testSelectRecoveryExpression() throws Exception {
         SQLResponse response = execute("select recovery, " +
-                                       "recovery['files'], recovery['files']['used'], recovery['files']['reused'], recovery['files']['recovered'], " +
-                                       "recovery['size'], recovery['size']['used'], recovery['size']['reused'], recovery['size']['recovered'] " +
-                                       "from sys.shards");
+            "recovery['files'], recovery['files']['used'], recovery['files']['reused'], recovery['files']['recovered'], " +
+            "recovery['size'], recovery['size']['used'], recovery['size']['reused'], recovery['size']['recovered'] " +
+            "from sys.shards");
         for (Object[] row : response.rows()) {
             Map<String, Object> recovery = (Map<String, Object>) row[0];
             Map<String, Integer> files = (Map<String, Integer>) row[1];
@@ -402,7 +403,7 @@ public class SysShardsTest extends IntegTestCase {
         execute("create table t1 (id integer) clustered into 1 shards with (number_of_replicas=0)");
         ensureYellow();
         Asserts.assertSQLError(() -> execute(
-            "select 1/0 from sys.shards"))
+                "select 1/0 from sys.shards"))
             .hasPGError(INTERNAL_ERROR)
             .hasHTTPError(BAD_REQUEST, 4000)
             .hasMessageContaining("/ by zero");
@@ -428,7 +429,7 @@ public class SysShardsTest extends IntegTestCase {
         int numberOfReplicas = numberOfReplicas();
         execute(
             "create table doc.tbl (x int) with (number_of_replicas = ?)",
-            new Object[] { numberOfReplicas }
+            new Object[]{numberOfReplicas}
         );
         execute("insert into doc.tbl values(1)");
         ensureGreen(); // All shards must be available before close; otherwise they're skipped
@@ -461,5 +462,23 @@ public class SysShardsTest extends IntegTestCase {
                 e -> Asserts.assertThat(e)
                     .isExactlyInstanceOf(ClusterBlockException.class)
                     .hasMessageContaining("Table or partition preparing to close."));
+    }
+
+    @Test
+    public void test_last_write_before() {
+        long startTime = System.currentTimeMillis();
+        execute("create table doc.tbl (x int) clustered into 1 shards with(number_of_replicas=0)");
+        execute("insert into doc.tbl values(1)");
+        execute("refresh table doc.tbl");
+
+        execute("select last_write_before from sys.shards where table_name = 'tbl'");
+        long lastTimeBefore1 = (long) response.rows()[0][0];
+        assertThat(lastTimeBefore1).isGreaterThan(startTime);
+
+        execute("update doc.tbl set x = x + 1");
+        execute("refresh table doc.tbl");
+        execute("select last_write_before from sys.shards where table_name = 'tbl'");
+        long lastTimeBefore2 = (long) response.rows()[0][0];
+        assertThat(lastTimeBefore2).isGreaterThan(lastTimeBefore1);
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/UnassignedShardsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/UnassignedShardsTest.java
@@ -37,5 +37,7 @@ public class UnassignedShardsTest extends IntegTestCase {
         execute("select state, id, table_name from sys.shards where schema_name = ? AND table_name='t' order by state", new Object[]{sqlExecutor.getCurrentSchema()});
         assertThat(TestingHelpers.printedTable(response.rows())).isEqualTo("STARTED| 0| t\n" +
                "UNASSIGNED| 0| t\n");
+        execute("select state, last_write_before from sys.shards where state = 'UNASSIGNED'");
+        assertThat(TestingHelpers.printedTable(response.rows())).isEqualTo("UNASSIGNED| NULL\n");
     }
 }


### PR DESCRIPTION
This returns a timestamp before which the last write to the shard is guaranteed to have happened.  The value is not persisted across restarts, so may only report the time at which the node started, but it can be used as a hard end time for the last write.

Relates to #17481
