### PR TITLE
Verify analyzer specified in MATCH query is same as the analyzer used to index

### DIFF
--- a/docs/appendices/release-notes/5.10.4.rst
+++ b/docs/appendices/release-notes/5.10.4.rst
@@ -68,3 +68,7 @@ Fixes
   a complete partitioned table to not reset the setting on all partitions, but
   only on the table itself, so the reset value of the setting would only have
   taken effect for new partitions.
+
+- Fixed an issue that caused a ``MATCH`` query to silently override the
+  specified analyzer with the analyzer that was used to index the corresponding
+  column. Since this is not allowed, an error is now thrown.

--- a/docs/general/dql/fulltext.rst
+++ b/docs/general/dql/fulltext.rst
@@ -64,11 +64,10 @@ relevant the row::
     SELECT 2 rows in set (... sec)
 
 The MATCH predicate in its simplest form performs a fulltext search against a
-single column. It takes the ``query_term`` and, if no ``analyzer`` was
-provided, analyzes the term with the analyzer configured on
-``column_or_idx_ident``. The resulting tokens are then matched against the
-index at ``column_or_idx_ident`` and if one of them matches, MATCH returns
-``TRUE``.
+single column. It takes the ``query_term`` and analyzes the term with the
+analyzer configured on ``column_or_idx_ident``. The resulting tokens are then
+matched against the index at ``column_or_idx_ident`` and if one of them
+matches, MATCH returns ``TRUE``.
 
 The MATCH predicate can be also used to perform a fulltext search on multiple
 columns with a single ``query_term`` and to add weight to specific columns it's
@@ -111,11 +110,9 @@ Arguments
   The default boost is 1.
 
 :query_term:
-  This string is analyzed (using the explicitly given ``analyzer`` or
-  the analyzer of the columns to perform the search on) and the
-  resulting tokens are compared to the index. The tokens used for search
-  are combined using the boolean ``OR`` operator unless stated otherwise
-  using the ``operator`` option.
+  This string is analyzed and the resulting tokens are compared to the index.
+  The tokens used for search are combined using the boolean ``OR`` operator
+  unless stated otherwise using the ``operator`` option.
 
 :match_type:
   Optional. Defaults to ``best_fields`` for fulltext indices. For
@@ -197,7 +194,9 @@ certain match type works. Not all options are applicable to all match types.
 See the options below for details.
 
 :analyzer:
-  The analyzer used to convert the ``query_term`` into tokens.
+  The analyzer used to convert the ``query_term`` into tokens. Currently the
+  only acceptable analyzer is the one that is used to index the
+  ``column_or_idx_ident``.
 
 :boost:
   This numeric value is multiplied with the resulting :ref:`_score

--- a/plugins/es-analysis-common/src/test/java/io/crate/analysis/common/FulltextITest.java
+++ b/plugins/es-analysis-common/src/test/java/io/crate/analysis/common/FulltextITest.java
@@ -53,7 +53,7 @@ public class FulltextITest extends IntegTestCase {
         execute("refresh table locations");
 
         execute("select name, _score from locations where match((kind, name_description_ft), 'galaxy') " +
-                "using best_fields with (analyzer='english') order by _score desc");
+                "using best_fields order by _score desc");
         assertThat(response).hasRows(
             "End of the Galaxy| 0.895417",
             "Altair| 0.49754602",
@@ -182,7 +182,7 @@ public class FulltextITest extends IntegTestCase {
         this.setup.setUpLocationsWithFTIndex();
         execute("refresh table locations");
         execute("select name, description, kind, _score from locations " +
-                "where match((kind, name_description_ft 0.5), 'Planet earth') using most_fields with (analyzer='english') order by _score desc");
+                "where match((kind, name_description_ft 0.5), 'Planet earth') using most_fields order by _score desc");
         assertThat(response).hasRows(
             "Alpha Centauri| 4.1 light-years northwest of earth| Star System| 0.57336456",
             "Bartledan| An Earthlike planet on which Arthur Dent lived for a short time, Bartledan is inhabited by Bartledanians, a race that appears human but only physically.| Planet| 0.32080865",

--- a/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/server/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -944,4 +944,14 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
                 );
         }
     }
+
+    @Test
+    public void test_cannot_query_index_ref_with_analyzer_that_is_not_used_to_index_with() {
+        assertThatThrownBy(() -> convert("match(name, 'foo') USING phrase WITH (analyzer='dummy')"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Column 'name' was indexed with the 'keyword' analyzer, searching with a different analyzer, 'dummy' is not supported");
+        assertThatThrownBy(() -> convert("match(tags, 'foo') USING phrase WITH (analyzer='dummy')"))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Column 'tags' was indexed with the 'standard' analyzer, searching with a different analyzer, 'dummy' is not supported");
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Fixes https://github.com/crate/crate/issues/17681

To summarize the current behaviour:
```
cr> create table x (a text INDEX using fulltext with (analyzer = 'english'), b text INDEX using fulltext with (analyzer = 'german'));
CREATE OK, 1 row affected (1.736 sec)
cr> insert into x values ('Katzen', 'Katzen');
INSERT OK, 1 row affected (0.124 sec)

cr> select * from x where MATCH(b, 'Katze') USING phrase WITH (analyzer='english');
+--------+--------+
| a      | b      |
+--------+--------+
| Katzen | Katzen |  -- german analyzer used instead of english analyzer
+--------+--------+
SELECT 1 row in set (0.005 sec)

cr> CREATE ANALYZER foo ( TOKENIZER "letter");
CREATE OK, 1 row affected (0.097 sec)

cr> select * from x where MATCH(b, 'Katze') USING phrase WITH (analyzer='foo'); -- could not find the analyzer `foo` because it was not use anywhere in creating the table x
SQLParseException[No analyzer found for [foo]]
```
and for both cases, exceptions will be thrown saying that the specified analyzers in the match queries are different from the ones used to index.

## Checklist

 - [x] Added an entry in the latest `docs/appendices/release-notes/<x.y.0>.rst` for user facing changes
 - [x] Updated documentation & `sql_features` table for user facing changes
 - [x] Touched code is covered by tests
 - [x] This does not contain breaking changes, or if it does:
    - It is released within a major release
    - It is recorded in the latest `docs/appendices/release-notes/<x.y.0>.rst`
    - It was marked as deprecated in an earlier release if possible
    - You've thought about the consequences and other components are adapted
      (E.g. AdminUI)
