### PR TITLE
Add missing 5.9.13 change entries

### DIFF
--- a/docs/appendices/release-notes/5.9.13.rst
+++ b/docs/appendices/release-notes/5.9.13.rst
@@ -47,6 +47,14 @@ See the :ref:`version_5.9.0` release notes for a full list of changes in the
 Fixes
 =====
 
+- Tuned the sizing of internal intermediate result requests for statements like
+  JOINS to reduce memory pressure on clusters with more than one node.
+
+- Fixed an issue that could cause ``INSERT INTO`` statements which dynamically
+  create thousands of columns to overload the cluster state update process
+  before running into the ``mapping.total_fields.limit`` limit, causing other
+  statements trying to update the cluster state to timeout.
+
 - Fixed NPE when querying the :ref:`sys.allocations <sys-allocations>` table
   while no master node has been discovered. A proper exception is now thrown
   instead of an NPE.


### PR DESCRIPTION
No need to backport, change entries ported to 5.9 with their changes