### PR TITLE
Drop retention lease sync interval to 30 seconds

### DIFF
--- a/docs/appendices/release-notes/6.0.0.rst
+++ b/docs/appendices/release-notes/6.0.0.rst
@@ -121,6 +121,9 @@ Performance and Resilience Improvements
   certain cases, where a shard has become idle after 5 minutes of no write
   activity.
 
+- Increased the frequency of retention lease synchronization, which will make
+  merges more likely to be able to remove recovery source.
+
 Administration and Operations
 -----------------------------
 

--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -849,7 +849,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
     public static final Setting<TimeValue> RETENTION_LEASE_SYNC_INTERVAL_SETTING =
             Setting.timeSetting(
                     "index.soft_deletes.retention_lease.sync_interval",
-                    new TimeValue(5, TimeUnit.MINUTES),
+                    new TimeValue(30, TimeUnit.SECONDS),
                     new TimeValue(0, TimeUnit.MILLISECONDS),
                     Property.Dynamic,
                     Property.IndexScope,


### PR DESCRIPTION
This should make it more likely that any given merge will be able to remove recovery source.

