### PR TITLE
Remove IOException from CompressedXContent constructor

### DIFF
--- a/server/src/main/java/io/crate/execution/ddl/Templates.java
+++ b/server/src/main/java/io/crate/execution/ddl/Templates.java
@@ -42,7 +42,6 @@ import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.InvalidIndexTemplateException;
@@ -122,7 +121,7 @@ public final class Templates {
                 request.references(),
                 metadataBuilder.columnOidSupplier()
             );
-            var mapping = Map.of(
+            Map<String, Object> mapping = Map.of(
                 Constants.DEFAULT_MAPPING_TYPE,
                 MappingUtil.createMapping(
                     MappingUtil.AllocPosition.forNewTable(),
@@ -136,8 +135,7 @@ public final class Templates {
                 )
             );
             try {
-                templateBuilder
-                    .putMapping(new CompressedXContent(Strings.toString(JsonXContent.builder().map(mapping))));
+                templateBuilder.putMapping(new CompressedXContent(mapping));
             } catch (Exception e) {
                 throw new MapperParsingException("Failed to parse mapping: {}", e, e.getMessage());
             }

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/StoredRowLookup.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/StoredRowLookup.java
@@ -166,11 +166,7 @@ public abstract class StoredRowLookup implements StoredRow {
 
         @Override
         public String asRaw() {
-            try {
-                return CompressorFactory.uncompressIfNeeded(loadStoredFields()).utf8ToString();
-            } catch (IOException e) {
-                throw new UncheckedIOException("Failed to decompress source", e);
-            }
+            return CompressorFactory.uncompressIfNeeded(loadStoredFields()).utf8ToString();
 
         }
 

--- a/server/src/main/java/io/crate/metadata/cluster/DDLClusterStateHelpers.java
+++ b/server/src/main/java/io/crate/metadata/cluster/DDLClusterStateHelpers.java
@@ -29,7 +29,7 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.cluster.metadata.ColumnPositionResolver;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
-import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.DeprecationHandler;
@@ -76,14 +76,10 @@ public class DDLClusterStateHelpers {
         if (mapping.size() != 1 || mapping.containsKey(Constants.DEFAULT_MAPPING_TYPE) == false) {
             mapping = MapBuilder.<String, Object>newMapBuilder().put(Constants.DEFAULT_MAPPING_TYPE, mapping).map();
         }
-        try {
-            return new IndexTemplateMetadata.Builder(indexTemplateMetadata)
-                .settings(settings)
-                .putMapping(Strings.toString(JsonXContent.builder().map(mapping)))
-                .build();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        return new IndexTemplateMetadata.Builder(indexTemplateMetadata)
+            .settings(settings)
+            .putMapping(new CompressedXContent(mapping))
+            .build();
     }
 
     @Nullable

--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
@@ -50,11 +50,10 @@ import org.elasticsearch.cluster.metadata.IndexMetadata.State;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
-import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.index.Index;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -1096,7 +1095,7 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
                 .put(tableParameters.filter(s -> !indexTemplateMetadata.settings().hasValue(s)))
                 .build();
             var template = new IndexTemplateMetadata.Builder(indexTemplateMetadata)
-                .putMapping(Strings.toString(JsonXContent.builder().map(mapping)))
+                .putMapping(new CompressedXContent(mapping))
                 .settings(settings)
                 .version(version == null ? 1 : version + 1)
                 .build();

--- a/server/src/main/java/io/crate/metadata/upgrade/MetadataIndexUpgrader.java
+++ b/server/src/main/java/io/crate/metadata/upgrade/MetadataIndexUpgrader.java
@@ -24,7 +24,6 @@ package io.crate.metadata.upgrade;
 import static io.crate.execution.ddl.tables.MappingUtil.DROPPED_COLUMN_NAME_PREFIX;
 import static org.elasticsearch.cluster.metadata.Metadata.COLUMN_OID_UNASSIGNED;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -99,12 +98,7 @@ public class MetadataIndexUpgrader {
             }
         }
 
-        try {
-            return new MappingMetadata(Map.of(Constants.DEFAULT_MAPPING_TYPE, newMapping));
-        } catch (IOException e) {
-            logger.error("Failed to upgrade mapping for index '" + indexName + "'", e);
-            return mappingMetadata;
-        }
+        return new MappingMetadata(Map.of(Constants.DEFAULT_MAPPING_TYPE, newMapping));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -917,7 +917,7 @@ public class IndexMetadata implements Diffable<IndexMetadata> {
          * @deprecated mapping is on table level {@link RelationMetadata.Table}
          **/
         @Deprecated
-        public Builder putMapping(String source) throws IOException {
+        public Builder putMapping(String source) {
             putMapping(new MappingMetadata(XContentHelper.convertToMap(JsonXContent.JSON_XCONTENT, source, true)));
             return this;
         }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MappingMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MappingMetadata.java
@@ -42,11 +42,11 @@ public class MappingMetadata extends AbstractDiffable<MappingMetadata> {
 
     private final CompressedXContent source;
 
-    public MappingMetadata(CompressedXContent mapping) throws IOException {
+    public MappingMetadata(CompressedXContent mapping) {
         this.source = mapping;
     }
 
-    public MappingMetadata(Map<String, Object> mapping) throws IOException {
+    public MappingMetadata(Map<String, Object> mapping) {
         this.source = new CompressedXContent(mapping);
     }
 

--- a/server/src/main/java/org/elasticsearch/common/compress/Compressor.java
+++ b/server/src/main/java/org/elasticsearch/common/compress/Compressor.java
@@ -53,7 +53,7 @@ public interface Compressor {
      * @param bytesReference bytes to decompress
      * @return decompressed bytes
      */
-    BytesReference uncompress(BytesReference bytesReference) throws IOException;
+    BytesReference uncompress(BytesReference bytesReference);
 
     /**
      * Compress bytes into a newly allocated buffer.
@@ -61,5 +61,5 @@ public interface Compressor {
      * @param bytesReference bytes to compress
      * @return compressed bytes
      */
-    BytesReference compress(BytesReference bytesReference) throws IOException;
+    BytesReference compress(BytesReference bytesReference);
 }

--- a/server/src/main/java/org/elasticsearch/common/compress/CompressorFactory.java
+++ b/server/src/main/java/org/elasticsearch/common/compress/CompressorFactory.java
@@ -19,14 +19,12 @@
 
 package org.elasticsearch.common.compress;
 
-import java.io.IOException;
 import java.util.Objects;
-
-import org.jetbrains.annotations.Nullable;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.jetbrains.annotations.Nullable;
 
 import com.fasterxml.jackson.dataformat.smile.SmileConstants;
 
@@ -114,16 +112,16 @@ public class CompressorFactory {
     }
 
     /**
-     * Uncompress the provided data, data can be detected as compressed using {@link #isCompressed(BytesReference)}.
+     * Uncompress the provided data
      * @throws NullPointerException a NullPointerException will be thrown when bytes is null
      */
-    public static BytesReference uncompressIfNeeded(BytesReference bytes) throws IOException {
+    public static BytesReference uncompressIfNeeded(BytesReference bytes) {
         Compressor compressor = compressor(Objects.requireNonNull(bytes, "the BytesReference must not be null"));
         return compressor == null ? bytes : compressor.uncompress(bytes);
     }
 
     /** Decompress the provided {@link BytesReference}. */
-    public static BytesReference uncompress(BytesReference bytes) throws IOException {
+    public static BytesReference uncompress(BytesReference bytes) {
         Compressor compressor = compressor(bytes);
         if (compressor == null) {
             throw new NotCompressedException();


### PR DESCRIPTION
This is always working on in-memory bytes, so there's no actual possibility of throwing an IOException, and lets us tidy up various callsites.
