### PR TITLE
Add missing DisableGraphAttribute implementation

### DIFF
--- a/docs/appendices/release-notes/5.10.3.rst
+++ b/docs/appendices/release-notes/5.10.3.rst
@@ -50,3 +50,6 @@ Fixes
 
 - Fixed an issue that caused a :ref:`float vector <type-float_vector>` column
   to be created with length exceeding the maximum.
+
+- Fixed an issue that prevented the use of custom analyzers with
+  :ref:`shingle token filters<shingle-tokenfilter>`.

--- a/server/src/main/java/io/crate/lucene/DisableGraphAttributeImpl.java
+++ b/server/src/main/java/io/crate/lucene/DisableGraphAttributeImpl.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.lucene;
+
+import org.apache.lucene.util.AttributeImpl;
+import org.apache.lucene.util.AttributeReflector;
+
+/** Default implementation of {@link io.crate.lucene.DisableGraphAttribute} */
+public class DisableGraphAttributeImpl extends AttributeImpl implements DisableGraphAttribute {
+
+    @Override
+    public void clear() {
+
+    }
+
+    @Override
+    public void reflectWith(AttributeReflector reflector) {
+
+    }
+
+    @Override
+    public void copyTo(AttributeImpl target) {
+
+    }
+}


### PR DESCRIPTION
ShingleTokenFilter can produce multiple tokens at each position of differing lengths, which means downstream consumers that expect a well-formed token graph, such as FixedShingleFilter or query parsers, may produce nonsensical output. To prevent this, ShingleTokenFilter will mark its TokenStream with a DisableGraphAttribute if it produces output that cannot be coerced into a graph.

The concrete implementation class for this attribute was missing, meaning that attempts to use a shingle filter with output_unigrams=true or with differing min and max shingle sizes would cause errors on ingest.

Fixes #17558 
