### PR TITLE
Fix misbehaving columns with oids in partitioned tables < COLUMN_OID_VERSION

### DIFF
--- a/docs/appendices/release-notes/5.10.3.rst
+++ b/docs/appendices/release-notes/5.10.3.rst
@@ -67,3 +67,9 @@ Fixes
 - Fixed a regression introduced in :ref:`version_5.10.0` that
   caused settings set by the ``SET GLOBAL TRANSIENT`` statement be persisted
   and survive cluster restart.
+
+- Fixed an issue that caused selecting from partitioned tables created before
+  :ref:`version_5.5.0` to falsely return `NULL` values.
+
+- Fixed an issue that caused selecting from partitioned tables created before
+  :ref:`version_5.5.0` to return ``oids`` as column names of the result set.

--- a/server/src/test/java/io/crate/metadata/doc/DocTableInfoTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocTableInfoTest.java
@@ -250,6 +250,60 @@ public class DocTableInfoTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
+    public void test_lookup_name_by_source_with_columns_with_and_without_oids_added_to_table_created_before_5_5_0() {
+        RelationName relationName = new RelationName(Schemas.DOC_SCHEMA_NAME, "dummy");
+        SimpleReference withoutOid = new SimpleReference(
+            new ReferenceIdent(relationName, ColumnIdent.of("withoutOid", List.of())),
+            RowGranularity.DOC,
+            DataTypes.INTEGER,
+            IndexType.PLAIN,
+            true,
+            false,
+            1,
+            COLUMN_OID_UNASSIGNED,
+            false,
+            null
+        );
+        SimpleReference withOid = new SimpleReference(
+            new ReferenceIdent(relationName, ColumnIdent.of("withOid", List.of())),
+            RowGranularity.DOC,
+            DataTypes.INTEGER,
+            IndexType.PLAIN,
+            true,
+            false,
+            1,
+            1, // oid
+            false,
+            null
+        );
+        DocTableInfo docTableInfo = new DocTableInfo(
+            relationName,
+            Map.of(
+                withoutOid.column(), withoutOid,
+                withOid.column(), withOid
+            ),
+            Map.of(),
+            Set.of(),
+            null,
+            List.of(),
+            List.of(),
+            null,
+            Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 5)
+                .build(),
+            List.of(),
+            ColumnPolicy.DYNAMIC,
+            Version.V_5_4_0,
+            null,
+            false,
+            Operation.ALL,
+            0
+        );
+        assertThat(docTableInfo.lookupNameBySourceKey().apply("withoutOid")).isEqualTo("withoutOid");
+        assertThat(docTableInfo.lookupNameBySourceKey().apply("1")).isEqualTo("withOid");
+    }
+
+    @Test
     public void test_lookup_name_by_source_returns_null_for_deleted_columns() throws Exception {
         RelationName relationName = new RelationName(Schemas.DOC_SCHEMA_NAME, "dummy");
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Previously there was an issue with partitioned tables' `created version` being falsely updated(https://github.com/crate/crate/pull/17178). The initial mitigation(https://github.com/crate/crate/pull/17228) was only about the `created version` settings **not** oids. Now there are partitioned tables < `COLUMN_OID_VERSION` but with columns with oids assigned resulting in https://github.com/crate/crate/issues/17574.

Fixes https://github.com/crate/crate/issues/17574, https://github.com/crate/crate/issues/17575 

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
