### PR TITLE
Remove Actions from DependencyCarrier

### DIFF
--- a/server/src/main/java/io/crate/execution/TransportExecutorModule.java
+++ b/server/src/main/java/io/crate/execution/TransportExecutorModule.java
@@ -23,13 +23,8 @@ package io.crate.execution;
 
 import org.elasticsearch.common.inject.AbstractModule;
 
-import io.crate.execution.ddl.index.TransportSwapAndDropIndexNameAction;
 import io.crate.execution.jobs.JobSetup;
 import io.crate.lucene.LuceneQueryBuilder;
-import io.crate.replication.logical.action.TransportAlterPublicationAction;
-import io.crate.replication.logical.action.TransportCreatePublicationAction;
-import io.crate.replication.logical.action.TransportCreateSubscriptionAction;
-import io.crate.replication.logical.action.TransportDropPublicationAction;
 import io.crate.statistics.TransportAnalyzeAction;
 
 public class TransportExecutorModule extends AbstractModule {
@@ -39,12 +34,6 @@ public class TransportExecutorModule extends AbstractModule {
         bind(JobSetup.class).asEagerSingleton();
         bind(LuceneQueryBuilder.class).asEagerSingleton();
 
-        bind(TransportSwapAndDropIndexNameAction.class).asEagerSingleton();
         bind(TransportAnalyzeAction.class).asEagerSingleton();
-
-        bind(TransportCreatePublicationAction.class).asEagerSingleton();
-        bind(TransportDropPublicationAction.class).asEagerSingleton();
-        bind(TransportAlterPublicationAction.class).asEagerSingleton();
-        bind(TransportCreateSubscriptionAction.class).asEagerSingleton();
     }
 }

--- a/server/src/main/java/io/crate/execution/ddl/index/TransportSwapAndDropIndexName.java
+++ b/server/src/main/java/io/crate/execution/ddl/index/TransportSwapAndDropIndexName.java
@@ -21,8 +21,7 @@
 
 package io.crate.execution.ddl.index;
 
-import io.crate.execution.ddl.AbstractDDLTransportAction;
-import io.crate.metadata.cluster.SwapAndDropIndexExecutor;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateTaskExecutor;
@@ -31,26 +30,34 @@ import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
+
+import io.crate.execution.ddl.AbstractDDLTransportAction;
+import io.crate.metadata.cluster.SwapAndDropIndexExecutor;
 
 /**
  * Renames a sourceIndex to targetIndex, and drops the former targetIndex - effectively overriding the target
  */
