### PR TITLE
Change GCDanglingArtifactsPlan to work based on RelationMetadata

### DIFF
--- a/server/src/main/java/io/crate/execution/ddl/tables/GCDanglingArtifactsRequest.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/GCDanglingArtifactsRequest.java
@@ -19,29 +19,22 @@
  * software solely pursuant to the terms of the relevant commercial agreement.
  */
 
-package io.crate.metadata;
+package io.crate.execution.ddl.tables;
 
-import org.jetbrains.annotations.Nullable;
+import java.io.IOException;
 
-/**
- * Parts of an encoded index: Schema, table and partitionIdent.
- * Use {@link IndexName#decode(String)} to create instances from an indexName.
- */
-public record IndexParts(String schema, String table, @Nullable String partitionIdent) {
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
+import org.elasticsearch.common.io.stream.StreamInput;
 
-    public String partitionIdent() {
-        return isPartitioned() ? partitionIdent : "";
+public class GCDanglingArtifactsRequest extends AcknowledgedRequest<GCDanglingArtifactsRequest> {
+
+    public static final GCDanglingArtifactsRequest INSTANCE = new GCDanglingArtifactsRequest();
+
+    private GCDanglingArtifactsRequest() {
+        super();
     }
 
-    public boolean isPartitioned() {
-        return partitionIdent != null;
-    }
-
-    public RelationName toRelationName() {
-        return new RelationName(schema, table);
-    }
-
-    public String toFullyQualifiedName() {
-        return schema + "." + table;
+    public GCDanglingArtifactsRequest(StreamInput in) throws IOException {
+        super(in);
     }
 }

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportGCDanglingArtifactsAction.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportGCDanglingArtifactsAction.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.ddl.tables;
+
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateTaskExecutor;
+import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.cluster.metadata.MetadataDeleteIndexService;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+import io.crate.execution.ddl.AbstractDDLTransportAction;
+import io.crate.metadata.cluster.GCDanglingArtifactsClusterStateTaskExecutor;
+
+@Singleton
+public class TransportGCDanglingArtifactsAction extends AbstractDDLTransportAction<GCDanglingArtifactsRequest, AcknowledgedResponse> {
+
+    public static final Action ACTION = new Action();
+
+    public static class Action extends ActionType<AcknowledgedResponse> {
+        public static final String NAME = "internal:crate:admin/gc";
+
+        private Action() {
+            super(NAME);
+        }
+    }
+
+    private final GCDanglingArtifactsClusterStateTaskExecutor executor;
+
+    @Inject
+    public TransportGCDanglingArtifactsAction(TransportService transportService,
+                                              ClusterService clusterService,
+                                              ThreadPool threadPool,
+                                              MetadataDeleteIndexService deleteIndexService) {
+        super(
+            ACTION.name(),
+            transportService,
+            clusterService,
+            threadPool,
+            GCDanglingArtifactsRequest::new,
+            AcknowledgedResponse::new,
+            AcknowledgedResponse::new,
+            "gc"
+        );
+        executor = new GCDanglingArtifactsClusterStateTaskExecutor(deleteIndexService);
+    }
+
+    @Override
+    public ClusterStateTaskExecutor<GCDanglingArtifactsRequest> clusterStateTaskExecutor(GCDanglingArtifactsRequest request) {
+        return executor;
+    }
+
+    @Override
+    protected ClusterBlockException checkBlock(GCDanglingArtifactsRequest request, ClusterState state) {
+        return null;
+    }
+}

--- a/server/src/main/java/io/crate/metadata/cluster/GCDanglingArtifactsClusterStateTaskExecutor.java
+++ b/server/src/main/java/io/crate/metadata/cluster/GCDanglingArtifactsClusterStateTaskExecutor.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.metadata.cluster;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.MetadataDeleteIndexService;
+import org.elasticsearch.cluster.metadata.RelationMetadata;
+import org.elasticsearch.index.Index;
+
+import com.carrotsearch.hppc.cursors.ObjectCursor;
+
+import io.crate.execution.ddl.tables.GCDanglingArtifactsRequest;
+
+public class GCDanglingArtifactsClusterStateTaskExecutor extends DDLClusterStateTaskExecutor<GCDanglingArtifactsRequest> {
+
+    private final MetadataDeleteIndexService deleteIndexService;
+
+    public GCDanglingArtifactsClusterStateTaskExecutor(MetadataDeleteIndexService deleteIndexService) {
+        this.deleteIndexService = deleteIndexService;
+    }
+
+    @Override
+    protected ClusterState execute(ClusterState currentState, GCDanglingArtifactsRequest request) throws Exception {
+        Metadata metadata = currentState.metadata();
+
+        Set<Index> danglingIndicesToDelete = new HashSet<>();
+        Set<Index> allTableIndices = new HashSet<>();
+        for (RelationMetadata rm : metadata.relations(RelationMetadata.class)) {
+            allTableIndices.addAll(metadata.getIndices(
+                rm.name(),
+                List.of(),
+                false,
+                IndexMetadata::getIndex)
+            );
+        }
+        for (ObjectCursor<IndexMetadata> indexMetadata : metadata.indices().values()) {
+            Index index = indexMetadata.value.getIndex();
+            if (allTableIndices.contains(index) == false) {
+                danglingIndicesToDelete.add(index);
+            }
+        }
+
+        if (danglingIndicesToDelete.isEmpty()) {
+            return currentState;
+        }
+        return deleteIndexService.deleteIndices(currentState, danglingIndicesToDelete);
+    }
+}

--- a/server/src/main/java/io/crate/planner/DependencyCarrier.java
+++ b/server/src/main/java/io/crate/planner/DependencyCarrier.java
@@ -39,6 +39,7 @@ import io.crate.execution.ddl.RepositoryService;
 import io.crate.execution.ddl.TransportSwapRelationsAction;
 import io.crate.execution.ddl.tables.AlterTableClient;
 import io.crate.execution.ddl.tables.TransportDropTableAction;
+import io.crate.execution.ddl.tables.TransportGCDanglingArtifactsAction;
 import io.crate.execution.ddl.views.TransportCreateViewAction;
 import io.crate.execution.ddl.views.TransportDropViewAction;
 import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
@@ -89,7 +90,8 @@ public class DependencyCarrier {
     private final TransportCreateSubscriptionAction createSubscriptionAction;
     private final LogicalReplicationService logicalReplicationService;
     private final ElasticsearchClient client;
-    private CircuitBreakerService circuitBreakerService;
+    private final CircuitBreakerService circuitBreakerService;
+    private final TransportGCDanglingArtifactsAction transportGCDanglingArtifactsAction;
 
     @Inject
     public DependencyCarrier(Settings settings,
@@ -116,7 +118,8 @@ public class DependencyCarrier {
                              TransportDropPublicationAction dropPublicationAction,
                              TransportAlterPublicationAction alterPublicationAction,
                              TransportCreateSubscriptionAction createSubscriptionAction,
-                             LogicalReplicationService logicalReplicationService) {
+                             LogicalReplicationService logicalReplicationService,
+                             TransportGCDanglingArtifactsAction transportGCDanglingArtifactsAction) {
         this.settings = settings;
         this.client = node.client();
         this.phasesTaskFactory = phasesTaskFactory;
@@ -144,6 +147,7 @@ public class DependencyCarrier {
         this.alterPublicationAction = alterPublicationAction;
         this.createSubscriptionAction = createSubscriptionAction;
         this.logicalReplicationService = logicalReplicationService;
+        this.transportGCDanglingArtifactsAction = transportGCDanglingArtifactsAction;
     }
 
     public Schemas schemas() {
@@ -260,5 +264,9 @@ public class DependencyCarrier {
 
     public CircuitBreaker circuitBreaker(String name) {
         return circuitBreakerService.getBreaker(name);
+    }
+
+    public TransportGCDanglingArtifactsAction transportGCDanglingArtifactsAction() {
+        return transportGCDanglingArtifactsAction;
     }
 }

--- a/server/src/main/java/io/crate/planner/GCDanglingArtifactsPlan.java
+++ b/server/src/main/java/io/crate/planner/GCDanglingArtifactsPlan.java
@@ -21,16 +21,13 @@
 
 package io.crate.planner;
 
-import org.elasticsearch.action.admin.indices.delete.DeleteIndexAction;
-import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
-
 import io.crate.data.Row;
 import io.crate.data.RowConsumer;
+import io.crate.execution.ddl.tables.GCDanglingArtifactsRequest;
 import io.crate.execution.support.OneRowActionListener;
-import io.crate.metadata.IndexParts;
 import io.crate.planner.operators.SubQueryResults;
 
-public final class GCDangingArtifactsPlan implements Plan {
+public final class GCDanglingArtifactsPlan implements Plan {
 
     @Override
     public StatementType type() {
@@ -44,7 +41,8 @@ public final class GCDangingArtifactsPlan implements Plan {
                               Row params,
                               SubQueryResults subQueryResults) {
         var listener = OneRowActionListener.oneIfAcknowledged(consumer);
-        DeleteIndexRequest deleteRequest = new DeleteIndexRequest(IndexParts.DANGLING_INDICES_PREFIX_PATTERNS.toArray(new String[0]));
-        dependencies.client().execute(DeleteIndexAction.INSTANCE, deleteRequest).whenComplete(listener);
+        dependencies.transportGCDanglingArtifactsAction()
+            .execute(GCDanglingArtifactsRequest.INSTANCE)
+            .whenComplete(listener);
     }
 }

--- a/server/src/main/java/io/crate/planner/Planner.java
+++ b/server/src/main/java/io/crate/planner/Planner.java
@@ -300,7 +300,7 @@ public class Planner extends AnalyzedStatementVisitor<PlannerContext, Plan> {
 
     @Override
     public Plan visitGCDanglingArtifacts(AnalyzedGCDanglingArtifacts gcDanglingArtifacts, PlannerContext context) {
-        return new GCDangingArtifactsPlan();
+        return new GCDanglingArtifactsPlan();
     }
 
     @Override

--- a/server/src/main/java/io/crate/replication/logical/metadata/Publication.java
+++ b/server/src/main/java/io/crate/replication/logical/metadata/Publication.java
@@ -136,7 +136,7 @@ public class Publication implements Writeable {
 
         if (isForAllTables()) {
             Metadata metadata = state.metadata();
-            for (var table : metadata.tableRelations()) {
+            for (var table : metadata.relations(org.elasticsearch.cluster.metadata.RelationMetadata.Table.class)) {
                 relations.add(table.name());
             }
 

--- a/server/src/main/java/io/crate/replication/logical/repository/LogicalReplicationRepository.java
+++ b/server/src/main/java/io/crate/replication/logical/repository/LogicalReplicationRepository.java
@@ -172,7 +172,7 @@ public class LogicalReplicationRepository extends AbstractLifecycleComponent imp
 
                 // We update all tables with the subscription setting, not only the partitioned ones,
                 // as in getSnapshotIndexMetadata() we don't have access to the whole `Metadata` object.
-                for (RelationMetadata.Table table : remoteClusterState.metadata().tableRelations()) {
+                for (var table : remoteClusterState.metadata().relations(RelationMetadata.Table.class)) {
                     metadataBuilder.setTable(
                         table.name(),
                         table.columns(),

--- a/server/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -95,6 +95,7 @@ import io.crate.execution.ddl.tables.RenameColumnAction;
 import io.crate.execution.ddl.tables.TransportCreateBlobTableAction;
 import io.crate.execution.ddl.tables.TransportCreateTableAction;
 import io.crate.execution.ddl.tables.TransportDropTableAction;
+import io.crate.execution.ddl.tables.TransportGCDanglingArtifactsAction;
 import io.crate.execution.ddl.tables.TransportRenameColumnAction;
 import io.crate.execution.dml.delete.ShardDeleteAction;
 import io.crate.execution.dml.delete.TransportShardDeleteAction;
@@ -238,6 +239,7 @@ public class ActionModule extends AbstractModule {
         actions.register(TransportDropUserMapping.ACTION, TransportDropUserMapping.class);
 
         actions.register(TransportDropTableAction.ACTION, TransportDropTableAction.class);
+        actions.register(TransportGCDanglingArtifactsAction.ACTION, TransportGCDanglingArtifactsAction.class);
 
         actions.register(TransportPrivilegesAction.ACTION, TransportPrivilegesAction.class);
         actions.register(TransportCreateRoleAction.ACTION, TransportCreateRoleAction.class);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -1293,13 +1293,13 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata> {
         }
     }
 
-    public List<RelationMetadata.Table> tableRelations() {
-        ArrayList<RelationMetadata.Table> relations = new ArrayList<>();
+    public <T extends RelationMetadata> List<T> relations(Class<T> clazz) {
+        ArrayList<T> relations = new ArrayList<>();
         for (ObjectCursor<SchemaMetadata> cursor : schemas.values()) {
             for (ObjectCursor<RelationMetadata> relationCursor : cursor.value.relations().values()) {
                 RelationMetadata relationMetadata = relationCursor.value;
-                if (relationMetadata instanceof RelationMetadata.Table table) {
-                    relations.add(table);
+                if (clazz.isInstance(relationMetadata)) {
+                    relations.add(clazz.cast(relationMetadata));
                 }
             }
         }

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -263,7 +263,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
                 List<RelationMetadata.Table> relationsMetadata;
                 if (request.relationNames().isEmpty() && request.partitionNames().isEmpty()) {
                     // Resolve ALL tables
-                    relationsMetadata = currentState.metadata().tableRelations();
+                    relationsMetadata = currentState.metadata().relations(RelationMetadata.Table.class);
                 } else {
                     relationsMetadata = request.relationNames().stream()
                         .map(r -> currentState.metadata().getRelation(r))

--- a/server/src/test/java/io/crate/integrationtests/GCDanglingArtifactsIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/GCDanglingArtifactsIntegrationTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.integrationtests;
+
+import static io.crate.testing.Asserts.assertThat;
+import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_INDEX_UUID;
+import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_INDEX_VERSION_CREATED;
+import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
+import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_SHARDS;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateUpdateTask;
+import org.elasticsearch.cluster.ack.ClusterStateUpdateResponse;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.IntegTestCase;
+import org.junit.Test;
+
+import io.crate.action.FutureActionListener;
+
+public class GCDanglingArtifactsIntegrationTest extends IntegTestCase {
+
+    @Test
+    public void test_remove_dangling_indices() throws Exception {
+        List<String> danglingIndexNames = List.of(
+            "schema..partitioned.partitioned.ident",
+            "schema.ttemp",
+            ".blob_blobstemp");
+
+        execute("CREATE TABLE schema.t(a int)");
+        execute("INSERT INTO schema.t VALUES(10)");
+        execute("CREATE TABLE schema.partitioned(a int, p int) PARTITIONED BY(p)");
+        execute("INSERT INTO schema.partitioned(a, p) VALUES(11, 1)");
+        execute("INSERT INTO schema.partitioned(a, p) VALUES(22, 2)");
+        execute("REFRESH TABLE schema.t, schema.partitioned");
+        execute("CREATE BLOB TABLE blobs");
+
+        FutureActionListener<ClusterStateUpdateResponse> future = new FutureActionListener<>();
+        cluster().getCurrentMasterNodeInstance(ClusterService.class)
+            .submitStateUpdateTask("test-create-dangling-index", new ClusterStateUpdateTask(Priority.HIGH) {
+                @Override
+                public ClusterState execute(ClusterState currentState) {
+                    Metadata.Builder mdBuilder = Metadata.builder(currentState.metadata());
+                    for (String danglingIndexName : danglingIndexNames) {
+                        IndexMetadata indexMetadata = IndexMetadata.builder(danglingIndexName)
+                            .settings(Settings.builder()
+                                .put(SETTING_INDEX_UUID, UUIDs.randomBase64UUID())
+                                .put(SETTING_NUMBER_OF_SHARDS, 2)
+                                .put(SETTING_NUMBER_OF_REPLICAS, 0)
+                                .put(SETTING_INDEX_VERSION_CREATED.getKey(), Version.CURRENT)
+                                .build())
+                            .build();
+                        mdBuilder.put(indexMetadata, false);
+                    }
+                    return ClusterState.builder(currentState).metadata(mdBuilder).build();
+                }
+
+                @Override
+                public void onFailure(String source, Exception e) {
+                    future.onFailure(e);
+                }
+
+                @Override
+                public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+                    future.onResponse(null);
+                }
+            });
+        future.get(10, TimeUnit.SECONDS);
+
+        execute("alter cluster gc dangling artifacts");
+        assertBusy(() -> {
+            for (String danglingIndexName : danglingIndexNames) {
+                assertThat(cluster().clusterService().state().metadata().index(danglingIndexName)).isNull();
+            }
+        });
+        execute("SELECT * FROM schema.t");
+        assertThat(response).hasRows("10");
+        execute("SELECT * FROM schema.partitioned ORDER BY a");
+        assertThat(response).hasRows("11| 1", "22| 2");
+    }
+}


### PR DESCRIPTION
Instead of searching for temp indices with a specific prefix, determine which indices are not part of tables (simple/parted/blob) and remove them.

Also renamed the plan class, typo - missing `l`.
