### PR TITLE
Fix flaky testAbortedRestoreAlsoAbortFileRestores

### DIFF
--- a/server/src/test/java/org/elasticsearch/snapshots/AbortedRestoreIT.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/AbortedRestoreIT.java
@@ -83,7 +83,9 @@ public class AbortedRestoreIT extends AbstractSnapshotIntegTestCase {
             var indicesService = cluster().getInstance(IndicesService.class, dataNode);
             var indexService = indicesService.indexService(index);
             assertThat(indexService).isNotNull();
-            var shardA = indexService.getShard(0);
+            var shardA = indexService.getShardOrNull(0);
+            assertThat(shardA).isNotNull();
+            assertThat(shardA.recoveryState()).isNotNull();
             assertThat(shardA.recoveryState().getRecoverySource().getType()).isEqualTo(RecoverySource.Type.SNAPSHOT);
             assertThat(shardA.recoveryState().getStage()).isEqualTo(RecoveryState.Stage.INDEX);
         });


### PR DESCRIPTION
Use `getShardOrNull` instead of `getShard` as the latter throws a `ShardNotFoundException` and exits the `assertBusy` loop, e.g.:
```
[tbl/0RUT_IjOSIu9tObRza3L6g][[tbl][0]] org.elasticsearch.index.shard.ShardNotFoundException: no such shard
	at __randomizedtesting.SeedInfo.seed([AD2E28174D9F277D:32C40C47F08390C]:0)
	at org.elasticsearch.index.IndexService.getShard(IndexService.java:229)
	at org.elasticsearch.snapshots.AbortedRestoreIT.lambda$testAbortedRestoreAlsoAbortFileRestores$0(AbortedRestoreIT.java:86)
	at org.elasticsearch.test.ESTestCase.assertBusy(ESTestCase.java:697)
	at org.elasticsearch.test.ESTestCase.assertBusy(ESTestCase.java:683)
	at org.elasticsearch.snapshots.AbortedRestoreIT.testAbortedRestoreAlsoAbortFileRestores(AbortedRestoreIT.java:78)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at com.carrotsearch.randomizedtesting.RandomizedRunner.invoke(RandomizedRunner.java:1763)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$8.evaluate(RandomizedRunner.java:946)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$9.evaluate(RandomizedRunner.java:982)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$10.evaluate(RandomizedRunner.java:996)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.lang.Thread.run(Thread.java:1575)
```
