### PR TITLE
Percentile function: Switch to MergingDigest with 200 compression as default

### DIFF
--- a/docs/appendices/release-notes/6.0.0.rst
+++ b/docs/appendices/release-notes/6.0.0.rst
@@ -79,6 +79,15 @@ Breaking Changes
 
     SELECT 'a%' LIKE ANY(['a__']);
 
+- Updated the default ``compression`` of
+  :ref:`percentile aggregation <aggregation-percentile>` from ``100.0`` to
+  ``200.0`` which increases the accuracy of the approximations but with the
+  cost of slightly more memory consumption and increased execution time,
+  depending on the used data set.
+  To regain existing behaviour, adjust the ``compression`` argument of the
+  :ref:`percentile aggregation <aggregation-percentile>` accordingly.
+
+
 Deprecations
 ============
 
@@ -126,6 +135,9 @@ Scalar and Aggregation Functions
 - Added support for the :ref:`aggregation-stddev-pop` function to compute
   the population standard deviation.
 
+- Replaced `t-digest <https://github.com/tdunning/t-digest>`_ algorithm used by
+  :ref:`percentile aggregation <aggregation-percentile>` from ``AVLTreeDigest``
+  to ``MergingDigest`` to improve the consistency and accuracy of the result.
 
 Performance and Resilience Improvements
 ---------------------------------------

--- a/docs/general/builtins/aggregation.rst
+++ b/docs/general/builtins/aggregation.rst
@@ -708,7 +708,7 @@ To be able to calculate percentiles over a huge amount of data and to scale out
 CrateDB calculates approximate instead of accurate percentiles. The algorithm
 used by the percentile metric is called `TDigest`_. The accuracy/size trade-off
 of the algorithm is defined by a single ``compression`` parameter which has a
-default value of ``100.0``, but can be defined by passing in an optional 3rd
+default value of ``200.0``, but can be defined by passing in an optional 3rd
 ``double`` value argument as the ``compression``. However, there are a few
 guidelines to keep in mind in this implementation:
 

--- a/server/src/main/java/io/crate/execution/engine/aggregation/impl/TDigestState.java
+++ b/server/src/main/java/io/crate/execution/engine/aggregation/impl/TDigestState.java
@@ -27,14 +27,14 @@ import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
-import com.tdunning.math.stats.AVLTreeDigest;
 import com.tdunning.math.stats.Centroid;
+import com.tdunning.math.stats.MergingDigest;
 
