### PR TITLE
Extend filter on project set push down to work on subscripts

### DIFF
--- a/docs/appendices/release-notes/6.0.0.rst
+++ b/docs/appendices/release-notes/6.0.0.rst
@@ -124,6 +124,18 @@ Scalar and Aggregation Functions
 Performance and Resilience Improvements
 ---------------------------------------
 
+- Improved the logic to push down expressions within the ``WHERE`` clause to the
+  table to use index lookups instead of resulting in post-filtering when using
+  virtual tables involving table functions and object columns. For example, the
+  following case now gets optimized::
+
+    SELECT *
+    FROM (
+      SELECT *, unnest(document['arr'])
+      FROM tbl
+    ) t
+    WHERE document['field1'] >=1;
+
 - Improved the performance for ``SELECT COUNT(not_null_column) FROM tbl``. It is
   now executed the same way as ``SELECT COUNT(*) FROM tbl``.
 

--- a/server/src/main/java/io/crate/expression/symbol/Symbols.java
+++ b/server/src/main/java/io/crate/expression/symbol/Symbols.java
@@ -113,6 +113,27 @@ public final class Symbols {
         return false;
     }
 
+    /**
+     * Similar to {@link Collection#contains(Object) this will check if
+     * {@code symbol} is contained in {@code symbols} but opposed to
+     * {@link Collection#contains(Object)} this will also return true if
+     * {@code symbol} is a subscript on a column contained in {@code symbols}
+     **/
+    public static boolean contains(Collection<? extends Symbol> symbols, Symbol symbol) {
+        if (symbols.contains(symbol)) {
+            return true;
+        }
+        ColumnIdent column = symbol.toColumn();
+        if (!column.isRoot()) {
+            for (var parent : column.parents()) {
+                if (hasColumn(symbols, parent)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     public static void toStream(Collection<? extends Symbol> symbols, StreamOutput out) throws IOException {
         out.writeVInt(symbols.size());
         for (Symbol symbol : symbols) {

--- a/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathProjectSet.java
+++ b/server/src/main/java/io/crate/planner/optimizer/rule/MoveFilterBeneathProjectSet.java
@@ -29,9 +29,11 @@ import static io.crate.planner.optimizer.rule.Util.transpose;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import io.crate.expression.operator.AndOperator;
 import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.FunctionType;
 import io.crate.planner.operators.Filter;
 import io.crate.planner.operators.LogicalPlan;
@@ -72,8 +74,9 @@ public final class MoveFilterBeneathProjectSet implements Rule<Filter> {
         ArrayList<Symbol> toPushDown = new ArrayList<>();
         ArrayList<Symbol> toKeep = new ArrayList<>();
         for (var part : queryParts) {
-            if (!part.any(MoveFilterBeneathProjectSet::isTableFunction) &&
-                outputs.containsAll(extractColumns(part))) {
+            Set<Symbol> partColumns = extractColumns(part);
+            if (!part.any(MoveFilterBeneathProjectSet::isTableFunction)
+                    && partColumns.stream().allMatch(x -> Symbols.contains(outputs, x))) {
                 toPushDown.add(part);
             } else {
                 toKeep.add(part);

--- a/server/src/test/java/io/crate/expression/symbol/SymbolsTest.java
+++ b/server/src/test/java/io/crate/expression/symbol/SymbolsTest.java
@@ -24,11 +24,13 @@ package io.crate.expression.symbol;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
+import java.util.List;
 
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.junit.Test;
 
+import io.crate.metadata.Reference;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 
@@ -65,5 +67,21 @@ public class SymbolsTest extends CrateDummyClusterServiceUnitTest {
             .addTable("create table tbl (x int)");
         Symbol symbol = e.asSymbol("x + 10 > 100");
         assertThat(symbol.ramBytesUsed()).isEqualTo(912L);
+    }
+
+    @Test
+    public void test_contains_considers_subscripts() throws Exception {
+        var e = SQLExecutor.of(clusterService)
+            .addTable("create table tbl (y int, o object as (o1 object as (x int)))");
+        Reference y = (Reference) e.asSymbol("y");
+        Reference o = (Reference) e.asSymbol("o");
+        Reference o1 = (Reference) e.asSymbol("o['o1']");
+        Reference ox = (Reference) e.asSymbol("o['o1']['x']");
+
+        assertThat(Symbols.contains(List.of(o), o)).isEqualTo(true);
+        assertThat(Symbols.contains(List.of(o), ox)).isEqualTo(true);
+        assertThat(Symbols.contains(List.of(o), o1)).isEqualTo(true);
+        assertThat(Symbols.contains(List.of(o), y)).isEqualTo(false);
+        assertThat(Symbols.contains(List.of(o1), ox)).isEqualTo(true);
     }
 }


### PR DESCRIPTION
Squeezed this in while waiting on benchmark results

---

The rule to push filters on the standalone outputs of a `ProjectSet`
operator didn't work for cases like `obj['x'] = 1` where the standalone
output was `obj`.

Closes https://github.com/crate/crate/issues/17183
