### PR TITLE
Fix for missing jobs_log entries when jobs submitted via pgwire's simpleQuery failed

### DIFF
--- a/docs/appendices/release-notes/5.10.4.rst
+++ b/docs/appendices/release-notes/5.10.4.rst
@@ -47,3 +47,6 @@ Fixes
 - Fixed NPE when querying the :ref:`sys.allocations <sys-allocations>` table
   while no master node has been discovered. A proper exception is now thrown
   instead of an NPE.
+
+- Fixed an issue that caused queries submitted via PG wire to not be logged in
+  :ref:`sys.jobs_log <sys-logs>` in case of a parsing failure.

--- a/docs/appendices/release-notes/5.9.13.rst
+++ b/docs/appendices/release-notes/5.9.13.rst
@@ -50,3 +50,6 @@ Fixes
 - Fixed NPE when querying the :ref:`sys.allocations <sys-allocations>` table
   while no master node has been discovered. A proper exception is now thrown
   instead of an NPE.
+
+- Fixed an issue that caused queries submitted via PG wire to not be logged in
+  :ref:`sys.jobs_log <sys-logs>` in case of a parsing failure.

--- a/server/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
+++ b/server/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
@@ -62,7 +62,6 @@ import io.crate.metadata.settings.CoordinatorSessionSettings;
 import io.crate.metadata.settings.session.SessionSetting;
 import io.crate.metadata.settings.session.SessionSettingRegistry;
 import io.crate.protocols.postgres.DelayableWriteChannel.DelayedWrites;
-import io.crate.protocols.postgres.parser.PgArrayParser;
 import io.crate.protocols.postgres.types.PGType;
 import io.crate.protocols.postgres.types.PGTypes;
 import io.crate.role.Role;
@@ -70,7 +69,6 @@ import io.crate.session.DescribeResult;
 import io.crate.session.ResultReceiver;
 import io.crate.session.Session;
 import io.crate.session.Sessions;
-import io.crate.sql.parser.SqlParser;
 import io.crate.sql.tree.Statement;
 import io.crate.types.DataType;
 import io.netty.buffer.ByteBuf;
@@ -792,13 +790,7 @@ public class PostgresWireProtocol {
 
         List<Statement> statements;
         try {
-            statements = SqlParser.createStatementsForSimpleQuery(
-                    queryString,
-                    str -> PgArrayParser.parse(
-                            str,
-                            bytes -> new String(bytes, StandardCharsets.UTF_8)
-                    )
-                );
+            statements = session.simpleQuery(queryString);
         } catch (Exception ex) {
             Messages.sendErrorResponse(channel, getAccessControl.apply(session.sessionSettings()), ex);
             sendReadyForQuery(channel, TransactionState.IDLE);

--- a/server/src/main/java/io/crate/session/Session.java
+++ b/server/src/main/java/io/crate/session/Session.java
@@ -22,6 +22,7 @@
 package io.crate.session;
 
 import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -87,6 +88,7 @@ import io.crate.protocols.postgres.FormatCodes;
 import io.crate.protocols.postgres.JobsLogsUpdateListener;
 import io.crate.protocols.postgres.Portal;
 import io.crate.protocols.postgres.TransactionState;
+import io.crate.protocols.postgres.parser.PgArrayParser;
 import io.crate.sql.SqlFormatter;
 import io.crate.sql.parser.SqlParser;
 import io.crate.sql.tree.Declare;
@@ -611,6 +613,21 @@ public class Session implements AutoCloseable {
             var result = activeExecution;
             activeExecution = null;
             return result;
+        }
+    }
+
+    public List<Statement> simpleQuery(String queryString) {
+        try {
+            return SqlParser.createStatementsForSimpleQuery(
+                queryString,
+                str -> PgArrayParser.parse(
+                    str,
+                    bytes -> new String(bytes, StandardCharsets.UTF_8)
+                )
+            );
+        } catch (Throwable t) {
+            jobsLogs.logPreExecutionFailure(UUIDs.dirtyUUID(), queryString, SQLExceptions.messageOf(t), sessionSettings.sessionUser());
+            throw t;
         }
     }
 

--- a/server/src/test/java/io/crate/integrationtests/PostgresJobsLogsITest.java
+++ b/server/src/test/java/io/crate/integrationtests/PostgresJobsLogsITest.java
@@ -21,7 +21,7 @@
 
 package io.crate.integrationtests;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static io.crate.testing.Asserts.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 import java.sql.Connection;
@@ -177,6 +177,17 @@ public class PostgresJobsLogsITest extends IntegTestCase {
                 assertJobLogContains(conn, new String[]{insertNull}, true);
             }
         }
+    }
+
+    // tracks a bug: https://github.com/crate/crate/issues/17651
+    @Test
+    public void test_simple_query_failures_are_logged_in_sys_jobs_log() {
+        try {
+            sqlExecutor.newSession().simpleQuery("foo");
+        } catch (Exception e) {
+        }
+        execute("SELECT stmt FROM sys.jobs_log WHERE error IS NOT NULL AND stmt = 'foo'");
+        assertThat(response).hasRows("foo");
     }
 
     private void assertJobLogContains(final Connection conn,

--- a/server/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
+++ b/server/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
@@ -24,7 +24,11 @@ package io.crate.protocols.postgres;
 import static io.crate.protocols.postgres.PostgresWireProtocol.PG_SERVER_VERSION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyChar;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -817,8 +821,8 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
                                                      @Nullable Throwable failure,
                                                      @Nullable CompletableFuture future) {
         Sessions sqlOperations = Mockito.mock(Sessions.class);
-        Session session = mock(Session.class);
-        when(session.execute(any(String.class), any(int.class), any(RowCountReceiver.class))).thenReturn(future);
+        Session session = spy(this.sqlOperations.newSystemSession());
+        doReturn(future).when(session).execute(any(String.class), any(int.class), any(RowCountReceiver.class));
         var sessionSettings = new CoordinatorSessionSettings(Role.CRATE_USER);
         when(session.sessionSettings()).thenReturn(sessionSettings);
         when(session.newTimeoutToken()).thenReturn(
@@ -831,7 +835,7 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
         ).thenReturn(session);
         DescribeResult describeResult = mock(DescribeResult.class);
         when(describeResult.getFields()).thenReturn(null);
-        when(session.describe(Mockito.anyChar(), Mockito.anyString())).thenReturn(describeResult);
+        doReturn(describeResult).when(session).describe(anyChar(), anyString());
         when(session.transactionState()).thenReturn(TransactionState.IDLE);
 
         PostgresWireProtocol ctx =


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes https://github.com/crate/crate/issues/17651

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
