### PR TITLE
Fix new column collection to not contain duplicates

### DIFF
--- a/server/src/main/java/io/crate/execution/dml/Indexer.java
+++ b/server/src/main/java/io/crate/execution/dml/Indexer.java
@@ -31,6 +31,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -679,7 +680,7 @@ public class Indexer {
      * Looks for new columns in the values of the given IndexItem and returns them.
      */
     public List<Reference> collectSchemaUpdates(IndexItem item) throws IOException {
-        ArrayList<Reference> newColumns = new ArrayList<>();
+        LinkedHashSet<Reference> newColumns = new LinkedHashSet<>();
         Consumer<? super Reference> onDynamicColumn = ref -> {
             ref.column().validForCreate();
             newColumns.add(ref);
@@ -718,7 +719,7 @@ public class Indexer {
                 synthetics::get
             );
         }
-        return newColumns;
+        return newColumns.stream().toList();
     }
 
     /**

--- a/server/src/test/java/io/crate/execution/dml/IndexerTest.java
+++ b/server/src/test/java/io/crate/execution/dml/IndexerTest.java
@@ -25,6 +25,7 @@ import static io.crate.execution.dml.ArrayIndexer.ARRAY_LENGTH_FIELD_PREFIX;
 import static io.crate.execution.dml.ArrayIndexer.ARRAY_VALUES_FIELD_PREFIX;
 import static io.crate.execution.dml.ArrayIndexer.toArrayLengthFieldName;
 import static io.crate.testing.Asserts.assertThat;
+import static io.crate.testing.Asserts.isReference;
 import static io.crate.types.GeoShapeType.Names.TREE_BKD;
 import static io.crate.types.GeoShapeType.Names.TREE_GEOHASH;
 import static io.crate.types.GeoShapeType.Names.TREE_LEGACY_QUADTREE;
@@ -41,6 +42,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import org.apache.lucene.document.Field;
@@ -347,6 +349,45 @@ public class IndexerTest extends CrateDummyClusterServiceUnitTest {
         var parsedDoc = indexer.index(item(1));
         assertThat(source(parsedDoc, table)).isEqualTo(
             "{\"x\":1,\"y\":3}"
+        );
+    }
+
+    @Test
+    public void test_collect_columns_of_dynamic_object_array() throws Exception {
+        SQLExecutor executor = SQLExecutor.of(clusterService)
+            .addTable("CREATE TABLE tbl (data OBJECT(DYNAMIC))");
+        DocTableInfo table = executor.resolveTableInfo("tbl");
+        Reference x = table.getReference(ColumnIdent.of("data"));
+        Indexer indexer = new Indexer(
+            table.ident().indexNameOrAlias(),
+            table,
+            Version.CURRENT,
+            new CoordinatorTxnCtx(executor.getSessionSettings()),
+            executor.nodeCtx,
+            List.of(x),
+            null
+        );
+
+        // Create 1 object with a nested object array of 2 elements with 4 columns each
+        Map<String, Object> item = Map.of(
+            "a", 1,
+            "b", "foo",
+            "c", 2,
+            "d", 123
+        );
+        ArrayList<Map<String, Object>> list = new ArrayList<>();
+        IntStream.range(0, 2).forEach(_ -> list.add(item));
+        Map<String, Object> data = new HashMap<>();
+        data.put("list", list);
+
+        var references = indexer.collectSchemaUpdates(item(data));
+        // Must result in 5 columns, duplicates of each of the 2 elements must be ignored
+        assertThat(references).satisfiesExactly(
+            isReference("data['list']"),
+            isReference("data['list']['a']"),
+            isReference("data['list']['b']"),
+            isReference("data['list']['c']"),
+            isReference("data['list']['d']")
         );
     }
 


### PR DESCRIPTION
Duplicated new columns weren't a real issue besides memory consumption until the field limit detection on dynamically added columns was fixed by https://github.com/crate/crate/commit/ea6fa68af2.

Fixes #17691.