### PR TITLE
Simplify SingleShardRequest

### DIFF
--- a/server/src/main/java/io/crate/replication/logical/action/GetFileChunkAction.java
+++ b/server/src/main/java/io/crate/replication/logical/action/GetFileChunkAction.java
@@ -126,7 +126,7 @@ public class GetFileChunkAction extends ActionType<GetFileChunkAction.Response> 
         }
     }
 
-    public static class Request extends RestoreShardRequest<Request> {
+    public static class Request extends RestoreShardRequest {
 
         private final StoreFileMetadata storeFileMetadata;
         private final long offset;

--- a/server/src/main/java/io/crate/replication/logical/action/GetStoreMetadataAction.java
+++ b/server/src/main/java/io/crate/replication/logical/action/GetStoreMetadataAction.java
@@ -117,7 +117,7 @@ public class GetStoreMetadataAction extends ActionType<GetStoreMetadataAction.Re
         }
     }
 
-    public static class Request extends RestoreShardRequest<Request> {
+    public static class Request extends RestoreShardRequest {
 
         public Request(String restoreUUID,
                        DiscoveryNode node,

--- a/server/src/main/java/io/crate/replication/logical/action/ReleasePublisherResourcesAction.java
+++ b/server/src/main/java/io/crate/replication/logical/action/ReleasePublisherResourcesAction.java
@@ -108,7 +108,7 @@ public class ReleasePublisherResourcesAction extends ActionType<AcknowledgedResp
         }
     }
 
-    public static class Request extends RestoreShardRequest<Request> {
+    public static class Request extends RestoreShardRequest {
 
         public Request(String restoreUUID,
                        DiscoveryNode node,

--- a/server/src/main/java/io/crate/replication/logical/action/RestoreShardRequest.java
+++ b/server/src/main/java/io/crate/replication/logical/action/RestoreShardRequest.java
@@ -30,7 +30,7 @@ import org.elasticsearch.transport.RemoteClusterAwareRequest;
 
 import java.io.IOException;
 
-public class RestoreShardRequest<T extends SingleShardRequest<T>> extends SingleShardRequest<T>
+public class RestoreShardRequest extends SingleShardRequest
     implements RemoteClusterAwareRequest {
 
     private final String restoreUUID;

--- a/server/src/main/java/io/crate/replication/logical/action/ShardChangesAction.java
+++ b/server/src/main/java/io/crate/replication/logical/action/ShardChangesAction.java
@@ -233,7 +233,7 @@ public class ShardChangesAction extends ActionType<ShardChangesAction.Response> 
         }
     }
 
-    public static class Request extends SingleShardRequest<Request> {
+    public static class Request extends SingleShardRequest {
 
         private final ShardId shardId;
         private final long fromSeqNo;

--- a/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationRequest.java
@@ -22,10 +22,8 @@ package org.elasticsearch.action.support.replication;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
-import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.admin.indices.refresh.TransportShardRefreshAction;
 import org.elasticsearch.action.support.ActiveShardCount;
-import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.shard.ShardId;
@@ -38,8 +36,7 @@ import io.crate.common.unit.TimeValue;
  * Requests that are run on a particular replica, first on the primary and then on the replicas like
  * {@link TransportShardRefreshAction}.
  */
-public abstract class ReplicationRequest<Request extends ReplicationRequest<Request>> extends TransportRequest
-        implements IndicesRequest {
+public abstract class ReplicationRequest<Request extends ReplicationRequest<Request>> extends TransportRequest {
 
     public static final TimeValue DEFAULT_TIMEOUT = new TimeValue(1, TimeUnit.MINUTES);
 
@@ -99,16 +96,6 @@ public abstract class ReplicationRequest<Request extends ReplicationRequest<Requ
     public final Request index(String index) {
         this.index = index;
         return (Request) this;
-    }
-
-    @Override
-    public String[] indices() {
-        return new String[]{index};
-    }
-
-    @Override
-    public IndicesOptions indicesOptions() {
-        return IndicesOptions.STRICT_SINGLE_INDEX_NO_EXPAND_FORBID_CLOSED;
     }
 
     public ActiveShardCount waitForActiveShards() {

--- a/server/src/main/java/org/elasticsearch/action/support/single/shard/SingleShardRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/support/single/shard/SingleShardRequest.java
@@ -21,30 +21,19 @@ package org.elasticsearch.action.support.single.shard;
 
 import java.io.IOException;
 
-import org.elasticsearch.action.IndicesRequest;
-import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.transport.TransportRequest;
-import org.jetbrains.annotations.Nullable;
 
-public abstract class SingleShardRequest<Request extends SingleShardRequest<Request>> extends TransportRequest implements IndicesRequest {
-
-    public static final IndicesOptions INDICES_OPTIONS = IndicesOptions.STRICT_SINGLE_INDEX_NO_EXPAND_FORBID_CLOSED;
+public abstract class SingleShardRequest extends TransportRequest {
 
     /**
      * The concrete index name
-     *
-     * Whether index property is optional depends on the concrete implementation. If index property is required the
-     * concrete implementation should use {@link #validateNonNullIndex()} to check if the index property has been set
      */
-    @Nullable
-    protected String index;
-    ShardId internalShardId;
+    protected final String index;
 
-    public SingleShardRequest() {
-    }
+    ShardId internalShardId;
 
     public SingleShardRequest(StreamInput in) throws IOException {
         super(in);
@@ -59,40 +48,8 @@ public abstract class SingleShardRequest<Request extends SingleShardRequest<Requ
         this.index = index;
     }
 
-    protected void validateNonNullIndex() {
-        if (index == null) {
-            throw new IllegalArgumentException("index is missing");
-        }
-    }
-
-    /**
-     * @return The concrete index this request is targeted for or <code>null</code> if index is optional.
-     *         Whether index property is optional depends on the concrete implementation. If index property
-     *         is required the concrete implementation should use {@link #validateNonNullIndex()} to check
-     *         if the index property has been set
-     */
-    @Nullable
     public String index() {
         return index;
-    }
-
-    /**
-     * Sets the index.
-     */
-    @SuppressWarnings("unchecked")
-    public final Request index(String index) {
-        this.index = index;
-        return (Request) this;
-    }
-
-    @Override
-    public String[] indices() {
-        return new String[]{index};
-    }
-
-    @Override
-    public IndicesOptions indicesOptions() {
-        return INDICES_OPTIONS;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/support/single/shard/TransportSingleShardAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/single/shard/TransportSingleShardAction.java
@@ -59,7 +59,7 @@ import org.jetbrains.annotations.Nullable;
  * the read operation can be performed on other shard copies. Concrete implementations can provide their own list
  * of candidate shards to try the read operation on.
  */
-public abstract class TransportSingleShardAction<Request extends SingleShardRequest<Request>, Response extends TransportResponse>
+public abstract class TransportSingleShardAction<Request extends SingleShardRequest, Response extends TransportResponse>
     extends TransportAction<Request, Response> {
 
     protected final ThreadPool threadPool;

--- a/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseActions.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseActions.java
@@ -53,7 +53,7 @@ public class RetentionLeaseActions {
 
     public static final long RETAIN_ALL = -1;
 
-    abstract static class TransportRetentionLeaseAction<T extends Request<T>> extends TransportSingleShardAction<T, Response> {
+    abstract static class TransportRetentionLeaseAction<T extends Request> extends TransportSingleShardAction<T, Response> {
 
         private final IndicesService indicesService;
 
@@ -237,7 +237,7 @@ public class RetentionLeaseActions {
         }
     }
 
-    private abstract static class Request<T extends SingleShardRequest<T>> extends SingleShardRequest<T> {
+    private abstract static class Request extends SingleShardRequest {
 
         private final ShardId shardId;
 
@@ -272,7 +272,7 @@ public class RetentionLeaseActions {
 
     }
 
-    public static class AddOrRenewRequest extends Request<AddOrRenewRequest> {
+    public static class AddOrRenewRequest extends Request {
 
         private final long retainingSequenceNumber;
 
@@ -310,7 +310,7 @@ public class RetentionLeaseActions {
 
     }
 
-    public static class RemoveRequest extends Request<RemoveRequest> {
+    public static class RemoveRequest extends Request {
 
         RemoveRequest(StreamInput in) throws IOException {
             super(in);


### PR DESCRIPTION
This does not need to extend IndicesRequest, and the complex generics used for Builder-style construction are also unnecessary.