### PR TITLE
Fix sys.health to return a RED state when global blocks exists

### DIFF
--- a/docs/admin/system-information.rst
+++ b/docs/admin/system-information.rst
@@ -1821,16 +1821,18 @@ rejected due to an invalid license.
 Health
 ======
 
-The ``sys.health`` table lists the `health` of each table and table
-partition. The `health` is computed by checking the states of the shard of each
-table/partition.
+The ``sys.health`` table lists the `health` of each table and table partition
+or a single cluster-wide health entry. Each table `health` is computed by
+checking the states of the shards of each partition.
 
 +----------------------------+------------------------------------+--------------+
 | Column Name                | Description                        | Return Type  |
 +============================+====================================+==============+
-| ``table_name``             | The table name.                    | ``TEXT``     |
+| ``table_name``             | The table name or empty on         | ``TEXT``     |
+|                            | cluster-wide health.               |              |
 +----------------------------+------------------------------------+--------------+
-| ``table_schema``           | The schema of the table.           | ``TEXT``     |
+| ``table_schema``           | The schema of the table or empty   | ``TEXT``     |
+|                            | on cluster-wide health.            |              |
 +----------------------------+------------------------------------+--------------+
 | ``partition_ident``        | The `ident` of the partition.      | ``TEXT``     |
 |                            | NULL for non-partitioned tables.   |              |
@@ -1852,6 +1854,9 @@ Both ``missing_shards`` and ``underreplicated_shards`` might return ``-1`` if
 the cluster is in an unhealthy state that prevents the exact number from being
 calculated. This could be the case when the cluster can't elect a master,
 because there are not enough eligible nodes available.
+If the cluster is in a state were it cannot read any metadata of the tables,
+a single entry will be returned containing an empty ``table_name`` and
+``table_schema`` indicating a cluster-wide health status.
 
 ::
 

--- a/docs/appendices/release-notes/5.10.3.rst
+++ b/docs/appendices/release-notes/5.10.3.rst
@@ -73,3 +73,8 @@ Fixes
 
 - Fixed an issue that caused selecting from partitioned tables created before
   :ref:`version_5.5.0` to return ``oids`` as column names of the result set.
+
+- Fixed an issue that caused queries to ``sys.health`` to return an empty result
+  set when the cluster is in a recovery state, for example when (re-)starting
+  nodes. As the cluster is in a ``RED`` state in such cases, a single entry
+  is return now reflecting this state.

--- a/server/src/main/java/io/crate/metadata/sys/SysHealth.java
+++ b/server/src/main/java/io/crate/metadata/sys/SysHealth.java
@@ -26,6 +26,7 @@ import static io.crate.types.DataTypes.SHORT;
 import static io.crate.types.DataTypes.STRING;
 
 import io.crate.metadata.RelationName;
