### PR TITLE
Don't resolve refresh index names twice

### DIFF
--- a/server/src/test/java/io/crate/analyze/RefreshAnalyzerTest.java
+++ b/server/src/test/java/io/crate/analyze/RefreshAnalyzerTest.java
@@ -23,7 +23,6 @@ package io.crate.analyze;
 
 import static io.crate.testing.Asserts.assertThat;
 import static io.crate.testing.Asserts.isLiteral;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;


### PR DESCRIPTION
The underlying index names for a refresh request are already resolved from
table and/or partition names in RefreshTablePlan, so we don't need to
re-resolve them in the Transport action.

Relates to #17518 
