### PR TITLE
Revert "Don't treat warnings as errors during sphinx build"

### DIFF
--- a/blackbox/bin/sphinx
+++ b/blackbox/bin/sphinx
@@ -36,5 +36,5 @@ elif [ "$1" == "linkcheck" ]; then
     sphinx-build -n -W --keep-going -c "$DOCS_DIR" -b linkcheck -E "$DOCS_DIR" "$DOCS_DIR/_out/html"
 else
     printf "\033[1;44mBuilding server docs ...\033[0m\n"
-    sphinx-build -n -b html "$DOCS_DIR" "$DOCS_DIR/_out/html"
+    sphinx-build -n -W -b html "$DOCS_DIR" "$DOCS_DIR/_out/html"
 fi


### PR DESCRIPTION
This reverts commit c2eee1427c9126ed15f1904c2d9545fef1c6845b.

The nginx config was tweaked which should avoid the timeouts