-class TDigestState extends AVLTreeDigest {
+class TDigestState extends MergingDigest {
 
     public static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(TDigestState.class);
 
-    public static final double DEFAULT_COMPRESSION = 100.0;
+    public static final double DEFAULT_COMPRESSION = 200.0;
 
     private double[] fractions;
 

--- a/server/src/test/java/io/crate/execution/engine/aggregation/impl/PercentileAggregationTest.java
+++ b/server/src/test/java/io/crate/execution/engine/aggregation/impl/PercentileAggregationTest.java
@@ -279,11 +279,11 @@ public class PercentileAggregationTest extends AggregationTestCase {
         );
         RamAccounting ramAccounting = new PlainRamAccounting();
         Object state = impl.newState(ramAccounting, Version.CURRENT, Version.CURRENT, memoryManager);
-        assertThat(ramAccounting.totalBytes()).isEqualTo(64L);
+        assertThat(ramAccounting.totalBytes()).isEqualTo(112L);
         Literal<List<Double>> fractions = Literal.of(Collections.singletonList(0.95D), DataTypes.DOUBLE_ARRAY);
         impl.iterate(ramAccounting, memoryManager, state, Literal.of(10L), fractions);
         impl.iterate(ramAccounting, memoryManager, state, Literal.of(20L), fractions);
-        assertThat(ramAccounting.totalBytes()).isEqualTo(96L);
+        assertThat(ramAccounting.totalBytes()).isEqualTo(152L);
     }
 
     @Test


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

`MergingDigest` out performs `AVLTreeDigest` as investigated by Basti(https://github.com/crate/crate/issues/17137#issuecomment-2557070132):
Benchmark results:

V1: master (using `AVLTreeDigest`)
V2 s/merging-digest (using `MergingDigest`)

<details>
<summary>Small data set (the given one) and compression 200.0</summary>

```
# Results (server side duration in ms)
V1: 5.10.0-8126f3c8f82c1900047ef28f8bf5bedd20ab52dc
V2: 5.10.0-96ea92c232ccd541e14975a269535b50ac38d05e

Q: select percentile("i", [0.5, 0.75, 0.95], 200.0) from percentile_small
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |        1.119 ±    7.362 |      0.395 |      0.663 |      0.864 |    165.056 |
|   V2    |        1.025 ±    5.919 |      0.361 |      0.647 |      0.824 |    132.617 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -   8.75%                           -   2.52%   
There is a 17.56% probability that the observed difference is not random, and the best estimate of that difference is 8.75%
The test has no statistical significance


System/JVM Metrics (durations in ms, byte-values in MB)
    |    YOUNG GC            |       OLD GC           |      HEAP         |     ALLOC     
    |  cnt      avg      max |  cnt      avg      max |  initial     used |     rate      total
 V1 |    1     5.75     5.75 |    0     0.00     0.00 |      268       38 |   781.08        160
 V2 |    2     4.38     5.59 |    0     0.00     0.00 |      268       39 |  1327.20        269
    
Top allocation frames
  V1
    ImmutableCollections$AbstractImmutableList.iterator() total=68485232, count=2
    SignatureBinder.appendTypeRelationshipConstraintSolver(...) total=17316216, count=3
    StringLatin1.newString(...) total=11133792, count=1
    Arrays.copyOf(int[], int) total=10287912, count=49
    HashSet.<init>() total=8964736, count=1
    Arrays.copyOf(...) total=7750312, count=31
    CompositeBatchIterator$AsyncCompositeBI.lambda$loadNextBatch$0(int, int) total=2477648, count=13
    Double.valueOf(double) total=1962856, count=8
    MemorySegmentIndexInput$SingleSegmentImpl.<init>(...) total=1705696, count=1
    DoubleToDecimal.charsToString() total=1632152, count=1
  V2
    MergingDigest.<init>(...) total=154394048, count=124
    StreamSupport.stream(...) total=66069768, count=2
    HashMap.resize() total=14132784, count=2
    HashMap$KeySet.iterator() total=11141000, count=1
    Unsafe.allocateUninitializedArray(Class, int) total=4274256, count=4
    TDigestState.createEmptyState() total=2745776, count=2
    ParserATNSimulator.getEpsilonTarget(...) total=2362440, count=13
    MergingDigest$1$1.next() total=1303192, count=12
    Arrays.copyOf(...) total=964688, count=5
    Double.valueOf(double) total=872352, count=7

Top frames (by count)
  V1
    Arrays.copyOf(int[], int) total=10287912, count=49
    Arrays.copyOf(...) total=7750312, count=31
    CompositeBatchIterator$AsyncCompositeBI.lambda$loadNextBatch$0(int, int) total=2477648, count=13
    AVLGroupTree$2.next() total=1048456, count=8
    Double.valueOf(double) total=1962856, count=8
    ParserATNSimulator.getEpsilonTarget(...) total=1336056, count=7
    Unsafe.allocateInstance(Class) total=782504, count=7
    IdentityHashMap.init(int) total=1122104, count=6
    LinkedList.linkLast(Object) total=953936, count=5
    Integer.valueOf(int) total=1615424, count=5
  V2
    MergingDigest.<init>(...) total=154394048, count=124
    ParserATNSimulator.getEpsilonTarget(...) total=2362440, count=13
    MergingDigest$1$1.next() total=1303192, count=12
    Double.valueOf(double) total=872352, count=7
    Arrays.copyOf(...) total=964688, count=5
    Integer.valueOf(int) total=511072, count=5
    FlexibleHashMap.put(...) total=575680, count=4
    Unsafe.allocateUninitializedArray(Class, int) total=4274256, count=4
    IdentityHashMap.init(int) total=660288, count=4
    LinkedList.linkLast(Object) total=572448, count=3

```

</details>


<details>
<summary>Big amplab uservisits data set and compression 200.0</summary>

```
# Results (server side duration in ms)
V1: 5.10.0-8126f3c8f82c1900047ef28f8bf5bedd20ab52dc
V2: 5.10.0-96ea92c232ccd541e14975a269535b50ac38d05e

Q: select percentile("adRevenue", [0.5, 0.75, 0.95], 200.0) from uservisits
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |     5066.084 ±   52.656 |   5046.322 |   5052.115 |   5054.167 |   5284.883 |
|   V2    |     3524.688 ±   16.395 |   3494.571 |   3524.400 |   3533.454 |   3553.807 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  35.88%                           -  35.63%   
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 35.88%
The test has statistical significance


System/JVM Metrics (durations in ms, byte-values in MB)
    |    YOUNG GC            |       OLD GC           |      HEAP         |     ALLOC     
    |  cnt      avg      max |  cnt      avg      max |  initial     used |     rate      total
 V1 |    1     6.48     6.48 |    0     0.00     0.00 |      268     1957 |   178.63      17969
 V2 |    3     3.39     4.58 |    1    20.20    20.20 |      268     1909 |   282.34      19786
    
Top allocation frames
  V1
    CompositeBatchIterator$AsyncCompositeBI.lambda$loadNextBatch$0(int, int) total=10213311040, count=15
    DirectMethodHandle.allocateInstance(Object) total=6461164112, count=12
    Float.valueOf(float) total=1190305919, count=906
    ParserATNSimulator.getEpsilonTarget(...) total=25152664, count=12
    IdentityHashMap$KeySet.iterator() total=9991144, count=5
    AbstractQueuedSynchronizer.tryInitializeHead() total=7177856, count=5
    SelectorImpl.register(...) total=4687608, count=2
    Arrays.copyOf(...) total=4490784, count=4
    HashMap.resize() total=4371128, count=41
    ATNConfigSet$AbstractConfigHashSet.createBucket(int) total=4280384, count=2
  V2
    CompositeBatchIterator$AsyncCompositeBI.lambda$loadNextBatch$0(int, int) total=10259249416, count=31
    DirectMethodHandle.allocateInstance(Object) total=6463711792, count=20
    Double.valueOf(double) total=1803259208, count=1433
    Float.valueOf(float) total=1147067590, count=1029
    ParserATNSimulator.getEpsilonTarget(...) total=21542816, count=14
    SplitConstantPool.stringEntry(Utf8Entry) total=11274176, count=1
    LinkedList.listIterator(int) total=9048800, count=5
    IdentityHashMap$KeySet.iterator() total=7713400, count=5
    LinkedList.linkLast(Object) total=7077376, count=4
    HashMap.newNode(...) total=6639248, count=35

Top frames (by count)
  V1
    AVLTreeDigest.compress() total=5922, count=5922
    IntAVLTree.next(int) total=3853, count=3853
    Float.valueOf(float) total=1190305919, count=906
    IntAVLTree.first(int) total=513, count=513
    ObjectName.construct(String) total=399744, count=184
    StreamSupport.stream(...) total=290264, count=140
    IntAVLTree.update(int) total=132, count=132
    AVLGroupTree.headSum(int) total=78, count=78
    Unsafe.allocateUninitializedArray(Class, int) total=160664, count=73
    StringLatin1.toChars(byte[]) total=154704, count=73
  V2
    Sort.stableQuickSort(...) total=7386, count=7386
    Sort.stableInsertionSort(...) total=5968, count=5968
    Sort.reverse(...) total=3394, count=3394
    Double.valueOf(double) total=1803259208, count=1433
    MergingDigest.merge(...) total=1148, count=1148
    Float.valueOf(float) total=1147067590, count=1029
    Sort.stableSort(...) total=329, count=329
    ObjectName.construct(String) total=250128, count=90
    Random.next(int) total=82, count=82
    StreamSupport.stream(...) total=182736, count=64
```
</details>

<details>
<summary>Small data set (the given one) and default compression 100.0</summary>

```
# Results (server side duration in ms)
V1: 5.10.0-8126f3c8f82c1900047ef28f8bf5bedd20ab52dc
V2: 5.10.0-96ea92c232ccd541e14975a269535b50ac38d05e

Q: select percentile("i", [0.5, 0.75, 0.95], 100.0) from percentile_small
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |        1.065 ±    6.848 |      0.394 |      0.639 |      0.822 |    153.661 |
|   V2    |        1.053 ±    6.138 |      0.359 |      0.684 |      0.830 |    137.581 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -   1.11%                           +   6.81%   
There is a 2.28% probability that the observed difference is not random, and the best estimate of that difference is 1.11%
The test has no statistical significance


System/JVM Metrics (durations in ms, byte-values in MB)
    |    YOUNG GC            |       OLD GC           |      HEAP         |     ALLOC     
    |  cnt      avg      max |  cnt      avg      max |  initial     used |     rate      total
 V1 |    1     6.36     6.36 |    0     0.00     0.00 |      268       39 | 31886.55        171
 V2 |    2     4.65     6.37 |    0     0.00     0.00 |      268       40 |   355.38        249
    
Top allocation frames
  V1
    IntObjectHashMap.allocateBuffers(int) total=69261808, count=1
    StreamSupport.stream(...) total=18930704, count=4
    LinkedTransferQueue.xfer(...) total=14162232, count=11
    HashMap.keySet() total=11325016, count=2
    Arrays.copyOf(int[], int) total=10761257, count=40
    DocValuesAggregates.createAggregators(...) total=9421008, count=1
    Arrays.copyOf(...) total=5658152, count=22
    CompositeBatchIterator$AsyncCompositeBI.lambda$loadNextBatch$0(int, int) total=3033136, count=16
    ParserATNSimulator.getEpsilonTarget(...) total=2508408, count=14
    Unsafe.allocateInstance(Class) total=1978416, count=6
  V2
    MergingDigest.<init>(...) total=112784688, count=120
    Parser.createTerminalNode(...) total=69934720, count=1
    Memo.insertRecursive(...) total=19379416, count=1
    ArrayList.iterator() total=14390664, count=2
    HashMap$KeySet.iterator() total=11140352, count=1
    Double.valueOf(double) total=3539240, count=10
    Arrays.copyOf(...) total=1356745, count=9
    LinkedList.listIterator(int) total=1144912, count=6
    ParserATNSimulator.getEpsilonTarget(...) total=1144656, count=6
    MemorySegmentIndexInput.buildSlice(...) total=849080, count=8

Top frames (by count)
  V1
    Arrays.copyOf(int[], int) total=10761257, count=40
    Arrays.copyOf(...) total=5658152, count=22
    CompositeBatchIterator$AsyncCompositeBI.lambda$loadNextBatch$0(int, int) total=3033136, count=16
    ParserATNSimulator.getEpsilonTarget(...) total=2508408, count=14
    LinkedTransferQueue.xfer(...) total=14162232, count=11
    Unsafe.allocateUninitializedArray(Class, int) total=1762560, count=6
    LinkedList.listIterator(int) total=1144608, count=6
    AVLGroupTree$2.next() total=1288112, count=6
    AVLGroupTree.<init>(boolean) total=939976, count=6
    DirectMethodHandle.allocateInstance(Object) total=697976, count=6
  V2
    MergingDigest.<init>(...) total=112784688, count=120
    Double.valueOf(double) total=3539240, count=10
    Arrays.copyOf(...) total=1356745, count=9
    MemorySegmentIndexInput.buildSlice(...) total=849080, count=8
    Unsafe.allocateUninitializedArray(Class, int) total=831144, count=7
    ParserATNSimulator.getEpsilonTarget(...) total=1144656, count=6
    LinkedList.listIterator(int) total=1144912, count=6
    IdentityHashMap.init(int) total=843576, count=5
    ScaleFunction$4.k(...) total=621448, count=4
    HashMap.newNode(...) total=762928, count=4
```
</details>

<details>
<summary>Big amplab uservisits data set and default compression 100.0</summary>

```
# Results (server side duration in ms)
V1: 5.10.0-8126f3c8f82c1900047ef28f8bf5bedd20ab52dc
V2: 5.10.0-96ea92c232ccd541e14975a269535b50ac38d05e

Q: select percentile("adRevenue", [0.5, 0.75, 0.95], 100.0) from uservisits
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |     2915.982 ±   32.897 |   2899.939 |   2903.845 |   2915.847 |   3048.189 |
|   V2    |     1543.012 ±   44.925 |   1519.018 |   1529.530 |   1539.602 |   1727.939 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               -  61.58%                           -  62.00%   
There is a 100.00% probability that the observed difference is not random, and the best estimate of that difference is 61.58%
The test has statistical significance


System/JVM Metrics (durations in ms, byte-values in MB)
    |    YOUNG GC            |       OLD GC           |      HEAP         |     ALLOC     
    |  cnt      avg      max |  cnt      avg      max |  initial     used |     rate      total
 V1 |    2     5.67     7.44 |    0     0.00     0.00 |      268     1728 |   345.71      19887
 V2 |    1     8.63     8.63 |    0     0.00     0.00 |      268     1945 |   662.86      19894
    
Top allocation frames
  V1
    CompositeBatchIterator$AsyncCompositeBI.lambda$loadNextBatch$0(int, int) total=6839310224, count=29
    DirectMethodHandle.allocateInstance(Object) total=6522511208, count=22
    ThreadPoolExecutor.beforeExecute(...) total=3263881824, count=1
    Double.valueOf(double) total=1986925944, count=1280
    Float.valueOf(float) total=1173876636, count=939
    ParserATNSimulator.getEpsilonTarget(...) total=22862720, count=12
    IdentityHashMap$KeySet.iterator() total=11792872, count=6
    Arrays.copyOf(...) total=7015000, count=6
    ATNConfigSet$AbstractConfigHashSet.createBucket(int) total=6207312, count=3
    SelectorImpl.register(...) total=4685832, count=2
  V2
    CompositeBatchIterator$AsyncCompositeBI.lambda$loadNextBatch$0(int, int) total=10102945864, count=18
    DirectMethodHandle.allocateInstance(Object) total=6517388696, count=12
    Double.valueOf(double) total=2235540016, count=1074
    Float.valueOf(float) total=923078846, count=576
    Arrays.copyOf(...) total=14200784, count=5
    ConcurrentHashMap.initTable() total=11399920, count=1
    ParserATNSimulator.getEpsilonTarget(...) total=11294329, count=5
    IdentityHashMap$KeySet.iterator() total=10704144, count=4
    LinkedTransferQueue.sweepNow() total=6085704, count=4
    HashMap.newNode(...) total=5836960, count=11

Top frames (by count)
  V1
    AVLTreeDigest.compress() total=3384, count=3384
    IntAVLTree.next(int) total=2108, count=2108
    Double.valueOf(double) total=1986925944, count=1280
    Float.valueOf(float) total=1173876636, count=939
    IntAVLTree.first(int) total=193, count=193
    AVLGroupTree.headSum(int) total=115, count=115
    ObjectName.construct(String) total=256736, count=98
    IntAVLTree.update(int) total=91, count=91
    StreamSupport.stream(...) total=174232, count=69
    AVLGroupTree.floor(double) total=67, count=67
  V2
    Sort.stableQuickSort(...) total=2354, count=2354
    Sort.stableInsertionSort(...) total=2323, count=2323
    Sort.reverse(...) total=2274, count=2274
    Double.valueOf(double) total=2235540016, count=1074
    Float.valueOf(float) total=923078846, count=576
    MergingDigest.merge(...) total=547, count=547
    Random.next(int) total=214, count=214
    Sort.stableSort(...) total=145, count=145
    MergingDigest.mergeNewValues(...) total=88, count=88
    ObjectName.construct(String) total=112128, count=51
```
</details>

---

I have done followup experiments; `MergingDigest` with 200 compression against a few setup(https://github.com/crate/crate/issues/17137#issuecomment-2755474520):
- 10M entries of random numbers between 1 ~ 1M
- 10k entries of uneven distribution of numbers between 1-10k (unevenly and evenly partitioned)

I couldn't observe `MergingDigest` with 200 compression that looked far off. All of them stayed within ~5%. **However, I did observe as much as 10% error from `MergingDigest` with 100 compression while `AVLTreeDigest` with 100 compression was around 5% error.**

<details>
<summary> To reproduce the 10% error </summary>

```
cr> create table q (a int, b int generated always as (a % 10)) partitioned by (b) clustered into 1 shards;
CREATE OK, 1 row affected (0.102 sec)
cr> insert into q(a) SELECT
        CASE
            WHEN RANDOM() < 0.6 THEN
                FLOOR(RANDOM() * 1000) + 1
            WHEN RANDOM() < 0.8 THEN
                FLOOR(RANDOM() * 3000) + 1001
            ELSE
                FLOOR(RANDOM() * 6000) + 4001
        END as value
    FROM generate_series(1, 10000)
    ORDER BY value;
INSERT OK, 10000 rows affected (8.719 sec)
cr> SELECT PERCENTILE(a, 0.6, 100) FROM q;
+---------------------------+
| percentile(a, 0.6, 100.0) |
+---------------------------+
|        1133.5245336577452 |  -- where the actual value is ~1018
+---------------------------+
SELECT 1 row in set (0.218 sec)
```

</details>

---

Based on this experiments it was decided to proceed with increasing the default compression to `200`, https://github.com/crate/crate/issues/17137#issuecomment-2755651136.

## Checklist

 - [ ] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
