### PR TITLE
Update bug.yml issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -15,11 +15,11 @@ body:
     attributes:
       label: CrateDB setup information
       description: Number of nodes, HEAP setting, and tell us if you're using special master/data/client node configuration
-      placeholder: |-
+      value: |-
 
-        Number of nodes: 1
-        CRATE_HEAP_SIZE: 4g
-        CRATE_JAVA_OPTS: empty
+        Number of nodes: ?
+        CRATE_HEAP_SIZE: ?
+        CRATE_JAVA_OPTS: ?
 
         crate.yml contents:
 


### PR DESCRIPTION
Preserve the CrateDB Setup template text to fill out instead of having it as a placeholder that disappears when you type.
We could consider to keep the "1, 4g, empty" in the value text, but I'm concerned that we then can't be sure it's been actively considered or just not filled out, so therefore added a "?" that requires an update.

@mkleen experienced this and as a result forgot to mention some of it.

I kept the placeholder text for "Steps to reproduce" as that is just an inspirational example and not something that you always need as a template.