### PR TITLE
Adapt object casts to be consistent related to the column policy

### DIFF
--- a/docs/appendices/release-notes/6.0.0.rst
+++ b/docs/appendices/release-notes/6.0.0.rst
@@ -64,6 +64,15 @@ Breaking Changes
   The setting defaulted to ``true`` since 4.3.0, was deprecated in 4.5.0 and
   soft deletes became mandatory in 5.0.0.
 
+- When casting an expression of type :ref:`OBJECT <type-object>` to an
+  :ref:`OBJECT <type-object>`, the inner types are merged instead of being
+  replaced by the target type and the target
+  :ref:`column policy <type-object-column-policy>` is used. The only exception
+  is when the target column policy is set to
+  :ref:`STRICT <type-object-columns-strict>`. In this case, only the target
+  inner type definition is used. See also the related
+  :ref:`documentation <cast_to_object>`
+
 Deprecations
 ============
 

--- a/docs/general/builtins/scalar-functions.rst
+++ b/docs/general/builtins/scalar-functions.rst
@@ -3583,9 +3583,11 @@ Returns: ``array(text)``
 
 The ``concat(object, object)`` function combines two objects into a new object
 containing the union of their first level properties, taking the second
-object's values for duplicate properties.  If one of the objects is ``NULL``,
-the function returns the non-``NULL`` object. If both objects are ``NULL``,
-the function returns ``NULL``.
+object's values for duplicate properties. Additionally, the
+:ref:`column policy <type-object-column-policy>` of the second object is used
+for the return type. If one of the objects is ``NULL``, the function returns
+the non-``NULL`` object. If both objects are ``NULL``,the function returns
+``NULL``.
 
 Returns: ``object``
 

--- a/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -1677,7 +1677,7 @@ public class TestStatementBuilder {
     }
 
     @Test
