### PR TITLE
Ensure native epoll transport for netty can be loaded

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -181,6 +181,7 @@
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-epoll</artifactId>
       <version>${versions.netty}</version>
+      <classifier>linux-x86_64</classifier>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>


### PR DESCRIPTION
The classifier was missing which resulted in a native-epoll jar without
the `.so` file included. Because of that `Epoll.isAvailable()` always
returned `false` and the `NioIoHandler` was used.

`jcmd CrateDB Thread.print` output before:

    cratedb[Chaiserstock][netty-worker][T#1]" #135 [859531] daemon prio=5 os_prio=0 cpu=2.35ms elapsed=2.03s tid=0x0000775ea1ad97b0 nid=859531 runnable  [0x0000775d870f4000]
    java.lang.Thread.State: RUNNABLE
      at sun.nio.ch.EPoll.wait(java.base@24/Native Method)
      at sun.nio.ch.EPollSelectorImpl.doSelect(java.base@24/EPollSelectorImpl.java:117)
      at sun.nio.ch.SelectorImpl.lockAndDoSelect(java.base@24/SelectorImpl.java:130)
      - locked <0x000000041f0be9b0> (a io.netty.channel.nio.SelectedSelectionKeySet)
      - locked <0x000000041f0bf9d8> (a sun.nio.ch.EPollSelectorImpl)
      at sun.nio.ch.SelectorImpl.select(java.base@24/SelectorImpl.java:142)
      at io.netty.channel.nio.SelectedSelectionKeySetSelector.select(SelectedSelectionKeySetSelector.java:62)
      at io.netty.channel.nio.NioIoHandler.select(NioIoHandler.java:638)
      at io.netty.channel.nio.NioIoHandler.run(NioIoHandler.java:424)
      at io.netty.channel.SingleThreadIoEventLoop.runIo(SingleThreadIoEventLoop.java:204)
      at io.netty.channel.SingleThreadIoEventLoop.run(SingleThreadIoEventLoop.java:175)
      at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:1073)
      at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
      at java.lang.Thread.runWith(java.base@24/Thread.java:1460)
      at java.lang.Thread.run(java.base@24/Thread.java:1447)

After:

    cratedb[Pic des Cabottes][netty-worker][T#1]" #135 [863322] daemon prio=5 os_prio=0 cpu=2.27ms elapsed=3.49s tid=0x000074fb45af0820 nid=863322 runnable  [0x000074f9fa8f8000]
    java.lang.Thread.State: RUNNABLE
      at io.netty.channel.epoll.Native.epollWait0(Native Method)
      at io.netty.channel.epoll.Native.epollWait(Native.java:193)
      at io.netty.channel.epoll.EpollIoHandler.epollWait(EpollIoHandler.java:362)
      at io.netty.channel.epoll.EpollIoHandler.run(EpollIoHandler.java:425)
      at io.netty.channel.SingleThreadIoEventLoop.runIo(SingleThreadIoEventLoop.java:204)
      at io.netty.channel.SingleThreadIoEventLoop.run(SingleThreadIoEventLoop.java:175)
      at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:1073)
      at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
      at java.lang.Thread.runWith(java.base@24/Thread.java:1460)
      at java.lang.Thread.run(java.base@24/Thread.java:1447)
