### PR TITLE
Populate indnkeyatts in pg_index

### DIFF
--- a/docs/appendices/release-notes/6.0.0.rst
+++ b/docs/appendices/release-notes/6.0.0.rst
@@ -98,6 +98,9 @@ SQL Standard and PostgreSQL Compatibility
   :ref:`information_schema.administrable_role_authorizations <administrable_role_authorizations>`
   and :ref:`information_schema.role_table_grants <role_table_grants>` tables.
 
+- Populated the ``pg_index.indnkeyatts`` column with the number of key
+  attributes in the primary key.
+
 Data Types
 ----------
 

--- a/server/src/main/java/io/crate/metadata/pgcatalog/PgIndexTable.java
+++ b/server/src/main/java/io/crate/metadata/pgcatalog/PgIndexTable.java
@@ -44,7 +44,7 @@ public final class PgIndexTable {
         .add("indexrelid", REGCLASS, x -> x.indexRelId)
         .add("indrelid", REGCLASS, x -> x.indRelId)
         .add("indnatts", SHORT, x -> (short) 0)
-        .add("indnkeyatts", SHORT, x -> (short) 0)
+        .add("indnkeyatts", SHORT, x -> (short) x.indKey.size())
         .add("indisunique", BOOLEAN, x -> false)
         .add("indisprimary", BOOLEAN, x -> true)
         .add("indisexclusion", BOOLEAN, x -> false)

--- a/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PgCatalogITest.java
@@ -22,7 +22,6 @@
 package io.crate.integrationtests;
 
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -276,9 +275,10 @@ public class PgCatalogITest extends IntegTestCase {
     }
 
     @Test
-    public void test_primary_key_in_pg_index() {
-        execute("select i.indexrelid, i.indrelid, i.indkey from pg_index i, pg_class c where c.relname = 't1' and c.oid = i.indrelid;");
-        assertThat(response).hasRows("-649073482| 728874843| [1]");
+    public void test_composite_primary_key_in_pg_index() {
+        execute("create table doc.t2 (id int, id2 int, primary key (id, id2))");
+        execute("select i.indexrelid, i.indrelid, i.indkey, i.indnkeyatts from pg_index i, pg_class c where c.relname = 't2' and c.oid = i.indrelid;");
+        assertThat(response).hasRows("-811118696| 1737494392| [1, 2]| 2");
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

The `indnkeyatts` column in `pg_index` should be populated.

The latest release of the PG JDBC driver changes on how to derive the the columns forming the primary key for tables. We observe in https://github.com/crate/crate-qa/pull/333 that the recent change to the driver is causing issues, and this PR is a step to solve the issue.

It is unclear to me if we should consider it a breaking change or an improvement of our Postgres compatibility. I am targeting version 6.0 to be on the same side.

This closes #17486 

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
