### PR TITLE
Fix flaky ReplicaShardAllocatorIT.testRecentPrimaryInformation

### DIFF
--- a/server/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorIT.java
+++ b/server/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorIT.java
@@ -204,6 +204,7 @@ public class ReplicaShardAllocatorIT extends IntegTestCase {
             cluster().startDataOnlyNode(nodeWithReplicaSettings);
 
             // need to wait for events to ensure the reroute has happened since we perform it async when a new node joins.
+            ensureYellow();
             assertBusy(() -> {
                 execute("""
                     select


### PR DESCRIPTION
Test needs to make sure the new node has joined the cluster
Follow up to https://github.com/crate/crate/pull/17586