-    void test_array_overlap_operator() {
+    public void test_array_overlap_operator() {
         Expression expression = SqlParser.createExpression("[1] && [2]");
         assertThat(expression).isExactlyInstanceOf(FunctionCall.class);
         FunctionCall functionCall = (FunctionCall) expression;
@@ -2167,7 +2167,7 @@ public class TestStatementBuilder {
     }
 
     @Test
-    void test_alter_server() {
+    public void test_alter_server() {
         printStatement("ALTER SERVER jarvis OPTIONS (ADD host 'foo', SET dbname 'cratedb', DROP port)");
         printStatement("ALTER SERVER jarvis OPTIONS (ADD host 'foo')");
         printStatement("ALTER SERVER jarvis OPTIONS (SET dbname 'cratedb')");
@@ -2177,7 +2177,7 @@ public class TestStatementBuilder {
 
     @SuppressWarnings("unchecked")
     @Test
-    void test_alter_server_default_option_operation_is_add() {
+    public void test_alter_server_default_option_operation_is_add() {
         AlterServer<Expression> alterServer = (AlterServer<Expression>) SqlParser.createStatement("ALTER SERVER jarvis OPTIONS (host 'foo')");
         assertThat(alterServer.options()).contains(new AlterServer.Option<>(AlterServer.Operation.ADD, "host", new StringLiteral("foo")));
     }
@@ -2286,7 +2286,8 @@ public class TestStatementBuilder {
 
             println(SqlFormatter.formatSql(statement));
             println("");
-            assertFormattedSql(statement);
+            assertFormattedSql(statement, SqlFormatter::formatSql);
+            assertFormattedSql(statement, SqlFormatter::formatSqlInline);
         }
 
         println("=".repeat(60));

--- a/libs/sql-parser/src/test/java/io/crate/sql/parser/TreeAssertions.java
+++ b/libs/sql-parser/src/test/java/io/crate/sql/parser/TreeAssertions.java
@@ -21,13 +21,13 @@
 
 package io.crate.sql.parser;
 
-import static io.crate.sql.SqlFormatter.formatSql;
 import static io.crate.sql.parser.SqlParser.createStatement;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 
 import io.crate.common.collections.Lists;
 import io.crate.sql.tree.DefaultTraversalVisitor;
@@ -37,12 +37,12 @@ import io.crate.sql.tree.Statement;
 final class TreeAssertions {
     private TreeAssertions() {}
 
-    static void assertFormattedSql(Node expected) {
-        String formatted = formatSql(expected);
+    static void assertFormattedSql(Node expected, Function<Node, String> formatter) {
+        String formatted = formatter.apply(expected);
 
         // verify round-trip of formatting already-formatted SQL
         Statement actual = parseFormatted(formatted, expected);
-        assertThat(formatSql(actual)).isEqualTo(formatted);
+        assertThat(formatter.apply(actual)).isEqualTo(formatted);
 
         // compare parsed tree with parsed tree of formatted SQL
         if (!actual.equals(expected)) {

--- a/server/src/main/java/io/crate/expression/scalar/SubscriptFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/SubscriptFunction.java
@@ -222,19 +222,19 @@ public class SubscriptFunction extends Scalar<Object, Object> {
             }
             return result;
         } else if (base instanceof Map<?, ?> map) {
-            if (!map.containsKey(name)) {
-                ColumnPolicy columnPolicy = baseType.columnPolicy();
+            Object value = map.get(name);
+            ColumnPolicy columnPolicy = baseType.columnPolicy();
+            if (value == null) {
                 assert baseType instanceof ObjectType;
                 ObjectType objType = (ObjectType) baseType;
                 if (columnPolicy == ColumnPolicy.IGNORED
                     || (columnPolicy == ColumnPolicy.DYNAMIC && !errorOnUnknownObjectKey)
-                    || objType.innerTypes().containsKey(name)) {
+                    || (objType.innerTypes().containsKey(name))) {
                     return null;
                 }
                 throw ColumnUnknownException.ofUnknownRelation("The object `" + base + "` does not contain the key `" + name + "`");
-            } else {
-                return map.get(name);
             }
+            return value;
         } else {
             throw new IllegalArgumentException("Base argument to subscript must be an object or array-of-objects, not " + base);
         }

--- a/server/src/main/java/io/crate/expression/scalar/object/ObjectMergeFunction.java
+++ b/server/src/main/java/io/crate/expression/scalar/object/ObjectMergeFunction.java
@@ -41,7 +41,7 @@ public class ObjectMergeFunction extends Scalar<Map<String, Object>, Map<String,
         } else if (right instanceof ObjectType == false) {
             return left;
         }
-        return ObjectType.merge((ObjectType) left, (ObjectType) right, (l, r) -> r);
+        return ObjectType.merge((ObjectType) left, (ObjectType) right, (l, r) -> r, right.columnPolicy());
     }
 
     public ObjectMergeFunction(Signature signature, BoundSignature boundSignature) {

--- a/server/src/main/java/io/crate/types/ArrayType.java
+++ b/server/src/main/java/io/crate/types/ArrayType.java
@@ -391,11 +391,11 @@ public class ArrayType<T> extends DataType<List<T>> {
     }
 
     @Override
-    DataType<?> merge(DataType<?> other) {
+    DataType<?> merge(DataType<?> other, ColumnPolicy columnPolicy) {
         if (other instanceof ArrayType<?> o) {
             return new ArrayType<>(DataTypes.merge(this.innerType, o.innerType));
         } else {
-            return super.merge(other);
+            return super.merge(other, columnPolicy);
         }
     }
 
@@ -528,5 +528,13 @@ public class ArrayType<T> extends DataType<List<T>> {
     @Override
     public ColumnPolicy columnPolicy() {
         return innerType.columnPolicy();
+    }
+
+    @Override
+    public DataType<List<T>> withColumnPolicy(ColumnPolicy columnPolicy) {
+        if (innerType.columnPolicy() == columnPolicy) {
+            return this;
+        }
+        return new ArrayType<>(innerType.withColumnPolicy(columnPolicy));
     }
 }

--- a/server/src/main/java/io/crate/types/DataType.java
+++ b/server/src/main/java/io/crate/types/DataType.java
@@ -239,7 +239,7 @@ public abstract class DataType<T> implements Comparable<DataType<?>>, Writeable,
         return possibleConversions.contains(other.id());
     }
 
-    DataType<?> merge(DataType<?> other) {
+    DataType<?> merge(DataType<?> other, ColumnPolicy columnPolicy) {
         assert this.id() == other.id() || this.precedes(other) : "'this' precedes 'other' or they must be the same type";
         if (other.isConvertableTo(this, false)) {
             return this;
@@ -345,5 +345,9 @@ public abstract class DataType<T> implements Comparable<DataType<?>>, Writeable,
 
     public ColumnPolicy columnPolicy() {
         return ColumnPolicy.STRICT;
+    }
+
+    public DataType<T> withColumnPolicy(ColumnPolicy columnPolicy) {
+        return this;
     }
 }

--- a/server/src/main/java/io/crate/types/DataTypes.java
+++ b/server/src/main/java/io/crate/types/DataTypes.java
@@ -609,6 +609,10 @@ public final class DataTypes {
     }
 
     public static DataType<?> merge(DataType<?> leftType, DataType<?> rightType) {
+        return merge(leftType, rightType, ColumnPolicy.DYNAMIC);
+    }
+
+    public static DataType<?> merge(DataType<?> leftType, DataType<?> rightType, ColumnPolicy columnPolicy) {
         final DataType<?> higher;
         final DataType<?> lower;
         if (leftType.precedes(rightType)) {
@@ -618,7 +622,7 @@ public final class DataTypes {
             higher = rightType;
             lower = leftType;
         }
-        return higher.merge(lower);
+        return higher.merge(lower, columnPolicy);
     }
 
     public static DataType<?> fromId(Integer id) {

--- a/server/src/main/java/io/crate/types/NumericType.java
+++ b/server/src/main/java/io/crate/types/NumericType.java
@@ -42,6 +42,7 @@ import org.jetbrains.annotations.Nullable;
 
 import io.crate.Streamer;
 import io.crate.sql.tree.ColumnDefinition;
+import io.crate.sql.tree.ColumnPolicy;
 import io.crate.sql.tree.ColumnType;
 import io.crate.sql.tree.Expression;
 
@@ -176,11 +177,11 @@ public class NumericType extends DataType<BigDecimal> implements Streamer<BigDec
     }
 
     @Override
-    DataType<?> merge(DataType<?> other) {
+    DataType<?> merge(DataType<?> other, ColumnPolicy columnPolicy) {
         if (DataTypes.isNumeric(other)) { // if 'other' is a number type
             return NumericType.INSTANCE;
         } else {
-            return super.merge(other);
+            return super.merge(other, columnPolicy);
         }
     }
 

--- a/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -33,7 +33,6 @@ import static io.crate.testing.Asserts.isReference;
 import static io.crate.testing.Asserts.toCondition;
 import static io.crate.types.ArrayType.makeArray;
 import static org.assertj.core.api.Assertions.anyOf;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
@@ -2522,7 +2521,8 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         executor.getSessionSettings().setErrorOnUnknownObjectKey(true);
         assertThatThrownBy(() -> executor.analyze("SELECT ''::OBJECT['x']"))
             .isExactlyInstanceOf(ColumnUnknownException.class)
-            .hasMessageContaining("The object `{}` does not contain the key `x`");
+            .hasMessageContaining("The cast of `''` to return type `OBJECT(DYNAMIC)` does not contain the key `x`.\n" +
+                "Consider to include inner type definition in the `OBJECT` type while casting, disable DYNAMIC unknown key errors by the `error_on_unknown_object_key` setting or cast to `OBJECT(IGNORED)`.");
         executor.getSessionSettings().setErrorOnUnknownObjectKey(false);
         var analyzed = executor.analyze("SELECT ''::OBJECT['x']");
         assertThat(analyzed.outputs()).hasSize(1);
@@ -2531,7 +2531,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         executor.getSessionSettings().setErrorOnUnknownObjectKey(true);
         assertThatThrownBy(() -> executor.analyze("select (['{\"x\":1,\"y\":2}','{\"y\":2,\"z\":3}']::ARRAY(OBJECT))['x']"))
             .isExactlyInstanceOf(ColumnUnknownException.class)
-            .hasMessageContaining("The object `{y=2, z=3}` does not contain the key `x`");
+            .hasMessageContaining("The return type `ARRAY(OBJECT(DYNAMIC))` of the expression `[cast('{\"x\":1,\"y\":2}' AS OBJECT(DYNAMIC)), cast('{\"y\":2,\"z\":3}' AS OBJECT(DYNAMIC))]` does not contain the key `x`");
         executor.getSessionSettings().setErrorOnUnknownObjectKey(false);
         analyzed = executor.analyze("select (['{\"x\":1,\"y\":2}','{\"y\":2,\"z\":3}']::ARRAY(OBJECT))['x']");
         assertThat(analyzed.outputs()).hasSize(1);
@@ -3098,25 +3098,26 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
 
         // DYNAMIC object cast
         executor.getSessionSettings().setErrorOnUnknownObjectKey(true);
-        // If not wrapped into a sub-select, the JSON string expression gets normalized and results in a typed object literal
-        var analyzed = executor.analyze("SELECT '{\"a\":1}'::OBJECT['a']");
-        assertThat(analyzed.outputs().getFirst()).isLiteral(1, DataTypes.INTEGER);
-        // Normalization is not possible on references, such the return type is unknown
-        analyzed = executor.analyze("SELECT js::OBJECT['a'] FROM t1");
-        assertThat(analyzed.outputs().getFirst()).isFunction("subscript", DataTypes.UNDEFINED);
-
-        // Once wrapped, the subscript function gets resolved before any normalization, resulting in an exception
+        // Subscript on literals
+        assertThatThrownBy(() -> executor.analyze("SELECT '{\"a\":1}'::OBJECT['a']"))
+            .isExactlyInstanceOf(ColumnUnknownException.class)
+            .hasMessageContaining("The cast of `'{\"a\":1}'` to return type `OBJECT(DYNAMIC)` does not contain the key `a`.\n" +
+                "Consider to include inner type definition in the `OBJECT` type while casting, disable DYNAMIC unknown key errors by the `error_on_unknown_object_key` setting or cast to `OBJECT(IGNORED)`.");
         assertThatThrownBy(() -> executor.analyze("SELECT myobj['a'] FROM (SELECT '{\"a\":1}'::OBJECT as myobj) t"))
             .isExactlyInstanceOf(ColumnUnknownException.class)
             .hasMessageContaining("Column myobj['a'] unknown");
-        // Same for references, but no normalization is possible anyway
+        // Subscript on references
+        assertThatThrownBy(() -> executor.analyze("SELECT js::OBJECT AS (b int)['a'] FROM t1"))
+            .isExactlyInstanceOf(ColumnUnknownException.class)
+            .hasMessageContaining("The cast of `doc.t1.js` to return type `OBJECT(DYNAMIC) AS (\"b\" INTEGER)` does not contain the key `a`.\n" +
+                "Consider to include inner type definition in the `OBJECT` type while casting, disable DYNAMIC unknown key errors by the `error_on_unknown_object_key` setting or cast to `OBJECT(IGNORED)`.");
         assertThatThrownBy(() -> executor.analyze("SELECT myobj['a'] FROM (SELECT js::OBJECT as myobj FROM t1) t"))
             .isExactlyInstanceOf(ColumnUnknownException.class)
             .hasMessageContaining("Column myobj['a'] unknown");
 
         // Disabling error on unknown object key allows to use subscript without any error even that it is untyped
         executor.getSessionSettings().setErrorOnUnknownObjectKey(false);
-        analyzed = executor.analyze("SELECT myobj['a'] FROM (SELECT '{\"a\":1}'::OBJECT as myobj) t");
+        var analyzed = executor.analyze("SELECT myobj['a'] FROM (SELECT '{\"a\":1}'::OBJECT as myobj) t");
         assertThat(analyzed.outputs().getFirst()).isFunction("subscript", DataTypes.UNDEFINED);
         // Same for references
         analyzed = executor.analyze("SELECT myobj['a'] FROM (SELECT js::OBJECT as myobj FROM t1) t");

--- a/server/src/test/java/io/crate/expression/scalar/ParseURIFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ParseURIFunctionTest.java
@@ -21,12 +21,17 @@
 
 package io.crate.expression.scalar;
 
-import org.junit.Test;
-
-import io.crate.common.collections.MapBuilder;
+import static io.crate.testing.Asserts.isLiteral;
 
 import java.util.Locale;
 import java.util.Map;
+
+import org.junit.Test;
+
+import io.crate.common.collections.MapBuilder;
+import io.crate.sql.tree.ColumnPolicy;
+import io.crate.types.DataTypes;
+import io.crate.types.ObjectType;
 
 public class ParseURIFunctionTest extends ScalarTestCase {
 
@@ -47,7 +52,17 @@ public class ParseURIFunctionTest extends ScalarTestCase {
             .put("query", null)
             .put("fragment", null)
             .map();
-        assertEvaluate(String.format(Locale.ENGLISH,"parse_uri('%s')", uri), value);
+
+        ObjectType expectedType = ObjectType.of(ColumnPolicy.DYNAMIC)
+            .setInnerType("scheme", DataTypes.STRING)
+            .setInnerType("userinfo", DataTypes.STRING)
+            .setInnerType("hostname", DataTypes.STRING)
+            .setInnerType("port", DataTypes.INTEGER)
+            .setInnerType("path", DataTypes.STRING)
+            .setInnerType("query", DataTypes.STRING)
+            .setInnerType("fragment", DataTypes.STRING)
+            .build();
+        assertNormalize(String.format(Locale.ENGLISH,"parse_uri('%s')", uri), isLiteral(value, expectedType));
     }
 
     @Test
@@ -94,5 +109,4 @@ public class ParseURIFunctionTest extends ScalarTestCase {
             .map();
         assertEvaluate(String.format(Locale.ENGLISH,"parse_uri('%s')", uri), value);
     }
-
 }

--- a/server/src/test/java/io/crate/expression/scalar/ParseURLFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/ParseURLFunctionTest.java
@@ -21,14 +21,19 @@
 
 package io.crate.expression.scalar;
 
-import org.junit.Test;
-
-import io.crate.common.collections.MapBuilder;
+import static io.crate.testing.Asserts.isLiteral;
 
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Stream;
+
+import org.junit.Test;
+
+import io.crate.common.collections.MapBuilder;
+import io.crate.sql.tree.ColumnPolicy;
+import io.crate.types.DataTypes;
+import io.crate.types.ObjectType;
 
 public class ParseURLFunctionTest extends ScalarTestCase {
 
@@ -50,7 +55,17 @@ public class ParseURLFunctionTest extends ScalarTestCase {
             .put("parameters", null)
             .put("fragment", null)
             .map();
-        assertEvaluate(String.format(Locale.ENGLISH,"parse_url('%s')", uri), value);
+        ObjectType expectedType = ObjectType.of(ColumnPolicy.DYNAMIC)
+            .setInnerType("scheme", DataTypes.STRING)
+            .setInnerType("userinfo", DataTypes.STRING)
+            .setInnerType("hostname", DataTypes.STRING)
+            .setInnerType("port", DataTypes.INTEGER)
+            .setInnerType("path", DataTypes.STRING)
+            .setInnerType("query", DataTypes.STRING)
+            .setInnerType("fragment", DataTypes.STRING)
+            .setInnerType("parameters", ObjectType.of(ColumnPolicy.DYNAMIC).build())
+            .build();
+        assertNormalize(String.format(Locale.ENGLISH,"parse_url('%s')", uri), isLiteral(value, expectedType));
     }
 
     @Test

--- a/server/src/test/java/io/crate/expression/scalar/SubscriptFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/SubscriptFunctionTest.java
@@ -106,8 +106,8 @@ public class SubscriptFunctionTest extends ScalarTestCase {
     public void testIndexExpressionIsNotInteger() throws Exception {
         assertThatThrownBy(
             () -> assertNormalize("subscript(['Youri', 'Ruben'], 'foo')", isLiteral("Ruben")))
-            .isExactlyInstanceOf(ConversionException.class)
-                .hasMessage("Cannot cast `'foo'` of type `text` to type `integer`");
+            .isExactlyInstanceOf(ColumnUnknownException.class)
+            .hasMessage("Column text_array['foo'] unknown");
     }
 
     @Test
@@ -141,7 +141,7 @@ public class SubscriptFunctionTest extends ScalarTestCase {
         sqlExpressions.setErrorOnUnknownObjectKey(true);
         assertThatThrownBy(() -> assertEvaluate("{}::object(strict)['missing_key']", null))
             .isExactlyInstanceOf(ColumnUnknownException.class)
-            .hasMessageContaining("The object `{}` does not contain the key `missing_key`");
+            .hasMessageContaining("Column object['missing_key'] unknown");
         assertThatThrownBy(() -> assertEvaluate("{}::object(dynamic)['missing_key']", null))
             .isExactlyInstanceOf(ColumnUnknownException.class)
             .hasMessageContaining("The object `{}` does not contain the key `missing_key`");
@@ -149,7 +149,7 @@ public class SubscriptFunctionTest extends ScalarTestCase {
         sqlExpressions.setErrorOnUnknownObjectKey(false);
         assertThatThrownBy(() -> assertEvaluate("{}::object(strict)['missing_key']", null))
             .isExactlyInstanceOf(ColumnUnknownException.class)
-            .hasMessageContaining("The object `{}` does not contain the key `missing_key`");
+            .hasMessageContaining("Column object['missing_key'] unknown");
         assertEvaluateNull("{}::object(dynamic)['missing_key']");
         assertEvaluateNull("{}::object(ignored)['missing_key']");
     }

--- a/server/src/test/java/io/crate/expression/scalar/SubscriptFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/SubscriptFunctionTest.java
@@ -107,7 +107,7 @@ public class SubscriptFunctionTest extends ScalarTestCase {
         assertThatThrownBy(
             () -> assertNormalize("subscript(['Youri', 'Ruben'], 'foo')", isLiteral("Ruben")))
             .isExactlyInstanceOf(ColumnUnknownException.class)
-            .hasMessage("Column text_array['foo'] unknown");
+            .hasMessage("The return type `ARRAY(TEXT)` of the expression `['Youri', 'Ruben']` does not contain the key `foo`");
     }
 
     @Test
@@ -115,7 +115,7 @@ public class SubscriptFunctionTest extends ScalarTestCase {
         sqlExpressions.setErrorOnUnknownObjectKey(true);
         assertThatThrownBy(() -> assertEvaluate("{}['y']", null))
             .isExactlyInstanceOf(ColumnUnknownException.class)
-            .hasMessageContaining("The object `{}` does not contain the key `y`");
+            .hasMessageContaining("The literal `{}` does not contain the key `y`");
         sqlExpressions.setErrorOnUnknownObjectKey(false);
         assertEvaluateNull("{}['y']");
     }
@@ -125,7 +125,7 @@ public class SubscriptFunctionTest extends ScalarTestCase {
         sqlExpressions.setErrorOnUnknownObjectKey(true);
         assertThatThrownBy(() -> assertEvaluate("[{}]['y']", null))
             .isExactlyInstanceOf(ColumnUnknownException.class)
-            .hasMessageContaining("The object `{}` does not contain the key `y`");
+            .hasMessageContaining("The return type `ARRAY(OBJECT(DYNAMIC))` of the expression `[{}]` does not contain the key `y`");
 
         sqlExpressions.setErrorOnUnknownObjectKey(false);
         assertNormalize("[{}]['y']", isLiteral(Arrays.stream(new Object[1]).toList()));
@@ -141,15 +141,16 @@ public class SubscriptFunctionTest extends ScalarTestCase {
         sqlExpressions.setErrorOnUnknownObjectKey(true);
         assertThatThrownBy(() -> assertEvaluate("{}::object(strict)['missing_key']", null))
             .isExactlyInstanceOf(ColumnUnknownException.class)
-            .hasMessageContaining("Column object['missing_key'] unknown");
+            .hasMessageContaining("The cast of `{}` to return type `OBJECT(STRICT)` does not contain the key `missing_key`.")
+            .hasMessageContaining("Consider to include inner type definition in the `OBJECT` type while casting, disable DYNAMIC unknown key errors by the `error_on_unknown_object_key` setting or cast to `OBJECT(IGNORED)`.");
         assertThatThrownBy(() -> assertEvaluate("{}::object(dynamic)['missing_key']", null))
             .isExactlyInstanceOf(ColumnUnknownException.class)
-            .hasMessageContaining("The object `{}` does not contain the key `missing_key`");
+            .hasMessageContaining("The literal `{}` does not contain the key `missing_key`");
         assertEvaluateNull("{}::object(ignored)['missing_key']");
         sqlExpressions.setErrorOnUnknownObjectKey(false);
         assertThatThrownBy(() -> assertEvaluate("{}::object(strict)['missing_key']", null))
             .isExactlyInstanceOf(ColumnUnknownException.class)
-            .hasMessageContaining("Column object['missing_key'] unknown");
+            .hasMessageContaining("The cast of `{}` to return type `OBJECT(STRICT)` does not contain the key `missing_key`.");
         assertEvaluateNull("{}::object(dynamic)['missing_key']");
         assertEvaluateNull("{}::object(ignored)['missing_key']");
     }

--- a/server/src/test/java/io/crate/expression/scalar/cast/CastFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/cast/CastFunctionTest.java
@@ -359,7 +359,8 @@ public class CastFunctionTest extends ScalarTestCase {
     public void test_cast_object_to_object_uses_target_column_policy() {
         assertThatThrownBy(() -> assertNormalize("({a=1}::OBJECT(STRICT) AS (b TEXT))['a']", isLiteral(1, DataTypes.INTEGER)))
             .isExactlyInstanceOf(ColumnUnknownException.class)
-            .hasMessageContaining("Column object['a'] unknown");
+            .hasMessageContaining("The cast of `_map('a', 1)` to return type `OBJECT(STRICT) AS (\"b\" TEXT)` does not contain the key `a`.\n" +
+                "Consider to include inner type definition in the `OBJECT` type while casting, disable DYNAMIC unknown key errors by the `error_on_unknown_object_key` setting or cast to `OBJECT(IGNORED)`.");
 
         // Nested objects will also receive the target column policy
         var expectedType = ObjectType.of(ColumnPolicy.IGNORED)

--- a/server/src/test/java/io/crate/expression/scalar/systeminformation/PgTypeofFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/systeminformation/PgTypeofFunctionTest.java
@@ -161,11 +161,11 @@ public class PgTypeofFunctionTest extends ScalarTestCase {
         // Fields does not exist
         // STRICT (error based on type definition)
         assertThatThrownBy(() -> assertNormalize("pg_typeof({x=1}::object(STRICT)['y'])", isLiteral("")))
-            .hasMessage("Column object['y'] unknown");
+            .hasMessageContaining("The cast of `_map('x', 1)` to return type `OBJECT(STRICT)` does not contain the key `y`");
 
-        // DYNAMIC (error while evaluating the expression)
+        // DYNAMIC (different error as the `::OBJECT(DYNAMIC)` cast gets normalized away due to object cast merges)
         assertThatThrownBy(() -> assertNormalize("pg_typeof({x=1}::object(DYNAMIC)['y'])", isLiteral("")))
-            .hasMessage("The object `{x=1}` does not contain the key `y`");
+            .hasMessageContaining("The return type `OBJECT(DYNAMIC) AS (\"x\" INTEGER)` of the expression `_map('x', 1)` does not contain the key `y`");
 
         // IGNORED
         assertNormalize("pg_typeof({x=1}::object(IGNORED)['y'])", isLiteral(DataTypes.UNDEFINED.getName()));

--- a/server/src/test/java/io/crate/expression/scalar/systeminformation/PgTypeofFunctionTest.java
+++ b/server/src/test/java/io/crate/expression/scalar/systeminformation/PgTypeofFunctionTest.java
@@ -159,11 +159,11 @@ public class PgTypeofFunctionTest extends ScalarTestCase {
         assertNormalize("pg_typeof({x=1}['x'])", isLiteral(DataTypes.INTEGER.getName()));
 
         // Fields does not exist
-        // STRICT
+        // STRICT (error based on type definition)
         assertThatThrownBy(() -> assertNormalize("pg_typeof({x=1}::object(STRICT)['y'])", isLiteral("")))
-            .hasMessage("The object `{x=1}` does not contain the key `y`");
+            .hasMessage("Column object['y'] unknown");
 
-        // DYNAMIC
+        // DYNAMIC (error while evaluating the expression)
         assertThatThrownBy(() -> assertNormalize("pg_typeof({x=1}::object(DYNAMIC)['y'])", isLiteral("")))
             .hasMessage("The object `{x=1}` does not contain the key `y`");
 

--- a/server/src/test/java/io/crate/integrationtests/CreateTableAsIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/CreateTableAsIntegrationTest.java
@@ -150,12 +150,14 @@ public class CreateTableAsIntegrationTest extends IntegTestCase {
         // STRICT (error based on type definition)
         assertThatThrownBy(() -> execute("CREATE TABLE test_strict AS \n" +
             "SELECT '{\"field1\":123}'::OBJECT (STRICT) AS (field1 BIGINT) ['field2']"))
-            .hasMessageContaining("Column object['field2'] unknown");
+            .hasMessageContaining("The cast of `'{\"field1\":123}'` to return type `OBJECT(STRICT) AS (\"field1\" BIGINT)` does not contain the key `field2`.\n" +
+                "Consider to include inner type definition in the `OBJECT` type while casting, disable DYNAMIC unknown key errors by the `error_on_unknown_object_key` setting or cast to `OBJECT(IGNORED)`.");
 
-        // DYNAMIC (error while evaluating the expression)
+        // DYNAMIC (error based on type definition)
         assertThatThrownBy(() -> execute("CREATE TABLE test_dynamic AS \n" +
             "SELECT '{\"field1\":123}'::OBJECT (DYNAMIC) AS (field1 BIGINT) ['field2']"))
-            .hasMessageContaining("The object `{field1=123}` does not contain the key `field2`");
+            .hasMessageContaining("The cast of `'{\"field1\":123}'` to return type `OBJECT(DYNAMIC) AS (\"field1\" BIGINT)` does not contain the key `field2`.\n" +
+                "Consider to include inner type definition in the `OBJECT` type while casting, disable DYNAMIC unknown key errors by the `error_on_unknown_object_key` setting or cast to `OBJECT(IGNORED)`.");
 
         // IGNORED (error while using an undefined column as it cannot be stored)
         assertThatThrownBy(() -> execute("CREATE TABLE test_ignored AS \n" +

--- a/server/src/test/java/io/crate/integrationtests/ScalarIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/ScalarIntegrationTest.java
@@ -53,11 +53,12 @@ public class ScalarIntegrationTest extends IntegTestCase {
                         session))
                 .isExactlyInstanceOf(ColumnUnknownException.class)
                 .hasMessageContaining("The object `{y=2, z=3}` does not contain the key `x`");
+            // Different error due to wrapping the unnest in an array
             Assertions.assertThatThrownBy(() -> sqlExecutor.exec(
                     "SELECT [unnest]['x'] FROM UNNEST(['{\"x\":1,\"y\":2}','{\"y\":2,\"z\":3}']::ARRAY(OBJECT))",
                     session))
                 .isExactlyInstanceOf(ColumnUnknownException.class)
-                .hasMessageContaining("The object `{y=2, z=3}` does not contain the key `x`");
+                .hasMessageContaining("The return type `ARRAY(OBJECT(DYNAMIC))` of the expression `[unnest.unnest]` does not contain the key `x`");
         }
 
         try (var session2 = sqlExecutor.newSession()) {

--- a/server/src/testFixtures/java/io/crate/testing/SqlExpressions.java
+++ b/server/src/testFixtures/java/io/crate/testing/SqlExpressions.java
@@ -56,7 +56,7 @@ import io.crate.sql.parser.SqlParser;
 public class SqlExpressions {
 
     private final ExpressionAnalyzer expressionAnalyzer;
-    private final ExpressionAnalysisContext expressionAnalysisCtx;
+    private ExpressionAnalysisContext expressionAnalysisCtx;
     private final CoordinatorTxnCtx coordinatorTxnCtx;
     private final EvaluatingNormalizer normalizer;
     public final NodeContext nodeCtx;
@@ -134,5 +134,7 @@ public class SqlExpressions {
 
     public void setErrorOnUnknownObjectKey(boolean errorOnUnknownObjectKey) {
         this.coordinatorTxnCtx.sessionSettings().setErrorOnUnknownObjectKey(errorOnUnknownObjectKey);
+        // re-create the context to apply the new settings
+        expressionAnalysisCtx = new ExpressionAnalysisContext(coordinatorTxnCtx.sessionSettings());
     }
 }


### PR DESCRIPTION
- If both source and target types are an object, merge the inner type definitions. On conflicts, target inner types has precedence.
- Always use the column policy of the target type

Additionally, any subscript on a STRICT object type whereas the key does not exists in the object inner type definitions, will result in an ColumnUnknown exception instead of falling through to the subscript function evaluation.

Relates to #14828.