### PR TITLE
Shard snapshot deserialization must re-use FileInfo instances

### DIFF
--- a/docs/appendices/release-notes/5.10.3.rst
+++ b/docs/appendices/release-notes/5.10.3.rst
@@ -68,6 +68,11 @@ Fixes
   caused settings set by the ``SET GLOBAL TRANSIENT`` statement be persisted
   and survive cluster restart.
 
+- Fixed a regression introduced in :ref:`version_5.10.0` that
+  caused ``CREATE SNAPSHOT`` to write more data and, as a consequence, use more
+  memory when creating incremental snapshots and reading data of the previously
+  taken snapshots and fail with ``OutOfMemoryError`` under memory pressure.
+
 - Fixed an issue that caused selecting from partitioned tables created before
   :ref:`version_5.5.0` to falsely return `NULL` values.
 

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -248,7 +248,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         "snapshots",
         SNAPSHOT_INDEX_NAME_FORMAT,
         BlobStoreIndexShardSnapshots::fromXContent,
-        BlobStoreIndexShardSnapshots::new
+        BlobStoreIndexShardSnapshots::fromStream
     );
 
     private final boolean readOnly;

--- a/server/src/test/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshotsTest.java
+++ b/server/src/test/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshotsTest.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package org.elasticsearch.index.snapshots.blobstore;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.elasticsearch.repositories.blobstore.BlobStoreRepository.INDEX_SHARD_SNAPSHOTS_FORMAT;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot.FileInfo;
+import org.elasticsearch.index.store.StoreFileMetadata;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Test;
+
+public class BlobStoreIndexShardSnapshotsTest extends ESTestCase {
+
+    @Test
+    public void test_bwc_streaming() throws Exception {
+        BlobStoreIndexShardSnapshots blobStoreIndexShardSnapshots = prepareData();
+        BytesStreamOutput out = new BytesStreamOutput();
+        blobStoreIndexShardSnapshots.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        BlobStoreIndexShardSnapshots fromStream = BlobStoreIndexShardSnapshots.fromStream(in);
+        assertThat(isSame(blobStoreIndexShardSnapshots, fromStream)).isTrue();
+
+        out = new BytesStreamOutput();
+        out.setVersion(Version.V_5_10_1);
+        blobStoreIndexShardSnapshots.writeTo(out);
+
+        in = out.bytes().streamInput();
+        in.setVersion(org.elasticsearch.Version.V_5_10_1);
+        fromStream = BlobStoreIndexShardSnapshots.fromStream(in);
+        assertThat(isSame(blobStoreIndexShardSnapshots, fromStream)).isTrue();
+
+    }
+
+    @Test
+    public void test_number_of_unique_files_across_snapshots_equal_to_number_of_files() throws Exception {
+        BlobStoreIndexShardSnapshots blobStoreIndexShardSnapshots = prepareData();
+        BytesReference bytesReference = INDEX_SHARD_SNAPSHOTS_FORMAT.serialize(blobStoreIndexShardSnapshots, "dummyBlobName", true);
+
+        // FileInfo don't have equals/hashCode, so set will use identity check.
+        // That's exactly want we want:
+        // we need to make sure that we are using the same instance to save memory.
+        Set<FileInfo> uniqueFilesToWrite = new HashSet<>();
+        for(SnapshotFiles snapshotFiles: blobStoreIndexShardSnapshots.snapshots()) {
+            uniqueFilesToWrite.addAll(snapshotFiles.indexFiles());
+        }
+        assertThat(uniqueFilesToWrite.size()).isEqualTo(3);
+
+        blobStoreIndexShardSnapshots = INDEX_SHARD_SNAPSHOTS_FORMAT.deserialize(
+            "dummyBlobname",
+            writableRegistry(),
+            xContentRegistry(),
+            bytesReference
+        );
+
+        Set<FileInfo> uniqueReadFiles = new HashSet<>();
+        for(SnapshotFiles snapshotFiles: blobStoreIndexShardSnapshots.snapshots()) {
+            uniqueReadFiles.addAll(snapshotFiles.indexFiles());
+        }
+        assertThat(uniqueReadFiles.size()).isEqualTo(3);
+    }
+
+    /**
+     * Returns an instance with SnapshotFiles instances having their indexFiles overlapping
+     * and those overlaps being re-used as a same instance.
+     *
+     * We need to ensure that we can read such optimal file in a way that deserialized instance also has an optimal structure.
+     */
+    private static BlobStoreIndexShardSnapshots prepareData() throws Exception {
+        List<FileInfo> fileInfos = new ArrayList<>();
+        for (int i = 1; i <= 3; i++) {
+            String name = "name" + i;
+            fileInfos.add(
+                new FileInfo(
+                    name,
+                    new StoreFileMetadata(name, 1, "dummy_checksum", org.apache.lucene.util.Version.LUCENE_9_12_0),
+                    new ByteSizeValue(i)
+                )
+            );
+        }
+
+        // Different SnapshotFiles can refer to the same FileInfo-s in the SnapshotFiles.indexFiles field.
+        // Setup: 2 lists share 1 instance, so in total we should see 3 writes and reads of FileInfo.
+        SnapshotFiles snapshot1 = new SnapshotFiles("1", fileInfos.subList(0, 2), null);
+        SnapshotFiles snapshot2 = new SnapshotFiles("1", fileInfos.subList(1, 3), null);
+        return new BlobStoreIndexShardSnapshots(List.of(snapshot1, snapshot2));
+    }
+
+    private static boolean isSame(BlobStoreIndexShardSnapshots shardSnapshot1, BlobStoreIndexShardSnapshots shardSnapshot2) {
+        Map<String, FileInfo> files1 = shardSnapshot1.files();
+        Map<String, FileInfo> files2 = shardSnapshot2.files();
+        if (files1.size() != files2.size()) {
+            return false;
+        }
+        for (Map.Entry<String, FileInfo> entry : files1.entrySet()) {
+            if (entry.getValue().isSame(files2.get(entry.getKey())) == false) {
+                return false;
+            }
+        }
+
+        Map<String, List<FileInfo>> physicalFiles1 = shardSnapshot1.physicalFiles();
+        Map<String, List<FileInfo>> physicalFiles2 = shardSnapshot2.physicalFiles();
+        if (physicalFiles1.size() != physicalFiles2.size()) {
+            return false;
+        }
+        for (Map.Entry<String, List<FileInfo>> entry : physicalFiles1.entrySet()) {
+            List<FileInfo> list1 = entry.getValue();
+            List<FileInfo> list2 = physicalFiles2.get(entry.getKey());
+            if (list1.size() != list2.size()) {
+                return false;
+            }
+            for (int i = 0; i < list1.size(); i++) {
+                if (list1.get(i).isSame(list2.get(i)) == false) {
+                    return false;
+                }
+            }
+        }
+
+        List<SnapshotFiles> shapshotFiles1 = shardSnapshot1.snapshots();
+        List<SnapshotFiles> shapshotFiles2 = shardSnapshot2.snapshots();
+        if (shapshotFiles1.size() != shapshotFiles2.size()) {
+            return false;
+        }
+        for (int i = 0; i < shapshotFiles1.size(); i++) {
+            SnapshotFiles sf1 = shapshotFiles1.get(i);
+            SnapshotFiles sf2 = shapshotFiles2.get(i);
+            if (sf1.snapshot().equals(sf2.snapshot()) == false) {
+                return false;
+            }
+            if (Objects.equals(sf1.shardStateIdentifier(), sf2.shardStateIdentifier()) == false) {
+                return false;
+            }
+            List<FileInfo> list1 = sf1.indexFiles();
+            List<FileInfo> list2 = sf2.indexFiles();
+            if (list1.size() != list2.size()) {
+                return false;
+            }
+            for (int j = 0; j < list1.size(); j++) {
+                if (list1.get(j).isSame(list2.get(j)) == false) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
heap dump points to deserialization of `BlobStoreIndexShardSnapshots`

```
  at java.lang.OutOfMemoryError.<init>()V (OutOfMemoryError.java:48)
  at org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot$FileInfo.<init>(Lorg/elasticsearch/common/io/stream/StreamInput;)V (BlobStoreIndexShardSnapshot.java:93)
  at org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshots$$Lambda+0x0000000033e2b000.read(Lorg/elasticsearch/common/io/stream/StreamInput;)Ljava/lang/Object; (Unknown Source)
  at org.elasticsearch.common.io.stream.StreamInput.readList(Lorg/elasticsearch/common/io/stream/Writeable$Reader;)Ljava/util/List; (StreamInput.java:1087)
  at org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshots.lambda$new$2(Lorg/elasticsearch/common/io/stream/StreamInput;)Ljava/util/List; (BlobStoreIndexShardSnapshots.java:102)
  at org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshots$$Lambda+0x0000000033e2fc68.read(Lorg/elasticsearch/common/io/stream/StreamInput;)Ljava/lang/Object; (Unknown Source)
  at org.elasticsearch.common.io.stream.StreamInput.readMap(Lorg/elasticsearch/common/io/stream/Writeable$Reader;Lorg/elasticsearch/common/io/stream/Writeable$Reader;)Ljava/util/Map; (StreamInput.java:602)
  at org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshots.<init>(Lorg/elasticsearch/common/io/stream/StreamInput;)V (BlobStoreIndexShardSnapshots.java:102)
  at org.elasticsearch.repositories.blobstore.BlobStoreRepository$$Lambda+0x0000000033581618.read(Lorg/elasticsearch/common/io/stream/StreamInput;)Ljava/lang/Object; (Unknown Source)
  at org.elasticsearch.repositories.blobstore.ChecksumBlobStoreFormat.deserialize(Ljava/lang/String;Lorg/elasticsearch/common/io/stream/NamedWriteableRegistry;Lorg/elasticsearch/common/xcontent/NamedXContentRegistry;Lorg/elasticsearch/common/bytes/BytesReference;)Lorg/elasticsearch/common/io/stream/Writeable; (ChecksumBlobStoreFormat.java:138)
  at org.elasticsearch.repositories.blobstore.ChecksumBlobStoreFormat.read(Lorg/elasticsearch/common/blobstore/BlobContainer;Ljava/lang/String;Lorg/elasticsearch/common/io/stream/NamedWriteableRegistry;Lorg/elasticsearch/common/xcontent/NamedXContentRegistry;)Lorg/elasticsearch/common/io/stream/Writeable; (ChecksumBlobStoreFormat.java:104)
  at org.elasticsearch.repositories.blobstore.BlobStoreRepository.buildBlobStoreIndexShardSnapshots(Ljava/util/Set;Lorg/elasticsearch/common/blobstore/BlobContainer;Ljava/lang/String;)Lio/crate/common/collections/Tuple; (BlobStoreRepository.java:2267)
  at org.elasticsearch.repositories.blobstore.BlobStoreRepository$3.doRun()V (BlobStoreRepository.java:768)
  at org.elasticsearch.common.util.concurrent.AbstractRunnable.run()V (AbstractRunnable.java:37)
  at java.util.concurrent.ThreadPoolExecutor.runWorker(Ljava/util/concurrent/ThreadPoolExecutor$Worker;)V (ThreadPoolExecutor.java:1144)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run()V (ThreadPoolExecutor.java:642)
  at java.lang.Thread.runWith(Ljava/lang/Object;Ljava/lang/Runnable
```




**UPD**:

Shard snapshot deserialization must re-use FileInfo instances

Serialization code must reflect this idea as well and write files and then only links to those files like it was done before 5.10

Fixes a regression introduced in https://github.com/crate/crate/commit/8f941f829d1fe4193f968af9a96bd3e120708fd4
