### PR TITLE
Remove IndicesRequest implementation of the ClusterStateRequest.

### DIFF
--- a/server/src/main/java/io/crate/replication/logical/LogicalReplicationService.java
+++ b/server/src/main/java/io/crate/replication/logical/LogicalReplicationService.java
@@ -67,6 +67,7 @@ import org.jetbrains.annotations.VisibleForTesting;
 import io.crate.action.FutureActionListener;
 import io.crate.exceptions.RelationAlreadyExists;
 import io.crate.exceptions.SubscriptionRestoreException;
+import io.crate.metadata.NodeContext;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
 import io.crate.replication.logical.action.PublicationsStateAction;
@@ -101,7 +102,8 @@ public class LogicalReplicationService implements ClusterStateListener, Closeabl
                                      ThreadPool threadPool,
                                      Client client,
                                      AllocationService allocationService,
-                                     LogicalReplicationSettings replicationSettings) {
+                                     LogicalReplicationSettings replicationSettings,
+                                     NodeContext nodeContext) {
         this.clusterService = clusterService;
         this.threadPool = threadPool;
         this.remoteClusters = remoteClusters;
@@ -114,7 +116,8 @@ public class LogicalReplicationService implements ClusterStateListener, Closeabl
             replicationSettings,
             remoteClusters::getClient,
             clusterService,
-            allocationService
+            allocationService,
+            nodeContext
         );
         clusterService.addListener(this);
     }

