### PR TITLE
Fix NPE queries on `sys.allocations` if no master is discovered

### DIFF
--- a/docs/appendices/release-notes/5.10.4.rst
+++ b/docs/appendices/release-notes/5.10.4.rst
@@ -43,3 +43,7 @@ See the :ref:`version_5.10.0` release notes for a full list of changes in the
 
 Fixes
 =====
+
+- Fixed NPE when querying the :ref:`sys.allocations <sys-allocations>` table
+  while no master node has been discovered. A proper exception is now thrown
+  instead of an NPE.

--- a/docs/appendices/release-notes/5.9.13.rst
+++ b/docs/appendices/release-notes/5.9.13.rst
@@ -47,4 +47,6 @@ See the :ref:`version_5.9.0` release notes for a full list of changes in the
 Fixes
 =====
 
-None
+- Fixed NPE when querying the :ref:`sys.allocations <sys-allocations>` table
+  while no master node has been discovered. A proper exception is now thrown
+  instead of an NPE.

--- a/server/src/main/java/io/crate/metadata/Routing.java
+++ b/server/src/main/java/io/crate/metadata/Routing.java
@@ -27,11 +27,13 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 
+import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.discovery.MasterNotDiscoveredException;
 
 import com.carrotsearch.hppc.IntArrayList;
 import com.carrotsearch.hppc.IntIndexedContainer;
@@ -205,6 +207,14 @@ public class Routing implements Writeable {
             indicesByNode.put(node.getId(), shardsByIndex);
         }
         return new Routing(indicesByNode);
+    }
+
+    public static Routing forMasterNode(RelationName relationName, ClusterState clusterState) {
+        String masterNodeId = clusterState.nodes().getMasterNodeId();
+        if (masterNodeId == null) {
+            throw new MasterNotDiscoveredException();
+        }
+        return forTableOnSingleNode(relationName, masterNodeId);
     }
 
     @Override

--- a/server/src/main/java/io/crate/metadata/sys/SysAllocationsTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/sys/SysAllocationsTableInfo.java
@@ -56,6 +56,6 @@ public class SysAllocationsTableInfo {
             ColumnIdent.of("partition_ident"),
             ColumnIdent.of("shard_id")
         )
-        .withRouting((state, ignored, ignored2) -> Routing.forTableOnSingleNode(IDENT, state.nodes().getMasterNodeId()))
+        .withRouting((state, ignored, ignored2) -> Routing.forMasterNode(IDENT, state))
         .build();
 }

--- a/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/server/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -34,6 +34,7 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.Metadata;
@@ -701,7 +702,7 @@ public class LogicalPlanner {
         } catch (ConversionException e) {
             throw e;
         } catch (Exception e) {
-            if (e instanceof CrateException) {
+            if (e instanceof CrateException || e instanceof ElasticsearchException) {
                 // Don't hide errors like MissingShardOperationsException, UnavailableShardsException
                 throw e;
             }

--- a/server/src/test/java/io/crate/metadata/sys/SysAllocationsTableInfoTest.java
+++ b/server/src/test/java/io/crate/metadata/sys/SysAllocationsTableInfoTest.java
@@ -23,6 +23,7 @@ package io.crate.metadata.sys;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.elasticsearch.cluster.node.DiscoveryNodeRole.DATA_ROLE;
 import static org.elasticsearch.test.ClusterServiceUtils.setState;
 
@@ -33,6 +34,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.discovery.MasterNotDiscoveredException;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -63,5 +65,12 @@ public class SysAllocationsTableInfoTest extends CrateDummyClusterServiceUnitTes
         var allocationsTable = SysAllocationsTableInfo.INSTANCE;
         var routing = allocationsTable.getRouting(clusterService.state(), null, null, null, null);
         assertThat(routing.nodes()).contains(NODE_ID);
+    }
+
+    @Test
+    public void test_exception_is_thrown_when_no_master_is_discovered() {
+        var allocationsTable = SysAllocationsTableInfo.INSTANCE;
+        assertThatThrownBy(() -> allocationsTable.getRouting(ClusterState.EMPTY_STATE, null, null, null, null))
+            .isInstanceOf(MasterNotDiscoveredException.class);
     }
 }


### PR DESCRIPTION
If the master is not discovered, `getMasterNodeId()` will return NULL which causes the `forTableOnSingleNode` to fail.
Adding a new `Routing.forMasterNode()` method which catches this and throws the related exceptions fixes this.

This popped up while working on #17600.