### PR TITLE
Use table statistics to improve ram estimation for updates

### DIFF
--- a/docs/appendices/release-notes/5.10.4.rst
+++ b/docs/appendices/release-notes/5.10.4.rst
@@ -44,6 +44,11 @@ See the :ref:`version_5.10.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed ram-accounting accuracy for upsert statements by using the table stats
+  to estimate the average row size. If stats are not (yet) available, a rough
+  estimate based on the table columns data types is used. By this, nodes should
+  be prevented from running out of memory on large bulk updates.
+
 - Tuned the sizing of internal intermediate result requests for statements like
   JOINS to reduce memory pressure on clusters with more than one node.
 

--- a/docs/appendices/release-notes/5.9.13.rst
+++ b/docs/appendices/release-notes/5.9.13.rst
@@ -47,6 +47,11 @@ See the :ref:`version_5.9.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Fixed ram-accounting accuracy for upsert statements by using the table stats
+  to estimate the average row size. If stats are not (yet) available, a rough
+  estimate based on the table columns data types is used. By this, nodes should
+  be prevented from running out of memory on large bulk updates.
+
 - Tuned the sizing of internal intermediate result requests for statements like
   JOINS to reduce memory pressure on clusters with more than one node.
 

--- a/server/src/main/java/io/crate/execution/dml/ShardRequest.java
+++ b/server/src/main/java/io/crate/execution/dml/ShardRequest.java
@@ -43,8 +43,6 @@ public abstract class ShardRequest<T extends ShardRequest<T, I>, I extends Shard
     extends ReplicationRequest<T>
     implements Iterable<I>, Accountable {
 
-    private static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(ShardRequest.class);
-
     private final UUID jobId;
     protected List<I> items;
 
@@ -116,9 +114,11 @@ public abstract class ShardRequest<T extends ShardRequest<T, I>, I extends Shard
                '}';
     }
 
+    protected abstract long shallowSize();
+
     @Override
     public long ramBytesUsed() {
-        long bytes = SHALLOW_SIZE;
+        long bytes = shallowSize();
         for (var item : items) {
             bytes += item.ramBytesUsed();
         }

--- a/server/src/main/java/io/crate/execution/dml/delete/ShardDeleteRequest.java
+++ b/server/src/main/java/io/crate/execution/dml/delete/ShardDeleteRequest.java
@@ -34,6 +34,8 @@ import java.util.UUID;
 
 public class ShardDeleteRequest extends ShardRequest<ShardDeleteRequest, ShardDeleteRequest.Item> {
 
+    private static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(ShardDeleteRequest.class);
+
     private int skipFromLocation = -1;
 
     public ShardDeleteRequest(ShardId shardId, UUID jobId) {
@@ -61,6 +63,11 @@ public class ShardDeleteRequest extends ShardRequest<ShardDeleteRequest, ShardDe
         } else {
             out.writeBoolean(false);
         }
+    }
+
+    @Override
+    protected long shallowSize() {
+        return SHALLOW_SIZE;
     }
 
     public ShardDeleteRequest(StreamInput in) throws IOException {

--- a/server/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
+++ b/server/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
@@ -21,6 +21,7 @@
 
 package io.crate.execution.engine.pipeline;
 
+import static io.crate.execution.dml.upsert.ShardUpsertRequest.Item.sizeEstimateForUpdate;
 import static io.crate.execution.engine.pipeline.LimitAndOffset.NO_LIMIT;
 import static io.crate.execution.engine.pipeline.LimitAndOffset.NO_OFFSET;
 import static io.crate.planner.operators.InsertFromValues.checkConstraints;
@@ -555,6 +556,16 @@ public class ProjectionToProjectorVisitor
         Context context, UpdateProjection projection,
         Collector<ShardResponse, A, Iterable<Row>> collector) {
 
+        // Get Stats to improve ram estimation for the update items
+        assert shardId != null : "ShardId must be provided for updates";
+
+        String indexName = shardId.getIndexName();
+        RelationName relationName = RelationName.fromIndexName(indexName);
+
+        long sizeEstimate = sizeEstimateForUpdate(
+            nodeCtx.tableStats().getStats(relationName),
+            nodeCtx.schemas().getTableInfo(relationName)
+        );
         ShardUpsertRequest.Builder builder = new ShardUpsertRequest.Builder(
             context.txnCtx.sessionSettings(),
             ShardingUpsertExecutor.BULK_REQUEST_TIMEOUT_SETTING.get(settings),
@@ -584,7 +595,8 @@ public class ProjectionToProjectorVisitor
                     projection.assignments(),
                     requiredVersion == null ? Versions.MATCH_ANY : requiredVersion,
                     SequenceNumbers.UNASSIGNED_SEQ_NO,
-                    SequenceNumbers.UNASSIGNED_PRIMARY_TERM
+                    SequenceNumbers.UNASSIGNED_PRIMARY_TERM,
+                    sizeEstimate
                 );
             },
             (req, resp) -> elasticsearchClient.execute(ShardUpsertAction.INSTANCE, req).whenComplete(resp),

--- a/server/src/main/java/io/crate/metadata/NodeContext.java
+++ b/server/src/main/java/io/crate/metadata/NodeContext.java
@@ -46,6 +46,7 @@ public class NodeContext {
     private final long serverStartTimeInMs;
     private final Roles roles;
     private final Schemas schemas;
+    private final TableStats tableStats;
 
     public static NodeContext of(Environment environment,
                                  ClusterService clusterService,
@@ -73,14 +74,18 @@ public class NodeContext {
             );
             schemas.start();
             return schemas;
-        });
+        }, tableStats);
     }
 
