### PR TITLE
Enforce RHS param of like operators to be the patterns

### DIFF
--- a/docs/appendices/release-notes/6.0.0.rst
+++ b/docs/appendices/release-notes/6.0.0.rst
@@ -73,6 +73,12 @@ Breaking Changes
   inner type definition is used. See also the related
   :ref:`documentation <cast_to_object>`
 
+- Removed support for patterns on the left side argument of
+  :ref:`LIKE/ILIKE <sql_dql_like>` operators because it led to ambiguities when
+  both sides contained possible pattern like strings e.g.::
+
+    SELECT 'a%' LIKE ANY(['a__']);
+
 Deprecations
 ============
 

--- a/docs/general/dql/selects.rst
+++ b/docs/general/dql/selects.rst
@@ -612,17 +612,6 @@ For example, this query returns any row where the array
 This query combines the ``ANY`` operator with the :ref:`LIKE <sql_dql_like>`
 operator::
 
-    cr> select inhabitants['name'], inhabitants['interests'] from locations
-    ... where '%stories%' LIKE ANY(inhabitants['interests']);
-    +---------------------+------------------------------+
-    | inhabitants['name'] | inhabitants['interests']     |
-    +---------------------+------------------------------+
-    | Minories            | ["netball", "short stories"] |
-    +---------------------+------------------------------+
-    SELECT 1 row in set (... sec)
-
-For ``LIKE ANY`` operators, the patterns can be provided on either sides::
-
     cr> select name from locations where name ILIKE ANY(['al%', 'ar%']) order
     ... by name asc;
     +---------------------+

