### PR TITLE
Add `sys.cluster_health` table to get the overall cluster health

### DIFF
--- a/docs/admin/system-information.rst
+++ b/docs/admin/system-information.rst
@@ -1901,6 +1901,55 @@ Health definition
    The ``sys.health`` table is subject to :ref:`shard_table_permissions` as it
    will expose a summary of table shard states.
 
+.. _sys-cluster_health:
+
+Cluster Health
+==============
+
+The ``sys.cluster_health`` table returns the health of the entire cluster. Only
+a single entry is returned, containing the overall health of the cluster,
+including the overall number of missing shards and underreplicated shards of all
+tables. Any table-specific health issues, exposed by the
+:ref:`sys.health <sys-health>` will be reflected here as well.
+
++----------------------------+-------------------------------------+--------------+
+| Column Name                | Description                         | Return Type  |
++============================+=====================================+==============+
+| ``health``                 | The cluster health label.           | ``TEXT``     |
+|                            | Can be RED, YELLOW or GREEN.        |              |
++----------------------------+-------------------------------------+--------------+
+| ``severity``               | The health as a ``smallint`` value. | ``SMALLINT`` |
+|                            | Useful when ordering on health.     |              |
++----------------------------+-------------------------------------+--------------+
+| ``description``            | A description of the current health | ``TEXT``     |
++----------------------------+-------------------------------------+--------------+
+| ``missing_shards``         | The number of unassigned or not     | ``INTEGER``  |
+|                            | started shards of all tables.       |              |
++----------------------------+-------------------------------------+--------------+
+| ``underreplicated_shards`` | The number of shards which are      | ``INTEGER``  |
+|                            | not fully replicated of all tables. |              |
++----------------------------+-------------------------------------+--------------+
+
+Both ``missing_shards`` and ``underreplicated_shards`` might return ``-1`` if
+the cluster is in an unhealthy state that prevents the exact number from being
+calculated. This could be the case when the cluster can't elect a master,
+because there are not enough eligible nodes available. In this case, the
+``description`` field will contain appropriate explanation regarding the
+cluster status.
+
+::
+
+    cr> select * from sys.cluster_health order by severity desc;
+    +-------------+--------+----------------+----------+------------------------+
+    | description | health | missing_shards | severity | underreplicated_shards |
+    +-------------+--------+----------------+----------+------------------------+
+    |             | GREEN  |              0 |        1 |                      0 |
+    +-------------+--------+----------------+----------+------------------------+
+    SELECT 1 row in set (... sec)
+
+The `health` with the highest `severity` will always define the `health` of the
+query scope.
+
 .. _sys-repositories:
 
 Repositories

--- a/docs/appendices/release-notes/6.0.0.rst
+++ b/docs/appendices/release-notes/6.0.0.rst
@@ -147,5 +147,10 @@ Administration and Operations
   to give more information on ongoing merges and whether the recovery source is
   still present in merged segments.
 
+- Added the :ref:`sys.cluster_health <sys-cluster_health>` table to provide
+  information about the health of the whole cluster in comparison to
+  the :ref:`sys.health <sys-health>` table which exposes health about each
+  table only.
+
 Client interfaces
 -----------------

--- a/docs/general/information-schema.rst
+++ b/docs/general/information-schema.rst
@@ -124,6 +124,7 @@ number of replicas.
     | sys                | allocations                       | BASE TABLE |             NULL | NULL               |
     | sys                | checks                            | BASE TABLE |             NULL | NULL               |
     | sys                | cluster                           | BASE TABLE |             NULL | NULL               |
+    | sys                | cluster_health                    | BASE TABLE |             NULL | NULL               |
     | sys                | health                            | BASE TABLE |             NULL | NULL               |
     | sys                | jobs                              | BASE TABLE |             NULL | NULL               |
     | sys                | jobs_log                          | BASE TABLE |             NULL | NULL               |
