### PR TITLE
Add release notes for replica allocation issue

### DIFF
--- a/docs/appendices/release-notes/5.10.3.rst
+++ b/docs/appendices/release-notes/5.10.3.rst
@@ -73,3 +73,6 @@ Fixes
 
 - Fixed an issue that caused selecting from partitioned tables created before
   :ref:`version_5.5.0` to return ``oids`` as column names of the result set.
+
+- Fixed an issue that caused replica shards of partitioned tables created
+  before :ref:`version_5.5.0` to fail to be allocated.

--- a/docs/appendices/release-notes/5.9.12.rst
+++ b/docs/appendices/release-notes/5.9.12.rst
@@ -52,3 +52,6 @@ Fixes
 
 - Fixed an issue that caused selecting from partitioned tables created before
   :ref:`version_5.5.0` to return ``oids`` as column names of the result set.
+
+- Fixed an issue that caused replica shards of partitioned tables created
+  before :ref:`version_5.5.0` to fail to be allocated.


### PR DESCRIPTION
The issue of failing allocations of replica shards is also fixed by https://github.com/crate/crate/pull/17580, adding another release entry.

Relates to https://github.com/crate/support/issues/573.