### PR TITLE
bp: Don't Allocate Redundant Pages in BigArrays

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/BigArrays.java
+++ b/server/src/main/java/org/elasticsearch/common/util/BigArrays.java
@@ -52,15 +52,10 @@ public class BigArrays {
 
         long newSize;
         if (minTargetSize < pageSize) {
-            newSize = ArrayUtil.oversize((int)minTargetSize, bytesPerElement);
+            newSize = Math.min(ArrayUtil.oversize((int) minTargetSize, bytesPerElement), pageSize);
         } else {
-            newSize = minTargetSize + (minTargetSize >>> 3);
-        }
-
-        if (newSize > pageSize) {
-            // round to a multiple of pageSize
-            newSize = newSize - (newSize % pageSize) + pageSize;
-            assert newSize % pageSize == 0;
+            final long pages = (minTargetSize + pageSize - 1) / pageSize; // ceil(minTargetSize/pageSize)
+            newSize = pages * pageSize;
         }
 
         return newSize;

--- a/server/src/test/java/org/elasticsearch/common/util/BigArraysTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/BigArraysTests.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.common.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Test;
+
+public class BigArraysTests extends ESTestCase {
+
+    @Test
+    public void testOverSizeUsesMinPageCount() {
+        final int pageSize = 1 << (randomIntBetween(2, 16));
+        final int minSize = randomIntBetween(1, pageSize) * randomIntBetween(1, 100);
+        final long size = BigArrays.overSize(minSize, pageSize, 1);
+        assertThat(size).isGreaterThanOrEqualTo(minSize);
+        if (size >= pageSize) {
+            assertThat(size % pageSize)
+                .as(size + " is a multiple of " + pageSize)
+                .isEqualTo(0L);
+        }
+        assertThat(size - minSize).isLessThan(pageSize);
+    }
+}


### PR DESCRIPTION
backport of the  https://github.com/elastic/elasticsearch/commit/3bf4c01d8e978f04d9d08ee3af2024db1081f265

Relates to OOM on snapshot creation (https://github.com/elastic/elasticsearch/issues/60173)

We already ported https://github.com/crate/crate/commit/e9962228ebdad1a24d6ded0a429c3617cdeeef4f, 
porting another related patch
