### PR TITLE
Experiment

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshots.java
+++ b/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshots.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -101,6 +102,7 @@ public class BlobStoreIndexShardSnapshots implements Iterable<SnapshotFiles>, Wr
         this.shardSnapshots = in.readList(SnapshotFiles::new);
         this.physicalFiles = in.readMap(StreamInput::readString, x -> x.readList(FileInfo::new));
         this.files = in.readMap(StreamInput::readString, FileInfo::new);
+        throw new CircuitBreakingException("dummy");
     }
 
     @Override


### PR DESCRIPTION
Relates to https://github.com/crate/support/issues/554

>To my understanding, both DROP and CREATE snapshot go through previous shard snapshots to operate correctly.
BlobStoreIndexShardSnapshots construction in general is memory demanding.


> I wonder if we should add memory accounting for BlobStoreIndexShardSnapshots deserialzation.


Main concern was that interrupting CREATE/DROP snapshot amid deserialization might leave some unusable blobs behind.

Failure in `test_can_restore_snapshot_after_swap_table_with_drop_source`
`org.postgresql.util.PSQLException: ERROR: [my_repo:s2/lYz9bPF7QK2pIjigtTsMAw] index [zua.t02] wasn't fully snapshotted - cannot restore`