### PR TITLE
Remove allColumns on RelationInfo again

### DIFF
--- a/server/src/main/java/io/crate/analyze/InsertAnalyzer.java
+++ b/server/src/main/java/io/crate/analyze/InsertAnalyzer.java
@@ -119,7 +119,7 @@ class InsertAnalyzer {
         );
         List<Reference> targetColumns;
         if (insert.columns().isEmpty()) {
-            targetColumns = new ArrayList<>(tableInfo.columns());
+            targetColumns = new ArrayList<>(tableInfo.rootColumns());
         } else {
             targetColumns = insert.columns().stream()
                 .map(col -> tableInfo.resolveColumn(col, true, true))

--- a/server/src/main/java/io/crate/analyze/relations/DocTableRelation.java
+++ b/server/src/main/java/io/crate/analyze/relations/DocTableRelation.java
@@ -51,7 +51,7 @@ public class DocTableRelation extends AbstractTableRelation<DocTableInfo> {
         // E.g. in `select a._id from tbl as a`
         super(
             tableInfo,
-            List.copyOf(tableInfo.columns()),
+            List.copyOf(tableInfo.rootColumns()),
             concat(SysColumns.forTable(tableInfo.ident()), tableInfo.indexColumns())
         );
     }

--- a/server/src/main/java/io/crate/analyze/relations/TableRelation.java
+++ b/server/src/main/java/io/crate/analyze/relations/TableRelation.java
@@ -33,7 +33,7 @@ import io.crate.metadata.table.TableInfo;
 public class TableRelation extends AbstractTableRelation<TableInfo> {
 
     public TableRelation(TableInfo tableInfo) {
-        super(tableInfo, List.copyOf(tableInfo.columns()), List.of());
+        super(tableInfo, List.copyOf(tableInfo.rootColumns()), List.of());
     }
 
     @Override

--- a/server/src/main/java/io/crate/execution/dml/TranslogIndexer.java
+++ b/server/src/main/java/io/crate/execution/dml/TranslogIndexer.java
@@ -66,7 +66,7 @@ public class TranslogIndexer {
     @SuppressWarnings("unchecked")
     public TranslogIndexer(DocTableInfo table, Version shardCreatedVersion) {
         sourceParser = new SourceParser(table.lookupNameBySourceKey(), false);
-        for (var ref : table.columns()) {
+        for (var ref : table.rootColumns()) {
             var storageSupport = ref.valueType().storageSupport();
             if (storageSupport != null) {
                 var columnIndexer = new ColumnIndexer<>(

--- a/server/src/main/java/io/crate/execution/dml/upsert/ShardUpsertRequest.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/ShardUpsertRequest.java
@@ -338,8 +338,7 @@ public final class ShardUpsertRequest extends ShardRequest<ShardUpsertRequest, S
             // if stats are not available we fall back to estimate the size based on
             // column types. Therefore we need to get the column information.
             if (stats.isEmpty()) {
-                Collection<Reference> ramAccountedColumns = tableInfo.allColumns();
-                return stats.estimateSizeForColumns(ramAccountedColumns);
+                return stats.estimateSizeForColumns(tableInfo);
             } else {
                 return stats.averageSizePerRowInBytes();
             }

--- a/server/src/main/java/io/crate/execution/dml/upsert/UpdateToInsert.java
+++ b/server/src/main/java/io/crate/execution/dml/upsert/UpdateToInsert.java
@@ -161,7 +161,7 @@ public final class UpdateToInsert {
             this.columns.addAll(insertColumns);
         }
         List<String> updateColumnList = Arrays.asList(updateColumns);
-        for (var ref : table.columns()) {
+        for (var ref : table.rootColumns()) {
             // The Indexer later on injects the generated column values
             // We only include them here if they are provided in the `updateColumns` to validate
             // that users provided the right value (otherwise they'd get ignored and we'd generate them later)

--- a/server/src/main/java/io/crate/execution/engine/collect/sources/InformationSchemaIterables.java
+++ b/server/src/main/java/io/crate/execution/engine/collect/sources/InformationSchemaIterables.java
@@ -220,7 +220,7 @@ public class InformationSchemaIterables {
             info.ident(),
             info.ident().name(),
             toEntryType(info.relationType()),
-            info.columns().size(),
+            info.rootColumns().size(),
             !info.primaryKey().isEmpty());
     }
 
@@ -231,7 +231,7 @@ public class InformationSchemaIterables {
             info.ident(),
             info.pkConstraintNameOrDefault(),
             PgClassTable.Entry.Type.INDEX,
-            info.columns().size(),
+            info.rootColumns().size(),
             !info.primaryKey().isEmpty());
     }
 

--- a/server/src/main/java/io/crate/expression/reference/doc/lucene/StoredRowLookup.java
+++ b/server/src/main/java/io/crate/expression/reference/doc/lucene/StoredRowLookup.java
@@ -125,7 +125,7 @@ public abstract class StoredRowLookup implements StoredRow {
     }
 
     public void registerAll() {
-        for (Reference ref : table.columns()) {
+        for (Reference ref : table.rootColumns()) {
             if (ref.column().isSystemColumn() == false & ref.granularity() == RowGranularity.DOC) {
                 registerRef(DocReferences.toDocLookup(ref));
             }

--- a/server/src/main/java/io/crate/fdw/ForeignTable.java
+++ b/server/src/main/java/io/crate/fdw/ForeignTable.java
@@ -149,7 +149,7 @@ public record ForeignTable(RelationName name,
     }
 
     @Override
-    public Collection<Reference> columns() {
+    public Collection<Reference> rootColumns() {
         return references.values();
     }
 

--- a/server/src/main/java/io/crate/fdw/ForeignTableRelation.java
+++ b/server/src/main/java/io/crate/fdw/ForeignTableRelation.java
@@ -37,7 +37,7 @@ import io.crate.metadata.table.Operation;
 public class ForeignTableRelation extends AbstractTableRelation<ForeignTable> {
 
     public ForeignTableRelation(ForeignTable table) {
-        super(table, List.copyOf(table.columns()), List.of());
+        super(table, List.copyOf(table.rootColumns()), List.of());
     }
 
     @Override

--- a/server/src/main/java/io/crate/metadata/RelationInfo.java
+++ b/server/src/main/java/io/crate/metadata/RelationInfo.java
@@ -60,10 +60,6 @@ public interface RelationInfo extends Iterable<Reference> {
      */
     Collection<Reference> columns();
 
-    default Collection<Reference> allColumns() {
-        return columns();
-    }
-
     default Collection<Reference> droppedColumns() {
         return List.of();
     }

--- a/server/src/main/java/io/crate/metadata/RelationInfo.java
+++ b/server/src/main/java/io/crate/metadata/RelationInfo.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.jetbrains.annotations.Nullable;
 
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.Operation;
 import io.crate.sql.tree.CheckConstraint;
 
@@ -56,16 +57,25 @@ public interface RelationInfo extends Iterable<Reference> {
     }
 
     /**
-     * returns the top level columns of this table with predictable order
+     * Returns the root columns of this table with predictable order.
+     * Excludes system columns.
+     * <p>
+     * Use {@link #iterator()} to get root, child and system columns.
+     * </p>
+     * <p>
+     * Use {@link DocTableInfo#allReferences()} to get both active and dropped
+     * columns for all:
+     * root, child, system and index columns.
+     * </p>
      */
-    Collection<Reference> columns();
+    Collection<Reference> rootColumns();
 
     default Collection<Reference> droppedColumns() {
         return List.of();
     }
 
     default int maxPosition() {
-        return columns().stream()
+        return rootColumns().stream()
             .filter(ref -> !ref.column().isSystemColumn())
             .mapToInt(Reference::position)
             .max()

--- a/server/src/main/java/io/crate/metadata/SystemTable.java
+++ b/server/src/main/java/io/crate/metadata/SystemTable.java
@@ -125,7 +125,7 @@ public final class SystemTable<T> implements TableInfo {
     }
 
     @Override
-    public Collection<Reference> columns() {
+    public Collection<Reference> rootColumns() {
         return rootColumns;
     }
 

--- a/server/src/main/java/io/crate/metadata/blob/BlobTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/blob/BlobTableInfo.java
@@ -99,7 +99,7 @@ public class BlobTableInfo implements TableInfo, ShardedTable, StoredTable {
     }
 
     @Override
-    public Collection<Reference> columns() {
+    public Collection<Reference> rootColumns() {
         return columns;
     }
 

--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
@@ -376,11 +376,6 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
     }
 
     @Override
-    public Collection<Reference> allColumns() {
-        return allColumns.values();
-    }
-
-    @Override
     public Set<Reference> droppedColumns() {
         return droppedColumns;
     }

--- a/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
+++ b/server/src/main/java/io/crate/metadata/doc/DocTableInfo.java
@@ -174,7 +174,7 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
     public static final Setting<Long> DEPTH_LIMIT_SETTING =
         Setting.longSetting("index.mapping.depth.limit", 20L, 1, Property.Dynamic, Property.IndexScope);
 
-    private final List<Reference> topLevelColumns;
+    private final List<Reference> rootColumns;
     private final Set<Reference> droppedColumns;
     private final List<GeneratedReference> generatedColumns;
     private final List<Reference> partitionedByColumns;
@@ -234,7 +234,7 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
         this.allColumns = references.entrySet().stream()
             .filter(entry -> !entry.getValue().isDropped())
             .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
-        this.topLevelColumns = this.allColumns.values().stream()
+        this.rootColumns = this.allColumns.values().stream()
             .filter(r -> !r.column().isSystemColumn())
             .filter(r -> r.column().isRoot())
             .sorted(Reference.CMP_BY_POSITION_THEN_NAME)
@@ -371,8 +371,8 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
     }
 
     @Override
-    public List<Reference> columns() {
-        return topLevelColumns;
+    public List<Reference> rootColumns() {
+        return rootColumns;
     }
 
     @Override
@@ -730,7 +730,7 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
 
 
     private void validateDropColumns(List<DropColumn> dropColumns) {
-        var leftOverCols = columns().stream().map(Reference::column).collect(Collectors.toSet());
+        var leftOverCols = rootColumns().stream().map(Reference::column).collect(Collectors.toSet());
         for (int i = 0 ; i < dropColumns.size(); i++) {
             var refToDrop = dropColumns.get(i).ref();
             var colToDrop = refToDrop.column();

--- a/server/src/main/java/io/crate/metadata/view/ViewInfo.java
+++ b/server/src/main/java/io/crate/metadata/view/ViewInfo.java
@@ -65,7 +65,7 @@ public class ViewInfo implements RelationInfo {
     }
 
     @Override
-    public Collection<Reference> columns() {
+    public Collection<Reference> rootColumns() {
         return columns;
     }
 

--- a/server/src/main/java/io/crate/planner/statement/CopyFromPlan.java
+++ b/server/src/main/java/io/crate/planner/statement/CopyFromPlan.java
@@ -180,7 +180,7 @@ public final class CopyFromPlan implements Plan {
         var header = settings.getAsBoolean("header", true);
         var targetColumns = copyFrom.targetColumns();
         if (!header && copyFrom.targetColumns().isEmpty()) {
-            targetColumns = Lists.map(copyFrom.tableInfo().columns(), Reference::toString);
+            targetColumns = Lists.map(copyFrom.tableInfo().rootColumns(), Reference::toString);
         }
 
         return new BoundCopyFrom(

--- a/server/src/main/java/io/crate/statistics/Stats.java
+++ b/server/src/main/java/io/crate/statistics/Stats.java
@@ -22,7 +22,6 @@
 package io.crate.statistics;
 
 import java.io.IOException;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -138,7 +137,7 @@ public class Stats implements Writeable {
         return statsByColumn.get(column);
     }
 
-    public <T extends Symbol> long estimateSizeForColumns(Collection<T> toCollect) {
+    public long estimateSizeForColumns(Iterable<? extends Symbol> toCollect) {
         long sum = 0L;
         for (Symbol symbol : toCollect) {
             ColumnStats<?> columnStats = null;

--- a/server/src/test/java/io/crate/execution/ddl/tables/DropColumnTaskTest.java
+++ b/server/src/test/java/io/crate/execution/ddl/tables/DropColumnTaskTest.java
@@ -23,6 +23,7 @@ package io.crate.execution.ddl.tables;
 
 import static io.crate.testing.Asserts.assertThat;
 import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
@@ -78,7 +79,7 @@ public class DropColumnTaskTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo newTable = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
 
         assertThat(newTable.getReference(colToDrop.column())).isNull();
-        assertThat(newTable.columns()).hasSize(2);
+        assertThat(newTable.rootColumns()).hasSize(2);
         assertThat(newTable.droppedColumns()).satisfiesExactly(
             x -> assertThat(x)
                 .hasName("y")
@@ -112,7 +113,7 @@ public class DropColumnTaskTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo newTable = new DocTableInfoFactory(e.nodeCtx).create(tbl.ident(), newState.metadata());
 
         assertThat(newTable.getReference(colToDrop.column())).isNull();
-        assertThat(newTable.columns()).hasSize(2);
+        assertThat(newTable.rootColumns()).hasSize(2);
         assertThat(newTable.droppedColumns()).satisfiesExactly(
             x -> assertThat(x)
                 .hasName("y")

--- a/server/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
+++ b/server/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
@@ -163,7 +163,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
         // Avoid null pointer exceptions
         DocTableInfo tableInfo = mock(DocTableInfo.class);
         Schemas schemas = mock(Schemas.class);
-        when(tableInfo.columns()).thenReturn(Collections.<Reference>emptyList());
+        when(tableInfo.rootColumns()).thenReturn(Collections.<Reference>emptyList());
         when(tableInfo.versionCreated()).thenReturn(Version.CURRENT);
         when(schemas.getTableInfo(any(RelationName.class))).thenReturn(tableInfo);
 

--- a/server/src/test/java/io/crate/execution/engine/collect/HandlerSideLevelCollectTest.java
+++ b/server/src/test/java/io/crate/execution/engine/collect/HandlerSideLevelCollectTest.java
@@ -147,7 +147,7 @@ public class HandlerSideLevelCollectTest extends IntegTestCase {
             routingProvider,
             WhereClause.MATCH_ALL, RoutingProvider.ShardSelection.ANY, CoordinatorSessionSettings.systemDefaults());
         List<Symbol> toCollect = new ArrayList<>();
-        for (Reference reference : tablesTableInfo.columns()) {
+        for (Reference reference : tablesTableInfo.rootColumns()) {
             toCollect.add(reference);
         }
         Symbol tableNameRef = toCollect.get(12);
@@ -172,7 +172,7 @@ public class HandlerSideLevelCollectTest extends IntegTestCase {
             routingProvider,
             WhereClause.MATCH_ALL, RoutingProvider.ShardSelection.ANY, CoordinatorSessionSettings.systemDefaults());
         List<Symbol> toCollect = new ArrayList<>();
-        for (Reference ref : tableInfo.columns()) {
+        for (Reference ref : tableInfo.rootColumns()) {
             if (Set.of("column_name", "data_type", "table_name").contains(ref.column().name())) {
                 toCollect.add(ref);
             }

--- a/server/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
@@ -31,6 +31,7 @@ import static io.netty.handler.codec.http.HttpResponseStatus.CONFLICT;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static io.netty.handler.codec.rtsp.RtspResponseStatuses.BAD_REQUEST;
 import static io.netty.handler.codec.rtsp.RtspResponseStatuses.INTERNAL_SERVER_ERROR;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -1525,14 +1526,14 @@ public class PartitionedTableIntegrationTest extends IntegTestCase {
         execute("refresh table dynamic_table");
 
         DocTableInfo table = getTable("dynamic_table");
-        assertThat(table.columns()).hasSize(2);
+        assertThat(table.rootColumns()).hasSize(2);
         assertThat(table.partitionedBy()).containsExactly(ColumnIdent.of("score"));
 
         execute("alter table dynamic_table set (column_policy= 'dynamic')");
         waitNoPendingTasksOnAll();
 
         table = getTable("dynamic_table");
-        assertThat(table.columns()).hasSize(2);
+        assertThat(table.rootColumns()).hasSize(2);
         assertThat(table.partitionedBy()).containsExactly(ColumnIdent.of("score"));
     }
 

--- a/server/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
+++ b/server/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
@@ -27,6 +27,7 @@ import static io.crate.testing.Asserts.assertThat;
 import static io.netty.handler.codec.http.HttpResponseStatus.CONFLICT;
 import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
 import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -389,7 +390,7 @@ public class SnapshotRestoreIntegrationTest extends IntegTestCase {
         assertThat((Long)response.rows()[0][0])
             .as("Documents were restored but the restored index mapping was older than some " +
                 "documents and misses some of their fields")
-            .isLessThanOrEqualTo(table.columns().size());
+            .isLessThanOrEqualTo(table.rootColumns().size());
     }
 
     @Test

--- a/server/src/test/java/io/crate/metadata/SchemasITest.java
+++ b/server/src/test/java/io/crate/metadata/SchemasITest.java
@@ -67,7 +67,7 @@ public class SchemasITest extends IntegTestCase {
         DocTableInfo ti = schemas.getTableInfo(new RelationName(sqlExecutor.getCurrentSchema(), "t1"));
         assertThat(ti.ident().name()).isEqualTo("t1");
 
-        assertThat(ti.columns()).hasSize(3);
+        assertThat(ti.rootColumns()).hasSize(3);
         assertThat(ti.primaryKey()).hasSize(1);
         assertThat(ti.primaryKey().get(0)).isEqualTo(ColumnIdent.of("id"));
         assertThat(ti.clusteredBy()).isEqualTo(ColumnIdent.of("id"));

--- a/server/src/test/java/io/crate/metadata/SystemTableTest.java
+++ b/server/src/test/java/io/crate/metadata/SystemTableTest.java
@@ -46,7 +46,7 @@ public class SystemTableTest {
             .endObject()
             .build();
 
-        assertThat(table.columns()).satisfiesExactly(isReference("obj_a"));
+        assertThat(table.rootColumns()).satisfiesExactly(isReference("obj_a"));
         assertThat(table.getReference(ColumnIdent.of("obj_a", List.of("obj_b", "x"))))
             .hasName("obj_a['obj_b']['x']");
 

--- a/server/src/test/java/io/crate/metadata/doc/DocIndexMetadataTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocIndexMetadataTest.java
@@ -26,6 +26,7 @@ import static io.crate.testing.Asserts.isLiteral;
 import static io.crate.testing.Asserts.isReference;
 import static io.crate.testing.TestingHelpers.createNodeContext;
 import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
@@ -217,7 +218,7 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
             .endObject();
         IndexMetadata metadata = getIndexMetadata("test1", builder);
         DocTableInfo table = newTable(metadata, "test1");
-        assertThat(table.columns()).hasSize(4);
+        assertThat(table.rootColumns()).hasSize(4);
         assertThat(table).hasSize(20);
         assertThat(((table.getReference(ColumnIdent.of("implicit_dynamic")).valueType().columnPolicy()))).isEqualTo(ColumnPolicy.DYNAMIC);
         assertThat(((table.getReference(ColumnIdent.of("explicit_dynamic")).valueType().columnPolicy()))).isEqualTo(ColumnPolicy.DYNAMIC);
@@ -302,7 +303,7 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
         IndexMetadata metadata = getIndexMetadata("test1", builder);
         DocTableInfo table = newTable(metadata, "test1");
 
-        assertThat(table.columns()).hasSize(11);
+        assertThat(table.rootColumns()).hasSize(11);
         assertThat(table).hasSize(23);
 
         Reference birthday = table.getReference(ColumnIdent.of("person", "birthday"));
@@ -417,7 +418,7 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
         IndexMetadata metadata = getIndexMetadata("test1", builder);
         DocTableInfo table = newTable(metadata, "test1");
 
-        assertThat(table.columns()).hasSize(7);
+        assertThat(table.rootColumns()).hasSize(7);
         assertThat(table).hasSize(17);
 
         Reference birthday = table.getReference(ColumnIdent.of("birthday"));
@@ -526,7 +527,7 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
         IndexMetadata metadata = getIndexMetadata("test1", builder);
         DocTableInfo table = newTable(metadata, "test1");
 
-        assertThat(table.columns()).hasSize(6);
+        assertThat(table.rootColumns()).hasSize(6);
         assertThat(table).hasSize(19);
         assertThat(table.partitionedByColumns()).hasSize(1);
         assertThat(table.partitionedByColumns().get(0).valueType()).isEqualTo(DataTypes.TIMESTAMPZ);
@@ -562,7 +563,7 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo table = newTable(metadata, "test1");
 
         // partitioned by column is not added twice
-        assertThat(table.columns()).hasSize(2);
+        assertThat(table.rootColumns()).hasSize(2);
         assertThat(table).hasSize(12);
         assertThat(table.partitionedByColumns()).hasSize(1);
     }
@@ -599,7 +600,7 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo table = newTable(metadata, "test1");
 
         // partitioned by column is not added twice
-        assertThat(table.columns()).hasSize(2);
+        assertThat(table.rootColumns()).hasSize(2);
         assertThat(table).hasSize(13);
         assertThat(table.partitionedByColumns()).hasSize(1);
     }
@@ -650,7 +651,7 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
             .endObject();
         IndexMetadata metadata = getIndexMetadata("test2", builder);
         DocTableInfo table = newTable(metadata, "test2");
-        assertThat(table.columns()).isEmpty();
+        assertThat(table.rootColumns()).isEmpty();
     }
 
     @Test
@@ -872,7 +873,7 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
         IndexMetadata metadata = getIndexMetadata("test_notnull_columns", builder);
         DocTableInfo table = newTable(metadata, "test_notnull_columns");
 
-        assertThat(table.columns().stream().map(Reference::isNullable).collect(Collectors.toList())).containsExactly(
+        assertThat(table.rootColumns().stream().map(Reference::isNullable).collect(Collectors.toList())).containsExactly(
             false, false
         );
     }
@@ -942,7 +943,7 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
         IndexMetadata metadata = getIndexMetadata("test1", builder);
         DocTableInfo table = newTable(metadata, "test1");
 
-        assertThat(table.columns()).hasSize(2);
+        assertThat(table.rootColumns()).hasSize(2);
         Reference week = table.getReference(ColumnIdent.of("week"));
         assertThat(week)
             .isNotNull()
@@ -1091,7 +1092,7 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
                 .endObject()
             .endObject();
         DocTableInfo table = newTable(getIndexMetadata("test_analyzer", builder), "test_analyzer");
-        List<Reference> columns = new ArrayList<>(table.columns());
+        List<Reference> columns = new ArrayList<>(table.rootColumns());
         assertThat(columns).hasSize(2);
         assertThat(columns.get(0).indexType()).isEqualTo(IndexType.FULLTEXT);
         assertThat(columns.get(0).column().fqn()).isEqualTo("content_de");
@@ -1102,8 +1103,8 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testGeoPointType() throws Exception {
         DocTableInfo table = getDocIndexMetadataFromStatement("create table foo (p geo_point)");
-        assertThat(table.columns()).hasSize(1);
-        Reference reference = table.columns().iterator().next();
+        assertThat(table.rootColumns()).hasSize(1);
+        Reference reference = table.rootColumns().iterator().next();
         assertThat(reference.valueType()).isEqualTo(DataTypes.GEO_POINT);
     }
 
@@ -1119,7 +1120,7 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
                                                                "date timestamp with time zone primary key" +
                                                                ") partitioned by (date)");
 
-        assertThat(table.columns()).hasSize(4);
+        assertThat(table.rootColumns()).hasSize(4);
         assertThat(table.primaryKey()).containsExactly(ColumnIdent.of("id"), ColumnIdent.of("date"));
         assertThat(table.getReference(ColumnIdent.of("tags")).valueType()).isEqualTo(
             new ArrayType<>(DataTypes.STRING));
@@ -1139,7 +1140,7 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testCreateTableMappingGenerationAndParsingCompatNoMeta() throws Exception {
         DocTableInfo table = getDocIndexMetadataFromStatement("create table foo (id int, name string)");
-        assertThat(table.columns()).hasSize(2);
+        assertThat(table.rootColumns()).hasSize(2);
         assertThat(table.hasAutoGeneratedPrimaryKey()).isTrue();
     }
 
@@ -1210,7 +1211,7 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
                                                                "  INDEX fun_name_ft using fulltext(name, fun)" +
                                                                ")");
         assertThat(table.indexColumns()).hasSize(1);
-        assertThat(table.columns()).hasSize(3);
+        assertThat(table.rootColumns()).hasSize(3);
         assertThat(table.indexColumn(ColumnIdent.fromPath("fun_name_ft"))).isExactlyInstanceOf(IndexReference.class);
         IndexReference indexInfo = table.indexColumn(ColumnIdent.fromPath("fun_name_ft"));
         assertThat(indexInfo.indexType()).isEqualTo(IndexType.FULLTEXT);
@@ -1228,7 +1229,7 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
                                                                "  INDEX fun_name_ft using fulltext(name, o['fun'])" +
                                                                ")");
         assertThat(table.indexColumns()).hasSize(1);
-        assertThat(table.columns()).hasSize(3);
+        assertThat(table.rootColumns()).hasSize(3);
         assertThat(table.indexColumn(ColumnIdent.fromPath("fun_name_ft"))).isExactlyInstanceOf(IndexReference.class);
         IndexReference indexInfo = table.indexColumn(ColumnIdent.fromPath("fun_name_ft"));
         assertThat(indexInfo.indexType()).isEqualTo(IndexType.FULLTEXT);
@@ -1490,7 +1491,7 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
         DocTableInfo table = getDocIndexMetadataFromStatement(
             "create table t (tags array(string) index using fulltext)");
 
-        Reference reference = table.columns().iterator().next();
+        Reference reference = table.rootColumns().iterator().next();
         assertThat(reference.valueType()).isEqualTo(new ArrayType<>(DataTypes.STRING));
     }
 
@@ -1527,7 +1528,7 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
         IndexMetadata metadata = getIndexMetadata("test1", builder);
         DocTableInfo table = newTable(metadata, "test1");
 
-        assertThat(table.columns()).hasSize(2);
+        assertThat(table.rootColumns()).hasSize(2);
         Reference week = table.getReference(ColumnIdent.of("week"));
         assertThat(week)
             .isNotNull()
@@ -1577,7 +1578,7 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
             .endObject();
         DocTableInfo table = newTable(getIndexMetadata("test", builder), "test");
 
-        assertThat(table.columns()).hasSize(2);
+        assertThat(table.rootColumns()).hasSize(2);
         assertThat(table.getReference(ColumnIdent.of("tz")).valueType()).isEqualTo(DataTypes.TIMESTAMPZ);
         assertThat(table.getReference(ColumnIdent.of("t")).valueType()).isEqualTo(DataTypes.TIMESTAMP);
     }
@@ -1586,7 +1587,7 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
     public void testColumnStoreBooleanIsParsedCorrectly() throws Exception {
         DocTableInfo table = getDocIndexMetadataFromStatement(
                 "create table t1 (x string STORAGE WITH (columnstore = false))");
-        assertThat(table.columns().iterator().next().hasDocValues()).isFalse();
+        assertThat(table.rootColumns().iterator().next().hasDocValues()).isFalse();
     }
 
     @Test
@@ -1631,7 +1632,7 @@ public class DocIndexMetadataTest extends CrateDummyClusterServiceUnitTest {
     public void test_nested_geo_shape_column_is_not_added_as_top_level_column() throws Exception {
         DocTableInfo table = getDocIndexMetadataFromStatement(
             "create table tbl (x int, y object as (z geo_shape))");
-        assertThat(table.columns()).satisfiesExactlyInAnyOrder(isReference("x"), isReference("y"));
+        assertThat(table.rootColumns()).satisfiesExactlyInAnyOrder(isReference("x"), isReference("y"));
         assertThat(table.getReference(ColumnIdent.of("y", "z"))).isNotNull();
     }
 

--- a/server/src/test/java/io/crate/metadata/doc/DocTableInfoTest.java
+++ b/server/src/test/java/io/crate/metadata/doc/DocTableInfoTest.java
@@ -455,7 +455,7 @@ public class DocTableInfoTest extends CrateDummyClusterServiceUnitTest {
             List.of(newReference),
             new IntArrayList(),
             Map.of());
-        assertThat(table2.columns()).satisfiesExactly(
+        assertThat(table2.rootColumns()).satisfiesExactly(
             x -> assertThat(x)
                 .hasName("x")
                 .hasType(DataTypes.INTEGER)

--- a/server/src/testFixtures/java/io/crate/testing/TableInfoAssert.java
+++ b/server/src/testFixtures/java/io/crate/testing/TableInfoAssert.java
@@ -50,7 +50,7 @@ public class TableInfoAssert extends AbstractAssert<TableInfoAssert, TableInfo> 
     }
 
     public <K extends Comparable<K>> TableInfoAssert hasColsSortedBy(final Function<Reference, K> extractSortingKeyFunction) {
-        refsSortedBy(actual.columns(), extractSortingKeyFunction, false, null);
+        refsSortedBy(actual.rootColumns(), extractSortingKeyFunction, false, null);
         return this;
     }
 


### PR DESCRIPTION
`RelationInfo` already implements `Iterable<Reference>` which returns
the same data.

Follow up to https://github.com/crate/crate/pull/17664
