### PR TITLE
Fix flaky testDynamicTransientSettings

### DIFF
--- a/server/src/test/java/io/crate/integrationtests/SysClusterSettingsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SysClusterSettingsTest.java
@@ -132,14 +132,17 @@ public class SysClusterSettingsTest extends IntegTestCase {
 
         cluster().fullRestart();
 
-        execute("select settings from sys.cluster");
-        // Transient settings are back to defaults.
-        assertSettingsDefault(JobsLogService.STATS_JOBS_LOG_SIZE_SETTING);
-        assertSettingsDefault(JobsLogService.STATS_OPERATIONS_LOG_SIZE_SETTING);
-        assertSettingsDefault(JobsLogService.STATS_ENABLED_SETTING);
+        // Can take a bit for state recovery to load persisted settings
+        assertBusy(() -> {
+            execute("select settings from sys.cluster");
+            // Transient settings are back to defaults.
+            assertSettingsDefault(JobsLogService.STATS_JOBS_LOG_SIZE_SETTING);
+            assertSettingsDefault(JobsLogService.STATS_OPERATIONS_LOG_SIZE_SETTING);
+            assertSettingsDefault(JobsLogService.STATS_ENABLED_SETTING);
 
-        // Persisted value survived restart.
-        assertSettingsValue(JobsLogService.STATS_JOBS_LOG_EXPIRATION_SETTING.getKey(), "123ms");
+            // Persisted value survived restart.
+            assertSettingsValue(JobsLogService.STATS_JOBS_LOG_EXPIRATION_SETTING.getKey(), "123ms");
+        });
     }
 
     @Test


### PR DESCRIPTION
Failed because gateway recovery is async and can take a bit

    org.opentest4j.AssertionFailedError:

    expected: "123ms"
     but was: "0s"
    	at __randomizedtesting.SeedInfo.seed([CB271DC30292CF1:3DC8AD8C3EAFFBBD]:0)
    	at io.crate.integrationtests.SysClusterSettingsTest.assertSettingsValue(SysClusterSettingsTest.java:246)
    	at io.crate.integrationtests.SysClusterSettingsTest.testDynamicTransientSettings(SysClusterSettingsTest.java:142)
    	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
    	at com.carrotsearch.randomizedtesting.RandomizedRunner.invoke(RandomizedRunner.java:1763)
    	at com.carrotsearch.randomizedtesting.RandomizedRunner$8.evaluate(RandomizedRunner.java:946)
    	at com.carrotsearch.randomizedtesting.RandomizedRunner$9.evaluate(RandomizedRunner.java:982)
    	at com.carrotsearch.randomizedtesting.RandomizedRunner$10.evaluate(RandomizedRunner.java:996)
    	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
    	at java.base/java.lang.Thread.run(Thread.java:1575)
