### PR TITLE
Remove GET threadpool in favour of SEARCH

### DIFF
--- a/docs/config/cluster.rst
+++ b/docs/config/cluster.rst
@@ -1203,8 +1203,6 @@ dedicated to specific operations. The most important pools are:
   defaults to ``fixed``.
 * ``search``: Used for read operations like ``SELECT`` statements. The ``type``
   defaults to ``fixed``.
-* ``get``: Used for some specific read operations. For example on tables like
-  ``sys.shards`` or ``sys.nodes``. The ``type`` defaults to ``fixed``.
 * ``refresh``: Used for :ref:`refresh operations <refresh_data>`. The ``type``
   defaults to ``scaling``.
 * ``generic``: For internal tasks like cluster state management. The ``type``
@@ -1271,7 +1269,6 @@ settings.
 **thread_pool.<name>.queue_size**
   | *Default write:*  ``200``
   | *Default search:* ``1000``
-  | *Default get:* ``100``
   | *Runtime:*  ``no``
 
   Size of the queue for pending requests. A value of ``-1`` sets it to

--- a/extensions/jmx-monitoring/src/main/java/io/crate/beans/ThreadPools.java
+++ b/extensions/jmx-monitoring/src/main/java/io/crate/beans/ThreadPools.java
@@ -21,18 +21,11 @@
 
 package io.crate.beans;
 
-import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.threadpool.ThreadPoolStats;
-
-import org.jetbrains.annotations.Nullable;
-import java.beans.ConstructorProperties;
-
 import static org.elasticsearch.threadpool.ThreadPool.Names.FETCH_SHARD_STARTED;
 import static org.elasticsearch.threadpool.ThreadPool.Names.FETCH_SHARD_STORE;
 import static org.elasticsearch.threadpool.ThreadPool.Names.FLUSH;
 import static org.elasticsearch.threadpool.ThreadPool.Names.FORCE_MERGE;
 import static org.elasticsearch.threadpool.ThreadPool.Names.GENERIC;
-import static org.elasticsearch.threadpool.ThreadPool.Names.GET;
 import static org.elasticsearch.threadpool.ThreadPool.Names.LISTENER;
 import static org.elasticsearch.threadpool.ThreadPool.Names.LOGICAL_REPLICATION;
 import static org.elasticsearch.threadpool.ThreadPool.Names.MANAGEMENT;
@@ -40,6 +33,12 @@ import static org.elasticsearch.threadpool.ThreadPool.Names.REFRESH;
 import static org.elasticsearch.threadpool.ThreadPool.Names.SEARCH;
 import static org.elasticsearch.threadpool.ThreadPool.Names.SNAPSHOT;
 import static org.elasticsearch.threadpool.ThreadPool.Names.WRITE;
