### PR TITLE
Use List<PartitionNames> instead of List<List<Values>>

### DIFF
--- a/server/src/main/java/io/crate/execution/ddl/tables/DropPartitionsRequest.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/DropPartitionsRequest.java
@@ -29,33 +29,34 @@ import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
+import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
 
 public class DropPartitionsRequest extends AcknowledgedRequest<DropPartitionsRequest> {
 
     private final RelationName relationName;
-    private final List<List<String>> partitionValues;
+    private final List<PartitionName> partitions;
 
-    public DropPartitionsRequest(RelationName relationName, List<List<String>> partitionValues) {
+    public DropPartitionsRequest(RelationName relationName, List<PartitionName> partitions) {
         this.relationName = relationName;
-        this.partitionValues = partitionValues;
+        this.partitions = partitions;
     }
 
     public RelationName relationName() {
         return relationName;
     }
 
-    public List<List<String>> partitionValues() {
-        return partitionValues;
+    public List<PartitionName> partitions() {
+        return partitions;
     }
 
     public DropPartitionsRequest(StreamInput in) throws IOException {
         super(in);
         relationName = new RelationName(in);
         int size = in.readVInt();
-        partitionValues = new ArrayList<>(size);
+        partitions = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {
-            partitionValues.add(in.readStringList());
+            partitions.add(new PartitionName(relationName, in.readStringList()));
         }
     }
 
@@ -63,9 +64,9 @@ public class DropPartitionsRequest extends AcknowledgedRequest<DropPartitionsReq
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         relationName.writeTo(out);
-        out.writeVInt(partitionValues.size());
-        for (List<String> values : partitionValues) {
-            out.writeStringCollection(values);
+        out.writeVInt(partitions.size());
+        for (PartitionName partition : partitions) {
+            out.writeStringCollection(partition.values());
         }
     }
 }

--- a/server/src/main/java/io/crate/execution/ddl/tables/TransportDropPartitionsAction.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/TransportDropPartitionsAction.java
@@ -42,6 +42,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
 import io.crate.execution.ddl.AbstractDDLTransportAction;
+import io.crate.metadata.PartitionName;
 import io.crate.metadata.cluster.DDLClusterStateTaskExecutor;
 
 @Singleton
@@ -92,7 +93,7 @@ public class TransportDropPartitionsAction extends AbstractDDLTransportAction<Dr
                                                 DropPartitionsRequest request,
                                                 Function<IndexMetadata, T> mapFunction) {
         Collection<T> indices;
-        if (request.partitionValues().isEmpty()) {
+        if (request.partitions().isEmpty()) {
             indices = currentState.metadata().getIndices(
                 request.relationName(),
                 List.of(),
@@ -100,10 +101,10 @@ public class TransportDropPartitionsAction extends AbstractDDLTransportAction<Dr
                 mapFunction);
         } else {
             indices = new HashSet<>();
-            for (List<String> values : request.partitionValues()) {
+            for (PartitionName partition : request.partitions()) {
                 indices.addAll(currentState.metadata().getIndices(
                     request.relationName(),
-                    values,
+                    partition.values(),
                     false,
                     mapFunction)
                 );

--- a/server/src/main/java/io/crate/planner/statement/DeletePlanner.java
+++ b/server/src/main/java/io/crate/planner/statement/DeletePlanner.java
@@ -143,10 +143,10 @@ public final class DeletePlanner {
                 plannerContext.clusterState().metadata());
             if (!where.partitions().isEmpty()
                 && (!where.hasQuery() || Literal.BOOLEAN_TRUE.equals(where.query()))) {
-                List<List<String>> partitionValues = new ArrayList<>(where.partitions().size());
+                List<PartitionName> partitionValues = new ArrayList<>(where.partitions().size());
                 for (String partition : where.partitions()) {
-                    PartitionName partitionName = new PartitionName(table.relationName(), IndexName.decode(partition).partitionIdent());
-                    partitionValues.add(partitionName.values());
+                    partitionValues.add(new PartitionName(
+                        table.relationName(), IndexName.decode(partition).partitionIdent()));
                 }
                 dependencies.client().execute(
                     TransportDropPartitionsAction.ACTION,

--- a/server/src/test/java/io/crate/planner/node/ddl/DeletePartitionsTest.java
+++ b/server/src/test/java/io/crate/planner/node/ddl/DeletePartitionsTest.java
@@ -44,19 +44,20 @@ public class DeletePartitionsTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testIndexNameGeneration() throws Exception {
+        RelationName relationName = new RelationName("doc", "parted_pks");
         SQLExecutor e = SQLExecutor.of(clusterService)
             .addTable(
                 TableDefinitions.PARTED_PKS_TABLE_DEFINITION,
-                new PartitionName(new RelationName("doc", "parted_pks"), singletonList("1395874800000")).asIndexName(),
-                new PartitionName(new RelationName("doc", "parted_pks"), singletonList("1395961200000")).asIndexName());
+                new PartitionName(relationName, singletonList("1395874800000")).asIndexName(),
+                new PartitionName(relationName, singletonList("1395961200000")).asIndexName());
         DeletePartitions plan = e.plan("delete from parted_pks where date = ?");
 
         Object[] args1 = {"1395874800000"};
-        assertThat(plan.getPartitionValues(txnCtx, e.nodeCtx, new RowN(args1), SubQueryResults.EMPTY)).containsExactly(
-            List.of("1395874800000"));
+        assertThat(plan.getPartitions(relationName, txnCtx, e.nodeCtx, new RowN(args1), SubQueryResults.EMPTY))
+            .containsExactly(new PartitionName(relationName, List.of("1395874800000")));
 
         Object[] args2 = {"1395961200000"};
-        assertThat(plan.getPartitionValues(txnCtx, e.nodeCtx, new RowN(args2), SubQueryResults.EMPTY)).containsExactly(
-            List.of("1395961200000"));
+        assertThat(plan.getPartitions(relationName, txnCtx, e.nodeCtx, new RowN(args2), SubQueryResults.EMPTY))
+            .containsExactly(new PartitionName(relationName, List.of("1395961200000")));
     }
 }


### PR DESCRIPTION
Use a List<PartitionName> for DropPartitionsRequest to make nicer in it's API, but keep the same streaming logic to avoid restreaming the relationName multiple times.

Follows: #17727

