### PR TITLE
Eagerly check for column limit on add column

### DIFF
--- a/docs/appendices/release-notes/5.10.4.rst
+++ b/docs/appendices/release-notes/5.10.4.rst
@@ -44,6 +44,11 @@ See the :ref:`version_5.10.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed an issue that could cause ``INSERT INTO`` statements which dynamically
+  create thousands of columns to overload the cluster state update process
+  before running into the ``mapping.total_fields.limit`` limit, causing other
+  statements trying to update the cluster state to timeout.
+
 - Fixed NPE when querying the :ref:`sys.allocations <sys-allocations>` table
   while no master node has been discovered. A proper exception is now thrown
   instead of an NPE.

--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
@@ -175,14 +175,17 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
     public static final Setting<Long> DEPTH_LIMIT_SETTING =
         Setting.longSetting("index.mapping.depth.limit", 20L, 1, Property.Dynamic, Property.IndexScope);
 
-    private final List<Reference> columns;
+    private final List<Reference> topLevelColumns;
     private final Set<Reference> droppedColumns;
     private final List<GeneratedReference> generatedColumns;
     private final List<Reference> partitionedByColumns;
     private final List<Reference> defaultExpressionColumns;
     private final Collection<ColumnIdent> notNullColumns;
     private final Map<ColumnIdent, IndexReference> indexColumns;
-    private final Map<ColumnIdent, Reference> references;
+    /**
+     * Top level and nested columns, including system columns. Excludes dropped columns
+     **/
+    private final Map<ColumnIdent, Reference> allColumns;
     private final Map<String, Reference> leafByOid;
     private final RelationName ident;
     @Nullable
@@ -229,27 +232,27 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
             .map(Reference::column)
             .toList();
         this.droppedColumns = droppedColumns;
-        this.references = references.entrySet().stream()
+        this.allColumns = references.entrySet().stream()
             .filter(entry -> !entry.getValue().isDropped())
             .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
-        SysColumns.forTable(ident, this.references::put);
-        this.columns = this.references.values().stream()
+        this.topLevelColumns = this.allColumns.values().stream()
             .filter(r -> !r.column().isSystemColumn())
             .filter(r -> r.column().isRoot())
             .sorted(Reference.CMP_BY_POSITION_THEN_NAME)
             .toList();
+        SysColumns.forTable(ident, this.allColumns::put);
         this.partitionedByColumns = Lists.map(partitionedBy, x -> {
-            Reference ref = this.references.get(x);
+            Reference ref = this.allColumns.get(x);
             assert ref != null : "Column in `partitionedBy` must be present in `references`";
             return ref;
         });
-        this.generatedColumns = this.references.values().stream()
+        this.generatedColumns = this.allColumns.values().stream()
             .filter(r -> r instanceof GeneratedReference && !r.isDropped())
             .map(r -> (GeneratedReference) r)
             .toList();
         this.indexColumns = indexColumns;
         leafByOid = new HashMap<>();
-        Stream.concat(Stream.concat(this.references.values().stream(), indexColumns.values().stream()), droppedColumns.stream())
+        Stream.concat(Stream.concat(this.allColumns.values().stream(), indexColumns.values().stream()), droppedColumns.stream())
             .filter(r -> r.oid() != COLUMN_OID_UNASSIGNED)
             .forEach(r -> leafByOid.put(Long.toString(r.oid()), r));
         this.ident = ident;
@@ -285,8 +288,8 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
         this.versionUpgraded = versionUpgraded;
         this.closed = closed;
         this.supportedOperations = supportedOperations;
-        this.docColumn = new TableColumn(SysColumns.DOC, this.references);
-        this.defaultExpressionColumns = this.references.values()
+        this.docColumn = new TableColumn(SysColumns.DOC, this.allColumns);
+        this.defaultExpressionColumns = this.allColumns.values()
             .stream()
             .filter(r -> r.defaultExpression() != null)
             .toList();
@@ -302,7 +305,7 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
 
     @Nullable
     public Reference getReference(ColumnIdent columnIdent) {
-        Reference reference = references.get(columnIdent);
+        Reference reference = allColumns.get(columnIdent);
         if (reference == null) {
             return docColumn.getReference(ident(), columnIdent);
         }
@@ -313,7 +316,7 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
     public Reference getReference(String storageIdent) {
         try {
             long oid = Long.parseLong(storageIdent);
-            for (var ref : references.values()) {
+            for (var ref : allColumns.values()) {
                 if (ref.oid() == oid) {
                     return ref;
                 }
@@ -363,14 +366,14 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
 
     private ReferenceTree referenceTree() {
         if (refTree == null) {
-            refTree = ReferenceTree.of(references.values());
+            refTree = ReferenceTree.of(allColumns.values());
         }
         return refTree;
     }
 
     @Override
     public List<Reference> columns() {
-        return columns;
+        return topLevelColumns;
     }
 
     @Override
@@ -380,7 +383,7 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
 
     public int maxPosition() {
         return Math.max(
-            references.values().stream()
+            allColumns.values().stream()
                 .filter(ref -> !ref.column().isSystemColumn())
                 .mapToInt(Reference::position)
                 .max()
@@ -575,7 +578,7 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
 
     @Override
     public Iterator<Reference> iterator() {
-        return references.values().stream()
+        return allColumns.values().stream()
             .sorted(Reference.CMP_BY_POSITION_THEN_NAME)
             .iterator();
     }
@@ -627,7 +630,7 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
 
     @Nullable
     public String getAnalyzerForColumnIdent(ColumnIdent ident) {
-        Reference reference = references.get(ident);
+        Reference reference = allColumns.get(ident);
         if (reference instanceof GeneratedReference gen) {
             reference = gen.reference();
         }
@@ -820,7 +823,7 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
         }
         return new DocTableInfo(
             ident,
-            references,
+            allColumns,
             indexColumns,
             droppedColumns,
             pkConstraintName,
@@ -840,11 +843,11 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
 
     public DocTableInfo dropColumns(List<DropColumn> columns) {
         validateDropColumns(columns);
-        HashMap<ColumnIdent, Reference> newReferences = new HashMap<>(references);
+        HashMap<ColumnIdent, Reference> newReferences = new HashMap<>(allColumns);
         Set<Reference> newDroppedColumns = new HashSet<>();
         for (var column : columns) {
             ColumnIdent columnIdent = column.ref().column();
-            Reference reference = references.get(columnIdent);
+            Reference reference = allColumns.get(columnIdent);
             if (newDroppedColumns.contains(reference)) {
                 continue;
             }
@@ -862,7 +865,7 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
             Reference droppedRef = reference.withDropped(true);
             newDroppedColumns.add(droppedRef);
             newReferences.replace(columnIdent, droppedRef);
-            for (var ref : references.values()) {
+            for (var ref : allColumns.values()) {
                 if (ref.column().isChildOf(columnIdent)) {
                     newDroppedColumns.add(ref.withDropped(true));
                     newReferences.remove(ref.column());
@@ -936,7 +939,7 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
         // where 1) is used to perform 2).
 
         Map<ColumnIdent, Reference> oldNameToRenamedRefs = new HashMap<>();
-        for (var ref : references.values()) {
+        for (var ref : allColumns.values()) {
             ColumnIdent column = ref.column();
             if (toBeRenamed.test(column)) {
                 var renamedRef = ref.withReferenceIdent(
@@ -1021,7 +1024,7 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
                     droppedColumns.stream(),
                     indexColumns.values().stream()
                 ),
-                references.values().stream()
+                this.allColumns.values().stream()
             )
             .filter(ref -> !ref.column().isSystemColumn())
             .sorted(Reference.CMP_BY_POSITION_THEN_NAME)
@@ -1190,7 +1193,12 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
                                    IntArrayList pKeyIndices,
                                    Map<String, String> newCheckConstraints) {
         newColumns.forEach(ref -> ref.column().validForCreate());
-        HashMap<ColumnIdent, Reference> newReferences = new HashMap<>(references);
+        long allowedTotalColumns = TOTAL_COLUMNS_LIMIT.get(tableParameters);
+        int numSysColumns = SysColumns.COLUMN_IDENTS.size();
+        if (newColumns.size() + allColumns.size() - numSysColumns > allowedTotalColumns) {
+            throw new IllegalArgumentException("Limit of total columns [" + allowedTotalColumns + "] in table [" + ident + "] exceeded");
+        }
+        HashMap<ColumnIdent, Reference> newReferences = new HashMap<>(allColumns);
         int maxPosition = maxPosition();
         AtomicInteger positions = new AtomicInteger(maxPosition);
         List<Reference> newColumnsWithParents = addMissingParents(newColumns);

--- a/server/src/test/java/io/crate/metadata/doc/DocTableInfoTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocTableInfoTest.java
@@ -23,6 +23,7 @@ package io.crate.metadata.doc;
 
 import static io.crate.testing.Asserts.assertThat;
 import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
 
@@ -33,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
 
 import org.assertj.core.api.Assertions;
 import org.elasticsearch.Version;
@@ -569,6 +571,31 @@ public class DocTableInfoTest extends CrateDummyClusterServiceUnitTest {
         assertThat(newTable.getReference(ColumnIdent.of("o")))
             .hasName("o")
             .hasType(oType);
+    }
+
+    @Test
+    public void test_add_columns_fails_eagerly_on_too_many_columns() throws Exception {
+        SQLExecutor e = SQLExecutor.of(clusterService)
+            .addTable("create table tbl (x int) with (\"mapping.total_fields.limit\" = 3)");
+        DocTableInfo table = e.resolveTableInfo("tbl");
+        Function<String, Reference> newRef = name -> new SimpleReference(
+            new ReferenceIdent(table.ident(), ColumnIdent.of(name)),
+            RowGranularity.DOC,
+            DataTypes.INTEGER,
+            -1,
+            null
+        );
+        Reference a = newRef.apply("a");
+        Reference b = newRef.apply("b");
+        Reference c = newRef.apply("c");
+        assertThatThrownBy(() -> table.addColumns(
+            e.nodeCtx,
+            e.fulltextAnalyzerResolver(),
+            () -> 1,
+            List.of(a, b, c),
+            new IntArrayList(),
+            Map.of()
+        )).hasMessage("Limit of total columns [3] in table [doc.tbl] exceeded");
     }
 
     @Test


### PR DESCRIPTION
The column limit is checked in `DocTableInfo.writeTo`, which for dynamic
mapping updates happens after `DocTableInfo.addColumns`.

`.addColumns` could take a long time if trying to add a couple hundred
thousand columns - blocking other cluster state updates for a long time
before eventually running into the limit.

![image](https://github.com/user-attachments/assets/a19fedaa-e684-4ab7-8318-37cbb4c782a0)

I also tried to change `addMissingParents` to do the `hasColumn` checks based on a set, but that only moves the bottle neck:

![image](https://github.com/user-attachments/assets/8c3a01e0-afe8-4a71-911c-bdf35c1c9979)


(In the scenario a `INSER INTO` resulted in adding 438976 columns)