+
+import java.beans.ConstructorProperties;
+
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.threadpool.ThreadPoolStats;
+import org.jetbrains.annotations.Nullable;
 
 public class ThreadPools implements ThreadPoolsMXBean {
 
@@ -139,11 +138,6 @@ public class ThreadPools implements ThreadPoolsMXBean {
     @Override
     public ThreadPoolInfo getListener() {
         return getThreadPoolInfo(LISTENER);
-    }
-
-    @Override
-    public ThreadPoolInfo getGet() {
-        return getThreadPoolInfo(GET);
     }
 
     @Override

--- a/extensions/jmx-monitoring/src/main/java/io/crate/beans/ThreadPoolsMXBean.java
+++ b/extensions/jmx-monitoring/src/main/java/io/crate/beans/ThreadPoolsMXBean.java
@@ -21,14 +21,11 @@
 
 package io.crate.beans;
 
-@SuppressWarnings("unused")
 public interface ThreadPoolsMXBean {
 
     ThreadPools.ThreadPoolInfo getGeneric();
 
     ThreadPools.ThreadPoolInfo getListener();
-
-    ThreadPools.ThreadPoolInfo getGet();
 
     ThreadPools.ThreadPoolInfo getWrite();
 

--- a/server/src/main/java/io/crate/replication/logical/action/GetFileChunkAction.java
+++ b/server/src/main/java/io/crate/replication/logical/action/GetFileChunkAction.java
@@ -79,7 +79,7 @@ public class GetFileChunkAction extends ActionType<GetFileChunkAction.Response> 
                 clusterService,
                 transportService,
                 Request::new,
-                ThreadPool.Names.GET
+                ThreadPool.Names.SEARCH
             );
             this.indicesService = indicesService;
             this.publisherRestoreService = publisherRestoreService;

--- a/server/src/main/java/io/crate/replication/logical/action/ReleasePublisherResourcesAction.java
+++ b/server/src/main/java/io/crate/replication/logical/action/ReleasePublisherResourcesAction.java
@@ -76,7 +76,7 @@ public class ReleasePublisherResourcesAction extends ActionType<AcknowledgedResp
                 clusterService,
                 transportService,
                 Request::new,
-                ThreadPool.Names.GET
+                ThreadPool.Names.SAME // operation is fairly fast
             );
             this.publisherRestoreService = publisherRestoreService;
             TransportActionProxy.registerProxyAction(

--- a/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -63,7 +63,6 @@ public class ThreadPool implements Scheduler {
         public static final String SAME = "same";
         public static final String GENERIC = "generic";
         public static final String LISTENER = "listener";
-        public static final String GET = "get";
         public static final String WRITE = "write";
         public static final String SEARCH = "search";
         public static final String MANAGEMENT = "management";
@@ -137,7 +136,6 @@ public class ThreadPool implements Scheduler {
         final int genericThreadPoolMax = boundedBy(4 * availableProcessors, 128, 512);
         builders.put(Names.GENERIC, new ScalingExecutorBuilder(Names.GENERIC, 4, genericThreadPoolMax, TimeValue.timeValueSeconds(30)));
         builders.put(Names.WRITE, new FixedExecutorBuilder(settings, Names.WRITE, availableProcessors, 200));
-        builders.put(Names.GET, new FixedExecutorBuilder(settings, Names.GET, halfProcMaxAt10, 100));
         builders.put(Names.SEARCH, new FixedExecutorBuilder(settings, Names.SEARCH, searchThreadPoolSize(availableProcessors), 1000));
         builders.put(Names.MANAGEMENT, new ScalingExecutorBuilder(Names.MANAGEMENT, 1, 5, TimeValue.timeValueMinutes(5)));
         // no queue as this means clients will need to handle rejections on listener queue even if the operation succeeded

--- a/server/src/test/java/io/crate/execution/engine/collect/CollectTaskTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/CollectTaskTest.java
@@ -21,9 +21,9 @@
 
 package io.crate.execution.engine.collect;
 
-import static io.crate.testing.Asserts.assertThat;
-import static io.crate.testing.Asserts.assertThatThrownBy;
-import static io.crate.testing.Asserts.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -141,13 +141,13 @@ public class CollectTaskTest extends ESTestCase {
         // sys.nodes (single row collector)
         when(collectPhase.maxRowGranularity()).thenReturn(RowGranularity.NODE);
         threadPoolExecutorName = CollectTask.threadPoolName(collectPhase, true);
-        assertThat(threadPoolExecutorName).isEqualTo(ThreadPool.Names.GET);
+        assertThat(threadPoolExecutorName).isEqualTo(ThreadPool.Names.SEARCH);
 
         // sys.shards
         when(routing.containsShards(localNodeId)).thenReturn(true);
         when(collectPhase.maxRowGranularity()).thenReturn(RowGranularity.SHARD);
         threadPoolExecutorName = CollectTask.threadPoolName(collectPhase, true);
-        assertThat(threadPoolExecutorName).isEqualTo(ThreadPool.Names.GET);
+        assertThat(threadPoolExecutorName).isEqualTo(ThreadPool.Names.SEARCH);
         when(routing.containsShards(localNodeId)).thenReturn(false);
 
         // information_schema.*


### PR DESCRIPTION
GET was mostly used for sys.shards/sys.nodes with the intention of
having a separate queue/pool to ensure these queries get scheduled
independent of how occupied the SEARCH pool is.

The problem with that approach is that although they'll get scheduled
faster because of the separate queue, they compete for CPU time with
all the running SEARCH activities, including new arrivals.

This removes GET, with the intention to follow up integrating a
`PriorityQueue` so that system queries can skip ahead of the queue, and
then have to compete with fewer active tasks for CPU time.
