### PR TITLE
Disable AWS SDK v1 warnings

### DIFF
--- a/app/src/main/java/io/crate/bootstrap/CrateDB.java
+++ b/app/src/main/java/io/crate/bootstrap/CrateDB.java
@@ -63,6 +63,10 @@ public class CrateDB extends EnvironmentAwareCommand {
      * Main entry point for starting crate
      */
     public static void main(final String[] args) throws Exception {
+        // Remove once AWS SDK is upgraded to v2
+        // https://github.com/crate/crate/issues/12098
+        System.setProperty("aws.java.v1.disableDeprecationAnnouncement", "true");
+
         LogConfigurator.registerErrorListener();
         try (CrateDB crate = new CrateDB()) {
             int status = crate.main(args, Terminal.DEFAULT);


### PR DESCRIPTION
Disable "ugly" warnings during CrateDB bootstrap, until we upgrad to AWS SDK v2.

Relates: #12098
Follows: #17569

