### PR TITLE
Fix NPE in DropPartitionsRequest streaming

### DIFF
--- a/server/src/main/java/io/crate/execution/ddl/tables/DropPartitionsRequest.java
+++ b/server/src/main/java/io/crate/execution/ddl/tables/DropPartitionsRequest.java
@@ -56,7 +56,12 @@ public class DropPartitionsRequest extends AcknowledgedRequest<DropPartitionsReq
         int size = in.readVInt();
         partitions = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {
-            partitions.add(new PartitionName(relationName, in.readStringList()));
+            int numValues = in.readVInt();
+            ArrayList<String> values = new ArrayList<>(numValues);
+            for (int j = 0; j < numValues; j++) {
+                values.add(in.readOptionalString());
+            }
+            partitions.add(new PartitionName(relationName, values));
         }
     }
 
@@ -66,7 +71,13 @@ public class DropPartitionsRequest extends AcknowledgedRequest<DropPartitionsReq
         relationName.writeTo(out);
         out.writeVInt(partitions.size());
         for (PartitionName partition : partitions) {
-            out.writeStringCollection(partition.values());
+            assert partition.relationName().equals(relationName)
+                : "RelationName of PartitionName must match requets' relationName";
+            List<String> values = partition.values();
+            out.writeVInt(values.size());
+            for (String value : values) {
+                out.writeOptionalString(value);
+            }
         }
     }
 }

--- a/server/src/test/java/io/crate/execution/ddl/tables/DropPartitionsRequestTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/tables/DropPartitionsRequestTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to Crate.io GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.ddl.tables;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.junit.Test;
+
+import io.crate.metadata.PartitionName;
+import io.crate.metadata.RelationName;
+
+public class DropPartitionsRequestTest {
+
+    @Test
+    public void test_serialization() throws Exception {
+        var relationName = new RelationName("foo", "bar");
+        List<PartitionName> partitions = List.of(
+            new PartitionName(relationName, List.of("1", "2")),
+            new PartitionName(relationName, Arrays.asList("1", null))
+        );
+        var req = new DropPartitionsRequest(relationName, partitions);
+        try (var out = new BytesStreamOutput()) {
+            req.writeTo(out);
+            try (var in = out.bytes().streamInput()) {
+                var reqIn = new DropPartitionsRequest(in);
+                assertThat(reqIn.relationName()).isEqualTo(relationName);
+                assertThat(reqIn.partitions()).isEqualTo(partitions);
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
Partition values can be null, e.g. the following is allowed:

    create table tbl (x int, y int, z int) partitioned by (y, z);
    insert into tbl (x, y, z) values (1, 2, null);
