### PR TITLE
Adapt max size for internal paged requests based on downstream nodes

### DIFF
--- a/server/src/main/java/io/crate/execution/engine/distribution/DistributingConsumerFactory.java
+++ b/server/src/main/java/io/crate/execution/engine/distribution/DistributingConsumerFactory.java
@@ -33,7 +33,6 @@ import org.elasticsearch.node.Node;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import io.crate.Streamer;
-import io.crate.data.RowConsumer;
 import io.crate.data.breaker.RamAccounting;
 import io.crate.execution.dsl.phases.ExecutionPhases;
 import io.crate.execution.dsl.phases.NodeOperation;
@@ -60,11 +59,11 @@ public class DistributingConsumerFactory {
         this.distributedResultAction = req -> node.client().execute(DistributedResultAction.INSTANCE, req);
     }
 
-    public RowConsumer create(NodeOperation nodeOperation,
-                              RamAccounting ramAccounting,
-                              DistributionInfo distributionInfo,
-                              UUID jobId,
-                              int pageSize) {
+    public DistributingConsumer create(NodeOperation nodeOperation,
+                                       RamAccounting ramAccounting,
+                                       DistributionInfo distributionInfo,
+                                       UUID jobId,
+                                       int pageSize) {
         Streamer<?>[] streamers = nodeOperation.executionPhase().getStreamers();
         assert !ExecutionPhases.hasDirectResponseDownstream(nodeOperation.downstreamNodes())
             : "trying to build a DistributingDownstream but nodeOperation has a directResponse downstream";


### PR DESCRIPTION
Benchmark results against dev cluster:

No real difference with 3 nodes but should help reduce memory pressure

I'd tend to get this in - give it a couple days of nightly runs and if there is no noticable difference maybe even add a release notes entry and backport.

```
Q: select * from articles inner join colors on articles.id = colors.id order by articles.id limit 1000
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |      110.641 ±   44.248 |     82.773 |     98.808 |    105.693 |    413.523 |
|   V2    |      106.545 ±   34.721 |     68.486 |     96.952 |    104.409 |    259.688 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -   3.77%                           -   1.90%
There is a 69.63% probability that the observed difference is not random, and the best estimate of that difference is 3.77%
The test has no statistical significance

Q: select articles.name as article from articles, colors order by article limit 10000
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |       35.546 ±    3.898 |     27.553 |     35.577 |     36.801 |    108.096 |
|   V2    |       34.913 ±    3.542 |     26.070 |     34.698 |     36.263 |     93.071 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -   1.80%                           -   2.50%
There is a 99.99% probability that the observed difference is not random, and the best estimate of that difference is 1.80%
The test has statistical significance

Q: select * from articles CROSS JOIN colors limit 1 offset 10000
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |       11.743 ±    1.732 |      7.187 |     11.496 |     11.918 |     25.808 |
|   V2    |       11.459 ±    1.512 |      7.008 |     11.075 |     11.471 |     20.335 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -   2.45%                           -   3.73%
There is a 91.89% probability that the observed difference is not random, and the best estimate of that difference is 2.45%
The test has no statistical significance

Q: select * from articles inner join colors on articles.id = colors.id where colors.id = -1
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |       91.453 ±   52.496 |     73.475 |     79.675 |     81.513 |    522.916 |
|   V2    |       94.533 ±   59.051 |     74.965 |     82.616 |     85.131 |    645.604 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               +   3.31%                           +   3.62%
There is a 36.66% probability that the observed difference is not random, and the best estimate of that difference is 3.31%
The test has no statistical significance


Q: select t1."sourceIP" from uservisits_large t1 inner join uservisits_small t2 on t1."sourceIP" = t2."sourceIP" limit 1000
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |      885.530 ±  130.221 |    636.802 |    890.053 |    952.738 |   1125.797 |
|   V2    |      937.746 ±  125.401 |    672.787 |    938.324 |   1019.009 |   1185.156 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               +   5.73%                           +   5.28%
There is a 79.57% probability that the observed difference is not random, and the best estimate of that difference is 5.73%
The test has no statistical significance
```


