### PR TITLE
Fix flaky TranslogTests.testWithRandomException

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
+++ b/server/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
@@ -2454,16 +2454,22 @@ public class TranslogTests extends ESTestCase {
         }
     }
 
-    private Translog getFailableTranslog(final FailSwitch fail, final TranslogConfig config, final boolean partialWrites,
-                                         final boolean throwUnknownException, String translogUUID,
-                                         final TranslogDeletionPolicy deletionPolicy) throws IOException {
+    private Translog getFailableTranslog(FailSwitch fail,
+                                         TranslogConfig config,
+                                         boolean partialWrites,
+                                         boolean throwUnknownException,
+                                         String translogUUID,
+                                         TranslogDeletionPolicy deletionPolicy) throws IOException {
         return getFailableTranslog(fail, config, partialWrites, throwUnknownException, translogUUID, deletionPolicy, null);
     }
 
-    private Translog getFailableTranslog(final FailSwitch fail, final TranslogConfig config, final boolean partialWrites,
-                                         final boolean throwUnknownException, String translogUUID,
-                                         final TranslogDeletionPolicy deletionPolicy,
-                                         final List<FileChannel> fileChannels) throws IOException {
+    private Translog getFailableTranslog(FailSwitch fail,
+                                         TranslogConfig config,
+                                         boolean partialWrites,
+                                         boolean throwUnknownException,
+                                         String translogUUID,
+                                         TranslogDeletionPolicy deletionPolicy,
+                                         List<FileChannel> fileChannels) throws IOException {
         final ChannelFactory channelFactory = (file, openOption) -> {
             FileChannel channel = FileChannel.open(file, openOption);
             if (fileChannels != null) {
@@ -2764,8 +2770,14 @@ public class TranslogTests extends ESTestCase {
             String generationUUID = null;
             try {
                 boolean committing = false;
-                final Translog failableTLog = getFailableTranslog(fail, config, randomBoolean(), false,
-                    generationUUID, createTranslogDeletionPolicy());
+                final Translog failableTLog = getFailableTranslog(
+                    fail,
+                    config,
+                    randomBoolean(),
+                    false,
+                    generationUUID,
+                    createTranslogDeletionPolicy()
+                );
                 try {
                     LineFileDocs lineFileDocs = new LineFileDocs(random()); //writes pretty big docs so we cross buffer boarders regularly
                     for (int opsAdded = 0; opsAdded < numOps; opsAdded++) {
@@ -2789,7 +2801,6 @@ public class TranslogTests extends ESTestCase {
                             syncedDocs.clear();
                             failableTLog.trimUnreferencedReaders();
                             committing = false;
-                            syncedDocs.clear();
                         }
                     }
                     // we survived all the randomness!!!
@@ -2805,7 +2816,9 @@ public class TranslogTests extends ESTestCase {
                     assertThat(ex).isEqualTo(failableTLog.getTragicException());
                 } catch (RuntimeException ex) {
                     assertThat("simulated").isEqualTo(ex.getMessage());
-                    assertThat(ex).isEqualTo(failableTLog.getTragicException());
+                    assertThat(failableTLog.getTragicException())
+                        .as("Don't consider failures while trimming unreferenced readers as tragedy")
+                        .isNull();
                 } finally {
                     Checkpoint checkpoint = Translog.readCheckpoint(config.getTranslogPath());
                     if (checkpoint.numOps == unsynced.size() + syncedDocs.size()) {


### PR DESCRIPTION
    org.opentest4j.AssertionFailedError:
    expected:
      null
     but was:
      java.lang.RuntimeException: simulated
      	at org.elasticsearch.index.translog.TranslogTests$8.deleteReaderFiles(TranslogTests.java:2501)
      	at org.elasticsearch.index.translog.Translog.trimUnreferencedReaders(Translog.java:1667)
      	at org.elasticsearch.index.translog.TranslogTests.testWithRandomException(TranslogTests.java:2790)
      	...(39 remaining lines not displayed - this can be changed with Assertions.setMaxStackTraceElementsDisplayed)
    	at __randomizedtesting.SeedInfo.seed([518193DACCAB5405:3759F8C5B74FDA14]:0)
    	at org.elasticsearch.index.translog.TranslogTests.testWithRandomException(TranslogTests.java:2808)

This is loosely based on https://github.com/elastic/elasticsearch/commit/60f894111b2f794c9d333be3a1ee519e39a2dba4 which was still apache licensed
