### PR TITLE
Fix create shard lock retry logic

### DIFF
--- a/docs/appendices/release-notes/5.10.4.rst
+++ b/docs/appendices/release-notes/5.10.4.rst
@@ -58,3 +58,8 @@ Fixes
 
 - Fixed an issue that caused queries submitted via PG wire to not be logged in
   :ref:`sys.jobs_log <sys-logs>` in case of a parsing failure.
+
+- Fixed an issue causing shards to not be allocated if the shard was not
+  closed properly, e.g. due to an unclean node shutdown and the node was
+  restarting with still holding a lock on the shard. The existing retry logic
+  to solve this situation was not working in some cases.

--- a/docs/appendices/release-notes/5.9.13.rst
+++ b/docs/appendices/release-notes/5.9.13.rst
@@ -53,3 +53,8 @@ Fixes
 
 - Fixed an issue that caused queries submitted via PG wire to not be logged in
   :ref:`sys.jobs_log <sys-logs>` in case of a parsing failure.
+
+- Fixed an issue causing shards to not be allocated if the shard was not
+  closed properly, e.g. due to an unclean node shutdown and the node was
+  restarting with still holding a lock on the shard. The existing retry logic
+  to solve this situation was not working in some cases.

--- a/server/src/test/java/io/crate/integrationtests/ShardLockIT.java
+++ b/server/src/test/java/io/crate/integrationtests/ShardLockIT.java
@@ -25,22 +25,34 @@ import static io.crate.testing.Asserts.assertExpectedLogMessages;
 import static io.crate.testing.Asserts.assertThat;
 
 import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.env.ShardLock;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.indices.cluster.IndicesClusterStateService;
 import org.elasticsearch.test.IntegTestCase;
 import org.elasticsearch.test.IntegTestCase.ClusterScope;
 import org.elasticsearch.test.MockLogAppender;
 import org.elasticsearch.test.junit.annotations.TestLogging;
+import org.junit.After;
 import org.junit.Test;
 
 @ClusterScope(numDataNodes = 1)
 public class ShardLockIT extends IntegTestCase {
 
+    @After
+    @Override
+    public void tearDown() throws Exception {
+        execute("RESET GLOBAL stats.jobs_log_size");
+        super.tearDown();
+    }
+
     @Test
-    @TestLogging("org.elasticsearch.indices.IndicesService:DEBUG")
+    @TestLogging("org.elasticsearch.indices.IndicesService:DEBUG,org.elasticsearch.index.engine:TRACE,org.elasticsearch.index.IndexService:TRACE")
     public void test_create_shard_retries_on_shard_lock() throws Exception {
         String nodeName = cluster().startDataOnlyNode();
         execute("""
@@ -57,6 +69,32 @@ public class ShardLockIT extends IntegTestCase {
         ShardId shardId = new ShardId(index, 0);
         NodeEnvironment nodeEnv = cluster().getInstance(NodeEnvironment.class, nodeName);
 
+        Logger testLogger = LogManager.getLogger(IndicesClusterStateService.class);
+        MockLogAppender appender = new MockLogAppender();
+        Loggers.addAppender(testLogger, appender);
+        appender.start();
+        var expectationShardFailure = new MockLogAppender.UnseenEventExpectation(
+            "Shard failure",
+            IndicesClusterStateService.class.getName(),
+            Level.WARN,
+            "[tbl][0] marking and sending shard failed due to [failed to create shard]"
+        );
+        appender.addExpectation(expectationShardFailure);
+
+        Thread thread = new Thread(() -> {
+            int i = 0;
+            // trigger some cluster state changes which the retry logic has to account for
+            while (i++ < 10) {
+                execute("SET GLOBAL PERSISTENT stats.jobs_log_size = ?", new Object[] { i });
+                try {
+                    Thread.sleep(10);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
+        thread.start();
+
         var expectation = new MockLogAppender.PatternSeenEventExcpectation(
             "Logs retries",
             IndicesService.class.getName(),
@@ -69,6 +107,17 @@ public class ShardLockIT extends IntegTestCase {
                 IndicesService.class.getName(),
                 expectation
             );
+        } finally {
+            thread.join();
+        }
+
+        // Verify that the shard was never marked as failed.
+        // If new cluster state changes are applied, the shard would be created again even that it failed before.
+        // But the shard creation should never fail, but the retry logic should succeed.
+        try {
+            appender.assertAllExpectationsMatched();
+        } finally {
+            Loggers.removeAppender(testLogger, appender);
         }
 
         ensureGreen();


### PR DESCRIPTION
The retry logic for the shard creation in case of a lock did not work as expected if a cluster state change happened in-between.
