### PR TITLE
Validate length limits of float vector types when creating tables

### DIFF
--- a/docs/appendices/release-notes/5.10.3.rst
+++ b/docs/appendices/release-notes/5.10.3.rst
@@ -47,3 +47,6 @@ Fixes
 - Fixed an issue that would prevent users with ``DDL`` privilege on ``CLUSTER``
   level, to execute :ref:`DROP ANALYZER<drop-analyzer>`, thus before the fix,
   only allowing the ``crate`` superuser to execute ``DROP ANALYZER`` statements.
+
+- Fixed an issue that caused a :ref:`float vector <type-float_vector>` column
+  to be created with length exceeding the maximum.

--- a/server/src/main/java/io/crate/types/FloatVectorType.java
+++ b/server/src/main/java/io/crate/types/FloatVectorType.java
@@ -103,6 +103,9 @@ public class FloatVectorType extends DataType<float[]> implements Streamer<float
     private final int dimensions;
 
     public FloatVectorType(int dimensions) {
+        if (dimensions > MAX_DIMENSIONS) {
+            throw new IllegalArgumentException("Float vector type's length cannot exceed " + MAX_DIMENSIONS);
+        }
         this.dimensions = dimensions;
     }
 

--- a/server/src/test/java/io/crate/types/FloatVectorTypeTest.java
+++ b/server/src/test/java/io/crate/types/FloatVectorTypeTest.java
@@ -28,7 +28,7 @@ import java.util.ArrayList;
 import org.junit.Test;
 
 public class FloatVectorTypeTest extends DataTypeTestCase<float[]> {
-    
+
     @Override
     protected DataDef<float[]> getDataDef() {
         return DataDef.fromType(new FloatVectorType(4));
@@ -49,5 +49,12 @@ public class FloatVectorTypeTest extends DataTypeTestCase<float[]> {
         assertThatThrownBy(() -> floatVectorType.sanitizeValue(insertValues))
             .isExactlyInstanceOf(UnsupportedOperationException.class)
             .hasMessage("null values are not allowed for float_vector");
+    }
+
+    @Test
+    public void test_cannot_create_float_vector_type_exceeding_max_length() {
+        assertThatThrownBy(() -> new FloatVectorType(2049))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Float vector type's length cannot exceed 2048");
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes https://github.com/crate/crate/issues/17570.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
