### PR TITLE
WIP: Enable TCP fallback for SRV DNS seed lookups

### DIFF
--- a/plugins/dns-discovery/src/main/java/io/crate/discovery/SrvUnicastHostsProvider.java
+++ b/plugins/dns-discovery/src/main/java/io/crate/discovery/SrvUnicastHostsProvider.java
@@ -47,6 +47,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioDatagramChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.codec.dns.DefaultDnsQuestion;
 import io.netty.handler.codec.dns.DefaultDnsRawRecord;
 import io.netty.handler.codec.dns.DefaultDnsRecordDecoder;
@@ -117,7 +118,8 @@ public class SrvUnicastHostsProvider implements AutoCloseable, SeedHostsProvider
 
     private DnsNameResolver buildResolver(Settings settings) {
         DnsNameResolverBuilder resolverBuilder = new DnsNameResolverBuilder(eventLoopGroup.next());
-        resolverBuilder.channelType(NioDatagramChannel.class);
+        resolverBuilder.datagramChannelType(NioDatagramChannel.class);
+        resolverBuilder.socketChannelType(NioSocketChannel.class);
 
         InetSocketAddress resolverAddress = parseResolverAddress(settings);
         if (resolverAddress != null) {


### PR DESCRIPTION
According to the [netty docs](https://netty.io/4.1/api/io/netty/resolver/dns/DnsNameResolverBuilder.html#socketChannelType-java.lang.Class-), TCP fallback is only enabled when setting a `socket` channel factory.
@mfussenegger Any idea how we could test this?


Closes #17148.