### PR TITLE
Add priority queue for search threadpool

### DIFF
--- a/docs/appendices/release-notes/6.0.0.rst
+++ b/docs/appendices/release-notes/6.0.0.rst
@@ -142,6 +142,11 @@ Scalar and Aggregation Functions
 Performance and Resilience Improvements
 ---------------------------------------
 
+- Changed how scheduling and prioritization for read queries, in particular
+  queries against ``sys.shards`` and ``sys.nodes`` work. This should help
+  continue monitoring a cluster that is overloaded with too many concurrent
+  queries.
+
 - Improved the logic to push down expressions within the ``WHERE`` clause to the
   table to use index lookups instead of resulting in post-filtering when using
   virtual tables involving table functions and object columns. For example, the

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportCloseTable.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportCloseTable.java
@@ -525,7 +525,7 @@ public final class TransportCloseTable extends TransportMasterNodeAction<CloseTa
         }
 
         @Override
-        protected void doRun() throws Exception {
+        public void doRun() throws Exception {
             final Map<Index, AcknowledgedResponse> results = new ConcurrentHashMap<>();
             final CountDown countDown = new CountDown(blockedIndices.size());
             final ClusterState state = clusterService.state();

--- a/server/src/main/java/org/elasticsearch/action/ActionRunnable.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionRunnable.java
@@ -19,16 +19,17 @@
 
 package org.elasticsearch.action;
 
-import io.crate.common.CheckedSupplier;
 import org.elasticsearch.common.CheckedConsumer;
 import org.elasticsearch.common.CheckedRunnable;
-import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.common.util.concurrent.RejectableRunnable;
+
+import io.crate.common.CheckedSupplier;
 
 /**
  * Base class for {@link Runnable}s that need to call {@link ActionListener#onFailure(Exception)} in case an uncaught
  * exception or error is thrown while the actual action is run.
  */
-public abstract class ActionRunnable<Response> extends AbstractRunnable {
+public abstract class ActionRunnable<Response> implements RejectableRunnable {
 
     protected final ActionListener<Response> listener;
 
@@ -41,7 +42,7 @@ public abstract class ActionRunnable<Response> extends AbstractRunnable {
     public static <T> ActionRunnable<T> run(ActionListener<T> listener, CheckedRunnable<Exception> runnable) {
         return new ActionRunnable<>(listener) {
             @Override
-            protected void doRun() throws Exception {
+            public void doRun() throws Exception {
                 runnable.run();
                 listener.onResponse(null);
             }
@@ -69,7 +70,7 @@ public abstract class ActionRunnable<Response> extends AbstractRunnable {
     public static <T> ActionRunnable<T> wrap(ActionListener<T> listener, CheckedConsumer<ActionListener<T>, Exception> consumer) {
         return new ActionRunnable<>(listener) {
             @Override
-            protected void doRun() throws Exception {
+            public void doRun() throws Exception {
                 consumer.accept(listener);
             }
         };

--- a/server/src/main/java/org/elasticsearch/action/support/RetryableAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/RetryableAction.java
@@ -89,7 +89,7 @@ public abstract class RetryableAction<Response> {
         return new ActionRunnable<Response>(retryingListener) {
 
             @Override
-            protected void doRun() {
+            public void doRun() {
                 retryTask = null;
                 // It is possible that the task was cancelled in between the retry being dispatched and now
                 if (isDone.get() == false) {

--- a/server/src/main/java/org/elasticsearch/action/support/ThreadedActionListener.java
+++ b/server/src/main/java/org/elasticsearch/action/support/ThreadedActionListener.java
@@ -23,7 +23,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRunnable;
-import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.common.util.concurrent.RejectableRunnable;
 import org.elasticsearch.threadpool.ThreadPool;
 
 /**
@@ -58,7 +58,7 @@ public final class ThreadedActionListener<Response> implements ActionListener<Re
             }
 
             @Override
-            protected void doRun() {
+            public void doRun() {
                 listener.onResponse(response);
             }
         });
@@ -66,14 +66,14 @@ public final class ThreadedActionListener<Response> implements ActionListener<Re
 
     @Override
     public void onFailure(final Exception e) {
-        threadPool.executor(executor).execute(new AbstractRunnable() {
+        threadPool.executor(executor).execute(new RejectableRunnable() {
             @Override
             public boolean isForceExecution() {
                 return forceExecution;
             }
 
             @Override
-            protected void doRun() throws Exception {
+            public void doRun() throws Exception {
                 listener.onFailure(e);
             }
 

--- a/server/src/main/java/org/elasticsearch/cluster/InternalClusterInfoService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/InternalClusterInfoService.java
@@ -50,8 +50,8 @@ import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
+import org.elasticsearch.common.util.concurrent.RejectableRunnable;
 import org.elasticsearch.index.store.StoreStats;
 import org.elasticsearch.monitor.fs.FsInfo;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -420,7 +420,7 @@ public class InternalClusterInfoService implements ClusterInfoService, ClusterSt
     /**
      * Runs {@link InternalClusterInfoService#refresh()}, logging failures/rejections appropriately.
      */
-    private class RefreshRunnable extends AbstractRunnable {
+    private class RefreshRunnable implements RejectableRunnable {
         private final String reason;
 
         RefreshRunnable(String reason) {
@@ -428,7 +428,7 @@ public class InternalClusterInfoService implements ClusterInfoService, ClusterSt
         }
 
         @Override
-        protected void doRun() {
+        public void doRun() {
             if (enabled) {
                 LOGGER.trace("refreshing cluster info [{}]", reason);
                 refresh();
@@ -460,7 +460,7 @@ public class InternalClusterInfoService implements ClusterInfoService, ClusterSt
         }
 
         @Override
-        protected void doRun() {
+        public void doRun() {
             if (this == refreshAndRescheduleRunnable.get()) {
                 super.doRun();
             } else {

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/FollowersChecker.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/FollowersChecker.java
@@ -41,7 +41,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.common.util.concurrent.RejectableRunnable;
 import org.elasticsearch.monitor.NodeHealthService;
 import org.elasticsearch.monitor.StatusInfo;
 import org.elasticsearch.threadpool.ThreadPool.Names;
@@ -183,9 +183,9 @@ public class FollowersChecker {
             throw new CoordinationStateRejectedException("rejecting " + request + " since local state is " + this);
         }
 
-        transportService.getThreadPool().generic().execute(new AbstractRunnable() {
+        transportService.getThreadPool().generic().execute(new RejectableRunnable() {
             @Override
-            protected void doRun() throws IOException {
+            public void doRun() throws IOException {
                 LOGGER.trace("responding to {} on slow path", request);
                 try {
                     handleRequestAndUpdateState.accept(request);

--- a/server/src/main/java/org/elasticsearch/cluster/routing/DelayedAllocationService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/DelayedAllocationService.java
@@ -34,7 +34,7 @@ import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.common.util.concurrent.RejectableRunnable;
 import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.ThreadPool;
 
@@ -92,9 +92,9 @@ public class DelayedAllocationService extends AbstractLifecycleComponent impleme
         }
 
         public void schedule() {
-            cancellable = threadPool.schedule(new AbstractRunnable() {
+            cancellable = threadPool.schedule(new RejectableRunnable() {
                 @Override
-                protected void doRun() throws Exception {
+                public void doRun() throws Exception {
                     if (cancelScheduling.get()) {
                         return;
                     }

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/AbstractLifecycleRunnable.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/AbstractLifecycleRunnable.java
@@ -19,17 +19,17 @@
 
 package org.elasticsearch.common.util.concurrent;
 
+import java.util.Objects;
+
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.component.Lifecycle;
 
-import java.util.Objects;
-
 /**
- * {@code AbstractLifecycleRunnable} is a service-lifecycle aware {@link AbstractRunnable}.
+ * {@code AbstractLifecycleRunnable} is a service-lifecycle aware {@link RejectableRunnable}.
  * <p>
  * This simplifies the running and rescheduling of {@link Lifecycle}-based {@code Runnable}s.
  */
-public abstract class AbstractLifecycleRunnable extends AbstractRunnable {
+public abstract class AbstractLifecycleRunnable implements RejectableRunnable {
     /**
      * The monitored lifecycle for the associated service.
      */
@@ -58,7 +58,7 @@ public abstract class AbstractLifecycleRunnable extends AbstractRunnable {
      * immediately.
      */
     @Override
-    protected final void doRun() throws Exception {
+    public final void doRun() throws Exception {
         // prevent execution if the service is stopped
         if (lifecycle.stoppedOrClosed()) {
             logger.trace("lifecycle is stopping. exiting");

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/EsAbortPolicy.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/EsAbortPolicy.java
@@ -19,24 +19,24 @@
 
 package org.elasticsearch.common.util.concurrent;
 
-import org.elasticsearch.common.metrics.CounterMetric;
-
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
+
+import org.elasticsearch.common.metrics.CounterMetric;
 
 public class EsAbortPolicy implements XRejectedExecutionHandler {
     private final CounterMetric rejected = new CounterMetric();
 
     @Override
     public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
-        if (r instanceof AbstractRunnable) {
-            if (((AbstractRunnable) r).isForceExecution()) {
+        if (r instanceof RejectableRunnable abstractRunnable) {
+            if (abstractRunnable.isForceExecution()) {
                 BlockingQueue<Runnable> queue = executor.getQueue();
                 if (!(queue instanceof SizeBlockingQueue)) {
                     throw new IllegalStateException("forced execution, but expected a size queue");
                 }
                 try {
-                    ((SizeBlockingQueue) queue).forcePut(r);
+                    ((SizeBlockingQueue<? super Runnable>) queue).forcePut(r);
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                     throw new IllegalStateException("forced execution, but got interrupted", e);

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
@@ -212,13 +212,11 @@ public class EsExecutors {
 
         @Override
         public Thread newThread(Runnable r) {
-            Thread t = new Thread(group, r,
-                    namePrefix + "[T#" + threadNumber.getAndIncrement() + "]",
-                    0);
+            String name = namePrefix + "[T#" + threadNumber.getAndIncrement() + "]";
+            Thread t = new Thread(group, r, name, 0);
             t.setDaemon(true);
             return t;
         }
-
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/EsThreadPoolExecutor.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/EsThreadPoolExecutor.java
@@ -41,7 +41,7 @@ public class EsThreadPoolExecutor extends ThreadPoolExecutor {
         return name;
     }
 
-    EsThreadPoolExecutor(String name,
+    public EsThreadPoolExecutor(String name,
                          int corePoolSize,
                          int maximumPoolSize,
                          long keepAliveTime,
@@ -52,7 +52,7 @@ public class EsThreadPoolExecutor extends ThreadPoolExecutor {
     }
 
     @SuppressForbidden(reason = "properly rethrowing errors, see EsExecutors.rethrowErrors")
-    EsThreadPoolExecutor(String name,
+    public EsThreadPoolExecutor(String name,
                          int corePoolSize,
                          int maximumPoolSize,
                          long keepAliveTime,
@@ -70,14 +70,11 @@ public class EsThreadPoolExecutor extends ThreadPoolExecutor {
         try {
             super.execute(command);
         } catch (EsRejectedExecutionException ex) {
-            if (command instanceof AbstractRunnable runnable) {
-                // If we are an abstract runnable we can handle the rejection
-                // directly and don't need to rethrow it.
+            if (command instanceof RejectableRunnable runnable) {
                 try {
                     runnable.onRejection(ex);
                 } finally {
                     runnable.onAfter();
-
                 }
             } else {
                 throw ex;

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/PriorityRunnable.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/PriorityRunnable.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package org.elasticsearch.common.util.concurrent;
+
+import org.elasticsearch.common.Priority;
+
+public class PriorityRunnable {
+
+    private PriorityRunnable() {}
+
+    public static PrioritizedRunnable of(Priority priority, Runnable runnable) {
+        return runnable instanceof RejectableRunnable rejectableRunnable
+            ? new RejectablePriorityRunnable(priority, rejectableRunnable)
+            : new SimplePriorityRunnable(priority, runnable);
+    }
+
+    public static class RejectablePriorityRunnable extends PrioritizedRunnable implements RejectableRunnable, WrappedRunnable {
+
+        private final RejectableRunnable runnable;
+
+        private RejectablePriorityRunnable(Priority priority, RejectableRunnable runnable) {
+            super(priority);
+            this.runnable = runnable;
+        }
+
+        @Override
+        public void onFailure(Exception e) {
+            runnable.onFailure(e);
+        }
+
+        @Override
+        public void onRejection(Exception e) {
+            runnable.onRejection(e);
+        }
+
+        @Override
+        public boolean isForceExecution() {
+            return runnable.isForceExecution();
+        }
+
+        @Override
+        public void doRun() throws Exception {
+            runnable.doRun();
+        }
+
+        @Override
+        public Runnable unwrap() {
+            return runnable;
+        }
+    }
+
+    public static class SimplePriorityRunnable extends PrioritizedRunnable implements WrappedRunnable {
+
+        private final Runnable runnable;
+
+        private SimplePriorityRunnable(Priority priority, Runnable runnable) {
+            super(priority);
+            this.runnable = runnable;
+        }
+
+        @Override
+        public void run() {
+            runnable.run();
+        }
+
+        @Override
+        public Runnable unwrap() {
+            return runnable;
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/RejectableRunnable.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/RejectableRunnable.java
@@ -21,18 +21,17 @@ package org.elasticsearch.common.util.concurrent;
 
 /**
  * An extension to runnable.
- */
-public abstract class AbstractRunnable implements Runnable {
+ **/
+public interface RejectableRunnable extends Runnable {
 
     /**
      * Should the runnable force its execution in case it gets rejected?
      */
-    public boolean isForceExecution() {
+    default boolean isForceExecution() {
         return false;
     }
 
-    @Override
-    public final void run() {
+    default void run() {
         try {
             doRun();
         } catch (Exception t) {
@@ -46,20 +45,20 @@ public abstract class AbstractRunnable implements Runnable {
      * This method is called in a finally block after successful execution
      * or on a rejection.
      */
-    public void onAfter() {
+    default void onAfter() {
         // nothing by default
     }
 
     /**
      * This method is invoked for all exception thrown by {@link #doRun()}
      */
-    public abstract void onFailure(Exception e);
+    void onFailure(Exception e);
 
     /**
      * This should be executed if the thread-pool executing this action rejected the execution.
      * The default implementation forwards to {@link #onFailure(Exception)}
      */
-    public void onRejection(Exception e) {
+    default void onRejection(Exception e) {
         onFailure(e);
     }
 
@@ -67,5 +66,5 @@ public abstract class AbstractRunnable implements Runnable {
      * This method has the same semantics as {@link Runnable#run()}
      * @throws InterruptedException if the run method throws an InterruptedException
      */
-    protected abstract void doRun() throws Exception;
+    void doRun() throws Exception;
 }

--- a/server/src/main/java/org/elasticsearch/discovery/HandshakingTransportAddressConnector.java
+++ b/server/src/main/java/org/elasticsearch/discovery/HandshakingTransportAddressConnector.java
@@ -35,7 +35,7 @@ import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
-import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.common.util.concurrent.RejectableRunnable;
 import org.elasticsearch.discovery.PeerFinder.TransportAddressConnector;
 import org.elasticsearch.node.NodeClosedException;
 import org.elasticsearch.transport.ConnectTransportException;
@@ -73,11 +73,11 @@ public class HandshakingTransportAddressConnector implements TransportAddressCon
 
     @Override
     public void connectToRemoteMasterNode(TransportAddress transportAddress, ActionListener<DiscoveryNode> listener) {
-        transportService.getThreadPool().generic().execute(new AbstractRunnable() {
-            private final AbstractRunnable thisConnectionAttempt = this;
+        transportService.getThreadPool().generic().execute(new RejectableRunnable() {
+            private final RejectableRunnable thisConnectionAttempt = this;
 
             @Override
-            protected void doRun() {
+            public void doRun() {
                 // We could skip this if the transportService were already connected to the given address, but the savings would be minimal
                 // so we open a new connection anyway.
 

--- a/server/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
+++ b/server/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
@@ -55,9 +55,9 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.EsThreadPoolExecutor;
+import org.elasticsearch.common.util.concurrent.RejectableRunnable;
 import org.elasticsearch.env.NodeMetadata;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -348,7 +348,7 @@ public class GatewayMetaState implements Closeable {
         private void scheduleUpdate() {
             assert Thread.holdsLock(mutex);
             assert threadPoolExecutor.getQueue().isEmpty() : "threadPoolExecutor queue not empty";
-            threadPoolExecutor.execute(new AbstractRunnable() {
+            threadPoolExecutor.execute(new RejectableRunnable() {
 
                 @Override
                 public void onFailure(Exception e) {
@@ -361,7 +361,7 @@ public class GatewayMetaState implements Closeable {
                 }
 
                 @Override
-                protected void doRun() {
+                public void doRun() {
                     final Long term;
                     final ClusterState clusterState;
                     synchronized (mutex) {

--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -58,7 +58,7 @@ import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.concurrent.AbstractAsyncTask;
-import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.common.util.concurrent.RejectableRunnable;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.env.ShardLock;
 import org.elasticsearch.gateway.MetadataStateFormat;
@@ -585,14 +585,14 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
                 // it doesn't matter if we move from or to <code>-1</code>  in both cases we want
                 // docs to become visible immediately. This also flushes all pending indexing / search requests
                 // that are waiting for a refresh.
-                threadPool.executor(ThreadPool.Names.REFRESH).execute(new AbstractRunnable() {
+                threadPool.executor(ThreadPool.Names.REFRESH).execute(new RejectableRunnable() {
                     @Override
                     public void onFailure(Exception e) {
                         logger.warn("forced refresh failed after interval change", e);
                     }
 
                     @Override
-                    protected void doRun() throws Exception {
+                    public void doRun() throws Exception {
                         maybeRefreshEngine(true);
                     }
 

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShardOperationPermits.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShardOperationPermits.java
@@ -36,7 +36,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.common.CheckedRunnable;
 import org.elasticsearch.common.lease.Releasable;
-import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.common.util.concurrent.RejectableRunnable;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import io.crate.common.collections.Tuple;
@@ -121,7 +121,7 @@ final class IndexShardOperationPermits implements Closeable {
      */
     public void asyncBlockOperations(final ActionListener<Releasable> onAcquired, final long timeout, final TimeUnit timeUnit) {
         delayOperations();
-        threadPool.executor(ThreadPool.Names.GENERIC).execute(new AbstractRunnable() {
+        threadPool.executor(ThreadPool.Names.GENERIC).execute(new RejectableRunnable() {
 
             final AtomicBoolean released = new AtomicBoolean(false);
 
@@ -135,7 +135,7 @@ final class IndexShardOperationPermits implements Closeable {
             }
 
             @Override
-            protected void doRun() throws Exception {
+            public void doRun() throws Exception {
                 final Releasable releasable = acquireAll(timeout, timeUnit);
                 onAcquired.onResponse(() -> {
                     try {
@@ -264,7 +264,7 @@ final class IndexShardOperationPermits implements Closeable {
                                 }
 
                                 @Override
-                                protected void doRun() {
+                                public void doRun() {
                                     listener.onResponse(r);
                                 }
 

--- a/server/src/main/java/org/elasticsearch/index/shard/PrimaryReplicaSyncer.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/PrimaryReplicaSyncer.java
@@ -34,7 +34,7 @@ import org.elasticsearch.action.support.replication.ReplicationResponse;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
-import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.common.util.concurrent.RejectableRunnable;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.seqno.SequenceNumbers;
 import org.elasticsearch.index.translog.Translog;
@@ -183,7 +183,7 @@ public class PrimaryReplicaSyncer {
                   ActionListener<ReplicationResponse> listener);
     }
 
-    static class SnapshotSender extends AbstractRunnable implements ActionListener<ReplicationResponse> {
+    static class SnapshotSender implements RejectableRunnable, ActionListener<ReplicationResponse> {
         private final SyncAction syncAction;
         private final ResyncTask task; // to track progress
         private final String primaryAllocationId;
@@ -240,7 +240,7 @@ public class PrimaryReplicaSyncer {
         private static final Translog.Operation[] EMPTY_ARRAY = new Translog.Operation[0];
 
         @Override
-        protected void doRun() throws Exception {
+        public void doRun() throws Exception {
             long size = 0;
             final List<Translog.Operation> operations = new ArrayList<>();
 

--- a/server/src/main/java/org/elasticsearch/indices/IndexingMemoryController.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndexingMemoryController.java
@@ -38,7 +38,7 @@ import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
-import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.common.util.concurrent.RejectableRunnable;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.IndexShardState;
@@ -173,7 +173,7 @@ public class IndexingMemoryController implements IndexingOperationListener, Clos
 
     /** ask this shard to refresh, in the background, to free up heap */
     protected void writeIndexingBufferAsync(IndexShard shard) {
-        threadPool.executor(ThreadPool.Names.REFRESH).execute(new AbstractRunnable() {
+        threadPool.executor(ThreadPool.Names.REFRESH).execute(new RejectableRunnable() {
             @Override
             public void doRun() {
                 shard.writeIndexingBuffer();

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -74,10 +74,10 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.concurrent.AbstractRefCounted;
-import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.common.util.concurrent.EsThreadPoolExecutor;
+import org.elasticsearch.common.util.concurrent.RejectableRunnable;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.env.ShardLock;
 import org.elasticsearch.env.ShardLockObtainFailedException;
@@ -1088,14 +1088,14 @@ public class IndicesService extends AbstractLifecycleComponent
             LOGGER.trace("triggered dangling indices update for {}", index);
             final long triggeredTimeMillis = threadPool.relativeTimeInMillis();
             try {
-                danglingIndicesThreadPoolExecutor.execute(new AbstractRunnable() {
+                danglingIndicesThreadPoolExecutor.execute(new RejectableRunnable() {
                     @Override
                     public void onFailure(Exception e) {
                         LOGGER.warn(() -> new ParameterizedMessage("failed to write dangling indices state for index {}", index), e);
                     }
 
                     @Override
-                    protected void doRun() {
+                    public void doRun() {
                         final boolean exists = danglingIndicesToWrite.remove(index);
                         assert exists : "removed non-existing item for " + index;
                         final IndexService indexService = indices.get(index.getUUID());

--- a/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -65,7 +65,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.common.util.concurrent.RejectableRunnable;
 import org.elasticsearch.env.ShardLockObtainFailedException;
 import org.elasticsearch.gateway.GatewayService;
 import org.elasticsearch.index.Index;
@@ -340,14 +340,14 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
                 }
             }
             if (indexSettings != null) {
-                threadPool.generic().execute(new AbstractRunnable() {
+                threadPool.generic().execute(new RejectableRunnable() {
                     @Override
                     public void onFailure(Exception e) {
                         LOGGER.warn(() -> new ParameterizedMessage("[{}] failed to complete pending deletion for index", index), e);
                     }
 
                     @Override
-                    protected void doRun() throws Exception {
+                    public void doRun() throws Exception {
                         try {
                             // we are waiting until we can lock the index / all shards on the node and then we ack the delete of the store
                             // to the master. If we can't acquire the locks here immediately there might be a shard of this index still

--- a/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
@@ -46,7 +46,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.CancellableThreads;
-import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.common.util.concurrent.RejectableRunnable;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.engine.RecoveryEngineException;
 import org.elasticsearch.index.mapper.MapperException;
@@ -538,7 +538,7 @@ public class PeerRecoveryTargetService implements IndexEventListener {
         return listener;
     }
 
-    class RecoveryRunner extends AbstractRunnable {
+    class RecoveryRunner implements RejectableRunnable {
 
         final long recoveryId;
         private final StartRecoveryRequest startRecoveryRequest;

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveriesCollection.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveriesCollection.java
@@ -30,7 +30,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.common.util.concurrent.RejectableRunnable;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.IndexShardClosedException;
 import org.elasticsearch.index.shard.ShardId;
@@ -252,7 +252,7 @@ public class RecoveriesCollection {
         }
     }
 
-    private class RecoveryMonitor extends AbstractRunnable {
+    private class RecoveryMonitor implements RejectableRunnable {
         private final long recoveryId;
         private final TimeValue checkInterval;
 
@@ -270,7 +270,7 @@ public class RecoveriesCollection {
         }
 
         @Override
-        protected void doRun() throws Exception {
+        public void doRun() throws Exception {
             RecoveryTarget status = onGoingRecoveries.get(recoveryId);
             if (status == null) {
                 logger.trace("[monitor] no status found for [{}], shutting down", recoveryId);

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoriesService.java
@@ -248,7 +248,7 @@ public class RepositoriesService extends AbstractLifecycleComponent implements C
         threadPool.executor(ThreadPool.Names.SNAPSHOT).execute(new ActionRunnable<>(listener) {
 
             @Override
-            protected void doRun() {
+            public void doRun() {
                 final String verificationToken = repository.startVerification();
                 if (verificationToken != null) {
                     try {

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -101,7 +101,7 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
-import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.common.util.concurrent.RejectableRunnable;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
@@ -558,9 +558,9 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         if (isReadOnly()) {
             listener.onFailure(new RepositoryException(metadata.name(), "cannot delete snapshot from a readonly repository"));
         } else {
-            threadPool.executor(ThreadPool.Names.SNAPSHOT).execute(new AbstractRunnable() {
+            threadPool.executor(ThreadPool.Names.SNAPSHOT).execute(new RejectableRunnable() {
                 @Override
-                protected void doRun() throws Exception {
+                public void doRun() throws Exception {
                     final Map<String, BlobMetadata> rootBlobs = blobContainer().listBlobs();
                     final RepositoryData repositoryData = safeRepositoryData(repositoryStateId, rootBlobs);
                     // Cache the indices that were found before writing out the new index-N blob so that a stuck master will never
@@ -756,9 +756,9 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                     new GroupedActionListener<>(deleteIndexMetadataListener, shardCount);
                 for (int shardId = 0; shardId < shardCount; shardId++) {
                     final int finalShardId = shardId;
-                    executor.execute(new AbstractRunnable() {
+                    executor.execute(new RejectableRunnable() {
                         @Override
-                        protected void doRun() throws Exception {
+                        public void doRun() throws Exception {
                             final BlobContainer shardContainer = shardContainer(indexId, finalShardId);
                             final Set<String> blobs = shardContainer.listBlobs().keySet();
                             final BlobStoreIndexShardSnapshots blobStoreIndexShardSnapshots;

--- a/server/src/main/java/org/elasticsearch/snapshots/InternalSnapshotsInfoService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/InternalSnapshotsInfoService.java
@@ -46,7 +46,7 @@ import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.common.util.concurrent.RejectableRunnable;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.repositories.IndexId;
 import org.elasticsearch.repositories.RepositoriesService;
@@ -198,7 +198,7 @@ public class InternalSnapshotsInfoService implements ClusterStateListener, Snaps
         }
     }
 
-    private class FetchingSnapshotShardSizeRunnable extends AbstractRunnable {
+    private class FetchingSnapshotShardSizeRunnable implements RejectableRunnable {
 
         private final SnapshotShard snapshotShard;
         private boolean removed;
@@ -210,7 +210,7 @@ public class InternalSnapshotsInfoService implements ClusterStateListener, Snaps
         }
 
         @Override
-        protected void doRun() throws Exception {
+        public void doRun() throws Exception {
             final RepositoriesService repositories = repositoriesService.get();
             assert repositories != null;
             final Repository repository = repositories.repository(snapshotShard.snapshot.getRepository());

--- a/server/src/main/java/org/elasticsearch/threadpool/FixedExecutorBuilder.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/FixedExecutorBuilder.java
@@ -55,7 +55,7 @@ public final class FixedExecutorBuilder extends ExecutorBuilder {
         final String sizeKey = settingsKey(prefix, "size");
         this.sizeSetting = new Setting<>(
             sizeKey,
-            s -> Integer.toString(size),
+            _ -> Integer.toString(size),
             s -> Setting.parseInt(s, 1, applyHardSizeLimit(settings, name), sizeKey),
             DataTypes.INTEGER,
             Setting.Property.NodeScope
@@ -91,9 +91,9 @@ public final class FixedExecutorBuilder extends ExecutorBuilder {
         return String.format(
             Locale.ROOT,
             "name [%s], size [%d], queue size [%s]",
-            info.getName(),
-            info.getMax(),
-            info.getQueueSize() == null ? "unbounded" : info.getQueueSize());
+            info.name(),
+            info.max(),
+            info.queueSize() == null ? "unbounded" : info.queueSize());
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/threadpool/FixedExecutorBuilder.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/FixedExecutorBuilder.java
@@ -36,10 +36,10 @@ import io.crate.types.DataTypes;
 /**
  * A builder for fixed executors.
  */
-public final class FixedExecutorBuilder extends ExecutorBuilder {
+public class FixedExecutorBuilder extends ExecutorBuilder {
 
-    private final Setting<Integer> sizeSetting;
-    private final Setting<Integer> queueSizeSetting;
+    protected final Setting<Integer> sizeSetting;
+    protected final Setting<Integer> queueSizeSetting;
 
     /**
      * Construct a fixed executor builder.

--- a/server/src/main/java/org/elasticsearch/threadpool/PrioFixedExecutorBuilder.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/PrioFixedExecutorBuilder.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package org.elasticsearch.threadpool;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.PriorityBlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+
+import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.SizeValue;
+import org.elasticsearch.common.util.concurrent.EsAbortPolicy;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.common.util.concurrent.EsThreadPoolExecutor;
+import org.elasticsearch.common.util.concurrent.PrioritizedEsThreadPoolExecutor;
+import org.elasticsearch.common.util.concurrent.PrioritizedRunnable;
+import org.elasticsearch.common.util.concurrent.PriorityRunnable;
+import org.elasticsearch.common.util.concurrent.SizeBlockingQueue;
+import org.elasticsearch.node.Node;
+
+/**
+ * Like {@link FixedExecutorBuilder} but uses a PriorityQueue. If scheduling
+ * {@link Runnable} that are not {@link PrioritizedRunnable} it wraps them into
+ * a {@link PriorityRunnable} with priority normal.
+ *
+ * <p>
+ * Doesn't use {@link PrioritizedEsThreadPoolExecutor} but a simpler variant of
+ * {@link EsThreadPoolExecutor} because timeout handling and strict tie breaking
+ * is not needed.
+ * </p>
+ **/
+public final class PrioFixedExecutorBuilder extends FixedExecutorBuilder {
+
+    /**
+     * Construct a fixed executor builder.
+     *
+     * @param settings  the node-level settings
+     * @param name      the name of the executor
+     * @param size      the fixed number of threads
+     * @param queueSize the size of the backing queue
+     */
+    public PrioFixedExecutorBuilder(Settings settings, String name, int size, int queueSize) {
+        super(settings, name, size, queueSize);
+    }
+
+
+    @Override
+    ThreadPool.ExecutorHolder build(final Settings settings) {
+        final String nodeName = Node.NODE_NAME_SETTING.get(settings);
+        final int size = sizeSetting.get(settings);
+        final int queueSize = queueSizeSetting.get(settings);
+        final ThreadFactory threadFactory = EsExecutors.daemonThreadFactory(EsExecutors.threadName(nodeName, name()));
+        ExecutorService executor = new EsThreadPoolExecutor(
+            nodeName + "/" + name(),
+            size,
+            size,
+            0,
+            TimeUnit.MILLISECONDS,
+            new SizeBlockingQueue<>(new PriorityBlockingQueue<>(queueSize), queueSize),
+            threadFactory,
+            new EsAbortPolicy()
+        ) {
+            @Override
+            protected Runnable wrapRunnable(Runnable command) {
+                if (command instanceof PrioritizedRunnable) {
+                    return command;
+                }
+                return PriorityRunnable.of(Priority.NORMAL, command);
+            }
+        };
+        final ThreadPool.Info info = new ThreadPool.Info(
+            name(),
+            ThreadPool.ThreadPoolType.FIXED,
+            size,
+            size,
+            null,
+            new SizeValue(queueSize)
+        );
+        return new ThreadPool.ExecutorHolder(executor, info);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/threadpool/ScalingExecutorBuilder.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/ScalingExecutorBuilder.java
@@ -90,9 +90,9 @@ public final class ScalingExecutorBuilder extends ExecutorBuilder {
         return String.format(
             Locale.ROOT,
             "name [%s], core [%d], max [%d], keep alive [%s]",
-            info.getName(),
-            info.getMin(),
-            info.getMax(),
-            info.getKeepAlive());
+            info.name(),
+            info.min(),
+            info.max(),
+            info.keepAlive());
     }
 }

--- a/server/src/main/java/org/elasticsearch/threadpool/Scheduler.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/Scheduler.java
@@ -27,10 +27,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.EsAbortPolicy;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
+import org.elasticsearch.common.util.concurrent.RejectableRunnable;
 
 import io.crate.common.SuppressForbidden;
 import io.crate.common.exceptions.Exceptions;
@@ -169,7 +169,7 @@ public interface Scheduler {
      * {@link ScheduledThreadPoolExecutor#scheduleWithFixedDelay(Runnable, long, long, TimeUnit)} semantics as an exception there would
      * terminate the rescheduling of the runnable.
      */
-    final class ReschedulingRunnable extends AbstractRunnable implements Cancellable {
+    final class ReschedulingRunnable implements RejectableRunnable, Cancellable {
 
         private final Runnable runnable;
         private final TimeValue interval;

--- a/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -135,7 +135,7 @@ public class ThreadPool implements Scheduler {
         final int genericThreadPoolMax = boundedBy(4 * availableProcessors, 128, 512);
         builders.put(Names.GENERIC, new ScalingExecutorBuilder(Names.GENERIC, 4, genericThreadPoolMax, TimeValue.timeValueSeconds(30)));
         builders.put(Names.WRITE, new FixedExecutorBuilder(settings, Names.WRITE, availableProcessors, 200));
-        builders.put(Names.SEARCH, new FixedExecutorBuilder(settings, Names.SEARCH, searchThreadPoolSize(availableProcessors), 1000));
+        builders.put(Names.SEARCH, new PrioFixedExecutorBuilder(settings, Names.SEARCH, searchThreadPoolSize(availableProcessors), 1000));
         builders.put(Names.MANAGEMENT, new ScalingExecutorBuilder(Names.MANAGEMENT, 1, 5, TimeValue.timeValueMinutes(5)));
         // no queue as this means clients will need to handle rejections on listener queue even if the operation succeeded
         // the assumption here is that the listeners should be very lightweight on the listeners side

--- a/server/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationAllPermitsAcquisitionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationAllPermitsAcquisitionTests.java
@@ -263,7 +263,7 @@ public class TransportReplicationAllPermitsAcquisitionTests extends IndexShardTe
                 TransportReplicationAction.AsyncPrimaryAction asyncPrimaryAction =
                     singlePermitAction.new AsyncPrimaryAction(primaryRequest, listener) {
                         @Override
-                        protected void doRun() throws Exception {
+                        public void doRun() throws Exception {
                             if (delayed) {
                                 logger.trace("op [{}] has started and will resume execution once allPermitsAction is terminated", threadId);
                                 delayedOperationsBarrier.await();

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/RunOnceTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/RunOnceTests.java
@@ -78,9 +78,9 @@ public class RunOnceTests extends ESTestCase {
         final AtomicInteger onFailure = new AtomicInteger(0);
         final AtomicInteger onAfter = new AtomicInteger(0);
 
-        final RunOnce runOnce = new RunOnce(new AbstractRunnable() {
+        final RunOnce runOnce = new RunOnce(new RejectableRunnable() {
             @Override
-            protected void doRun() throws Exception {
+            public void doRun() throws Exception {
                 onRun.incrementAndGet();
                 throw new RuntimeException("failure");
             }

--- a/server/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
+++ b/server/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
@@ -39,7 +39,7 @@ import org.apache.lucene.index.SegmentInfos;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.common.io.PathUtils;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.common.util.concurrent.RejectableRunnable;
 import org.elasticsearch.gateway.MetadataStateFormat;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexSettings;
@@ -257,7 +257,7 @@ public class NodeEnvironmentTests extends ESTestCase {
         final CountDownLatch blockLatch = new CountDownLatch(1);
         final CountDownLatch start = new CountDownLatch(1);
         if (randomBoolean()) {
-            Thread t = new Thread(new AbstractRunnable() {
+            Thread t = new Thread(new RejectableRunnable() {
                 @Override
                 public void onFailure(Exception e) {
                     logger.error("unexpected error", e);
@@ -267,7 +267,7 @@ public class NodeEnvironmentTests extends ESTestCase {
                 }
 
                 @Override
-                protected void doRun() throws Exception {
+                public void doRun() throws Exception {
                     start.await();
                     try (ShardLock autoCloses = env.shardLock(new ShardId(index, 0), "2")) {
                         blockLatch.countDown();

--- a/server/src/test/java/org/elasticsearch/index/seqno/LocalCheckpointTrackerTests.java
+++ b/server/src/test/java/org/elasticsearch/index/seqno/LocalCheckpointTrackerTests.java
@@ -35,7 +35,7 @@ import java.util.stream.IntStream;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.Randomness;
-import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.common.util.concurrent.RejectableRunnable;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Before;
 
@@ -173,14 +173,14 @@ public class LocalCheckpointTrackerTests extends ESTestCase {
         final CyclicBarrier barrier = new CyclicBarrier(threads.length);
         for (int t = 0; t < threads.length; t++) {
             final int threadId = t;
-            threads[t] = new Thread(new AbstractRunnable() {
+            threads[t] = new Thread(new RejectableRunnable() {
                 @Override
                 public void onFailure(Exception e) {
                     throw new ElasticsearchException("failure in background thread", e);
                 }
 
                 @Override
-                protected void doRun() throws Exception {
+                public void doRun() throws Exception {
                     barrier.await();
                     for (int i = 0; i < opsPerThread; i++) {
                         long seqNo = tracker.generateSeqNo();
@@ -225,14 +225,14 @@ public class LocalCheckpointTrackerTests extends ESTestCase {
         final CyclicBarrier barrier = new CyclicBarrier(threads.length);
         for (int t = 0; t < threads.length; t++) {
             final int threadId = t;
-            threads[t] = new Thread(new AbstractRunnable() {
+            threads[t] = new Thread(new RejectableRunnable() {
                 @Override
                 public void onFailure(Exception e) {
                     throw new ElasticsearchException("failure in background thread", e);
                 }
 
                 @Override
-                protected void doRun() throws Exception {
+                public void doRun() throws Exception {
                     barrier.await();
                     Integer[] ops = seqNoPerThread[threadId];
                     for (int seqNo : ops) {

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -102,9 +102,9 @@ import org.elasticsearch.common.lease.Releasable;
 import org.elasticsearch.common.lease.Releasables;
 import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
 import org.elasticsearch.common.util.concurrent.FutureUtils;
+import org.elasticsearch.common.util.concurrent.RejectableRunnable;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
@@ -2950,14 +2950,14 @@ public class IndexShardTests extends IndexShardTestCase {
         IndexShardTestCase.updateRoutingEntry(shard, relocationRouting);
         CyclicBarrier cyclicBarrier = new CyclicBarrier(3);
         AtomicReference<Exception> relocationException = new AtomicReference<>();
-        Thread relocationThread = new Thread(new AbstractRunnable() {
+        Thread relocationThread = new Thread(new RejectableRunnable() {
             @Override
             public void onFailure(Exception e) {
                 relocationException.set(e);
             }
 
             @Override
-            protected void doRun() throws Exception {
+            public void doRun() throws Exception {
                 cyclicBarrier.await();
                 shard.relocated(
                     relocationRouting.getTargetRelocatingShard().allocationId().getId(),
@@ -2966,14 +2966,14 @@ public class IndexShardTests extends IndexShardTestCase {
         });
         relocationThread.start();
         AtomicReference<Exception> cancellingException = new AtomicReference<>();
-        Thread cancellingThread = new Thread(new AbstractRunnable() {
+        Thread cancellingThread = new Thread(new RejectableRunnable() {
             @Override
             public void onFailure(Exception e) {
                 cancellingException.set(e);
             }
 
             @Override
-            protected void doRun() throws Exception {
+            public void doRun() throws Exception {
                 cyclicBarrier.await();
                 IndexShardTestCase.updateRoutingEntry(shard, originalRouting);
             }

--- a/server/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
+++ b/server/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
@@ -103,7 +103,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
-import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.common.util.concurrent.RejectableRunnable;
 import org.elasticsearch.common.util.concurrent.ReleasableLock;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.VersionType;
@@ -862,7 +862,7 @@ public class TranslogTests extends ESTestCase {
         for (int i = 0; i < writers.length; i++) {
             final String threadName = "writer_" + i;
             final int threadId = i;
-            writers[i] = new Thread(new AbstractRunnable() {
+            writers[i] = new Thread(new RejectableRunnable() {
                 @Override
                 public void doRun() throws BrokenBarrierException, InterruptedException, IOException {
                     barrier.await();
@@ -928,7 +928,7 @@ public class TranslogTests extends ESTestCase {
 
         for (int i = 0; i < readers.length; i++) {
             final String threadId = "reader_" + i;
-            readers[i] = new Thread(new AbstractRunnable() {
+            readers[i] = new Thread(new RejectableRunnable() {
                 Closeable retentionLock = null;
                 long committedLocalCheckpointAtView;
 
@@ -960,7 +960,7 @@ public class TranslogTests extends ESTestCase {
                 }
 
                 @Override
-                protected void doRun() throws Exception {
+                public void doRun() throws Exception {
                     barrier.await();
                     int iter = 0;
                     while (idGenerator.get() < maxOps) {

--- a/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryTest.java
+++ b/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryTest.java
@@ -97,7 +97,7 @@ public class BlobStoreRepositoryTest extends IntegTestCase {
         final int testBlobLen = randomIntBetween(1, 100);
         genericExec.execute(new ActionRunnable<>(future) {
             @Override
-            protected void doRun() throws Exception {
+            public void doRun() throws Exception {
                 final BlobStore blobStore = repo.blobStore();
                 blobStore.blobContainer(repo.basePath().add("foo"))
                     .writeBlob("nested-blob", new ByteArrayInputStream(randomByteArrayOfLength(testBlobLen)), testBlobLen, false);
@@ -122,7 +122,7 @@ public class BlobStoreRepositoryTest extends IntegTestCase {
         final BlobStoreRepository repository = getRepository();
         repository.threadPool().generic().execute(new ActionRunnable<>(future) {
             @Override
-            protected void doRun() throws Exception {
+            public void doRun() throws Exception {
                 final BlobStore blobStore = repository.blobStore();
                 future.onResponse(blobStore.blobContainer(path).listBlobsByPrefix(prefix));
             }
@@ -143,7 +143,7 @@ public class BlobStoreRepositoryTest extends IntegTestCase {
         final BlobStoreRepository repository = getRepository();
         repository.threadPool().generic().execute(new ActionRunnable<>(future) {
             @Override
-            protected void doRun() throws Exception {
+            public void doRun() throws Exception {
                 final BlobStore blobStore = repository.blobStore();
                 future.onResponse(blobStore.blobContainer(path).children().keySet());
             }

--- a/server/src/testFixtures/java/org/elasticsearch/common/lucene/store/ESIndexInputTestCase.java
+++ b/server/src/testFixtures/java/org/elasticsearch/common/lucene/store/ESIndexInputTestCase.java
@@ -29,10 +29,10 @@ import java.util.concurrent.CountDownLatch;
 import org.apache.lucene.store.IndexInput;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainFuture;
-import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.EsThreadPoolExecutor;
 import org.elasticsearch.common.util.concurrent.FutureUtils;
+import org.elasticsearch.common.util.concurrent.RejectableRunnable;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -121,14 +121,14 @@ public class ESIndexInputTestCase extends ESTestCase {
                     final int mainThreadReadEnd = randomIntBetween(readPos + 1, length);
 
                     for (int i = 0; i < cloneCount; i++) {
-                        executor.execute(new AbstractRunnable() {
+                        executor.execute(new RejectableRunnable() {
                             @Override
                             public void onFailure(Exception e) {
                                 throw new AssertionError(e);
                             }
 
                             @Override
-                            protected void doRun() throws Exception {
+                            public void doRun() throws Exception {
                                 final IndexInput clone;
                                 final int readStart = between(0, length);
                                 final int readEnd = between(readStart, length);

--- a/server/src/testFixtures/java/org/elasticsearch/test/transport/MockTransportService.java
+++ b/server/src/testFixtures/java/org/elasticsearch/test/transport/MockTransportService.java
@@ -49,7 +49,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.util.PageCacheRecycler;
-import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.common.util.concurrent.RejectableRunnable;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.plugins.Plugin;
@@ -401,7 +401,7 @@ public final class MockTransportService extends TransportService {
                 request.writeTo(bStream);
                 final TransportRequest clonedRequest = reg.newRequest(bStream.bytes().streamInput());
 
-                Runnable runnable = new AbstractRunnable() {
+                Runnable runnable = new RejectableRunnable() {
                     AtomicBoolean requestSent = new AtomicBoolean();
 
                     @Override
@@ -410,7 +410,7 @@ public final class MockTransportService extends TransportService {
                     }
 
                     @Override
-                    protected void doRun() throws IOException {
+                    public void doRun() throws IOException {
                         if (requestSent.compareAndSet(false, true)) {
                             connection.sendRequest(requestId, action, clonedRequest, options);
                         }


### PR DESCRIPTION
See commits & https://github.com/crate/crate/pull/17678 for explanation

Had to change `AbstractRunnable` to an interface (now `RejectableRunnable`) in order to have an implementation that can be both `Prioritized` and `Rejectable`. Otherwise the rejected execution handling logic would've gone missing when wrapping a `Runnable`.

---

Running 

```bash
systemd-run --user -d --pty \
    -p "IOReadBandwidthMax=/dev/nvme1n1/nvme1n1p3 20M" \
    -p CPUQuota=200% \
    cr8 run-crate <version> --keep-data -e CRATE_HEAP_SIZE=1G -e CRATE_JAVA_OPTS=-XX:MaxDirectMemorySize=1024M -s path.data=<path>
```

And in two terminals:

```bash
cr8 run-spec specs/overload_read.py localhost:4200 --action queries
```


And in another:


```bash
cr8 timeit -w 0 -s "select * from sys.shards" --duration 120 --hosts localhost:4200 --output-fmt json > results.json
```

Results in the following diff for the `select * from sys.shards` queries:

```
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |   810902.800 ±    0.000 | 810902.800 | 810902.800 | 810902.800 | 810902.800 |
|   V2    |     7583.212 ± 5961.302 |    701.776 |   5000.403 |  12301.423 |  16604.844 |
├---------┴-------------------------┴------------┴------------┴------------┴------------┘
|               - 196.29%                           - 197.55%
```