--- a/server/src/main/java/io/crate/replication/logical/metadata/Publication.java
+++ b/server/src/main/java/io/crate/replication/logical/metadata/Publication.java
@@ -136,6 +136,10 @@ public class Publication implements Writeable {
 
         if (isForAllTables()) {
             Metadata metadata = state.metadata();
+            for (var table : metadata.tableRelations()) {
+                relations.add(table.name());
+            }
+
             for (var cursor : metadata.templates().keys()) {
                 String templateName = cursor.value;
                 IndexParts indexParts = IndexName.decode(templateName);

--- a/server/src/main/java/io/crate/replication/logical/repository/LogicalReplicationRepository.java
+++ b/server/src/main/java/io/crate/replication/logical/repository/LogicalReplicationRepository.java
@@ -43,13 +43,13 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.StepListener;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
-import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.RelationMetadata;
 import org.elasticsearch.cluster.metadata.RepositoryMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -77,6 +77,8 @@ import io.crate.common.exceptions.Exceptions;
 import io.crate.common.io.IOUtils;
 import io.crate.common.unit.TimeValue;
 import io.crate.exceptions.SQLExceptions;
+import io.crate.metadata.IndexName;
+import io.crate.metadata.RelationName;
 import io.crate.replication.logical.LogicalReplicationService;
 import io.crate.replication.logical.LogicalReplicationSettings;
 import io.crate.replication.logical.action.GetStoreMetadataAction;
@@ -155,7 +157,7 @@ public class LogicalReplicationRepository extends AbstractLifecycleComponent imp
     @Override
     public CompletableFuture<Metadata> getSnapshotGlobalMetadata(SnapshotId snapshotId) {
         return getPublicationsState()
-            .thenCompose(resp -> getRemoteClusterState(false, true, resp.concreteIndices(), resp.concreteTemplates()))
+            .thenCompose(resp -> getRemoteClusterState(false, true, resp.tables().stream().toList()))
             .thenApply(remoteClusterStateResp -> {
                 ClusterState remoteClusterState = remoteClusterStateResp.getState();
                 var metadataBuilder = Metadata.builder(remoteClusterState.metadata());
@@ -170,6 +172,25 @@ public class LogicalReplicationRepository extends AbstractLifecycleComponent imp
                         .settings(settings);
                     metadataBuilder.put(templateMetadata);
                 }
+                for (RelationMetadata.Table table : remoteClusterState.metadata().tableRelations()) {
+                    var settings = Settings.builder()
+                        .put(table.settings())
+                        .put(REPLICATION_SUBSCRIPTION_NAME.getKey(), subscriptionName)
+                        .build();
+                    metadataBuilder.setTable(
+                        table.name(),
+                        table.columns(),
+                        settings,
+                        table.routingColumn(),
+                        table.columnPolicy(),
+                        table.pkConstraintName(),
+                        table.checkConstraints(),
+                        table.primaryKeys(),
+                        table.partitionedBy(),
+                        table.state(),
+                        table.indexUUIDs()
+                    );
+                }
                 return metadataBuilder.build();
             });
     }
@@ -179,8 +200,8 @@ public class LogicalReplicationRepository extends AbstractLifecycleComponent imp
                                                                                  SnapshotId snapshotId,
                                                                                  Collection<IndexId> indexIds) {
         assert SNAPSHOT_ID.equals(snapshotId) : "SubscriptionRepository only supports " + SNAPSHOT_ID + " as the SnapshotId";
-        var remoteIndices = indexIds.stream().map(IndexId::getName).toArray(String[]::new);
-        return getRemoteClusterState(remoteIndices).thenApply(response -> {
+        var remoteRelationNames = indexIds.stream().map(indexId -> IndexName.decode(indexId.getName()).toRelationName()).toArray(RelationName[]::new);
+        return getRemoteClusterState(remoteRelationNames).thenApply(response -> {
             var result = new ArrayList<IndexMetadata>();
             ClusterState remoteClusterState = response.getState();
             for (var i : remoteClusterState.metadata().indices()) {
@@ -207,7 +228,8 @@ public class LogicalReplicationRepository extends AbstractLifecycleComponent imp
                                                                      SnapshotId snapshotId,
                                                                      IndexId index) {
         assert SNAPSHOT_ID.equals(snapshotId) : "SubscriptionRepository only supports " + SNAPSHOT_ID + " as the SnapshotId";
-        return getRemoteClusterState(index.getName()).thenApply(response -> {
+        RelationName relationName = IndexName.decode(index.getName()).toRelationName();
+        return getRemoteClusterState(relationName).thenApply(response -> {
             ClusterState remoteClusterState = response.getState();
             var indexMetadata = remoteClusterState.metadata().index(index.getName());
             // Add replication specific settings, this setting will trigger a custom engine, see {@link SQLPlugin#getEngineFactory}
@@ -225,7 +247,7 @@ public class LogicalReplicationRepository extends AbstractLifecycleComponent imp
     @Override
     public CompletableFuture<RepositoryData> getRepositoryData() {
         return getPublicationsState()
-            .thenCompose(resp -> getRemoteClusterState(false, false, resp.concreteIndices(), resp.concreteTemplates()))
+            .thenCompose(resp -> getRemoteClusterState(false, false, resp.tables().stream().toList()))
             .thenApply(remoteStateResp -> {
                 var remoteClusterState = remoteStateResp.getState();
                 var remoteMetadata = remoteClusterState.metadata();
@@ -345,7 +367,8 @@ public class LogicalReplicationRepository extends AbstractLifecycleComponent imp
                                                      RecoveryState recoveryState,
                                                      ActionListener<Void> listener) {
         // 1. Get all the files info from the publisher cluster for this shardId
-        var remoteClusterState = getRemoteClusterState(true, true, List.of(indexId.getName()), List.of());
+        RelationName relationName = IndexName.decode(indexId.getName()).toRelationName();
+        var remoteClusterState = getRemoteClusterState(true, true, List.of(relationName));
         remoteClusterState.whenComplete((resp, err) -> {
             if (err != null) {
                 listener.onFailure(Exceptions.toException(err));
@@ -436,22 +459,19 @@ public class LogicalReplicationRepository extends AbstractLifecycleComponent imp
         return remoteClusters.getClient(subscriptionName);
     }
 
-    private CompletableFuture<ClusterStateResponse> getRemoteClusterState(String... remoteIndices) {
-        return getRemoteClusterState(false, true, Arrays.asList(remoteIndices), List.of());
+    private CompletableFuture<ClusterStateResponse> getRemoteClusterState(RelationName... remoteRelationNames) {
+        return getRemoteClusterState(false, true, Arrays.asList(remoteRelationNames));
     }
 
     private CompletableFuture<ClusterStateResponse> getRemoteClusterState(boolean includeNodes,
                                                                           boolean includeRouting,
-                                                                          List<String> remoteIndices,
-                                                                          List<String> remoteTemplates) {
+                                                                          List<RelationName> relationNames) {
         Client remoteClient = getRemoteClient();
         var clusterStateRequest = new ClusterStateRequest()
-            .indices(remoteIndices.toArray(new String[0]))
-            .templates(remoteTemplates.toArray(new String[0]))
+            .relationNames(relationNames)
             .metadata(true)
             .nodes(includeNodes)
             .routingTable(includeRouting)
-            .indicesOptions(IndicesOptions.STRICT_SINGLE_INDEX_NO_EXPAND_FORBID_CLOSED)
             .waitForTimeout(new TimeValue(REMOTE_CLUSTER_REPO_REQ_TIMEOUT_IN_MILLI_SEC));
         return remoteClient.admin().cluster().state(clusterStateRequest);
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequest.java
@@ -20,9 +20,11 @@
 package org.elasticsearch.action.admin.cluster.state;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
 
 import org.elasticsearch.Version;
-import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.MasterNodeReadRequest;
 import org.elasticsearch.common.Strings;
@@ -30,8 +32,11 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import io.crate.common.unit.TimeValue;
+import io.crate.metadata.IndexName;
+import io.crate.metadata.PartitionName;
+import io.crate.metadata.RelationName;
 
-public class ClusterStateRequest extends MasterNodeReadRequest<ClusterStateRequest> implements IndicesRequest {
+public class ClusterStateRequest extends MasterNodeReadRequest<ClusterStateRequest> {
 
     public static final TimeValue DEFAULT_WAIT_FOR_NODE_TIMEOUT = TimeValue.timeValueMinutes(1);
 
@@ -42,9 +47,7 @@ public class ClusterStateRequest extends MasterNodeReadRequest<ClusterStateReque
     private boolean customs = true;
     private Long waitForMetadataVersion;
     private TimeValue waitForTimeout = DEFAULT_WAIT_FOR_NODE_TIMEOUT;
-    private String[] indices = Strings.EMPTY_ARRAY;
-    private String[] templates = Strings.EMPTY_ARRAY;
-    private IndicesOptions indicesOptions = IndicesOptions.LENIENT_EXPAND_OPEN;
+    private List<RelationName> relationNames = new ArrayList<>();
 
     public ClusterStateRequest() {
     }
@@ -55,8 +58,7 @@ public class ClusterStateRequest extends MasterNodeReadRequest<ClusterStateReque
         metadata = true;
         blocks = true;
         customs = true;
-        indices = Strings.EMPTY_ARRAY;
-        templates = Strings.EMPTY_ARRAY;
+        relationNames = new ArrayList<>();
         return this;
     }
 
@@ -66,8 +68,7 @@ public class ClusterStateRequest extends MasterNodeReadRequest<ClusterStateReque
         metadata = false;
         blocks = false;
         customs = false;
-        indices = Strings.EMPTY_ARRAY;
-        templates = Strings.EMPTY_ARRAY;
+        relationNames = new ArrayList<>();
         return this;
     }
 
@@ -107,33 +108,13 @@ public class ClusterStateRequest extends MasterNodeReadRequest<ClusterStateReque
         return this;
     }
 
-    @Override
-    public String[] indices() {
-        return indices;
-    }
-
-    public ClusterStateRequest indices(String... indices) {
-        this.indices = indices;
+    public ClusterStateRequest relationNames(List<RelationName> relationNames) {
+        this.relationNames = relationNames;
         return this;
     }
 
-    @Override
-    public IndicesOptions indicesOptions() {
-        return this.indicesOptions;
-    }
-
-    public final ClusterStateRequest indicesOptions(IndicesOptions indicesOptions) {
-        this.indicesOptions = indicesOptions;
-        return this;
-    }
-
-    public String[] templates() {
-        return templates;
-    }
-
-    public ClusterStateRequest templates(String... templates) {
-        this.templates = templates;
-        return this;
+    public List<RelationName> relationNames() {
+        return relationNames;
     }
 
     public ClusterStateRequest customs(boolean customs) {
@@ -165,15 +146,31 @@ public class ClusterStateRequest extends MasterNodeReadRequest<ClusterStateReque
         metadata = in.readBoolean();
         blocks = in.readBoolean();
         customs = in.readBoolean();
-        indices = in.readStringArray();
-        indicesOptions = IndicesOptions.readIndicesOptions(in);
+        String[] oldIndices = Strings.EMPTY_ARRAY;
+        if (in.getVersion().before(Version.V_6_0_0)) {
+            oldIndices = in.readStringArray();
+            IndicesOptions.readIndicesOptions(in);
+        }
         if (in.getVersion().onOrAfter(Version.V_4_4_0)) {
             waitForTimeout = in.readTimeValue();
             waitForMetadataVersion = in.readOptionalLong();
         }
-        if (in.getVersion().onOrAfter(Version.V_4_8_0)) {
-            templates = in.readStringArray();
+        String[] oldTemplates = Strings.EMPTY_ARRAY;
+        if (in.getVersion().before(Version.V_6_0_0)) {
+            oldTemplates = in.readStringArray();
         }
+        HashSet<RelationName> relationNamesSet = new HashSet<>();
+        if (in.getVersion().onOrAfter(Version.V_6_0_0)) {
+            relationNamesSet.addAll(in.readList(RelationName::new));
+        }
+        for (String index : oldIndices) {
+            relationNamesSet.add(IndexName.decode(index).toRelationName());
+        }
+        for (String template : oldTemplates) {
+            RelationName relationName = IndexName.decode(template).toRelationName();
+            relationNamesSet.add(relationName);
+        }
+        relationNames = new ArrayList<>(relationNamesSet);
     }
 
     @Override
@@ -184,14 +181,25 @@ public class ClusterStateRequest extends MasterNodeReadRequest<ClusterStateReque
         out.writeBoolean(metadata);
         out.writeBoolean(blocks);
         out.writeBoolean(customs);
-        out.writeStringArray(indices);
-        indicesOptions.writeIndicesOptions(out);
+        if (out.getVersion().before(Version.V_6_0_0)) {
+            // old indices
+            out.writeStringArray(relationNames.stream().map(RelationName::indexNameOrAlias).toArray(String[]::new));
+            IndicesOptions.LENIENT_EXPAND_OPEN.writeIndicesOptions(out);
+        }
         if (out.getVersion().onOrAfter(Version.V_4_4_0)) {
             out.writeTimeValue(waitForTimeout);
             out.writeOptionalLong(waitForMetadataVersion);
         }
-        if (out.getVersion().onOrAfter(Version.V_4_8_0)) {
-            out.writeStringArray(templates);
+        if (out.getVersion().before(Version.V_6_0_0)) {
+            // old templates
+            out.writeStringArray(
+                relationNames.stream()
+                .map(r -> PartitionName.templateName(r.schema(), r.name()))
+                .toArray(String[]::new)
+            );
+        }
+        if (out.getVersion().onOrAfter(Version.V_6_0_0)) {
+            out.writeList(relationNames);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -1293,6 +1293,19 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
         }
     }
 
+    public List<RelationMetadata.Table> tableRelations() {
+        ArrayList<RelationMetadata.Table> relations = new ArrayList<>();
+        for (ObjectCursor<SchemaMetadata> cursor : schemas.values()) {
+            for (ObjectCursor<RelationMetadata> relationCursor : cursor.value.relations().values()) {
+                RelationMetadata relationMetadata = relationCursor.value;
+                if (relationMetadata instanceof RelationMetadata.Table table) {
+                    relations.add(table);
+                }
+            }
+        }
+        return relations;
+    }
+
     /**
      * <p>
      * Resolve the indices for a relation and return their data either as

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -622,7 +622,8 @@ public class Node implements Closeable {
                 threadPool,
                 client,
                 clusterModule.getAllocationService(),
-                logicalReplicationSettings
+                logicalReplicationSettings,
+                nodeContext
             );
             resourcesToClose.add(logicalReplicationService);
 

--- a/server/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
@@ -137,7 +137,7 @@ public class PartitionedTableConcurrentIntegrationTest extends IntegTestCase {
 
         Thread relocatingThread = new Thread(() -> {
             while (relocations.getCount() > 0) {
-                ClusterStateResponse clusterStateResponse = FutureUtils.get(admin().cluster().state(new ClusterStateRequest().indices(indexName)));
+                ClusterStateResponse clusterStateResponse = FutureUtils.get(admin().cluster().state(new ClusterStateRequest().relationNames(List.of(partitionName.relationName()))));
                 List<ShardRouting> shardRoutings = clusterStateResponse.getState().routingTable().allShards(indexName);
 
                 int numMoves = 0;

--- a/server/src/test/java/io/crate/replication/logical/MetadataTrackerTest.java
+++ b/server/src/test/java/io/crate/replication/logical/MetadataTrackerTest.java
@@ -23,6 +23,7 @@ package io.crate.replication.logical;
 
 import static io.crate.replication.logical.LogicalReplicationSettings.REPLICATION_SUBSCRIPTION_NAME;
 import static io.crate.role.Role.CRATE_USER;
+import static io.crate.testing.TestingHelpers.createNodeContext;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_INDEX_UUID;
@@ -264,7 +265,9 @@ public class MetadataTrackerTest extends ESTestCase {
             SubscriptionsMetadata.get(SUBSCRIBER_CLUSTER_STATE.metadata()).get("sub1"),
             SUBSCRIBER_CLUSTER_STATE,
             publicationsStateResponse,
-            IndexScopedSettings.DEFAULT_SCOPED_SETTINGS);
+            IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
+            createNodeContext()
+        );
         // Nothing in the indexMetadata changed, so the cluster state must be equal
         assertThat(SUBSCRIBER_CLUSTER_STATE).isEqualTo(syncedSubscriberClusterState);
 
@@ -287,7 +290,8 @@ public class MetadataTrackerTest extends ESTestCase {
             SubscriptionsMetadata.get(SUBSCRIBER_CLUSTER_STATE.metadata()).get("sub1"),
             SUBSCRIBER_CLUSTER_STATE,
             updatedResponse,
-            IndexScopedSettings.DEFAULT_SCOPED_SETTINGS
+            IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
+            createNodeContext()
         );
 
         assertThat(SUBSCRIBER_CLUSTER_STATE).isNotEqualTo(syncedSubscriberClusterState);
@@ -315,7 +319,8 @@ public class MetadataTrackerTest extends ESTestCase {
             SubscriptionsMetadata.get(SUBSCRIBER_CLUSTER_STATE.metadata()).get("sub1"),
             SUBSCRIBER_CLUSTER_STATE,
             updatedResponse,
-            IndexScopedSettings.DEFAULT_SCOPED_SETTINGS
+            IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
+            createNodeContext()
         );
         var syncedIndexMetadata = syncedSubscriberClusterState.metadata().index("test");
         assertThat(syncedIndexMetadata.getSettings().getAsInt(IndexSettings.MAX_NGRAM_DIFF_SETTING.getKey(), null)).isEqualTo(5);
@@ -342,7 +347,8 @@ public class MetadataTrackerTest extends ESTestCase {
             SubscriptionsMetadata.get(SUBSCRIBER_CLUSTER_STATE.metadata()).get("sub1"),
             SUBSCRIBER_CLUSTER_STATE,
             updatedResponse,
-            IndexScopedSettings.DEFAULT_SCOPED_SETTINGS
+            IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
+            createNodeContext()
         );
         var syncedIndexMetadata = syncedSubscriberClusterState.metadata().index("test");
         assertThat(syncedIndexMetadata.getSettings().get(SETTING_INDEX_UUID, "default")).isNotEqualTo(publisherIndexUuid);
@@ -367,7 +373,8 @@ public class MetadataTrackerTest extends ESTestCase {
             SubscriptionsMetadata.get(SUBSCRIBER_CLUSTER_STATE.metadata()).get("sub1"),
             SUBSCRIBER_CLUSTER_STATE,
             updatedResponse,
-            IndexScopedSettings.DEFAULT_SCOPED_SETTINGS
+            IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
+            createNodeContext()
         );
         var syncedIndexMetadata = syncedSubscriberClusterState.metadata().index("test");
         assertThat(INDEX_NUMBER_OF_REPLICAS_SETTING.get(syncedIndexMetadata.getSettings())).isEqualTo(0);

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequestTest.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequestTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package org.elasticsearch.action.admin.cluster.state;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.tasks.TaskId;
+import org.junit.Test;
+
+import io.crate.common.unit.TimeValue;
+import io.crate.metadata.PartitionName;
+import io.crate.metadata.RelationName;
+
+public class ClusterStateRequestTest {
+
+    @Test
+    public void test_streaming_bwc_can_be_read_on_5() throws Exception {
+        RelationName table = new RelationName("foo", "bar");
+
+        ClusterStateRequest request = new ClusterStateRequest();
+        request.relationNames(List.of(table));
+
+        try (var out = new BytesStreamOutput()) {
+            out.setVersion(Version.V_5_10_0);
+            request.writeTo(out);
+            try (var in = out.bytes().streamInput()) {
+                TaskId.readFromStream(in);
+                in.readTimeValue();
+                in.readBoolean();
+                in.readBoolean();
+                in.readBoolean();
+                in.readBoolean();
+                in.readBoolean();
+                in.readBoolean();
+                var indices = in.readStringArray();
+                var indicesOptions = IndicesOptions.readIndicesOptions(in);
+                in.readTimeValue();
+                in.readOptionalLong();
+                var templates = in.readStringArray();
+
+                assertThat(indices).containsExactly(table.indexNameOrAlias());
+                assertThat(templates).containsExactly(PartitionName.templateName(table.schema(), table.name()));
+                assertThat(indicesOptions).isEqualTo(IndicesOptions.LENIENT_EXPAND_OPEN);
+            }
+        }
+    }
+
+    @Test
+    public void test_streaming_bwc_can_be_read_from_5() throws Exception {
+        RelationName table = new RelationName("foo", "bar");
+        String[] indices = new String[] { table.indexNameOrAlias() };
+        String[] templates = new String[] { PartitionName.templateName(table.schema(), table.name()) };
+
+        try (var out = new BytesStreamOutput()) {
+            TaskId.EMPTY_TASK_ID.writeTo(out);
+            out.writeTimeValue(new TimeValue(30, TimeUnit.SECONDS));
+            out.writeBoolean(true);
+
+            out.writeBoolean(true);
+            out.writeBoolean(true);
+            out.writeBoolean(true);
+            out.writeBoolean(true);
+            out.writeBoolean(true);
+            out.writeStringArray(indices);
+            IndicesOptions.LENIENT_EXPAND_OPEN.writeIndicesOptions(out);
+            out.writeTimeValue(new TimeValue(30, TimeUnit.SECONDS));
+            out.writeOptionalLong(null);
+            out.writeStringArray(templates);
+            try (var in = out.bytes().streamInput()) {
+                in.setVersion(Version.V_5_10_0);
+                var request = new ClusterStateRequest(in);
+                assertThat(request.relationNames()).containsExactly(table);
+            }
+        }
+    }
+}

--- a/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
+++ b/server/src/testFixtures/java/io/crate/testing/SQLExecutor.java
@@ -374,7 +374,8 @@ public class SQLExecutor {
                 threadPool,
                 new NodeClient(settings, threadPool),
                 allocationService,
-                logicalReplicationSettings
+                logicalReplicationSettings,
+                nodeCtx
             );
             logicalReplicationService.repositoriesService(mock(RepositoriesService.class));
             var foreignDataWrappers = new ForeignDataWrappers(settings, clusterService, nodeCtx);


### PR DESCRIPTION
Use RelationNames on the ClusterStateRequest instead of indices/templates.

Relates to #17666 and #17518.