@@ -143,7 +144,7 @@ number of replicas.
     | sys                | summits                           | BASE TABLE |             NULL | NULL               |
     | sys                | users                             | BASE TABLE |             NULL | NULL               |
     +--------------------+-----------------------------------+------------+------------------+--------------------+
-    SELECT 76 rows in set (... sec)
+    SELECT 77 rows in set (... sec)
 
 
 The table also contains additional information such as the specified

--- a/server/src/main/java/io/crate/metadata/sys/SysClusterHealth.java
+++ b/server/src/main/java/io/crate/metadata/sys/SysClusterHealth.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.metadata.sys;
+
+import static io.crate.types.DataTypes.LONG;
+import static io.crate.types.DataTypes.SHORT;
+import static io.crate.types.DataTypes.STRING;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlock;
+import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.rest.RestStatus;
+
+import io.crate.metadata.RelationName;
+import io.crate.metadata.SystemTable;
+
+public class SysClusterHealth {
+
+    public static final RelationName IDENT = new RelationName(SysSchemaInfo.NAME, "cluster_health");
+
+    static SystemTable<ClusterHealth> INSTANCE = SystemTable.<ClusterHealth>builder(IDENT)
+        .add("health", STRING, ClusterHealth::getHealth)
+        .add("severity", SHORT, ClusterHealth::getSeverity)
+        .add("description", STRING, ClusterHealth::description)
+        .add("missing_shards", LONG, ClusterHealth::missingShards)
+        .add("underreplicated_shards", LONG, ClusterHealth::underreplicatedShards)
+        .build();
+
+    public static CompletableFuture<Iterable<ClusterHealth>> compute(ClusterState clusterState) {
+        // Following implementation of {@link org.elasticsearch.cluster.health.ClusterStateHealth}
+        Set<ClusterBlock> blocksRed = clusterState.blocks().global(RestStatus.SERVICE_UNAVAILABLE);
+        if (!blocksRed.isEmpty()) {
+            var block = blocksRed.iterator().next();
+            ClusterHealth clusterHealth = new ClusterHealth(
+                TableHealth.Health.RED,
+                block.description(),
+                -1,
+                -1
+            );
+            return CompletableFuture.completedFuture(List.of(clusterHealth));
+        }
+        Set<ClusterBlock> blocksYellow = clusterState.blocks().global(ClusterBlockLevel.METADATA_WRITE);
+        final TableHealth.Health clusterHealth = !blocksYellow.isEmpty() ? TableHealth.Health.YELLOW : TableHealth.Health.GREEN;
+        final String description = !blocksYellow.isEmpty() ? blocksYellow.iterator().next().description() : "";
+        return TableHealth.compute(clusterState)
+            .thenApply((it) -> {
+                long missingShards = 0;
+                long underreplicatedShards = 0;
+                TableHealth.Health health = clusterHealth;
+                String finalDescription = description;
+                for (var tableHealth : it) {
+                    if (tableHealth.health().severity() > health.severity()) {
+                        health = tableHealth.health();
+                        // shard level health is only set to RED if there are missing primary shards that were
+                        // allocated before see {@link ClusterShardHealth#getInactivePrimaryHealth()}.
+                        // Otherwise, the table health is set to YELLOW.
+                        if (health == TableHealth.Health.RED || tableHealth.getMissingShards() > 0) {
+                            finalDescription = "One or more tables are missing shards";
+                        } else if (health == TableHealth.Health.YELLOW) {
+                            finalDescription = "One or more tables have underreplicated shards";
+                        }
+                    }
+                    missingShards += tableHealth.getMissingShards();
+                    underreplicatedShards += tableHealth.getUnderreplicatedShards();
+                }
+                return List.of(new ClusterHealth(health, finalDescription, missingShards, underreplicatedShards));
+            });
+    }
+
+    public record ClusterHealth(TableHealth.Health health, String description, long missingShards, long underreplicatedShards) {
+
+        public String getHealth() {
+            return health.name();
+        }
+
+        public short getSeverity() {
+            return health.severity();
+        }
+    }
+}

