### PR TITLE
Remove GCDanglingArtifactsAction from DependencyCarrier

### DIFF
--- a/server/src/main/java/io/crate/planner/DependencyCarrier.java
+++ b/server/src/main/java/io/crate/planner/DependencyCarrier.java
@@ -39,7 +39,6 @@ import io.crate.execution.ddl.RepositoryService;
 import io.crate.execution.ddl.TransportSwapRelationsAction;
 import io.crate.execution.ddl.tables.AlterTableClient;
 import io.crate.execution.ddl.tables.TransportDropTableAction;
-import io.crate.execution.ddl.tables.TransportGCDanglingArtifactsAction;
 import io.crate.execution.ddl.views.TransportCreateViewAction;
 import io.crate.execution.ddl.views.TransportDropViewAction;
 import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
@@ -91,7 +90,6 @@ public class DependencyCarrier {
     private final LogicalReplicationService logicalReplicationService;
     private final ElasticsearchClient client;
     private final CircuitBreakerService circuitBreakerService;
-    private final TransportGCDanglingArtifactsAction transportGCDanglingArtifactsAction;
 
     @Inject
     public DependencyCarrier(Settings settings,
@@ -118,8 +116,7 @@ public class DependencyCarrier {
                              TransportDropPublicationAction dropPublicationAction,
                              TransportAlterPublicationAction alterPublicationAction,
                              TransportCreateSubscriptionAction createSubscriptionAction,
-                             LogicalReplicationService logicalReplicationService,
-                             TransportGCDanglingArtifactsAction transportGCDanglingArtifactsAction) {
+                             LogicalReplicationService logicalReplicationService) {
         this.settings = settings;
         this.client = node.client();
         this.phasesTaskFactory = phasesTaskFactory;
@@ -147,7 +144,6 @@ public class DependencyCarrier {
         this.alterPublicationAction = alterPublicationAction;
         this.createSubscriptionAction = createSubscriptionAction;
         this.logicalReplicationService = logicalReplicationService;
-        this.transportGCDanglingArtifactsAction = transportGCDanglingArtifactsAction;
     }
 
     public Schemas schemas() {
@@ -264,9 +260,5 @@ public class DependencyCarrier {
 
     public CircuitBreaker circuitBreaker(String name) {
         return circuitBreakerService.getBreaker(name);
-    }
-
-    public TransportGCDanglingArtifactsAction transportGCDanglingArtifactsAction() {
-        return transportGCDanglingArtifactsAction;
     }
 }

--- a/server/src/main/java/io/crate/planner/GCDanglingArtifactsPlan.java
+++ b/server/src/main/java/io/crate/planner/GCDanglingArtifactsPlan.java
@@ -24,6 +24,7 @@ package io.crate.planner;
 import io.crate.data.Row;
 import io.crate.data.RowConsumer;
 import io.crate.execution.ddl.tables.GCDanglingArtifactsRequest;
+import io.crate.execution.ddl.tables.TransportGCDanglingArtifactsAction;
 import io.crate.execution.support.OneRowActionListener;
 import io.crate.planner.operators.SubQueryResults;
 
@@ -41,8 +42,7 @@ public final class GCDanglingArtifactsPlan implements Plan {
                               Row params,
                               SubQueryResults subQueryResults) {
         var listener = OneRowActionListener.oneIfAcknowledged(consumer);
-        dependencies.transportGCDanglingArtifactsAction()
-            .execute(GCDanglingArtifactsRequest.INSTANCE)
+        dependencies.client().execute(TransportGCDanglingArtifactsAction.ACTION, GCDanglingArtifactsRequest.INSTANCE)
             .whenComplete(listener);
     }
 }

--- a/server/src/test/java/io/crate/integrationtests/GCDanglingArtifactsIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/GCDanglingArtifactsIntegrationTest.java
@@ -92,7 +92,7 @@ public class GCDanglingArtifactsIntegrationTest extends IntegTestCase {
                     future.onResponse(null);
                 }
             });
-        future.get(10, TimeUnit.SECONDS);
+        assertThat(future).succeedsWithin(10, TimeUnit.SECONDS);
 
         execute("alter cluster gc dangling artifacts");
         assertBusy(() -> {


### PR DESCRIPTION
Use the `client().execute()` instead.

Follows: #17705