+import io.crate.metadata.Routing;
 import io.crate.metadata.SystemTable;
 
 public class SysHealth {
@@ -40,5 +41,7 @@ public class SysHealth {
         .add("severity", SHORT, TableHealth::getSeverity)
         .add("missing_shards", LONG, TableHealth::getMissingShards)
         .add("underreplicated_shards", LONG, TableHealth::getUnderreplicatedShards)
+        .withRouting((state, routingProvider, sessionSettings) ->
+            Routing.forTableOnSingleNode(IDENT, state.nodes().getMasterNodeId()))
         .build();
 }

--- a/server/src/main/java/io/crate/metadata/sys/SysTableDefinitions.java
+++ b/server/src/main/java/io/crate/metadata/sys/SysTableDefinitions.java
@@ -204,7 +204,7 @@ public class SysTableDefinitions {
             Map.entry(
                 SysHealth.IDENT,
                 new StaticTableDefinition<>(
-                    () -> TableHealth.compute(clusterService),
+                    () -> TableHealth.compute(clusterService.state()),
                     SysHealth.INSTANCE.expressions(),
                     (user, tableHealth) -> roles.hasAnyPrivilege(user, Securable.TABLE, tableHealth.fqn()),
                     true

--- a/server/src/main/java/io/crate/metadata/sys/SysTableDefinitions.java
+++ b/server/src/main/java/io/crate/metadata/sys/SysTableDefinitions.java
@@ -204,7 +204,7 @@ public class SysTableDefinitions {
             Map.entry(
                 SysHealth.IDENT,
                 new StaticTableDefinition<>(
-                    () -> TableHealth.compute(clusterService.state()),
+                    () -> TableHealth.compute(clusterService),
                     SysHealth.INSTANCE.expressions(),
                     (user, tableHealth) -> roles.hasAnyPrivilege(user, Securable.TABLE, tableHealth.fqn()),
                     true

--- a/server/src/main/java/io/crate/metadata/sys/TableHealth.java
+++ b/server/src/main/java/io/crate/metadata/sys/TableHealth.java
@@ -56,8 +56,8 @@ class TableHealth {
         "",
         null,
         Health.RED,
-        0,
-        0
+        -1,
+        -1
     );
 
     public static CompletableFuture<Iterable<TableHealth>> compute(ClusterState clusterState) {

--- a/server/src/main/java/io/crate/metadata/sys/TableHealth.java
+++ b/server/src/main/java/io/crate/metadata/sys/TableHealth.java
@@ -27,10 +27,10 @@ import java.util.stream.StreamSupport;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.health.ClusterIndexHealth;
 import org.elasticsearch.cluster.health.ClusterStateHealth;
-import org.elasticsearch.cluster.service.ClusterService;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
 
@@ -60,8 +60,7 @@ class TableHealth {
         0
     );
 
-    public static CompletableFuture<Iterable<TableHealth>> compute(ClusterService clusterService) {
-        var clusterState = clusterService.state();
+    public static CompletableFuture<Iterable<TableHealth>> compute(ClusterState clusterState) {
         if (clusterState.blocks().hasGlobalBlockWithLevel(ClusterBlockLevel.METADATA_READ)) {
             LOGGER.warn("Global block with level METADATA_READ is set, cannot compute tables health. Global blocks: {}", clusterState.blocks().global());
             return CompletableFuture.completedFuture(List.of(GLOBAL_HEALTH_RED));

--- a/server/src/test/java/io/crate/metadata/sys/TableHealthTest.java
+++ b/server/src/test/java/io/crate/metadata/sys/TableHealthTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.metadata.sys;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.EnumSet;
+
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlock;
+import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.block.ClusterBlocks;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.test.ClusterServiceUtils;
+import org.junit.Test;
+
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+
+public class TableHealthTest extends CrateDummyClusterServiceUnitTest {
+
+    @Test
+    public void test_global_red_health_on_global_block() {
+        var emptyState = clusterService.state();
+        var globalBlock = new ClusterBlock(
+            1,
+            "uuid",
+            "",
+            true,
+            true,
+            true,
+            RestStatus.INTERNAL_SERVER_ERROR,
+            EnumSet.of(ClusterBlockLevel.METADATA_READ)
+        );
+        var newState = ClusterState.builder(clusterService.state())
+                .blocks(ClusterBlocks.builder().addGlobalBlock(globalBlock))
+                .build();
+        ClusterServiceUtils.setState(clusterService, newState);
+
+        var future = TableHealth.compute(clusterService);
+        assertThat(future.isDone()).isTrue();
+        var healths = future.join();
+        assertThat(healths.iterator().next()).isEqualTo(TableHealth.GLOBAL_HEALTH_RED);
+
+        ClusterServiceUtils.setState(clusterService, emptyState);
+        future = TableHealth.compute(clusterService);
+        assertThat(future.isDone()).isTrue();
+        healths = future.join();
+        assertThat(healths.iterator().hasNext()).isFalse();
+    }
+}

--- a/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/IntegTestCase.java
@@ -1419,7 +1419,7 @@ public abstract class IntegTestCase extends ESTestCase {
 
                 @Override
                 public Sessions sqlOperations() {
-                    return cluster().getInstance(Sessions.class);
+                    return cluster().getInstance(Sessions.class, nodeName);
                 }
             });
     }


### PR DESCRIPTION
In some cases like initializing and or ongoing global recovery, the cluster is actually in a `RED` state.
The `sys.health` result set must reflect this, otherwise an empty result set would be returned which would be also happen when no tables exists but otherwise all is up and running (GREEN).

A global entry with a `RED` state is now returned when any global block containing a `METADATA_READ` exists.

This popped up by https://github.com/crate/crate/pull/17600, but it's a general issue.