--- a/server/src/main/java/io/crate/metadata/sys/SysSchemaInfo.java
+++ b/server/src/main/java/io/crate/metadata/sys/SysSchemaInfo.java
@@ -64,6 +64,7 @@ public class SysSchemaInfo implements SchemaInfo {
             Map.entry(SysSummitsTableInfo.IDENT.name(), SysSummitsTableInfo.INSTANCE),
             Map.entry(SysAllocationsTableInfo.IDENT.name(), SysAllocationsTableInfo.INSTANCE),
             Map.entry(SysHealth.IDENT.name(), SysHealth.INSTANCE),
+            Map.entry(SysClusterHealth.IDENT.name(), SysClusterHealth.INSTANCE),
             Map.entry(SysMetricsTableInfo.NAME.name(), SysMetricsTableInfo.create(localNode)),
             Map.entry(SysSegmentsTableInfo.IDENT.name(), SysSegmentsTableInfo.create(clusterService::localNode)),
             Map.entry(

--- a/server/src/main/java/io/crate/metadata/sys/SysTableDefinitions.java
+++ b/server/src/main/java/io/crate/metadata/sys/SysTableDefinitions.java
@@ -211,6 +211,14 @@ public class SysTableDefinitions {
                 )
             ),
             Map.entry(
+                SysClusterHealth.IDENT,
+                new StaticTableDefinition<>(
+                    () -> SysClusterHealth.compute(clusterService.state()),
+                    SysClusterHealth.INSTANCE.expressions(),
+                    false
+                )
+            ),
+            Map.entry(
                 SysMetricsTableInfo.NAME,
                 new StaticTableDefinition<>(
                     () -> completedFuture(jobsLogs.metrics()), SysMetricsTableInfo.create(localNode).expressions(), false)

--- a/server/src/main/java/io/crate/metadata/sys/TableHealth.java
+++ b/server/src/main/java/io/crate/metadata/sys/TableHealth.java
@@ -118,6 +118,10 @@ class TableHealth {
         return partitionIdent;
     }
 
+    public Health health() {
+        return health;
+    }
+
     public String getHealth() {
         return health.toString();
     }

--- a/server/src/main/java/org/elasticsearch/cluster/block/ClusterBlocks.java
+++ b/server/src/main/java/org/elasticsearch/cluster/block/ClusterBlocks.java
@@ -76,6 +76,16 @@ public class ClusterBlocks extends AbstractDiffable<ClusterBlocks> {
         return levelHolders.get(level).global();
     }
 
+    public Set<ClusterBlock> global(RestStatus status) {
+        Set<ClusterBlock> blocks = new HashSet<>();
+        for (ClusterBlock clusterBlock : global) {
+            if (clusterBlock.status().equals(status)) {
+                blocks.add(clusterBlock);
+            }
+        }
+        return blocks;
+    }
+
     public ImmutableOpenMap<String, Set<ClusterBlock>> indices(ClusterBlockLevel level) {
         return levelHolders.get(level).indices();
     }

--- a/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/server/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -24,7 +24,6 @@ package io.crate.integrationtests;
 import static io.crate.protocols.postgres.PGErrorStatus.INTERNAL_ERROR;
 import static io.crate.testing.Asserts.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
 import java.util.List;
@@ -114,6 +113,7 @@ public class InformationSchemaTest extends IntegTestCase {
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| crate| allocations| sys| BASE TABLE| NULL",
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| crate| checks| sys| BASE TABLE| NULL",
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| crate| cluster| sys| BASE TABLE| NULL",
+            "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| crate| cluster_health| sys| BASE TABLE| NULL",
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| crate| health| sys| BASE TABLE| NULL",
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| crate| jobs| sys| BASE TABLE| NULL",
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| crate| jobs_log| sys| BASE TABLE| NULL",
@@ -213,12 +213,12 @@ public class InformationSchemaTest extends IntegTestCase {
     @Test
     public void testSearchInformationSchemaTablesRefresh() {
         execute("select * from information_schema.tables");
-        assertThat(response.rowCount()).isEqualTo(72L);
+        assertThat(response.rowCount()).isEqualTo(73L);
 
         execute("create table t4 (col1 integer, col2 string) with(number_of_replicas=0)");
 
         execute("select * from information_schema.tables");
-        assertThat(response.rowCount()).isEqualTo(73L);
+        assertThat(response.rowCount()).isEqualTo(74L);
     }
 
     @Test
@@ -571,7 +571,7 @@ public class InformationSchemaTest extends IntegTestCase {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertThat(response.rowCount()).isEqualTo(1042);
+        assertThat(response.rowCount()).isEqualTo(1047);
     }
 
     @Test
@@ -889,7 +889,7 @@ public class InformationSchemaTest extends IntegTestCase {
         execute("create table t3 (id integer, col1 string) clustered into 3 shards with(number_of_replicas=0)");
         execute("select count(*) from information_schema.tables");
         assertThat(response.rowCount()).isEqualTo(1);
-        assertThat(response.rows()[0][0]).isEqualTo(75L);
+        assertThat(response.rows()[0][0]).isEqualTo(76L);
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/TableSettingsTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TableSettingsTest.java
@@ -94,7 +94,7 @@ public class TableSettingsTest extends IntegTestCase {
     public void testFilterOnNull() throws Exception {
         execute("select * from information_schema.tables " +
                 "where settings IS NULL");
-        assertThat(response.rowCount()).isEqualTo(72L);
+        assertThat(response.rowCount()).isEqualTo(73L);
         execute("select * from information_schema.tables " +
                 "where table_name = 'settings_table' and settings['blocks']['read'] IS NULL");
         assertThat(response.rowCount()).isEqualTo(0);

--- a/server/src/test/java/io/crate/metadata/sys/SysClusterHealthTest.java
+++ b/server/src/test/java/io/crate/metadata/sys/SysClusterHealthTest.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.metadata.sys;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.EnumSet;
+
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlock;
+import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.block.ClusterBlocks;
+import org.elasticsearch.rest.RestStatus;
+import org.junit.Test;
+
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+
+public class SysClusterHealthTest extends CrateDummyClusterServiceUnitTest {
+
+    @Test
+    public void test_green_no_tables() {
+        var healths = SysClusterHealth.compute(clusterService.state()).join();
+        var expected = new SysClusterHealth.ClusterHealth(
+            TableHealth.Health.GREEN,
+            "",
+            0,
+            0
+        );
+        assertThat(healths).containsExactly(expected);
+    }
+
+    @Test
+    public void test_green_with_tables() throws IOException {
+        SQLExecutor executor = SQLExecutor.builder(clusterService).build()
+            .addTable("create table doc.t1 (id int) with (number_of_replicas = 0)");
+        executor.startShards("doc.t1");
+
+        var healths = SysClusterHealth.compute(clusterService.state()).join();
+        var expected = new SysClusterHealth.ClusterHealth(
+            TableHealth.Health.GREEN,
+            "",
+            0,
+            0
+        );
+        assertThat(healths).containsExactly(expected);
+    }
+
+    @Test
+    public void test_cluster_is_yellow() {
+        var globalBlock = new ClusterBlock(
+            1,
+            "uuid",
+            "cannot write metadata",
+            true,
+            true,
+            true,
+            RestStatus.INTERNAL_SERVER_ERROR,
+            EnumSet.of(ClusterBlockLevel.METADATA_WRITE)
+        );
+        var newState = ClusterState.builder(clusterService.state())
+            .blocks(ClusterBlocks.builder().addGlobalBlock(globalBlock))
+            .build();
+        var healths = SysClusterHealth.compute(newState).join();
+        var expected = new SysClusterHealth.ClusterHealth(
+            TableHealth.Health.YELLOW,
+            "cannot write metadata",
+            0,
+            0
+        );
+        assertThat(healths).containsExactly(expected);
+    }
+
+    @Test
+    public void test_tables_are_yellow() throws Exception {
+        SQLExecutor executor = SQLExecutor.builder(clusterService).build()
+            .addTable("create table doc.t1 (id int) with (number_of_replicas = 1)");
+
+        var healths = SysClusterHealth.compute(clusterService.state()).join();
+        var expected = new SysClusterHealth.ClusterHealth(
+            TableHealth.Health.YELLOW,
+            "One or more tables are missing shards",
+            4,
+            4
+        );
+        assertThat(healths).containsExactly(expected);
+
+        executor.startShards("doc.t1");
+
+        healths = SysClusterHealth.compute(clusterService.state()).join();
+        expected = new SysClusterHealth.ClusterHealth(
+            TableHealth.Health.YELLOW,
+            "One or more tables have underreplicated shards",
+            0,
+            4
+        );
+        assertThat(healths).containsExactly(expected);
+    }
+
+    @Test
+    public void test_cluster_and_tables_are_yellow() throws Exception {
+        SQLExecutor executor = SQLExecutor.builder(clusterService).build()
+            .addTable("create table doc.t1 (id int) with (number_of_replicas = 1)");
+        executor.startShards("doc.t1");
+
+        var globalBlock = new ClusterBlock(
+            1,
+            "uuid",
+            "Cannot write metadata",
+            true,
+            true,
+            true,
+            RestStatus.INTERNAL_SERVER_ERROR,
+            EnumSet.of(ClusterBlockLevel.METADATA_WRITE)
+        );
+        var newState = ClusterState.builder(clusterService.state())
+            .blocks(ClusterBlocks.builder().addGlobalBlock(globalBlock))
+            .build();
+        var healths = SysClusterHealth.compute(newState).join();
+        var expected = new SysClusterHealth.ClusterHealth(
+            TableHealth.Health.YELLOW,
+            "Cannot write metadata",    // cluster level message takes precedence
+            0,
+            4
+        );
+        assertThat(healths).containsExactly(expected);
+    }
+
+    @Test
+    public void test_cluster_is_red() throws Exception {
+        // Without starting the shards, the table will be red as well.
+        SQLExecutor.builder(clusterService).build()
+            .addTable("create table doc.t1 (id int)");
+        var globalBlock = new ClusterBlock(
+            1,
+            "uuid",
+            "recovering",
+            true,
+            true,
+            true,
+            RestStatus.SERVICE_UNAVAILABLE,
+            EnumSet.of(ClusterBlockLevel.METADATA_READ)
+        );
+        var newState = ClusterState.builder(clusterService.state())
+                .blocks(ClusterBlocks.builder().addGlobalBlock(globalBlock))
+                .build();
+
+        var healths = SysClusterHealth.compute(newState).join();
+        var expected = new SysClusterHealth.ClusterHealth(
+            TableHealth.Health.RED,
+            "recovering",   // cluster level message takes precedence
+            -1,
+            -1
+        );
+        assertThat(healths).containsExactly(expected);
+    }
+
+    @Test
+    public void test_tables_are_red() throws Exception {
+        var executor = SQLExecutor.builder(clusterService).build()
+            .addTable("create table doc.t1 (id int)");
+        executor.startShards("doc.t1");
+        executor.failShards("doc.t1");
+
+        var healths = SysClusterHealth.compute(clusterService.state()).join();
+        var expected = new SysClusterHealth.ClusterHealth(
+            TableHealth.Health.RED,
+            "One or more tables are missing shards",
+            4,
+            0
+        );
+        assertThat(healths).containsExactly(expected);
+    }
+}


### PR DESCRIPTION
This new table will expose the overall cluster health based on the cluster state and individual table health exposed by the existing `sys.health` table.
For example, if the cluster is starting and recovering, no table is yet available, such `sys.health` will return an empty result set. Such a state will result in a `RED` overal cluster health exposed by this new table.

Relates to #17600.