### PR TITLE
Treat UnavailableShardsException as shard failure for read retries

### DIFF
--- a/docs/appendices/release-notes/6.0.0.rst
+++ b/docs/appendices/release-notes/6.0.0.rst
@@ -112,6 +112,10 @@ Scalar and Aggregation Functions
 Performance and Resilience Improvements
 ---------------------------------------
 
+- Improved the handling of temporary unavailable shards during read-only
+  queries. There's now a higher chance that the system can deal with the
+  temporary failure without surfacing the error to the client.
+
 - Improved execution for queries with mixed implicit and explicit joins.
   Joins are now always executed in the original order of the query.
 

--- a/server/src/main/java/io/crate/exceptions/SQLExceptions.java
+++ b/server/src/main/java/io/crate/exceptions/SQLExceptions.java
@@ -40,6 +40,7 @@ import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.ElasticsearchWrapperException;
 import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.action.NoShardAvailableActionException;
+import org.elasticsearch.action.UnavailableShardsException;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.common.io.stream.NotSerializableExceptionWrapper;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
@@ -175,7 +176,9 @@ public class SQLExceptions {
 
     public static boolean isShardFailure(Throwable e) {
         e = SQLExceptions.unwrap(e);
-        return e instanceof ShardNotFoundException || e instanceof IllegalIndexShardStateException;
+        return e instanceof ShardNotFoundException
+            || e instanceof IllegalIndexShardStateException
+            || e instanceof UnavailableShardsException;
     }
 
     /***
@@ -191,6 +194,7 @@ public class SQLExceptions {
             || t instanceof NoSeedNodeLeftException
             || t instanceof IndexNotFoundException
             || t instanceof NoShardAvailableActionException
+            || t instanceof UnavailableShardsException
             || t instanceof AlreadyClosedException
             || t instanceof ElasticsearchTimeoutException;
     }

--- a/server/src/test/java/io/crate/exceptions/SQLExceptionsTest.java
+++ b/server/src/test/java/io/crate/exceptions/SQLExceptionsTest.java
@@ -27,11 +27,22 @@ import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
 import org.apache.lucene.index.CorruptIndexException;
+import org.elasticsearch.action.UnavailableShardsException;
+import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.index.shard.ShardId;
 import org.junit.Test;
 
 import io.crate.common.exceptions.Exceptions;
 
 public class SQLExceptionsTest {
+
+    @Test
+    public void test_unavailable_shard_exception_is_shard_failure() throws Exception {
+        ShardId shardId = new ShardId("idx1", UUIDs.randomBase64UUID(), 0);
+        UnavailableShardsException ex = new UnavailableShardsException(shardId);
+        assertThat(SQLExceptions.isShardFailure(ex)).isTrue();
+        assertThat(SQLExceptions.maybeTemporary(ex)).isTrue();
+    }
 
     @Test
     public void testUnwrap() {


### PR DESCRIPTION
`Session` uses the `RetryOnFailureResultReceiver` to retry read
operations on shard failures. `UnavailableShardsException` was so far
not recognized as a shard failure, skipping the retry.
