### PR TITLE
Remove IndicesRequest.Replaceable interface

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/IndicesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/IndicesRequest.java
@@ -40,10 +40,4 @@ public interface IndicesRequest {
      */
     IndicesOptions indicesOptions();
 
-    interface Replaceable extends IndicesRequest {
-        /**
-         * Sets the indices that the action relates to.
-         */
-        IndicesRequest indices(String... indices);
-    }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequest.java
@@ -36,7 +36,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 
 import io.crate.common.unit.TimeValue;
 
-public class ClusterHealthRequest extends MasterNodeReadRequest<ClusterHealthRequest> implements IndicesRequest.Replaceable {
+public class ClusterHealthRequest extends MasterNodeReadRequest<ClusterHealthRequest> implements IndicesRequest {
 
     private String[] indices = Strings.EMPTY_ARRAY;
     private IndicesOptions indicesOptions = IndicesOptions.LENIENT_EXPAND_OPEN_CLOSED;
@@ -66,7 +66,6 @@ public class ClusterHealthRequest extends MasterNodeReadRequest<ClusterHealthReq
         return indices;
     }
 
-    @Override
     public ClusterHealthRequest indices(String... indices) {
         assert indices != null : "Must not set indices to null";
         this.indices = indices;

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequest.java
@@ -56,8 +56,7 @@ import org.elasticsearch.common.xcontent.json.JsonXContent;
  * <li>must not contain invalid file name characters {@link org.elasticsearch.common.Strings#INVALID_FILENAME_CHARS} </li>
  * </ul>
  */
-public class CreateSnapshotRequest extends MasterNodeRequest<CreateSnapshotRequest>
-    implements IndicesRequest.Replaceable {
+public class CreateSnapshotRequest extends MasterNodeRequest<CreateSnapshotRequest> implements IndicesRequest {
 
     private String snapshot;
 
@@ -170,7 +169,6 @@ public class CreateSnapshotRequest extends MasterNodeRequest<CreateSnapshotReque
      *
      * @return this request
      */
-    @Override
     public CreateSnapshotRequest indices(String... indices) {
         this.indices = indices;
         return this;

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequest.java
@@ -31,7 +31,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 
 import io.crate.common.unit.TimeValue;
 
-public class ClusterStateRequest extends MasterNodeReadRequest<ClusterStateRequest> implements IndicesRequest.Replaceable {
+public class ClusterStateRequest extends MasterNodeReadRequest<ClusterStateRequest> implements IndicesRequest {
 
     public static final TimeValue DEFAULT_WAIT_FOR_NODE_TIMEOUT = TimeValue.timeValueMinutes(1);
 
@@ -112,7 +112,6 @@ public class ClusterStateRequest extends MasterNodeReadRequest<ClusterStateReque
         return indices;
     }
 
-    @Override
     public ClusterStateRequest indices(String... indices) {
         this.indices = indices;
         return this;

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/TransportResizeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/TransportResizeAction.java
@@ -101,9 +101,8 @@ public class TransportResizeAction extends TransportMasterNodeAction<ResizeReque
 
         // there is no need to fetch docs stats for split but we keep it simple and do it anyway for simplicity of the code
         final String resizedIndex = AlterTableClient.RESIZE_PREFIX + sourceIndex;
-        client.admin().indices().stats(new IndicesStatsRequest()
+        client.admin().indices().stats(new IndicesStatsRequest(sourceIndex)
             .clear()
-            .indices(sourceIndex)
             .docs(true))
             .thenCompose(statsResponse -> createIndexService.resizeIndex(request, statsResponse))
             .thenCompose(resizeResp -> {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsRequest.java
@@ -54,19 +54,6 @@ public class IndicesStatsRequest extends BroadcastRequest<IndicesStatsRequest> {
         return this;
     }
 
-    /**
-     * Sets specific search group stats to retrieve the stats for. Mainly affects search
-     * when enabled.
-     */
-    public IndicesStatsRequest groups(String... groups) {
-        flags.groups(groups);
-        return this;
-    }
-
-    public String[] groups() {
-        return this.flags.groups();
-    }
-
     public IndicesStatsRequest docs(boolean docs) {
         flags.set(Flag.Docs, docs);
         return this;
@@ -85,33 +72,6 @@ public class IndicesStatsRequest extends BroadcastRequest<IndicesStatsRequest> {
         return flags.isSet(Flag.Store);
     }
 
-    public IndicesStatsRequest fieldDataFields(String... fieldDataFields) {
-        flags.fieldDataFields(fieldDataFields);
-        return this;
-    }
-
-    public String[] fieldDataFields() {
-        return flags.fieldDataFields();
-    }
-
-    public IndicesStatsRequest completionFields(String... completionDataFields) {
-        flags.completionDataFields(completionDataFields);
-        return this;
-    }
-
-    public String[] completionFields() {
-        return flags.completionDataFields();
-    }
-
-    public boolean includeSegmentFileSizes() {
-        return flags.includeSegmentFileSizes();
-    }
-
-    public IndicesStatsRequest includeSegmentFileSizes(boolean includeSegmentFileSizes) {
-        flags.includeSegmentFileSizes(includeSegmentFileSizes);
-        return this;
-    }
-
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
@@ -123,6 +83,7 @@ public class IndicesStatsRequest extends BroadcastRequest<IndicesStatsRequest> {
         flags = new CommonStatsFlags(in);
     }
 
-    public IndicesStatsRequest() {
+    public IndicesStatsRequest(String... indices) {
+        super(indices);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastRequest.java
@@ -27,7 +27,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.transport.TransportRequest;
 
-public class BroadcastRequest<Request extends BroadcastRequest<Request>> extends TransportRequest implements IndicesRequest.Replaceable {
+public class BroadcastRequest<Request extends BroadcastRequest<Request>> extends TransportRequest implements IndicesRequest {
 
     protected String[] indices;
     private IndicesOptions indicesOptions = IndicesOptions.STRICT_EXPAND_OPEN_FORBID_CLOSED;
@@ -47,13 +47,6 @@ public class BroadcastRequest<Request extends BroadcastRequest<Request>> extends
     @Override
     public String[] indices() {
         return indices;
-    }
-
-    @SuppressWarnings("unchecked")
-    @Override
-    public final Request indices(String... indices) {
-        this.indices = indices;
-        return (Request) this;
     }
 
     @Override

--- a/server/src/test/java/io/crate/integrationtests/DiskThresholdDeciderIT.java
+++ b/server/src/test/java/io/crate/integrationtests/DiskThresholdDeciderIT.java
@@ -250,7 +250,7 @@ public class DiskThresholdDeciderIT extends IntegTestCase {
 
             execute("refresh table " + tableName);
 
-            var indicesStats = client().admin().indices().stats(new IndicesStatsRequest().indices(indexName).store(true)).get();
+            var indicesStats = client().admin().indices().stats(new IndicesStatsRequest(indexName).store(true)).get();
             final List<ShardStats> shardStatses = indicesStats.getIndex(indexName).getShards();
 
             final long[] shardSizes = new long[shardStatses.size()];

--- a/server/src/test/java/io/crate/integrationtests/disruption/discovery/MasterDisruptionIT.java
+++ b/server/src/test/java/io/crate/integrationtests/disruption/discovery/MasterDisruptionIT.java
@@ -242,7 +242,7 @@ public class MasterDisruptionIT extends AbstractDisruptionTestCase {
 
         String indexName = IndexName.encode(sqlExecutor.getCurrentSchema(), "t", null);
         assertBusy(() -> {
-            IndicesStatsResponse stats = FutureUtils.get(client().admin().indices().stats(new IndicesStatsRequest().indices(indexName).clear()));
+            IndicesStatsResponse stats = FutureUtils.get(client().admin().indices().stats(new IndicesStatsRequest(indexName).clear()));
             for (ShardStats shardStats : stats.getShards()) {
                 assertThat(shardStats.getSeqNoStats().getGlobalCheckpoint()).as(shardStats.getShardRouting().toString()).isEqualTo(shardStats.getSeqNoStats().getLocalCheckpoint());
             }

--- a/server/src/test/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
@@ -1463,7 +1463,7 @@ public class IndexRecoveryIT extends IntegTestCase {
         execute("OPTIMIZE TABLE doc.test");
         // wait for all history to be discarded
         assertBusy(() -> {
-            var indicesStats = client().admin().indices().stats(new IndicesStatsRequest().indices(indexName)).get();
+            var indicesStats = client().admin().indices().stats(new IndicesStatsRequest(indexName)).get();
             for (ShardStats shardStats : indicesStats.getShards()) {
                 final long maxSeqNo = shardStats.getSeqNoStats().getMaxSeqNo();
                 assertThat(shardStats.getRetentionLeaseStats().leases().leases().stream().allMatch(
@@ -1472,7 +1472,7 @@ public class IndexRecoveryIT extends IntegTestCase {
         });
         execute("OPTIMIZE TABLE doc.test"); // ensure that all operations are in the safe commit
 
-        var indicesStats = client().admin().indices().stats(new IndicesStatsRequest().indices(indexName)).get();
+        var indicesStats = client().admin().indices().stats(new IndicesStatsRequest(indexName)).get();
         final ShardStats shardStats = indicesStats.getShards()[0];
         final long docCount = shardStats.getStats().docs.getCount();
         assertThat(shardStats.getStats().docs.getDeleted()).isEqualTo(0L);
@@ -1483,7 +1483,7 @@ public class IndexRecoveryIT extends IntegTestCase {
         final IndexShardRoutingTable indexShardRoutingTable = clusterService().state().routingTable().shardRoutingTable(shardId);
 
         final ShardRouting replicaShardRouting = indexShardRoutingTable.replicaShards().get(0);
-        indicesStats = client().admin().indices().stats(new IndicesStatsRequest().indices(indexName)).get();
+        indicesStats = client().admin().indices().stats(new IndicesStatsRequest(indexName)).get();
         assertThat(indicesStats.getShards()[0].getRetentionLeaseStats()
                        .leases().contains(ReplicationTracker.getPeerRecoveryRetentionLeaseId(replicaShardRouting))).as("should have lease for " + replicaShardRouting).isTrue();
         cluster().restartNode(discoveryNodes.get(replicaShardRouting.currentNodeId()).getName(),
@@ -1528,7 +1528,7 @@ public class IndexRecoveryIT extends IntegTestCase {
                                               execute("OPTIMIZE TABLE doc.test");
 
                                               assertBusy(() -> {
-                                                  var indicesStats = client().admin().indices().stats(new IndicesStatsRequest().indices(indexName)).get();
+                                                  var indicesStats = client().admin().indices().stats(new IndicesStatsRequest(indexName)).get();
                                                   assertThat(indicesStats.getShards()[0].getRetentionLeaseStats().leases().contains(
                                                             ReplicationTracker.getPeerRecoveryRetentionLeaseId(replicaShardRouting))).as(
                                                         "should no longer have lease for " + replicaShardRouting).isFalse();

--- a/server/src/test/java/org/elasticsearch/snapshots/AbortedRestoreIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/AbortedRestoreIT.java
@@ -77,9 +77,8 @@ public class AbortedRestoreIT extends AbstractSnapshotIntegTestCase {
 
         String indexName = "tbl";
         assertBusy(() -> {
-            RecoveryRequest request = new RecoveryRequest();
+            RecoveryRequest request = new RecoveryRequest(indexName);
             request
-                .indices(indexName)
                 .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN)
                 .activeOnly(true);
             final RecoveryResponse recoveries = client().admin().indices().recoveries(request).get(5, TimeUnit.SECONDS);


### PR DESCRIPTION
This was never called as an interface, only directly through concrete classes, and just makes it harder to see which requests have mutable index sets.