### PR TITLE
Set MIN_MEM to match MAX_MEM on crate.bat

### DIFF
--- a/app/src/main/dist/bin/crate.bat
+++ b/app/src/main/dist/bin/crate.bat
@@ -27,7 +27,7 @@ for %%I in ("%SCRIPT_DIR%..") do set CRATE_HOME=%%~dpfI
 REM ***** JAVA options *****
 
 if "%CRATE_MIN_MEM%" == "" (
-set CRATE_MIN_MEM=256m
+set CRATE_MIN_MEM=1g
 )
 
 if "%CRATE_MAX_MEM%" == "" (

--- a/docs/appendices/release-notes/5.10.4.rst
+++ b/docs/appendices/release-notes/5.10.4.rst
@@ -64,5 +64,4 @@ Fixes
   restarting with still holding a lock on the shard. The existing retry logic
   to solve this situation was not working in some cases.
 
-- Fixed the default ``CRATE_MIN_MEM`` value in the ``crate.bat`` script used
-  in Windows environments to match ``CRATE_MAX_MEM``.
+- Fixed an issue causing a CrateDB node to fail on startup in Windows environments when no custom CRATE_HEAP environment variable is set.

--- a/docs/appendices/release-notes/5.10.4.rst
+++ b/docs/appendices/release-notes/5.10.4.rst
@@ -64,4 +64,5 @@ Fixes
   restarting with still holding a lock on the shard. The existing retry logic
   to solve this situation was not working in some cases.
 
-- Fixed an issue causing a CrateDB node to fail on startup in Windows environments when no custom CRATE_HEAP environment variable is set.
+- Fixed an issue causing a CrateDB node to fail on startup in Windows
+  environments when no custom CRATE_HEAP_SIZE environment variable is set.

--- a/docs/appendices/release-notes/5.10.4.rst
+++ b/docs/appendices/release-notes/5.10.4.rst
@@ -63,3 +63,6 @@ Fixes
   closed properly, e.g. due to an unclean node shutdown and the node was
   restarting with still holding a lock on the shard. The existing retry logic
   to solve this situation was not working in some cases.
+
+- Fixed the default ``CRATE_MIN_MEM`` value in the ``crate.bat`` script used
+  in Windows environments to match ``CRATE_MAX_MEM``.


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

This changes the default `CRATE_MIN_MEM` to match `CRATE_MAX_MEM` to not fail the `HeapSizeCheck` `BootstrapCheck` when `CRATE_HEAP_SIZE` is not specified.

## Checklist

 - [X] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [ ] Updated documentation & `sql_features` table for user facing changes
 - [ ] Touched code is covered by tests
 - [ ] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