-@Singleton
-public class TransportSwapAndDropIndexNameAction extends AbstractDDLTransportAction<SwapAndDropIndexRequest, AcknowledgedResponse> {
+public class TransportSwapAndDropIndexName extends AbstractDDLTransportAction<SwapAndDropIndexRequest, AcknowledgedResponse> {
 
-    private static final String ACTION_NAME = "internal:crate:sql/index/swap_and_drop_index";
-
+    public static final Action ACTION = new Action();
     private final SwapAndDropIndexExecutor executor;
 
+    public static class Action extends ActionType<AcknowledgedResponse> {
+        private static final String NAME = "internal:crate:sql/index/swap_and_drop_index";
+
+        private Action() {
+            super(NAME);
+        }
+    }
+
     @Inject
-    public TransportSwapAndDropIndexNameAction(TransportService transportService,
-                                               ClusterService clusterService,
-                                               ThreadPool threadPool,
-                                               AllocationService allocationService) {
-        super(ACTION_NAME,
+    public TransportSwapAndDropIndexName(TransportService transportService,
+                                         ClusterService clusterService,
+                                         ThreadPool threadPool,
+                                         AllocationService allocationService) {
+        super(ACTION.name(),
             transportService,
             clusterService,
             threadPool,

--- a/server/src/main/java/io/crate/planner/DependencyCarrier.java
+++ b/server/src/main/java/io/crate/planner/DependencyCarrier.java
@@ -44,10 +44,6 @@ import io.crate.metadata.FulltextAnalyzerResolver;
 import io.crate.metadata.NodeContext;
 import io.crate.metadata.Schemas;
 import io.crate.replication.logical.LogicalReplicationService;
-import io.crate.replication.logical.action.TransportAlterPublicationAction;
-import io.crate.replication.logical.action.TransportCreatePublicationAction;
-import io.crate.replication.logical.action.TransportCreateSubscriptionAction;
-import io.crate.replication.logical.action.TransportDropPublicationAction;
 import io.crate.session.DCLStatementDispatcher;
 import io.crate.statistics.TransportAnalyzeAction;
 
@@ -71,10 +67,6 @@ public class DependencyCarrier {
     private final RepositoryService repositoryService;
     private final RepositoryParamValidator repositoryParamValidator;
     private final NodeLimits nodeLimits;
-    private final TransportCreatePublicationAction createPublicationAction;
-    private final TransportDropPublicationAction dropPublicationAction;
-    private final TransportAlterPublicationAction alterPublicationAction;
-    private final TransportCreateSubscriptionAction createSubscriptionAction;
     private final LogicalReplicationService logicalReplicationService;
     private final ElasticsearchClient client;
     private final CircuitBreakerService circuitBreakerService;
@@ -94,10 +86,6 @@ public class DependencyCarrier {
                              FulltextAnalyzerResolver fulltextAnalyzerResolver,
                              RepositoryService repositoryService,
                              RepositoryParamValidator repositoryParamValidator,
-                             TransportCreatePublicationAction createPublicationAction,
-                             TransportDropPublicationAction dropPublicationAction,
-                             TransportAlterPublicationAction alterPublicationAction,
-                             TransportCreateSubscriptionAction createSubscriptionAction,
                              LogicalReplicationService logicalReplicationService) {
         this.settings = settings;
         this.client = node.client();
@@ -115,10 +103,6 @@ public class DependencyCarrier {
         this.fulltextAnalyzerResolver = fulltextAnalyzerResolver;
         this.repositoryService = repositoryService;
         this.repositoryParamValidator = repositoryParamValidator;
-        this.createPublicationAction = createPublicationAction;
-        this.dropPublicationAction = dropPublicationAction;
-        this.alterPublicationAction = alterPublicationAction;
-        this.createSubscriptionAction = createSubscriptionAction;
         this.logicalReplicationService = logicalReplicationService;
     }
 
@@ -184,22 +168,6 @@ public class DependencyCarrier {
 
     public NodeLimits nodeLimits() {
         return nodeLimits;
-    }
-
-    public TransportCreatePublicationAction createPublicationAction() {
-        return createPublicationAction;
-    }
-
-    public TransportDropPublicationAction dropPublicationAction() {
-        return dropPublicationAction;
-    }
-
-    public TransportAlterPublicationAction alterPublicationAction() {
-        return alterPublicationAction;
-    }
-
-    public TransportCreateSubscriptionAction createSubscriptionAction() {
-        return createSubscriptionAction;
     }
 
     public LogicalReplicationService logicalReplicationService() {

--- a/server/src/main/java/io/crate/replication/logical/action/TransportAlterPublication.java
+++ b/server/src/main/java/io/crate/replication/logical/action/TransportAlterPublication.java
@@ -29,6 +29,7 @@ import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
@@ -43,8 +44,8 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
-
 import org.jetbrains.annotations.VisibleForTesting;
+
 import io.crate.exceptions.RelationUnknown;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
@@ -53,18 +54,25 @@ import io.crate.replication.logical.metadata.Publication;
 import io.crate.replication.logical.metadata.PublicationsMetadata;
 import io.crate.sql.tree.AlterPublication;
 
-public class TransportAlterPublicationAction extends TransportMasterNodeAction<TransportAlterPublicationAction.Request, AcknowledgedResponse> {
+public class TransportAlterPublication extends TransportMasterNodeAction<TransportAlterPublication.Request, AcknowledgedResponse> {
 
-    public static final String NAME = "internal:crate:replication/logical/publication/alter";
+    public static final Action ACTION = new Action();
+    private static final Logger LOGGER = LogManager.getLogger(TransportAlterPublication.class);
 
-    private static final Logger LOGGER = LogManager.getLogger(TransportAlterPublicationAction.class);
+    public static class Action extends ActionType<AcknowledgedResponse> {
+        private static final String NAME = "internal:crate:replication/logical/publication/alter";
+
+        private Action() {
+            super(NAME);
+        }
+    }
 
     @Inject
-    public TransportAlterPublicationAction(TransportService transportService,
-                                           ClusterService clusterService,
-                                           ThreadPool threadPool) {
+    public TransportAlterPublication(TransportService transportService,
+                                     ClusterService clusterService,
+                                     ThreadPool threadPool) {
         super(
-            NAME,
+            ACTION.name(),
             transportService,
             clusterService,
             threadPool,

--- a/server/src/main/java/io/crate/replication/logical/action/TransportCreatePublication.java
+++ b/server/src/main/java/io/crate/replication/logical/action/TransportCreatePublication.java
@@ -21,14 +21,9 @@
 
 package io.crate.replication.logical.action;
 
-import io.crate.exceptions.RelationUnknown;
-import io.crate.execution.ddl.AbstractDDLTransportAction;
-import io.crate.metadata.PartitionName;
-import io.crate.metadata.cluster.DDLClusterStateTaskExecutor;
-import io.crate.replication.logical.exceptions.PublicationAlreadyExistsException;
-import io.crate.replication.logical.metadata.Publication;
-import io.crate.replication.logical.metadata.PublicationsMetadata;
-import io.crate.role.Roles;
+import java.util.Locale;
+
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateTaskExecutor;
@@ -37,24 +32,37 @@ import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
-import java.util.Locale;
+import io.crate.exceptions.RelationUnknown;
+import io.crate.execution.ddl.AbstractDDLTransportAction;
+import io.crate.metadata.PartitionName;
+import io.crate.metadata.cluster.DDLClusterStateTaskExecutor;
+import io.crate.replication.logical.exceptions.PublicationAlreadyExistsException;
+import io.crate.replication.logical.metadata.Publication;
+import io.crate.replication.logical.metadata.PublicationsMetadata;
+import io.crate.role.Roles;
 
-@Singleton
-public class TransportCreatePublicationAction extends AbstractDDLTransportAction<CreatePublicationRequest, AcknowledgedResponse> {
+public class TransportCreatePublication extends AbstractDDLTransportAction<CreatePublicationRequest, AcknowledgedResponse> {
 
-    public static final String ACTION_NAME = "internal:crate:replication/logical/publication/create";
+    public static final Action ACTION = new Action();
     private final Roles roles;
 
+    public static class Action extends ActionType<AcknowledgedResponse> {
+        private static final String NAME = "internal:crate:replication/logical/publication/create";
+
+        private Action() {
+            super(NAME);
+        }
+    }
+
     @Inject
-    public TransportCreatePublicationAction(TransportService transportService,
-                                            ClusterService clusterService,
-                                            ThreadPool threadPool,
-                                            Roles roles) {
-        super(ACTION_NAME,
+    public TransportCreatePublication(TransportService transportService,
+                                      ClusterService clusterService,
+                                      ThreadPool threadPool,
+                                      Roles roles) {
+        super(ACTION.name(),
               transportService,
               clusterService,
               threadPool,

--- a/server/src/main/java/io/crate/replication/logical/action/TransportCreateSubscription.java
+++ b/server/src/main/java/io/crate/replication/logical/action/TransportCreateSubscription.java
@@ -28,6 +28,7 @@ import java.util.concurrent.CompletableFuture;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
@@ -53,21 +54,28 @@ import io.crate.replication.logical.metadata.Subscription;
 import io.crate.replication.logical.metadata.SubscriptionsMetadata;
 import io.crate.role.Roles;
 
-public class TransportCreateSubscriptionAction extends TransportMasterNodeAction<CreateSubscriptionRequest, AcknowledgedResponse> {
+public class TransportCreateSubscription extends TransportMasterNodeAction<CreateSubscriptionRequest, AcknowledgedResponse> {
 
-    public static final String ACTION_NAME = "internal:crate:replication/logical/subscription/create";
-
+    public static final Action ACTION = new Action();
     private final String source;
     private final LogicalReplicationService logicalReplicationService;
     private final Roles roles;
 
+    public static class Action extends ActionType<AcknowledgedResponse> {
+        private static final String NAME = "internal:crate:replication/logical/subscription/create";
+
+        private Action() {
+            super(NAME);
+        }
+    }
+
     @Inject
-    public TransportCreateSubscriptionAction(TransportService transportService,
-                                             ClusterService clusterService,
-                                             LogicalReplicationService logicalReplicationService,
-                                             ThreadPool threadPool,
-                                             Roles roles) {
-        super(ACTION_NAME,
+    public TransportCreateSubscription(TransportService transportService,
+                                       ClusterService clusterService,
+                                       LogicalReplicationService logicalReplicationService,
+                                       ThreadPool threadPool,
+                                       Roles roles) {
+        super(ACTION.name(),
               transportService,
               clusterService,
               threadPool,

--- a/server/src/main/java/io/crate/replication/logical/action/TransportDropPublication.java
+++ b/server/src/main/java/io/crate/replication/logical/action/TransportDropPublication.java
@@ -21,10 +21,7 @@
 
 package io.crate.replication.logical.action;
 
-import io.crate.execution.ddl.AbstractDDLTransportAction;
-import io.crate.metadata.cluster.DDLClusterStateTaskExecutor;
-import io.crate.replication.logical.exceptions.PublicationUnknownException;
-import io.crate.replication.logical.metadata.PublicationsMetadata;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateTaskExecutor;
@@ -33,21 +30,31 @@ import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
-@Singleton
-public class TransportDropPublicationAction extends AbstractDDLTransportAction<DropPublicationRequest, AcknowledgedResponse> {
+import io.crate.execution.ddl.AbstractDDLTransportAction;
+import io.crate.metadata.cluster.DDLClusterStateTaskExecutor;
+import io.crate.replication.logical.exceptions.PublicationUnknownException;
+import io.crate.replication.logical.metadata.PublicationsMetadata;
 
-    public static final String ACTION_NAME = "internal:crate:replication/logical/publication/drop";
+public class TransportDropPublication extends AbstractDDLTransportAction<DropPublicationRequest, AcknowledgedResponse> {
 
+    public static final Action ACTION = new Action();
+
+    public static class Action extends ActionType<AcknowledgedResponse> {
+        private static final String NAME = "internal:crate:replication/logical/publication/drop";
+
+        private Action() {
+            super(NAME);
+        }
+    }
 
     @Inject
-    public TransportDropPublicationAction(TransportService transportService,
-                                          ClusterService clusterService,
-                                          ThreadPool threadPool) {
-        super(ACTION_NAME,
+    public TransportDropPublication(TransportService transportService,
+                                    ClusterService clusterService,
+                                    ThreadPool threadPool) {
+        super(ACTION.name(),
               transportService,
               clusterService,
               threadPool,

--- a/server/src/main/java/io/crate/replication/logical/plan/AlterPublicationPlan.java
+++ b/server/src/main/java/io/crate/replication/logical/plan/AlterPublicationPlan.java
@@ -29,7 +29,7 @@ import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Plan;
 import io.crate.planner.PlannerContext;
 import io.crate.planner.operators.SubQueryResults;
-import io.crate.replication.logical.action.TransportAlterPublicationAction;
+import io.crate.replication.logical.action.TransportAlterPublication;
 import io.crate.replication.logical.analyze.AnalyzedAlterPublication;
 
 public class AlterPublicationPlan implements Plan {
@@ -51,12 +51,12 @@ public class AlterPublicationPlan implements Plan {
                               RowConsumer consumer,
                               Row params,
                               SubQueryResults subQueryResults) throws Exception {
-        var request = new TransportAlterPublicationAction.Request(
+        var request = new TransportAlterPublication.Request(
             alterPublication.name(),
             alterPublication.operation(),
             alterPublication.tables()
         );
-        dependencies.alterPublicationAction().execute(request)
+        dependencies.client().execute(TransportAlterPublication.ACTION, request)
             .whenComplete(new OneRowActionListener<>(consumer, rCount -> new Row1(rCount == null ? -1L : 1L)));
     }
 }

--- a/server/src/main/java/io/crate/replication/logical/plan/CreatePublicationPlan.java
+++ b/server/src/main/java/io/crate/replication/logical/plan/CreatePublicationPlan.java
@@ -30,6 +30,7 @@ import io.crate.planner.Plan;
 import io.crate.planner.PlannerContext;
 import io.crate.planner.operators.SubQueryResults;
 import io.crate.replication.logical.action.CreatePublicationRequest;
+import io.crate.replication.logical.action.TransportCreatePublication;
 import io.crate.replication.logical.analyze.AnalyzedCreatePublication;
 
 public class CreatePublicationPlan implements Plan {
@@ -57,7 +58,7 @@ public class CreatePublicationPlan implements Plan {
             analyzedCreatePublication.tables()
         );
 
-        dependencies.createPublicationAction().execute(request)
+        dependencies.client().execute(TransportCreatePublication.ACTION, request)
             .whenComplete(new OneRowActionListener<>(consumer, rCount -> new Row1(rCount == null ? -1L : 1L)));
     }
 }

--- a/server/src/main/java/io/crate/replication/logical/plan/CreateSubscriptionPlan.java
+++ b/server/src/main/java/io/crate/replication/logical/plan/CreateSubscriptionPlan.java
@@ -38,6 +38,7 @@ import io.crate.planner.Plan;
 import io.crate.planner.PlannerContext;
 import io.crate.planner.operators.SubQueryResults;
 import io.crate.replication.logical.action.CreateSubscriptionRequest;
+import io.crate.replication.logical.action.TransportCreateSubscription;
 import io.crate.replication.logical.analyze.AnalyzedCreateSubscription;
 import io.crate.replication.logical.exceptions.CreateSubscriptionException;
 import io.crate.replication.logical.metadata.ConnectionInfo;
@@ -93,7 +94,7 @@ public class CreateSubscriptionPlan implements Plan {
             settings
         );
 
-        dependencies.createSubscriptionAction().execute(request)
+        dependencies.client().execute(TransportCreateSubscription.ACTION, request)
             .whenComplete(new OneRowActionListener<>(consumer, rCount -> new Row1(rCount == null ? -1 : 1L)));
     }
 

--- a/server/src/main/java/io/crate/replication/logical/plan/DropPublicationPlan.java
+++ b/server/src/main/java/io/crate/replication/logical/plan/DropPublicationPlan.java
@@ -30,6 +30,7 @@ import io.crate.planner.Plan;
 import io.crate.planner.PlannerContext;
 import io.crate.planner.operators.SubQueryResults;
 import io.crate.replication.logical.action.DropPublicationRequest;
+import io.crate.replication.logical.action.TransportDropPublication;
 import io.crate.replication.logical.analyze.AnalyzedDropPublication;
 
 public class DropPublicationPlan implements Plan {
@@ -51,7 +52,7 @@ public class DropPublicationPlan implements Plan {
                               RowConsumer consumer,
                               Row params, SubQueryResults subQueryResults) throws Exception {
         var request = new DropPublicationRequest(analyzedDropPublication.name(), analyzedDropPublication.ifExists());
-        dependencies.dropPublicationAction().execute(request)
+        dependencies.client().execute(TransportDropPublication.ACTION, request)
             .whenComplete(new OneRowActionListener<>(consumer, rCount -> new Row1(rCount == null ? -1 : 1L)));
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -80,6 +80,7 @@ import io.crate.blob.TransportStartBlob;
 import io.crate.cluster.decommission.DecommissionNodeAction;
 import io.crate.cluster.decommission.TransportDecommissionNodeAction;
 import io.crate.execution.ddl.TransportSwapRelations;
+import io.crate.execution.ddl.index.TransportSwapAndDropIndexName;
 import io.crate.execution.ddl.tables.TransportAddColumn;
 import io.crate.execution.ddl.tables.TransportAlterTable;
 import io.crate.execution.ddl.tables.TransportCloseTable;
@@ -129,6 +130,10 @@ import io.crate.replication.logical.action.PublicationsStateAction;
 import io.crate.replication.logical.action.ReleasePublisherResourcesAction;
 import io.crate.replication.logical.action.ReplayChangesAction;
 import io.crate.replication.logical.action.ShardChangesAction;
+import io.crate.replication.logical.action.TransportAlterPublication;
+import io.crate.replication.logical.action.TransportCreatePublication;
+import io.crate.replication.logical.action.TransportCreateSubscription;
+import io.crate.replication.logical.action.TransportDropPublication;
 import io.crate.replication.logical.action.UpdateSubscriptionAction;
 import io.crate.role.TransportAlterRole;
 import io.crate.role.TransportCreateRole;
@@ -212,6 +217,10 @@ public class ActionModule extends AbstractModule {
         actions.register(TransportAlterRole.ACTION, TransportAlterRole.class);
 
         // Logical replication actions
+        actions.register(TransportCreatePublication.ACTION, TransportCreatePublication.class);
+        actions.register(TransportAlterPublication.ACTION, TransportAlterPublication.class);
+        actions.register(TransportDropPublication.ACTION, TransportDropPublication.class);
+        actions.register(TransportCreateSubscription.ACTION, TransportCreateSubscription.class);
         actions.register(PublicationsStateAction.INSTANCE, PublicationsStateAction.TransportAction.class);
         actions.register(UpdateSubscriptionAction.INSTANCE, UpdateSubscriptionAction.TransportAction.class);
         actions.register(DropSubscriptionAction.INSTANCE, DropSubscriptionAction.TransportAction.class);
@@ -263,6 +272,7 @@ public class ActionModule extends AbstractModule {
         // Misc actions
         actions.register(TransportIndicesStats.ACTION, TransportIndicesStats.class);
         actions.register(TransportDeleteIndex.ACTION, TransportDeleteIndex.class);
+        actions.register(TransportSwapAndDropIndexName.ACTION, TransportSwapAndDropIndexName.class);
         actions.register(TransportGCDanglingArtifacts.ACTION, TransportGCDanglingArtifacts.class);
 
         return unmodifiableMap(actions.getRegistry());

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/TransportResize.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/TransportResize.java
@@ -36,7 +36,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
 import io.crate.execution.ddl.index.SwapAndDropIndexRequest;
-import io.crate.execution.ddl.index.TransportSwapAndDropIndexNameAction;
+import io.crate.execution.ddl.index.TransportSwapAndDropIndexName;
 import io.crate.execution.ddl.tables.AlterTableClient;
 import io.crate.execution.ddl.tables.GCDanglingArtifactsRequest;
 import io.crate.execution.ddl.tables.TransportGCDanglingArtifacts;
@@ -59,7 +59,7 @@ public class TransportResize extends TransportMasterNodeAction<ResizeRequest, Re
 
     private final MetadataCreateIndexService createIndexService;
     private final Client client;
-    private final TransportSwapAndDropIndexNameAction swapAndDropIndexAction;
+    private final TransportSwapAndDropIndexName swapAndDropIndexAction;
     private final TransportGCDanglingArtifacts gcDanglingArtifactsAction;
 
     @Inject
@@ -67,7 +67,7 @@ public class TransportResize extends TransportMasterNodeAction<ResizeRequest, Re
                            ClusterService clusterService,
                            ThreadPool threadPool,
                            MetadataCreateIndexService createIndexService,
-                           TransportSwapAndDropIndexNameAction swapAndDropIndexAction,
+                           TransportSwapAndDropIndexName swapAndDropIndexAction,
                            TransportGCDanglingArtifacts gcDanglingArtifactsAction,
                            Client client) {
         super(ACTION.name(), transportService, clusterService, threadPool, ResizeRequest::new);

--- a/server/src/test/java/io/crate/replication/logical/action/TransportAlterPublicationTest.java
+++ b/server/src/test/java/io/crate/replication/logical/action/TransportAlterPublicationTest.java
@@ -37,19 +37,19 @@ import io.crate.replication.logical.metadata.Publication;
 import io.crate.sql.tree.AlterPublication;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 
-public class TransportAlterPublicationActionTest extends CrateDummyClusterServiceUnitTest {
+public class TransportAlterPublicationTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void test_unknown_table_raises_exception() {
         var pub = new Publication("owner", false, List.of());
         var metadata = Metadata.builder().build();
-        var request = new TransportAlterPublicationAction.Request(
+        var request = new TransportAlterPublication.Request(
             "pub1",
             AlterPublication.Operation.SET,
             List.of(RelationName.fromIndexName("t1"))
         );
 
-        assertThatThrownBy(() -> TransportAlterPublicationAction.updatePublication(request, metadata, pub))
+        assertThatThrownBy(() -> TransportAlterPublication.updatePublication(request, metadata, pub))
             .isExactlyInstanceOf(RelationUnknown.class);
     }
 
@@ -65,13 +65,13 @@ public class TransportAlterPublicationActionTest extends CrateDummyClusterServic
                 true
             )
             .build();
-        var request = new TransportAlterPublicationAction.Request(
+        var request = new TransportAlterPublication.Request(
             "pub1",
             AlterPublication.Operation.SET,
             List.of(RelationName.fromIndexName("t2"))
         );
 
-        var newPublication = TransportAlterPublicationAction.updatePublication(request, metadata, oldPublication);
+        var newPublication = TransportAlterPublication.updatePublication(request, metadata, oldPublication);
         assertThat(newPublication).isNotEqualTo(oldPublication);
         assertThat(newPublication.tables()).containsExactly(RelationName.fromIndexName("t2"));
     }
@@ -88,13 +88,13 @@ public class TransportAlterPublicationActionTest extends CrateDummyClusterServic
                 true
             )
             .build();
-        var request = new TransportAlterPublicationAction.Request(
+        var request = new TransportAlterPublication.Request(
             "pub1",
             AlterPublication.Operation.ADD,
             List.of(RelationName.fromIndexName("t2"))
         );
 
-        var newPublication = TransportAlterPublicationAction.updatePublication(request, metadata, oldPublication);
+        var newPublication = TransportAlterPublication.updatePublication(request, metadata, oldPublication);
         assertThat(newPublication).isNotEqualTo(oldPublication);
         assertThat(newPublication.tables()).containsExactlyInAnyOrder(
             RelationName.fromIndexName("t1"), RelationName.fromIndexName("t2"));
@@ -116,13 +116,13 @@ public class TransportAlterPublicationActionTest extends CrateDummyClusterServic
                 true
             )
             .build();
-        var request = new TransportAlterPublicationAction.Request(
+        var request = new TransportAlterPublication.Request(
             "pub1",
             AlterPublication.Operation.DROP,
             List.of(RelationName.fromIndexName("t2"))
         );
 
-        var newPublication = TransportAlterPublicationAction.updatePublication(request, metadata, oldPublication);
+        var newPublication = TransportAlterPublication.updatePublication(request, metadata, oldPublication);
         assertThat(newPublication).isNotEqualTo(oldPublication);
         assertThat(newPublication.tables()).containsExactly(RelationName.fromIndexName("t1"));
     }

--- a/server/src/test/java/io/crate/replication/logical/action/TransportCreateSubscriptionTest.java
+++ b/server/src/test/java/io/crate/replication/logical/action/TransportCreateSubscriptionTest.java
@@ -58,13 +58,11 @@ import io.crate.role.Roles;
 import io.crate.role.StubRoleManager;
 import io.crate.sql.tree.QualifiedName;
 
-public class TransportCreateSubscriptionActionTest {
+public class TransportCreateSubscriptionTest {
 
     private final LogicalReplicationService logicalReplicationService = mock(LogicalReplicationService.class);
     private final Roles roles = new StubRoleManager();
     private final ClusterService clusterService = mock(ClusterService.class);
-    private TransportCreateSubscriptionAction transportCreateSubscriptionAction;
-
 
     @Test
     public void test_subscribing_to_tables_with_higher_version_raises_error() throws Exception {
@@ -87,7 +85,7 @@ public class TransportCreateSubscriptionActionTest {
 
     private void subscribeToTablesWithVersion(FutureActionListener<AcknowledgedResponse> responseFuture,
                                               int internalVersionId) throws Exception {
-        transportCreateSubscriptionAction = new TransportCreateSubscriptionAction(
+        var transportCreateSubscription = new TransportCreateSubscription(
             mock(TransportService.class),
             clusterService,
             logicalReplicationService,
@@ -135,7 +133,7 @@ public class TransportCreateSubscriptionActionTest {
         when(logicalReplicationService.getPublicationState(anyString(), any(List.class), any(ConnectionInfo.class)))
             .thenReturn(CompletableFuture.completedFuture(response));
 
-        transportCreateSubscriptionAction.masterOperation(
+        transportCreateSubscription.masterOperation(
             new CreateSubscriptionRequest(
                 "crate",
                 "dummy",
@@ -147,5 +145,4 @@ public class TransportCreateSubscriptionActionTest {
             responseFuture
         );
     }
-
 }


### PR DESCRIPTION
Register `ACTION`s in `ActionModule` and  use `NodeClient.execute()` in the respective plans.
