### PR TITLE
Cleanup/fixes around logical replication

### DIFF
--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportAlterTableAction.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportAlterTableAction.java
@@ -28,7 +28,6 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
-import org.elasticsearch.cluster.metadata.MetadataCreateIndexService;
 import org.elasticsearch.cluster.metadata.MetadataUpdateSettingsService;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
@@ -53,7 +52,6 @@ public class TransportAlterTableAction extends AbstractDDLTransportAction<AlterT
                                      ClusterService clusterService,
                                      ThreadPool threadPool,
                                      IndexScopedSettings indexScopedSettings,
-                                     MetadataCreateIndexService metadataCreateIndexService,
                                      MetadataUpdateSettingsService updateSettingsService,
                                      NodeContext nodeContext) {
         super(ACTION_NAME,
@@ -66,7 +64,6 @@ public class TransportAlterTableAction extends AbstractDDLTransportAction<AlterT
               "alter-table");
         executor = new AlterTableClusterStateExecutor(
             indexScopedSettings,
-            metadataCreateIndexService,
             updateSettingsService,
             nodeContext
         );
@@ -91,5 +88,4 @@ public class TransportAlterTableAction extends AbstractDDLTransportAction<AlterT
     public ClusterBlockException checkBlock(AlterTableRequest request, ClusterState state) {
         return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
     }
-
 }

--- a/server/src/main/java/io/crate/metadata/cluster/AlterTableClusterStateExecutor.java
+++ b/server/src/main/java/io/crate/metadata/cluster/AlterTableClusterStateExecutor.java
@@ -40,7 +40,6 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
-import org.elasticsearch.cluster.metadata.MetadataCreateIndexService;
 import org.elasticsearch.cluster.metadata.MetadataUpdateSettingsService;
 import org.elasticsearch.cluster.metadata.RelationMetadata;
 import org.elasticsearch.common.regex.Regex;
@@ -63,16 +62,13 @@ import io.crate.sql.tree.ColumnPolicy;
 public class AlterTableClusterStateExecutor extends DDLClusterStateTaskExecutor<AlterTableRequest> {
 
     private final IndexScopedSettings indexScopedSettings;
-    private final MetadataCreateIndexService metadataCreateIndexService;
     private final NodeContext nodeContext;
     private final MetadataUpdateSettingsService updateSettingsService;
 
     public AlterTableClusterStateExecutor(IndexScopedSettings indexScopedSettings,
-                                          MetadataCreateIndexService metadataCreateIndexService,
                                           MetadataUpdateSettingsService updateSettingsService,
                                           NodeContext nodeContext) {
         this.indexScopedSettings = indexScopedSettings;
-        this.metadataCreateIndexService = metadataCreateIndexService;
         this.nodeContext = nodeContext;
         this.updateSettingsService = updateSettingsService;
     }

--- a/server/src/test/java/io/crate/replication/logical/MetadataTrackerTest.java
+++ b/server/src/test/java/io/crate/replication/logical/MetadataTrackerTest.java
@@ -57,6 +57,7 @@ import org.junit.Test;
 
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
+import io.crate.metadata.doc.DocTableInfoFactory;
 import io.crate.replication.logical.action.PublicationsStateAction;
 import io.crate.replication.logical.action.PublicationsStateAction.Response;
 import io.crate.replication.logical.metadata.ConnectionInfo;
@@ -266,7 +267,7 @@ public class MetadataTrackerTest extends ESTestCase {
             SUBSCRIBER_CLUSTER_STATE,
             publicationsStateResponse,
             IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
-            createNodeContext()
+            new DocTableInfoFactory(createNodeContext())
         );
         // Nothing in the indexMetadata changed, so the cluster state must be equal
         assertThat(SUBSCRIBER_CLUSTER_STATE).isEqualTo(syncedSubscriberClusterState);
@@ -291,7 +292,7 @@ public class MetadataTrackerTest extends ESTestCase {
             SUBSCRIBER_CLUSTER_STATE,
             updatedResponse,
             IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
-            createNodeContext()
+            new DocTableInfoFactory(createNodeContext())
         );
 
         assertThat(SUBSCRIBER_CLUSTER_STATE).isNotEqualTo(syncedSubscriberClusterState);
@@ -320,7 +321,7 @@ public class MetadataTrackerTest extends ESTestCase {
             SUBSCRIBER_CLUSTER_STATE,
             updatedResponse,
             IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
-            createNodeContext()
+            new DocTableInfoFactory(createNodeContext())
         );
         var syncedIndexMetadata = syncedSubscriberClusterState.metadata().index("test");
         assertThat(syncedIndexMetadata.getSettings().getAsInt(IndexSettings.MAX_NGRAM_DIFF_SETTING.getKey(), null)).isEqualTo(5);
@@ -348,7 +349,7 @@ public class MetadataTrackerTest extends ESTestCase {
             SUBSCRIBER_CLUSTER_STATE,
             updatedResponse,
             IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
-            createNodeContext()
+            new DocTableInfoFactory(createNodeContext())
         );
         var syncedIndexMetadata = syncedSubscriberClusterState.metadata().index("test");
         assertThat(syncedIndexMetadata.getSettings().get(SETTING_INDEX_UUID, "default")).isNotEqualTo(publisherIndexUuid);
@@ -374,7 +375,7 @@ public class MetadataTrackerTest extends ESTestCase {
             SUBSCRIBER_CLUSTER_STATE,
             updatedResponse,
             IndexScopedSettings.DEFAULT_SCOPED_SETTINGS,
-            createNodeContext()
+            new DocTableInfoFactory(createNodeContext())
         );
         var syncedIndexMetadata = syncedSubscriberClusterState.metadata().index("test");
         assertThat(INDEX_NUMBER_OF_REPLICAS_SETTING.get(syncedIndexMetadata.getSettings())).isEqualTo(0);


### PR DESCRIPTION
 -  Clean up unused arg in AlterTableClusterStateExecutor

 -  Avoid creating new DocTableInfoFactory objects
    Follows: #17680

 -  Extract add subscription setting to a method
    Follows: #17680