-    public NodeContext(Functions functions, Roles roles, Function<NodeContext, Schemas> createSchemas) {
+    public NodeContext(Functions functions,
+                       Roles roles,
+                       Function<NodeContext, Schemas> createSchemas,
+                       TableStats tableStats) {
         this.functions = functions;
         this.serverStartTimeInMs = SystemClock.currentInstant().toEpochMilli();
         this.roles = roles;
         this.schemas = createSchemas.apply(this);
+        this.tableStats = tableStats;
     }
 
     public Functions functions() {
@@ -97,5 +102,9 @@ public class NodeContext {
 
     public Schemas schemas() {
         return schemas;
+    }
+
+    public TableStats tableStats() {
+        return tableStats;
     }
 }

--- a/server/src/main/java/io/crate/metadata/RelationInfo.java
+++ b/server/src/main/java/io/crate/metadata/RelationInfo.java
@@ -60,6 +60,10 @@ public interface RelationInfo extends Iterable<Reference> {
      */
     Collection<Reference> columns();
 
+    default Collection<Reference> allColumns() {
+        return columns();
+    }
+
     default Collection<Reference> droppedColumns() {
         return List.of();
     }

--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
@@ -376,6 +376,11 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
     }
 
     @Override
+    public Collection<Reference> allColumns() {
+        return allColumns.values();
+    }
+
+    @Override
     public Set<Reference> droppedColumns() {
         return droppedColumns;
     }

--- a/server/src/main/java/io/crate/planner/node/dml/UpdateById.java
+++ b/server/src/main/java/io/crate/planner/node/dml/UpdateById.java
@@ -173,7 +173,8 @@ public final class UpdateById implements Plan {
                 assignmentSources,
                 version,
                 seqNo,
-                primaryTerm
+                primaryTerm,
+                0
             );
             request.add(location, item);
         }

--- a/server/src/main/java/io/crate/statistics/Stats.java
+++ b/server/src/main/java/io/crate/statistics/Stats.java
@@ -22,8 +22,8 @@
 package io.crate.statistics;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import org.apache.lucene.util.RamUsageEstimator;
@@ -138,10 +138,9 @@ public class Stats implements Writeable {
         return statsByColumn.get(column);
     }
 
-    public long estimateSizeForColumns(List<Symbol> toCollect) {
+    public <T extends Symbol> long estimateSizeForColumns(Collection<T> toCollect) {
         long sum = 0L;
-        for (int i = 0; i < toCollect.size(); i++) {
-            Symbol symbol = toCollect.get(i);
+        for (Symbol symbol : toCollect) {
             ColumnStats<?> columnStats = null;
             while (symbol instanceof AliasSymbol alias) {
                 symbol = alias.symbol();

--- a/server/src/test/java/io/crate/execution/dml/upsert/ShardUpsertRequestTest.java
+++ b/server/src/test/java/io/crate/execution/dml/upsert/ShardUpsertRequestTest.java
@@ -25,12 +25,16 @@ package io.crate.execution.dml.upsert;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.seqno.SequenceNumbers;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.translog.Translog;
@@ -41,13 +45,18 @@ import io.crate.common.unit.TimeValue;
 import io.crate.execution.dml.upsert.ShardUpsertRequest.DuplicateKeyAction;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.SearchPath;
 import io.crate.metadata.SimpleReference;
+import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.settings.SessionSettings;
+import io.crate.metadata.table.Operation;
+import io.crate.sql.tree.ColumnPolicy;
+import io.crate.statistics.Stats;
 import io.crate.types.DataTypes;
 
 public class ShardUpsertRequestTest extends ESTestCase {
@@ -209,4 +218,79 @@ public class ShardUpsertRequestTest extends ESTestCase {
         ShardUpsertRequest request2 = new ShardUpsertRequest(in);
         assertThat(request2.items().get(0).seqNo()).isEqualTo(SequenceNumbers.SKIP_ON_REPLICA);
     }
+
+    @Test
+    public void test_ram_estimation_with_stats() {
+        Stats stats = new Stats(10L, 1000L, Map.of());
+        ShardUpsertRequest request = new ShardUpsertRequest.Builder(
+            new SessionSettings("dummyUser", SearchPath.createSearchPathFrom("dummySchema")),
+            TimeValue.timeValueSeconds(30),
+            DuplicateKeyAction.UPDATE_OR_FAIL,
+            false,
+            new String[]{ID_REF.column().name(), NAME_REF.column().name()},
+            new Reference[]{},
+            null,
+            UUID.randomUUID()
+        ).newRequest(new ShardId("test", UUIDs.randomBase64UUID(), 1));
+        assertThat(request.ramBytesUsed()).isEqualTo(72L);
+
+        long sizeEstimate = ShardUpsertRequest.Item.sizeEstimateForUpdate(stats, DOC_TABLE_INFO);
+        request.add(42, ShardUpsertRequest.Item.forUpdate(
+            "42",
+            new Symbol[]{ID_REF, NAME_REF},
+            1,
+            1,
+            1,
+            sizeEstimate
+        ));
+        assertThat(request.ramBytesUsed()).isEqualTo(836L);
+    }
+
+    @Test
+    public void test_ram_estimation_with_empty_stats_using_columns_estimates() {
+        ShardUpsertRequest request = new ShardUpsertRequest.Builder(
+            new SessionSettings("dummyUser", SearchPath.createSearchPathFrom("dummySchema")),
+            TimeValue.timeValueSeconds(30),
+            DuplicateKeyAction.UPDATE_OR_FAIL,
+            false,
+            new String[]{ID_REF.column().name(), NAME_REF.column().name()},
+            new Reference[]{},
+            null,
+            UUID.randomUUID()
+        ).newRequest(new ShardId("test", UUIDs.randomBase64UUID(), 1));
+        assertThat(request.ramBytesUsed()).isEqualTo(72L);
+
+        long sizeEstimate = ShardUpsertRequest.Item.sizeEstimateForUpdate(Stats.EMPTY, DOC_TABLE_INFO);
+        request.add(42, ShardUpsertRequest.Item.forUpdate(
+            "42",
+            new Symbol[]{ID_REF, NAME_REF},
+            1,
+            1,
+            1,
+            sizeEstimate
+        ));
+        assertThat(request.ramBytesUsed()).isEqualTo(2160L);
+    }
+
+    private static final DocTableInfo DOC_TABLE_INFO = new DocTableInfo(
+        CHARACTERS_IDENTS,
+        Map.of(ID_REF.column(), ID_REF, NAME_REF.column(), NAME_REF),
+        Map.of(),
+        Set.of(),
+        null,
+        List.of(),
+        List.of(),
+        null,
+        Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 5)
+            .build(),
+        List.of(),
+        ColumnPolicy.DYNAMIC,
+        Version.CURRENT,
+        null,
+        false,
+        Operation.ALL,
+        0
+    );
+
 }

--- a/server/src/testFixtures/java/io/crate/testing/TestingHelpers.java
+++ b/server/src/testFixtures/java/io/crate/testing/TestingHelpers.java
@@ -72,6 +72,7 @@ import io.crate.metadata.SimpleReference;
 import io.crate.metadata.settings.session.SessionSettingRegistry;
 import io.crate.planner.optimizer.LoadedRules;
 import io.crate.role.Role;
+import io.crate.statistics.TableStats;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 
@@ -223,7 +224,8 @@ public class TestingHelpers {
         return new NodeContext(
             Functions.load(Settings.EMPTY, new SessionSettingRegistry(Set.of(LoadedRules.INSTANCE))),
             () -> roles,
-            nodeContext -> schemas
+            nodeContext -> schemas,
+            new TableStats()
         );
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This improves the ram estimation by using table statistics for `ShardUpsertRequest` for the update use case where the updated values are not part of the request. This prevents update workloads that can exceed the node's memory.

Fixes https://github.com/crate/crate/issues/17643


## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