--- a/server/src/main/java/io/crate/expression/operator/all/AllLikeOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/all/AllLikeOperator.java
@@ -51,9 +51,7 @@ public final class AllLikeOperator extends AllOperator<String> {
 
     @Override
     boolean matches(String probe, String candidate) {
-        // Accept both sides of arguments to be patterns
-        return LikeOperators.matches(probe, candidate, LikeOperators.DEFAULT_ESCAPE, caseSensitivity) ||
-            LikeOperators.matches(candidate, probe, LikeOperators.DEFAULT_ESCAPE, caseSensitivity);
+        return LikeOperators.matches(probe, candidate, LikeOperators.DEFAULT_ESCAPE, caseSensitivity);
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/operator/all/AllNotLikeOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/all/AllNotLikeOperator.java
@@ -50,9 +50,7 @@ public final class AllNotLikeOperator extends AllOperator<String> {
 
     @Override
     boolean matches(String probe, String candidate) {
-        // Accept both sides of arguments to be patterns
-        return !LikeOperators.matches(probe, candidate, LikeOperators.DEFAULT_ESCAPE, caseSensitivity) &&
-            !LikeOperators.matches(candidate, probe, LikeOperators.DEFAULT_ESCAPE, caseSensitivity);
+        return !LikeOperators.matches(probe, candidate, LikeOperators.DEFAULT_ESCAPE, caseSensitivity);
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/operator/any/AnyLikeOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/any/AnyLikeOperator.java
@@ -57,9 +57,7 @@ public final class AnyLikeOperator extends AnyOperator<String> {
 
     @Override
     boolean matches(String probe, String candidate) {
-        // Accept both sides of arguments to be patterns
-        return LikeOperators.matches(probe, candidate, LikeOperators.DEFAULT_ESCAPE, caseSensitivity) ||
-               LikeOperators.matches(candidate, probe, LikeOperators.DEFAULT_ESCAPE, caseSensitivity);
+        return LikeOperators.matches(probe, candidate, LikeOperators.DEFAULT_ESCAPE, caseSensitivity);
     }
 
     @Override
@@ -87,7 +85,7 @@ public final class AnyLikeOperator extends AnyOperator<String> {
 
     @Override
     protected Query literalMatchesAnyArrayRef(Function any, Literal<?> probe, Reference candidates, Context context) {
-        return caseSensitivity.likeQuery(candidates.storageIdent(), (String) probe.value(), LikeOperators.DEFAULT_ESCAPE, candidates.indexType() != IndexType.NONE);
+        return null;
     }
 
     @Override

--- a/server/src/main/java/io/crate/expression/operator/any/AnyNotLikeOperator.java
+++ b/server/src/main/java/io/crate/expression/operator/any/AnyNotLikeOperator.java
@@ -58,8 +58,7 @@ public final class AnyNotLikeOperator extends AnyOperator<String> {
     @Override
     boolean matches(String probe, String candidate) {
         // Accept both sides of arguments to be patterns
-        return !LikeOperators.matches(probe, candidate, LikeOperators.DEFAULT_ESCAPE, caseSensitivity) &&
-               !LikeOperators.matches(candidate, probe, LikeOperators.DEFAULT_ESCAPE, caseSensitivity);
+        return !LikeOperators.matches(probe, candidate, LikeOperators.DEFAULT_ESCAPE, caseSensitivity);
     }
 
     @Override

--- a/server/src/test/java/io/crate/expression/operator/all/AllLikeOperatorTest.java
+++ b/server/src/test/java/io/crate/expression/operator/all/AllLikeOperatorTest.java
@@ -40,44 +40,40 @@ public class AllLikeOperatorTest extends ScalarTestCase {
     @Test
     public void testNormalizeSymbolLikeZeroOrMore() {
         // Following tests: wildcard: '%' ... zero or more characters (0...N)
-        assertNormalize("'%bar' like all (['foobar', 'bar'])", isLiteral(true));
-        assertNormalize("'%bar' like all (['bar'])", isLiteral(true));
-        assertNormalize("'%bar' like all (['ar', 'car'])", isLiteral(false));
-        assertNormalize("'foo%' like all (['foobar', 'foobar'])", isLiteral(true));
-        assertNormalize("'foo%' like all (['foo', 'fooo'])", isLiteral(true));
-        assertNormalize("'foo%' like all (['fo', 'kuh'])", isLiteral(false));
-        assertNormalize("'%oob%' like all (['foobar'])", isLiteral(true));
-        assertNormalize("'%bar' ilike all (['FOObAr'])", isLiteral(true));
-        assertNormalize("'foo%' ilike all (['fO', 'kuh'])", isLiteral(false));
-        assertNormalize("'%oob%' ilike all (['bOOb'])", isLiteral(true));
+        assertNormalize("'bar' like all (['%bar'])", isLiteral(true));
+        assertNormalize("'foobar' like all (['%bar'])", isLiteral(true));
+        assertNormalize("'bar' like all (['%ar', '%car'])", isLiteral(false));
+        assertNormalize("'bar' like all (['%car', '%dar'])", isLiteral(false));
+        assertNormalize("'foobar' like all (['%oob%'])", isLiteral(true));
+        assertNormalize("'FOObAr' ilike all (['%bar'])", isLiteral(true));
+        assertNormalize("'bOOb' ilike all (['%oob%'])", isLiteral(true));
     }
 
     @Test
     public void testNormalizeSymbolLikeExactlyOne() {
         // Following tests: wildcard: '_' ... all single character (exactly one)
-        assertNormalize("'_ar' like all (['bar'])", isLiteral(true));
-        assertNormalize("'_bar' like all (['bar'])", isLiteral(false));
-        assertNormalize("'fo_' like all (['foo', 'for'])", isLiteral(true));
-        assertNormalize("'foo_' like all (['foo'])", isLiteral(false));
-        assertNormalize("'_o_' like all (['foo'])", isLiteral(true));
-        assertNormalize("'_foobar_' like all (['foobar'])", isLiteral(false));
-        assertNormalize("'_ar' ilike all (['bAR'])", isLiteral(true));
-        assertNormalize("'_o_' ilike all (['fOo'])", isLiteral(true));
-        assertNormalize("'fOO_' ilike all (['foo'])", isLiteral(false));
+        assertNormalize("'bar' like all (['_ar'])", isLiteral(true));
+        assertNormalize("'bar' like all (['_bar'])", isLiteral(false));
+        assertNormalize("'foot' like all (['foo_'])", isLiteral(true));
+        assertNormalize("'foo' like all (['foo_'])", isLiteral(false));
+        assertNormalize("'foo' like all (['_o_'])", isLiteral(true));
+        assertNormalize("'foobar' like all (['_foobar_'])", isLiteral(false));
+        assertNormalize("'bAR' ilike all (['_ar'])", isLiteral(true));
+        assertNormalize("'fOo' ilike all (['_o_'])", isLiteral(true));
+        assertNormalize("'foo' ilike all (['fOO_'])", isLiteral(false));
     }
 
     // Following tests: mixed wildcards:
 
     @Test
     public void testNormalizeSymbolLikeMixed() {
-        assertNormalize("'%o_ar' like all (['foobar', 'obar'])", isLiteral(true));
-        assertNormalize("'%a_' like all (['foobar'])", isLiteral(true));
-        assertNormalize("'%o_a%' like all (['foobar'])", isLiteral(true));
-        assertNormalize("'%i%m%' like all (['Lorem ipsum dolor...'])", isLiteral(true));
-        assertNormalize("'%%%sum%%' like all (['Lorem ipsum dolor...'])", isLiteral(true));
-        assertNormalize("'%i%m' like all (['Lorem ipsum dolor...'])", isLiteral(false));
-        assertNormalize("'%o_a%' ilike all (['fOObar'])", isLiteral(true));
-        assertNormalize("'%%%sum%%' ilike all (['Lorem IpSuM dolor...'])", isLiteral(true));
+        assertNormalize("'foobar' like all (['%o_ar'])", isLiteral(true));
+        assertNormalize("'foobar' like all (['%o_a%'])", isLiteral(true));
+        assertNormalize("'Lorem ipsum dolor...' like all (['%i%m%'])", isLiteral(true));
+        assertNormalize("'Lorem ipsum dolor...' like all (['%%%sum%%'])", isLiteral(true));
+        assertNormalize("'Lorem ipsum dolor...' like all (['%i%m'])", isLiteral(false));
+        assertNormalize("'fOObar' ilike all (['%o_a%'])", isLiteral(true));
+        assertNormalize("'Lorem IpSuM dolor...' ilike all (['%%%sum%%'])", isLiteral(true));
     }
 
     @Test
@@ -90,14 +86,13 @@ public class AllLikeOperatorTest extends ScalarTestCase {
 
     @Test
     public void testEvaluateLikeMixed() {
-        assertEvaluate("'%o_ar' like all (['foobar', 'obar'])", true);
-        assertEvaluate("'%a_' like all (['foobar'])", true);
-        assertEvaluate("'%o_a%' like all (['foobar'])", true);
-        assertEvaluate("'%i%m%' like all (['Lorem ipsum dolor...'])", true);
-        assertEvaluate("'%%%sum%%' like all (['Lorem ipsum dolor...'])", true);
-        assertEvaluate("'%i%m' like all (['Lorem ipsum dolor...'])", false);
-        assertEvaluate("'%o_a%' ilike all (['fOObar'])", true);
-        assertEvaluate("'%%%sum%%' ilike all (['Lorem IpSuM dolor...'])", true);
+        assertEvaluate("'foobar' like all (['%o_ar'])", true);
+        assertEvaluate("'foobar' like all (['%o_a%'])", true);
+        assertEvaluate("'Lorem ipsum dolor...' like all (['%i%m%'])", true);
+        assertEvaluate("'Lorem ipsum dolor...' like all (['%%%sum%%'])", true);
+        assertEvaluate("'Lorem ipsum dolor...' like all (['%i%m'])", false);
+        assertEvaluate("'fOObar' ilike all (['%o_a%'])", true);
+        assertEvaluate("'Lorem IpSuM dolor...' ilike all (['%%%sum%%'])", true);
     }
 
     @Test
@@ -125,16 +120,6 @@ public class AllLikeOperatorTest extends ScalarTestCase {
     }
 
     @Test
-    public void test_patterns_on_right_arg() {
-        assertNormalize("'foobar' like all (['%bar'])", isLiteral(true));
-        assertNormalize("'bar' like all (['_ar'])", isLiteral(true));
-        assertNormalize("'foobar' like all (['%o_a%'])", isLiteral(true));
-        assertNormalize("'fOobAR' ilike all (['%BaR'])", isLiteral(true));
-        assertNormalize("'BaR' ilike all (['_ar'])", isLiteral(true));
-        assertNormalize("'foobar' ilike all (['%O_a%'])", isLiteral(true));
-    }
-
-    @Test
     public void test_non_string_values() {
         assertNormalize("1 like all ([1, null, 1])", isLiteral(null));
         assertNormalize("1 not like all ([1])", isLiteral(false));
@@ -156,5 +141,10 @@ public class AllLikeOperatorTest extends ScalarTestCase {
         assertThatThrownBy(() -> assertEvaluate("'TextToMatch' ILIKE ALL (['a', 'b', 'ab\\'])", false))
             .isExactlyInstanceOf(IllegalArgumentException.class)
             .hasMessage("pattern 'ab\\' must not end with escape character '\\'");
+    }
+
+    @Test
+    public void test_only_rhs_arg_can_be_pattern() {
+        assertEvaluate("'a%' like all(['a__'])", false);
     }
 }

--- a/server/src/test/java/io/crate/expression/operator/all/AllNotLikeOperatorTest.java
+++ b/server/src/test/java/io/crate/expression/operator/all/AllNotLikeOperatorTest.java
@@ -42,48 +42,39 @@ public class AllNotLikeOperatorTest extends ScalarTestCase {
     @Test
     public void testNormalizeSymbolLikeZeroOrMore() {
         // Following tests: wildcard: '%' ... zero or more characters (0...N)
-        assertNormalize("'%bar' not like all (['foobar', 'bar'])", isLiteral(false));
-        assertNormalize("'%bar' not like all (['bar'])", isLiteral(false));
-        assertNormalize("'%bar' not like all (['ar', 'car'])", isLiteral(true));
-        assertNormalize("'foo%' not like all (['foobar', 'kuhbar'])", isLiteral(false));
-        assertNormalize("'foo%' not like all (['foo', 'kuh'])", isLiteral(false));
-        assertNormalize("'foo%' not like all (['fo', 'kuh'])", isLiteral(true));
-        assertNormalize("'%oob%' not like all (['foobar'])", isLiteral(false));
-
-        assertNormalize("'foo%' not ilike all (['FOO', 'foo'])", isLiteral(false));
-        assertNormalize("'foo%' not ilike all (['fo', 'kuh'])", isLiteral(true));
-        assertNormalize("'%oob%' not ilike all (['FOOBAR'])", isLiteral(false));
+        assertNormalize("'bar' not like all (['%bar'])", isLiteral(false));
+        assertNormalize("'foobar' not like all (['%bar'])", isLiteral(false));
+        assertNormalize("'bar' not like all (['%ar', '%car'])", isLiteral(false));
+        assertNormalize("'bar' not like all (['%car', '%dar'])", isLiteral(true));
+        assertNormalize("'foobar' not like all (['%oob%'])", isLiteral(false));
+        assertNormalize("'FOObAr' not ilike all (['%bar'])", isLiteral(false));
+        assertNormalize("'bOOb' not ilike all (['%oob%'])", isLiteral(false));
     }
 
     @Test
     public void testNormalizeSymbolLikeExactlyOne() {
         // Following tests: wildcard: '_' ... all single character (exactly one)
-        assertNormalize("'_ar' not like all (['bar'])", isLiteral(false));
-        assertNormalize("'_bar' not like all (['bar'])", isLiteral(true));
-        assertNormalize("'fo_' not like all (['foo', 'for'])", isLiteral(false));
-        assertNormalize("'foo_' not like all (['foo', 'foo'])", isLiteral(true));
-        assertNormalize("'_o_' not like all (['foo'])", isLiteral(false));
-        assertNormalize("'_foobar_' not like all (['foobar'])", isLiteral(true));
-
-        assertNormalize("'foo_' not ilike all (['FOO'])", isLiteral(true));
-        assertNormalize("'_o_' not ilike all (['fOo'])", isLiteral(false));
-        assertNormalize("'_foobar_' not ilike all (['foObar'])", isLiteral(true));
+        assertNormalize("'bar' not like all (['_ar'])", isLiteral(false));
+        assertNormalize("'bar' not like all (['_bar'])", isLiteral(true));
+        assertNormalize("'foot' not like all (['foo_'])", isLiteral(false));
+        assertNormalize("'foo' not like all (['foo_'])", isLiteral(true));
+        assertNormalize("'foo' not like all (['_o_'])", isLiteral(false));
+        assertNormalize("'foobar' not like all (['_foobar_'])", isLiteral(true));
+        assertNormalize("'bAR' not ilike all (['_ar'])", isLiteral(false));
+        assertNormalize("'fOo' not ilike all (['_o_'])", isLiteral(false));
+        assertNormalize("'foo' not ilike all (['fOO_'])", isLiteral(true));
     }
 
     // Following tests: mixed wildcards:
 
     @Test
     public void testNormalizeSymbolLikeMixed() {
-        assertNormalize("'%o_ar' not like all (['oar', 'aoar'])", isLiteral(true));
-        assertNormalize("'%a_' not like all (['foobar'])", isLiteral(false));
-        assertNormalize("'%o_a%' not like all (['foobar'])", isLiteral(false));
-        assertNormalize("'%i%m%' not like all (['Lorem ipsum dolor...'])", isLiteral(false));
-        assertNormalize("'%%%sum%%' not like all (['Lorem ipsum dolor...'])", isLiteral(false));
-        assertNormalize("'%i%m' not like all (['Lorem ipsum dolor...'])", isLiteral(true));
-
-        assertNormalize("'%i%m%' not ilike all (['LOREM IPSUM DOLOR...'])", isLiteral(false));
-        assertNormalize("'%%%sum%%' not ilike all (['LOREM IPSUM DOLOR...'])", isLiteral(false));
-        assertNormalize("'%i%m' not ilike all (['LOREM IPSUM DOLOR...'])", isLiteral(true));
+        assertNormalize("'foobar' not like all (['%o_ar', '%o_a%'])", isLiteral(false));
+        assertNormalize("'Lorem ipsum dolor...' not like all (['%i%m%'])", isLiteral(false));
+        assertNormalize("'Lorem ipsum dolor...' not like all (['%%%sum%%'])", isLiteral(false));
+        assertNormalize("'Lorem ipsum dolor...' not like all (['%i%m'])", isLiteral(true));
+        assertNormalize("'fOObar' not ilike all (['%o_a%'])", isLiteral(false));
+        assertNormalize("'Lorem IpSuM dolor...' not ilike all (['%%%sum%%'])", isLiteral(false));
     }
 
     @Test
@@ -100,14 +91,12 @@ public class AllNotLikeOperatorTest extends ScalarTestCase {
 
     @Test
     public void testEvaluateLikeMixed() {
-        assertEvaluate("'%o_ar' not like all (['foobar', 'foobaz'])", false);
-        assertEvaluate("'%a_' not like all (['foobar'])", false);
-        assertEvaluate("'%o_a%' not like all (['foobar'])", false);
-        assertEvaluate("'%i%m%' not like all (['Lorem ipsum dolor..'])", false);
-        assertEvaluate("'%%%sum%%' not like all (['Lorem ipsum dolor...'])", false);
-        assertEvaluate("'%i%m' not like all (['Lorem ipsum dolor...'])", true);
-        assertEvaluate("'%%%sum%%' not ilike all (['Lorem IPSUM dolor...'])", false);
-
+        assertEvaluate("'foobar' not like all (['%o_ar', '%o_a%'])", false);
+        assertEvaluate("'Lorem ipsum dolor...' not like all (['%i%m%'])", false);
+        assertEvaluate("'Lorem ipsum dolor...' not like all (['%%%sum%%'])", false);
+        assertEvaluate("'Lorem ipsum dolor...' not like all (['%i%m'])", true);
+        assertEvaluate("'fOObar' not ilike all (['%o_a%'])", false);
+        assertEvaluate("'Lorem IpSuM dolor...' not ilike all (['%%%sum%%'])", false);
     }
 
     @Test
@@ -133,16 +122,6 @@ public class AllNotLikeOperatorTest extends ScalarTestCase {
     }
 
     @Test
-    public void test_patterns_on_right_arg() {
-        assertNormalize("'foobar' not like all (['%barr'])", isLiteral(true));
-        assertNormalize("'bar' not like all (['_ar'])", isLiteral(false));
-        assertNormalize("'foobar' not like all (['%o_a%'])", isLiteral(false));
-        assertNormalize("'fOobAR' not ilike all (['%BaR'])", isLiteral(false));
-        assertNormalize("'BaR' not ilike all (['z_ar'])", isLiteral(true));
-        assertNormalize("'foobar' not ilike all (['%O_a%'])", isLiteral(false));
-    }
-
-    @Test
     public void test_wildcard_escaped_in_c_style_string() {
         assertEvaluate("'TextToMatch' NOT LIKE ALL ([E'Te\\%tch'])", false);
         assertEvaluate("'TextToMatch' NOT ILIKE ALL ([E'te\\%tch'])", false);
@@ -156,5 +135,10 @@ public class AllNotLikeOperatorTest extends ScalarTestCase {
         assertThatThrownBy(() -> assertEvaluate("'TextToMatch' NOT ILIKE ALL (['texttomatch', 'ab\\'])", false))
             .isExactlyInstanceOf(IllegalArgumentException.class)
             .hasMessage("pattern 'ab\\' must not end with escape character '\\'");
+    }
+
+    @Test
+    public void test_only_rhs_arg_can_be_pattern() {
+        assertEvaluate("'a%' not like all(['a__'])", true);
     }
 }

--- a/server/src/test/java/io/crate/expression/operator/any/AnyLikeOperatorTest.java
+++ b/server/src/test/java/io/crate/expression/operator/any/AnyLikeOperatorTest.java
@@ -40,45 +40,40 @@ public class AnyLikeOperatorTest extends ScalarTestCase {
     @Test
     public void testNormalizeSymbolLikeZeroOrMore() {
         // Following tests: wildcard: '%' ... zero or more characters (0...N)
-        assertNormalize("'%bar' like any (['foobar', 'bar'])", isLiteral(true));
-        assertNormalize("'%bar' like any (['bar'])", isLiteral(true));
-        assertNormalize("'%bar' like any (['ar', 'car'])", isLiteral(false));
-        assertNormalize("'foo%' like any (['foobar', 'kuhbar'])", isLiteral(true));
-        assertNormalize("'foo%' like any (['foo', 'kuh'])", isLiteral(true));
-        assertNormalize("'foo%' like any (['fo', 'kuh'])", isLiteral(false));
-        assertNormalize("'%oob%' like any (['foobar'])", isLiteral(true));
-        assertNormalize("'%bar' ilike any (['FOObAr'])", isLiteral(true));
-        assertNormalize("'foo%' ilike any (['fO', 'kuh'])", isLiteral(false));
-        assertNormalize("'%oob%' ilike any (['fobar', 'bOOb'])", isLiteral(true));
+        assertNormalize("'bar' like any (['%bar'])", isLiteral(true));
+        assertNormalize("'foobar' like any (['%bar'])", isLiteral(true));
+        assertNormalize("'bar' like any (['%ar', '%car'])", isLiteral(true));
+        assertNormalize("'bar' like any (['%car', '%dar'])", isLiteral(false));
+        assertNormalize("'foobar' like any (['%oob%'])", isLiteral(true));
+        assertNormalize("'FOObAr' ilike any (['%bar'])", isLiteral(true));
+        assertNormalize("'bOOb' ilike any (['%oob%'])", isLiteral(true));
     }
 
     @Test
     public void testNormalizeSymbolLikeExactlyOne() {
         // Following tests: wildcard: '_' ... any single character (exactly one)
-        assertNormalize("'_ar' like any (['bar'])", isLiteral(true));
-        assertNormalize("'_bar' like any (['bar'])", isLiteral(false));
-        assertNormalize("'fo_' like any (['bar', 'for'])", isLiteral(true));
-        assertNormalize("'foo_' like any (['foo', 'foot'])", isLiteral(true));
-        assertNormalize("'foo_' like any (['foo'])", isLiteral(false));
-        assertNormalize("'_o_' like any (['foo'])", isLiteral(true));
-        assertNormalize("'_foobar_' like any (['foobar'])", isLiteral(false));
-        assertNormalize("'_ar' ilike any (['bAR'])", isLiteral(true));
-        assertNormalize("'_o_' ilike any (['fOo'])", isLiteral(true));
-        assertNormalize("'fOO_' ilike any (['foo'])", isLiteral(false));
+        assertNormalize("'bar' like any (['_ar'])", isLiteral(true));
+        assertNormalize("'bar' like any (['_bar'])", isLiteral(false));
+        assertNormalize("'foot' like any (['foo_'])", isLiteral(true));
+        assertNormalize("'foo' like any (['foo_'])", isLiteral(false));
+        assertNormalize("'foo' like any (['_o_'])", isLiteral(true));
+        assertNormalize("'foobar' like any (['_foobar_'])", isLiteral(false));
+        assertNormalize("'bAR' ilike any (['_ar'])", isLiteral(true));
+        assertNormalize("'fOo' ilike any (['_o_'])", isLiteral(true));
+        assertNormalize("'foo' ilike any (['fOO_'])", isLiteral(false));
     }
 
     // Following tests: mixed wildcards:
 
     @Test
     public void testNormalizeSymbolLikeMixed() {
-        assertNormalize("'%o_ar' like any (['foobar', 'foobaz'])", isLiteral(true));
-        assertNormalize("'%a_' like any (['foobar'])", isLiteral(true));
-        assertNormalize("'%o_a%' like any (['foobar'])", isLiteral(true));
-        assertNormalize("'%i%m%' like any (['Lorem ipsum dolor...'])", isLiteral(true));
-        assertNormalize("'%%%sum%%' like any (['Lorem ipsum dolor...'])", isLiteral(true));
-        assertNormalize("'%i%m' like any (['Lorem ipsum dolor...'])", isLiteral(false));
-        assertNormalize("'%o_a%' ilike any (['fOObar'])", isLiteral(true));
-        assertNormalize("'%%%sum%%' ilike any (['Lorem IpSuM dolor...'])", isLiteral(true));
+        assertNormalize("'foobar' like any (['%o_ar'])", isLiteral(true));
+        assertNormalize("'foobar' like any (['%o_a%'])", isLiteral(true));
+        assertNormalize("'Lorem ipsum dolor...' like any (['%i%m%'])", isLiteral(true));
+        assertNormalize("'Lorem ipsum dolor...' like any (['%%%sum%%'])", isLiteral(true));
+        assertNormalize("'Lorem ipsum dolor...' like any (['%i%m'])", isLiteral(false));
+        assertNormalize("'fOObar' ilike any (['%o_a%'])", isLiteral(true));
+        assertNormalize("'Lorem IpSuM dolor...' ilike any (['%%%sum%%'])", isLiteral(true));
     }
 
     @Test
@@ -91,14 +86,13 @@ public class AnyLikeOperatorTest extends ScalarTestCase {
 
     @Test
     public void testEvaluateLikeMixed() {
-        assertEvaluate("'%o_ar' like any (['foobar', 'foobaz'])", true);
-        assertEvaluate("'%a_' like any (['foobar'])", true);
-        assertEvaluate("'%o_a%' like any (['foobar'])", true);
-        assertEvaluate("'%i%m%' like any (['Lorem ipsum dolor...'])", true);
-        assertEvaluate("'%%%sum%%' like any (['Lorem ipsum dolor...'])", true);
-        assertEvaluate("'%i%m' like any (['Lorem ipsum dolor...'])", false);
-        assertEvaluate("'%o_a%' ilike any (['fOObar'])", true);
-        assertEvaluate("'%%%sum%%' ilike any (['Lorem IpSuM dolor...'])", true);
+        assertEvaluate("'foobar' like any (['%o_ar'])", true);
+        assertEvaluate("'foobar' like any (['%o_a%'])", true);
+        assertEvaluate("'Lorem ipsum dolor...' like any (['%i%m%'])", true);
+        assertEvaluate("'Lorem ipsum dolor...' like any (['%%%sum%%'])", true);
+        assertEvaluate("'Lorem ipsum dolor...' like any (['%i%m'])", false);
+        assertEvaluate("'fOObar' ilike any (['%o_a%'])", true);
+        assertEvaluate("'Lorem IpSuM dolor...' ilike any (['%%%sum%%'])", true);
     }
 
     @Test
@@ -126,16 +120,6 @@ public class AnyLikeOperatorTest extends ScalarTestCase {
     }
 
     @Test
-    public void test_patterns_on_right_arg() {
-        assertNormalize("'foobar' like any (['%bar'])", isLiteral(true));
-        assertNormalize("'bar' like any (['_ar'])", isLiteral(true));
-        assertNormalize("'foobar' like any (['%o_a%'])", isLiteral(true));
-        assertNormalize("'fOobAR' ilike any (['%BaR'])", isLiteral(true));
-        assertNormalize("'BaR' ilike any (['_ar'])", isLiteral(true));
-        assertNormalize("'foobar' ilike any (['%O_a%'])", isLiteral(true));
-    }
-
-    @Test
     public void test_non_string_values() {
         assertNormalize("1 like any ([1, null, 2])", isLiteral(true));
         assertNormalize("1 not like any ([1])", isLiteral(false));
@@ -157,5 +141,10 @@ public class AnyLikeOperatorTest extends ScalarTestCase {
         assertThatThrownBy(() -> assertEvaluate("'TextToMatch' ILIKE ANY (['a', 'b', 'ab\\'])", false))
             .isExactlyInstanceOf(IllegalArgumentException.class)
             .hasMessage("pattern 'ab\\' must not end with escape character '\\'");
+    }
+
+    @Test
+    public void test_only_rhs_arg_can_be_pattern() {
+        assertEvaluate("'a%' like any(['a__'])", false);
     }
 }

--- a/server/src/test/java/io/crate/expression/operator/any/AnyNotLikeOperatorTest.java
+++ b/server/src/test/java/io/crate/expression/operator/any/AnyNotLikeOperatorTest.java
@@ -42,49 +42,39 @@ public class AnyNotLikeOperatorTest extends ScalarTestCase {
     @Test
     public void testNormalizeSymbolLikeZeroOrMore() {
         // Following tests: wildcard: '%' ... zero or more characters (0...N)
-        assertNormalize("'%bar' not like any (['foobar', 'bar'])", isLiteral(false));
-        assertNormalize("'%bar' not like any (['bar'])", isLiteral(false));
-        assertNormalize("'%bar' not like any (['ar', 'car'])", isLiteral(true));
-        assertNormalize("'foo%' not like any (['foobar', 'kuhbar'])", isLiteral(true));
-        assertNormalize("'foo%' not like any (['foo', 'kuh'])", isLiteral(true));
-        assertNormalize("'foo%' not like any (['fo', 'kuh'])", isLiteral(true));
-        assertNormalize("'%oob%' not like any (['foobar'])", isLiteral(false));
-
-        assertNormalize("'foo%' not ilike any (['FOO', 'kuh'])", isLiteral(true));
-        assertNormalize("'foo%' not ilike any (['fo', 'kuh'])", isLiteral(true));
-        assertNormalize("'%oob%' not ilike any (['FOOBAR'])", isLiteral(false));
+        assertNormalize("'bar' not like any (['%bar'])", isLiteral(false));
+        assertNormalize("'foobar' not like any (['%bar'])", isLiteral(false));
+        assertNormalize("'bar' not like any (['%ar', '%car'])", isLiteral(true));
+        assertNormalize("'bar' not like any (['%car', '%dar'])", isLiteral(true));
+        assertNormalize("'foobar' not like any (['%oob%'])", isLiteral(false));
+        assertNormalize("'FOObAr' not ilike any (['%bar'])", isLiteral(false));
+        assertNormalize("'bOOb' not ilike any (['%oob%'])", isLiteral(false));
     }
 
     @Test
     public void testNormalizeSymbolLikeExactlyOne() {
         // Following tests: wildcard: '_' ... any single character (exactly one)
-        assertNormalize("'_ar' not like any (['bar'])", isLiteral(false));
-        assertNormalize("'_bar' not like any (['bar'])", isLiteral(true));
-        assertNormalize("'fo_' not like any (['foo', 'for'])", isLiteral(false));
-        assertNormalize("'foo_' not like any (['foo', 'foot'])", isLiteral(true));
-        assertNormalize("'foo_' not like any (['foo'])", isLiteral(true));
-        assertNormalize("'_o_' not like any (['foo'])", isLiteral(false));
-        assertNormalize("'_foobar_' not like any (['foobar'])", isLiteral(true));
-
-        assertNormalize("'foo_' not ilike any (['FOO'])", isLiteral(true));
-        assertNormalize("'_o_' not ilike any (['fOo'])", isLiteral(false));
-        assertNormalize("'_foobar_' not ilike any (['foObar'])", isLiteral(true));
+        assertNormalize("'bar' not like any (['_ar'])", isLiteral(false));
+        assertNormalize("'bar' not like any (['_bar'])", isLiteral(true));
+        assertNormalize("'foot' not like any (['foo_'])", isLiteral(false));
+        assertNormalize("'foo' not like any (['foo_'])", isLiteral(true));
+        assertNormalize("'foo' not like any (['_o_'])", isLiteral(false));
+        assertNormalize("'foobar' not like any (['_foobar_'])", isLiteral(true));
+        assertNormalize("'bAR' not ilike any (['_ar'])", isLiteral(false));
+        assertNormalize("'fOo' not ilike any (['_o_'])", isLiteral(false));
+        assertNormalize("'foo' not ilike any (['fOO_'])", isLiteral(true));
     }
 
     // Following tests: mixed wildcards:
 
     @Test
     public void testNormalizeSymbolLikeMixed() {
-        assertNormalize("'%o_ar' not like any (['foobar', 'foobaz'])", isLiteral(true));
-        assertNormalize("'%a_' not like any (['foobar'])", isLiteral(false));
-        assertNormalize("'%o_a%' not like any (['foobar'])", isLiteral(false));
-        assertNormalize("'%i%m%' not like any (['Lorem ipsum dolor...'])", isLiteral(false));
-        assertNormalize("'%%%sum%%' not like any (['Lorem ipsum dolor...'])", isLiteral(false));
-        assertNormalize("'%i%m' not like any (['Lorem ipsum dolor...'])", isLiteral(true));
-
-        assertNormalize("'%i%m%' not ilike any (['LOREM IPSUM DOLOR...'])", isLiteral(false));
-        assertNormalize("'%%%sum%%' not ilike any (['LOREM IPSUM DOLOR...'])", isLiteral(false));
-        assertNormalize("'%i%m' not ilike any (['LOREM IPSUM DOLOR...'])", isLiteral(true));
+        assertNormalize("'foobar' not like any (['%o_ar', '%o_a%'])", isLiteral(false));
+        assertNormalize("'Lorem ipsum dolor...' not like any (['%i%m%'])", isLiteral(false));
+        assertNormalize("'Lorem ipsum dolor...' not like any (['%%%sum%%'])", isLiteral(false));
+        assertNormalize("'Lorem ipsum dolor...' not like any (['%i%m'])", isLiteral(true));
+        assertNormalize("'fOObar' not ilike any (['%o_a%'])", isLiteral(false));
+        assertNormalize("'Lorem IpSuM dolor...' not ilike any (['%%%sum%%'])", isLiteral(false));
     }
 
     @Test
@@ -101,14 +91,12 @@ public class AnyNotLikeOperatorTest extends ScalarTestCase {
 
     @Test
     public void testEvaluateLikeMixed() {
-        assertEvaluate("'%o_ar' not like any (['foobar', 'foobaz'])", true);
-        assertEvaluate("'%a_' not like any (['foobar'])", false);
-        assertEvaluate("'%o_a%' not like any (['foobar'])", false);
-        assertEvaluate("'%i%m%' not like any (['Lorem ipsum dolor..'])", false);
-        assertEvaluate("'%%%sum%%' not like any (['Lorem ipsum dolor...'])", false);
-        assertEvaluate("'%i%m' not like any (['Lorem ipsum dolor...'])", true);
-        assertEvaluate("'%%%sum%%' not ilike any (['Lorem IPSUM dolor...'])", false);
-
+        assertEvaluate("'foobar' not like any (['%o_ar', '%o_a%'])", false);
+        assertEvaluate("'Lorem ipsum dolor...' not like any (['%i%m%'])", false);
+        assertEvaluate("'Lorem ipsum dolor...' not like any (['%%%sum%%'])", false);
+        assertEvaluate("'Lorem ipsum dolor...' not like any (['%i%m'])", true);
+        assertEvaluate("'fOObar' not ilike any (['%o_a%'])", false);
+        assertEvaluate("'Lorem IpSuM dolor...' not ilike any (['%%%sum%%'])", false);
     }
 
     @Test
@@ -134,16 +122,6 @@ public class AnyNotLikeOperatorTest extends ScalarTestCase {
     }
 
     @Test
-    public void test_patterns_on_right_arg() {
-        assertNormalize("'foobar' not like any (['%barr'])", isLiteral(true));
-        assertNormalize("'bar' not like any (['_ar'])", isLiteral(false));
-        assertNormalize("'foobar' not like any (['%o_a%'])", isLiteral(false));
-        assertNormalize("'fOobAR' not ilike any (['%BaR'])", isLiteral(false));
-        assertNormalize("'BaR' not ilike any (['z_ar'])", isLiteral(true));
-        assertNormalize("'foobar' not ilike any (['%O_a%'])", isLiteral(false));
-    }
-
-    @Test
     public void test_wildcard_escaped_in_c_style_string() {
         assertEvaluate("'TextToMatch' NOT LIKE ANY ([E'Te\\%tch'])", false);
         assertEvaluate("'TextToMatch' NOT ILIKE ANY ([E'te\\%tch'])", false);
@@ -157,5 +135,10 @@ public class AnyNotLikeOperatorTest extends ScalarTestCase {
         assertThatThrownBy(() -> assertEvaluate("'TextToMatch' NOT ILIKE ANY (['texttomatch', 'ab\\'])", false))
             .isExactlyInstanceOf(IllegalArgumentException.class)
             .hasMessage("pattern 'ab\\' must not end with escape character '\\'");
+    }
+
+    @Test
+    public void test_only_rhs_arg_can_be_pattern() {
+        assertEvaluate("'a%' not like any(['a__'])", true);
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/AnyIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/AnyIntegrationTest.java
@@ -22,7 +22,6 @@
 package io.crate.integrationtests;
 
 import static io.crate.testing.Asserts.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import org.elasticsearch.test.IntegTestCase;
 import org.junit.Test;
@@ -41,14 +40,14 @@ public class AnyIntegrationTest extends IntegTestCase {
         execute("insert into t (i, ia, s, sa) values (?, ?, ?, ?)", new Object[][]{
             {1, new Object[]{1, 2, 3}, "foo", new Object[]{"abc", "def", "ghi"}},
             {2, new Object[]{3, 4, 5}, "bar", new Object[]{"rst", "uvw", "aaa"}},
-            {3, new Object[]{7, 8, 9}, "baz", new Object[]{"bar", "baz"}}
+            {3, new Object[]{7, 8, 9}, "baz", new Object[]{"baz"}}
         });
         execute("refresh table t");
 
         execute("select i, s from t where i = ANY([1,2,4]) order by i");
         assertThat(response).hasRows("1| foo", "2| bar");
 
-        execute("select i, sa from t where 'ba%' not like ANY(sa) order by i");
+        execute("select i, sa from t where s not like ANY(sa) order by i");
         assertThat(response).hasRows("1| [abc, def, ghi]", "2| [rst, uvw, aaa]");
 
         execute("update t set s='updated' where i > ANY([?, ?, ?])", new Object[]{2, 4, 5});
@@ -58,12 +57,12 @@ public class AnyIntegrationTest extends IntegTestCase {
         execute("select s from t order by i");
         assertThat(response).hasRows("foo", "bar", "updated");
 
-        execute("delete from t where 'a%' like ANY (sa)");
+        execute("delete from t where s like ANY (['f%', 'ba_'])");
         assertThat(response).hasRowCount(2);
         execute("refresh table t");
 
         execute("select * from t");
-        assertThat(response).hasRows("3| [7, 8, 9]| updated| [bar, baz]");
+        assertThat(response).hasRows("3| [7, 8, 9]| updated| [baz]");
     }
 
     @Test

--- a/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/server/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -1091,7 +1091,7 @@ public class TransportSQLActionTest extends IntegTestCase {
             "3| [Hangelsberg, Berlin]"
         );
 
-        execute("select id, names from any_table where 'Ber%' LIKE ANY (names) order by id");
+        execute("select id, names from any_table where names[2] LIKE ANY (['Ber%']) order by id");
         assertThat(response).hasRows(
             "1| [Dornbirn, Berlin, St. Margrethen]",
             "3| [Hangelsberg, Berlin]"
@@ -1120,17 +1120,16 @@ public class TransportSQLActionTest extends IntegTestCase {
     public void testAnyLike() throws Exception {
         this.setup.setUpArrayTables();
 
-        execute("select id from any_table where 'kuh%' LIKE ANY (tags) order by id");
+        execute("select id from any_table where tags[1] LIKE ANY (['kuh%']) order by id");
         assertThat(response).hasRows(
             "3",
             "4"
         );
 
-        execute("select id from any_table where 'kuh%' NOT LIKE ANY (tags) order by id");
+        execute("select id from any_table where tags[1] NOT LIKE ANY (['kuh%']) order by id");
         assertThat(response).hasRows(
             "1",
-            "2",
-            "3"
+            "2"
         );
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Resolves https://github.com/crate/crate/issues/16619 - reverts 7c9d9d57085e099dc98ac7c864bab537ab60ca5c and some cleanups.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
